### PR TITLE
Rename `Private` to `Direct` for left sidebar (Partial)

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -319,7 +319,7 @@ async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<voi
     await page.click("#left-sidebar-navigation-list .top_left_all_messages a");
     await expect_home(page);
 
-    const all_private_messages_icon = "#show_all_private_messages";
+    const all_private_messages_icon = "#show-all-direct-messages";
     await page.waitForSelector(all_private_messages_icon, {visible: true});
     await page.click(all_private_messages_icon);
     await expect_all_direct_messages(page);

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -56,7 +56,7 @@ async function navigate_to_subscriptions(page: Page): Promise<void> {
 async function navigate_to_private_messages(page: Page): Promise<void> {
     console.log("Navigate to direct messages");
 
-    const all_private_messages_icon = "#show_all_private_messages";
+    const all_private_messages_icon = "#show-all-direct-messages";
     await page.waitForSelector(all_private_messages_icon, {visible: true});
     await page.click(all_private_messages_icon);
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -781,7 +781,7 @@ export function initialize() {
         "click",
         ".direct-messages-container.zoom-out #direct-messages-section-header",
         (e) => {
-            if ($(e.target).closest("#show_all_private_messages").length === 1) {
+            if ($(e.target).closest("#show-all-direct-messages").length === 1) {
                 // Let the browser handle the "direct message feed" widget.
                 return;
             }

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -779,7 +779,7 @@ export function initialize() {
 
     $("body").on(
         "click",
-        ".direct-messages-container.zoom-out #private_messages_section_header",
+        ".direct-messages-container.zoom-out #direct-messages-section-header",
         (e) => {
             if ($(e.target).closest("#show_all_private_messages").length === 1) {
                 // Let the browser handle the "direct message feed" widget.
@@ -813,7 +813,7 @@ export function initialize() {
      * this click handler rather than just a link. */
     $("body").on(
         "click",
-        ".direct-messages-container.zoom-in #private_messages_section_header",
+        ".direct-messages-container.zoom-in #direct-messages-section-header",
         (e) => {
             e.preventDefault();
             e.stopPropagation();

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -32,8 +32,8 @@ export function set_count(count: number): void {
 
 export function close(): void {
     private_messages_collapsed = true;
-    $("#toggle_private_messages_section_icon").removeClass("fa-caret-down");
-    $("#toggle_private_messages_section_icon").addClass("fa-caret-right");
+    $("#toggle-direct-messages-section-icon").removeClass("fa-caret-down");
+    $("#toggle-direct-messages-section-icon").addClass("fa-caret-right");
 
     update_private_messages();
 }
@@ -102,8 +102,8 @@ export function update_private_messages(): void {
 export function expand(): void {
     private_messages_collapsed = false;
 
-    $("#toggle_private_messages_section_icon").addClass("fa-caret-down");
-    $("#toggle_private_messages_section_icon").removeClass("fa-caret-right");
+    $("#toggle-direct-messages-section-icon").addClass("fa-caret-down");
+    $("#toggle-direct-messages-section-icon").removeClass("fa-caret-right");
     update_private_messages();
 }
 

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -23,9 +23,7 @@ let private_messages_collapsed = false;
 let zoomed = false;
 
 function get_private_messages_section_header(): JQuery {
-    return $(
-        ".direct-messages-container #direct-messages-section #private_messages_section_header",
-    );
+    return $(".direct-messages-container #direct-messages-section #direct-messages-section-header");
 }
 
 export function set_count(count: number): void {
@@ -130,7 +128,7 @@ function unhighlight_all_private_messages_view(): void {
 
 function scroll_pm_into_view($target_li: JQuery): void {
     const $container = $("#left_sidebar_scroll_container");
-    const pm_header_height = $("#private_messages_section_header").outerHeight();
+    const pm_header_height = $("#direct-messages-section-header").outerHeight();
     if ($target_li.length > 0) {
         scroll_util.scroll_element_into_container($target_li, $container, pm_header_height);
     }

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -24,7 +24,7 @@ let zoomed = false;
 
 function get_private_messages_section_header(): JQuery {
     return $(
-        ".direct-messages-container #private_messages_section #private_messages_section_header",
+        ".direct-messages-container #direct-messages-section #private_messages_section_header",
     );
 }
 

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -45,7 +45,7 @@ type DisplayObject = {
 };
 
 export function get_conversations(): DisplayObject[] {
-    const private_messages = pm_conversations.recent.get();
+    const conversations = pm_conversations.recent.get();
     const display_objects = [];
 
     // The user_ids_string for the current view, if any.
@@ -53,12 +53,14 @@ export function get_conversations(): DisplayObject[] {
 
     if (
         active_user_ids_string !== undefined &&
-        !private_messages.map((obj) => obj.user_ids_string).includes(active_user_ids_string)
+        !conversations
+            .map((conversation) => conversation.user_ids_string)
+            .includes(active_user_ids_string)
     ) {
-        private_messages.unshift({user_ids_string: active_user_ids_string, max_message_id: -1});
+        conversations.unshift({user_ids_string: active_user_ids_string, max_message_id: -1});
     }
 
-    for (const conversation of private_messages) {
+    for (const conversation of conversations) {
         const user_ids_string = conversation.user_ids_string;
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
         assert(reply_to !== undefined);

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -30,7 +30,7 @@ function get_new_heights(): {
         Number.parseInt($("#left-sidebar-navigation-area").css("marginTop"), 10) -
         Number.parseInt($("#left-sidebar-navigation-area").css("marginBottom"), 10) -
         ($("#left-sidebar-navigation-list").outerHeight(true) ?? 0) -
-        ($("#private_messages_sticky_header").outerHeight(true) ?? 0);
+        ($("#direct-messages-sticky-header").outerHeight(true) ?? 0);
 
     // Don't let us crush the stream sidebar completely out of view
     stream_filters_max_height = Math.max(80, stream_filters_max_height);

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -874,11 +874,11 @@ export function set_event_handlers({
         assert(scroll_position !== undefined);
         assert(pm_list_height !== undefined);
         if (scroll_position > pm_list_height) {
-            $("#toggle_private_messages_section_icon").addClass("fa-caret-right");
-            $("#toggle_private_messages_section_icon").removeClass("fa-caret-down");
+            $("#toggle-direct-messages-section-icon").addClass("fa-caret-right");
+            $("#toggle-direct-messages-section-icon").removeClass("fa-caret-down");
         } else {
-            $("#toggle_private_messages_section_icon").addClass("fa-caret-down");
-            $("#toggle_private_messages_section_icon").removeClass("fa-caret-right");
+            $("#toggle-direct-messages-section-icon").addClass("fa-caret-down");
+            $("#toggle-direct-messages-section-icon").removeClass("fa-caret-right");
         }
     }
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -474,7 +474,7 @@ export function initialize(): void {
                 return false;
             }
 
-            if ($("#toggle_private_messages_section_icon").hasClass("fa-caret-down")) {
+            if ($("#toggle-direct-messages-section-icon").hasClass("fa-caret-down")) {
                 instance.setContent(
                     $t({
                         defaultMessage: "Collapse direct messages",

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -139,7 +139,7 @@ export function initialize(): void {
     // thus hovering it is a way to find out what it does, give
     // it the faster LONG_HOVER_DELAY.
     tippy.delegate("body", {
-        target: "#show_all_private_messages",
+        target: "#show-all-direct-messages",
         placement: "right",
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -219,7 +219,7 @@ li.show-more-topics {
        in the DM section. */
     margin-right: 12px;
 
-    #private_messages_section_header {
+    #direct-messages-section-header {
         grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
         grid-template-rows: var(--line-height-sidebar-row-prominent);
         /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
@@ -748,7 +748,7 @@ li.top_left_scheduled_messages {
     grid-template-areas: "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset";
 }
 
-#private_messages_section_header,
+#direct-messages-section-header,
 #streams_header,
 #topics_header {
     display: grid;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -328,7 +328,7 @@ li.show-more-topics {
 .active-direct-messages-section {
     background-color: var(--color-background-active-narrow-filter);
 
-    #private_messages_section {
+    #direct-messages-section {
         border-radius: 4px 4px 0 0;
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -335,10 +335,6 @@ li.show-more-topics {
     #direct-messages-list {
         border-radius: 0 0 4px 4px;
     }
-
-    #more_private_messages_sidebar_title {
-        font-weight: 600;
-    }
 }
 
 :not(.active-sub-filter) {
@@ -1374,10 +1370,6 @@ li.topic-list-item {
 
     &.direct-messages-container ul.dm-list {
         margin-bottom: $bottom_scrolling_buffer;
-    }
-
-    #more_private_messages_sidebar_title {
-        display: inline;
     }
 
     #hide-more-direct-messages {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -244,7 +244,7 @@ li.show-more-topics {
             align-items: center;
         }
 
-        #show_all_private_messages {
+        #show-all-direct-messages {
             width: var(--left-sidebar-header-icon-width);
             display: flex;
             align-items: center;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -229,7 +229,7 @@ li.show-more-topics {
         cursor: pointer;
         white-space: nowrap;
 
-        #toggle_private_messages_section_icon {
+        #toggle-direct-messages-section-icon {
             grid-area: starting-anchor-element;
         }
 
@@ -300,7 +300,7 @@ li.show-more-topics {
     }
 }
 
-#toggle_private_messages_section_icon,
+#toggle-direct-messages-section-icon,
 #toggle-top-left-navigation-area-icon {
     opacity: 0.7;
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -146,8 +146,8 @@
     <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="direct-messages-section">
             <div id="direct-messages-section-header" class="zoom-out zoom-in-sticky">
-                <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-                <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
+                <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+                <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
                         <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -149,7 +149,7 @@
                 <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                 <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
-                    <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
+                    <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
                         <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
                     </a>
                     <span class="unread_count"></span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -143,7 +143,7 @@
         </ul>
     </div>
 
-    <div id="private_messages_sticky_header" class="direct-messages-container zoom-out hidden-for-spectators">
+    <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="private_messages_section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
                 <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -149,7 +149,7 @@
                 <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                 <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
-                    <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
+                    <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                         <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
                     </a>
                     <span class="unread_count"></span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -145,7 +145,7 @@
 
     <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="direct-messages-section">
-            <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
+            <div id="direct-messages-section-header" class="zoom-out zoom-in-sticky">
                 <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                 <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -144,7 +144,7 @@
     </div>
 
     <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
-        <div id="private_messages_section">
+        <div id="direct-messages-section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
                 <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                 <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -146,7 +146,7 @@
     <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
         <div id="direct-messages-section">
             <div id="direct-messages-section-header" class="zoom-out zoom-in-sticky">
-                <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+                <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                 <h4 class="left-sidebar-title toggle_private_messages_section"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
                 <div class="heading-markers-and-controls">
                     <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -137,7 +137,7 @@
     {{t 'Drafts' }}
     {{tooltip_hotkey_hints "D"}}
 </template>
-<template id="show-all-pms-template">
+<template id="show-all-direct-messages-template">
     {{t 'Direct message feed' }}
     {{tooltip_hotkey_hints "Shift" "P"}}
 </template>

--- a/web/tests/pm_list.test.js
+++ b/web/tests/pm_list.test.js
@@ -13,7 +13,7 @@ run_test("update_dom_with_unread_counts", () => {
 
     const $total_count = $.create("total-count-stub");
     const $private_li = $(
-        ".direct-messages-container #direct-messages-section #private_messages_section_header",
+        ".direct-messages-container #direct-messages-section #direct-messages-section-header",
     );
     $private_li.set_find_results(".unread_count", $total_count);
 

--- a/web/tests/pm_list.test.js
+++ b/web/tests/pm_list.test.js
@@ -13,7 +13,7 @@ run_test("update_dom_with_unread_counts", () => {
 
     const $total_count = $.create("total-count-stub");
     const $private_li = $(
-        ".direct-messages-container #private_messages_section #private_messages_section_header",
+        ".direct-messages-container #direct-messages-section #private_messages_section_header",
     );
     $private_li.set_find_results(".unread_count", $total_count);
 


### PR DESCRIPTION
This is a partial rename for `private` to `direct` mainly for the left sidebar. This only does renames for code encountered while working on #30332 and does not attempt the complete rename.

I've also hyphenated the relevant attributes during the rename.

There are two commits here that are not renaming commits:

1. c1ef62d74cf957401f3a8a3044a089a2d8651a29: Removes unused `toggle_private_messages_section` class. A `git grep` would show you two occurrences for this name in `pm_list.ts` and `click_handlers.js`, but in that case `toggle_private_messages_section` is a function inside `pm_list` which is unrelated to the the html class.
2. bca302f12cd03bc45fc528c4441d7526a7d82a06: Remove unused `more_private_messages_sidebar_title` css. There were some css rules for `more_private_messages_sidebar_title`, but this class was not present in any html or js. 

Both of these removals are done in this commit since they were discovered while trying to rename them, and since they were unused, it is better to remove them.

I have not attached any screenshots, since it is mostly renames without any behavioural change. The only removals are the above two commits, where there's no specific area to screenshot since it's removing unused code. 

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
