### PR TITLE
`stream_edit_subscribers`: Fix incorrect error result test, rename misleading variable

### DIFF
--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -248,16 +248,13 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
 
         const failure_response_schema = z
             .object({
+                result: z.literal("error"),
                 msg: z.string(),
                 code: z.string(),
-                result: z.string(),
             })
             .safeParse(xhr.responseJSON);
 
-        if (
-            failure_response_schema.success &&
-            failure_response_schema.data.code === "BAD_REQUEST"
-        ) {
+        if (failure_response_schema.success) {
             message = failure_response_schema.data.msg;
         }
         show_stream_subscription_request_result({

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -246,7 +246,7 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
     function invite_failure(xhr: JQuery.jqXHR): void {
         let message = "Failed to subscribe user!";
 
-        const failure_response_schema = z
+        const parsed = z
             .object({
                 result: z.literal("error"),
                 msg: z.string(),
@@ -254,8 +254,8 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
             })
             .safeParse(xhr.responseJSON);
 
-        if (failure_response_schema.success) {
-            message = failure_response_schema.data.msg;
+        if (parsed.success) {
+            message = parsed.data.msg;
         }
         show_stream_subscription_request_result({
             message,


### PR DESCRIPTION
`.safeParse` does not return a “schema”.