### PR TITLE
invite-user: Add validation on custom time input and extract custom time logic for reuse.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -167,6 +167,11 @@ IGNORED_PHRASES = [
     r"deactivated",
     # This is a reference to a setting/secret and should be lowercase.
     r"zulip_org_id",
+    # These are custom time unit options for modal dropdowns
+    r"minutes",
+    r"hours",
+    r"days",
+    r"weeks",
 ]
 
 # Sort regexes in descending order of their lengths. As a result, the

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -433,8 +433,6 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             set_expires_on_text();
         });
 
-        $("#expires_on").text(valid_to(Number.parseFloat($expires_in.val()!)));
-
         $("#custom-expiration-time-input").on("keydown", (e) => {
             if (e.key === "Enter") {
                 e.preventDefault();

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -67,7 +67,10 @@ function get_common_invitation_data(): {
     if (raw_expires_in === "null") {
         expires_in = null;
     } else if (raw_expires_in === "custom") {
-        expires_in = get_expiration_time_in_minutes();
+        expires_in = util.get_custom_time_in_minutes(
+            custom_expiration_time_unit,
+            custom_expiration_time_input,
+        );
     } else {
         expires_in = Number.parseFloat(raw_expires_in);
     }
@@ -151,7 +154,10 @@ function submit_invitation_form(): void {
             if ($expires_in.val() === "custom") {
                 // Hide the custom inputs if the custom input is set
                 // to one of the dropdown's standard options.
-                const time_in_minutes = get_expiration_time_in_minutes();
+                const time_in_minutes = util.get_custom_time_in_minutes(
+                    custom_expiration_time_unit,
+                    custom_expiration_time_input,
+                );
                 for (const option of Object.values(settings_config.expires_in_values)) {
                     if (option.value === time_in_minutes) {
                         $("#custom-invite-expiration-time").hide();
@@ -261,24 +267,18 @@ function valid_to(time_valid: number): string {
     return $t({defaultMessage: "Expires on {date} at {time}"}, {date, time});
 }
 
-function get_expiration_time_in_minutes(): number {
-    switch (custom_expiration_time_unit) {
-        case "hours":
-            return custom_expiration_time_input * 60;
-        case "days":
-            return custom_expiration_time_input * 24 * 60;
-        case "weeks":
-            return custom_expiration_time_input * 7 * 24 * 60;
-        default:
-            return custom_expiration_time_input;
-    }
-}
-
 function set_expires_on_text(): void {
     const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
     if ($expires_in.val() === "custom") {
         $("#expires_on").hide();
-        $("#custom_expires_on").text(valid_to(get_expiration_time_in_minutes()));
+        $("#custom_expires_on").text(
+            valid_to(
+                util.get_custom_time_in_minutes(
+                    custom_expiration_time_unit,
+                    custom_expiration_time_input,
+                ),
+            ),
+        );
     } else {
         $("#expires_on").show();
         $("#expires_on").text(valid_to(Number.parseFloat($expires_in.val()!)));
@@ -449,7 +449,14 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             custom_expiration_time_unit = $<HTMLSelectOneElement>(
                 "select:not([multiple])#custom-expiration-time-unit",
             ).val()!;
-            $("#custom_expires_on").text(valid_to(get_expiration_time_in_minutes()));
+            $("#custom_expires_on").text(
+                valid_to(
+                    util.get_custom_time_in_minutes(
+                        custom_expiration_time_unit,
+                        custom_expiration_time_input,
+                    ),
+                ),
+            );
         });
 
         $("#invite_check_all_button").on("click", () => {

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -351,14 +351,13 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
     e.stopPropagation();
     e.preventDefault();
 
-    const time_unit_choices = ["minutes", "hours", "days", "weeks"];
     const html_body = render_invite_user_modal({
         is_admin: current_user.is_admin,
         is_owner: current_user.is_owner,
         development_environment: page_params.development_environment,
         invite_as_options: settings_config.user_role_values,
         expires_in_options: settings_config.expires_in_values,
-        time_choices: time_unit_choices,
+        time_choices: settings_config.custom_time_unit_values,
         show_select_default_streams_option: stream_data.get_default_stream_ids().length !== 0,
         user_has_email_set: !settings_data.user_email_not_configured(),
         can_subscribe_other_users: settings_data.user_can_subscribe_other_users(),

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -349,22 +349,6 @@ export function set_time_limit_setting(property_name: MessageTimeLimitSetting): 
     );
 }
 
-function check_valid_number_input(input_value: string, keep_number_as_float = false): number {
-    // This check is important to make sure that inputs like "24a" are
-    // considered invalid and this function returns NaN for such inputs.
-    // Number.parseInt and Number.parseFloat will convert strings like
-    // "24a" to 24.
-    if (Number.isNaN(Number(input_value))) {
-        return Number.NaN;
-    }
-
-    if (keep_number_as_float) {
-        return Number.parseFloat(Number.parseFloat(input_value).toFixed(1));
-    }
-
-    return Number.parseInt(input_value, 10);
-}
-
 function get_message_retention_setting_value(
     $input_elem: JQuery<HTMLSelectElement>,
     for_api_data = true,
@@ -391,7 +375,7 @@ function get_message_retention_setting_value(
     if (custom_input_val.length === 0) {
         return settings_config.retain_message_forever;
     }
-    return check_valid_number_input(custom_input_val);
+    return util.check_time_input(custom_input_val);
 }
 
 export const select_field_data_schema = z.record(z.object({text: z.string(), order: z.string()}));
@@ -764,7 +748,7 @@ export function get_auth_method_list_data(): Record<string, boolean> {
 }
 
 export function parse_time_limit($elem: JQuery<HTMLInputElement>): number {
-    const time_limit_in_minutes = check_valid_number_input($elem.val()!, true);
+    const time_limit_in_minutes = util.check_time_input($elem.val()!, true);
     return Math.floor(time_limit_in_minutes * 60);
 }
 
@@ -803,7 +787,7 @@ function get_time_limit_setting_value(
     if ($input_elem.attr("id") === "id_realm_waiting_period_threshold") {
         // For realm waiting period threshold setting, the custom input element contains
         // number of days.
-        return check_valid_number_input($custom_input_elem.val()!);
+        return util.check_time_input($custom_input_elem.val()!);
     }
 
     return parse_time_limit($custom_input_elem);
@@ -1343,7 +1327,7 @@ function should_disable_save_button_for_time_limit_settings(
         const $custom_input_elem = $(setting_elem).find<HTMLInputElement>(
             "input.time-limit-custom-input",
         );
-        const custom_input_elem_val = check_valid_number_input($custom_input_elem.val()!);
+        const custom_input_elem_val = util.check_time_input($custom_input_elem.val()!);
 
         const for_realm_default_settings =
             $dropdown_elem.closest(".settings-section.show").attr("id") ===

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -547,6 +547,25 @@ export const expires_in_values = {
     },
 };
 
+export const custom_time_unit_values = {
+    minutes: {
+        name: "minutes",
+        description: $t({defaultMessage: "minutes"}),
+    },
+    hours: {
+        name: "hours",
+        description: $t({defaultMessage: "hours"}),
+    },
+    days: {
+        name: "days",
+        description: $t({defaultMessage: "days"}),
+    },
+    weeks: {
+        name: "weeks",
+        description: $t({defaultMessage: "weeks"}),
+    },
+};
+
 const user_role_array = Object.values(user_role_values);
 export const user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
 

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -451,6 +451,22 @@ export function get_custom_time_in_minutes(time_unit: string, time_input: number
     }
 }
 
+export function check_time_input(input_value: string, keep_number_as_float = false): number {
+    // This check is important to make sure that inputs like "24a" are
+    // considered invalid and this function returns NaN for such inputs.
+    // Number.parseInt and Number.parseFloat will convert strings like
+    // "24a" to 24.
+    if (Number.isNaN(Number(input_value))) {
+        return Number.NaN;
+    }
+
+    if (keep_number_as_float) {
+        return Number.parseFloat(Number.parseFloat(input_value).toFixed(1));
+    }
+
+    return Number.parseInt(input_value, 10);
+}
+
 // Helper for shorthand for Typescript to get an item from a list with
 // exactly one item.
 export function the<T>(items: T[] | JQuery<T>): T {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -467,6 +467,13 @@ export function check_time_input(input_value: string, keep_number_as_float = fal
     return Number.parseInt(input_value, 10);
 }
 
+export function validate_custom_time_input(time_input: number): boolean {
+    if (Number.isNaN(time_input) || time_input < 0) {
+        return false;
+    }
+    return true;
+}
+
 // Helper for shorthand for Typescript to get an item from a list with
 // exactly one item.
 export function the<T>(items: T[] | JQuery<T>): T {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -438,6 +438,19 @@ export function get_remaining_time(start_time: number, duration: number): number
     return Math.max(0, start_time + duration - Date.now());
 }
 
+export function get_custom_time_in_minutes(time_unit: string, time_input: number): number {
+    switch (time_unit) {
+        case "hours":
+            return time_input * 60;
+        case "days":
+            return time_input * 24 * 60;
+        case "weeks":
+            return time_input * 7 * 24 * 60;
+        default:
+            return time_input;
+    }
+}
+
 // Helper for shorthand for Typescript to get an item from a list with
 // exactly one item.
 export function the<T>(items: T[] | JQuery<T>): T {

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -46,7 +46,7 @@
             <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="" maxlength="3"/>
             <select class="custom-expiration-time invite-user-select modal_select bootstrap-focus-style" id="custom-expiration-time-unit">
                 {{#each time_choices}}
-                    <option name="custom_time_choice" class="custom_time_choice" value="{{this}}">{{this}}</option>
+                    <option name="custom_time_choice" class="custom_time_choice" value="{{this.name}}">{{this.description}}</option>
                 {{/each}}
             </select>
             <p id="custom_expires_on"></p>

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -408,20 +408,24 @@ run_test("check_and_validate_custom_time_input", () => {
     const input_is_nan = "24abc";
     let checked_input = util.check_time_input(input_is_nan);
     assert.equal(checked_input, Number.NaN);
+    assert.equal(util.validate_custom_time_input(checked_input), false);
 
     const input_is_negative = "-24";
     checked_input = util.check_time_input(input_is_negative);
     assert.equal(checked_input, -24);
+    assert.equal(util.validate_custom_time_input(input_is_negative), false);
 
     const input_is_float = "24.5";
     checked_input = util.check_time_input(input_is_float);
     assert.equal(checked_input, 24);
     checked_input = util.check_time_input(input_is_float, true);
     assert.equal(checked_input, 24.5);
+    assert.equal(util.validate_custom_time_input(input_is_float), true);
 
     const input_is_integer = "10";
     checked_input = util.check_time_input(input_is_integer);
     assert.equal(checked_input, 10);
+    assert.equal(util.validate_custom_time_input(input_is_integer), true);
 });
 
 run_test("the", () => {

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -388,6 +388,22 @@ run_test("get_remaining_time", () => {
     MockDate.reset();
 });
 
+run_test("get_custom_time_in_minutes", () => {
+    const time_input = 15;
+    assert.equal(util.get_custom_time_in_minutes("weeks", time_input), time_input * 7 * 24 * 60);
+    assert.equal(util.get_custom_time_in_minutes("days", time_input), time_input * 24 * 60);
+    assert.equal(util.get_custom_time_in_minutes("hours", time_input), time_input * 60);
+    assert.equal(util.get_custom_time_in_minutes("minutes", time_input), time_input);
+    // Unknown time unit returns same time input
+    assert.equal(util.get_custom_time_in_minutes("invalid", time_input), time_input);
+    /// NaN time input returns NaN
+    const invalid_time_input = Number.NaN;
+    assert.equal(
+        util.get_custom_time_in_minutes("minutes", invalid_time_input),
+        invalid_time_input,
+    );
+});
+
 run_test("the", () => {
     const list_with_one_item = ["foo"];
     assert.equal(util.the(list_with_one_item), "foo");

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -404,6 +404,26 @@ run_test("get_custom_time_in_minutes", () => {
     );
 });
 
+run_test("check_and_validate_custom_time_input", () => {
+    const input_is_nan = "24abc";
+    let checked_input = util.check_time_input(input_is_nan);
+    assert.equal(checked_input, Number.NaN);
+
+    const input_is_negative = "-24";
+    checked_input = util.check_time_input(input_is_negative);
+    assert.equal(checked_input, -24);
+
+    const input_is_float = "24.5";
+    checked_input = util.check_time_input(input_is_float);
+    assert.equal(checked_input, 24);
+    checked_input = util.check_time_input(input_is_float, true);
+    assert.equal(checked_input, 24.5);
+
+    const input_is_integer = "10";
+    checked_input = util.check_time_input(input_is_integer);
+    assert.equal(checked_input, 10);
+});
+
 run_test("the", () => {
     const list_with_one_item = ["foo"];
     assert.equal(util.the(list_with_one_item), "foo");


### PR DESCRIPTION
These updates are based on the 3rd/4th commits in #26109 as well as review feedback from that PR.

**Notes**:
- Extracts reusable elements from the custom time logic in the invite user modal as prep for setting a realm data deletion custom date on realm deactivation (see issue #24677).
- Adds some basic validation/disabling the submit button when invalid custom dates are input into the modal form.
- Updates the custom time units that are displayed in the dropdown to be internationalized.

---

**Screenshots and screen captures:**

<details>
<summary>Negative number as custom time input</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-20 21-09-54](https://github.com/zulip/zulip/assets/63245456/81eadd2e-e028-4a20-b4ce-3b2782016f49) | ![Screenshot from 2024-06-20 21-09-21](https://github.com/zulip/zulip/assets/63245456/dfba1840-e4f4-4a8b-9f11-743b9a12eded)
</details>
<details>
<summary>Non-integer number as a custom time input</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-06-20 21-10-26](https://github.com/zulip/zulip/assets/63245456/9f24930d-eb4c-4913-a8a4-58ebf71379f2) | ![Screenshot from 2024-06-20 21-10-59](https://github.com/zulip/zulip/assets/63245456/d4476f2d-1f7d-4805-87cf-7f8d8f4ad44d)
</summary>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
