### PR TITLE
left_sidebar: Fix tooltips not hidden on blur.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -41,7 +41,6 @@ import * as stream_popover from "./stream_popover";
 import * as topic_list from "./topic_list";
 import * as ui_util from "./ui_util";
 import {parse_html} from "./ui_util";
-import * as user_topics from "./user_topics";
 import * as util from "./util";
 
 export function initialize() {
@@ -415,42 +414,6 @@ export function initialize() {
         const message_id = rows.id_for_recipient_row($recipient_row);
         const topic_name = $(e.target).attr("data-topic-name");
         message_edit.toggle_resolve_topic(message_id, topic_name, false, $recipient_row);
-    });
-
-    // Mute topic in a unmuted stream
-    $("body").on("click", ".message_header .stream_unmuted.on_hover_topic_mute", (e) => {
-        e.stopPropagation();
-        user_topics.set_visibility_policy_for_element(
-            $(e.target),
-            user_topics.all_visibility_policies.MUTED,
-        );
-    });
-
-    // Unmute topic in a unmuted stream
-    $("body").on("click", ".message_header .stream_unmuted.on_hover_topic_unmute", (e) => {
-        e.stopPropagation();
-        user_topics.set_visibility_policy_for_element(
-            $(e.target),
-            user_topics.all_visibility_policies.INHERIT,
-        );
-    });
-
-    // Unmute topic in a muted stream
-    $("body").on("click", ".message_header .stream_muted.on_hover_topic_unmute", (e) => {
-        e.stopPropagation();
-        user_topics.set_visibility_policy_for_element(
-            $(e.target),
-            user_topics.all_visibility_policies.UNMUTED,
-        );
-    });
-
-    // Mute topic in a muted stream
-    $("body").on("click", ".message_header .stream_muted.on_hover_topic_mute", (e) => {
-        e.stopPropagation();
-        user_topics.set_visibility_policy_for_element(
-            $(e.target),
-            user_topics.all_visibility_policies.INHERIT,
-        );
     });
 
     // RECIPIENT BARS

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -825,7 +825,7 @@ function focus_clicked_list_element($elt: JQuery): void {
     update_triggered_by_user = true;
 }
 
-function revive_current_focus(): void {
+export function revive_current_focus(): void {
     if (is_list_focused()) {
         set_list_focus();
     } else {
@@ -1551,6 +1551,12 @@ export function initialize(): void {
         } else {
             unread_ops.mark_stream_as_read(stream_id);
         }
+    });
+
+    $("body").on("click", "#inbox-list .change_visibility_policy", function (this: HTMLElement) {
+        const $elt = $(this);
+        col_focus = COLUMNS.TOPIC_VISIBILITY;
+        focus_clicked_list_element($elt);
     });
 
     $("body").on("click", "#inbox-clear-search", () => {

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1564,58 +1564,6 @@ export function initialize(): void {
         compose_closed_ui.set_standard_text_for_reply_button();
     });
 
-    // Mute topic in a unmuted stream
-    $("body").on(
-        "click",
-        "#inbox-list .stream_unmuted.on_hover_topic_mute",
-        function (this: HTMLElement, e) {
-            e.stopPropagation();
-            user_topics.set_visibility_policy_for_element(
-                $(this),
-                user_topics.all_visibility_policies.MUTED,
-            );
-        },
-    );
-
-    // Unmute topic in a unmuted stream
-    $("body").on(
-        "click",
-        "#inbox-list .stream_unmuted.on_hover_topic_unmute",
-        function (this: HTMLElement, e) {
-            e.stopPropagation();
-            user_topics.set_visibility_policy_for_element(
-                $(this),
-                user_topics.all_visibility_policies.INHERIT,
-            );
-        },
-    );
-
-    // Unmute topic in a muted stream
-    $("body").on(
-        "click",
-        "#inbox-list .stream_muted.on_hover_topic_unmute",
-        function (this: HTMLElement, e) {
-            e.stopPropagation();
-            user_topics.set_visibility_policy_for_element(
-                $(this),
-                user_topics.all_visibility_policies.UNMUTED,
-            );
-        },
-    );
-
-    // Mute topic in a muted stream
-    $("body").on(
-        "click",
-        "#inbox-list .stream_muted.on_hover_topic_mute",
-        function (this: HTMLElement, e) {
-            e.stopPropagation();
-            user_topics.set_visibility_policy_for_element(
-                $(this),
-                user_topics.all_visibility_policies.INHERIT,
-            );
-        },
-    );
-
     $(document).on("compose_canceled.zulip", () => {
         if (is_visible()) {
             revive_current_focus();

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -458,8 +458,6 @@ export class MessageList {
         $recipient_row.find(".always_visible_topic_edit").hide();
         $recipient_row.find(".on_hover_topic_resolve").hide();
         $recipient_row.find(".on_hover_topic_unresolve").hide();
-        $recipient_row.find(".on_hover_topic_mute").hide();
-        $recipient_row.find(".on_hover_topic_unmute").hide();
     }
 
     hide_edit_topic_on_recipient_row($recipient_row) {
@@ -471,8 +469,6 @@ export class MessageList {
         $recipient_row.find(".always_visible_topic_edit").show();
         $recipient_row.find(".on_hover_topic_resolve").show();
         $recipient_row.find(".on_hover_topic_unresolve").show();
-        $recipient_row.find(".on_hover_topic_mute").show();
-        $recipient_row.find(".on_hover_topic_unmute").show();
     }
 
     reselect_selected_id() {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1836,6 +1836,11 @@ export function initialize({
         window.location.href = $(e.currentTarget).find("a").attr("href")!;
     });
 
+    $("body").on("click", "#recent-view-content-table .change_visibility_policy", (e) => {
+        const topic_row_index = $(e.target).closest("tr").index();
+        focus_clicked_element(topic_row_index, COLUMNS.mute);
+    });
+
     // Search for all table rows (this combines stream & topic names)
     $("body").on(
         "keyup",

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1429,9 +1429,7 @@ function left_arrow_navigation(row: number, col: number): void {
 }
 
 function right_arrow_navigation(row: number, col: number): void {
-    const type = get_row_type(row);
-
-    if (type === "stream" && col === 1 && !has_unread(row)) {
+    if (col === 1 && !has_unread(row)) {
         col_focus += 1;
     }
 

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -743,6 +743,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         other_sender_names_html: displayed_other_names.map((name) => _.escape(name)).join("<br />"),
         last_msg_url: hash_util.by_conversation_and_time_url(last_msg),
         is_spectator: page_params.is_spectator,
+        column_indexes: COLUMNS,
     };
     if (is_private) {
         assert(dm_context !== undefined);
@@ -1528,6 +1529,40 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
     // preventDefault/stopPropagation; false will let the browser
     // handle the key.
 
+    if (input_key === "tab" || input_key === "shift_tab") {
+        // Tabbing should be handled by browser but to keep the focus element same
+        // when we update recent view or user uses other hotkeys, we need to track
+        // the current focused element.
+        setTimeout(() => {
+            const post_tab_focus_elem = document.activeElement;
+            if (!(post_tab_focus_elem instanceof HTMLElement)) {
+                return;
+            }
+
+            if (
+                post_tab_focus_elem.id === "recent_view_search" ||
+                post_tab_focus_elem.classList.contains("btn-recent-filters") ||
+                post_tab_focus_elem.classList.contains("dropdown-widget-button")
+            ) {
+                $current_focus_elem = $(post_tab_focus_elem);
+            }
+
+            if ($(post_tab_focus_elem).parents("#recent-view-content-table").length) {
+                $current_focus_elem = "table";
+                const topic_row_index = $(post_tab_focus_elem).closest("tr").index();
+                const col_index = $(post_tab_focus_elem)
+                    .closest(".recent_view_focusable")
+                    .attr("data-col-index");
+                if (!col_index) {
+                    return;
+                }
+                col_focus = Number.parseInt(col_index, 10);
+                row_focus = topic_row_index;
+            }
+        }, 0);
+        return false;
+    }
+
     if ($elt.attr("id") === "recent_view_search") {
         // Since the search box a text area, we want the browser to handle
         // Left/Right and selection within the widget; but if the user
@@ -1551,17 +1586,11 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
             case "vim_up":
             case "open_recent_view":
                 return false;
-            case "shift_tab":
-                $current_focus_elem = filter_buttons().last();
-                break;
             case "left_arrow":
                 if (start !== 0 || is_selected) {
                     return false;
                 }
                 $current_focus_elem = filter_buttons().last();
-                break;
-            case "tab":
-                $current_focus_elem = filter_buttons().first();
                 break;
             case "right_arrow":
                 if (end !== text_length || is_selected) {
@@ -1594,7 +1623,6 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
             case "click":
                 $current_focus_elem = $elt;
                 return true;
-            case "shift_tab":
             case "vim_left":
             case "left_arrow":
                 if (filter_buttons().first()[0] === $elt[0]) {
@@ -1603,7 +1631,6 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
                     $current_focus_elem = $elt.prev();
                 }
                 break;
-            case "tab":
             case "vim_right":
             case "right_arrow":
                 if (filter_buttons().last()[0] === $elt[0]) {
@@ -1638,12 +1665,10 @@ export function change_focused_element($elt: JQuery, input_key: string): boolean
             case "open_recent_view":
                 set_default_focus();
                 return true;
-            case "shift_tab":
             case "vim_left":
             case "left_arrow":
                 left_arrow_navigation(row_focus, col_focus);
                 break;
-            case "tab":
             case "vim_right":
             case "right_arrow":
                 right_arrow_navigation(row_focus, col_focus);

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1749,68 +1749,6 @@ export function initialize({
         },
     );
 
-    $("body").on(
-        "keydown",
-        ".on_hover_topic_mute, .on_hover_topic_unmute",
-        ui_util.convert_enter_to_click,
-    );
-
-    // Mute topic in a unmuted stream
-    $("body").on("click", "#recent-view-content-table .stream_unmuted.on_hover_topic_mute", (e) => {
-        e.stopPropagation();
-        assert(e.target instanceof HTMLElement);
-        const $elt = $(e.target);
-        const topic_row_index = $elt.closest("tr").index();
-        focus_clicked_element(topic_row_index, COLUMNS.mute);
-        user_topics.set_visibility_policy_for_element(
-            $elt,
-            user_topics.all_visibility_policies.MUTED,
-        );
-    });
-
-    // Unmute topic in a unmuted stream
-    $("body").on(
-        "click",
-        "#recent-view-content-table .stream_unmuted.on_hover_topic_unmute",
-        (e) => {
-            e.stopPropagation();
-            assert(e.target instanceof HTMLElement);
-            const $elt = $(e.target);
-            const topic_row_index = $elt.closest("tr").index();
-            focus_clicked_element(topic_row_index, COLUMNS.mute);
-            user_topics.set_visibility_policy_for_element(
-                $elt,
-                user_topics.all_visibility_policies.INHERIT,
-            );
-        },
-    );
-
-    // Unmute topic in a muted stream
-    $("body").on("click", "#recent-view-content-table .stream_muted.on_hover_topic_unmute", (e) => {
-        e.stopPropagation();
-        assert(e.target instanceof HTMLElement);
-        const $elt = $(e.target);
-        const topic_row_index = $elt.closest("tr").index();
-        focus_clicked_element(topic_row_index, COLUMNS.mute);
-        user_topics.set_visibility_policy_for_element(
-            $elt,
-            user_topics.all_visibility_policies.UNMUTED,
-        );
-    });
-
-    // Mute topic in a muted stream
-    $("body").on("click", "#recent-view-content-table .stream_muted.on_hover_topic_mute", (e) => {
-        e.stopPropagation();
-        assert(e.target instanceof HTMLElement);
-        const $elt = $(e.target);
-        const topic_row_index = $elt.closest("tr").index();
-        focus_clicked_element(topic_row_index, COLUMNS.mute);
-        user_topics.set_visibility_policy_for_element(
-            $elt,
-            user_topics.all_visibility_policies.INHERIT,
-        );
-    });
-
     $("body").on("click", "#recent_view_search", (e) => {
         e.stopPropagation();
         assert(e.target instanceof HTMLElement);

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -167,6 +167,16 @@ export function initialize(): void {
             if ($container.data("view-code") === user_settings.web_home_view) {
                 $container.find(".views-tooltip-home-view-note").removeClass("hide");
             }
+
+            // Since the tooltip is attached the anchor tag which doesn't
+            // include with of the ellipsis icon, we need to offset the
+            // tooltip so that the tooltip is displayed to right of the
+            // ellipsis icon.
+            if (instance.reference.classList.contains("left-sidebar-navigation-label-container")) {
+                instance.setProps({
+                    offset: [0, 40],
+                });
+            }
         },
         onHidden(instance) {
             instance.destroy();

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -622,7 +622,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: "#userlist-toggle",
+        target: "#userlist-toggle-button",
         delay: LONG_HOVER_DELAY,
         placement: "bottom",
         appendTo: () => document.body,

--- a/web/src/user_topic_popover.js
+++ b/web/src/user_topic_popover.js
@@ -102,6 +102,10 @@ export function initialize() {
                 .removeClass("visibility-policy-popover-visible");
             instance.destroy();
             popover_menus.popover_instances.change_visibility_policy = undefined;
+
+            // If the reference is in recent view / inbox, we would ideally restore focus
+            // to the reference icon here but we don't do that because there are a lot of
+            // reasons why the popover might be hidden (e.g. user clicking outside the popover).
         },
     });
 }

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -230,9 +230,7 @@
 }
 
 .always_visible_topic_edit,
-.on_hover_topic_read,
-.stream_unmuted.on_hover_topic_unmute,
-.stream_muted.on_hover_topic_mute {
+.on_hover_topic_read {
     opacity: 0.7;
 
     &:hover {
@@ -243,9 +241,7 @@
 
 .on_hover_topic_edit,
 .on_hover_topic_unresolve,
-.on_hover_topic_resolve,
-.stream_unmuted.on_hover_topic_mute,
-.stream_muted.on_hover_topic_unmute {
+.on_hover_topic_resolve {
     opacity: 0.2;
 
     &:hover {

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -1,13 +1,13 @@
 {{#if is_stream}}
     {{> inbox_stream_header_row}}
 {{else}}
-    <div id="inbox-row-conversation-{{conversation_key}}" class="inbox-row {{#if is_hidden}}hidden_by_filters{{/if}} {{#if is_collapsed}}collapsed_container{{/if}}" tabindex="0">
+    <div id="inbox-row-conversation-{{conversation_key}}" class="inbox-row {{#if is_hidden}}hidden_by_filters{{/if}} {{#if is_collapsed}}collapsed_container{{/if}}" tabindex="0" data-col-index="{{ column_indexes.RECIPIENT }}">
         <div class="inbox-focus-border">
             <div class="inbox-left-part-wrapper">
                 <div class="inbox-left-part">
-                    <div class="hide fake-collapse-button" tabindex="0"></div>
+                    <div class="hide fake-collapse-button" tabindex="0" data-col-index="{{ column_indexes.COLLAPSE_BUTTON }}"></div>
                     {{#if is_direct}}
-                        <a class="recipients_info {{#unless user_circle_class}}inbox-group-or-bot-dm{{/unless}}" href="{{dm_url}}">
+                        <a class="recipients_info {{#unless user_circle_class}}inbox-group-or-bot-dm{{/unless}}" href="{{dm_url}}" tabindex="-1">
                             <span class="user_block">
                                 {{#if is_bot}}
                                 <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
@@ -19,7 +19,7 @@
                                 <span class="recipients_name">{{{rendered_dm_with}}}</span>
                             </span>
                         </a>
-                        <div class="unread-count-focus-outline" tabindex="0">
+                        <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                             <span class="unread_count tippy-zulip-tooltip on_hover_dm_read"
                               data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}"
                               aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
@@ -33,7 +33,7 @@
                         <span class="unread_mention_info tippy-zulip-tooltip
                           {{#unless mention_in_unread}}hidden{{/unless}}"
                           data-tippy-content="{{t 'You have mentions'}}">@</span>
-                        <div class="unread-count-focus-outline" tabindex="0">
+                        <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                             <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                               data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
                               data-tippy-content="{{t 'Mark as read' }}" aria-label="{{t 'Mark as read' }}">
@@ -48,7 +48,7 @@
                 <div class="inbox-right-part">
                     {{#if is_topic}}
                         <span class="visibility-policy-indicator change_visibility_policy hidden-for-spectators{{#if (eq visibility_policy all_visibility_policies.INHERIT)}} inbox-row-visibility-policy-inherit{{/if}}"
-                          data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}" tabindex="0">
+                          data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}" tabindex="0" data-col-index="{{ column_indexes.TOPIC_VISIBILITY }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
                                 <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
@@ -66,7 +66,7 @@
                     {{/if}}
                     <div class="inbox-action-button inbox-topic-menu"
                       {{#if is_topic}}data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
-                      data-topic-url="{{topic_url}}"{{/if}} tabindex="0">
+                      data-topic-url="{{topic_url}}"{{/if}} tabindex="0" data-col-index="{{ column_indexes.ACTION_MENU }}">
                         <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                     </div>
                 </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -51,8 +51,8 @@
             </div>
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
-            <li class="tippy-views-tooltip top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="inbox-tooltip-template">
-                <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container">
+            <li class="top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}">
+                <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="inbox-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
@@ -62,8 +62,8 @@
                 </a>
                 <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="tippy-views-tooltip top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="recent-conversations-tooltip-template">
-                <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container">
+            <li class="top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
+                <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
                     </span>
@@ -75,8 +75,8 @@
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </li>
-            <li class="tippy-views-tooltip top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}" data-tooltip-template-id="all-message-tooltip-template">
-                <a href="#feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container">
+            <li class="top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
+                <a href="#feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
@@ -98,8 +98,8 @@
                     <span class="unread_count"></span>
                 </a>
             </li>
-            <li class="tippy-views-tooltip top_left_my_reactions top_left_row hidden-for-spectators" data-tooltip-template-id="my-reactions-tooltip-template">
-                <a class="left-sidebar-navigation-label-container" href="#narrow/has/reaction/sender/me">
+            <li class="top_left_my_reactions top_left_row hidden-for-spectators">
+                <a class="left-sidebar-navigation-label-container tippy-views-tooltip" href="#narrow/has/reaction/sender/me" data-tooltip-template-id="my-reactions-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-smile" aria-hidden="true"></i>
                     </span>
@@ -119,8 +119,8 @@
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="tippy-left-sidebar-tooltip top_left_drafts top_left_row hidden-for-spectators" data-tooltip-template-id="drafts-tooltip-template">
-                <a href="#drafts" class="left-sidebar-navigation-label-container">
+            <li class="top_left_drafts top_left_row hidden-for-spectators">
+                <a href="#drafts" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
                     </span>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -104,7 +104,7 @@
     </td>
     <td class="recent_topic_timestamp">
         <div class="last_msg_time tippy-zulip-tooltip" data-tippy-content="{{this.full_last_msg_date_time}}">
-            <a href="{{last_msg_url}}">{{ last_msg_time }}</a>
+            <a href="{{last_msg_url}}" tabindex="-1">{{ last_msg_time }}</a>
         </div>
     </td>
 </tr>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -1,7 +1,7 @@
 <tr id="recent_conversation:{{conversation_key}}" class="{{#if unread_count}}unread_topic{{/if}} {{#if is_private}}private_conversation_row{{/if}}">
     <td class="recent_topic_stream">
         <div class="flex_container flex_container_pm">
-            <div class="left_part recent_view_focusable">
+            <div class="left_part recent_view_focusable" data-col-index="{{ column_indexes.stream }}">
                 {{#if is_private}}
                 <span class="fa fa-envelope"></span>
                 <a href="{{pm_url}}">{{t "Direct messages" }}</a>
@@ -30,7 +30,7 @@
     </td>
     <td class="recent_topic_name"{{#if (not is_spectator) }} colspan="2"{{/if}}>
         <div class="flex_container">
-            <div class="left_part recent_view_focusable line_clamp">
+            <div class="left_part recent_view_focusable line_clamp" data-col-index="{{ column_indexes.topic }}">
                 {{#if is_private}}
                 <a href="{{pm_url}}">{{{rendered_pm_with}}}</a>
                 {{else}}
@@ -40,12 +40,12 @@
             <div class="right_part">
                 {{#if is_private}}
                 <div class="recent_topic_actions">
-                    <div class="recent_view_focusable">
+                    <div class="recent_view_focusable" data-col-index="{{ column_indexes.read }}">
                         <span class="unread_count unread_count_pm {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                     </div>
                 </div>
                 <div class="recent_topic_actions dummy_action_button">
-                    <div class="recent_view_focusable">
+                    <div class="recent_view_focusable" data-col-index="{{ column_indexes.read }}">
                         {{!-- Invisible icon, used only for alignment of unread count. --}}
                         <i class="zulip-icon zulip-icon-mute on_hover_topic_unmute recipient_bar_icon"></i>
                     </div>
@@ -54,13 +54,13 @@
                 <span class="unread_mention_info tippy-zulip-tooltip {{#unless mention_in_unread}}unread_hidden{{/unless}}"
                   data-tippy-content="{{t 'You have mentions'}}">@</span>
                 <div class="recent_topic_actions">
-                    <div class="recent_view_focusable hidden-for-spectators">
+                    <div class="recent_view_focusable hidden-for-spectators" data-col-index="{{ column_indexes.read }}">
                         <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                     </div>
                 </div>
                 <div class="recent_topic_actions">
                     <div class="hidden-for-spectators">
-                        <span class="recent_view_focusable change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
+                        <span class="recent_view_focusable change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-col-index="{{ column_indexes.mute }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
                                 <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
                                   role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -413,6 +413,7 @@ function generate_topic_data(topic_info_array) {
             visibility_policy,
             all_visibility_policies,
             is_spectator: page_params.is_spectator,
+            column_indexes: rt.COLUMNS,
         });
     }
     return data;


### PR DESCRIPTION
The elements which received focus didn't have tooltips attached to them, thus when blur was triggered on `a`, the tooltip didn't hide as it was not listening on it for the blur event.

We move the toolip to `a` elements so that when focus and blur are triggered tippy is able to capture them.

Reproducer: Click to expand the views tab and press tab multiple times, tooltips will show but won't hide.

<img width="531" alt="Screenshot 2024-06-20 at 3 37 41 PM" src="https://github.com/zulip/zulip/assets/25124304/b4b0bfa4-02fd-4715-b782-5d360f681713">
