### PR TITLE
Fix visual bugs in stream settings.

### DIFF
--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -252,6 +252,13 @@ export function enable_or_disable_permission_settings_in_edit_panel(sub) {
 
     const $general_settings_container = $stream_settings.find($("#stream_permission_settings"));
     $general_settings_container
+        .find("input, button")
+        .prop("disabled", !sub.can_change_stream_permissions);
+
+    const $advanced_configurations_container = $stream_settings.find(
+        $("#stream-advanced-configurations"),
+    );
+    $advanced_configurations_container
         .find("input, select, button")
         .prop("disabled", !sub.can_change_stream_permissions);
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1117,6 +1117,7 @@ div.overlay {
     &:disabled {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
+        opacity: 0.7;
     }
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -350,7 +350,8 @@
     :disabled,
     input:not([type="radio"]):read-only,
     textarea:read-only,
-    #organization-permissions .dropdown-widget-button:disabled {
+    #organization-permissions .dropdown-widget-button:disabled,
+    #stream-advanced-configurations .dropdown-widget-button:disabled {
         color: inherit;
         opacity: 0.5;
     }
@@ -405,6 +406,7 @@
     .user-status-content-wrapper,
     #custom-expiration-time-input,
     #organization-permissions .dropdown-widget-button,
+    #stream-advanced-configurations .dropdown-widget-button,
     #compose_recipient_box {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -351,6 +351,7 @@
     input:not([type="radio"]):read-only,
     textarea:read-only,
     #organization-permissions .dropdown-widget-button:disabled,
+    #organization-settings .dropdown-widget-button:disabled,
     #stream-advanced-configurations .dropdown-widget-button:disabled {
         color: inherit;
         opacity: 0.5;
@@ -406,6 +407,7 @@
     .user-status-content-wrapper,
     #custom-expiration-time-input,
     #organization-permissions .dropdown-widget-button,
+    #organization-settings .dropdown-widget-button,
     #stream-advanced-configurations .dropdown-widget-button,
     #compose_recipient_box {
         background-color: hsl(0deg 0% 0% / 20%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1017,7 +1017,8 @@
         }
     }
 
-    .panel_user_list > .pill-container {
+    .panel_user_list > .pill-container,
+    .stream_creator_details > .display_only_pill {
         &:hover {
             color: inherit;
         }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -374,6 +374,9 @@
         /* The background-color of select elements inside modal is different than the others in
         settings pages, because the background of the modal is brighter than the setting page. */
         background-color: hsl(0deg 0% 90%);
+
+        /* This is reset for other browsers to use Chrome's opacity. */
+        opacity: 0.7;
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -864,6 +864,12 @@ input[type="checkbox"] {
     }
 }
 
+#organization-settings {
+    .dropdown-widget-button {
+        color: hsl(0deg 0% 33%);
+    }
+}
+
 .progressive-table-wrapper {
     position: relative;
     max-height: calc(95vh - 220px);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -861,11 +861,6 @@ input[type="checkbox"] {
     .dropdown-widget-button {
         width: 325px;
         color: hsl(0deg 0% 33%);
-
-        &:disabled {
-            cursor: not-allowed;
-            background-color: hsl(0deg 0% 93%);
-        }
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -865,7 +865,6 @@ input[type="checkbox"] {
         &:disabled {
             cursor: not-allowed;
             background-color: hsl(0deg 0% 93%);
-            opacity: 0.7;
         }
     }
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -371,6 +371,9 @@ td .button {
     &:disabled {
         cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
+
+        /* This is reset for other browsers to use Chrome's opacity. */
+        opacity: 0.7;
     }
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1074,6 +1074,12 @@ div.settings-radio-input-parent {
     }
 }
 
+#stream-advanced-configurations {
+    .dropdown-widget-button {
+        color: hsl(0deg 0% 33%);
+    }
+}
+
 #change_user_group_description,
 #change_stream_description {
     width: 100%;

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -43,7 +43,7 @@
     </div>
 </div>
 
-<div class="advanced-configurations-container stream-permissions {{#if is_stream_edit}}settings-subsection-parent{{/if}}">
+<div id="stream-advanced-configurations" class="advanced-configurations-container stream-permissions {{#if is_stream_edit}}settings-subsection-parent{{/if}}">
     <div class="advance-config-title-container {{#if is_stream_edit}}subsection-header{{/if}}">
         <i class="fa fa-sm fa-caret-right toggle-advanced-configurations-icon" aria-hidden="true"></i>
         <h4 class="stream_setting_subsection_title"><span>{{t 'Advanced configurations' }}</span></h4>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

**First commit**, fixes crreator pill dark theme issue reported in [#29425(comment)](https://github.com/zulip/zulip/pull/29425#discussion_r1573483703)
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/1e64533c-0981-43ec-b89f-511575c408b9) | ![image](https://github.com/zulip/zulip/assets/133781250/43f5e7a1-dbf9-4177-8055-d52b119deac2) | 

**Second and third commit**, fixes `Advanced configurations` issue reported in [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Stream.20settings.20advanced.20configurations.20always.20enabled/near/1831470)
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/3f783382-0824-4110-afa3-79a53589e096) ![image](https://github.com/zulip/zulip/assets/133781250/5501ca4f-7de2-48be-9270-a427261ba236) | ![image](https://github.com/zulip/zulip/assets/133781250/7dacf919-b7e3-429a-ba41-c9ab589874ce) ![image](https://github.com/zulip/zulip/assets/133781250/8efe9bb2-20c5-4282-9f5a-de67200d213d) |

`git grep` on new css id:
```css
[tnmkr@fedora zulip]$ git grep -n "stream-advanced-configurations"
web/src/stream_ui_updates.js:258:        $("#stream-advanced-configurations"),
web/templates/stream_settings/stream_types.hbs:46:<div id="stream-advanced-configurations" class="advanced-configurations-container stream-permissions {{#if is_stream_edit}}settings-subsection-parent{{/if}}">
```

**Fourth commit**, fixes opacity on Firefox.
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/be484487-f6dc-4b62-9cff-930e12ea8b68) | ![image](https://github.com/zulip/zulip/assets/133781250/26834db2-ad1e-45c4-93a2-a19bc79adf2e)|



**Fifth commit**, Makes opacity for `.dropdown-widget-button` same as `disabled` select dropdowns.

**Sixth commit**. CSS refactor with no visual change.

**Seventh and eighth commit**, fix text color in `Organization Settings`.
| Header | Header |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/aa3cd792-f62b-4be2-9013-8baea6a5bad3) ![image](https://github.com/zulip/zulip/assets/133781250/9cc3aae6-d558-4605-b281-97690da2932d) | ![image](https://github.com/zulip/zulip/assets/133781250/68227951-7eae-43a2-a8b2-34cf85a989b7) ![image](https://github.com/zulip/zulip/assets/133781250/82844a09-8569-487b-bf8e-9a45d06032fd) | 

**Commit second to eighth dark mode**, should be unchanged
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/5e215dad-fcf3-4526-b7cf-7ae9e1fdb493) ![image](https://github.com/zulip/zulip/assets/133781250/c7cd91a0-6293-469f-a982-aedcda5caf43)  ![image](https://github.com/zulip/zulip/assets/133781250/7500fc21-26b3-471a-9490-4714cc728634) | ![image](https://github.com/zulip/zulip/assets/133781250/f2f95572-c839-4192-8f2c-981e73833113) ![image](https://github.com/zulip/zulip/assets/133781250/a7c9d9cc-1255-4eea-a14e-53aeab87d6f7) ![image](https://github.com/zulip/zulip/assets/133781250/00b1059f-d940-4244-9056-5df1cefc85dd) |


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
