### PR TITLE
css: Remove unused css for channel & topic list filter.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -445,22 +445,6 @@ div.overlay {
     margin: 15px 0 -5px 23px;
 }
 
-@media (width < $md_min) {
-    /* Override Bootstrap's responsive grid to display input at full width */
-    .input-append .stream-list-filter {
-        /* Input width = 100% - 10px margin x2 - 6px padding x2 - 1px border x2. */
-        width: calc(100% - 34px);
-        margin-left: 10px;
-    }
-
-    .input-append .topic-list-filter {
-        /* Input width = 100% - 11px margin x2 - 6px padding x2 - 1px border x2. */
-        width: calc(100% - 36px);
-        margin-left: 11px;
-        margin-bottom: 5px;
-    }
-}
-
 .topic-list-filter {
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
The margin properties in question were getting overridden by other css, so they were not important. The width was not making a difference in case of channel filter, since its parent was a flexbox. For the topic list, the width was getting overriden by
`#stream_filters .input-append.topic_search_section input`.

This one was made during #30332, but pulling this out into another PR to make it easier to review

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Channel list filter before and after:
| Before | After |
| --- | --- |
| <img width="505" alt="current channel filter" src="https://github.com/zulip/zulip/assets/13910561/88da3e35-babd-4280-9131-9538e88b3d47"> |  <img width="505" alt="new channel filter" src="https://github.com/zulip/zulip/assets/13910561/1478fea2-6bd7-41d3-837f-c25f9022bb08">

### Topic list filter before and after:
| Before | After |
| --- | --- |
| <img width="505" alt="current topic filter" src="https://github.com/zulip/zulip/assets/13910561/1011a33f-5be0-4dbc-8c45-c5eeca12e9c1"> |  <img width="505" alt="new topic filter" src="https://github.com/zulip/zulip/assets/13910561/18b9029c-077f-4727-91b8-81924ee40a70">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
