### PR TITLE
Validate more of state_data using Zod

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -2,6 +2,7 @@ import _ from "lodash";
 
 import type {Message} from "./message_store";
 import * as people from "./people";
+import type {StateData} from "./state_data";
 
 // For simplicity, we use a list for our internal
 // data, since that matches what the server sends us.
@@ -91,6 +92,6 @@ export function notifies(message: Message): boolean {
     return !people.is_current_user(message.sender_email) && message.alerted;
 }
 
-export const initialize = (params: {alert_words: string[]}): void => {
+export const initialize = (params: StateData["alert_words"]): void => {
     set_words(params.alert_words);
 };

--- a/web/src/bot_data.ts
+++ b/web/src/bot_data.ts
@@ -1,6 +1,8 @@
-import {z} from "zod";
+import type {z} from "zod";
 
+import {server_add_bot_schema, server_update_bot_schema, services_schema} from "./bot_types";
 import * as people from "./people";
+import type {StateData} from "./state_data";
 
 export type ServerUpdateBotData = z.infer<typeof server_update_bot_schema>;
 export type ServerAddBotData = z.infer<typeof server_add_bot_schema>;
@@ -8,59 +10,16 @@ export type Bot = Omit<ServerAddBotData, "services">;
 
 export type Services = z.infer<typeof services_schema>;
 
-export type BotDataParams = {
-    realm_bots: ServerAddBotData[];
-};
-
 const bots = new Map<number, Bot>();
 const services = new Map<number, Services>();
-
-// Define zod schema for data validation
-const basic_bot_schema = z.object({
-    api_key: z.string(),
-    avatar_url: z.string(),
-    bot_type: z.number(),
-    default_all_public_streams: z.boolean(),
-    default_events_register_stream: z.string().nullable(),
-    default_sending_stream: z.string().nullable(),
-    email: z.string(),
-    full_name: z.string(),
-    is_active: z.boolean(),
-    owner_id: z.number().nullable(),
-    user_id: z.number(),
-});
-
-const outgoing_service_schema = z.object({
-    base_url: z.string(),
-    interface: z.number(),
-    token: z.string(),
-});
-
-const embedded_service_schema = z.object({
-    config_data: z.record(z.string()),
-    service_name: z.string(),
-});
-
-const services_schema = z.union([
-    z.array(outgoing_service_schema),
-    z.array(embedded_service_schema),
-]);
-
-const server_update_bot_schema = basic_bot_schema.extend({
-    services: services_schema,
-});
-
-const server_add_bot_schema = server_update_bot_schema.extend({
-    bot_type: z.number(),
-    email: z.string(),
-    is_active: z.boolean(),
-});
 
 export function all_user_ids(): number[] {
     return [...bots.keys()];
 }
 
 export function add(bot_data: ServerAddBotData): void {
+    // TODO/typescript: Move validation to the caller when
+    // server_events_dispatch.js is converted to TypeScript.
     const {services: bot_services, ...clean_bot} = server_add_bot_schema.parse(bot_data);
     bots.set(clean_bot.user_id, clean_bot);
 
@@ -74,6 +33,8 @@ export function del(bot_id: number): void {
 
 export function update(bot_id: number, bot_update: ServerUpdateBotData): void {
     const bot = bots.get(bot_id)!;
+    // TODO/typescript: Move validation to the caller when
+    // server_events_dispatch.js is converted to TypeScript.
     Object.assign(bot, server_update_bot_schema.deepPartial().parse(bot_update));
 
     // We currently only support one service per bot.
@@ -125,7 +86,7 @@ export function get_services(bot_id: number): Services | undefined {
     return services.get(bot_id);
 }
 
-export function initialize(params: BotDataParams): void {
+export function initialize(params: StateData["bot"]): void {
     bots.clear();
     for (const bot of params.realm_bots) {
         add(bot);

--- a/web/src/bot_types.ts
+++ b/web/src/bot_types.ts
@@ -1,0 +1,41 @@
+import {z} from "zod";
+
+const basic_bot_schema = z.object({
+    api_key: z.string(),
+    avatar_url: z.string(),
+    bot_type: z.number(),
+    default_all_public_streams: z.boolean(),
+    default_events_register_stream: z.string().nullable(),
+    default_sending_stream: z.string().nullable(),
+    email: z.string(),
+    full_name: z.string(),
+    is_active: z.boolean(),
+    owner_id: z.number().nullable(),
+    user_id: z.number(),
+});
+
+const outgoing_service_schema = z.object({
+    base_url: z.string(),
+    interface: z.number(),
+    token: z.string(),
+});
+
+const embedded_service_schema = z.object({
+    config_data: z.record(z.string()),
+    service_name: z.string(),
+});
+
+export const services_schema = z.union([
+    z.array(outgoing_service_schema),
+    z.array(embedded_service_schema),
+]);
+
+export const server_update_bot_schema = basic_bot_schema.extend({
+    services: services_schema,
+});
+
+export const server_add_bot_schema = server_update_bot_schema.extend({
+    bot_type: z.number(),
+    email: z.string(),
+    is_active: z.boolean(),
+});

--- a/web/src/emoji.ts
+++ b/web/src/emoji.ts
@@ -1,22 +1,13 @@
 import _ from "lodash";
+import type {z} from "zod";
 
 import * as blueslip from "./blueslip";
-import type {User} from "./people";
+import type {StateData, realm_emoji_map_schema, server_emoji_schema} from "./state_data";
 
 // This is the data structure that we get from the server on initialization.
-export type ServerEmoji = {
-    id: string;
-    author_id: number;
-    deactivated: boolean;
-    name: string;
-    source_url: string;
-    still_url: string | null;
+export type ServerEmoji = z.infer<typeof server_emoji_schema>;
 
-    // Added later in `settings_emoji.ts` when setting up the emoji settings.
-    author?: User | null;
-};
-
-type RealmEmojiMap = Record<string, ServerEmoji>;
+type RealmEmojiMap = z.infer<typeof realm_emoji_map_schema>;
 
 // The data the server provides about unicode emojis.
 type ServerUnicodeEmojiData = {
@@ -25,11 +16,6 @@ type ServerUnicodeEmojiData = {
     emoji_catalog: Record<string, string[]>;
     emoticon_conversions: Record<string, string>;
     names: string[];
-};
-
-type EmojiParams = {
-    realm_emoji: RealmEmojiMap;
-    emoji_codes: ServerUnicodeEmojiData;
 };
 
 export type EmoticonTranslation = {
@@ -379,7 +365,9 @@ function build_default_emoji_aliases({
     return map;
 }
 
-export function initialize(params: EmojiParams): void {
+export function initialize(
+    params: StateData["emoji"] & {emoji_codes: ServerUnicodeEmojiData},
+): void {
     emoji_codes = params.emoji_codes;
 
     emoticon_translations = build_emoticon_translations({

--- a/web/src/local_message.ts
+++ b/web/src/local_message.ts
@@ -1,5 +1,6 @@
 import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
+import type {StateData} from "./state_data";
 
 let max_message_id: number;
 
@@ -41,6 +42,6 @@ export const get_next_id_float = (function () {
     };
 })();
 
-export function initialize(params: {max_message_id: number}): void {
+export function initialize(params: StateData["local_message"]): void {
     max_message_id = params.max_message_id;
 }

--- a/web/src/muted_users.ts
+++ b/web/src/muted_users.ts
@@ -1,11 +1,11 @@
+import type {z} from "zod";
+
 import * as channel from "./channel";
+import type {StateData, muted_user_schema} from "./state_data";
 import * as timerender from "./timerender";
 import {get_time_from_date_muted} from "./util";
 
-export type RawMutedUser = {
-    id: number;
-    timestamp: number;
-};
+export type RawMutedUser = z.infer<typeof muted_user_schema>;
 
 type MutedUser = {
     id: number;
@@ -81,6 +81,6 @@ export function unmute_user(user_id: number): void {
     });
 }
 
-export function initialize(params: {muted_users: RawMutedUser[]}): void {
+export function initialize(params: StateData["muted_users"]): void {
     set_muted_users(params.muted_users);
 }

--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -1,19 +1,8 @@
-import {z} from "zod";
+import type {z} from "zod";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
-
-const one_time_notice_schema = z.object({
-    name: z.string(),
-    type: z.literal("one_time_notice"),
-});
-
-/* We may introduce onboarding step of types other than 'one time notice'
-in future. Earlier, we had 'hotspot' and 'one time notice' as the two
-types. We can simply do:
-const onboarding_step_schema = z.union([one_time_notice_schema, other_type_schema]);
-to avoid major refactoring when new type is introduced in the future. */
-const onboarding_step_schema = one_time_notice_schema;
+import type {StateData, onboarding_step_schema} from "./state_data";
 
 export type OnboardingStep = z.output<typeof onboarding_step_schema>;
 
@@ -45,6 +34,6 @@ export function update_onboarding_steps_to_display(onboarding_steps: OnboardingS
     }
 }
 
-export function initialize(params: {onboarding_steps: OnboardingStep[]}): void {
+export function initialize(params: StateData["onboarding_steps"]): void {
     update_onboarding_steps_to_display(params.onboarding_steps);
 }

--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -2,6 +2,7 @@ import {FoldDict} from "./fold_dict";
 import type {Message} from "./message_store";
 import * as muted_users from "./muted_users";
 import * as people from "./people";
+import type {StateData} from "./state_data";
 
 type PMConversation = {
     user_ids_string: string;
@@ -89,12 +90,7 @@ class RecentDirectMessages {
             .map((conversation) => conversation.user_ids_string);
     }
 
-    initialize(params: {
-        recent_private_conversations: {
-            max_message_id: number;
-            user_ids: number[];
-        }[];
-    }): void {
+    initialize(params: StateData["pm_conversations"]): void {
         for (const conversation of params.recent_private_conversations) {
             this.insert(conversation.user_ids, conversation.max_message_id);
         }

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -178,7 +178,7 @@ export function update_info_from_event(
 export function set_info(
     presences: Record<number, Omit<RawPresence, "server_timestamp">>,
     server_timestamp: number,
-    last_update_id: number,
+    last_update_id = -1,
 ): void {
     /*
         Example `presences` data:
@@ -297,7 +297,7 @@ export function last_active_date(user_id: number): Date | undefined {
 export function initialize(params: {
     presences: Record<number, Omit<RawPresence, "server_timestamp">>;
     server_timestamp: number;
-    presence_last_update_id: number;
+    presence_last_update_id: number | undefined;
 }): void {
     set_info(params.presences, params.server_timestamp, params.presence_last_update_id);
 }

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -1,11 +1,12 @@
+import type {z} from "zod";
+
 import * as people from "./people";
+import type {StateData, presence_schema} from "./state_data";
 import {realm} from "./state_data";
 import {user_settings} from "./user_settings";
 
-export type RawPresence = {
+export type RawPresence = z.infer<typeof presence_schema> & {
     server_timestamp: number;
-    active_timestamp?: number | undefined;
-    idle_timestamp?: number | undefined;
 };
 
 export type PresenceStatus = {
@@ -176,7 +177,7 @@ export function update_info_from_event(
 }
 
 export function set_info(
-    presences: Record<number, Omit<RawPresence, "server_timestamp">>,
+    presences: Record<number, z.infer<typeof presence_schema>>,
     server_timestamp: number,
     last_update_id = -1,
 ): void {
@@ -294,10 +295,6 @@ export function last_active_date(user_id: number): Date | undefined {
     return new Date(info.last_active * 1000);
 }
 
-export function initialize(params: {
-    presences: Record<number, Omit<RawPresence, "server_timestamp">>;
-    server_timestamp: number;
-    presence_last_update_id: number | undefined;
-}): void {
+export function initialize(params: StateData["presence"]): void {
     set_info(params.presences, params.server_timestamp, params.presence_last_update_id);
 }

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -4,8 +4,8 @@ import {page_params} from "./base_page_params";
 import {$t, $t_html} from "./i18n";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults";
 import {realm} from "./state_data";
+import {StreamPostPolicy} from "./stream_types";
 import type {StreamSpecificNotificationSettings} from "./sub_store";
-import {StreamPostPolicy} from "./sub_store";
 import type {
     FollowedTopicNotificationSettings,
     PmNotificationSettings,

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -152,6 +152,22 @@ export const muted_user_schema = z.object({
     timestamp: z.number(),
 });
 
+const unread_stream_info_schema = z.object({
+    stream_id: z.number(),
+    topic: z.string(),
+    unread_message_ids: z.array(z.number()),
+});
+
+export const unread_direct_message_info_schema = z.object({
+    other_user_id: z.number(),
+    unread_message_ids: z.array(z.number()),
+});
+
+export const unread_direct_message_group_info_schema = z.object({
+    user_ids_string: z.string(),
+    unread_message_ids: z.array(z.number()),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -405,7 +421,20 @@ export const state_data_schema = z
             .object({realm_user_groups: z.array(user_group_schema)})
             .transform((user_groups) => ({user_groups})),
     )
-    .and(z.object({unread_msgs: NOT_TYPED_YET}).transform((unread) => ({unread})))
+    .and(
+        z
+            .object({
+                unread_msgs: z.object({
+                    pms: z.array(unread_direct_message_info_schema),
+                    streams: z.array(unread_stream_info_schema),
+                    huddles: z.array(unread_direct_message_group_info_schema),
+                    mentions: z.array(z.number()),
+                    count: z.number(),
+                    old_unreads_missing: z.boolean(),
+                }),
+            })
+            .transform((unread) => ({unread})),
+    )
     .and(
         z
             .object({muted_users: z.array(muted_user_schema)})

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -174,6 +174,18 @@ export const presence_schema = z.object({
     idle_timestamp: z.number().optional(),
 });
 
+const one_time_notice_schema = z.object({
+    name: z.string(),
+    type: z.literal("one_time_notice"),
+});
+
+/* We may introduce onboarding step of types other than 'one time notice'
+in future. Earlier, we had 'hotspot' and 'one time notice' as the two
+types. We can simply do:
+const onboarding_step_schema = z.union([one_time_notice_schema, other_type_schema]);
+to avoid major refactoring when new type is introduced in the future. */
+export const onboarding_step_schema = one_time_notice_schema;
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -484,7 +496,7 @@ export const state_data_schema = z
     .and(z.object({max_message_id: z.number()}).transform((local_message) => ({local_message})))
     .and(
         z
-            .object({onboarding_steps: NOT_TYPED_YET})
+            .object({onboarding_steps: z.array(onboarding_step_schema)})
             .transform((onboarding_steps) => ({onboarding_steps})),
     )
     .and(current_user_schema.transform((current_user) => ({current_user})))

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -139,6 +139,13 @@ export const user_group_schema = z.object({
     can_mention_group: z.number(),
 });
 
+export const user_topic_schema = z.object({
+    stream_id: z.number(),
+    topic_name: z.string(),
+    last_updated: z.number(),
+    visibility_policy: z.number(),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -394,7 +401,11 @@ export const state_data_schema = z
     )
     .and(z.object({unread_msgs: NOT_TYPED_YET}).transform((unread) => ({unread})))
     .and(z.object({muted_users: NOT_TYPED_YET}).transform((muted_users) => ({muted_users})))
-    .and(z.object({user_topics: NOT_TYPED_YET}).transform((user_topics) => ({user_topics})))
+    .and(
+        z
+            .object({user_topics: z.array(user_topic_schema)})
+            .transform((user_topics) => ({user_topics})),
+    )
     .and(z.object({user_status: NOT_TYPED_YET}).transform((user_status) => ({user_status})))
     .and(
         z

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -7,6 +7,7 @@ import {
     stream_subscription_schema,
 } from "./stream_types";
 import {user_settings_schema} from "./user_settings";
+import {user_status_schema} from "./user_status_types";
 
 const NOT_TYPED_YET = z.unknown();
 
@@ -415,7 +416,11 @@ export const state_data_schema = z
             .object({user_topics: z.array(user_topic_schema)})
             .transform((user_topics) => ({user_topics})),
     )
-    .and(z.object({user_status: NOT_TYPED_YET}).transform((user_status) => ({user_status})))
+    .and(
+        z
+            .object({user_status: z.record(user_status_schema)})
+            .transform((user_status) => ({user_status})),
+    )
     .and(
         z
             .object({user_settings: user_settings_schema})

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -124,6 +124,16 @@ export const server_emoji_schema = z.object({
 
 export const realm_emoji_map_schema = z.record(server_emoji_schema);
 
+export const user_group_schema = z.object({
+    description: z.string(),
+    id: z.number(),
+    name: z.string(),
+    members: z.array(z.number()),
+    is_system_group: z.boolean(),
+    direct_subgroup_ids: z.array(z.number()),
+    can_mention_group: z.number(),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -365,7 +375,11 @@ export const state_data_schema = z
             })
             .transform((stream_data) => ({stream_data})),
     )
-    .and(z.object({realm_user_groups: NOT_TYPED_YET}).transform((user_groups) => ({user_groups})))
+    .and(
+        z
+            .object({realm_user_groups: z.array(user_group_schema)})
+            .transform((user_groups) => ({user_groups})),
+    )
     .and(z.object({unread_msgs: NOT_TYPED_YET}).transform((unread) => ({unread})))
     .and(z.object({muted_users: NOT_TYPED_YET}).transform((muted_users) => ({muted_users})))
     .and(z.object({user_topics: NOT_TYPED_YET}).transform((user_topics) => ({user_topics})))

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -169,6 +169,11 @@ export const unread_direct_message_group_info_schema = z.object({
     unread_message_ids: z.array(z.number()),
 });
 
+export const presence_schema = z.object({
+    active_timestamp: z.number().optional(),
+    idle_timestamp: z.number().optional(),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -396,9 +401,9 @@ export const state_data_schema = z
     .and(
         z
             .object({
-                presences: NOT_TYPED_YET,
-                server_timestamp: NOT_TYPED_YET,
-                presence_last_update_id: NOT_TYPED_YET,
+                presences: z.record(z.coerce.number(), presence_schema),
+                server_timestamp: z.number(),
+                presence_last_update_id: z.number().optional(),
             })
             .transform((presence) => ({presence})),
     )

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -409,7 +409,7 @@ export const state_data_schema = z
             })
             .transform((server_events) => ({server_events})),
     )
-    .and(z.object({max_message_id: NOT_TYPED_YET}).transform((local_message) => ({local_message})))
+    .and(z.object({max_message_id: z.number()}).transform((local_message) => ({local_message})))
     .and(
         z
             .object({onboarding_steps: NOT_TYPED_YET})

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -353,7 +353,14 @@ export const state_data_schema = z
     )
     .and(
         z
-            .object({recent_private_conversations: NOT_TYPED_YET})
+            .object({
+                recent_private_conversations: z.array(
+                    z.object({
+                        max_message_id: z.number(),
+                        user_ids: z.array(z.number()),
+                    }),
+                ),
+            })
             .transform((pm_conversations) => ({pm_conversations})),
     )
     .and(

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -146,6 +146,11 @@ export const user_topic_schema = z.object({
     visibility_policy: z.number(),
 });
 
+export const muted_user_schema = z.object({
+    id: z.number(),
+    timestamp: z.number(),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -400,7 +405,11 @@ export const state_data_schema = z
             .transform((user_groups) => ({user_groups})),
     )
     .and(z.object({unread_msgs: NOT_TYPED_YET}).transform((unread) => ({unread})))
-    .and(z.object({muted_users: NOT_TYPED_YET}).transform((muted_users) => ({muted_users})))
+    .and(
+        z
+            .object({muted_users: z.array(muted_user_schema)})
+            .transform((muted_users) => ({muted_users})),
+    )
     .and(
         z
             .object({user_topics: z.array(user_topic_schema)})

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -1,5 +1,6 @@
 import {z} from "zod";
 
+import {server_add_bot_schema} from "./bot_types";
 import {realm_default_settings_schema} from "./realm_user_settings_defaults";
 import {
     never_subscribed_stream_schema,
@@ -370,7 +371,7 @@ export const state_data_schema = z
     .object({alert_words: z.array(z.string())})
     .transform((alert_words) => ({alert_words}))
     .and(z.object({realm_emoji: realm_emoji_map_schema}).transform((emoji) => ({emoji})))
-    .and(z.object({realm_bots: NOT_TYPED_YET}).transform((bot) => ({bot})))
+    .and(z.object({realm_bots: z.array(server_add_bot_schema)}).transform((bot) => ({bot})))
     .and(
         z
             .object({

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -333,7 +333,7 @@ const realm_schema = z.object({
 });
 
 export const state_data_schema = z
-    .object({alert_words: NOT_TYPED_YET})
+    .object({alert_words: z.array(z.string())})
     .transform((alert_words) => ({alert_words}))
     .and(z.object({realm_emoji: realm_emoji_map_schema}).transform((emoji) => ({emoji})))
     .and(z.object({realm_bots: NOT_TYPED_YET}).transform((bot) => ({bot})))

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -1,6 +1,11 @@
 import {z} from "zod";
 
 import {realm_default_settings_schema} from "./realm_user_settings_defaults";
+import {
+    never_subscribed_stream_schema,
+    stream_schema,
+    stream_subscription_schema,
+} from "./stream_types";
 import {user_settings_schema} from "./user_settings";
 
 const NOT_TYPED_YET = z.unknown();
@@ -368,10 +373,10 @@ export const state_data_schema = z
     .and(
         z
             .object({
-                subscriptions: NOT_TYPED_YET,
-                unsubscribed: NOT_TYPED_YET,
-                never_subscribed: NOT_TYPED_YET,
-                realm_default_streams: NOT_TYPED_YET,
+                subscriptions: z.array(stream_subscription_schema),
+                unsubscribed: z.array(stream_subscription_schema),
+                never_subscribed: z.array(never_subscribed_stream_schema),
+                realm_default_streams: z.array(stream_schema),
             })
             .transform((stream_data) => ({stream_data})),
     )

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -110,6 +110,20 @@ export const cross_realm_bot_schema = user_schema.and(
     }),
 );
 
+export const server_emoji_schema = z.object({
+    id: z.string(),
+    author_id: z.number(),
+    deactivated: z.boolean(),
+    name: z.string(),
+    source_url: z.string(),
+    still_url: z.string().nullable(),
+
+    // Added later in `settings_emoji.ts` when setting up the emoji settings.
+    author: user_schema.nullish(),
+});
+
+export const realm_emoji_map_schema = z.record(server_emoji_schema);
+
 // Sync this with zerver.lib.events.do_events_register.
 const current_user_schema = z.object({
     avatar_source: z.string(),
@@ -311,7 +325,7 @@ const realm_schema = z.object({
 export const state_data_schema = z
     .object({alert_words: NOT_TYPED_YET})
     .transform((alert_words) => ({alert_words}))
-    .and(z.object({realm_emoji: NOT_TYPED_YET}).transform((emoji) => ({emoji})))
+    .and(z.object({realm_emoji: realm_emoji_map_schema}).transform((emoji) => ({emoji})))
     .and(z.object({realm_bots: NOT_TYPED_YET}).transform((bot) => ({bot})))
     .and(
         z

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -7,26 +7,20 @@ import type {User} from "./people";
 import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
+import type {StateData} from "./state_data";
 import {current_user, realm} from "./state_data";
+import type {StreamPostPolicy} from "./stream_types";
 import * as sub_store from "./sub_store";
 import type {
     ApiStreamSubscription,
     NeverSubscribedStream,
     Stream,
-    StreamPostPolicy,
     StreamSpecificNotificationSettings,
     StreamSubscription,
 } from "./sub_store";
 import * as user_groups from "./user_groups";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
-
-type StreamInitParams = {
-    subscriptions: ApiStreamSubscription[];
-    unsubscribed: ApiStreamSubscription[];
-    never_subscribed: NeverSubscribedStream[];
-    realm_default_streams: Stream[];
-};
 
 // Type for the parameter of `create_sub_from_server_data` function.
 type ApiGenericStreamSubscription =
@@ -834,7 +828,7 @@ export function get_new_stream_announcements_stream(): string {
     return "";
 }
 
-export function initialize(params: StreamInitParams): void {
+export function initialize(params: StateData["stream_data"]): void {
     /*
         We get `params` data, which is data that we "own"
         and which has already been removed from `state_data`.

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -1,0 +1,57 @@
+import {z} from "zod";
+
+export const enum StreamPostPolicy {
+    EVERYONE = 1,
+    ADMINS = 2,
+    RESTRICT_NEW_MEMBERS = 3,
+    MODERATORS = 4,
+}
+
+// These types are taken from the `zerver/lib/types.py`.
+export const stream_schema = z.object({
+    creator_id: z.number().nullable(),
+    date_created: z.number(),
+    description: z.string(),
+    first_message_id: z.number().nullable(),
+    history_public_to_subscribers: z.boolean(),
+    invite_only: z.boolean(),
+    is_announcement_only: z.boolean(),
+    is_web_public: z.boolean(),
+    message_retention_days: z.number().nullable(),
+    name: z.string(),
+    rendered_description: z.string(),
+    stream_id: z.number(),
+    stream_post_policy: z.nativeEnum({
+        EVERYONE: StreamPostPolicy.EVERYONE,
+        ADMINS: StreamPostPolicy.ADMINS,
+        RESTRICT_NEW_MEMBERS: StreamPostPolicy.RESTRICT_NEW_MEMBERS,
+        MODERATORS: StreamPostPolicy.MODERATORS,
+    }),
+    can_remove_subscribers_group: z.number(),
+});
+
+export const stream_specific_notification_settings_schema = z.object({
+    audible_notifications: z.boolean().nullable(),
+    desktop_notifications: z.boolean().nullable(),
+    email_notifications: z.boolean().nullable(),
+    push_notifications: z.boolean().nullable(),
+    wildcard_mentions_notify: z.boolean().nullable(),
+});
+
+export const never_subscribed_stream_schema = stream_schema.extend({
+    stream_weekly_traffic: z.number().nullable(),
+    subscribers: z.array(z.number()).optional(),
+});
+
+export const stream_properties_schema = stream_specific_notification_settings_schema.extend({
+    color: z.string(),
+    is_muted: z.boolean(),
+    pin_to_top: z.boolean(),
+});
+
+// This is the raw data we get from the server for a subscription.
+export const stream_subscription_schema = stream_schema.merge(stream_properties_schema).extend({
+    email_address: z.string().optional(),
+    stream_weekly_traffic: z.number().nullable(),
+    subscribers: z.array(z.number()).optional(),
+});

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -48,7 +48,7 @@ export type StreamProperties = StreamSpecificNotificationSettings & {
 
 // This is the raw data we get from the server for a subscription.
 export type ApiStreamSubscription = (Stream & StreamProperties) & {
-    email_address: string;
+    email_address?: string;
     stream_weekly_traffic: number | null;
     subscribers?: number[];
 };

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -1,57 +1,23 @@
+import type {z} from "zod";
+
 import * as blueslip from "./blueslip";
+import type {
+    never_subscribed_stream_schema,
+    stream_properties_schema,
+    stream_schema,
+    stream_specific_notification_settings_schema,
+    stream_subscription_schema,
+} from "./stream_types";
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 
-export const enum StreamPostPolicy {
-    EVERYONE = 1,
-    ADMINS = 2,
-    RESTRICT_NEW_MEMBERS = 3,
-    MODERATORS = 4,
-}
-
-// These types are taken from the `zerver/lib/types.py`.
-export type Stream = {
-    creator_id: number | null;
-    date_created: number;
-    description: string;
-    first_message_id: number | null;
-    history_public_to_subscribers: boolean;
-    invite_only: boolean;
-    is_announcement_only: boolean;
-    is_web_public: boolean;
-    message_retention_days: number | null;
-    name: string;
-    rendered_description: string;
-    stream_id: number;
-    stream_post_policy: StreamPostPolicy;
-    can_remove_subscribers_group: number;
-};
-
-export type StreamSpecificNotificationSettings = {
-    audible_notifications: boolean | null;
-    desktop_notifications: boolean | null;
-    email_notifications: boolean | null;
-    push_notifications: boolean | null;
-    wildcard_mentions_notify: boolean | null;
-};
-
-export type NeverSubscribedStream = Stream & {
-    stream_weekly_traffic: number | null;
-    subscribers?: number[];
-};
-
-export type StreamProperties = StreamSpecificNotificationSettings & {
-    color: string;
-    is_muted: boolean;
-    pin_to_top: boolean;
-};
-
-// This is the raw data we get from the server for a subscription.
-export type ApiStreamSubscription = (Stream & StreamProperties) & {
-    email_address?: string;
-    stream_weekly_traffic: number | null;
-    subscribers?: number[];
-};
+export type Stream = z.infer<typeof stream_schema>;
+export type StreamSpecificNotificationSettings = z.infer<
+    typeof stream_specific_notification_settings_schema
+>;
+export type NeverSubscribedStream = z.infer<typeof never_subscribed_stream_schema>;
+export type StreamProperties = z.infer<typeof stream_properties_schema>;
+export type ApiStreamSubscription = z.infer<typeof stream_subscription_schema>;
 
 // These properties are added in `stream_data` when hydrating the streams and are not present in the data we get from the server.
 export type ExtraStreamAttrs = {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -467,7 +467,7 @@ export function initialize_everything(state_data) {
     // The emoji module must be initialized before the right sidebar
     // module, so that we can display custom emoji in statuses.
     emoji.initialize({
-        realm_emoji: state_data.emoji.realm_emoji,
+        ...state_data.emoji,
         emoji_codes: generated_emoji_codes,
     });
 

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -1067,8 +1067,6 @@ type UnreadStreamInfo = {
 
 type UnreadDirectMessageInfo = {
     other_user_id: number;
-    // Deprecated and misleading synonym for other_user_id
-    sender_id: number;
     unread_message_ids: number[];
 };
 

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -1,3 +1,5 @@
+import type {z} from "zod";
+
 import * as blueslip from "./blueslip";
 import {FoldDict} from "./fold_dict";
 import * as message_store from "./message_store";
@@ -5,6 +7,11 @@ import type {Message} from "./message_store";
 import * as people from "./people";
 import * as recent_view_util from "./recent_view_util";
 import * as settings_config from "./settings_config";
+import type {
+    StateData,
+    unread_direct_message_group_info_schema,
+    unread_direct_message_info_schema,
+} from "./state_data";
 import * as stream_data from "./stream_data";
 import type {TopicHistoryEntry} from "./stream_topic_history";
 import * as sub_store from "./sub_store";
@@ -1059,34 +1066,10 @@ export function get_msg_ids_for_starred(): number[] {
     return [];
 }
 
-type UnreadStreamInfo = {
-    stream_id: number;
-    topic: string;
-    unread_message_ids: number[];
-};
+type UnreadDirectMessageInfo = z.infer<typeof unread_direct_message_info_schema>;
+type UnreadDirectMessageGroupInfo = z.infer<typeof unread_direct_message_group_info_schema>;
 
-type UnreadDirectMessageInfo = {
-    other_user_id: number;
-    unread_message_ids: number[];
-};
-
-type UnreadDirectMessageGroupInfo = {
-    user_ids_string: string;
-    unread_message_ids: number[];
-};
-
-type UnreadMessagesParams = {
-    unread_msgs: {
-        pms: UnreadDirectMessageInfo[];
-        streams: UnreadStreamInfo[];
-        huddles: UnreadDirectMessageGroupInfo[];
-        mentions: number[];
-        count: number;
-        old_unreads_missing: boolean;
-    };
-};
-
-export function initialize(params: UnreadMessagesParams): void {
+export function initialize(params: StateData["unread"]): void {
     const unread_msgs = params.unread_msgs;
 
     old_unreads_missing = unread_msgs.old_unreads_missing;

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -1,26 +1,21 @@
+import type {z} from "zod";
+
 import * as blueslip from "./blueslip";
 import {FoldDict} from "./fold_dict";
 import * as group_permission_settings from "./group_permission_settings";
 import * as settings_config from "./settings_config";
+import type {StateData, user_group_schema} from "./state_data";
 import {current_user} from "./state_data";
 import type {UserOrMention} from "./typeahead_helper";
 import type {UserGroupUpdateEvent} from "./types";
 
-export type UserGroup = {
-    description: string;
-    id: number;
-    name: string;
-    members: Set<number>;
-    is_system_group: boolean;
-    direct_subgroup_ids: Set<number>;
-    can_mention_group: number;
-};
+type UserGroupRaw = z.infer<typeof user_group_schema>;
 
 // The members field is a number array which we convert
 // to a Set in the initialize function.
-type UserGroupRaw = Omit<UserGroup, "members" | "direct_subgroup_ids"> & {
-    members: number[];
-    direct_subgroup_ids: number[];
+export type UserGroup = Omit<UserGroupRaw, "members" | "direct_subgroup_ids"> & {
+    members: Set<number>;
+    direct_subgroup_ids: Set<number>;
 };
 
 type UserGroupForDropdownListWidget = {
@@ -168,7 +163,7 @@ export function remove_subgroups(user_group_id: number, subgroup_ids: number[]):
     }
 }
 
-export function initialize(params: {realm_user_groups: UserGroupRaw[]}): void {
+export function initialize(params: StateData["user_groups"]): void {
     for (const user_group of params.realm_user_groups) {
         add(user_group);
     }

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -18,7 +18,10 @@ export type UserGroup = {
 
 // The members field is a number array which we convert
 // to a Set in the initialize function.
-type UserGroupRaw = Omit<UserGroup, "members"> & {members: number[]};
+type UserGroupRaw = Omit<UserGroup, "members" | "direct_subgroup_ids"> & {
+    members: number[];
+    direct_subgroup_ids: number[];
+};
 
 type UserGroupForDropdownListWidget = {
     name: string;

--- a/web/src/user_status.ts
+++ b/web/src/user_status.ts
@@ -3,29 +3,14 @@ import {z} from "zod";
 import * as channel from "./channel";
 import * as emoji from "./emoji";
 import type {EmojiRenderingDetails} from "./emoji";
+import type {StateData} from "./state_data";
 import {user_settings} from "./user_settings";
+import {user_status_schema} from "./user_status_types";
 
 export type UserStatus = z.infer<typeof user_status_schema>;
 export type UserStatusEmojiInfo = EmojiRenderingDetails & {
     emoji_alt_code?: boolean;
 };
-
-const user_status_schema = z.intersection(
-    z.object({
-        status_text: z.string().optional(),
-        away: z.boolean().optional(),
-    }),
-    z.union([
-        z.object({
-            emoji_name: z.string(),
-            emoji_code: z.string(),
-            reaction_type: z.enum(["zulip_extra_emoji", "realm_emoji", "unicode_emoji"]),
-        }),
-        z.object({
-            emoji_name: z.undefined(),
-        }),
-    ]),
-);
 
 const user_status_event_schema = z.intersection(
     z.object({
@@ -37,8 +22,6 @@ const user_status_event_schema = z.intersection(
 );
 
 export type UserStatusEvent = z.infer<typeof user_status_event_schema>;
-
-const user_status_param_schema = z.record(z.string(), user_status_schema);
 
 const user_info = new Map<number, string>();
 const user_status_emoji_info = new Map<number, UserStatusEmojiInfo>();
@@ -102,6 +85,8 @@ export function get_status_emoji(user_id: number): UserStatusEmojiInfo | undefin
 }
 
 export function set_status_emoji(event: UserStatusEvent): void {
+    // TODO/typescript: Move validation to the caller when
+    // server_events_dispatch.js is converted to TypeScript.
     const opts = user_status_event_schema.parse(event);
 
     if (!opts.emoji_name) {
@@ -119,12 +104,10 @@ export function set_status_emoji(event: UserStatusEvent): void {
     });
 }
 
-export function initialize(params: {user_status: unknown}): void {
+export function initialize(params: StateData["user_status"]): void {
     user_info.clear();
 
-    const user_status = user_status_param_schema.parse(params.user_status);
-
-    for (const [str_user_id, dct] of Object.entries(user_status)) {
+    for (const [str_user_id, dct] of Object.entries(params.user_status)) {
         // JSON does not allow integer keys, so we
         // convert them here.
         const user_id = Number.parseInt(str_user_id, 10);

--- a/web/src/user_status_types.ts
+++ b/web/src/user_status_types.ts
@@ -1,0 +1,18 @@
+import {z} from "zod";
+
+export const user_status_schema = z.intersection(
+    z.object({
+        status_text: z.string().optional(),
+        away: z.boolean().optional(),
+    }),
+    z.union([
+        z.object({
+            emoji_name: z.string(),
+            emoji_code: z.string(),
+            reaction_type: z.enum(["zulip_extra_emoji", "realm_emoji", "unicode_emoji"]),
+        }),
+        z.object({
+            emoji_name: z.undefined(),
+        }),
+    ]),
+);

--- a/web/src/user_topics.ts
+++ b/web/src/user_topics.ts
@@ -31,7 +31,6 @@ const user_topic_schema = z.object({
     topic_name: z.string(),
     last_updated: z.number(),
     visibility_policy: z.number(),
-    stream__name: z.string().optional(),
 });
 
 const all_user_topics = new Map<

--- a/web/src/user_topics.ts
+++ b/web/src/user_topics.ts
@@ -1,4 +1,4 @@
-import {z} from "zod";
+import type {z} from "zod";
 
 import render_topic_muted from "../templates/topic_muted.hbs";
 
@@ -10,6 +10,7 @@ import {FoldDict} from "./fold_dict";
 import {$t} from "./i18n";
 import * as loading from "./loading";
 import * as settings_ui from "./settings_ui";
+import type {StateData, user_topic_schema} from "./state_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
@@ -25,13 +26,6 @@ export type UserTopic = {
     date_updated_str: string;
     visibility_policy: number;
 };
-
-const user_topic_schema = z.object({
-    stream_id: z.number(),
-    topic_name: z.string(),
-    last_updated: z.number(),
-    visibility_policy: z.number(),
-});
 
 const all_user_topics = new Map<
     number,
@@ -233,8 +227,6 @@ export function set_user_topics(user_topics: ServerUserTopic[]): void {
     }
 }
 
-export function initialize(params: {user_topics: ServerUserTopic[]}): void {
-    const user_topics = user_topic_schema.array().parse(params.user_topics);
-
-    set_user_topics(user_topics);
+export function initialize(params: StateData["user_topics"]): void {
+    set_user_topics(params.user_topics);
 }


### PR DESCRIPTION
- Followup to #30519.

This validates everything from `state_data` except the part for `server_events.js` and the parts of `current_user` and `realm` not yet used from TypeScript.