### PR TITLE
server_dispatch: Calculate typography vars on dense_mode.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -779,6 +779,7 @@ export function dispatch_normal_event(event) {
             if (event.property === "dense_mode") {
                 $("body").toggleClass("less-dense-mode");
                 $("body").toggleClass("more-dense-mode");
+                information_density.set_base_typography_css_variables();
             }
             if (
                 event.property === "web_font_size_px" ||

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -955,6 +955,7 @@ run_test("user_settings", ({override}) => {
 
     event = event_fixtures.user_settings__dense_mode;
     user_settings.dense_mode = false;
+    override(information_density, "set_base_typography_css_variables", noop);
     toggled = [];
     dispatch(event);
     assert_same(user_settings.dense_mode, true);


### PR DESCRIPTION
Owing to logic added in #30050, which accounts for the legacy line- height value, toggling dense mode requires recalculating the typography vars--otherwise, a non-legacy line-height value will not be picked up until a refresh.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>