### PR TITLE
info_density: Expose info density controls for testing on CZO.

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -160,7 +160,7 @@ export const information_section_checkbox_group: DisplaySettings = {
 
 /* istanbul ignore next */
 export const get_information_density_preferences = (): DisplaySettings => ({
-    render_group: page_params.development_environment,
+    render_group: true,
     settings: {
         user_display_settings: ["web_font_size_px", "web_line_height_percent"],
     },
@@ -175,10 +175,14 @@ type SettingsRenderOnly = {
 
 /* istanbul ignore next */
 export const get_settings_render_only = (): SettingsRenderOnly => ({
-    dense_mode: page_params.development_environment,
+    // Render these controls outside of dev for the sake of
+    // early testing on CZO. Ultimately these controls will
+    // not ship in 9.0, so they should be reverted as such
+    // once a suitable 9.0 UI is in place.
+    dense_mode: true,
     high_contrast_mode: page_params.development_environment,
-    web_font_size_px: page_params.development_environment,
-    web_line_height_percent: page_params.development_environment,
+    web_font_size_px: true,
+    web_line_height_percent: true,
 });
 
 export const email_address_visibility_values = {
@@ -552,7 +556,7 @@ export const user_role_map = new Map(user_role_array.map((role) => [role.code, r
 
 export const preferences_settings_labels = {
     default_language_settings_label: $t({defaultMessage: "Language"}),
-    dense_mode: $t({defaultMessage: "Dense mode"}),
+    dense_mode: $t({defaultMessage: "Show legacy information density"}),
     display_emoji_reaction_users: new Handlebars.SafeString(
         $t_html({
             defaultMessage:


### PR DESCRIPTION
This PR exposes a relabeled `dense_mode` checkbox (_Show legacy information density_) along with the font-size and line-height inputs outside of the development environment. These changes are only meant to expedite testing of 16/140 on CZO while a toggle-like UI is developed for the 9.0 release.

CZO users should be informed that to test, the font-size should be set to 16, the line-height to 140, and "Show legacy information density" should be unchecked (to restore their usual CZO experience, users need only to check the box again).

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/testing.20info.20density.20on.20CZO/near/1836802)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

![temporary-info-density](https://github.com/zulip/zulip/assets/170719/b057a5dc-4aec-473a-bbac-c71a40c6ebe9)
