### PR TITLE
reactions view: Add narrow title.

### DIFF
--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as favicon from "./favicon";
@@ -57,6 +58,13 @@ export function compute_narrow_title(filter?: Filter): string {
             return $t({defaultMessage: "Invalid users"});
         }
         return $t({defaultMessage: "Invalid user"});
+    }
+
+    if (
+        _.isEqual(filter._sorted_term_types, ["sender", "has-reaction"]) &&
+        filter.operands("sender")[0] === people.my_current_email()
+    ) {
+        return $t({defaultMessage: "Reactions"});
     }
 
     if (filter.has_operator("sender")) {


### PR DESCRIPTION
Earlier the narrow title for `sender:me` was being displayed.
Instead, display the narrow title for `has:reaction sender:me`.

Before:
![image](https://github.com/zulip/zulip/assets/29176437/c458fa7c-eb93-4892-97a1-65cb3d26d5ba)

After:
![Screenshot 2024-06-26 120938](https://github.com/zulip/zulip/assets/29176437/fc0b812e-cee0-4f33-a874-9549af822847)

