### PR TITLE
message_controls: Reduce control button width to match padded icon.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -162,7 +162,8 @@
     --message-box-markdown-aligned-vertical-space: var(
         --markdown-interelement-space-px
     );
-    --message-box-icon-width: 26px;
+    /* 22px matches to the width of the padded icon. */
+    --message-box-icon-width: 22px;
     --message-box-icon-height: 25px;
     --message-box-height-senderless-single-line-message: calc(
         var(--base-line-height-unitless) * var(--base-font-size-px) +

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -924,11 +924,17 @@ td.pointer {
                values ensure a 26px x 25px clickable area for the icon. */
             padding: 2.5px 3px;
 
-            &:active {
+            &::before {
+                /* We specify block display so the
+                   scaling transform below works as
+                   expected. */
+                display: block;
+            }
+
+            &:active::before {
                 transform: scale(0.92);
                 transform-origin: center;
                 outline: 0;
-                transition: unset;
             }
 
             &:focus {


### PR DESCRIPTION
This PR reduces the total width of the hover-control area from a legacy 78px (which I believe existed prior to the grid-rewrites) to an icon + padding-sized 66px (22px width per icon).

There is more than can be done to tune this area and how it behaves with 16/140, but first it's better to decide how narrower icon targets and a narrower hover-control area feel.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/message.20width/near/1836122)

**Screenshots and screen captures:**

| Before (26px width per icon) | After (22px per icon) |
| --- | --- |
| ![hover-controls-before](https://github.com/zulip/zulip/assets/170719/29984933-57e9-46b5-9b84-b6c0b927da14) | ![hover-controls-after](https://github.com/zulip/zulip/assets/170719/2fb5f543-fa60-4b96-9290-76ebbe2ce58d) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
