### PR TITLE
unread_counts: Scale unread counts with UI.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -588,9 +588,11 @@ div.overlay {
 .unread_count {
     float: right;
     padding: 0 4px;
-    height: 16px;
-    line-height: 16px;
-    font-size: 12px;
+    /* 12px at 14px/em */
+    font-size: 0.8571em;
+    /* 16px at 12px/em, owing to font-size above. */
+    height: 1.3333em;
+    line-height: 1.3333em;
     font-weight: normal;
     border-radius: 4px;
     background-color: var(--color-background-unread-counter);

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -335,7 +335,11 @@
                 align-items: center;
                 justify-content: center;
                 border-radius: 3px;
-                padding: 5px;
+                padding: 0 5px;
+                /* Stretch to the row to keep unread
+                   count from affecting overall row
+                   size as test scales up. */
+                align-self: stretch;
 
                 &:focus {
                     outline: 2px solid var(--color-outline-focus);

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -324,6 +324,12 @@
             }
 
             .unread-count-focus-outline {
+                /* Because the inbox view font-size will
+                   never be smaller than the em-equivalent
+                   of 15px, we restate the base font-size
+                   here so that unreads match others in
+                   the UI at legacy size (14px). */
+                font-size: var(--base-font-size-px);
                 grid-area: unread_count;
                 display: flex;
                 align-items: center;

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -255,8 +255,9 @@
 
             .user_circle {
                 /* size of the user activity circle */
-                min-width: 6px;
-                height: 6px;
+                /* 6px at 15px/1em */
+                min-width: 0.4em;
+                height: 0.4em;
                 margin-right: 5px;
                 top: 0;
             }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -542,8 +542,9 @@ li.active-sub-filter {
             background: var(--color-background-hover-narrow-filter);
 
             .unread_count {
-                top: -6px;
-                right: -6px;
+                /* 6px at 12px/1em */
+                top: -0.5em;
+                right: -0.5em;
                 background: var(--color-background-unread-counter-no-alpha);
             }
         }


### PR DESCRIPTION
This PR sets font-sizing and related dimensions on the unread counts to scale across the UI, including in sidebars and the Recent and Inbox views.

There is a change to how focus rings are sized in the inbox view; as the screenshots below show, there is no visible effect to that change (previous use of padding was perfectly sized to the row, but `align-self: stretch` now has the same effect, without blowing out the size of the rows with unreads that scale up.

There is also a commit to ensure that user-circles scale in the inbox, which should have been a part of #30591, but makes sense enough to include here, given parallel inbox fixes with this PR.

Fixes parts of #30476

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy, before | Legacy, after (no change) |
| --- | --- |
| ![legacy-recent-before](https://github.com/zulip/zulip/assets/170719/43c91c95-71ca-4370-bdc4-c3bb6165f317) | ![legacy-recent-after](https://github.com/zulip/zulip/assets/170719/f18e7828-d3f8-4a4c-aeaf-14f1b81e4484) |


| 16/140, before | 16/140, after |
| --- | --- |
| ![16-140-recent-after](https://github.com/zulip/zulip/assets/170719/bd2d218f-b3e0-46ec-9295-800d8fbba7f5) | ![16-140-recent-before](https://github.com/zulip/zulip/assets/170719/e38f414e-148a-4116-837a-be1e3a064893) |
| ![16-140-inbox-before](https://github.com/zulip/zulip/assets/170719/99e73179-f4bb-44f8-9df0-955611ef9fa5) | ![16-140-inbox-after](https://github.com/zulip/zulip/assets/170719/e0ab27c2-ff77-4f3f-af53-9d097cded256) |

| Inbox unread focus ring, before | Inbox unread focus ring, after (no change at legacy sizes) |
| --- | --- |
| ![focus-ring-legacy-before](https://github.com/zulip/zulip/assets/170719/2c96cc52-6140-4a8c-ae5b-70596352d387) | ![focus-ring-legacy-after](https://github.com/zulip/zulip/assets/170719/26b1fe56-5db8-4940-82dd-8cf0f57a068b) |
| ![focus-ring-16-140-before](https://github.com/zulip/zulip/assets/170719/ac341ed7-2083-43e5-8715-b61550144bf7) | ![focus-ring-16-140-after](https://github.com/zulip/zulip/assets/170719/1e18f330-d951-4246-941c-c471266341ed) |

| 16/140 collapsed views, before | 16/140 collapsed views, after |
| --- | --- |
| ![16-140-collapsed-views-before](https://github.com/zulip/zulip/assets/170719/08152e71-7afc-4b90-845f-58bea963848b) | ![16-140-collapsed-views-after](https://github.com/zulip/zulip/assets/170719/33c5378f-4c4c-40f8-86d7-771eae43f861) |
