### PR TITLE
Fix incorrect topics order when moving messages.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -584,4 +584,5 @@ export function remove_messages(message_ids) {
     recent_view_ui.update_topics_of_deleted_message_ids(message_ids);
     starred_messages.remove(message_ids);
     starred_messages_ui.rerender_ui();
+    message_store.remove(message_ids);
 }

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -301,3 +301,9 @@ export function reify_message_id({old_id, new_id}: {old_id: number; new_id: numb
         stored_messages.delete(old_id);
     }
 }
+
+export function remove(message_ids: number[]): void {
+    for (const message_id of message_ids) {
+        stored_messages.delete(message_id);
+    }
+}

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -187,8 +187,10 @@ export class PerStreamHistory {
             const existing = this.topics.get(topic_name);
 
             if (existing) {
-                // Trust out local data more, since it
-                // maintains counts.
+                // If we have a topic in our cache, we update
+                // the message_id to accurately reflect the latest
+                // message in the topic.
+                existing.message_id = message_id;
                 continue;
             }
 

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -1,3 +1,4 @@
+import assert from "minimalistic-assert";
 import {z} from "zod";
 
 import * as channel from "./channel";
@@ -36,6 +37,53 @@ export function get_server_history(stream_id: number, on_success: () => void): v
         },
         error() {
             stream_topic_history.remove_request_pending_for(stream_id);
+        },
+    });
+}
+
+export function update_topic_last_message_id(
+    stream_id: number,
+    topic_name: string,
+    update_dom_on_success: () => void,
+): void {
+    void channel.get({
+        url: "/json/messages",
+        data: {
+            narrow: JSON.stringify([
+                {operator: "stream", operand: stream_id},
+                {operator: "topic", operand: topic_name},
+            ]),
+            anchor: "newest",
+            num_before: 1,
+            num_after: 0,
+        },
+        success(data) {
+            const {messages} = z
+                .object({
+                    messages: z.array(
+                        z.object({
+                            id: z.number(),
+                        }),
+                    ),
+                })
+                .parse(data);
+            if (messages.length !== 1) {
+                return;
+            }
+
+            const last_message = messages[0];
+            assert(last_message !== undefined);
+            stream_topic_history.add_history(stream_id, [
+                {
+                    name: topic_name,
+                    max_id: last_message.id,
+                },
+            ]);
+            update_dom_on_success();
+        },
+        error() {
+            // Ideally we would retry since we should always be able to get a success response
+            // from the server for this request, but for now we just ignore the error.
         },
     });
 }

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -124,6 +124,8 @@ import * as stream_list from "./stream_list";
 import * as stream_list_sort from "./stream_list_sort";
 import * as stream_popover from "./stream_popover";
 import * as stream_settings_ui from "./stream_settings_ui";
+import * as stream_topic_history from "./stream_topic_history";
+import * as stream_topic_history_util from "./stream_topic_history_util";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as tippyjs from "./tippyjs";
@@ -486,6 +488,15 @@ export function initialize_everything(state_data) {
     settings.initialize();
     initialize_navbar();
     initialize_message_feed_errors();
+
+    // Needs to be set before we fetch any messages.
+    stream_topic_history.set_update_topic_last_message_id((stream_id, topic_name) => {
+        stream_topic_history_util.update_topic_last_message_id(
+            stream_id,
+            topic_name,
+            stream_list.update_streams_sidebar,
+        );
+    });
 
     realm_logo.initialize();
     message_lists.initialize();

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -357,3 +357,45 @@ test("update_property", () => {
     assert.equal(message2.stream_id, denmark.stream_id);
     assert.equal(message2.display_recipient, denmark.name);
 });
+
+test("remove", () => {
+    const message1 = {
+        type: "stream",
+        sender_full_name: alice.full_name,
+        sender_id: alice.user_id,
+        stream_id: devel.stream_id,
+        stream: devel.name,
+        display_recipient: devel.name,
+        topic: "test",
+        id: 100,
+    };
+    const message2 = {
+        type: "stream",
+        sender_full_name: bob.full_name,
+        sender_id: bob.user_id,
+        stream_id: denmark.stream_id,
+        stream: denmark.name,
+        display_recipient: denmark.name,
+        topic: "test",
+        id: 101,
+    };
+    const message3 = {
+        type: "stream",
+        sender_full_name: cindy.full_name,
+        sender_id: cindy.user_id,
+        stream_id: denmark.stream_id,
+        stream: denmark.name,
+        display_recipient: denmark.name,
+        topic: "test",
+        id: 102,
+    };
+    for (const message of [message1, message2]) {
+        message_helper.process_new_message(message);
+    }
+
+    const deleted_message_ids = [message1.id, message3.id, 104];
+    message_store.remove(deleted_message_ids);
+    assert.equal(message_store.get(message1.id), undefined);
+    assert.equal(message_store.get(message2.id).id, message2.id);
+    assert.equal(message_store.get(message3.id), undefined);
+});

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -15,6 +15,8 @@ const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const stream_topic_history_util = zrequire("stream_topic_history_util");
 
+stream_topic_history.set_update_topic_last_message_id(noop);
+
 function test(label, f) {
     run_test(label, (helpers) => {
         unread.declare_bankruptcy();
@@ -391,4 +393,71 @@ test("all_topics_in_cache", ({override}) => {
 
     sub.first_message_id = 2;
     assert.equal(stream_topic_history.all_topics_in_cache(sub), true);
+});
+
+test("ask_server_for_latest_topic_data", () => {
+    stream_topic_history.set_update_topic_last_message_id((stream_id, topic_name) => {
+        stream_topic_history_util.update_topic_last_message_id(stream_id, topic_name, noop);
+    });
+    const stream_id = 1080;
+
+    let success_callback;
+    let get_message_request_triggered = false;
+    channel.get = (opts) => {
+        get_message_request_triggered = true;
+        assert.equal(opts.url, "/json/messages");
+        assert.deepEqual(opts.data, {
+            anchor: "newest",
+            narrow: '[{"operator":"stream","operand":1080},{"operator":"topic","operand":"Topic1"}]',
+            num_after: 0,
+            num_before: 1,
+        });
+        success_callback = opts.success;
+    };
+
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 101,
+        topic_name: "topic1",
+    });
+
+    let history = stream_topic_history.get_recent_topic_names(stream_id);
+    let max_message_id = stream_topic_history.get_max_message_id(stream_id);
+    assert.deepEqual(history, ["topic1"]);
+    assert.deepEqual(max_message_id, 101);
+
+    // Remove all cached messages from the topic. This sends a request to the server
+    // to check for the latest message id in the topic.
+    stream_topic_history.remove_messages({
+        stream_id,
+        topic_name: "Topic1",
+        num_messages: 1,
+        max_removed_msg_id: 104,
+    });
+    assert.equal(get_message_request_triggered, true);
+    get_message_request_triggered = false;
+
+    // Until we process the response from the server,
+    // the topic is not available.
+    history = stream_topic_history.get_recent_topic_names(stream_id);
+    assert.deepEqual(history, []);
+
+    // Simulate the server responses.
+    // Topic is empty.
+    success_callback({
+        messages: [],
+    });
+    history = stream_topic_history.get_recent_topic_names(stream_id);
+    assert.deepEqual(history, []);
+
+    // Topic has a different max_message_id.
+    success_callback({
+        messages: [{id: 102}],
+    });
+
+    // The topic is now available.
+    history = stream_topic_history.get_recent_topic_names(stream_id);
+    max_message_id = stream_topic_history.get_max_message_id(stream_id);
+    assert.deepEqual(history, ["Topic1"]);
+    assert.deepEqual(max_message_id, 102);
 });


### PR DESCRIPTION
Fixes #27500

This simplifies the code by removing the concept of historical topics and just asking server for the correct order when we are not sure what is the right order of the topics.
