### PR TITLE
Cleanup tests for custom profile fields + small refactors

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -436,8 +436,7 @@ export function read_field_data_from_form(
 ): FieldData | undefined {
     const field_types = realm.custom_profile_field_types;
 
-    // Only read field data if we are creating a select field
-    // or external account field.
+    // Only the following field types support associated field data.
     if (field_type_id === field_types.SELECT.id) {
         return read_select_field_data_from_form($profile_field_form, old_field_data);
     } else if (field_type_id === field_types.EXTERNAL_ACCOUNT.id) {

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -3,7 +3,7 @@
     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     <input type='text' class="modal_text_input" placeholder='{{t "New option" }}' value="{{ text }}" />
 
-    <button type='button' class="button rounded small delete-choice {{#if new_empty_choice_row}} hide {{/if}}" title="{{t 'Delete' }}">
+    <button type='button' class="button rounded small delete-choice tippy-zulip-tooltip {{#if new_empty_choice_row}} hide {{/if}}" data-tippy-content="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
 </div>

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -471,19 +471,6 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         )
         self.assert_json_error(result, "Label cannot be blank.")
 
-        self.assertEqual(CustomProfileField.objects.count(), self.original_count)
-        result = self.client_patch(
-            f"/json/realm/profile_fields/{field.id}",
-            info={"name": "New phone number"},
-        )
-        self.assert_json_success(result)
-        field = CustomProfileField.objects.get(id=field.id, realm=realm)
-        self.assertEqual(CustomProfileField.objects.count(), self.original_count)
-        self.assertEqual(field.name, "New phone number")
-        self.assertIs(field.hint, "")
-        self.assertEqual(field.field_type, CustomProfileField.SHORT_TEXT)
-        self.assertEqual(field.required, False)
-
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
             info={"name": "*" * 41},


### PR DESCRIPTION
This PR does not make any behavioural changes, but since we want to discuss what the exact behaviour should be for #29880, this is a seperate PR consisting of cleanups. 

There is one behaviour change on this PR where we use `tippy` for the select field delete button
**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
