### PR TITLE
Duplicate conversation rows in left sidebar.

### DIFF
--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -28,7 +28,11 @@ export function get_active_user_ids_string(): string | undefined {
         return undefined;
     }
 
-    return people.emails_strings_to_user_ids_string(emails);
+    const users_ids_array = people.emails_strings_to_user_ids_array(emails);
+    if (!users_ids_array || users_ids_array.length === 0) {
+        return undefined;
+    }
+    return people.sorted_other_user_ids(users_ids_array).join(",");
 }
 
 type DisplayObject = {

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -140,6 +140,11 @@ function choose_topics(
     }
 }
 
+function contains_topic(topic_names: string[], narrowed_topic: string): boolean {
+    const lower_cased_topics = topic_names.map((name) => name.toLowerCase());
+    return lower_cased_topics.includes(narrowed_topic.toLowerCase());
+}
+
 type TopicListInfo = {
     items: TopicInfo[];
     num_possible_topics: number;
@@ -174,7 +179,7 @@ export function get_list_info(
     if (
         stream_id === narrow_state.stream_id() &&
         narrowed_topic &&
-        !topic_names.includes(narrowed_topic)
+        !contains_topic(topic_names, narrowed_topic)
     ) {
         topic_names.unshift(narrowed_topic);
     }

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
+const blueslip = require("./lib/zblueslip");
 
 const unread = mock_esm("../src/unread");
 
@@ -215,6 +216,14 @@ test("get_active_user_ids_string", () => {
     assert.equal(pm_list_data.get_active_user_ids_string(), undefined);
 
     set_pm_with_filter("bob@zulip.com,alice@zulip.com");
+    assert.equal(pm_list_data.get_active_user_ids_string(), "101,102");
+
+    blueslip.expect("warn", "Unknown emails");
+    set_pm_with_filter("invalid@zulip.com");
+    assert.equal(pm_list_data.get_active_user_ids_string(), undefined);
+    blueslip.reset();
+
+    set_pm_with_filter("bob@zulip.com,alice@zulip.com,me@zulip.com");
     assert.equal(pm_list_data.get_active_user_ids_string(), "101,102");
 });
 


### PR DESCRIPTION
When narrowing to an existing topic name with different casing, left sidebar renders duplicate topic rows for the existing topic name and one with the different casing. Since topic names are case insensitive, it should narrow to the existing row only.

Also when narrowing to a DM with their own user pill in recipient, a duplicate DM row gets rendered.

Fixes: regression introduced in #29175 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:

![image](https://github.com/zulip/zulip/assets/33497322/847f2be2-2f9a-49e6-b632-1dc07b4c673f)
![Screenshot from 2024-06-26 02-04-36](https://github.com/zulip/zulip/assets/33497322/ea26844c-b5fd-4ee8-8deb-b549077b24cf)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
