### PR TITLE
onboarding_step: Don't show 'visibility_policy_banner' to new users.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -42,6 +42,7 @@ from zerver.models import (
     DefaultStreamGroup,
     Message,
     NamedUserGroup,
+    OnboardingStep,
     PreregistrationRealm,
     PreregistrationUser,
     Realm,
@@ -229,6 +230,7 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
 # * Fills in some recent historical messages
 # * Notifies other users in realm and Zulip about the signup
 # * Deactivates PreregistrationUser objects
+# * Mark 'visibility_policy_banner' as read
 def process_new_human_user(
     user_profile: UserProfile,
     prereg_user: Optional[PreregistrationUser] = None,
@@ -304,6 +306,10 @@ def process_new_human_user(
     from zerver.lib.onboarding import send_initial_direct_message
 
     send_initial_direct_message(user_profile)
+
+    # The 'visibility_policy_banner' is only displayed to existing users.
+    # Mark it as read for a new user.
+    OnboardingStep.objects.create(user=user_profile, onboarding_step="visibility_policy_banner")
 
 
 def notify_created_user(user_profile: UserProfile, notify_user_ids: List[int]) -> None:

--- a/zerver/tests/test_onboarding_steps.py
+++ b/zerver/tests/test_onboarding_steps.py
@@ -19,7 +19,10 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
         )
 
     def test_some_done_some_not(self) -> None:
-        do_mark_onboarding_step_as_read(self.user, "visibility_policy_banner")
+        # "visibility_policy_banner" is already marked as read for a new user.
+        onboarding_step = OnboardingStep.objects.get(user=self.user)
+        self.assertEqual(onboarding_step.onboarding_step, "visibility_policy_banner")
+
         do_mark_onboarding_step_as_read(self.user, "intro_inbox_view_modal")
         onboarding_steps = get_next_onboarding_steps(self.user)
         self.assert_length(onboarding_steps, 3)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -939,7 +939,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        with self.assert_database_query_count(90), self.assert_memcached_count(14):
+        with self.assert_database_query_count(91), self.assert_memcached_count(14):
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -908,7 +908,7 @@ class QueryCountTest(ZulipTestCase):
 
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
-        with self.assert_database_query_count(80):
+        with self.assert_database_query_count(81):
             with self.assert_memcached_count(19):
                 with self.capture_send_event_calls(expected_num_events=10) as events:
                     fred = do_create_user(


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Don't.20show.20the.20.22Now.20following.22.20banner.20to.20new.20users.20.2330615/near/1840176)

Earlier, a one-time `visibility_policy_banner` was displayed to existing as well as new users to inform them about the new **"follow/unmute topics"** feature.

It makes sense to educate only the existing Zulip users about the new feature using this banner. New users don't need to know about following topics right away.

This PR makes changes to NOT show the banner to new users.

Fixes: #30615





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
