### PR TITLE
giphy: Split `is_giphy_enabled` to a separate module

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -112,6 +112,7 @@ EXEMPT_FILES = make_set(
         "web/src/flatpickr.ts",
         "web/src/gear_menu.js",
         "web/src/giphy.js",
+        "web/src/giphy_state.ts",
         "web/src/global.ts",
         "web/src/hash_util.ts",
         "web/src/hashchange.js",

--- a/web/src/compose_popovers.js
+++ b/web/src/compose_popovers.js
@@ -5,7 +5,7 @@ import render_compose_control_buttons_popover from "../templates/popovers/compos
 import render_mobile_message_buttons_popover from "../templates/popovers/mobile_message_buttons_popover.hbs";
 
 import * as compose_actions from "./compose_actions";
-import * as giphy from "./giphy";
+import * as giphy_state from "./giphy_state";
 import * as narrow_state from "./narrow_state";
 import * as popover_menus from "./popover_menus";
 import * as popovers from "./popovers";
@@ -80,7 +80,7 @@ export function initialize() {
             instance.setContent(
                 parse_html(
                     render_compose_control_buttons_popover({
-                        giphy_enabled: giphy.is_giphy_enabled(),
+                        giphy_enabled: giphy_state.is_giphy_enabled(),
                         preview_mode_on,
                         inside_popover: true,
                     }),

--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -26,13 +26,6 @@ export function focus_current_edit_message() {
     $(`#edit_form_${CSS.escape(edit_message_id)} .message_edit_content`).trigger("focus");
 }
 
-export function is_giphy_enabled() {
-    return (
-        realm.giphy_api_key !== "" &&
-        realm.realm_giphy_rating !== realm.giphy_rating_options.disabled.id
-    );
-}
-
 export function update_giphy_rating() {
     if (
         realm.realm_giphy_rating === realm.giphy_rating_options.disabled.id ||

--- a/web/src/giphy_state.ts
+++ b/web/src/giphy_state.ts
@@ -1,0 +1,8 @@
+import {realm} from "./state_data";
+
+export function is_giphy_enabled(): boolean {
+    return (
+        realm.giphy_api_key !== "" &&
+        realm.realm_giphy_rating !== realm.giphy_rating_options.disabled.id
+    );
+}

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -27,7 +27,7 @@ import {show_copied_confirmation} from "./copied_tooltip";
 import * as dialog_widget from "./dialog_widget";
 import * as echo from "./echo";
 import * as feedback_widget from "./feedback_widget";
-import * as giphy from "./giphy";
+import * as giphy_state from "./giphy_state";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
@@ -471,7 +471,7 @@ function edit_message($row, raw_content) {
             is_editable,
             content: raw_content,
             file_upload_enabled,
-            giphy_enabled: giphy.is_giphy_enabled(),
+            giphy_enabled: giphy_state.is_giphy_enabled(),
             minutes_to_edit: Math.floor(realm.realm_message_content_edit_limit_seconds / 60),
             max_message_length: realm.max_message_length,
         }),

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -223,8 +223,10 @@ const realm_schema = z.object({
         PRONOUNS: z.object({id: z.number(), name: z.string()}),
     }),
     demo_organization_scheduled_deletion_date: z.optional(z.number()),
-    giphy_api_key: NOT_TYPED_YET,
-    giphy_rating_options: NOT_TYPED_YET,
+    giphy_api_key: z.string(),
+    giphy_rating_options: z
+        .record(z.object({id: z.number(), name: z.string()}))
+        .and(z.object({disabled: z.object({id: z.number(), name: z.string()})})),
     max_avatar_file_size_mib: z.number(),
     max_file_upload_size_mib: z.number(),
     max_icon_file_size_mib: z.number(),
@@ -291,7 +293,7 @@ const realm_schema = z.object({
     realm_enable_guest_user_indicator: z.boolean(),
     realm_enable_read_receipts: NOT_TYPED_YET,
     realm_enable_spectator_access: z.boolean(),
-    realm_giphy_rating: NOT_TYPED_YET,
+    realm_giphy_rating: z.number(),
     realm_icon_source: z.string(),
     realm_icon_url: z.string(),
     realm_incoming_webhook_bots: z.array(

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -46,6 +46,7 @@ import * as emoji_picker from "./emoji_picker";
 import * as emojisets from "./emojisets";
 import * as gear_menu from "./gear_menu";
 import * as giphy from "./giphy";
+import * as giphy_state from "./giphy_state";
 import * as hashchange from "./hashchange";
 import * as hotkey from "./hotkey";
 import * as i18n from "./i18n";
@@ -178,7 +179,7 @@ function initialize_compose_box() {
             render_compose({
                 embedded: $("#compose").attr("data-embedded") === "",
                 file_upload_enabled: realm.max_file_upload_size_mib > 0 && upload.feature_check(),
-                giphy_enabled: giphy.is_giphy_enabled(),
+                giphy_enabled: giphy_state.is_giphy_enabled(),
                 max_stream_name_length: realm.max_stream_name_length,
                 max_topic_length: realm.max_topic_length,
                 max_message_length: realm.max_message_length,


### PR DESCRIPTION
This removes `giphy` from the critical path of the TypeScript migration.

![](https://github.com/zulip/zulip/assets/26471/e2b8cd40-5765-4676-bd82-b8c455744669)
