### PR TITLE
typeahead_helper: Straighten `CombinedPill` types

### DIFF
--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -3,7 +3,7 @@ import * as keydown_util from "./keydown_util";
 import type {User} from "./people";
 import * as pill_typeahead from "./pill_typeahead";
 import * as stream_pill from "./stream_pill";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
 import * as user_pill from "./user_pill";
 
@@ -65,8 +65,8 @@ export function create({
 }: {
     $pill_container: JQuery;
     get_potential_subscribers: () => User[];
-}): input_pill.InputPillContainer<CombinedPillItem> {
-    const pill_widget = input_pill.create<CombinedPillItem>({
+}): CombinedPillContainer {
+    const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -4,16 +4,15 @@ import render_new_stream_user from "../templates/stream_settings/new_stream_user
 import render_new_stream_users from "../templates/stream_settings/new_stream_users.hbs";
 
 import * as add_subscribers_pill from "./add_subscribers_pill";
-import type {InputPillContainer} from "./input_pill";
 import * as ListWidget from "./list_widget";
 import type {ListWidget as ListWidgetType} from "./list_widget";
 import * as people from "./people";
 import {current_user} from "./state_data";
 import * as stream_create_subscribers_data from "./stream_create_subscribers_data";
-import type {CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPillContainer} from "./typeahead_helper";
 import * as user_sort from "./user_sort";
 
-let pill_widget: InputPillContainer<CombinedPillItem>;
+let pill_widget: CombinedPillContainer;
 let all_users_list_widget: ListWidgetType<number, people.User>;
 
 export function get_principals(): number[] {

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -13,7 +13,6 @@ import * as blueslip from "./blueslip";
 import * as confirm_dialog from "./confirm_dialog";
 import * as hash_parser from "./hash_parser";
 import {$t, $t_html} from "./i18n";
-import type {InputPillContainer} from "./input_pill";
 import * as ListWidget from "./list_widget";
 import type {ListWidget as ListWidgetType} from "./list_widget";
 import * as peer_data from "./peer_data";
@@ -27,7 +26,7 @@ import type {SettingsSubscription} from "./stream_settings_data";
 import * as sub_store from "./sub_store";
 import type {StreamSubscription} from "./sub_store";
 import * as subscriber_api from "./subscriber_api";
-import type {CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPillContainer} from "./typeahead_helper";
 import * as user_sort from "./user_sort";
 
 const remove_user_id_api_response_schema = z.object({
@@ -40,7 +39,7 @@ const add_user_ids_api_response_schema = z.object({
     already_subscribed: z.record(z.string(), z.array(z.string())),
 });
 
-export let pill_widget: InputPillContainer<CombinedPillItem>;
+export let pill_widget: CombinedPillContainer;
 let current_stream_id: number;
 let subscribers_list_widget: ListWidgetType<User, User>;
 

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -33,12 +33,9 @@ export type UserOrMentionPillData = UserOrMention & {
     is_silent?: boolean;
 };
 
-export type CombinedPillContainer = InputPillContainer<StreamPill | UserGroupPill | UserPill>;
-
-export type CombinedPillItem =
-    | InputPillItem<UserPill>
-    | InputPillItem<UserGroupPill>
-    | InputPillItem<StreamPill>;
+export type CombinedPill = StreamPill | UserGroupPill | UserPill;
+export type CombinedPillContainer = InputPillContainer<CombinedPill>;
+export type CombinedPillItem = InputPillItem<CombinedPill>;
 
 export function build_highlight_regex(query: string): RegExp {
     const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -4,16 +4,15 @@ import render_new_user_group_user from "../templates/stream_settings/new_stream_
 import render_new_user_group_users from "../templates/user_group_settings/new_user_group_users.hbs";
 
 import * as add_subscribers_pill from "./add_subscribers_pill";
-import type {InputPillContainer} from "./input_pill";
 import * as ListWidget from "./list_widget";
 import type {ListWidget as ListWidgetType} from "./list_widget";
 import * as people from "./people";
 import {current_user} from "./state_data";
-import type {CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPillContainer} from "./typeahead_helper";
 import * as user_group_create_members_data from "./user_group_create_members_data";
 import * as user_sort from "./user_sort";
 
-let pill_widget: InputPillContainer<CombinedPillItem>;
+let pill_widget: CombinedPillContainer;
 let all_users_list_widget: ListWidgetType<number, people.User>;
 
 export function get_principals(): number[] {


### PR DESCRIPTION
The generic argument of `InputPillContainer` should not be `InputPillItem<…>`, as `InputPillContainer` already uses `InputPillItem` where applicable.