### PR TITLE
info_density: Relocate and improve timestamp-column calculations.

### DIFF
--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import {stringify_time} from "./timerender";
 import {user_settings} from "./user_settings";
 
 // These are all relative-unit values for Source Sans Pro VF,
@@ -95,6 +96,43 @@ export function set_base_typography_css_variables(): void {
     set_vertical_alignment_values(line_height_unitless);
 }
 
+export function calculate_timestamp_widths(): void {
+    const $temp_time_div = $("<div>");
+    $temp_time_div.attr("id", "calculated-timestamp-widths");
+    // Size the div to the width of the largest timestamp,
+    // but the div out of the document flow with absolute positioning.
+    $temp_time_div.css({
+        width: "max-content",
+        visibility: "hidden",
+        position: "absolute",
+        top: "-100vh",
+    });
+    // We should get a reasonable max-width by looking only at
+    // the first and last minutes of AM and PM
+    const candidate_times = ["00:00", "11:59", "12:00", "23:59"];
+
+    for (const time of candidate_times) {
+        const $temp_time_element = $("<a>");
+        $temp_time_element.attr("class", "message-time");
+        // stringify_time only returns the time, so the date here is
+        // arbitrary and only required for creating a Date object
+        const candidate_timestamp = stringify_time(Date.parse(`1999-07-01T${time}`));
+        $temp_time_element.text(candidate_timestamp);
+        $temp_time_div.append($temp_time_element);
+    }
+
+    // Append the <div> element to calculate the maximum rendered width
+    $("body").append($temp_time_div);
+    const max_timestamp_width = $temp_time_div.width();
+    // Set the width as a CSS variable
+    $(":root").css("--message-box-timestamp-column-width", `${max_timestamp_width}px`);
+    // Clean up by removing the temporary <div> element
+    $temp_time_div.remove();
+}
+
 export function initialize(): void {
     set_base_typography_css_variables();
+    // We calculate the widths of a candidate set of timestamps,
+    // and use the largest to set `--message-box-timestamp-column-width`
+    calculate_timestamp_widths();
 }

--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -37,11 +37,12 @@ const BODY_FONT_CONTENT_BOX = BODY_FONT_ASCENT + BODY_FONT_DESCENT;
 // than the line-height.
 const MAXIMUM_BLOCK_HEIGHT_IN_EMS = BODY_FONT_CONTENT_BOX / BODY_FONT_EM_SIZE;
 
-// Eventually this legacy value and references to it should be removed;
+// Eventually these legacy values and references to them should be removed;
 // but in the awkward stage where legacy values are in play for
 // certain things (e.g., calculating line-height-based offsets for
-// emoji alignment), it's necessary to have access to this value.
+// emoji alignment), it's necessary to have access to these values.
 const LEGACY_LINE_HEIGHT_UNITLESS = 1.214;
+const LEGACY_FONT_SIZE_PX = 14;
 
 function set_vertical_alignment_values(line_height_unitless: number): void {
     // We work in ems to keep this agnostic to the font size.
@@ -97,11 +98,19 @@ export function set_base_typography_css_variables(): void {
 }
 
 export function calculate_timestamp_widths(): void {
+    const base_font_size_px = user_settings.dense_mode
+        ? LEGACY_FONT_SIZE_PX
+        : user_settings.web_font_size_px;
     const $temp_time_div = $("<div>");
     $temp_time_div.attr("id", "calculated-timestamp-widths");
     // Size the div to the width of the largest timestamp,
-    // but the div out of the document flow with absolute positioning.
+    // but the div out of the document flow with absolute
+    // positioning.
+    // We set the base font-size ordinarily on body so that
+    // the correct em-size timestamps can be calculated along
+    // with all the other information density values.
     $temp_time_div.css({
+        "font-size": base_font_size_px,
         width: "max-content",
         visibility: "hidden",
         position: "absolute",

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -3,7 +3,6 @@ import $ from "jquery";
 import * as inbox_util from "./inbox_util";
 import type {MessageListData} from "./message_list_data";
 import type {Message} from "./message_store";
-import {stringify_time} from "./timerender";
 import * as ui_util from "./ui_util";
 
 // TODO(typescript): Move this to message_list_view when it's
@@ -147,44 +146,7 @@ export function update_recipient_bar_background_color(): void {
     inbox_util.update_stream_colors();
 }
 
-export function calculate_timestamp_widths(): void {
-    const $temp_time_div = $("<div>");
-    $temp_time_div.attr("id", "calculated-timestamp-widths");
-    // Size the div to the width of the largest timestamp,
-    // but the div out of the document flow with absolute positioning.
-    $temp_time_div.css({
-        width: "max-content",
-        visibility: "hidden",
-        position: "absolute",
-        top: "-100vh",
-    });
-    // We should get a reasonable max-width by looking only at
-    // the first and last minutes of AM and PM
-    const candidate_times = ["00:00", "11:59", "12:00", "23:59"];
-
-    for (const time of candidate_times) {
-        const $temp_time_element = $("<a>");
-        $temp_time_element.attr("class", "message-time");
-        // stringify_time only returns the time, so the date here is
-        // arbitrary and only required for creating a Date object
-        const candidate_timestamp = stringify_time(Date.parse(`1999-07-01T${time}`));
-        $temp_time_element.text(candidate_timestamp);
-        $temp_time_div.append($temp_time_element);
-    }
-
-    // Append the <div> element to calculate the maximum rendered width
-    $("body").append($temp_time_div);
-    const max_timestamp_width = $temp_time_div.width();
-    // Set the width as a CSS variable
-    $(":root").css("--message-box-timestamp-column-width", `${max_timestamp_width}px`);
-    // Clean up by removing the temporary <div> element
-    $temp_time_div.remove();
-}
-
 export function initialize(): void {
-    // We calculate the widths of a candidate set of timestamps,
-    // and use the largest to set `--message-box-timestamp-column-width`
-    calculate_timestamp_widths();
     // For users with automatic color scheme, we need to detect change
     // in `prefers-color-scheme` as it changes based on time.
     ui_util.listener_for_preferred_color_scheme_change(update_recipient_bar_background_color);

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -777,12 +777,14 @@ export function dispatch_normal_event(event) {
                 $("body").toggleClass("less-dense-mode");
                 $("body").toggleClass("more-dense-mode");
                 information_density.set_base_typography_css_variables();
+                information_density.calculate_timestamp_widths();
             }
             if (
                 event.property === "web_font_size_px" ||
                 event.property === "web_line_height_percent"
             ) {
                 information_density.set_base_typography_css_variables();
+                information_density.calculate_timestamp_widths();
             }
             if (event.property === "web_mark_read_on_scroll_policy") {
                 unread_ui.update_unread_banner();

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -751,7 +751,7 @@ export function dispatch_normal_event(event) {
             }
             if (event.property === "twenty_four_hour_time") {
                 // Recalculate timestamp column width
-                message_lists.calculate_timestamp_widths();
+                information_density.calculate_timestamp_widths();
                 // Rerender the whole message list UI
                 for (const msg_list of message_lists.all_rendered_message_lists()) {
                     msg_list.rerender();

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -889,7 +889,7 @@ run_test("user_settings", ({override}) => {
     let event = event_fixtures.user_settings__default_language;
     user_settings.default_language = "en";
     override(settings_preferences, "update_page", noop);
-    override(message_lists, "calculate_timestamp_widths", noop);
+    override(information_density, "calculate_timestamp_widths", noop);
     override(overlays, "settings_open", () => true);
     dispatch(event);
     assert_same(user_settings.default_language, "fr");


### PR DESCRIPTION
This PR fixes a regression I detected stemming from #30472, where an incorrect/missing base `em` unit caused timestamp columns to always be sized to a browser-default 16px em, even at smaller font sizes (that made this bug impossible to spot at 16/140).

Because a number of server events call for recalculating the width of the column, and because the column width is dependent on the base font-size in play, this PR moves the `calculate_timestamp_widths()` function definition into the information density file, and also calls the function in the info-density initialization function as well as on dense-mode and font-size/line-height server events. Prior to this PR, in other words, the timestamp column would not be recalculated from changes to dense mode, the font size, or the line height.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/message.20width/near/1836525)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy, before (way too wide!) | Legacy, after (correct) |
| --- | --- |
| ![timestamp-column-on-load-before](https://github.com/zulip/zulip/assets/170719/e20b72f4-d2f1-4425-a9a9-c3e6bbab3b11) | ![timestamp-column-on-load-after](https://github.com/zulip/zulip/assets/170719/a9276d80-75cb-44c1-9b42-5a18d1660046) |

| 16/140, before (on load) | 16/140, after (on load; no change, by happy accident) |
| --- | --- |
| ![timestamp-column-on-16-140-before-happy-accident](https://github.com/zulip/zulip/assets/170719/310a5ef2-76ff-4e2a-afbd-567e1c9deaa7) | ![timestamp-column-on-16-140-after](https://github.com/zulip/zulip/assets/170719/f76a9952-bacd-45ba-9c42-9b088b8e0043) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>