### PR TITLE
Improve channels typeahead on invite modal #30577

### DIFF
--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -87,7 +87,7 @@ export function set_up_stream(
     };
     opts.help_on_empty_strings ||= false;
     new Typeahead(bootstrap_typeahead_input, {
-        items: 5,
+        items: 12,
         dropup: true,
         helpOnEmptyStrings: true,
         source(_query: string): StreamPillData[] {

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -115,7 +115,7 @@ export function set_up_stream(
             if (query.startsWith("#")) {
                 query = query.slice(1);
             }
-            return typeahead_helper.sort_streams(stream_matches, query);
+            return typeahead_helper.sort_streams_by_name(stream_matches, query);
         },
         updater(item: StreamPillData, _query: string): undefined {
             stream_pill.append_stream(item, pills, false);

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -628,6 +628,10 @@ export function compare_by_activity(
     return util.strcmp(stream_a.name, stream_b.name);
 }
 
+function compare_by_name(stream_a: StreamSubscription, stream_b: StreamSubscription): number {
+    return util.strcmp(stream_a.name, stream_b.name);
+}
+
 export function sort_streams(matches: StreamPillData[], query: string): StreamPillData[] {
     const name_results = typeahead.triage(query, matches, (x) => x.name, compare_by_activity);
     const desc_results = typeahead.triage(
@@ -638,6 +642,11 @@ export function sort_streams(matches: StreamPillData[], query: string): StreamPi
     );
 
     return [...name_results.matches, ...desc_results.matches, ...desc_results.rest];
+}
+
+export function sort_streams_by_name(matches: StreamPillData[], query: string): StreamPillData[] {
+    const results = typeahead.triage(query, matches, (x) => x.name, compare_by_name);
+    return [...results.matches, ...results.rest];
 }
 
 export function query_matches_person(

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -255,7 +255,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
 
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);
-        assert.equal(config.items, 5);
+        assert.equal(config.items, 12);
         assert.ok(config.dropup);
         assert.ok(config.stopAdvance);
 

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -226,7 +226,7 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
 
 run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
     override_rewire(typeahead_helper, "render_stream", () => $fake_rendered_stream);
-    override_rewire(typeahead_helper, "sort_streams", ({streams}) => {
+    override_rewire(typeahead_helper, "sort_streams_by_name", ({streams}) => {
         sort_streams_called = true;
         return streams;
     });

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -211,6 +211,15 @@ test("sort_streams", ({override, override_rewire}) => {
     assert.deepEqual(test_streams[4].name, "dead"); // Completely inactive stream
     assert.deepEqual(test_streams[5].name, "Derp"); // Muted stream last
 
+    // Sort streams by name
+    test_streams = th.sort_streams_by_name(test_streams, "d");
+    assert.deepEqual(test_streams[0].name, "dead");
+    assert.deepEqual(test_streams[1].name, "dead (almost)");
+    assert.deepEqual(test_streams[2].name, "Denmark");
+    assert.deepEqual(test_streams[3].name, "Derp");
+    assert.deepEqual(test_streams[4].name, "Dev");
+    assert.deepEqual(test_streams[5].name, "Docs");
+
     override_rewire(compose_state, "stream_name", () => "Different");
     // Test sort streams with description
     test_streams = [


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This does following things:

- [x] Show 12 options in the typeahead (rather than 5).
- [x]  Alphabetize all the channels in the typeahead, ignoring whether or not they are pinned, and anything else having to do with the user's personal relationship with the channel.

Fixes: #30577

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
