### PR TITLE
ListWidget: Fix sliding of action column to right in tables which are using ListWidget.

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -130,13 +130,14 @@ function sort_mentioned_in(a: Attachment, b: Attachment): number {
     return -1;
 }
 
+let attachmetFilesWidget: ListWidget.ListWidget<Attachment, Attachment>;
 function render_attachments_ui(): void {
     set_upload_space_stats();
 
     const $uploaded_files_table = $("#uploaded_files_table").expectOne();
     const $search_input = $<HTMLInputElement>("input#upload_file_search");
 
-    ListWidget.create<Attachment>($uploaded_files_table, attachments, {
+    attachmetFilesWidget = ListWidget.create<Attachment>($uploaded_files_table, attachments, {
         name: "uploaded-files-list",
         get_item: ListWidget.default_get_item,
         modifier_html(attachment) {
@@ -151,6 +152,10 @@ function render_attachments_ui(): void {
                 scroll_util.reset_scrollbar(
                     $uploaded_files_table.closest(".progressive-table-wrapper"),
                 );
+                ListWidget.updateActionsColumn(
+                    attachmetFilesWidget.get_total_rows_to_render(),
+                    "#uploaded_files_table_action_column",
+                );
             },
         },
         $parent_container: $("#attachments-settings").expectOne(),
@@ -163,7 +168,10 @@ function render_attachments_ui(): void {
         },
         $simplebar_container: $("#attachments-settings .progressive-table-wrapper"),
     });
-
+    ListWidget.updateActionsColumn(
+        attachmetFilesWidget.get_total_rows_to_render(),
+        "#uploaded_files_table_action_column",
+    );
     scroll_util.reset_scrollbar($uploaded_files_table.closest(".progressive-table-wrapper"));
 }
 

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -83,6 +83,7 @@ export type ListWidget<Key, Item = Key> = BaseListWidget & {
     ) => void;
     sort: (sorting_function: string, prop?: string) => void;
     replace_list_data: (list: Key[], should_redraw?: boolean) => void;
+    get_total_rows_to_render: () => number;
 };
 
 const DEFAULTS = {
@@ -561,6 +562,9 @@ export function create<Key, Item = Key>(
                 widget.hard_redraw();
             }
         },
+        get_total_rows_to_render() {
+            return meta.filtered_list.length;
+        },
     };
 
     widget.set_up_event_handlers();
@@ -627,3 +631,16 @@ export function handle_sort<Key, Item>($th: JQuery, list: ListWidget<Key, Item>)
 }
 
 export const default_get_item = <T>(item: T): T => item;
+
+export function updateActionsColumn(list_widget: number, id: string): void {
+    // id of action column is required so that the affected action column should belong to that particular
+    // table where the changes are required and not to each table where the action column is used.
+    const rows: number = list_widget;
+    const $actionsColumn = $(id);
+    // Add or remove the "on-empty-table" class based on the number of rows
+    if (rows === 0) {
+        $actionsColumn.addClass("on-empty-table");
+    } else {
+        $actionsColumn.removeClass("on-empty-table");
+    }
+}

--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -81,6 +81,8 @@ function sort_invitee(a: Invite, b: Invite): number {
     return util.strcmp(str1, str2);
 }
 
+let invitationWidget: ListWidget.ListWidget<Invite, Invite>;
+
 function populate_invites(invites_data: {invites: Invite[]}): void {
     if (!meta.loaded) {
         return;
@@ -89,7 +91,7 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
     add_invited_as_text(invites_data.invites);
 
     const $invites_table = $("#admin_invites_table").expectOne();
-    ListWidget.create($invites_table, invites_data.invites, {
+    invitationWidget = ListWidget.create($invites_table, invites_data.invites, {
         name: "admin_invites_list",
         get_item: ListWidget.default_get_item,
         modifier_html(item) {
@@ -123,6 +125,12 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
                 const invitee_email_matched = item.email.toLowerCase().includes(value);
                 return referrer_email_matched || referrer_name_matched || invitee_email_matched;
             },
+            onupdate() {
+                ListWidget.updateActionsColumn(
+                    invitationWidget.get_total_rows_to_render(),
+                    "#admin_invites_table_action_column",
+                );
+            },
         },
         $parent_container: $("#admin-invites-list").expectOne(),
         init_sort: sort_invitee,
@@ -138,6 +146,10 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
         $simplebar_container: $("#admin-invites-list .progressive-table-wrapper"),
     });
 
+    ListWidget.updateActionsColumn(
+        invitationWidget.get_total_rows_to_render(),
+        "#admin_invites_table_action_column",
+    );
     loading.destroy_indicator($("#admin_page_invites_loading_indicator"));
 }
 
@@ -204,6 +216,12 @@ function do_resend_invite({$row, invite_id}: {$row: JQuery; invite_id: string}):
         success() {
             $resend_button.text($t({defaultMessage: "Sent!"}));
             $resend_button.removeClass("resend btn-warning").addClass("sea-green");
+            if (invitationWidget) {
+                ListWidget.updateActionsColumn(
+                    invitationWidget.get_total_rows_to_render(),
+                    "#admin_invites_table_action_column",
+                );
+            }
         },
     });
 }

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -155,13 +155,26 @@ function handle_linkifier_api_error(
     }
 }
 
+let linkifiersWidget: ListWidget.ListWidget<
+    {
+        id: number;
+        pattern: string;
+        url_template: string;
+    },
+    {
+        id: number;
+        pattern: string;
+        url_template: string;
+    }
+>;
+
 export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
     if (!meta.loaded) {
         return;
     }
 
     const $linkifiers_table = $("#admin_linkifiers_table").expectOne();
-    ListWidget.create($linkifiers_table, linkifiers_data, {
+    linkifiersWidget = ListWidget.create($linkifiers_table, linkifiers_data, {
         name: "linkifiers_list",
         get_item: ListWidget.default_get_item,
         modifier_html(linkifier, filter_value) {
@@ -187,12 +200,20 @@ export function populate_linkifiers(linkifiers_data: RealmLinkifiers): void {
             },
             onupdate() {
                 scroll_util.reset_scrollbar($linkifiers_table);
+                ListWidget.updateActionsColumn(
+                    linkifiersWidget.get_total_rows_to_render(),
+                    "#admin_linkifiers_table_action_column",
+                );
             },
         },
         $parent_container: $("#linkifier-settings").expectOne(),
         $simplebar_container: $("#linkifier-settings .progressive-table-wrapper"),
     });
 
+    ListWidget.updateActionsColumn(
+        linkifiersWidget.get_total_rows_to_render(),
+        "#admin_linkifiers_table_action_column",
+    );
     if (current_user.is_admin) {
         new SortableJS($linkifiers_table[0]!, {
             onUpdate: update_linkifiers_order,

--- a/web/src/settings_streams.ts
+++ b/web/src/settings_streams.ts
@@ -100,13 +100,18 @@ export function maybe_disable_widgets(): void {
         .prop("disabled", true);
 }
 
+let defaultStreamWidget: ListWidget.ListWidget<
+    sub_store.StreamSubscription,
+    Record<"name", string>
+>;
+
 export function build_default_stream_table(): void {
     const $table = $("#admin_default_streams_table").expectOne();
 
     const stream_ids = stream_data.get_default_stream_ids();
     const subs = stream_ids.map((stream_id) => sub_store.get(stream_id)!);
 
-    ListWidget.create($table, subs, {
+    defaultStreamWidget = ListWidget.create($table, subs, {
         name: "default_streams_list",
         get_item: ListWidget.default_get_item,
         modifier_html(item) {
@@ -122,6 +127,10 @@ export function build_default_stream_table(): void {
             },
             onupdate() {
                 scroll_util.reset_scrollbar($table);
+                ListWidget.updateActionsColumn(
+                    defaultStreamWidget.get_total_rows_to_render(),
+                    "#admin_default_streams_table_action_column",
+                );
             },
         },
         $parent_container: $("#admin-default-channels-list").expectOne(),
@@ -131,7 +140,10 @@ export function build_default_stream_table(): void {
         },
         $simplebar_container: $("#admin-default-channels-list .progressive-table-wrapper"),
     });
-
+    ListWidget.updateActionsColumn(
+        defaultStreamWidget.get_total_rows_to_render(),
+        "#admin_default_streams_table_action_column",
+    );
     loading.destroy_indicator($("#admin_page_default_streams_loading_indicator"));
 }
 

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -133,6 +133,10 @@ function add_value_to_filters(section, key, value) {
     // This hard_redraw will rerun the relevant predicate function
     // and in turn apply the new filters.
     section.list_widget.hard_redraw();
+    ListWidget.updateActionsColumn(
+        section.list_widget.get_total_rows_to_render(),
+        "#admin_deactivated_users_table_action_column",
+    );
 }
 
 function role_selected_handler(event, dropdown, widget) {
@@ -394,6 +398,12 @@ section.deactivated.create_table = (deactivated_users) => {
     );
 
     loading.destroy_indicator($("#admin_page_deactivated_users_loading_indicator"));
+
+    ListWidget.updateActionsColumn(
+        section.deactivated.list_widget.get_total_rows_to_render(),
+        "#admin_deactivated_users_table_action_column",
+    );
+
     $("#admin_deactivated_users_table").show();
 };
 
@@ -450,6 +460,10 @@ export function redraw_deactivated_users_list() {
     }
     const deactivated_user_ids = people.get_non_active_human_ids();
     redraw_users_list(section.deactivated, deactivated_user_ids);
+    ListWidget.updateActionsColumn(
+        section.deactivated.list_widget.get_total_rows_to_render(),
+        "#admin_deactivated_users_table_action_column",
+    );
     should_redraw_deactivated_users_list = false;
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -782,6 +782,11 @@ div.overlay {
     .actions {
         width: 1%;
         white-space: nowrap;
+
+        /* When the on-empty-table class is applied, change width to auto */
+        &.on-empty-table {
+            width: auto;
+        }
     }
 
     & th,

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -13,7 +13,7 @@
                 <th class="active upload-date" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
                 <th class="upload-mentioned-in" data-sort="mentioned_in">{{t "Mentioned in" }}</th>
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
-                <th class="upload-actions actions">{{t "Actions" }}</th>
+                <th class="upload-actions actions" id="uploaded_files_table_action_column">{{t "Actions" }}</th>
             </thead>
             <tbody data-empty="{{t 'You have not uploaded any files.' }}" data-search-results-empty="{{t 'No uploaded files match your current filter.' }}" id="uploaded_files_table"></tbody>
         </table>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -19,7 +19,7 @@
                 <th {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}}>{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 {{#if is_admin}}
-                <th class="actions">{{t "Actions" }}</th>
+                <th class="actions" id="admin_deactivated_users_table_action_column">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
             <tbody id="admin_deactivated_users_table" class="admin_user_table"

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -16,7 +16,7 @@
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
                 {{#if is_admin}}
-                <th class="actions">{{t "Actions" }}</th>
+                <th class="actions" id="admin_default_streams_table_action_column">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
             <tbody data-empty="{{t 'There are no default channels.' }}" data-search-results-empty="{{t 'No default channels match your current filter.' }}"

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -21,7 +21,7 @@
                 <th data-sort="numeric" data-sort-prop="invited">{{t "Invited at" }}</th>
                 <th data-sort="numeric" data-sort-prop="expiry_date">{{t "Expires at" }}</th>
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
-                <th class="actions">{{t "Actions" }}</th>
+                <th class="actions" id="admin_invites_table_action_column">{{t "Actions" }}</th>
             </thead>
             <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'There are no invitations.' }}" data-search-results-empty="{{t 'No invitations match your current filter.' }}"></tbody>
         </table>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -68,7 +68,7 @@
                     <th>{{t "Pattern" }}</th>
                     <th>{{t "URL template" }}</th>
                     {{#if is_admin}}
-                    <th class="actions">{{t "Actions" }}</th>
+                    <th class="actions" id="admin_linkifiers_table_action_column">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
                 <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers configured.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>


### PR DESCRIPTION
This pr fixes the issue of sliding of action column of the tables which are using ListWidget to the extreme right when the table is empty. In total 5 such tables were showing this effect and those have been fixed in this issue.

Fixes: #29633 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Deactivated user table:

https://github.com/zulip/zulip/assets/142340063/70e01f64-a764-4f16-ae7f-a39b431b7b09

Invitations table:

![Invitations table](https://github.com/zulip/zulip/assets/142340063/8e6f39ed-9645-4d2b-a725-31009aa9bc9b)

linkifiers table:

![linkifiers table](https://github.com/zulip/zulip/assets/142340063/ff6e610d-f0f5-4af6-ae3d-72f4bf29c9b3)

default channel table:

![default channel table](https://github.com/zulip/zulip/assets/142340063/3431422e-a62c-4b34-89c2-47411981f63b)

uploaded files table:

![uploaded files table](https://github.com/zulip/zulip/assets/142340063/c0c372bf-59c3-4b49-8ad8-739be84ffc73)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
