### PR TITLE
user_circles: Allow status circles to scale.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -209,6 +209,13 @@
     --outer-spacing-input-pill-container: var(--vertical-spacing-input-pill);
     --horizontal-spacing-input-pill: 6px;
 
+    /* User circles. */
+    /* 8px at 14px/1em */
+    --length-user-status-circle: 0.5714em;
+    /* Shrink the user activity circle for the Recent Conversations context. */
+    /* 7px at 14px/1em */
+    --length-user-status-circle-recent-conversations: 0.5em;
+
     /* Overlay heights for streams modal */
     --overlay-container-height: 95vh;
     --overlay-container-max-height: 1000px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1068,10 +1068,6 @@ li.topic-list-item {
     .user_circle {
         width: 8px;
         height: 8px;
-        /* TODO: Remove these after right-sidebar
-           row rewrites. */
-        float: none;
-        position: static;
     }
 
     .zulip-icon.zulip-icon-bot {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1066,8 +1066,8 @@ li.topic-list-item {
     }
 
     .user_circle {
-        width: 8px;
-        height: 8px;
+        width: var(--length-user-status-circle);
+        height: var(--length-user-status-circle);
     }
 
     .zulip-icon.zulip-icon-bot {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -412,14 +412,23 @@ ul {
 
 .user_profile_presence,
 .popover_user_presence {
-    width: 8px;
-    height: 8px;
+    width: var(--length-user-status-circle);
+    height: var(--length-user-status-circle);
     margin: 0 5px;
     display: inline-block;
     float: initial;
     position: relative;
     top: 0;
     flex-shrink: 0;
+}
+
+.user_profile_presence {
+    /* Remove font-size to allow this to scale
+       with the menu header text. Declaring font-size
+       here maintains the legacy design of keeping
+       the user-circle smaller, despite the larger
+       surrounding text and icons. */
+    font-size: var(--base-font-size-px);
 }
 
 .bot-owner-name {
@@ -1106,8 +1115,8 @@ ul {
 
     .status-circle {
         position: absolute;
-        width: 8px;
-        height: 8px;
+        width: var(--length-user-status-circle);
+        height: var(--length-user-status-circle);
         top: unset;
         left: unset;
         right: -1px;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -482,9 +482,10 @@
             }
 
             .user_circle {
-                /* Shrink the user activity circle for the Recent Conversations context. */
-                min-width: 7px;
-                height: 7px;
+                min-width: var(
+                    --length-user-status-circle-recent-conversations
+                );
+                height: var(--length-user-status-circle-recent-conversations);
                 float: left;
                 position: unset;
             }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -117,8 +117,8 @@ $user_status_emoji_width: 24px;
     }
 
     .user_circle {
-        width: 8px;
-        height: 8px;
+        width: var(--length-user-status-circle);
+        height: var(--length-user-status-circle);
         grid-area: starting-anchor-element;
         place-self: center center;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -828,8 +828,8 @@ strong {
             Most of the style rules related to color, gradient etc. which are generally common throughout
             the app are defined in user_circles.css and are not overridden here. */
             .user_circle {
-                width: 8px;
-                height: 8px;
+                width: var(--length-user-status-circle);
+                height: var(--length-user-status-circle);
                 margin: 0 5px 0 -6px;
                 position: relative;
                 float: left;


### PR DESCRIPTION
This PR allows status circles to scale, while maintaining adjustments (e.g., in the Recent conversations area) present in the current design.

Note that user circles on the typeahead menu do not yet scale at 16/140, but will once typeahead text scales with the rest of the UI.

Fixes part of #30476 

**Screenshots and screen captures:**

| Before | After (no change at legacy sizes) |
| --- | --- |
| ![user-circles-legacy-before](https://github.com/zulip/zulip/assets/170719/f1219a4f-ded1-4dc3-b172-5e5f18eed2ca) | ![user-circles-legacy-after](https://github.com/zulip/zulip/assets/170719/2acd7acd-8e22-4419-bf1a-43d77281f906) |
| ![user-circles-16-140-before](https://github.com/zulip/zulip/assets/170719/58f3aecb-f65c-4e99-9498-891420dc5b26) | ![user-circles-16-140-after](https://github.com/zulip/zulip/assets/170719/126e5d55-76d1-4019-a175-ba11ca682f31) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

