### PR TITLE
narrow: Expand descriptive text when starred and mentioned views are empty.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -44,6 +44,23 @@ const MENTIONS_VIEW_EMPTY_BANNER = {
     ),
 };
 
+const STARRED_MESSAGES_VIEW_EMPTY_BANNER = {
+    title: $t({defaultMessage: "You have no starred messages."}),
+    html: $t_html(
+        {
+            defaultMessage:
+                "Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, hover over a message and click the <star-icon></star-icon>. <z-link>Learn more</z-link>",
+        },
+        {
+            "star-icon": () => `<i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>`,
+            "z-link": (content_html) =>
+                `<a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">${content_html.join(
+                    "",
+                )}</a>`,
+        },
+    ),
+};
+
 function retrieve_search_query_data(): SearchData {
     // when search bar contains multiple filters, only retrieve search queries
     const current_filter = narrow_state.filter();
@@ -208,22 +225,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
         case "is":
             switch (first_operand) {
                 case "starred":
-                    // You currently have no starred messages.
-                    return {
-                        title: $t({defaultMessage: "You have no starred messages."}),
-                        html: $t_html(
-                            {
-                                defaultMessage:
-                                    "Learn more about starring messages <z-link>here</z-link>.",
-                            },
-                            {
-                                "z-link": (content_html) =>
-                                    `<a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">${content_html.join(
-                                        "",
-                                    )}</a>`,
-                            },
-                        ),
-                    };
+                    return STARRED_MESSAGES_VIEW_EMPTY_BANNER;
                 case "mentioned":
                     return MENTIONS_VIEW_EMPTY_BANNER;
                 case "dm":

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -28,6 +28,22 @@ const SPECTATOR_STREAM_NARROW_BANNER = {
     ),
 };
 
+const MENTIONS_VIEW_EMPTY_BANNER = {
+    title: $t({defaultMessage: "This view will show messages where you are mentioned."}),
+    html: $t_html(
+        {
+            defaultMessage:
+                "To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a stream. Type @ in the compose box, and choose who you'd like to mention from the list of suggestions. <z-link>Learn more</z-link>",
+        },
+        {
+            "z-link": (content_html) =>
+                `<a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">${content_html.join(
+                    "",
+                )}</a>`,
+        },
+    ),
+};
+
 function retrieve_search_query_data(): SearchData {
     // when search bar contains multiple filters, only retrieve search queries
     const current_filter = narrow_state.filter();
@@ -209,20 +225,7 @@ function pick_empty_narrow_banner(): NarrowBannerData {
                         ),
                     };
                 case "mentioned":
-                    return {
-                        title: $t({defaultMessage: "You haven't been mentioned yet!"}),
-                        html: $t_html(
-                            {
-                                defaultMessage: "Learn more about mentions <z-link>here</z-link>.",
-                            },
-                            {
-                                "z-link": (content_html) =>
-                                    `<a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">${content_html.join(
-                                        "",
-                                    )}</a>`,
-                            },
-                        ),
-                    };
+                    return MENTIONS_VIEW_EMPTY_BANNER;
                 case "dm":
                     // You have no direct messages.
                     if (

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1619,6 +1619,8 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 }
 
 .empty_feed_notice {
+    max-width: 600px;
+    margin: 0 auto;
     padding: 3em 1em;
     text-align: center;
 }

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -284,7 +284,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
             "translated: You have no starred messages.",
-            'translated HTML: Learn more about starring messages <a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">here</a>.',
+            'translated HTML: Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, hover over a message and click the <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>. <a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">Learn more</a>',
         ),
     );
 

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -293,8 +293,8 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You haven't been mentioned yet!",
-            'translated HTML: Learn more about mentions <a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">here</a>.',
+            "translated: This view will show messages where you are mentioned.",
+            'translated HTML: To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a stream. Type @ in the compose box, and choose who you\'d like to mention from the list of suggestions. <a target="_blank" rel="noopener noreferrer" href="/help/mention-a-user-or-group">Learn more</a>',
         ),
     );
 


### PR DESCRIPTION
Expands the descriptive text for both the starred messages and mentions views when they are empty.

**Notes**:
- Because this text is much longer than what's normally in these empty narrow banners, the max-width for the empty narrow feed is now set to 600px. See [relevant CZO design discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Provide.20more.20info.20in.20empty.20views.20.2329378/near/1791960).
- I edited the text for the starred view from what's specified in the issue (see fixes note below). Specifically, I changed the instruction for how to star a message to better match what we say in the help center.
- Instead of creating a new `hbs` template for these empty narrows, I put the longer text in some constants at the top of `web/src/narrow_banner.ts` so it was easier to read in the file.

Fixes #29378.

---

New strings to be translated in `translations.json`:
- `"Starring messages is a good way to keep track of important messages, such as tasks you need to go back to, or useful references. To star a message, hover over a message and click the <star-icon></star-icon>. <z-link>Learn more</z-link>"`
- `"This view will show messages where you are mentioned."`
- `"To call attention to a message, you can mention a user, a group, topic participants, or all subscribers to a stream. Type @ in the compose box, and choose who you'd like to mention from the list of suggestions. <z-link>Learn more</z-link>"`

---

**Screenshots and screen captures:**

<details>
<summary>Updated empty starred messages view</summary>

![Screenshot from 2024-06-25 17-03-50](https://github.com/zulip/zulip/assets/63245456/e7633d43-b2c7-4748-a6e6-2a4217813d85)
</details>
<details>
<summary>Updated empty mentions view</summary>

![Screenshot from 2024-06-25 17-04-04](https://github.com/zulip/zulip/assets/63245456/1e4b84c0-9e04-43ec-9fee-60c888c9b297)
</details>
<details>
<summary>Updated empty mentions view with wider browser window</summary>

![Screenshot from 2024-06-25 17-14-57](https://github.com/zulip/zulip/assets/63245456/2d2fda58-c797-48d6-b4f3-d03f9898ee32)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
