### PR TITLE
message_box: Space message box elements evenly, based on single-line reference.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -150,9 +150,13 @@
     --message-box-avatar-width: 35px;
     --message-box-avatar-height: var(--message-box-avatar-width);
     --message-box-avatar-column-width: 46px;
-    /* 6px appears to provide 5px of space between the avatar
-       and the selected-message outline, which is offset by -1px. */
-    --message-box-vertical-margin: 6px;
+    /* Increase the margin here to account for the
+       focus ring, which is is offset by -1px, as well
+       as the vertical height between the hover icons
+       and focus ring. */
+    --message-box-vertical-margin: calc(
+        var(--markdown-interelement-space-px) * 1.4
+    );
     --message-box-markdown-aligned-vertical-space: var(
         --markdown-interelement-space-px
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -147,9 +147,11 @@
     /*
     Message box elements and values.
     */
-    --message-box-avatar-width: 35px;
+    /* 35px at 14px/1em */
+    --message-box-avatar-width: 2.5em;
     --message-box-avatar-height: var(--message-box-avatar-width);
-    --message-box-avatar-column-width: 46px;
+    /* 46px at 14px/1em */
+    --message-box-avatar-column-width: 3.2857em;
     /* Increase the margin here to account for the
        focus ring, which is is offset by -1px, as well
        as the vertical height between the hover icons

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -162,10 +162,18 @@
     );
     --message-box-icon-width: 26px;
     --message-box-icon-height: 25px;
+    --message-box-height-senderless-single-line-message: calc(
+        var(--base-line-height-unitless) * var(--base-font-size-px) +
+            calc(var(--markdown-interelement-space-px) * 2)
+    );
     /* The line-height on the sender line should coordinate with the
-       height of the hover icons. The sender line never wraps, so this
-       just keeps the two in line with the grid definition. */
-    --message-box-sender-line-height: var(--message-box-icon-height);
+       height of a single-line, senderless message, but never be smaller
+       than the height of the hover icons. The sender line never wraps,
+       so this just keeps everything in line with the grid definition. */
+    --message-box-sender-line-height: max(
+        var(--message-box-icon-height),
+        var(--message-box-height-senderless-single-line-message)
+    );
     /* This width is updated with an exact pixel
        width upon UI initialization. */
     --message-box-timestamp-column-width: 0;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -280,6 +280,10 @@
                    to center me-messages within the baseline group. */
                 line-height: var(--message-box-avatar-height);
                 align-self: baseline;
+                /* Because the avatar may be the tallest element in a
+                   single-line me message, this margin preserves the
+                   overall height of the message box. */
+                margin-bottom: var(--message-box-vertical-margin);
             }
 
             .message_sender {
@@ -325,10 +329,7 @@
             grid-area: avatar;
             /* The picture should not participate in the baseline group. */
             align-self: start;
-            /* Because the avatar may be the tallest element in a
-              single-line me message, this margin preserves the
-              overall height of the message box. */
-            margin: var(--message-box-vertical-margin) 0;
+            margin-top: var(--message-box-vertical-margin);
         }
 
         .status-message {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -104,7 +104,7 @@
         ensures the timestamp will always have enough space
         in the column. */
     grid-template:
-        var(--message-box-icon-height) repeat(3, auto) /
+        var(--message-box-sender-line-height) repeat(3, auto) /
         var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
             3 * var(--message-box-icon-width)
         )
@@ -336,8 +336,13 @@
         }
 
         .message_content {
-            /* Top padding is reduced when there is a sender line. */
-            padding-top: 3px;
+            /* Pull message content up closer to sender to
+               let the text baseline sit adjacent the bottom
+               of the avatar. */
+            margin-top: calc(
+                var(--message-box-markdown-aligned-vertical-space) * 0.5 * -1
+            );
+            padding-top: 0;
             grid-area: message;
         }
 

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -3,7 +3,7 @@
     user-select: none;
 
     &:has(.message_reaction) {
-        padding-bottom: 5px;
+        margin-bottom: var(--message-box-markdown-aligned-vertical-space);
     }
 
     .message_reaction {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1212,7 +1212,7 @@ div.focused-message-list {
         display: none;
         width: 100%;
         height: 24px;
-        margin-bottom: 4px;
+        margin-bottom: var(--message-box-markdown-aligned-vertical-space);
         color: var(--color-text-show-more-less-button);
         background-color: var(--color-show-more-less-button-background);
         border-radius: 4px;


### PR DESCRIPTION
This PR extends the use of Markdown-derived interelement spacing to provide a more consistently sizable message box. Previous inconsistent space beneath reactions and Show more/Show less toggles now also take values derived from interelement spacing.

In making for consistent spacing, however, this PR introduces some subtle design changes that become more pronounced at 16/140, especially regarding the apparent alignment of the username and the top of the avatar. However, note in the screenshots that the avatar and the hover icons share a similar vertical distance from the top of the message box. That is a consequence of trying to vertically center-align the hover icons with the username and timestamp, while also keeping a consistent distance between the focus ring and hover icons between messages with senders, and those without.

Even more noticeable at the far righthand side of the message box is that the focus ring is the same distance from the timestamp, with and without a sender.

Additionally, the avatar now scales with font-size changes.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/spacing.20around.20message-box.20elements/near/1840391)

Fixes part of: #30476

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Updates from latest CZO discussion about the space between sender and first lines:_

| Legacy | 16/140 |
| --- | --- |
| ![legacy-propsed](https://github.com/zulip/zulip/assets/170719/9a89d890-1e03-4d93-906d-8e71f4eb08f9) | ![16-140-proposed](https://github.com/zulip/zulip/assets/170719/d079c1a5-86f4-4639-a1b9-61e0b1f81166) |

<details><summary>Previous screenshots</summary>



| Legacy, before | Legacy, after |
| --- | --- |
| ![message-space-0627-legacy-before](https://github.com/zulip/zulip/assets/170719/eec22140-b553-4b69-980e-338b64ffb08c) | ![message-space-0627-legacy-after](https://github.com/zulip/zulip/assets/170719/7dae85f1-13a1-48f9-8d63-3ef9f1a964c3) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![message-space-0627-16-140-before](https://github.com/zulip/zulip/assets/170719/88b4c70b-4a2b-4dc0-8a69-eb12b9ab8f28) | ![message-space-0627-16-140-after](https://github.com/zulip/zulip/assets/170719/f3ecb5c8-c96e-4265-92ae-aa37c60c37b7) |

| Toggles & emoji, before | Toggles & emoji, after |
| --- | --- |
| ![legacy-show-more-before](https://github.com/zulip/zulip/assets/170719/31601e7e-ddbc-4035-b852-325fcb9cb813) | ![legacy-show-more-after](https://github.com/zulip/zulip/assets/170719/6850dfef-cd08-4d08-9cfd-ddd613f26822) |
| ![16-140-show-more-before](https://github.com/zulip/zulip/assets/170719/0e0f4b9b-fc93-4b6c-a5b6-ad95508273f9) | ![16-140-show-more-after](https://github.com/zulip/zulip/assets/170719/9373f7fe-662e-4d65-b0e7-5035d65c7efc) |


_There are errors in the next set of screenshots; disregard._

| Legacy, before | Legacy, after |
| --- | --- |
| ![message-space-legacy-before](https://github.com/zulip/zulip/assets/170719/d47880be-9baa-4b37-8403-35c18227a3f1) | ![message-space-legacy-after](https://github.com/zulip/zulip/assets/170719/5adc2c3f-091c-4839-9067-9d3585b94e4b) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![message-space-16-140-before](https://github.com/zulip/zulip/assets/170719/cc1942e5-fd79-4e15-aa69-8f75cc471ec2) | ![message-space-16-140-after](https://github.com/zulip/zulip/assets/170719/ce3c5331-fc69-423b-beb2-c5d31cc36e13) |

_To better compare this work against [Vlad's mocks](https://www.figma.com/design/jbNOiBWvbtLuHaiTj4CW0G/Zulip-Web-App?node-id=2039-132344&t=d2cmmNBwOM21Uz4B-0) from #22022, here are screenshots with those density values in place (15px font size, 19px line height, or 1.2667 unitless, or 127%)._

| Vlad mock values (15/127), before | Vlad mock values (15/127), after |
| --- | --- |
| ![message-space-vlad-mock-15-127-before](https://github.com/zulip/zulip/assets/170719/76964a54-7633-43df-96bb-ffb42af58d04) | ![message-space-vlad-mock-15-127-after](https://github.com/zulip/zulip/assets/170719/c54a7df1-0562-4264-bbd8-b1c3ed25939b) |



| Legacy, before | Legacy, after |
| --- | --- |
| ![message-spacing-legacy-before](https://github.com/zulip/zulip/assets/170719/2e243568-ea07-4d1b-86df-29d609dd5902) | ![message-spacing-legacy-after](https://github.com/zulip/zulip/assets/170719/c567b6de-d9e7-448f-a9e8-e2cceebae48f) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![message-spacing-16-140-before](https://github.com/zulip/zulip/assets/170719/d9c3d268-1406-4d0f-9e23-ea31f0573692) | ![message-spacing-16-140-after](https://github.com/zulip/zulip/assets/170719/2e2f63fc-bda0-434d-9a5c-d9732fc3b196) |

| Navigating through 16/140, before | Navigating through 16/140, after |
| --- | --- |
| ![navigating-through-messages-before](https://github.com/zulip/zulip/assets/170719/9153f61b-93fe-428a-8035-f745f58967af) | ![navigating-through-messages-after](https://github.com/zulip/zulip/assets/170719/80df1e64-fec8-42db-b185-6a3d3de381c4) |

</details>


