### PR TITLE
stream_settings: Fix jitter behavior of plus/checkmark.

### DIFF
--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -9,7 +9,6 @@ import * as confirm_dialog from "./confirm_dialog";
 import * as dropdown_widget from "./dropdown_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
-import * as loading from "./loading";
 import * as overlays from "./overlays";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
@@ -115,42 +114,9 @@ export function dropdown_setup() {
     });
 }
 
-/* For the given stream_row, remove the tick and replace by a spinner. */
-function display_subscribe_toggle_spinner(stream_row) {
-    /* Prevent sending multiple requests by removing the button class. */
-    $(stream_row).find(".check").removeClass("sub_unsub_button");
-
-    /* Hide the tick. */
-    const $tick = $(stream_row).find("svg");
-    $tick.addClass("hide");
-
-    /* Add a spinner to show the request is in process. */
-    const $spinner = $(stream_row).find(".sub_unsub_status").expectOne();
-    $spinner.show();
-    loading.make_indicator($spinner);
-}
-
-/* For the given stream_row, add the tick and delete the spinner. */
-function hide_subscribe_toggle_spinner(stream_row) {
-    /* Re-enable the button to handle requests. */
-    $(stream_row).find(".check").addClass("sub_unsub_button");
-
-    /* Show the tick. */
-    const $tick = $(stream_row).find("svg");
-    $tick.removeClass("hide");
-
-    /* Destroy the spinner. */
-    const $spinner = $(stream_row).find(".sub_unsub_status").expectOne();
-    loading.destroy_indicator($spinner);
-}
-
-export function ajaxSubscribe(stream, color, $stream_row) {
+export function ajaxSubscribe(stream, color) {
     // Subscribe yourself to a single stream.
     let true_stream_name;
-
-    if ($stream_row !== undefined) {
-        display_subscribe_toggle_spinner($stream_row);
-    }
     return channel.post({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([{name: stream, color}])},
@@ -172,15 +138,8 @@ export function ajaxSubscribe(stream, color, $stream_row) {
                 );
             }
             // The rest of the work is done via the subscribe event we will get
-
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
         },
         error(xhr) {
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
             ui_report.error(
                 $t_html({defaultMessage: "Error adding subscription"}),
                 xhr,
@@ -190,26 +149,16 @@ export function ajaxSubscribe(stream, color, $stream_row) {
     });
 }
 
-function ajaxUnsubscribe(sub, $stream_row) {
+function ajaxUnsubscribe(sub) {
     // TODO: use stream_id when backend supports it
-    if ($stream_row !== undefined) {
-        display_subscribe_toggle_spinner($stream_row);
-    }
     return channel.del({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([sub.name])},
         success() {
             $(".stream_change_property_info").hide();
             // The rest of the work is done via the unsubscribe event we will get
-
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
         },
         error(xhr) {
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
             ui_report.error(
                 $t_html({defaultMessage: "Error removing subscription"}),
                 xhr,

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -441,7 +441,7 @@ export function enable_or_disable_add_subscribers_elements(
         const $add_subscribers_button = $container_elem
             .find('button[name="add_subscriber"]')
             .expectOne();
-        $add_subscribers_button.prop("disabled", !enable_elem);
+        $add_subscribers_button.prop("disabled", true);
         if (enable_elem) {
             $add_subscribers_button.css("pointer-events", "");
         }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -563,7 +563,6 @@ h4.user_group_setting_subsection_title {
             cursor: not-allowed;
         }
 
-        .sub_unsub_status,
         .join_leave_status {
             display: inline-block !important;
             height: auto !important;

--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -17,7 +17,6 @@
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
                 <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
             </svg>
-            <div class='sub_unsub_status'></div>
         </div>
     {{else}}
         <div class="check sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}} tippy-zulip-tooltip"
@@ -44,7 +43,6 @@
             <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
                 <path d="M459.319,229.668c0,22.201-17.992,40.193-40.205,40.193H269.85v149.271c0,22.207-17.998,40.199-40.196,40.193   c-11.101,0-21.149-4.492-28.416-11.763c-7.276-7.281-11.774-17.324-11.769-28.419l-0.006-149.288H40.181   c-11.094,0-21.134-4.492-28.416-11.774c-7.264-7.264-11.759-17.312-11.759-28.413C0,207.471,17.992,189.475,40.202,189.475h149.267   V40.202C189.469,17.998,207.471,0,229.671,0c22.192,0.006,40.178,17.986,40.19,40.187v149.288h149.282   C441.339,189.487,459.308,207.471,459.319,229.668z"/>
             </svg>
-            <div class='sub_unsub_status'></div>
         </div>
     {{/if}}
     {{> subscription_setting_icon }}

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -4,7 +4,6 @@
     </div>
     <br />
 
-
     {{t "Do you want to add everyone?"}}
     <span class="add_all_users_to_stream_btn_container">
         <button class="add_all_users_to_stream small button rounded sea-green">{{t 'Add all users'}}</button>


### PR DESCRIPTION
Previously, we show loading spinner in each streams rows. Now we show directly plus or checkmark icon instead of loading spinner.

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/jitter.20when.20subscribing.2Funsubscribing.20to.20a.20channel/near/1814234)

**Screenshots and screen captures:**
**Before:**
![stream2](https://github.com/zulip/zulip/assets/73663475/af030491-de6e-40c3-9e35-1de89ce20787)

**After:**

![stream3](https://github.com/zulip/zulip/assets/73663475/bb6a9642-0956-4d83-8b87-74ac6600bddb)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
