### PR TITLE
status_emoji: Allow status emoji to scale with text.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1653,11 +1653,12 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 }
 
 .status-emoji {
-    height: 16px;
-    width: 16px;
+    /* 16px at 14px/1em */
+    height: 1.1429em;
+    width: 1.1429em;
     /* We are setting minimum width here because when the user's name is very long,
     emoji's width decreases and causes it to break. */
-    min-width: 16px;
+    min-width: 1.1429em;
     /* In most contexts, status emoji appear immediately after a name
       field with no margin. Position the status emoji with 3px of left
       margin to space it from the name, and set no right margin so


### PR DESCRIPTION
This does not affect status emoji in popovers, which should be handled alongside scaling popover text (that has been noted in #30476).

Fixes part of #30476

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change at legacy sizes) |
| --- | --- |
| ![status-emoji-legacy-before](https://github.com/zulip/zulip/assets/170719/a320116c-6a4b-4660-86d3-28b3e8dccfb5) | ![status-emoji-legacy-after](https://github.com/zulip/zulip/assets/170719/c7e9f576-8ce4-45ac-bbe9-4a831b862457) |
| ![status-emoji-16-140-before](https://github.com/zulip/zulip/assets/170719/adf51426-9089-43c2-b970-8db800cb2e57) | ![status-emoji-16-140-after](https://github.com/zulip/zulip/assets/170719/98603c73-e4c4-48c0-b01d-0ee89f957512) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

