### PR TITLE
typeahead: Remove all sources of white space inside `strong` element.

### DIFF
--- a/web/templates/inline_decorated_stream_name.hbs
+++ b/web/templates/inline_decorated_stream_name.hbs
@@ -1,8 +1,8 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
-{{#if stream.invite_only }}
+{{~#if stream.invite_only ~}}
 <i class="zulip-icon zulip-icon-lock stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
-{{ else if stream.is_web_public }}
+{{~ else if stream.is_web_public ~}}
 <i class="zulip-icon zulip-icon-globe stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
-{{ else }}
+{{~ else ~}}
 <i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
-{{/if}}
+{{~/if~}}

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -19,11 +19,11 @@
 {{!-- Separate container to ensure overflowing text remains in this container. --}}
 <div class="typeahead-text-container">
     <strong class="typeahead-strong-section">
-        {{~#if stream}}
-            {{> inline_decorated_stream_name stream=stream }}
-        {{else}}
+        {{~#if stream~}}
+            {{~> inline_decorated_stream_name stream=stream ~}}
+            {{~else~}}
             {{~ primary ~}}
-        {{/if}}
+        {{~/if~}}
     </strong>
     {{~#if has_pronouns}}
         <span class="pronouns">({{pronouns}})</span>

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -896,7 +896,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 actual_value = options.highlighter_html("kronor");
                 expected_value =
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">kronor    </strong></div>\n';
+                    '    <strong class="typeahead-strong-section">kronor</strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 // Highlighted content should be escaped.
@@ -904,14 +904,14 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 actual_value = options.highlighter_html("<&>");
                 expected_value =
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">&lt;&amp;&gt;    </strong></div>\n';
+                    '    <strong class="typeahead-strong-section">&lt;&amp;&gt;</strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 options.query = "even m";
                 actual_value = options.highlighter_html("even more ice");
                 expected_value =
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">even more ice    </strong></div>\n';
+                    '    <strong class="typeahead-strong-section">even more ice</strong></div>\n';
                 assert.equal(actual_value, expected_value);
 
                 // options.sorter()
@@ -1136,7 +1136,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                     `    <span class="user_circle_empty user_circle"></span>\n` +
                     `    <img class="typeahead-image" src="http://zulip.zulipdev.com/avatar/${othello.user_id}?s&#x3D;50" />\n` +
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">Othello, the Moor of Venice    </strong>    <small class="autocomplete_secondary">othello@zulip.com</small>\n' +
+                    '    <strong class="typeahead-strong-section">Othello, the Moor of Venice</strong>    <small class="autocomplete_secondary">othello@zulip.com</small>\n' +
                     "</div>\n";
                 assert.equal(actual_value, expected_value);
                 // Reset the email such that this does not affect further tests.
@@ -1148,7 +1148,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 expected_value =
                     '    <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>\n' +
                     '<div class="typeahead-text-container">\n' +
-                    '    <strong class="typeahead-strong-section">hamletcharacters    </strong>    <small class="autocomplete_secondary">Characters of Hamlet</small>\n' +
+                    '    <strong class="typeahead-strong-section">hamletcharacters</strong>    <small class="autocomplete_secondary">Characters of Hamlet</small>\n' +
                     "</div>\n";
                 assert.equal(actual_value, expected_value);
 


### PR DESCRIPTION
We are using `white-space: pre` which doesn't condense whitespaces, so we need to remove any unintentional whitespaces here.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/channel.20typeaheads.20indented

| before | after |
| --- | --- |
| ![image](https://github.com/zulip/zulip/assets/25124304/08cd617b-4b82-4e47-b300-dfdacf84e117) | <img width="562" alt="Screenshot 2024-06-27 at 3 50 06 PM" src="https://github.com/zulip/zulip/assets/25124304/94f38056-c766-45df-9328-078fcc105160"> |
| ![image](https://github.com/zulip/zulip/assets/25124304/fb707328-b6bc-407c-8783-0a496188f07a) | <img width="562" alt="Screenshot 2024-06-27 at 3 51 04 PM" src="https://github.com/zulip/zulip/assets/25124304/759a5747-4f75-4d26-8615-1a0c87d974fb"> |
