### PR TITLE
Corporate typed endpoint migration

### DIFF
--- a/corporate/views/installation_activity.py
+++ b/corporate/views/installation_activity.py
@@ -27,7 +27,7 @@ from corporate.lib.activity import (
 from corporate.lib.stripe import cents_to_dollar_string
 from corporate.views.support import get_plan_type_string
 from zerver.decorator import require_server_admin
-from zerver.lib.request import has_request_variables
+from zerver.lib.typed_endpoint import typed_endpoint_without_parameters
 from zerver.models import Realm
 from zerver.models.realm_audit_logs import RealmAuditLog
 from zerver.models.realms import get_org_type_display_name
@@ -291,7 +291,7 @@ def realm_summary_table() -> str:
 
 
 @require_server_admin
-@has_request_variables
+@typed_endpoint_without_parameters
 def get_installation_activity(request: HttpRequest) -> HttpResponse:
     content: str = realm_summary_table()
     title = "Installation activity"

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -26,9 +26,9 @@ from zerver.lib.integrations import (
     WebhookIntegration,
     get_all_event_types_for_integration,
 )
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.templates import render_markdown_path
+from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.models import Realm
 from zerver.openapi.openapi import get_endpoint_from_operationid, get_openapi_summary
 
@@ -363,8 +363,8 @@ class IntegrationView(ApiURLView):
         return context
 
 
-@has_request_variables
-def integration_doc(request: HttpRequest, integration_name: str = REQ()) -> HttpResponse:
+@typed_endpoint
+def integration_doc(request: HttpRequest, *, integration_name: PathOnly[str]) -> HttpResponse:
     # FIXME: This check is jQuery-specific.
     if request.headers.get("x-requested-with") != "XMLHttpRequest":
         return HttpResponseNotFound()


### PR DESCRIPTION
Convert `documentation`, `installation_activity` and `support` to `typed_endpoint`.