### PR TITLE
Fix translation for desktop notifications.

### DIFF
--- a/web/src/message_notifications.js
+++ b/web/src/message_notifications.js
@@ -13,6 +13,7 @@ import * as ui_util from "./ui_util";
 import * as unread from "./unread";
 import {user_settings} from "./user_settings";
 import * as user_topics from "./user_topics";
+import * as util from "./util";
 
 function get_notification_content(message) {
     let content;
@@ -89,29 +90,46 @@ function get_notification_title(message, msg_count) {
     let title_prefix = message.sender_full_name;
     let title_suffix = "";
     let other_recipients;
+    let other_recipients_translated;
 
     if (msg_count > 1) {
-        title_prefix = msg_count + " messages from " + message.sender_full_name;
+        title_prefix = $t(
+            {defaultMessage: "{msg_count} messages from {sender_name}"},
+            {msg_count, sender_name: message.sender_full_name},
+        );
     }
 
     switch (message.type) {
         case "private":
-            other_recipients = remove_sender_from_list_of_recipients(message);
             if (message.display_recipient.length > 2) {
+                other_recipients = remove_sender_from_list_of_recipients(message);
+                // Same as compose_ui.compute_placeholder_text.
+                other_recipients_translated = util.format_array_as_list(
+                    other_recipients.split(", "),
+                    "long",
+                    "conjunction",
+                );
                 // Character limit taken from https://www.pushengage.com/push-notification-character-limits
                 // We use a higher character limit so that the 3rd sender can at least be partially visible so that
                 // the user can distinguish the group DM.
                 // If the message has too many recipients to list them all...
-                if (title_prefix.length + other_recipients.length > 50) {
+                if (title_prefix.length + other_recipients_translated.length > 50) {
                     // Then count how many people are in the conversation and summarize
-                    other_recipients = message.display_recipient.length - 2 + " more";
+                    title_suffix = $t(
+                        {defaultMessage: "(to you and {participants_count} more)"},
+                        {participants_count: message.display_recipient.length - 2},
+                    );
+                } else {
+                    title_suffix = $t(
+                        {defaultMessage: "(to you and {other_participant_names})"},
+                        {other_participant_names: other_recipients_translated},
+                    );
                 }
-
-                title_suffix = " (to you and " + other_recipients + ")";
             } else {
-                title_suffix = " (to you)";
+                title_suffix = $t({defaultMessage: "(to you)"});
             }
-            break;
+
+            return title_prefix + " " + title_suffix;
         case "stream": {
             const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
             title_suffix = " (#" + stream_name + " > " + message.topic + ")";

--- a/web/src/message_notifications.js
+++ b/web/src/message_notifications.js
@@ -94,9 +94,6 @@ function get_notification_title(message, msg_count) {
     }
 
     switch (message.type) {
-        case "test-notification":
-            other_recipients = remove_sender_from_list_of_recipients(message);
-            break;
         case "private":
             other_recipients = remove_sender_from_list_of_recipients(message);
             if (message.display_recipient.length > 2) {

--- a/web/src/message_notifications.js
+++ b/web/src/message_notifications.js
@@ -86,11 +86,12 @@ function remove_sender_from_list_of_recipients(message) {
 }
 
 function get_notification_title(message, msg_count) {
-    let title = message.sender_full_name;
+    let title_prefix = message.sender_full_name;
+    let title_suffix = "";
     let other_recipients;
 
     if (msg_count > 1) {
-        title = msg_count + " messages from " + title;
+        title_prefix = msg_count + " messages from " + message.sender_full_name;
     }
 
     switch (message.type) {
@@ -101,24 +102,24 @@ function get_notification_title(message, msg_count) {
                 // We use a higher character limit so that the 3rd sender can at least be partially visible so that
                 // the user can distinguish the group DM.
                 // If the message has too many recipients to list them all...
-                if (title.length + other_recipients.length > 50) {
+                if (title_prefix.length + other_recipients.length > 50) {
                     // Then count how many people are in the conversation and summarize
                     other_recipients = message.display_recipient.length - 2 + " more";
                 }
 
-                title += " (to you and " + other_recipients + ")";
+                title_suffix = " (to you and " + other_recipients + ")";
             } else {
-                title += " (to you)";
+                title_suffix = " (to you)";
             }
             break;
         case "stream": {
             const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
-            title += " (#" + stream_name + " > " + message.topic + ")";
+            title_suffix = " (#" + stream_name + " > " + message.topic + ")";
             break;
         }
     }
 
-    return title;
+    return title_prefix + title_suffix;
 }
 
 export function process_notification(notification) {


### PR DESCRIPTION
Fixes #21032

There are no visual changes but the strings are tagged for translation now.


Testing:

Test notification:
<img width="486" alt="Screenshot 2024-06-24 at 2 02 00 PM" src="https://github.com/zulip/zulip/assets/25124304/989c4949-8495-49f8-b035-1c0f0cd26ede">


Stream message
<img width="486" alt="Screenshot 2024-06-24 at 2 03 26 PM" src="https://github.com/zulip/zulip/assets/25124304/af9a844f-4a7a-45c4-9bad-b393ad208ed2">


DM
<img width="486" alt="Screenshot 2024-06-24 at 2 04 04 PM" src="https://github.com/zulip/zulip/assets/25124304/622fc730-b529-4217-9303-20773847f8b2">


Huddle:
<img width="486" alt="Screenshot 2024-06-24 at 2 04 50 PM" src="https://github.com/zulip/zulip/assets/25124304/47bdd820-ca55-4b82-bb94-503e17f86bfb">
<img width="486" alt="Screenshot 2024-06-24 at 2 05 16 PM" src="https://github.com/zulip/zulip/assets/25124304/c668b610-08b8-4153-95f6-c508d812c87e">


Multiple notifications:
<img width="486" alt="Screenshot 2024-06-24 at 2 05 45 PM" src="https://github.com/zulip/zulip/assets/25124304/78ca583e-a724-451f-b2a5-b0405131a116">
