### PR TITLE
Add keyboard navigation for userlist-toggle-button.

### DIFF
--- a/web/src/gear_menu.js
+++ b/web/src/gear_menu.js
@@ -89,6 +89,7 @@ function render(instance) {
         popover_menus_data.get_gear_menu_content_context(),
     );
     instance.setContent(parse_html(rendered_gear_menu));
+    $("#gear-menu").addClass("active-navbar-menu");
 }
 
 export function initialize() {
@@ -165,6 +166,7 @@ export function initialize() {
         },
         onShow: render,
         onHidden(instance) {
+            $("#gear-menu").removeClass("active-navbar-menu");
             instance.destroy();
             popover_menus.popover_instances.gear_menu = undefined;
         },

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -308,6 +308,11 @@ export function process_escape_key(e) {
         return true;
     }
 
+    if (navbar_menus.any_focused()) {
+        navbar_menus.blur_focused();
+        return true;
+    }
+
     if (processing_text()) {
         if (activity_ui.searching()) {
             activity_ui.clear_search();
@@ -832,7 +837,7 @@ export function process_hotkey(e, hotkey) {
 
     // Handle hotkeys for active popovers here which can handle keys other than `menu_dropdown_hotkeys`.
     if (
-        navbar_menus.is_navbar_menus_displayed() &&
+        (navbar_menus.is_navbar_menus_displayed() || navbar_menus.any_focused()) &&
         navbar_menus.handle_keyboard_events(event_name)
     ) {
         return true;

--- a/web/src/navbar_help_menu.ts
+++ b/web/src/navbar_help_menu.ts
@@ -36,10 +36,12 @@ export function initialize(): void {
                     }),
                 ),
             );
+            $("#help-menu").addClass("active-navbar-menu");
         },
         onHidden(instance) {
             instance.destroy();
             popover_menus.popover_instances.help_menu = null;
+            $("#help-menu").removeClass("active-navbar-menu");
         },
     });
 }

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -17,7 +17,10 @@ export function handle_keyboard_events(event_name) {
     if (!allowed_events.has(event_name)) {
         return false;
     }
+    return change_active_navbar_menu(event_name);
+}
 
+function change_active_navbar_menu(event_name) {
     // We don't need to process arrow keys in navbar menus for spectators
     // since they only have gear menu present.
     if (

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -14,6 +14,16 @@ export function is_navbar_menus_displayed() {
     );
 }
 
+export function any_focused() {
+    return $(".navbar-item:visible").is(":focus");
+}
+
+export function blur_focused() {
+    if (any_focused()) {
+        $(".navbar-item:visible").filter(":focus").trigger("blur");
+    }
+}
+
 export function handle_keyboard_events(event_name) {
     const allowed_events = new Set(["gear_menu", "left_arrow", "right_arrow"]);
     if (!allowed_events.has(event_name)) {
@@ -21,10 +31,11 @@ export function handle_keyboard_events(event_name) {
     }
 
     if (event_name === "gear_menu") {
+        blur_focused();
         gear_menu.toggle();
         return true;
     }
-    const $current_navbar_menu = $(".navbar-item:visible").filter(".active-navbar-menu");
+    const $current_navbar_menu = $(".navbar-item:visible").filter(".active-navbar-menu, :focus");
     const target_menu = get_target_navbar_menu(event_name, $current_navbar_menu);
 
     if (!target_menu) {
@@ -35,6 +46,7 @@ export function handle_keyboard_events(event_name) {
 
 function change_active_navbar_menu(target_menu) {
     popovers.hide_all();
+    blur_focused();
     switch (target_menu) {
         case "gear-menu":
             gear_menu.toggle();
@@ -44,6 +56,9 @@ function change_active_navbar_menu(target_menu) {
             return true;
         case "personal-menu":
             personal_menu_popover.toggle();
+            return true;
+        case "userlist-toggle-button":
+            $(`#${target_menu}`).trigger("focus");
             return true;
         default:
             return false;

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -2,9 +2,9 @@ import $ from "jquery";
 
 import * as gear_menu from "./gear_menu.js";
 import * as navbar_help_menu from "./navbar_help_menu.ts";
-import {page_params} from "./page_params.ts";
 import * as personal_menu_popover from "./personal_menu_popover.ts";
 import * as popover_menus from "./popover_menus.ts";
+import * as popovers from "./popovers.ts";
 
 export function is_navbar_menus_displayed() {
     return (
@@ -34,44 +34,20 @@ export function handle_keyboard_events(event_name) {
 }
 
 function change_active_navbar_menu(target_menu) {
-    // We don't need to process arrow keys in navbar menus for spectators
-    // since they only have gear menu present.
-    if (
-        popover_menus.is_personal_menu_popover_displayed() &&
-        target_menu === "gear-menu" &&
-        !page_params.is_spectator
-    ) {
-        // Open gear menu popover on left arrow.
-        personal_menu_popover.toggle();
-        gear_menu.toggle();
-        return true;
-    }
-
-    if (popover_menus.is_help_menu_popover_displayed() && target_menu === "gear-menu") {
-        // Open gear menu popover on right arrow.
-        navbar_help_menu.toggle();
-        gear_menu.toggle();
-        return true;
-    }
-
-    if (popover_menus.is_gear_menu_popover_displayed()) {
-        if (target_menu === "gear-menu") {
+    popovers.hide_all();
+    switch (target_menu) {
+        case "gear-menu":
             gear_menu.toggle();
             return true;
-        } else if (target_menu === "personal-menu" && !page_params.is_spectator) {
-            // Open personal menu popover on g + right arrow.
-            gear_menu.toggle();
-            personal_menu_popover.toggle();
-            return true;
-        } else if (target_menu === "help-menu") {
-            // Open help menu popover on g + left arrow.
-            gear_menu.toggle();
+        case "help-menu":
             navbar_help_menu.toggle();
             return true;
-        }
+        case "personal-menu":
+            personal_menu_popover.toggle();
+            return true;
+        default:
+            return false;
     }
-
-    return false;
 }
 
 function get_target_navbar_menu(event_name, $current_navbar_menu) {

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -13,6 +13,11 @@ export function is_navbar_menus_displayed() {
 }
 
 export function handle_keyboard_events(event_name) {
+    const allowed_events = new Set(["gear_menu", "left_arrow", "right_arrow"]);
+    if (!allowed_events.has(event_name)) {
+        return false;
+    }
+
     // We don't need to process arrow keys in navbar menus for spectators
     // since they only have gear menu present.
     if (

--- a/web/src/navbar_menus.js
+++ b/web/src/navbar_menus.js
@@ -58,6 +58,7 @@ function change_active_navbar_menu(target_menu) {
             personal_menu_popover.toggle();
             return true;
         case "userlist-toggle-button":
+        case "login_button":
             $(`#${target_menu}`).trigger("focus");
             return true;
         default:

--- a/web/src/personal_menu_popover.ts
+++ b/web/src/personal_menu_popover.ts
@@ -110,10 +110,12 @@ export function initialize(): void {
         onShow(instance) {
             const args = popover_menus_data.get_personal_menu_content_context();
             instance.setContent(parse_html(render_navbar_personal_menu_popover(args)));
+            $("#personal-menu").addClass("active-navbar-menu");
         },
         onHidden(instance) {
             instance.destroy();
             popover_menus.popover_instances.personal_menu = null;
+            $("#personal-menu").removeClass("active-navbar-menu");
         },
     });
 }

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -116,6 +116,14 @@ export function initialize(): void {
         window.location.href = spectators.build_login_link();
     });
 
+    $("body").on("keydown", ".login_button", (e) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            e.stopPropagation();
+            window.location.href = spectators.build_login_link();
+        }
+    });
+
     $("#userlist-toggle-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -147,6 +147,7 @@ export function is_in_focus(): boolean {
         !overlays.any_active() &&
         !modals.any_active_or_animating() &&
         !$(".home-page-input").is(":focus") &&
-        !$("#search_query").is(":focus")
+        !$("#search_query").is(":focus") &&
+        !$(".navbar-item:visible").is(":focus")
     );
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -462,7 +462,8 @@ body.has-overlay-scrollbar {
                 --color-navbar-spectator-medium-attention-brand-button-background
             );
 
-            &:hover {
+            &:hover,
+            &:focus {
                 color: var(
                     --color-navbar-spectator-medium-attention-brand-button-text
                 );

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -37,7 +37,7 @@
         </div>
         <div class="column-right">
             <div class="spectator_login_buttons only-visible-for-spectators">
-                <a class="login_button" tabindex="0">
+                <a id="login_button" class="login_button navbar-item" tabindex="0">
                     {{t 'Log in' }}
                 </a>
             </div>
@@ -62,7 +62,7 @@
                 </a>
             </div>
             <div class="spectator_narrow_login_button only-visible-for-spectators" data-tippy-content="{{t 'Log in' }}" data-tippy-placement="bottom">
-                <a class="header-button login_button" tabindex="0">
+                <a id="login_button" class="header-button login_button navbar-item" tabindex="0">
                     <i class="zulip-icon zulip-icon-log-in"></i>
                 </a>
             </div>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -37,7 +37,7 @@
         </div>
         <div class="column-right">
             <div class="spectator_login_buttons only-visible-for-spectators">
-                <a class="login_button">
+                <a class="login_button" tabindex="0">
                     {{t 'Log in' }}
                 </a>
             </div>
@@ -62,7 +62,7 @@
                 </a>
             </div>
             <div class="spectator_narrow_login_button only-visible-for-spectators" data-tippy-content="{{t 'Log in' }}" data-tippy-placement="bottom">
-                <a class="header-button login_button">
+                <a class="header-button login_button" tabindex="0">
                     <i class="zulip-icon zulip-icon-log-in"></i>
                 </a>
             </div>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -46,17 +46,17 @@
                     <i class="zulip-icon zulip-icon-user-list"></i>
                 </a>
             </div>
-            <div id="help-menu">
+            <div id="help-menu" class="navbar-item">
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="help-menu-tooltip-template">
                     <i class="zulip-icon zulip-icon-help-bigger" aria-hidden="true"></i>
                 </a>
             </div>
-            <div id="gear-menu" class="{{#if embedded}}hide-navbar-buttons-visibility{{/if}}">
+            <div id="gear-menu" class="{{#if embedded}}hide-navbar-buttons-visibility{{/if}} navbar-item">
                 <a id="settings-dropdown" tabindex="0" role="button" class="header-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="gear-menu-tooltip-template">
                     <i class="zulip-icon zulip-icon-gear" aria-hidden="true"></i>
                 </a>
             </div>
-            <div id="personal-menu" class="hidden-for-spectators">
+            <div id="personal-menu" class="hidden-for-spectators navbar-item">
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="personal-menu-tooltip-template">
                     <img class="header-button-avatar" src="{{user_avatar}}"/>
                 </a>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -42,7 +42,7 @@
                 </a>
             </div>
             <div id="userlist-toggle" class="hidden-for-spectators">
-                <a id="userlist-toggle-button" role="button" class="header-button" tabindex="0">
+                <a id="userlist-toggle-button" role="button" class="header-button navbar-item" tabindex="0">
                     <i class="zulip-icon zulip-icon-user-list"></i>
                 </a>
             </div>


### PR DESCRIPTION
Earlier, keyboard navigation only worked for `gear_menu`, `help_menu` and `personal_menu` in the navbar.

This commit introduces the ability to navigate to userlist-toggle-button and login/sigunup button using keyboard from `gear_menu`

Fixes: zulip#29465.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
userlist button:

![Screenshot from 2024-06-21 03-13-15](https://github.com/zulip/zulip/assets/33497322/5ec94bd1-b72e-4e2b-8212-29d18c00f5e1)

[Screencast from 21-06-24 03:13:59 AM IST.webm](https://github.com/zulip/zulip/assets/33497322/3538e7ff-d9b0-4383-a09e-d494740d71c9)

Login and signup button:

![Screenshot from 2024-06-21 03-13-30](https://github.com/zulip/zulip/assets/33497322/a7805376-8174-419d-9c3f-9ca6c887ca78)
![Screenshot from 2024-06-21 03-13-42](https://github.com/zulip/zulip/assets/33497322/55912247-3e76-4fa9-9dd7-c5c8246756fd)

[Screencast from 21-06-24 03:21:35 AM IST.webm](https://github.com/zulip/zulip/assets/33497322/9077279b-e2e8-42f5-b523-1488a41986bc)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
