### PR TITLE
Expand middle column to occupy the unused space when left sidebar is hidden.

### DIFF
--- a/web/src/realm_icon.ts
+++ b/web/src/realm_icon.ts
@@ -36,7 +36,10 @@ export function build_realm_icon_widget(upload_function: UploadFunction): void {
 }
 
 export function rerender(): void {
-    $("#realm-icon-upload-widget .image-block").attr("src", realm.realm_icon_url);
+    $("#realm-icon-upload-widget .image-block, #realm-navbar-icon-logo").attr(
+        "src",
+        realm.realm_icon_url,
+    );
     if (realm.realm_icon_source === "U") {
         $("#realm-icon-upload-widget .image-delete-button").show();
     } else {

--- a/web/src/realm_logo.ts
+++ b/web/src/realm_logo.ts
@@ -88,9 +88,9 @@ export function render(): void {
     }
 
     if (settings_data.using_dark_theme() && realm.realm_night_logo_source !== "D") {
-        $("#realm-logo").attr("src", realm.realm_night_logo_url);
+        $("#realm-navbar-wide-logo").attr("src", realm.realm_night_logo_url);
     } else {
-        $("#realm-logo").attr("src", realm.realm_logo_url);
+        $("#realm-navbar-wide-logo").attr("src", realm.realm_logo_url);
     }
 
     change_logo_delete_button(
@@ -109,6 +109,6 @@ export function initialize(): void {
     // render once
     render();
 
-    // Rerender the realm-logo when the browser detects color scheme changes.
+    // Rerender the realm-navbar-wide-logo when the browser detects color scheme changes.
     ui_util.listener_for_preferred_color_scheme_change(render);
 }

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -630,7 +630,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: "#realm-logo",
+        target: "#realm-navbar-wide-logo",
         placement: "right",
         appendTo: () => document.body,
         onShow(instance) {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -166,6 +166,7 @@ function initialize_navbar() {
     const rendered_navbar = render_navbar({
         embedded: page_params.narrow_stream !== undefined,
         user_avatar: current_user.avatar_url_medium,
+        realm_icon_url: realm.realm_icon_url,
     });
 
     $("#header-container").html(rendered_navbar);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -55,6 +55,8 @@
     */
     --left-sidebar-collapse-widget-gutter: 10px;
     --left-sidebar-width: 270px;
+    /* 15px (left margin) + 40px (toggle icon) + 10px (margin) + 20px logo + 10px right margin */
+    --left-sidebar-width-with-realm-icon-logo: 95px;
     --right-sidebar-width: 250px;
     --left-sidebar-header-icon-width: 15px;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2046,7 +2046,7 @@ body:not(.hide-left-sidebar) {
             display: inline-block;
         }
 
-        #realm-logo {
+        #realm-navbar-wide-logo {
             display: none;
         }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1421,10 +1421,13 @@ nav {
         justify-content: left;
         gap: 4px;
 
+        .brand {
+            display: flex;
+            align-items: center;
+        }
+
         .nav-logo {
             display: inline-block;
-            vertical-align: top;
-            margin-top: 10px;
             height: 20px;
             max-width: 200px;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1953,6 +1953,12 @@ select.invite-as {
     }
 }
 
+#realm-navbar-icon-logo {
+    display: none;
+    width: 20px;
+    height: 20px;
+}
+
 .hide-right-sidebar {
     @extend %hide-right-sidebar;
 
@@ -2034,6 +2040,22 @@ body:not(.hide-left-sidebar) {
         #compose-content,
         .app-main .column-middle {
             margin-left: 7px;
+        }
+
+        #realm-navbar-icon-logo {
+            display: inline-block;
+        }
+
+        #realm-logo {
+            display: none;
+        }
+
+        #top_navbar .column-left {
+            width: auto;
+        }
+
+        #navbar-middle {
+            margin-left: var(--left-sidebar-width-with-realm-icon-logo);
         }
     }
 }

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -7,6 +7,7 @@
             </a>
             <a href="" class="brand no-style">
                 <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>
+                <img id="realm-navbar-icon-logo" alt="" src="{{ realm_icon_url }}" class="nav-logo no-drag"/>
             </a>
         </div>
         <div class="column-middle" id="navbar-middle">

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -6,7 +6,7 @@
                 <span class="left-sidebar-toggle-unreadcount">0</span>
             </a>
             <a href="" class="brand no-style">
-                <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>
+                <img id="realm-navbar-wide-logo" src="" alt="" class="nav-logo no-drag"/>
                 <img id="realm-navbar-icon-logo" alt="" src="{{ realm_icon_url }}" class="nav-logo no-drag"/>
             </a>
         </div>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/left.20sidebar.20toggle.20icon




| before | after |
| --- | --- |
| <img width="811" alt="Screenshot 2024-06-18 at 12 09 21 AM" src="https://github.com/zulip/zulip/assets/25124304/6d54468d-de7c-47ee-8059-cc1c50f5fa4d"> | <img width="811" alt="Screenshot 2024-06-18 at 12 08 44 AM" src="https://github.com/zulip/zulip/assets/25124304/acec85c8-34a5-4730-bbce-0bb758496fb6"> |


Search open.
<img width="811" alt="Screenshot 2024-06-18 at 12 08 49 AM" src="https://github.com/zulip/zulip/assets/25124304/20a7ab73-01fa-4b85-a0d0-07f379179077">


Tested:
* Light / dark theme
* Full width layout 
* Search box
* left sidebar expanded / non-expanded states.
* with or without a realm logo icon set.
* Updating the realm logo icon.
* Small height window.



