### PR TITLE
ui_init: Restore guard against direct use of `page_params.state_data`

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -670,7 +670,7 @@ export function initialize_everything(state_data) {
     $("#app-loading").addClass("loaded");
 }
 
-$(async () => {
+$(() => {
     if (page_params.is_spectator) {
         const data = {
             apply_markdown: true,
@@ -699,7 +699,9 @@ $(async () => {
             },
         });
     } else {
-        assert(page_params.state_data !== undefined);
-        initialize_everything(page_params.state_data);
+        const state_data = page_params.state_data;
+        assert(state_data !== null);
+        page_params.state_data = null;
+        initialize_everything(state_data);
     }
 });


### PR DESCRIPTION
Before commit fd253539e036c4960fee5719681b4f3a80a1423c (#30519), each part of `state_data` was removed by `pop_fields`, to ensure that it was only used by its associated module and not manipulated directly. Restore this guarantee by removing `page_params.state_data` itself.