### PR TITLE
topic_name: Fix compressing of display topic names

### DIFF
--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -60,6 +60,7 @@
             font-size: 1.1em;
             line-height: normal;
             margin-bottom: 5px;
+            white-space: pre-wrap;
         }
     }
 

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -363,6 +363,7 @@
 
                 & a {
                     padding: 1px 0;
+                    white-space: pre;
                 }
             }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -910,6 +910,10 @@ li.top_left_scheduled_messages {
     overflow-x: hidden;
     overflow-x: clip;
     text-overflow: ellipsis;
+
+    span.sidebar-topic-name-inner {
+        white-space: pre;
+    }
 }
 
 .searching-for-more-topics img {

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -59,6 +59,10 @@
                 top: 0.5px;
                 overflow: hidden;
                 text-overflow: ellipsis;
+
+                span.stream-topic-inner {
+                    white-space: pre;
+                }
             }
         }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -291,6 +291,7 @@
         color: var(--color-text-popover-menu);
         line-height: 1.1;
         margin-top: 4px;
+        white-space: pre-wrap;
     }
 }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -202,6 +202,11 @@
         }
     }
 
+    .stream-topic {
+        /* Display whitespace within topics. */
+        white-space: pre-wrap;
+    }
+
     .user-group-mention {
         &:hover {
             background-color: var(--color-background-text-hover-group-mention);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -357,6 +357,14 @@ body.has-overlay-scrollbar {
     background-color: hsl(0deg 0% 0% / 70%);
 }
 
+.white-space-preserve-wrap {
+    white-space: pre-wrap;
+}
+
+.white-space-preserve {
+    white-space: pre;
+}
+
 /* Set flex display on login buttons only in the
    spectator view. We want them to display none
    otherwise. */
@@ -1368,6 +1376,10 @@ div.focused-message-list {
 
     a {
         color: inherit;
+
+        strong.typeahead-strong-section {
+            white-space: pre;
+        }
     }
 
     .active {

--- a/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
+++ b/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
@@ -3,12 +3,12 @@
         {{#if followed}}
             {{#tr}}
                 Now following <z-link>{channel_topic}</z-link>.
-                {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link"}}<a class="above_compose_banner_action_link white-space-preserve-wrap" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{else}}
             {{#tr}}
                 Unmuted <z-link>{channel_topic}</z-link>.
-                {{#*inline "z-link"}}<a class="above_compose_banner_action_link" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link"}}<a class="above_compose_banner_action_link white-space-preserve-wrap" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         {{/if}}
     </p>

--- a/web/templates/confirm_dialog/confirm_delete_topic.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_topic.hbs
@@ -1,6 +1,4 @@
 <p>
     {{t "Deleting a topic will immediately remove it and its messages for everyone. Other users may find this confusing, especially if they had received an email or push notification related to the deleted messages." }}
 </p>
-<p>
-    {{#tr}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}
-</p>
+<p class="white-space-preserve-wrap">{{#tr}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}</p>

--- a/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
+++ b/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
@@ -1,6 +1,7 @@
 <p>
     {{#tr}}
-    The topic <strong>{topic_name}</strong> already exists in this channel.
+    The topic <z-topic-name>{topic_name}</z-topic-name> already exists in this channel.
     Are you sure you want to combine messages from these topics? This cannot be undone.
+    {{#*inline "z-topic-name"}}<strong class="white-space-preserve-wrap">{{> @partial-block}}</strong>{{/inline}}
     {{/tr}}
 </p>

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -16,7 +16,7 @@
                 <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>
                 <span class="stream_topic">
                     <div class="message_label_clickable narrows_by_topic">
-                        {{topic}}
+                        <span class="stream-topic-inner">{{topic}}</span>
                     </div>
                 </span>
                 <span class="recipient_bar_controls"></span>

--- a/web/templates/message_moved_widget_body.hbs
+++ b/web/templates/message_moved_widget_body.hbs
@@ -1,6 +1,6 @@
 <div>
     {{#tr}}
     Message moved to <z-link>{stream_topic}</z-link>.
-    {{#*inline "z-link"}}<a href="{{new_location_url}}">{{> @partial-block}}</a>{{/inline}}
+    {{#*inline "z-link"}}<a class="white-space-preserve-wrap" href="{{new_location_url}}">{{> @partial-block}}</a>{{/inline}}
     {{/tr}}
 </div>

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -1,5 +1,5 @@
 {{#unless (or from_message_actions_popover only_topic_edit)}}
-<p>{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
+<p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
 {{/unless}}
 <form class="new-style" id="move_topic_form">
     {{#if only_topic_edit }}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -34,7 +34,7 @@
                 {{#if is_private}}
                 <a href="{{pm_url}}">{{{rendered_pm_with}}}</a>
                 {{else}}
-                <a href="{{topic_url}}">{{topic}}</a>
+                <a class="white-space-preserve-wrap" href="{{topic_url}}">{{topic}}</a>
                 {{/if}}
             </div>
             <div class="right_part">

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -24,9 +24,9 @@
               href="{{topic_url}}"
               data-tippy-content="{{t 'Go to #{display_recipient} > {topic}' }}">
                 {{#if use_match_properties}}
-                    {{{match_topic}}}
+                    <span class="stream-topic-inner">{{{match_topic}}}</span>
                 {{else}}
-                    {{topic}}
+                    <span class="stream-topic-inner">{{topic}}</span>
                 {{/if}}
             </a>
         </span>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -13,7 +13,7 @@
                     <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>
                     <span class="stream_topic">
                         <div class="message_label_clickable narrows_by_topic">
-                            {{topic}}
+                            <span>{{topic}}</span>
                         </div>
                     </span>
                     <span class="recipient_bar_controls"></span>

--- a/web/templates/stream_topic_widget.hbs
+++ b/web/templates/stream_topic_widget.hbs
@@ -1,3 +1,3 @@
 <strong>
-    <span class="stream">{{stream_name}}</span> &gt; <span class="topic">{{topic}}</span>
+    <span class="stream">{{stream_name}}</span> &gt; <span class="topic white-space-preserve-wrap">{{topic}}</span>
 </strong>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -4,7 +4,7 @@
             {{topic_resolved_prefix}}
         </span>
         <a href="{{url}}" class="sidebar-topic-name" title="{{topic_name}}">
-            {{topic_display_name}}
+            <span class="sidebar-topic-name-inner">{{topic_display_name}}</span>
         </a>
         <div class="topic-markers-and-controls">
             {{#if contains_unread_mention}}

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -17,7 +17,7 @@
 {{else if is_user_group}}
     <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>
 {{/if}}
-<strong>
+<strong class="typeahead-strong-section">
     {{~#if stream}}
         {{> inline_decorated_stream_name stream=stream }}
     {{else}}

--- a/web/templates/user_topic_ui_row.hbs
+++ b/web/templates/user_topic_ui_row.hbs
@@ -1,7 +1,7 @@
 {{#with user_topic}}
 <tr data-stream-id="{{stream_id}}" data-stream="{{stream}}" data-topic="{{topic}}" data-date-updated="{{date_updated_str}}" data-visibility-policy="{{visibility_policy}}">
     <td>{{stream}}</td>
-    <td>{{topic}}</td>
+    <td class="white-space-preserve-wrap">{{topic}}</td>
     <td>
         <select class="settings_user_topic_visibility_policy list_select bootstrap-focus-style" data-setting-widget-type="number">
             {{#each ../user_topic_visibility_policy_values}}

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -894,18 +894,18 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 // options.highlighter_html()
                 options.query = "Kro";
                 actual_value = options.highlighter_html("kronor");
-                expected_value = "<strong>kronor</strong>";
+                expected_value = '<strong class="typeahead-strong-section">kronor</strong>';
                 assert.equal(actual_value, expected_value);
 
                 // Highlighted content should be escaped.
                 options.query = "<";
                 actual_value = options.highlighter_html("<&>");
-                expected_value = "<strong>&lt;&amp;&gt;</strong>";
+                expected_value = '<strong class="typeahead-strong-section">&lt;&amp;&gt;</strong>';
                 assert.equal(actual_value, expected_value);
 
                 options.query = "even m";
                 actual_value = options.highlighter_html("even more ice");
-                expected_value = "<strong>even more ice</strong>";
+                expected_value = '<strong class="typeahead-strong-section">even more ice</strong>';
                 assert.equal(actual_value, expected_value);
 
                 // options.sorter()
@@ -1129,7 +1129,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 expected_value =
                     `    <span class="user_circle_empty user_circle"></span>\n` +
                     `    <img class="typeahead-image" src="http://zulip.zulipdev.com/avatar/${othello.user_id}?s&#x3D;50" />\n` +
-                    `<strong>Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n` +
+                    `<strong class="typeahead-strong-section">Othello, the Moor of Venice</strong>&nbsp;&nbsp;\n` +
                     `<small class="autocomplete_secondary">othello@zulip.com</small>\n`;
                 assert.equal(actual_value, expected_value);
                 // Reset the email such that this does not affect further tests.
@@ -1139,7 +1139,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 ct.get_or_set_token_for_testing("hamletcharacters");
                 actual_value = options.highlighter_html(hamletcharacters);
                 expected_value =
-                    '    <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>\n<strong>hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
+                    '    <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>\n<strong class="typeahead-strong-section">hamletcharacters</strong>&nbsp;&nbsp;\n<small class="autocomplete_secondary">Characters of Hamlet</small>\n';
                 assert.equal(actual_value, expected_value);
 
                 // matching


### PR DESCRIPTION
Set `white-space` to `pre` or `pre-wrap` to fix compressing of display topic names everywhere in the web UI that we display topics.

To replace white-space default/normal value, used `pre-wrap` and to replace nowrap value used `pre`.

Using span where ever necessary because of `pre`. It considers new line characters from templates to add space so a better practice is to set `pre-wrap` inside a span.

Referred to the [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#syntax).

Fixes part of: #30478 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
| ![Screenshot from 2024-06-21 13-12-23](https://github.com/zulip/zulip/assets/78212328/37480045-7d26-4302-a124-b0f331e02abf) | ![Screenshot from 2024-06-21 13-12-09](https://github.com/zulip/zulip/assets/78212328/4f475789-e6b4-4ae5-ab74-26233b04b903) |

![Screenshot from 2024-06-22 00-01-16](https://github.com/zulip/zulip/assets/78212328/a4f8d82e-8a49-42fc-93b9-f04bf64037e9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
