### PR TITLE
Make the active narrow background color for DM section consistent

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -121,11 +121,11 @@ export function update_dom_with_unread_counts(counts: FullUnreadCountsData): voi
 }
 
 export function highlight_all_private_messages_view(): void {
-    $(".direct-messages-container").addClass("active_private_messages_section");
+    $(".direct-messages-container").addClass("active-direct-messages-section");
 }
 
 function unhighlight_all_private_messages_view(): void {
-    $(".direct-messages-container").removeClass("active_private_messages_section");
+    $(".direct-messages-container").removeClass("active-direct-messages-section");
 }
 
 function scroll_pm_into_view($target_li: JQuery): void {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -372,7 +372,7 @@
         color: inherit;
     }
 
-    .active_private_messages_section {
+    .active-direct-messages-section {
         background-color: hsl(199deg 33% 46% / 20%);
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -176,14 +176,6 @@
         background-color: var(--color-background-navbar);
     }
 
-    & body,
-    .app-main,
-    .column-middle,
-    #streams_header,
-    .direct-messages-container {
-        background-color: var(--color-background);
-    }
-
     #scroll-to-bottom-button-container {
         background: transparent;
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -364,10 +364,6 @@
         color: inherit;
     }
 
-    .active-direct-messages-section {
-        background-color: hsl(199deg 33% 46% / 20%);
-    }
-
     /* these are converting grey things to "new grey" */
     :disabled,
     input:not([type="radio"]):read-only,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -373,11 +373,7 @@
     }
 
     .active_private_messages_section {
-        #private_messages_section,
-        #direct-messages-list,
-        #hide-more-direct-messages {
-            background-color: hsl(199deg 33% 46% / 20%);
-        }
+        background-color: hsl(199deg 33% 46% / 20%);
     }
 
     /* these are converting grey things to "new grey" */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -326,11 +326,7 @@ li.show-more-topics {
 }
 
 .active_private_messages_section {
-    #private_messages_section,
-    #direct-messages-list,
-    #hide-more-direct-messages {
-        background-color: hsl(202deg 56% 91%);
-    }
+    background-color: hsl(202deg 56% 91%);
 
     #private_messages_section {
         border-radius: 4px 4px 0 0;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -326,7 +326,7 @@ li.show-more-topics {
 }
 
 .active-direct-messages-section {
-    background-color: hsl(202deg 56% 91%);
+    background-color: var(--color-background-active-narrow-filter);
 
     #private_messages_section {
         border-radius: 4px 4px 0 0;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -325,7 +325,7 @@ li.show-more-topics {
     }
 }
 
-.active_private_messages_section {
+.active-direct-messages-section {
     background-color: hsl(202deg 56% 91%);
 
     #private_messages_section {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #30467

[CZO Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/DM.20-.20active.20narrow.20filter.20background.20color.20dark.20mode/near/1829356)

This PR also take two refactor commits from #30332 and puts it as the first two commits so it's a bit easier to review and merge.

There's also one more commit that removes unused CSS applying `background-color` for dark theme: [fc90036](https://github.com/zulip/zulip/pull/30468/commits/fc90036d3e9a04bb54fe5ddc52dec07040883c9f). This would require some regression testing.

It would be good to get this PR merged before #30332 .

**Screenshots and screen captures:**
<img width="354" alt="Screenshot 2024-06-18 at 10 22 27 PM" src="https://github.com/zulip/zulip/assets/13910561/aa1b755b-04eb-499d-aa9b-8ca494bc0f22">

<details>
<summary>Home page screenshot before the PR</summary>
<img width="1728" alt="Screenshot 2024-06-19 at 4 41 56 PM" src="https://github.com/zulip/zulip/assets/13910561/7f2636c8-80ad-4877-84b1-4306dec209eb">

</details>

<details>
<summary>Home page screenshot after the PR</summary>

<img width="1728" alt="Screenshot 2024-06-19 at 4 41 11 PM" src="https://github.com/zulip/zulip/assets/13910561/423816e3-2c2f-4dd3-a2d1-08f913838664">


</details>

https://www.diffchecker.com/image-compare/ shows that the above two images are the same, just to check any color differences gone unnoticed by the naked eye.

<details>
<summary>Active DM narrow before the PR</summary>
<img width="380" alt="Screenshot 2024-06-19 at 4 46 13 PM" src="https://github.com/zulip/zulip/assets/13910561/1de3a03a-c8de-443c-a7fd-7299308721e1">


</details>

<details>
<summary>Active DM narrow after the PR</summary>

<img width="380" alt="Screenshot 2024-06-19 at 4 47 47 PM" src="https://github.com/zulip/zulip/assets/13910561/1c87cf69-4d21-4443-a4bf-4603546d1bc7">



</details>

https://www.diffchecker.com/image-compare/ shows that the above two images are the same, just to check any color differences gone unnoticed by the naked eye.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
