### PR TITLE
info_density: Remove unnecessary 14px-related styles after audit.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -777,9 +777,7 @@ input[type="checkbox"] {
     }
 
     #emoji-file-name {
-        font-size: 14px;
         white-space: nowrap;
-        height: 1rem;
         font-style: italic;
         color: hsl(0deg 0% 67%);
     }

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -42,7 +42,6 @@
     /* For the box-shadow to be visible on the left */
     .add-task,
     .add-desc {
-        font-size: 14px;
         font-weight: 400;
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -970,15 +970,6 @@ td.pointer {
         word-wrap: unset;
     }
 
-    > .view_read_receipts {
-        font-size: 14px;
-        height: 16px;
-
-        &:hover {
-            color: hsl(200deg 100% 40%);
-        }
-    }
-
     .edit_content {
         /* Icons for editing content are determined on message hover;
            we set an empty `.edit_content` to have 0 height in order to


### PR DESCRIPTION
This removes the remaining 14px font-size and related styles in the code base, except for instances in `popovers.css`, `tooltips.css`, and `right_sidebar.css`--all of which are being tracked for removal separately in #30476.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
