### PR TITLE
info_density: Refactor pills to follow font-size.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -200,6 +200,11 @@
        We expect `resize.ts` to update this once UI is initialized. */
     --recent-topics-filters-height: 50px;
 
+    /* Pill dimensions. */
+    /* 1.4286em is 20px at 14px/1em */
+    --height-input-pill: 1.4286em;
+    --length-input-pill-image: var(--height-input-pill);
+
     /* Overlay heights for streams modal */
     --overlay-container-height: 95vh;
     --overlay-container-max-height: 1000px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -204,6 +204,8 @@
     /* 1.4286em is 20px at 14px/1em */
     --height-input-pill: 1.4286em;
     --length-input-pill-image: var(--height-input-pill);
+    --vertical-spacing-input-pill: 2px;
+    --horizontal-spacing-input-pill: 6px;
 
     /* Overlay heights for streams modal */
     --overlay-container-height: 95vh;

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -16,7 +16,7 @@
         max-width: 100%;
         min-width: 0;
 
-        height: 20px;
+        height: var(--height-input-pill);
         margin: 1px 2px;
 
         color: inherit;
@@ -32,8 +32,8 @@
         }
 
         .pill-image {
-            height: 20px;
-            width: 20px;
+            height: var(--length-input-pill-image);
+            width: var(--length-input-pill-image);
             border-radius: 4px 0 0 4px;
         }
 
@@ -137,7 +137,10 @@
 
     .input {
         display: inline-block;
-        padding: 2px 4px;
+        /* This keeps the input sized to
+           the same height as pills. */
+        line-height: var(--height-input-pill);
+        padding: 0 4px;
 
         min-width: 2px;
         word-break: break-all;

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -17,7 +17,7 @@
         min-width: 0;
 
         height: var(--height-input-pill);
-        margin: 1px 2px;
+        margin: 0;
 
         color: inherit;
         border: 1px solid transparent;
@@ -157,7 +157,8 @@
 }
 
 #compose-direct-recipient .pill-container {
-    padding: 0 2px;
+    gap: var(--vertical-spacing-input-pill) var(--horizontal-spacing-input-pill);
+    padding: var(--vertical-spacing-input-pill);
     border: 1px solid hsl(0deg 0% 0% / 20%);
     background-color: hsl(0deg 0% 100%);
 


### PR DESCRIPTION
This PR aims to make pills participate in user-adjustable information density by tying their dimensions to the `font-size` in use.

Additionally, the PR begins by implementing better, more uniform spacing around pills in the recipient box in the compose area. Pills themselves become "dumb" about their spacing, and instead pill containers can use a combination of their own padding and the `gap` property to better control how pills are laid out--especially when they span onto multiple rows.

(A follow-up PR will improve the pill containers elsewhere in the UI.)

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/pill.20containers.20and.20pill.20spacing/near/1831577)

**Screenshots and screen captures:** (updated 21 June 2024)

| Before, Legacy | After, Legacy |
| --- | --- |
| ![legacy-light-before](https://github.com/zulip/zulip/assets/170719/240b6438-3b4d-4eb8-8156-43e4f4bc107e) | ![legacy-light-after](https://github.com/zulip/zulip/assets/170719/dcfbb7c3-9da3-41e7-8c77-85623c0dc07c) |
| ![legacy-dark-before](https://github.com/zulip/zulip/assets/170719/f0f3f605-fcef-47bd-9ba2-dc330fd48a65) | ![legacy-dark-after](https://github.com/zulip/zulip/assets/170719/18e7360b-8217-49f6-b3e7-73f03ef44630) |

| Before, 16/140 | After, 16/140 |
| --- | --- |
| ![16-140-light-before](https://github.com/zulip/zulip/assets/170719/95f20855-0538-49fc-97cf-9b2e6121c30f) | ![16-140-light-after](https://github.com/zulip/zulip/assets/170719/922d7505-522c-4548-a334-4f210f80018c) |
| ![16-140-dark-before](https://github.com/zulip/zulip/assets/170719/d8260329-ed66-4b30-822b-e6762701c930) | ![16-140-dark-after](https://github.com/zulip/zulip/assets/170719/afc1e6d9-ba1a-457c-9ce1-2f8485542691) |

<details>
<summary>Screenshots with previous pill design</summary>

| Pills, before | Pills, after (without layout commit) |
| --- | --- |
| ![pills-legacy-main](https://github.com/zulip/zulip/assets/170719/ea82aa23-8073-494b-b029-51dbb3c956b4) | ![pills-legacy-after](https://github.com/zulip/zulip/assets/170719/7a520a7c-9eed-4fe4-a20f-0a76e823c790) |
| ![pills-16-140-main](https://github.com/zulip/zulip/assets/170719/7052e28c-8017-43be-920f-7f791c9adfc0) | ![pills-16-140-after](https://github.com/zulip/zulip/assets/170719/fb6b91e3-718f-437f-8ea6-e3d40dd7a5c6) |

| Pills, before | Pills, after (with layout commit) |
| --- | --- |
| ![pills-legacy-layout-main](https://github.com/zulip/zulip/assets/170719/923db5ed-2fb3-4ceb-9ab0-564ed4f05fa3) | ![pills-legacy-layout-after](https://github.com/zulip/zulip/assets/170719/743a9a8a-f904-4913-93e5-e34e4d970056) |
| ![pills-16-140-layout-main](https://github.com/zulip/zulip/assets/170719/4e8799a2-49a4-48b6-917b-42d4ea311bc6) | ![pills-16-140-layout-after](https://github.com/zulip/zulip/assets/170719/d961c752-c7ac-453a-b173-88e575fd5575) |

| Search pills, before | Search pills, after (no change at legacy sizes |
| --- | --- |
| ![search-pills-legacy-main](https://github.com/zulip/zulip/assets/170719/66f8b104-cc50-4eaf-90df-f7b9bc0ee65c) | ![search-pills-legacy-after--no-change](https://github.com/zulip/zulip/assets/170719/e3998e09-f491-4b1c-b508-a1be2a9bacc9) |
| ![search-pills-16-140-main](https://github.com/zulip/zulip/assets/170719/eaa51b77-33ae-48f3-879e-9c1d64bc86cf) | ![search-pills-16-140-after](https://github.com/zulip/zulip/assets/170719/66d5f2fe-d8f2-4b22-a57f-68e2ee7d0b08) |

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
