### PR TITLE
custom_profile: Convert to typed_endpoint.

### DIFF
--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 from django_stubs_ext import StrPromise
-from typing_extensions import NotRequired, TypeAlias
+from typing_extensions import NotRequired, TypeAlias, TypedDict
 
 # See zerver/lib/validator.py for more details of Validators,
 # including many examples

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -39,7 +39,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         realm = get_realm("zulip")
         data: Dict[str, Any] = {"name": "Phone", "field_type": "text id"}
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, 'Argument "field_type" is not valid JSON.')
+        self.assert_json_error(result, "field_type is not valid JSON")
 
         data["name"] = ""
         data["field_type"] = 100
@@ -106,7 +106,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["field_data"] = "invalid"
         result = self.client_post("/json/realm/profile_fields", info=data)
-        error_msg = 'Argument "field_data" is not valid JSON.'
+        error_msg = "field_data is not valid JSON"
         self.assert_json_error(result, error_msg)
 
         data["field_data"] = orjson.dumps(
@@ -116,7 +116,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             }
         ).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, "field_data contains a value that is not an allowed_type")
+        self.assert_json_error(result, 'field_data["python"]["dict[str,str]"] is not a dict')
 
         data["field_data"] = orjson.dumps(
             {
@@ -152,7 +152,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             }
         ).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, "field_data contains a value that is not an allowed_type")
+        self.assert_json_error(result, 'field_data["0"]["dict[str,str]"]["order"] is not a string')
 
         data["field_data"] = orjson.dumps({}).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
@@ -247,7 +247,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         data["field_data"] = "invalid"
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, 'Argument "field_data" is not valid JSON.')
+        self.assert_json_error(result, "field_data is not valid JSON")
 
         data["field_data"] = orjson.dumps({}).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
@@ -307,7 +307,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             }
         ).decode()
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, "field_data contains a value that is not an allowed_type")
+        self.assert_json_error(result, 'field_data["url_pattern"]["dict[str,str]"] is not a dict')
 
         data["field_data"] = orjson.dumps(
             {
@@ -493,7 +493,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
                 "required": "invalid value",
             },
         )
-        msg = 'Argument "required" is not valid JSON.'
+        msg = "required is not valid JSON"
         self.assert_json_error(result, msg)
 
         result = self.client_patch(
@@ -555,7 +555,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
                 "display_in_profile_summary": "invalid value",
             },
         )
-        msg = 'Argument "display_in_profile_summary" is not valid JSON.'
+        msg = "display_in_profile_summary is not valid JSON"
         self.assert_json_error(result, msg)
 
         result = self.client_patch(
@@ -613,7 +613,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             f"/json/realm/profile_fields/{field.id}",
             info={"field_data": "invalid"},
         )
-        self.assert_json_error(result, 'Argument "field_data" is not valid JSON.')
+        self.assert_json_error(result, "field_data is not valid JSON")
 
         field_data = orjson.dumps(
             {


### PR DESCRIPTION
Convert `custom_profile_fields.py` to use
`typed_endpoint`.
Use `TypedDict` from `typing_extensions` instead of `typing`,
to support Pydantic's type checking.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
