### PR TITLE
Clarify test notifications UI

### DIFF
--- a/help/desktop-notifications.md
+++ b/help/desktop-notifications.md
@@ -73,7 +73,7 @@ and [mentions](/help/mention-a-user-or-group), or to include messages in
 
 {settings_tab|notifications}
 
-1. Under **Desktop message notifications**, click **Test desktop notification**.
+1. Under **Desktop message notifications**, click **Send a test notification**.
    If notifications are working, you will receive a **Test notification**.
 
 {end_tabs}

--- a/help/desktop-notifications.md
+++ b/help/desktop-notifications.md
@@ -74,7 +74,7 @@ and [mentions](/help/mention-a-user-or-group), or to include messages in
 {settings_tab|notifications}
 
 1. Under **Desktop message notifications**, click **Send a test notification**.
-   If notifications are working, you will receive a **Test notification**.
+   If notifications are working, you will receive a test notification.
 
 {end_tabs}
 

--- a/web/src/settings_notifications.js
+++ b/web/src/settings_notifications.js
@@ -303,7 +303,7 @@ export function set_up(settings_panel) {
     // organization-level defaults.
     $container.find(".send_test_notification").on("click", () => {
         message_notifications.send_test_notification(
-            $t({defaultMessage: "This is what a Zulip notification looks like."}),
+            $t({defaultMessage: "This is a test notification from Zulip."}),
         );
     });
 

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -97,7 +97,7 @@
         </div>
 
         {{#unless for_realm_settings}}
-        <p><a class="send_test_notification">{{t "Test desktop notification" }}</a></p>
+        <p><a class="send_test_notification">{{t "Send a test notification" }}</a></p>
         {{/unless}}
 
         {{#each notification_settings.desktop_notification_settings}}


### PR DESCRIPTION
Notes:
- I'm not sure if the notification needs to say that it's from Zulip -- we do have the URL just above.

![Screenshot 2024-06-25 at 16 42 02@2x](https://github.com/zulip/zulip/assets/2090066/9bbdb56c-9d0c-4461-bbc8-cf13a8fc6b02)


![Screenshot 2024-06-25 at 16 59 52@2x](https://github.com/zulip/zulip/assets/2090066/ca5c41e8-cce7-430c-a6b0-a6784ea39a13)
