### PR TITLE
left_sidebar: Restore righthand padding to DM partners.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -959,13 +959,6 @@ li.top_left_scheduled_messages {
     padding: 0 $before_unread_count_padding 0 0;
 }
 
-.conversation-partners-list {
-    /* TODO: See about consolidating or re-expressing
-       .stream-name spacing so as to not require
-       padding there, either. */
-    padding: 0;
-}
-
 /*
     All of our left sidebar handlers use absolute
     positioning.  We should fix that.


### PR DESCRIPTION
This removes a now-unnecessary style block that restores space to the righthand side of DM partners, so that collisions with unreads as shown in the Before screenshot below are no longer possible.

Fixes part of #30359 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Note the 1:1 DM to Prospero.

| Before | After |
| --- | --- |
| ![main-morning-of-2024-06-18](https://github.com/zulip/zulip/assets/170719/129dd2bc-ef3f-4ecb-90a3-0673a5c39437) | ![dm-partners-after](https://github.com/zulip/zulip/assets/170719/9d6652d2-045d-4eac-bf16-e0e6c05fd444) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>