### PR TITLE
Change interaction UI for adding users when creating streams

### DIFF
--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -99,6 +99,39 @@ export function create({
     return pill_widget;
 }
 
+export function create_without_add_button({
+    $pill_container,
+    get_potential_subscribers,
+    onPillCreateAction,
+    onPillRemoveAction,
+}: {
+    $pill_container: JQuery;
+    get_potential_subscribers: () => User[];
+    onPillCreateAction: (pill_user_ids: number[]) => void;
+    onPillRemoveAction: (pill_user_ids: number[]) => void;
+}): CombinedPillContainer {
+    const pill_widget = input_pill.create<CombinedPill>({
+        $container: $pill_container,
+        create_item_from_text,
+        get_text_from_item,
+    });
+    function get_users(): User[] {
+        const potential_subscribers = get_potential_subscribers();
+        return user_pill.filter_taken_users(potential_subscribers, pill_widget);
+    }
+
+    pill_widget.onPillCreate(() => {
+        onPillCreateAction(get_pill_user_ids(pill_widget));
+    });
+    pill_widget.onPillRemove(() => {
+        onPillRemoveAction(get_pill_user_ids(pill_widget));
+    });
+
+    set_up_pill_typeahead({pill_widget, $pill_container, get_users});
+
+    return pill_widget;
+}
+
 function get_pill_user_ids(pill_widget: CombinedPillContainer): number[] {
     const user_ids = user_pill.get_user_ids(pill_widget);
     const stream_user_ids = stream_pill.get_user_ids(pill_widget);

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -31,8 +31,13 @@ function add_all_users(): void {
     add_user_ids(user_ids);
 }
 
-function remove_user_ids(user_ids: number[]): void {
-    stream_create_subscribers_data.remove_user_ids(user_ids);
+function soft_remove_user_id(user_id: number): void {
+    stream_create_subscribers_data.soft_remove_user_id(user_id);
+    redraw_subscriber_list();
+}
+
+function undo_soft_remove_user_id(user_id: number): void {
+    stream_create_subscribers_data.undo_soft_remove_user_id(user_id);
     redraw_subscriber_list();
 }
 
@@ -68,7 +73,14 @@ export function create_handlers($container: JQuery): void {
         e.preventDefault();
         const $elem = $(e.target);
         const user_id = Number.parseInt($elem.attr("data-user-id")!, 10);
-        remove_user_ids([user_id]);
+        soft_remove_user_id(user_id);
+    });
+
+    $container.on("click", ".undo_soft_removed_potential_subscriber", (e) => {
+        e.preventDefault();
+        const $elem = $(e.target);
+        const user_id = Number.parseInt($elem.attr("data-user-id")!, 10);
+        undo_soft_remove_user_id(user_id);
     });
 }
 
@@ -95,6 +107,9 @@ export function build_widgets(): void {
                 is_current_user: user.user_id === current_user_id,
                 disabled: stream_create_subscribers_data.must_be_subscribed(user.user_id),
                 img_src: people.small_avatar_url_for_person(user),
+                soft_removed: stream_create_subscribers_data.user_id_in_soft_remove_list(
+                    user.user_id,
+                ),
             };
             return render_new_stream_user(item);
         },

--- a/web/src/stream_create_subscribers_data.ts
+++ b/web/src/stream_create_subscribers_data.ts
@@ -1,11 +1,15 @@
+import _ from "lodash";
+
 import * as people from "./people";
 import type {User} from "./people";
 import {current_user} from "./state_data";
 
 let user_id_set: Set<number>;
+let soft_remove_user_id_set: Set<number>;
 
 export function initialize_with_current_user(): void {
     user_id_set = new Set([current_user.user_id]);
+    soft_remove_user_id_set = new Set();
 }
 
 export function sorted_user_ids(): number[] {
@@ -24,7 +28,7 @@ export function get_all_user_ids(): number[] {
 
 export function get_principals(): number[] {
     // Return list of user ids which were selected by user.
-    return [...user_id_set];
+    return _.difference([...user_id_set], [...soft_remove_user_id_set]);
 }
 
 export function get_potential_subscribers(): User[] {
@@ -42,6 +46,9 @@ export function add_user_ids(user_ids: number[]): void {
             const user = people.maybe_get_user_by_id(user_id);
             if (user) {
                 user_id_set.add(user_id);
+                // Re-adding a user explicitly will not undo the soft remove on their row.
+                // e.g If `Iago` was added as part of a group and crossed out.
+                // Now, adding another group with Iago as part of it should not undo the soft remove.
             }
         }
     }
@@ -50,6 +57,7 @@ export function add_user_ids(user_ids: number[]): void {
 export function remove_user_ids(user_ids: number[]): void {
     for (const user_id of user_ids) {
         user_id_set.delete(user_id);
+        undo_soft_remove_user_id(user_id);
     }
 }
 
@@ -61,4 +69,16 @@ export function sync_user_ids(user_ids: number[]): void {
         user_ids.push(current_user.user_id);
     }
     user_id_set = new Set(user_ids);
+}
+
+export function soft_remove_user_id(user_id: number): void {
+    soft_remove_user_id_set.add(user_id);
+}
+
+export function undo_soft_remove_user_id(user_id: number): void {
+    soft_remove_user_id_set.delete(user_id);
+}
+
+export function user_id_in_soft_remove_list(user_id: number): boolean {
+    return soft_remove_user_id_set.has(user_id);
 }

--- a/web/src/stream_create_subscribers_data.ts
+++ b/web/src/stream_create_subscribers_data.ts
@@ -52,3 +52,13 @@ export function remove_user_ids(user_ids: number[]): void {
         user_id_set.delete(user_id);
     }
 }
+
+export function sync_user_ids(user_ids: number[]): void {
+    // Current user does not have their pill in their input
+    // box, so we need to make sure that we don't delete
+    // it unnecessarily while syncing.
+    if (user_id_set.has(current_user.user_id)) {
+        user_ids.push(current_user.user_id);
+    }
+    user_id_set = new Set(user_ids);
+}

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -408,16 +408,11 @@ export function enable_or_disable_add_subscribers_elements(
     stream_creation = false,
 ) {
     const $input_element = $container_elem.find(".input").expectOne();
-    const $add_subscribers_button = $container_elem
-        .find('button[name="add_subscriber"]')
-        .expectOne();
     const $add_subscribers_container = $(".edit_subscribers_for_stream .subscriber_list_settings");
 
     $input_element.prop("contenteditable", enable_elem);
-    $add_subscribers_button.prop("disabled", !enable_elem);
 
     if (enable_elem) {
-        $add_subscribers_button.css("pointer-events", "");
         $add_subscribers_container[0]?._tippy?.destroy();
         $container_elem.find(".add_subscribers_container").removeClass("add_subscribers_disabled");
     } else {
@@ -436,6 +431,14 @@ export function enable_or_disable_add_subscribers_elements(
             $container_elem
                 .find(".add_all_users_to_stream_btn_container")
                 .addClass("add_subscribers_disabled");
+        }
+    } else {
+        const $add_subscribers_button = $container_elem
+            .find('button[name="add_subscriber"]')
+            .expectOne();
+        $add_subscribers_button.prop("disabled", !enable_elem);
+        if (enable_elem) {
+            $add_subscribers_button.css("pointer-events", "");
         }
     }
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -201,6 +201,10 @@ h4.user_group_setting_subsection_title {
             th.user-remove-actions {
                 min-width: 80px;
             }
+
+            .strikethrough {
+                text-decoration: line-through;
+            }
         }
     }
 }

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -5,9 +5,11 @@
             {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
         </div>
     </div>
-    <div class="add_subscriber_btn_wrapper inline-block">
-        <button type="submit" name="add_subscriber" class="button add-subscriber-button add-users-button small rounded sea-green" tabindex="0">
-            {{t 'Add' }}
-        </button>
-    </div>
+    {{#if (not hide_add_button)}}
+        <div class="add_subscriber_btn_wrapper inline-block">
+            <button type="submit" name="add_subscriber" class="button add-subscriber-button add-users-button small rounded sea-green" tabindex="0">
+                {{t 'Add' }}
+            </button>
+        </div>
+    {{/if}}
 </div>

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -1,13 +1,17 @@
 <tr>
     <td class="panel_user_list">
-        {{> ../user_display_only_pill display_value=full_name}}
+        {{> ../user_display_only_pill display_value=full_name strikethrough=soft_removed}}
     </td>
     {{#if email}}
-        <td class="subscriber-email">{{email}}</td>
+        <td class="subscriber-email {{#if soft_removed}} strikethrough {{/if}}">{{email}}</td>
     {{else}}
-        <td class="hidden-subscriber-email">{{t "(hidden)"}}</td>
+        <td class="hidden-subscriber-email {{#if soft_removed}} strikethrough {{/if}}">{{t "(hidden)"}}</td>
     {{/if}}
     <td>
-        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded white">{{t 'Remove' }}</button>
+        {{#if soft_removed}}
+            <button data-user-id="{{user_id}}" class="undo_soft_removed_potential_subscriber button small rounded white">{{t 'Add' }}</button>
+        {{else}}
+            <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded white">{{t 'Remove' }}</button>
+        {{/if}}
     </td>
 </tr>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -12,7 +12,7 @@
 </div>
 
 <div class="create_stream_subscriber_list_header">
-    <h4 class="stream_setting_subsection_title">{{t 'Subscribers' }}</h4>
+    <h4 class="stream_setting_subsection_title">{{t 'Subscribers preview' }}</h4>
     <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter subscribers' }}" />
 </div>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -1,6 +1,6 @@
 <div class="subscriber_list_settings">
     <div class="subscriber_list_add float-left">
-        {{> add_subscribers_form}}
+        {{> add_subscribers_form hide_add_button=true}}
     </div>
     <br />
 

--- a/web/templates/user_display_only_pill.hbs
+++ b/web/templates/user_display_only_pill.hbs
@@ -3,7 +3,7 @@
         {{#if img_src}}
         <img class="pill-image" src="{{img_src}}" />
         {{/if}}
-        <span class="pill-label">
+        <span class="pill-label {{#if strikethrough}} strikethrough {{/if}}" >
             <span class="pill-value">{{display_value}}</span>
             {{#if is_current_user}}<span class="my_user_status">{{t '(you)'}}</span>{{/if}}
             {{~#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}

--- a/web/tests/stream_create_subscribers_data.test.js
+++ b/web/tests/stream_create_subscribers_data.test.js
@@ -78,3 +78,22 @@ test("must_be_subscribed", () => {
     assert.ok(!stream_create_subscribers_data.must_be_subscribed(me.user_id));
     assert.ok(!stream_create_subscribers_data.must_be_subscribed(test_user101.user_id));
 });
+
+test("sync_user_ids", () => {
+    // sync_user_ids should not remove current user if already present.
+    stream_create_subscribers_data.initialize_with_current_user();
+    stream_create_subscribers_data.sync_user_ids([test_user101.user_id, test_user102.user_id]);
+    assert.deepEqual(stream_create_subscribers_data.sorted_user_ids(), [
+        me.user_id,
+        test_user101.user_id,
+        test_user102.user_id,
+    ]);
+
+    // sync_user_ids should not add current user if already not present.
+    stream_create_subscribers_data.remove_user_ids([me.user_id]);
+    stream_create_subscribers_data.sync_user_ids([test_user101.user_id, test_user102.user_id]);
+    assert.deepEqual(stream_create_subscribers_data.sorted_user_ids(), [
+        test_user101.user_id,
+        test_user102.user_id,
+    ]);
+});

--- a/web/tests/stream_create_subscribers_data.test.js
+++ b/web/tests/stream_create_subscribers_data.test.js
@@ -97,3 +97,52 @@ test("sync_user_ids", () => {
         test_user102.user_id,
     ]);
 });
+
+test("soft remove", () => {
+    stream_create_subscribers_data.initialize_with_current_user();
+    stream_create_subscribers_data.add_user_ids([test_user101.user_id, test_user102.user_id]);
+
+    stream_create_subscribers_data.soft_remove_user_id(test_user102.user_id);
+    // sorted_user_ids should still have all the users.
+    assert.deepEqual(stream_create_subscribers_data.sorted_user_ids(), [
+        me.user_id,
+        test_user101.user_id,
+        test_user102.user_id,
+    ]);
+    assert.deepEqual(stream_create_subscribers_data.get_principals(), [
+        me.user_id,
+        test_user101.user_id,
+    ]);
+    assert.ok(stream_create_subscribers_data.user_id_in_soft_remove_list(test_user102.user_id));
+    assert.ok(!stream_create_subscribers_data.user_id_in_soft_remove_list(test_user101.user_id));
+
+    // Removing a user_id should also remove them from soft remove list.
+    stream_create_subscribers_data.remove_user_ids([test_user102.user_id]);
+    assert.ok(!stream_create_subscribers_data.user_id_in_soft_remove_list(test_user102.user_id));
+    assert.deepEqual(stream_create_subscribers_data.sorted_user_ids(), [
+        me.user_id,
+        test_user101.user_id,
+    ]);
+    assert.deepEqual(stream_create_subscribers_data.get_principals(), [
+        me.user_id,
+        test_user101.user_id,
+    ]);
+
+    // Undo soft remove
+    stream_create_subscribers_data.soft_remove_user_id(test_user101.user_id);
+    assert.deepEqual(stream_create_subscribers_data.sorted_user_ids(), [
+        me.user_id,
+        test_user101.user_id,
+    ]);
+    assert.deepEqual(stream_create_subscribers_data.get_principals(), [me.user_id]);
+
+    stream_create_subscribers_data.undo_soft_remove_user_id(test_user101.user_id);
+    assert.deepEqual(stream_create_subscribers_data.sorted_user_ids(), [
+        me.user_id,
+        test_user101.user_id,
+    ]);
+    assert.deepEqual(stream_create_subscribers_data.get_principals(), [
+        me.user_id,
+        test_user101.user_id,
+    ]);
+});


### PR DESCRIPTION
One additional detail to the specs described in #29825 is that we will not have a pill for the current user. Discussion can be found here: https://chat.zulip.org/#narrow/stream/6-frontend/topic/Disabled.2Fun-editable.20input.20pill/near/1838691
I've not added extra puppetteer tests, since adding users was not part of the existing tests.

While there are 2 commits in this PR and each of them will past the tests independently, the first commit has functional bugs, as it's an intermediate step. I've kept two commits here so it's a bit easier to review, we can squash it at the end.

Fixes: #29825.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="746" alt="Screenshot 2024-06-27 at 7 02 46 PM" src="https://github.com/zulip/zulip/assets/13910561/871183dc-0968-47cd-89de-57accbbe397b">

<details>
<summary>Screen capture</summary>

![create new channel](https://github.com/zulip/zulip/assets/13910561/81580406-4470-4a9d-9cdc-8c6d8e40176b)

Resultant subscriber list:
<img width="746" alt="Screenshot 2024-06-27 at 7 13 14 PM" src="https://github.com/zulip/zulip/assets/13910561/3ffdcda6-caba-4b48-9001-6400e8de8d30">


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
