### PR TITLE
stream_color: Fix stream icon color not changing on theme change.

### DIFF
--- a/web/src/inbox_util.ts
+++ b/web/src/inbox_util.ts
@@ -27,6 +27,12 @@ export function update_stream_colors(): void {
         }
         const color = stream_data.get_color(stream_id);
         const background_color = stream_color.get_recipient_bar_color(color);
+
+        const $stream_privacy_icon = $stream_header.find(".stream-privacy");
+        if ($stream_privacy_icon.length) {
+            $stream_privacy_icon.css("color", stream_color.get_stream_privacy_icon_color(color));
+        }
+
         $stream_header.css("background", background_color);
     });
 }

--- a/web/src/stream_color.ts
+++ b/web/src/stream_color.ts
@@ -20,6 +20,12 @@ export function update_stream_recipient_color($stream_header: JQuery): void {
         }
         const stream_color = stream_data.get_color(stream_id);
         const recipient_bar_color = get_recipient_bar_color(stream_color);
+
+        const $stream_privacy_icon = $stream_header.find(".stream-privacy");
+        if ($stream_privacy_icon.length) {
+            $stream_privacy_icon.css("color", get_stream_privacy_icon_color(stream_color));
+        }
+
         $stream_header
             .find(".message-header-contents")
             .css("background-color", recipient_bar_color);


### PR DESCRIPTION
Changing theme didn't change the color of the stream icons.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20colors.20ignore.20light.2Fdark.20mode.20toggle