### PR TITLE
message_fetch: Stop infinite fetch for first unread message id.

### DIFF
--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -465,7 +465,7 @@ export function maybe_load_older_messages(opts) {
 
         let found_first_unread = opts.first_unread_message_id === undefined;
         // This is a soft check because `first_unread_message_id` can be deleted.
-        if (!found_first_unread && msg_list_data.first() <= opts.first_unread_message_id) {
+        if (!found_first_unread && msg_list_data.first().id <= opts.first_unread_message_id) {
             found_first_unread = true;
         }
 


### PR DESCRIPTION
Found while migrating message_fetch to Typescript in #30509.

Tested by setting message fetch constants to single digit with some unreads and checking if we are hitting both `fetched_substantial_history` and `found_first_unread`.
