### PR TITLE
events: Optimize computing can_create_streams and related fields.

### DIFF
--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1170,7 +1170,7 @@ class FetchQueriesTest(ZulipTestCase):
         # count in production.
         realm = get_realm_with_settings(realm_id=user.realm_id)
 
-        with self.assert_database_query_count(44):
+        with self.assert_database_query_count(43):
             with mock.patch("zerver.lib.events.always_want") as want_mock:
                 fetch_initial_state_data(user, realm=realm)
 
@@ -1194,7 +1194,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_filters=0,
             realm_linkifiers=0,
             realm_playgrounds=1,
-            realm_user=5,
+            realm_user=4,
             realm_user_groups=5,
             realm_user_settings_defaults=1,
             recent_private_conversations=1,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -260,7 +260,7 @@ class HomeTest(ZulipTestCase):
         self.client_post("/json/bots", bot_info)
 
         # Verify succeeds once logged-in
-        with self.assert_database_query_count(55):
+        with self.assert_database_query_count(54):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page(stream="Denmark")
                 self.check_rendered_logged_in_app(result)
@@ -564,7 +564,7 @@ class HomeTest(ZulipTestCase):
     def test_num_queries_for_realm_admin(self) -> None:
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
-        with self.assert_database_query_count(55):
+        with self.assert_database_query_count(54):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)
@@ -595,7 +595,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(50):
+        with self.assert_database_query_count(49):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.


### PR DESCRIPTION
Currently, for computing fields like can_create_public_streams and can_create_private_steams fields, is_user_in_group is called to check whether the user is part of the group which has the permission. This means that there will be one DB query for each field.

To optimize this, we now first fetch all the groups that the user is member of, including the anonymous groups which are used for settings, such that we can then just check whether the user is part of the group which has the permission meaning we would need only one query to compute all the fields.

This would be helpful when settings for other similar fields will also be migrated to groups framework.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
