### PR TITLE
compose: Zero out UA padding on composebox buttons.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -314,6 +314,9 @@
 
     button {
         width: 24px;
+        /* Override any UA stylesheet padding, such as that
+           added by mobile Safari. */
+        padding: 0;
         border: none;
         aspect-ratio: 1 / 1;
         background-color: var(--color-composebox-button-background);


### PR DESCRIPTION
This corrects an issue on Safari for iPad and iPhone, where the UA stylesheet added 1em of inline padding to the start and end of buttons. This zeroes out the padding so that the `width` attribute has the final say on the size of the expand/collapse compose buttons.

As the screenshots below show, this change appears to have no affect on the rendering of the buttons on other browsers.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/misplaced.20expand.20compose.20button.20in.20Safari.2FiPad/near/1824281)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Mobile Safari, before | Mobile Safari, after |
| --- | --- |
| ![composebox-buttons-safari-iphone-before](https://github.com/zulip/zulip/assets/170719/cb169598-b055-4dc7-ac1d-a6e2fd57e5cd) | ![composebox-buttons-safari-iphone-after](https://github.com/zulip/zulip/assets/170719/591761a2-e8fd-48fd-be33-b9bded038eb1) |
| ![composebox-buttons-safari-ipad-after](https://github.com/zulip/zulip/assets/170719/a558fc16-ab3c-4c88-800b-465b6f1e4135) | ![composebox-buttons-safari-ipad-before](https://github.com/zulip/zulip/assets/170719/d79032c3-64a2-4d0f-a085-25d6933d6d9a) |

| Chrome, before | Chrome, after (no change) |
| --- | --- |
| ![composebox-buttons-chrome-before](https://github.com/zulip/zulip/assets/170719/e2f0c6f0-1082-45d5-8489-6472359f1161) | ![composebox-buttgons-chrome-after](https://github.com/zulip/zulip/assets/170719/6c0fff66-ed46-48c3-8a2c-f1be62f4d9df) |

| Firefox, before | Firefox, after (no change) |
| --- | --- |
| ![composebox-button-firefox-before](https://github.com/zulip/zulip/assets/170719/03d683b8-5b68-4990-b727-e4fe81f40e14) | ![composebox-button-firefox-after](https://github.com/zulip/zulip/assets/170719/445d8cd0-52d7-477b-9d0e-2d039ae8276a) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>