### PR TITLE
visibility_policy_popover: Fix popover shrinking bug on Safari.

### DIFF
--- a/web/templates/popovers/change_visibility_policy_popover.hbs
+++ b/web/templates/popovers/change_visibility_policy_popover.hbs
@@ -5,24 +5,24 @@
                 <input type="radio" id="select-muted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
                 <label role="menuitemradio" class="tab-option-content" for="select-muted-policy" tabindex="0">
                     <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
-                    {{t "Mute"}}
+                    <span class="popover-menu-label">{{t "Mute"}}</span>
                 </label>
                 <input type="radio" id="select-inherit-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
                 <label role="menuitemradio" class="tab-option-content" for="select-inherit-policy" tabindex="0">
                     <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
-                    {{t "Default"}}
+                    <span class="popover-menu-label">{{t "Default"}}</span>
                 </label>
                 {{#if (or stream_muted topic_unmuted)}}
                 <input type="radio" id="select-unmuted-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
                 <label role="menuitemradio" class="tab-option-content" for="select-unmuted-policy" tabindex="0">
                     <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
-                    {{t "Unmute"}}
+                    <span class="popover-menu-label">{{t "Unmute"}}</span>
                 </label>
                 {{/if}}
                 <input type="radio" id="select-followed-policy" class="tab-option" name="visibility-policy-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
                 <label role="menuitemradio" class="tab-option-content" for="select-followed-policy" tabindex="0">
                     <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
-                    {{t "Follow"}}
+                    <span class="popover-menu-label">{{t "Follow"}}</span>
                 </label>
                 <span class="slider"></span>
             </div>


### PR DESCRIPTION
A bug was observed on Safari where the visibility policy switcher popover was shrinking beyond the width of the policy switcher, hiding a portion of the switcher component.

This was due to the presence of the `width: min-content` on the popover for supporting dynamic popover menu sizing based on the content of the menu items, in tandem with some issue in Safari since it worked fine on other browsers.

This commit adds the `.popover-menu-label` class to the visibility policy switcher's label to enforce `max-content` width on the label element, which in turn fixes the popover shrinking issue on Safari.

Fixes: [Issue reported on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/visibility.20popover.20cut.20off.20on.20Safari.20.28macOS.20and.20iOS.29/near/1828494)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-06-19 at 7 20 16 PM](https://github.com/zulip/zulip/assets/82862779/4a43f6f2-93e4-4d9c-a4fb-799f6bfabead) | ![Screenshot 2024-06-19 at 7 17 54 PM](https://github.com/zulip/zulip/assets/82862779/1929f050-6016-4582-ac0e-4ce10f1d7520) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
