### PR TITLE
settings: Fade label for disabled checkbox settings.

### DIFF
--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -62,6 +62,11 @@ export function maybe_disable_widgets() {
 
     $(".organization-box [data-name='organization-profile']").find(".image_upload_button").hide();
 
+    $(".organization-box [data-name='organization-profile']")
+        .find("input[type='checkbox']:disabled")
+        .closest(".input-group")
+        .addClass("control-label-disabled");
+
     $(".organization-box [data-name='organization-settings']")
         .find("input, textarea, button, select")
         .prop("disabled", true);
@@ -71,16 +76,18 @@ export function maybe_disable_widgets() {
         .hide();
 
     $(".organization-box [data-name='organization-settings']")
-        .find(".control-label-disabled")
-        .addClass("enabled");
+        .find("input[type='checkbox']:disabled")
+        .closest(".input-group")
+        .addClass("control-label-disabled");
 
     $(".organization-box [data-name='organization-permissions']")
         .find("input, textarea, button, select")
         .prop("disabled", true);
 
     $(".organization-box [data-name='organization-permissions']")
-        .find(".control-label-disabled")
-        .addClass("enabled");
+        .find("input[type='checkbox']:disabled")
+        .closest(".input-group")
+        .addClass("control-label-disabled");
 }
 
 export function get_organization_settings_options() {

--- a/web/src/settings_realm_user_settings_defaults.js
+++ b/web/src/settings_realm_user_settings_defaults.js
@@ -18,6 +18,11 @@ export function maybe_disable_widgets() {
             .prop("disabled", true);
 
         $(".organization-box [data-name='organization-level-user-defaults']")
+            .find("input[type='checkbox']:disabled")
+            .closest(".input-group")
+            .addClass("control-label-disabled");
+
+        $(".organization-box [data-name='organization-level-user-defaults']")
             .find(".play_notification_sound")
             .addClass("control-label-disabled");
     }

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -256,6 +256,7 @@ export function enable_or_disable_permission_settings_in_edit_panel(sub) {
         .prop("disabled", !sub.can_change_stream_permissions);
 
     if (!sub.can_change_stream_permissions) {
+        $general_settings_container.find(".default-stream").addClass("control-label-disabled");
         return;
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -720,11 +720,7 @@ input[type="checkbox"] {
 }
 
 .control-label-disabled {
-    color: hsl(0deg 0% 82%);
-
-    &.enabled {
-        color: hsl(0deg 0% 20%);
-    }
+    color: hsl(0deg 0% 64%);
 }
 
 .admin-realm-message-retention-days {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -49,10 +49,6 @@
     white-space: normal;
 }
 
-.control-label-disabled {
-    color: hsl(0deg 0% 64%);
-}
-
 .sub_setting_checkbox {
     display: flex;
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fade the label for disabled checkbox settings.
- Second commit is to fade the label for disabled checkbox stream settings.
- Third commit is for refactoring CSS.

Fixes: <!-- Issue link, or clear description.-->https://chat.zulip.org/#narrow/stream/101-design/topic/disabled.20checkbox.20label.20in.20settings

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/zulip/zulip/assets/35494118/441e70f9-fe6b-4662-a401-05fc2993884e) | ![image](https://github.com/zulip/zulip/assets/35494118/9c929de7-31e6-4207-8360-0ec7e64f89b4)  |
| ![image](https://github.com/zulip/zulip/assets/35494118/2bee7d38-718d-4c68-b588-580299b5f430) | ![image](https://github.com/zulip/zulip/assets/35494118/a65086b8-f0f7-4c0d-843d-75bcde7f1842)  |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
