### PR TITLE
compose: Make compose close icon small and reduce space above recipient area.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -373,6 +373,9 @@
     --color-compose-embedded-button-background-hover: hsl(
         231deg 100% 90% / 50%
     );
+    --color-compose-embedded-button-background-interactive: hsl(
+        231deg 100% 90% / 90%
+    );
     --color-compose-chevron-arrow: hsl(0deg 0% 58%);
     --color-limit-indicator: hsl(38deg 100% 36%);
     --color-limit-indicator-over-limit: hsl(3deg 80% 40%);
@@ -746,6 +749,9 @@
     --color-compose-embedded-button-background: transparent;
     --color-compose-embedded-button-background-hover: hsl(
         235deg 100% 70% / 11%
+    );
+    --color-compose-embedded-button-background-interactive: hsl(
+        235deg 100% 70% / 20%
     );
     --color-background-popover: hsl(212deg 32% 14%);
     --color-limit-indicator: hsl(38deg 100% 70%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -469,12 +469,12 @@
     right: 0;
     color: var(--color-compose-send-control-button);
     background: transparent;
-    font-size: 15px;
+    font-size: 12.5px;
     font-weight: normal;
     line-height: 20px;
     opacity: 0.7;
     border: 0;
-    padding: 5px 7px;
+    padding: 3px 7px;
     border-radius: 8px;
     vertical-align: unset;
     text-shadow: none;
@@ -483,6 +483,12 @@
         opacity: 1;
         background: var(--color-compose-embedded-button-background-hover);
         color: var(--color-compose-send-control-button-interactive);
+    }
+
+    &:active {
+        background-color: var(
+            --color-compose-embedded-button-background-interactive
+        );
     }
 
     &:focus:not(:focus-visible) {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -119,7 +119,7 @@
 /* Main geometry for this element is in zulip.css */
 #compose-content {
     background-color: hsl(232deg 30% 92%);
-    padding: 4px 4px 8px;
+    padding: 7px 7px 8px;
     border: 1px solid hsl(0deg 0% 0% / 10%);
     border-radius: 9px 9px 0 0;
     box-shadow: 0 0 0 hsl(236deg 11% 28%);
@@ -137,7 +137,7 @@
 
 .message_comp {
     display: none;
-    padding: 5px 10px 0 5px;
+    padding: 0 7px 0 0;
 
     #compose_banners {
         max-height: min(25vh, 240px);


### PR DESCRIPTION
compose: Make compose close cross button smaller and add active state.

The background color's opacity is reduced for the button's active state.

compose: Rework paddings for the compose content for more symmetry.

The space above and to the left of the recipient area is now matched to the space below it, and this is also the space above and on the sides of a collapsed compose row.

Fixes: [CZO message](https://chat.zulip.org/#narrow/stream/101-design/topic/compose.20close.20icon.20update/near/1834022)

**Screenshots and screen captures:**
Compose box open:
![image](https://github.com/zulip/zulip/assets/68962290/5c6dc87f-8ead-4a13-9391-7dd2cd3ad1f2)

Compose box collapsed:
![image](https://github.com/zulip/zulip/assets/68962290/1e9386b3-7c22-4b88-b354-a9f7d61ba9a9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
