### PR TITLE
compose: Redesign mobile message buttons popover.

### DIFF
--- a/web/src/compose_popovers.js
+++ b/web/src/compose_popovers.js
@@ -25,6 +25,7 @@ export function initialize() {
         // actions
         target: ".mobile_button_container",
         placement: "top",
+        theme: "popover-menu",
         onShow(instance) {
             popover_menus.popover_instances.compose_mobile_button = instance;
             popover_menus.on_show_prep(instance);

--- a/web/src/compose_popovers.js
+++ b/web/src/compose_popovers.js
@@ -6,7 +6,6 @@ import render_mobile_message_buttons_popover from "../templates/popovers/mobile_
 
 import * as compose_actions from "./compose_actions";
 import * as giphy_state from "./giphy_state";
-import * as narrow_state from "./narrow_state";
 import * as popover_menus from "./popover_menus";
 import * as popovers from "./popovers";
 import * as rows from "./rows";
@@ -29,13 +28,7 @@ export function initialize() {
         onShow(instance) {
             popover_menus.popover_instances.compose_mobile_button = instance;
             popover_menus.on_show_prep(instance);
-            instance.setContent(
-                parse_html(
-                    render_mobile_message_buttons_popover({
-                        is_in_private_narrow: narrow_state.narrowed_to_pms(),
-                    }),
-                ),
-            );
+            instance.setContent(parse_html(render_mobile_message_buttons_popover()));
         },
         onMount(instance) {
             const $popper = $(instance.popper);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1311,11 +1311,6 @@ textarea.new_message_textarea {
     }
 }
 
-.compose_mobile_stream_button i,
-.compose_mobile_direct_message_button i {
-    margin-right: 4px;
-}
-
 /* Class for send-area buttons, such as
    Drafts and the send-adjacent vdots */
 .send-control-button {

--- a/web/templates/popovers/mobile_message_buttons_popover.hbs
+++ b/web/templates/popovers/mobile_message_buttons_popover.hbs
@@ -1,22 +1,24 @@
-<ul class="nav nav-list">
-    <li>
-        <a class="compose_mobile_stream_button">
-            <i class="fa fa-bullhorn" aria-hidden="true"></i>
-            {{#if is_in_private_narrow }}
-            {{t "New channel message" }}
-            {{else}}
-            {{t "New topic" }}
-            {{/if}}
-        </a>
-    </li>
-    <li>
-        <a class="compose_mobile_direct_message_button">
-            <i class="fa fa-envelope" aria-hidden="true"></i>
-            {{#if is_in_private_narrow }}
-            {{t "New direct message" }}
-            {{else}}
-            {{t "New direct message" }}
-            {{/if}}
-        </a>
-    </li>
-</ul>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="compose_mobile_stream_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                {{#if is_in_private_narrow }}
+                <span class="popover-menu-label">{{t "New channel message" }}</span>
+                {{else}}
+                <span class="popover-menu-label">{{t "New topic" }}</span>
+                {{/if}}
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="compose_mobile_direct_message_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mail" aria-hidden="true"></i>
+                {{#if is_in_private_narrow }}
+                <span class="popover-menu-label">{{t "New direct message" }}</span>
+                {{else}}
+                <span class="popover-menu-label">{{t "New direct message" }}</span>
+                {{/if}}
+            </a>
+        </li>
+    </ul>
+</div>

--- a/web/templates/popovers/mobile_message_buttons_popover.hbs
+++ b/web/templates/popovers/mobile_message_buttons_popover.hbs
@@ -3,21 +3,15 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" class="compose_mobile_stream_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                {{#if is_in_private_narrow }}
-                <span class="popover-menu-label">{{t "New channel message" }}</span>
-                {{else}}
-                <span class="popover-menu-label">{{t "New topic" }}</span>
-                {{/if}}
+                <span class="popover-menu-label">{{t "Start new conversation" }}</span>
+                {{popover_hotkey_hints "C"}}
             </a>
         </li>
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" class="compose_mobile_direct_message_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mail" aria-hidden="true"></i>
-                {{#if is_in_private_narrow }}
                 <span class="popover-menu-label">{{t "New direct message" }}</span>
-                {{else}}
-                <span class="popover-menu-label">{{t "New direct message" }}</span>
-                {{/if}}
+                {{popover_hotkey_hints "X"}}
             </a>
         </li>
     </ul>


### PR DESCRIPTION
As part of the popover menu redesign, this redesigns the mobile message buttons popover using the new "popover-menu" tippy theme and improves accessibility by using appropriate ARIA attributes.

This PR also updates the logic for the mobile message buttons popover to mimic the "Start new conversation" button's logic — show new topic option only when in a stream narrow, else show the new channel message option. And removes the `is_in_private_narrow` check from the logic, as we show the new direct message option regardless of it.

Fixes part of #28699.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/compose.3A.20Redesign.20mobile.20message.20buttons.20popover.20.2330603/near/1839459)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Desc | Before | After |
|--------|--------|--------|
| Light Mode | <img width="302" alt="mobile-msg-popover-light-before" src="https://github.com/zulip/zulip/assets/82862779/40cfc644-27e2-4691-b37f-4cd26f21c6fe"> | <img width="302" alt="mob-msgs-update-after-light" src="https://github.com/zulip/zulip/assets/82862779/a6106fb6-42d4-4343-b754-91fc6c21f304"> |
| Dark Mode | <img width="302" alt="mobile-msg-popover-dark-before" src="https://github.com/zulip/zulip/assets/82862779/02fe6080-7eeb-4ee2-b104-7c4bf92bfe6c"> | <img width="302" alt="mob-msgs-update-after-dark" src="https://github.com/zulip/zulip/assets/82862779/a326825e-4e66-474e-b315-0381fd280398"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
