### PR TITLE
markdown_timestamp: Remove incorrect space

### DIFF
--- a/web/templates/markdown_timestamp.hbs
+++ b/web/templates/markdown_timestamp.hbs
@@ -1,2 +1,2 @@
 <i class="fa fa-clock-o"></i>
-{{ text }}
+{{ text ~}}

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -423,7 +423,7 @@ run_test("timestamp", ({mock_template}) => {
     rm.update_elements($content);
 
     // Final asserts
-    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nThu, Jan 1, 1970, 12:00 AM\n');
+    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nThu, Jan 1, 1970, 12:00 AM');
     assert.equal($timestamp_invalid.text(), "never-been-set");
 });
 
@@ -442,11 +442,11 @@ run_test("timestamp-twenty-four-hour-time", ({mock_template, override}) => {
     // We will temporarily change the 24h setting for this test.
     override(user_settings, "twenty_four_hour_time", true);
     rm.update_elements($content);
-    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nWed, Jul 15, 2020, 20:40\n');
+    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nWed, Jul 15, 2020, 20:40');
 
     override(user_settings, "twenty_four_hour_time", false);
     rm.update_elements($content);
-    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nWed, Jul 15, 2020, 8:40 PM\n');
+    assert.equal($timestamp.html(), '<i class="fa fa-clock-o"></i>\nWed, Jul 15, 2020, 8:40 PM');
 });
 
 run_test("timestamp-error", () => {


### PR DESCRIPTION
The space wasn’t visible because it was narrower than the padding on `.rendered_markdown time`, but it showed up in copy-and-paste.