### PR TITLE
Follow up restructure stream creation panel PR

### DIFF
--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -82,15 +82,15 @@ export const show_user_group_settings_pane = {
         set_active_group_id(group.id);
         $("#groups_overlay .user-group-info-title").text(group.name);
     },
-    create_user_group(container_name = "configure_user_group_settings") {
+    create_user_group(container_name = "configure_user_group_settings", group_name: string) {
         $(".user_group_creation").hide();
         if (container_name === "configure_user_group_settings") {
             $("#groups_overlay .user-group-info-title").text(
-                $t_html({defaultMessage: "Create user group: configure settings"}),
+                $t_html({defaultMessage: "Configure new group settings"}),
             );
         } else {
             $("#groups_overlay .user-group-info-title").text(
-                $t_html({defaultMessage: "Create user group: add members"}),
+                $t_html({defaultMessage: "Add members to {group_name}"}, {group_name}),
             );
         }
         update_footer_buttons(container_name);

--- a/web/src/user_group_create.js
+++ b/web/src/user_group_create.js
@@ -99,6 +99,7 @@ $("body").on("click", ".settings-sticky-footer #user_group_go_to_members", (e) =
     if (is_user_group_name_valid) {
         user_group_components.show_user_group_settings_pane.create_user_group(
             "user_group_members_container",
+            group_name,
         );
     }
 });

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -523,7 +523,7 @@ h4.user_group_setting_subsection_title {
     }
 
     #announce-new-stream {
-        margin: 25px auto;
+        margin: 20px auto;
 
         & div[class^="fa"] {
             margin-left: 3px;
@@ -1065,7 +1065,7 @@ div.settings-radio-input-parent {
     }
 
     .default-stream {
-        margin: 25px 0;
+        margin: 20px 0;
         width: fit-content;
 
         .inline {


### PR DESCRIPTION
this PR address the comment on #29433:

- Update user group panel titles _posted by @sujalshah-bit in https://github.com/zulip/zulip/issues/29433#issuecomment-2174264462_

|  Panel A|  Panel B|
|---|---|
| ![image](https://github.com/zulip/zulip/assets/73663475/7d4df38d-18d9-4e9e-9fb1-dd8ca50d09b5)  | ![image](https://github.com/zulip/zulip/assets/73663475/8cac0d9e-d1e8-4c3a-9b44-b4be1b665aa9)  | 




- Reduce Vertical margin between `default-streams` and `announce-streams` _posted by @sujalshah-bit in https://github.com/zulip/zulip/issues/29433#issuecomment-2174256476_
            
|  Before  |  After |
|---|---|
| ![image](https://github.com/zulip/zulip/assets/73663475/5816c597-35fb-487a-9f9a-509e3ba097c2)  |  ![image](https://github.com/zulip/zulip/assets/73663475/a1db8cb1-e38b-4a15-a247-681e526ee467) | 


Fixes part of  #29403.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
