### PR TITLE
Start validating the rest of `state_data` using Zod

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -31,17 +31,17 @@ export type User = {
     // used for caching result of remove_diacritics.
     name_with_diacritics_removed?: string | undefined;
     date_joined: string;
-    is_active: boolean;
+    is_active?: boolean;
     is_owner: boolean;
     is_admin: boolean;
     is_guest: boolean;
-    is_moderator: boolean;
-    is_billing_admin: boolean;
+    is_moderator?: boolean;
+    is_billing_admin?: boolean;
     role: number;
-    timezone: string;
+    timezone?: string;
     avatar_url?: string | null;
     avatar_version: number;
-    profile_data: Record<number, ProfileDatum>;
+    profile_data?: Record<number, ProfileDatum>;
     // used for fake user objects.
     is_missing_server_data?: boolean;
     // used for inaccessible user objects.
@@ -49,7 +49,7 @@ export type User = {
 } & (
     | {
           is_bot: false;
-          bot_type: null;
+          bot_type?: null;
       }
     | {
           is_bot: true;
@@ -1667,6 +1667,7 @@ export function set_custom_profile_field_data(
         return;
     }
     const person = get_by_user_id(user_id);
+    assert(person.profile_data !== undefined);
     person.profile_data[field.id] = {
         value: field.value,
         rendered_value: field.rendered_value,

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1,5 +1,6 @@
 import md5 from "blueimp-md5";
 import assert from "minimalistic-assert";
+import type {z} from "zod";
 
 import * as typeahead from "../shared/src/typeahead";
 
@@ -13,50 +14,19 @@ import {page_params} from "./page_params";
 import * as reload_state from "./reload_state";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
+import type {
+    StateData,
+    cross_realm_bot_schema,
+    profile_datum_schema,
+    user_schema,
+} from "./state_data";
 import {current_user, realm} from "./state_data";
 import * as timerender from "./timerender";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
 
-export type ProfileDatum = {
-    value: string;
-    rendered_value?: string | undefined;
-};
-
-export type User = {
-    user_id: number;
-    delivery_email: string | null;
-    email: string;
-    full_name: string;
-    // used for caching result of remove_diacritics.
-    name_with_diacritics_removed?: string | undefined;
-    date_joined: string;
-    is_active?: boolean;
-    is_owner: boolean;
-    is_admin: boolean;
-    is_guest: boolean;
-    is_moderator?: boolean;
-    is_billing_admin?: boolean;
-    role: number;
-    timezone?: string;
-    avatar_url?: string | null;
-    avatar_version: number;
-    profile_data?: Record<number, ProfileDatum>;
-    // used for fake user objects.
-    is_missing_server_data?: boolean;
-    // used for inaccessible user objects.
-    is_inaccessible_user?: boolean;
-} & (
-    | {
-          is_bot: false;
-          bot_type?: null;
-      }
-    | {
-          is_bot: true;
-          bot_type: number;
-          bot_owner_id: number | null;
-      }
-);
+export type ProfileDatum = z.infer<typeof profile_datum_schema>;
+export type User = z.infer<typeof user_schema>;
 
 export type SenderInfo = User & {
     avatar_url_small: string;
@@ -72,15 +42,7 @@ export type PseudoMentionUser = {
     idx: number;
 };
 
-export type CrossRealmBot = User & {
-    is_system_bot: boolean;
-};
-
-export type PeopleParams = {
-    realm_users: User[];
-    realm_non_active_users: User[];
-    cross_realm_bots: CrossRealmBot[];
-};
+export type CrossRealmBot = z.infer<typeof cross_realm_bot_schema>;
 
 let people_dict: FoldDict<User>;
 let people_by_name_dict: FoldDict<User>;
@@ -1757,7 +1719,7 @@ export function sort_but_pin_current_user_on_top(users: User[]): void {
     }
 }
 
-export function initialize(my_user_id: number, params: PeopleParams): void {
+export function initialize(my_user_id: number, params: StateData["people"]): void {
     for (const person of params.realm_users) {
         add_active_user(person);
     }

--- a/web/src/realm_user_settings_defaults.ts
+++ b/web/src/realm_user_settings_defaults.ts
@@ -1,59 +1,64 @@
-export type RealmDefaultSettings = {
-    automatically_follow_topics_policy: number;
-    automatically_follow_topics_where_mentioned: boolean;
-    automatically_unmute_topics_in_muted_streams_policy: number;
-    color_scheme: number;
-    default_language: string;
-    demote_inactive_streams: number;
-    dense_mode: boolean;
-    desktop_icon_count_display: number;
-    display_emoji_reaction_users: boolean;
-    email_notifications_batching_period_seconds: number;
-    emojiset: string;
-    enable_desktop_notifications: boolean;
-    enable_digest_emails: boolean;
-    enable_drafts_synchronization: boolean;
-    enable_followed_topic_audible_notifications: boolean;
-    enable_followed_topic_desktop_notifications: boolean;
-    enable_followed_topic_email_notifications: boolean;
-    enable_followed_topic_push_notifications: boolean;
-    enable_followed_topic_wildcard_mentions_notify: boolean;
-    enable_login_emails: boolean;
-    enable_marketing_emails: boolean;
-    enable_offline_email_notifications: boolean;
-    enable_offline_push_notifications: boolean;
-    enable_online_push_notifications: boolean;
-    enable_sounds: boolean;
-    enable_stream_audible_notifications: boolean;
-    enable_stream_desktop_notifications: boolean;
-    enable_stream_email_notifications: boolean;
-    enable_stream_push_notifications: boolean;
-    enter_sends: boolean;
-    fluid_layout_width: boolean;
-    high_contrast_mode: boolean;
-    message_content_in_email_notifications: boolean;
-    notification_sound: string;
-    pm_content_in_desktop_notifications: boolean;
-    presence_enabled: boolean;
-    realm_name_in_email_notifications_policy: number;
-    receives_typing_notifications: boolean;
-    send_private_typing_notifications: boolean;
-    send_stream_typing_notifications: boolean;
-    starred_message_counts: boolean;
-    translate_emoticons: boolean;
-    twenty_four_hour_time: boolean;
-    user_list_style: number;
-    web_escape_navigates_to_home_view: boolean;
-    web_font_size_px: number;
-    web_home_view: string;
-    web_line_height_percent: number;
-    web_mark_read_on_scroll_policy: number;
-    web_stream_unreads_count_display_policy: number;
-    wildcard_mentions_notify: boolean;
-};
+import {z} from "zod";
+
+import type {StateData} from "./state_data";
+
+export const realm_default_settings_schema = z.object({
+    automatically_follow_topics_policy: z.number(),
+    automatically_follow_topics_where_mentioned: z.boolean(),
+    automatically_unmute_topics_in_muted_streams_policy: z.number(),
+    color_scheme: z.number(),
+    default_language: z.string(),
+    demote_inactive_streams: z.number(),
+    dense_mode: z.boolean(),
+    desktop_icon_count_display: z.number(),
+    display_emoji_reaction_users: z.boolean(),
+    email_notifications_batching_period_seconds: z.number(),
+    emojiset: z.string(),
+    enable_desktop_notifications: z.boolean(),
+    enable_digest_emails: z.boolean(),
+    enable_drafts_synchronization: z.boolean(),
+    enable_followed_topic_audible_notifications: z.boolean(),
+    enable_followed_topic_desktop_notifications: z.boolean(),
+    enable_followed_topic_email_notifications: z.boolean(),
+    enable_followed_topic_push_notifications: z.boolean(),
+    enable_followed_topic_wildcard_mentions_notify: z.boolean(),
+    enable_login_emails: z.boolean(),
+    enable_marketing_emails: z.boolean(),
+    enable_offline_email_notifications: z.boolean(),
+    enable_offline_push_notifications: z.boolean(),
+    enable_online_push_notifications: z.boolean(),
+    enable_sounds: z.boolean(),
+    enable_stream_audible_notifications: z.boolean(),
+    enable_stream_desktop_notifications: z.boolean(),
+    enable_stream_email_notifications: z.boolean(),
+    enable_stream_push_notifications: z.boolean(),
+    enter_sends: z.boolean(),
+    fluid_layout_width: z.boolean(),
+    high_contrast_mode: z.boolean(),
+    message_content_in_email_notifications: z.boolean(),
+    notification_sound: z.string(),
+    pm_content_in_desktop_notifications: z.boolean(),
+    presence_enabled: z.boolean(),
+    realm_name_in_email_notifications_policy: z.number(),
+    receives_typing_notifications: z.boolean(),
+    send_private_typing_notifications: z.boolean(),
+    send_stream_typing_notifications: z.boolean(),
+    starred_message_counts: z.boolean(),
+    translate_emoticons: z.boolean(),
+    twenty_four_hour_time: z.boolean(),
+    user_list_style: z.number(),
+    web_escape_navigates_to_home_view: z.boolean(),
+    web_font_size_px: z.number(),
+    web_home_view: z.string(),
+    web_line_height_percent: z.number(),
+    web_mark_read_on_scroll_policy: z.number(),
+    web_stream_unreads_count_display_policy: z.number(),
+    wildcard_mentions_notify: z.boolean(),
+});
+export type RealmDefaultSettings = z.infer<typeof realm_default_settings_schema>;
 
 export let realm_user_settings_defaults: RealmDefaultSettings;
 
-export function initialize(params: {realm_user_settings_defaults: RealmDefaultSettings}): void {
+export function initialize(params: StateData["realm_settings_defaults"]): void {
     realm_user_settings_defaults = params.realm_user_settings_defaults;
 }

--- a/web/src/realm_user_settings_defaults.ts
+++ b/web/src/realm_user_settings_defaults.ts
@@ -42,7 +42,7 @@ export type RealmDefaultSettings = {
     starred_message_counts: boolean;
     translate_emoticons: boolean;
     twenty_four_hour_time: boolean;
-    user_list_style: boolean;
+    user_list_style: number;
     web_escape_navigates_to_home_view: boolean;
     web_font_size_px: number;
     web_home_view: string;

--- a/web/src/scheduled_messages.ts
+++ b/web/src/scheduled_messages.ts
@@ -1,24 +1,11 @@
+import type {z} from "zod";
+
 import * as channel from "./channel";
 import {$t} from "./i18n";
+import type {StateData, scheduled_message_schema} from "./state_data";
 import * as timerender from "./timerender";
 
-export type ScheduledMessage = {
-    scheduled_message_id: number;
-    content: string;
-    rendered_content: string;
-    scheduled_delivery_timestamp: number;
-    failed: boolean;
-} & (
-    | {
-          type: "private";
-          to: number[];
-      }
-    | {
-          type: "stream";
-          to: number;
-          topic: string;
-      }
-);
+export type ScheduledMessage = z.infer<typeof scheduled_message_schema>;
 
 type TimeKey =
     | "today_nine_am"
@@ -225,8 +212,6 @@ export function reset_selected_schedule_timestamp(): void {
     selected_send_later_timestamp = undefined;
 }
 
-export function initialize(scheduled_messages_params: {
-    scheduled_messages: ScheduledMessage[];
-}): void {
+export function initialize(scheduled_messages_params: StateData["scheduled_messages"]): void {
     add_scheduled_messages(scheduled_messages_params.scheduled_messages);
 }

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -14,11 +14,10 @@ import {$t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import * as scroll_util from "./scroll_util";
 import * as settings_ui from "./settings_ui";
-import type {realm_schema} from "./state_data";
 import {current_user, realm} from "./state_data";
 import * as ui_report from "./ui_report";
 
-type RealmLinkifiers = z.infer<typeof realm_schema>["realm_linkifiers"];
+type RealmLinkifiers = typeof realm.realm_linkifiers;
 
 const configure_linkifier_api_response_schema = z.object({
     id: z.number(),

--- a/web/src/starred_messages.ts
+++ b/web/src/starred_messages.ts
@@ -1,8 +1,9 @@
 import * as message_store from "./message_store";
+import type {StateData} from "./state_data";
 
 export const starred_ids = new Set<number>();
 
-export function initialize(starred_messages_params: {starred_messages: number[]}): void {
+export function initialize(starred_messages_params: StateData["starred_messages"]): void {
     starred_ids.clear();
 
     for (const id of starred_messages_params.starred_messages) {

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -1,5 +1,6 @@
 import {z} from "zod";
 
+import {realm_default_settings_schema} from "./realm_user_settings_defaults";
 import {user_settings_schema} from "./user_settings";
 
 const NOT_TYPED_YET = z.unknown();
@@ -312,7 +313,7 @@ export const state_data_schema = z
     )
     .and(
         z
-            .object({realm_user_settings_defaults: NOT_TYPED_YET})
+            .object({realm_user_settings_defaults: realm_default_settings_schema})
             .transform((realm_settings_defaults) => ({realm_settings_defaults})),
     )
     .and(

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -37,6 +37,28 @@ export const custom_profile_field_schema = z.object({
 
 export type CustomProfileField = z.output<typeof custom_profile_field_schema>;
 
+export const scheduled_message_schema = z
+    .object({
+        scheduled_message_id: z.number(),
+        content: z.string(),
+        rendered_content: z.string(),
+        scheduled_delivery_timestamp: z.number(),
+        failed: z.boolean(),
+    })
+    .and(
+        z.discriminatedUnion("type", [
+            z.object({
+                type: z.literal("private"),
+                to: z.array(z.number()),
+            }),
+            z.object({
+                type: z.literal("stream"),
+                to: z.number(),
+                topic: z.string(),
+            }),
+        ]),
+    );
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -295,7 +317,7 @@ export const state_data_schema = z
     )
     .and(
         z
-            .object({scheduled_messages: NOT_TYPED_YET})
+            .object({scheduled_messages: z.array(scheduled_message_schema)})
             .transform((scheduled_messages) => ({scheduled_messages})),
     )
     .and(

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -1,5 +1,7 @@
 import {z} from "zod";
 
+const NOT_TYPED_YET = z.unknown();
+
 const group_permission_setting_schema = z.object({
     require_system_group: z.boolean(),
     allow_internet_group: z.boolean(),
@@ -34,9 +36,19 @@ export const custom_profile_field_schema = z.object({
 export type CustomProfileField = z.output<typeof custom_profile_field_schema>;
 
 // Sync this with zerver.lib.events.do_events_register.
-export const current_user_schema = z.object({
+const current_user_schema = z.object({
     avatar_source: z.string(),
+    avatar_url: NOT_TYPED_YET,
+    avatar_url_medium: NOT_TYPED_YET,
+    can_create_private_streams: NOT_TYPED_YET,
+    can_create_public_streams: NOT_TYPED_YET,
+    can_create_streams: NOT_TYPED_YET,
+    can_create_web_public_streams: NOT_TYPED_YET,
+    can_invite_others_to_realm: NOT_TYPED_YET,
+    can_subscribe_other_users: NOT_TYPED_YET,
     delivery_email: z.string(),
+    email: NOT_TYPED_YET,
+    full_name: NOT_TYPED_YET,
     has_zoom_token: z.boolean(),
     is_admin: z.boolean(),
     is_billing_admin: z.boolean(),
@@ -47,7 +59,7 @@ export const current_user_schema = z.object({
 });
 
 // Sync this with zerver.lib.events.do_events_register.
-export const realm_schema = z.object({
+const realm_schema = z.object({
     custom_profile_fields: z.array(custom_profile_field_schema),
     custom_profile_field_types: z.object({
         SHORT_TEXT: z.object({id: z.number(), name: z.string()}),
@@ -60,14 +72,21 @@ export const realm_schema = z.object({
         PRONOUNS: z.object({id: z.number(), name: z.string()}),
     }),
     demo_organization_scheduled_deletion_date: z.optional(z.number()),
+    giphy_api_key: NOT_TYPED_YET,
+    giphy_rating_options: NOT_TYPED_YET,
     max_avatar_file_size_mib: z.number(),
     max_file_upload_size_mib: z.number(),
     max_icon_file_size_mib: z.number(),
     max_logo_file_size_mib: z.number(),
     max_message_length: z.number(),
+    max_stream_description_length: NOT_TYPED_YET,
+    max_stream_name_length: NOT_TYPED_YET,
     max_topic_length: z.number(),
+    password_min_guesses: NOT_TYPED_YET,
+    password_min_length: NOT_TYPED_YET,
     realm_add_custom_emoji_policy: z.number(),
     realm_allow_edit_history: z.boolean(),
+    realm_allow_message_editing: NOT_TYPED_YET,
     realm_authentication_methods: z.record(
         z.object({
             enabled: z.boolean(),
@@ -82,6 +101,7 @@ export const realm_schema = z.object({
         big_blue_button: z.optional(z.object({name: z.string(), id: z.number()})),
     }),
     realm_avatar_changes_disabled: z.boolean(),
+    realm_bot_creation_policy: NOT_TYPED_YET,
     realm_bot_domain: z.string(),
     realm_can_access_all_users_group: z.number(),
     realm_can_create_public_channel_group: z.number(),
@@ -103,6 +123,8 @@ export const realm_schema = z.object({
     realm_default_language: z.string(),
     realm_delete_own_message_policy: z.number(),
     realm_description: z.string(),
+    realm_digest_emails_enabled: NOT_TYPED_YET,
+    realm_digest_weekday: NOT_TYPED_YET,
     realm_disallow_disposable_email_addresses: z.boolean(),
     realm_domains: z.array(
         z.object({
@@ -111,10 +133,14 @@ export const realm_schema = z.object({
         }),
     ),
     realm_edit_topic_policy: z.number(),
+    realm_email_auth_enabled: NOT_TYPED_YET,
     realm_email_changes_disabled: z.boolean(),
     realm_emails_restricted_to_domains: z.boolean(),
+    realm_embedded_bots: NOT_TYPED_YET,
     realm_enable_guest_user_indicator: z.boolean(),
+    realm_enable_read_receipts: NOT_TYPED_YET,
     realm_enable_spectator_access: z.boolean(),
+    realm_giphy_rating: NOT_TYPED_YET,
     realm_icon_source: z.string(),
     realm_icon_url: z.string(),
     realm_incoming_webhook_bots: z.array(
@@ -125,6 +151,9 @@ export const realm_schema = z.object({
             // We currently ignore the `config` field in these objects.
         }),
     ),
+    realm_inline_image_preview: NOT_TYPED_YET,
+    realm_inline_url_embed_preview: NOT_TYPED_YET,
+    realm_invite_required: NOT_TYPED_YET,
     realm_invite_to_realm_policy: z.number(),
     realm_invite_to_stream_policy: z.number(),
     realm_is_zephyr_mirror_realm: z.boolean(),
@@ -139,6 +168,7 @@ export const realm_schema = z.object({
     realm_logo_source: z.string(),
     realm_logo_url: z.string(),
     realm_mandatory_topics: z.boolean(),
+    realm_message_content_allowed_in_email_notifications: NOT_TYPED_YET,
     realm_message_content_edit_limit_seconds: z.number().nullable(),
     realm_message_content_delete_limit_seconds: z.number().nullable(),
     realm_message_retention_days: z.number(),
@@ -151,6 +181,7 @@ export const realm_schema = z.object({
     realm_night_logo_source: z.string(),
     realm_night_logo_url: z.string(),
     realm_org_type: z.number(),
+    realm_password_auth_enabled: NOT_TYPED_YET,
     realm_plan_type: z.number(),
     realm_playgrounds: z.array(
         z.object({
@@ -163,16 +194,22 @@ export const realm_schema = z.object({
     realm_presence_disabled: z.boolean(),
     realm_private_message_policy: z.number(),
     realm_push_notifications_enabled: z.boolean(),
+    realm_push_notifications_enabled_end_timestamp: NOT_TYPED_YET,
     realm_require_unique_names: z.boolean(),
+    realm_send_welcome_emails: NOT_TYPED_YET,
     realm_signup_announcements_stream_id: z.number(),
     realm_upload_quota_mib: z.nullable(z.number()),
     realm_url: z.string(),
     realm_user_group_edit_policy: z.number(),
     realm_video_chat_provider: z.number(),
     realm_waiting_period_threshold: z.number(),
+    realm_want_advertise_in_communities_directory: NOT_TYPED_YET,
     realm_wildcard_mention_policy: z.number(),
     realm_zulip_update_announcements_stream_id: z.number(),
     server_avatar_changes_disabled: z.boolean(),
+    server_emoji_data_url: NOT_TYPED_YET,
+    server_inline_image_preview: NOT_TYPED_YET,
+    server_inline_url_embed_preview: NOT_TYPED_YET,
     server_jitsi_server_url: z.nullable(z.string()),
     server_name_changes_disabled: z.boolean(),
     server_needs_upgrade: z.boolean(),
@@ -187,25 +224,105 @@ export const realm_schema = z.object({
     server_typing_started_wait_period_milliseconds: z.number(),
     server_typing_stopped_wait_period_milliseconds: z.number(),
     server_web_public_streams_enabled: z.boolean(),
+    settings_send_digest_emails: NOT_TYPED_YET,
     stop_words: z.array(z.string()),
+    upgrade_text_for_wide_organization_logo: NOT_TYPED_YET,
+    zulip_feature_level: NOT_TYPED_YET,
     zulip_merge_base: z.string(),
     zulip_plan_is_not_limited: z.boolean(),
     zulip_version: z.string(),
 });
 
-export const state_data_schema = current_user_schema
-    .merge(realm_schema)
-    // TODO/typescript: Remove .passthrough() when all consumers have been
-    // converted to TypeScript and the schema is complete.
-    .passthrough();
+export const state_data_schema = z
+    .object({alert_words: NOT_TYPED_YET})
+    .transform((alert_words) => ({alert_words}))
+    .and(z.object({realm_emoji: NOT_TYPED_YET}).transform((emoji) => ({emoji})))
+    .and(z.object({realm_bots: NOT_TYPED_YET}).transform((bot) => ({bot})))
+    .and(
+        z
+            .object({
+                realm_users: NOT_TYPED_YET,
+                realm_non_active_users: NOT_TYPED_YET,
+                cross_realm_bots: NOT_TYPED_YET,
+            })
+            .transform((people) => ({people})),
+    )
+    .and(
+        z
+            .object({recent_private_conversations: NOT_TYPED_YET})
+            .transform((pm_conversations) => ({pm_conversations})),
+    )
+    .and(
+        z
+            .object({
+                presences: NOT_TYPED_YET,
+                server_timestamp: NOT_TYPED_YET,
+                presence_last_update_id: NOT_TYPED_YET,
+            })
+            .transform((presence) => ({presence})),
+    )
+    .and(
+        z
+            .object({starred_messages: NOT_TYPED_YET})
+            .transform((starred_messages) => ({starred_messages})),
+    )
+    .and(
+        z
+            .object({
+                subscriptions: NOT_TYPED_YET,
+                unsubscribed: NOT_TYPED_YET,
+                never_subscribed: NOT_TYPED_YET,
+                realm_default_streams: NOT_TYPED_YET,
+            })
+            .transform((stream_data) => ({stream_data})),
+    )
+    .and(z.object({realm_user_groups: NOT_TYPED_YET}).transform((user_groups) => ({user_groups})))
+    .and(z.object({unread_msgs: NOT_TYPED_YET}).transform((unread) => ({unread})))
+    .and(z.object({muted_users: NOT_TYPED_YET}).transform((muted_users) => ({muted_users})))
+    .and(z.object({user_topics: NOT_TYPED_YET}).transform((user_topics) => ({user_topics})))
+    .and(z.object({user_status: NOT_TYPED_YET}).transform((user_status) => ({user_status})))
+    .and(z.object({user_settings: NOT_TYPED_YET}).transform((user_settings) => ({user_settings})))
+    .and(
+        z
+            .object({realm_user_settings_defaults: NOT_TYPED_YET})
+            .transform((realm_settings_defaults) => ({realm_settings_defaults})),
+    )
+    .and(
+        z
+            .object({scheduled_messages: NOT_TYPED_YET})
+            .transform((scheduled_messages) => ({scheduled_messages})),
+    )
+    .and(
+        z
+            .object({
+                queue_id: NOT_TYPED_YET,
+                server_generation: NOT_TYPED_YET,
+                event_queue_longpoll_timeout_seconds: NOT_TYPED_YET,
+                last_event_id: NOT_TYPED_YET,
+            })
+            .transform((server_events) => ({server_events})),
+    )
+    .and(z.object({max_message_id: NOT_TYPED_YET}).transform((local_message) => ({local_message})))
+    .and(
+        z
+            .object({onboarding_steps: NOT_TYPED_YET})
+            .transform((onboarding_steps) => ({onboarding_steps})),
+    )
+    .and(current_user_schema.transform((current_user) => ({current_user})))
+    .and(realm_schema.transform((realm) => ({realm})));
 
-export let current_user: z.infer<typeof current_user_schema>;
-export let realm: z.infer<typeof realm_schema>;
+export type StateData = z.infer<typeof state_data_schema>;
 
-export function set_current_user(initial_current_user: z.infer<typeof current_user_schema>): void {
+export type CurrentUser = StateData["current_user"];
+export type Realm = StateData["realm"];
+
+export let current_user: CurrentUser;
+export let realm: Realm;
+
+export function set_current_user(initial_current_user: CurrentUser): void {
     current_user = initial_current_user;
 }
 
-export function set_realm(initial_realm: z.infer<typeof realm_schema>): void {
+export function set_realm(initial_realm: Realm): void {
     realm = initial_realm;
 }

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -338,7 +338,7 @@ export const state_data_schema = z
     )
     .and(
         z
-            .object({starred_messages: NOT_TYPED_YET})
+            .object({starred_messages: z.array(z.number())})
             .transform((starred_messages) => ({starred_messages})),
     )
     .and(

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -1,5 +1,7 @@
 import {z} from "zod";
 
+import {user_settings_schema} from "./user_settings";
+
 const NOT_TYPED_YET = z.unknown();
 
 const group_permission_setting_schema = z.object({
@@ -281,7 +283,11 @@ export const state_data_schema = z
     .and(z.object({muted_users: NOT_TYPED_YET}).transform((muted_users) => ({muted_users})))
     .and(z.object({user_topics: NOT_TYPED_YET}).transform((user_topics) => ({user_topics})))
     .and(z.object({user_status: NOT_TYPED_YET}).transform((user_status) => ({user_status})))
-    .and(z.object({user_settings: NOT_TYPED_YET}).transform((user_settings) => ({user_settings})))
+    .and(
+        z
+            .object({user_settings: user_settings_schema})
+            .transform((user_settings) => ({user_settings})),
+    )
     .and(
         z
             .object({realm_user_settings_defaults: NOT_TYPED_YET})

--- a/web/src/user_settings.ts
+++ b/web/src/user_settings.ts
@@ -1,72 +1,83 @@
-export type StreamNotificationSettings = {
-    enable_stream_audible_notifications: boolean;
-    enable_stream_desktop_notifications: boolean;
-    enable_stream_email_notifications: boolean;
-    enable_stream_push_notifications: boolean;
-    wildcard_mentions_notify: boolean;
-};
+import {z} from "zod";
 
-export type PmNotificationSettings = {
-    enable_desktop_notifications: boolean;
-    enable_offline_email_notifications: boolean;
-    enable_offline_push_notifications: boolean;
-    enable_sounds: boolean;
-};
+import type {StateData} from "./state_data";
 
-export type FollowedTopicNotificationSettings = {
-    enable_followed_topic_audible_notifications: boolean;
-    enable_followed_topic_desktop_notifications: boolean;
-    enable_followed_topic_email_notifications: boolean;
-    enable_followed_topic_push_notifications: boolean;
-    enable_followed_topic_wildcard_mentions_notify: boolean;
-};
+export const stream_notification_settings_schema = z.object({
+    enable_stream_audible_notifications: z.boolean(),
+    enable_stream_desktop_notifications: z.boolean(),
+    enable_stream_email_notifications: z.boolean(),
+    enable_stream_push_notifications: z.boolean(),
+    wildcard_mentions_notify: z.boolean(),
+});
+export type StreamNotificationSettings = z.infer<typeof stream_notification_settings_schema>;
 
-export type UserSettings = (StreamNotificationSettings &
-    PmNotificationSettings &
-    FollowedTopicNotificationSettings) & {
-    automatically_follow_topics_policy: number;
-    automatically_follow_topics_where_mentioned: boolean;
-    automatically_unmute_topics_in_muted_streams_policy: number;
-    color_scheme: number;
-    default_language: string;
-    demote_inactive_streams: number;
-    dense_mode: boolean;
-    desktop_icon_count_display: number;
-    display_emoji_reaction_users: boolean;
-    email_notifications_batching_period_seconds: number;
-    emojiset: string;
-    enable_digest_emails: boolean;
-    enable_drafts_synchronization: boolean;
-    enable_login_emails: boolean;
-    enable_marketing_emails: boolean;
-    enable_online_push_notifications: boolean;
-    enter_sends: boolean;
-    fluid_layout_width: boolean;
-    high_contrast_mode: boolean;
-    message_content_in_email_notifications: boolean;
-    notification_sound: string;
-    pm_content_in_desktop_notifications: boolean;
-    presence_enabled: boolean;
-    realm_name_in_email_notifications_policy: number;
-    receives_typing_notifications: boolean;
-    send_private_typing_notifications: boolean;
-    send_read_receipts: boolean;
-    send_stream_typing_notifications: boolean;
-    starred_message_counts: boolean;
-    timezone: string;
-    translate_emoticons: boolean;
-    twenty_four_hour_time: boolean;
-    user_list_style: number;
-    web_escape_navigates_to_home_view: boolean;
-    web_font_size_px: number;
-    web_home_view: "inbox" | "recent_topics" | "all_messages";
-    web_line_height_percent: number;
-    web_mark_read_on_scroll_policy: number;
-    web_stream_unreads_count_display_policy: number;
-};
+export const pm_notification_settings_schema = z.object({
+    enable_desktop_notifications: z.boolean(),
+    enable_offline_email_notifications: z.boolean(),
+    enable_offline_push_notifications: z.boolean(),
+    enable_sounds: z.boolean(),
+});
+export type PmNotificationSettings = z.infer<typeof pm_notification_settings_schema>;
+
+export const followed_topic_notification_settings_schema = z.object({
+    enable_followed_topic_audible_notifications: z.boolean(),
+    enable_followed_topic_desktop_notifications: z.boolean(),
+    enable_followed_topic_email_notifications: z.boolean(),
+    enable_followed_topic_push_notifications: z.boolean(),
+    enable_followed_topic_wildcard_mentions_notify: z.boolean(),
+});
+export type FollowedTopicNotificationSettings = z.infer<
+    typeof followed_topic_notification_settings_schema
+>;
+
+export const user_settings_schema = stream_notification_settings_schema
+    .merge(pm_notification_settings_schema)
+    .merge(followed_topic_notification_settings_schema)
+    .extend({
+        automatically_follow_topics_policy: z.number(),
+        automatically_follow_topics_where_mentioned: z.boolean(),
+        automatically_unmute_topics_in_muted_streams_policy: z.number(),
+        color_scheme: z.number(),
+        default_language: z.string(),
+        demote_inactive_streams: z.number(),
+        dense_mode: z.boolean(),
+        desktop_icon_count_display: z.number(),
+        display_emoji_reaction_users: z.boolean(),
+        email_notifications_batching_period_seconds: z.number(),
+        emojiset: z.string(),
+        enable_digest_emails: z.boolean(),
+        enable_drafts_synchronization: z.boolean(),
+        enable_login_emails: z.boolean(),
+        enable_marketing_emails: z.boolean(),
+        enable_online_push_notifications: z.boolean(),
+        enter_sends: z.boolean(),
+        fluid_layout_width: z.boolean(),
+        high_contrast_mode: z.boolean(),
+        message_content_in_email_notifications: z.boolean(),
+        notification_sound: z.string(),
+        pm_content_in_desktop_notifications: z.boolean(),
+        presence_enabled: z.boolean(),
+        realm_name_in_email_notifications_policy: z.number(),
+        receives_typing_notifications: z.boolean(),
+        send_private_typing_notifications: z.boolean(),
+        send_read_receipts: z.boolean(),
+        send_stream_typing_notifications: z.boolean(),
+        starred_message_counts: z.boolean(),
+        timezone: z.string(),
+        translate_emoticons: z.boolean(),
+        twenty_four_hour_time: z.boolean(),
+        user_list_style: z.number(),
+        web_escape_navigates_to_home_view: z.boolean(),
+        web_font_size_px: z.number(),
+        web_home_view: z.enum(["inbox", "recent_topics", "all_messages"]),
+        web_line_height_percent: z.number(),
+        web_mark_read_on_scroll_policy: z.number(),
+        web_stream_unreads_count_display_policy: z.number(),
+    });
+export type UserSettings = z.infer<typeof user_settings_schema>;
 
 export let user_settings: UserSettings;
 
-export function initialize_user_settings(params: {user_settings: UserSettings}): void {
+export function initialize_user_settings(params: StateData["user_settings"]): void {
     user_settings = params.user_settings;
 }


### PR DESCRIPTION
Until now there has been no validation for the parts of `state_data` split off by `pop_fields` in `ui_init.initialize_everything`. Start adding that validation gradually, to improve our confidence in the correctness of our annotations, and so we don’t have to do it all at once when we convert `ui_init.js` to TypeScript.

We use Zod’s `.transform` to replace `pop_fields` as the mechanism for splitting `state_data`. This leaves `state_data.state_data_schema` as the single source of truth for which fields are sent where.