### PR TITLE
pm_section: Fix ghost tooltip on collapse/expand DM toggle.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -487,6 +487,9 @@ export function initialize(): void {
         },
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
     });
 
     tippy.delegate("body", {


### PR DESCRIPTION
As reported in a bug report, the tooltip on the DM collapse/expand toggle was reappearing after switching in and out of the browser window.

This PR destroys the current instance of the tooltip when it is hidden. This clean up ensures that the tooltip does not appear again unless the triggered explicitly by the user.

Fixes: [Issue reported on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Expand.2FCollapse.20direct.20messages.20tooltip.20popping.20constantly/near/1768745)

Screencast as uploaded by the user:
![dm-ghost-tooltip-bug](https://github.com/zulip/zulip/assets/82862779/5b687755-9dc8-43c1-907a-f33ef425da84)

Steps to reproduce:
1) Open the "All messages" section.
2) Click on the expand/collapse dm button.
3) Then hover over the button to show the tooltip.
4) Then hover anywhere on the screen and then change window.
5) Return back to CZO window

(This bug was reported on a Macbook M1 using the Chrome browser)

> [!NOTE]  
> I was unable to replicate this bug from my end, even after following the steps to reproduce this error multiple times. However, this PR still tries to eliminate the possibility of this bug by destroying the tippy instance altogether when hidden.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
