### PR TITLE
Fix docs for importing Mattermost data

### DIFF
--- a/help/import-from-mattermost.md
+++ b/help/import-from-mattermost.md
@@ -187,9 +187,11 @@ Replace `<username>` and `<server_ip>` with the appropriate values below.
     {!import-self-hosted-server-tips.md!}
 
     ```
+    cd /tmp
+    tar -xf mattermost_data.tar.gz
     cd /home/zulip/deployments/current
     ./scripts/stop-server
-    ./manage.py convert_mattermost_data /tmp/mattermost_data.tar.gz --output /tmp/converted_mattermost_data
+    ./manage.py convert_mattermost_data /tmp/mattermost_data --output /tmp/converted_mattermost_data
     ./manage.py import '' /tmp/converted_mattermost_data/<team-name>
     ./scripts/start-server
     ```
@@ -197,9 +199,11 @@ Replace `<username>` and `<server_ip>` with the appropriate values below.
     Alternatively, to import into a custom subdomain, run:
 
     ```
+    cd /tmp
+    tar -xf mattermost_data.tar.gz
     cd /home/zulip/deployments/current
     ./scripts/stop-server
-    ./manage.py convert_mattermost_data /tmp/mattermost_data.tar.gz --output /tmp/converted_mattermost_data
+    ./manage.py convert_mattermost_data /tmp/mattermost_data --output /tmp/converted_mattermost_data
     ./manage.py import <subdomain> /tmp/converted_mattermost_data/<team-name>
     ./scripts/start-server
     ```


### PR DESCRIPTION
The created export-archive needs to extracted before converting

Added clarification for that in the documentation

Fixes: 

Fixes the error following Mattermost import:

```
zulip@3849e11c9576:~/deployments/current$ ./manage.py convert_mattermost_data /tmp/export.tar.gz --output /tmp/converted_mattermost_data
Converting data ...
Traceback (most recent call last):
  File "./manage.py", line 151, in <module>
    execute_from_command_line(sys.argv)
  File "./manage.py", line 116, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-venv-cache/bbd84a06bc651effedfe39cab337a1bf300cee02/zulip-py3-venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-venv-cache/bbd84a06bc651effedfe39cab337a1bf300cee02/zulip-py3-venv/lib/python3.8/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip-venv-cache/bbd84a06bc651effedfe39cab337a1bf300cee02/zulip-py3-venv/lib/python3.8/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/home/zulip/deployments/2024-05-09-18-59-10/zerver/management/commands/convert_mattermost_data.py", line 70, in handle
    do_convert_data(
  File "/home/zulip/deployments/2024-05-09-18-59-10/zerver/data_import/mattermost.py", line 885, in do_convert_data
    mattermost_data = mattermost_data_file_to_dict(mattermost_data_file)
  File "/home/zulip/deployments/2024-05-09-18-59-10/zerver/data_import/mattermost.py", line 864, in mattermost_data_file_to_dict
    with open(mattermost_data_file, "rb") as fp:
NotADirectoryError: [Errno 20] Not a directory: '/tmp/export.tar.gz/export.json'
```

