### PR TITLE
compose: Show focus ring on buttons only when using keyboard navigation.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -627,6 +627,7 @@
     --color-background-modal: hsl(212deg 28% 18%);
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 0% / 20%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
+    --color-outline-focus: hsl(0deg 0% 67%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);
     --color-background-search: hsl(0deg 0% 20%);
     --color-background-search-option-hover: hsl(0deg 0% 30%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -438,6 +438,14 @@
         background: var(--color-compose-embedded-button-background-hover);
         color: var(--color-compose-send-control-button-interactive);
     }
+
+    &:focus:not(:focus-visible) {
+        outline: none;
+    }
+
+    &:focus-visible {
+        outline-color: var(--color-outline-focus);
+    }
 }
 
 .main-view-banner {
@@ -1054,6 +1062,14 @@ textarea.new_message_textarea,
             opacity: 1;
             background-color: hsl(0deg 0% 0% / 10%);
         }
+
+        &:focus:not(:focus-visible) {
+            outline: none;
+        }
+
+        &:focus-visible {
+            outline-color: var(--color-outline-focus);
+        }
     }
 
     .compose_control_button_container.disabled-on-hover:hover {
@@ -1295,12 +1311,12 @@ textarea.new_message_textarea,
         transform: scale(0.96);
     }
 
-    &:focus {
-        outline: 0;
+    &:focus:not(:focus-visible) {
+        outline: none;
     }
 
     &:focus-visible {
-        outline: 2px solid var(--color-outline-focus);
+        outline-color: var(--color-outline-focus);
     }
 
     &:hover {


### PR DESCRIPTION
For the compose control buttons, the compose close button, and the send later vdots button, we show the focus ring only on `focus-visible` and not on `focus`.

Fixes part of: #27117.

css: Redefine `--color-outline-focus` for dark theme.

The css variable `--color-outline-focus`, which affects focus rings throughout the app, now has a different value defined for the dark theme but this should have no visible effect, and help clean up the code.

This is a prep commit for the next, which shows focus rings only on `focus-visible` and not on `focus` for composer buttons.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
