### PR TITLE
info_density: Scale reaction emoji with font-size.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -49,8 +49,9 @@
 
         .emoji {
             margin: 1px 3px;
-            height: 17px;
-            width: 17px;
+            /* 17px at 14px/1em */
+            height: 1.2143em;
+            width: 1.2143em;
             /* Preserve the emoji's dimensions, no
                matter what the flexbox does. */
             flex-shrink: 0;


### PR DESCRIPTION
While the count/usernames with reaction emoji currently resize along with font-size, this PR enables reaction emoji to scale, too. As can be seen in the screenshots below, there is a regrettable mismatch between the size of inline emoji and reaction emoji as the font-size increases.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/testing.20info.20density.20on.20CZO/near/1836805)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| 16/140, before | 16/140, after |
| --- | --- |
| ![16-140-reaction-emoji-before](https://github.com/zulip/zulip/assets/170719/75093fe2-9b68-4ca8-8d9d-a2ad6ec641cf) | ![16-140-reaction-emoji-after](https://github.com/zulip/zulip/assets/170719/c912212e-96da-4a36-be9b-085486eb81ca) |

| Legacy, before | Legacy, after (no change) |
| --- | --- |
| ![legacy-reaction-emoji-before](https://github.com/zulip/zulip/assets/170719/a8ca62b7-138a-4100-8ed1-26fb5dd558fb) | ![legacy-reaction-emoji-after](https://github.com/zulip/zulip/assets/170719/e5ca7478-c7a0-463e-8cd8-4c594dcacd6e) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
