### PR TITLE
list_widget: Fix more elements not rendered on scrolling to bottom.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -271,6 +271,10 @@ export function create<Key, Item = Key>(
         // We still keep `html` as `$scroll_container` to use
         // its various methods as `HTMLElement`.
         $scroll_listening_element = $(window);
+    } else {
+        // When `$scroll_container` is a specific element, we listen
+        // for scroll events on that element.
+        $scroll_listening_element = scroll_util.get_scroll_element(opts.$simplebar_container);
     }
 
     const meta: ListWidgetMeta<Key, Item> = {


### PR DESCRIPTION
This bug can be reproduced by scrolling anywhere where list widget is used except recent view.

`$scroll_container` was used before
371cd0da6cc4da913d05c0936a6e32458daa652b
to listen to scroll events which was incorrectly replaced by `opts.$simplebar_container` in the above commit. To fix this, we use the same function `scroll_util.get_scroll_element` to get the correct scroll element.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Scrolling.20user.20list
