### PR TITLE
navbar: Remove empty space to the left and right.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -55,8 +55,8 @@
     */
     --left-sidebar-collapse-widget-gutter: 10px;
     --left-sidebar-width: 270px;
-    /* 15px (left margin) + 40px (toggle icon) + 10px (margin) + 20px logo + 10px right margin */
-    --left-sidebar-width-with-realm-icon-logo: 95px;
+    /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
+    --left-sidebar-width-with-realm-icon-logo: 75px;
     --right-sidebar-width: 250px;
     --left-sidebar-header-icon-width: 15px;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1416,7 +1416,6 @@ div.focused-message-list {
 nav {
     .column-left {
         text-align: left;
-        margin-left: 15px;
         display: flex;
         justify-content: left;
         gap: 4px;
@@ -1436,13 +1435,9 @@ nav {
             }
         }
 
-        .left-sidebar-toggle-button {
-            margin-right: 5px;
-
-            .left-sidebar-toggle-unreadcount {
-                top: 10px;
-                left: 21px;
-            }
+        .left-sidebar-toggle-button .left-sidebar-toggle-unreadcount {
+            top: 10px;
+            left: 21px;
         }
     }
 
@@ -2025,8 +2020,8 @@ body:not(.hide-left-sidebar) {
         }
 
         #navbar-middle {
-            /* = (width of button, square with header) * 4 (number of buttons) + 10px extra margin. */
-            margin-right: calc(var(--header-height) * 4 + 10px);
+            /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
+            margin-right: calc(var(--header-height) * 4 + 3px);
         }
 
         #typing_notifications,
@@ -2379,9 +2374,6 @@ body:not(.hide-left-sidebar) {
     width: calc(var(--right-sidebar-width) - 7px - 7px);
     justify-content: flex-end;
     align-items: center;
-    /* Move the column to the right with absolute
-       positioning, rather than margin. */
-    right: 7px;
 
     & a:focus {
         filter: none;


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/left.20sidebar.20toggle.20icon

| before | after |
| --- | --- |
| ![image](https://github.com/zulip/zulip/assets/25124304/9a39c6d8-a609-40e7-8865-79b72d1b119a) | <img alt="image" src="https://github.com/zulip/zulip/assets/25124304/4451f1c4-8e99-420f-9868-0a5d1fd711ad"> |

| before | after |
| --- | --- |
| ![image](https://github.com/zulip/zulip/assets/25124304/3fe4f4f5-702a-491e-8818-08549050f56b) | ![image](https://github.com/zulip/zulip/assets/25124304/21a0eb24-27aa-4c29-a4fb-d8cb9f5242ac) |

| before | after |
| --- | --- |
| ![image](https://github.com/zulip/zulip/assets/25124304/672c193e-fe3f-4543-bd6d-30fca35fc18a) | ![image](https://github.com/zulip/zulip/assets/25124304/c006355b-e369-46a2-aaad-129c265312d0) |




