### PR TITLE
api-docs: Add example for BigBlueButton meeting_name parameter.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19751,7 +19751,8 @@ paths:
       summary: Create BigBlueButton video call
       description: |
         Create a video call URL for a BigBlueButton video call.
-        Requires BigBlueButton to be configured on the Zulip server.
+        Requires [BigBlueButton](/integrations/doc/big-blue-button)
+        to be configured on the Zulip server.
       parameters:
         - in: query
           name: meeting_name
@@ -19759,9 +19760,8 @@ paths:
             type: string
           required: true
           description: |
-            Title to use for the BigBlueButton meeting.
-
-            A good choice is something like "{channel_name} meeting".
+            Meeting name for the BigBlueButton video call.
+          example: "test_channel meeting"
       responses:
         "200":
           description: Success.


### PR DESCRIPTION
Also adds a link to the BigBlueButton integration documentation in the endpoint's main description.

_**Note**: Our API documentation rendering expects a documented example for endpoint parameters, so currently rendering this API endpoint doc raises an error._

**Screenshots and screen captures:**

<details>
<summary>Updated BigBlueButton create meeting API endpoint documentation</summary>

![Screenshot from 2024-06-26 14-32-06](https://github.com/zulip/zulip/assets/63245456/0b07a988-c4c7-4247-9a1f-8259b75d4a72)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
