### PR TITLE
Update custom profile fields admin table empty placeholder.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -670,10 +670,19 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
 
     let display_in_profile_summary_fields_count = 0;
 
+    for (const profile_field of profile_fields_data) {
+        order.push(profile_field.id);
+
+        // Keeping counts of all display_in_profile_summary profile fields,
+        // to keep track of whether the limit has been reached.
+        if (profile_field.display_in_profile_summary) {
+            display_in_profile_summary_fields_count += 1;
+        }
+    }
+
     ListWidget.create($profile_fields_table, profile_fields_data, {
         name: "settings_profile_fields_list",
         get_item(profile_field) {
-            order.push(profile_field.id);
             return profile_field;
         },
         modifier_html(profile_field) {
@@ -687,12 +696,6 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
 
             const display_in_profile_summary = profile_field.display_in_profile_summary === true;
             const required = profile_field.required;
-
-            // Keeping counts of all display_in_profile_summary profile fields, to keep track of
-            // whether the limit has been reached.
-            if (display_in_profile_summary) {
-                display_in_profile_summary_fields_count += 1;
-            }
 
             return render_admin_profile_field_list({
                 profile_field: {

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -20,7 +20,7 @@
                     {{/if}}
                 </tr>
             </thead>
-            <tbody id="admin_profile_fields_table" data-empty="{{t 'No custom profile field configured for this organization.' }}"></tbody>
+            <tbody id="admin_profile_fields_table" data-empty="{{t 'No custom profile fields configured.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -48,6 +48,15 @@ const Sortable = {create: noop};
 
 mock_esm("sortablejs", {default: Sortable});
 
+mock_esm("../src/list_widget", {
+    generic_sort_functions: noop,
+    create(_container, custom_profile_data, opts) {
+        for (const item of custom_profile_data) {
+            opts.modifier_html(item);
+        }
+    },
+});
+
 const settings_profile_fields = zrequire("settings_profile_fields");
 const {set_current_user, set_realm} = zrequire("state_data");
 
@@ -63,27 +72,14 @@ function test_populate(opts, template_data) {
         override(realm, "custom_profile_field_types", custom_profile_field_types);
         override(current_user, "is_admin", opts.is_admin);
         const $table = $("#admin_profile_fields_table");
-        const $rows = $.create("rows");
-        const $form = $.create("forms");
-        $table.set_find_results("tr.profile-field-row", $rows);
-        $table.set_find_results("tr.profile-field-form", $form);
 
         $table[0] = "stub";
-
-        $rows.remove = noop;
-        $form.remove = noop;
-
-        let num_appends = 0;
-        $table.append = () => {
-            num_appends += 1;
-        };
 
         loading.destroy_indicator = noop;
 
         settings_profile_fields.do_populate_profile_fields(fields_data);
 
         assert.deepEqual(template_data, opts.expected_template_data);
-        assert.equal(num_appends, fields_data.length);
     });
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Placeholder.20for.20profile.20fields.20org.20setting.20table.20.2327250/near/1822106) regarding whether to use ListWidget.

Fixes: #27250.

- [x] Add "No custom profile fields configured." placeholder text to SETTINGS / CUSTOM PROFILE FIELDS. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/133781250/879e297b-bea6-4a8d-a8d4-a8cd84ba89ba) | ![image](https://github.com/zulip/zulip/assets/133781250/6bbbe015-a788-42e0-a62c-66a118b7e4ca) |
| ![image](https://github.com/zulip/zulip/assets/133781250/bfe3a0ca-1311-49ad-a373-f5186ec6add6) | ![image](https://github.com/zulip/zulip/assets/133781250/8d85710d-7b71-4552-bbc1-50bd1763f4bf) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
