### PR TITLE
Fix issue on Open button shifting downward for youtube video previews

### DIFF
--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -229,7 +229,7 @@
         .media-actions {
             width: 100%;
             padding-left: 15px;
-            margin-top: 0;
+            margin-top: 20px;
         }
 
         .media-description {


### PR DESCRIPTION
This PR completes the work stated in #30497

The current lightbox overlay was giving issue when preview was clicked for any video in tall windows. 

Fixes: The official fix that was dedicated for it is to implement the CSS grid layout. But according to me it's much easier to change the margin top to 20px (intended) as it is the perfect alignment. If the grid layout is only intended then I may be able to work on this issue and can try for providing the solution. Issue #30497


Previously:
<img width="293" alt="Screenshot 2024-06-23 at 2 50 34 AM" src="https://github.com/zulip/zulip/assets/113302312/90e5b9f9-b69b-40db-9159-ad3e01b89811">
 
After Change: 
<img width="449" alt="Screenshot 2024-06-23 at 2 48 59 AM" src="https://github.com/zulip/zulip/assets/113302312/b823d508-e870-4ad1-bce0-5c1a68d69bb8">

<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
