### PR TITLE
stream_edit_subscribers: Use `raw_data` & `data` more.

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -210,13 +210,11 @@ export function set_up_attachments(): void {
 
     void channel.get({
         url: "/json/attachments",
-        success(data) {
-            const clean_data = attachment_api_response_schema.parse(data);
+        success(raw_data) {
+            const data = attachment_api_response_schema.parse(raw_data);
             loading.destroy_indicator($("#attachments_loading_indicator"));
-            attachments = clean_data.attachments.map((attachment) =>
-                format_attachment_data(attachment),
-            );
-            upload_space_used = clean_data.upload_space_used;
+            attachments = data.attachments.map((attachment) => format_attachment_data(attachment));
+            upload_space_used = data.upload_space_used;
             render_attachments_ui();
         },
         error(xhr) {

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -115,12 +115,12 @@ export function fetch_and_render_message_history(message: Message): void {
     void channel.get({
         url: "/json/messages/" + message.id + "/history",
         data: {message_id: JSON.stringify(message.id)},
-        success(data) {
-            const clean_data = server_message_history_schema.parse(data);
+        success(raw_data) {
+            const data = server_message_history_schema.parse(raw_data);
 
             const content_edit_history: EditHistoryEntry[] = [];
             let prev_stream_item: EditHistoryEntry | null = null;
-            for (const [index, msg] of clean_data.message_history.entries()) {
+            for (const [index, msg] of data.message_history.entries()) {
                 // Format times and dates nicely for display
                 const time = new Date(msg.timestamp * 1000);
                 const edited_at_time = timerender.get_full_datetime(time, "time");

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -262,12 +262,12 @@ export function build_page(): void {
             void channel.post({
                 url: "/json/realm/filters",
                 data: $(this).serialize(),
-                success(data) {
-                    const clean_data = configure_linkifier_api_response_schema.parse(data);
+                success(raw_data) {
+                    const data = configure_linkifier_api_response_schema.parse(raw_data);
                     $("#linkifier_pattern").val("");
                     $("#linkifier_template").val("");
                     $add_linkifier_button.prop("disabled", false);
-                    linkifier.id = clean_data.id;
+                    linkifier.id = data.id;
                     ui_report.success(
                         $t_html({defaultMessage: "Custom linkifier added!"}),
                         $linkifier_status,

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -224,13 +224,13 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
 
     const user_ids = [...user_id_set];
 
-    function invite_success(data: unknown): void {
-        const clean_data = add_user_ids_api_response_schema.parse(data);
+    function invite_success(raw_data: unknown): void {
+        const data = add_user_ids_api_response_schema.parse(raw_data);
         pill_widget.clear();
-        const subscribed_users = Object.keys(clean_data.subscribed).map(
+        const subscribed_users = Object.keys(data.subscribed).map(
             (email) => people.get_by_email(email)!,
         );
-        const already_subscribed_users = Object.keys(clean_data.already_subscribed).map(
+        const already_subscribed_users = Object.keys(data.already_subscribed).map(
             (email) => people.get_by_email(email)!,
         );
 
@@ -284,8 +284,8 @@ function remove_subscriber({
         return;
     }
 
-    function removal_success(data: unknown): void {
-        const clean_data = remove_user_id_api_response_schema.parse(data);
+    function removal_success(raw_data: unknown): void {
+        const data = remove_user_id_api_response_schema.parse(raw_data);
         let message;
 
         if (stream_id !== current_stream_id) {
@@ -293,7 +293,7 @@ function remove_subscriber({
             return;
         }
 
-        if (clean_data.removed.length > 0) {
+        if (data.removed.length > 0) {
             // Remove the user from the subscriber list.
             $list_entry.remove();
 

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -27,9 +27,9 @@ export function get_server_history(stream_id: number, on_success: () => void): v
     void channel.get({
         url,
         data: {},
-        success(data) {
-            const clean_data = stream_topic_history_response_schema.parse(data);
-            const server_history = clean_data.topics;
+        success(raw_data) {
+            const data = stream_topic_history_response_schema.parse(raw_data);
+            const server_history = data.topics;
             stream_topic_history.add_history(stream_id, server_history);
             stream_topic_history.remove_request_pending_for(stream_id);
             on_success();

--- a/web/src/zcommand.ts
+++ b/web/src/zcommand.ts
@@ -65,15 +65,15 @@ export function tell_user(msg: string): void {
 export function switch_to_light_theme(): void {
     send({
         command: "/day",
-        on_success(data) {
-            const clean_data = data_schema.parse(data);
+        on_success(raw_data) {
+            const data = data_schema.parse(raw_data);
             requestAnimationFrame(() => {
                 dark_theme.disable();
                 message_lists.update_recipient_bar_background_color();
             });
             feedback_widget.show({
                 populate($container) {
-                    const rendered_msg = markdown.parse_non_message(clean_data.msg);
+                    const rendered_msg = markdown.parse_non_message(data.msg);
                     $container.html(rendered_msg);
                 },
                 on_undo() {
@@ -91,15 +91,15 @@ export function switch_to_light_theme(): void {
 export function switch_to_dark_theme(): void {
     send({
         command: "/night",
-        on_success(data) {
-            const clean_data = data_schema.parse(data);
+        on_success(raw_data) {
+            const data = data_schema.parse(raw_data);
             requestAnimationFrame(() => {
                 dark_theme.enable();
                 message_lists.update_recipient_bar_background_color();
             });
             feedback_widget.show({
                 populate($container) {
-                    const rendered_msg = markdown.parse_non_message(clean_data.msg);
+                    const rendered_msg = markdown.parse_non_message(data.msg);
                     $container.html(rendered_msg);
                 },
                 on_undo() {


### PR DESCRIPTION
Prefer using `raw_data` and `data` instead of `data` and `clean_data`.

As advised by Andres in [#29243(comment)](https://github.com/zulip/zulip/pull/29243#discussion_r1603719919) and [#28432(comment)](https://github.com/zulip/zulip/pull/28432#discussion_r1442236806)

[Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/typescript.20migration/near/1554084)


