### PR TITLE
inbox_ui: Don't process scroll events if Inbox is not visible.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -811,7 +811,9 @@ function is_list_focused(): boolean {
 }
 
 function get_all_rows(): JQuery {
-    return $(".inbox-header, .inbox-row").not(".hidden_by_filters, .collapsed_container");
+    return $("#inbox-main .inbox-header, #inbox-main .inbox-row").not(
+        ".hidden_by_filters, .collapsed_container",
+    );
 }
 
 function get_row_index($elt: JQuery): number {
@@ -1369,7 +1371,7 @@ function center_focus_if_offscreen(): void {
 function move_focus_to_visible_area(): void {
     // Focus on the row below inbox filters if the focused
     // row is not visible.
-    if (!is_list_focused()) {
+    if (!is_visible() || !is_list_focused()) {
         return;
     }
 


### PR DESCRIPTION
![image](https://github.com/zulip/zulip/assets/25124304/ad9269c3-9479-4c1d-abc1-be3ae3e4ea8b)

The `get_all_rows` part in the above screenshot is removed after this change.



On 6x CPU slowdown:

| before | after |
| --- | --- |
| <img width="382" alt="Screenshot 2024-06-20 at 1 55 14 AM" src="https://github.com/zulip/zulip/assets/25124304/1fc93147-a1fe-443e-8eb1-9cf077ae9e29"> | <img width="382" alt="Screenshot 2024-06-20 at 1 54 59 AM" src="https://github.com/zulip/zulip/assets/25124304/7945d022-121a-4d68-a0a6-328e1ca670d8"> |

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/scrolling.20lag