### PR TITLE
Fix Align navbar heading to the left when using full width

### DIFF
--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -5,8 +5,10 @@ import {user_settings} from "./user_settings";
 export function set_layout_width(): void {
     if (user_settings.fluid_layout_width) {
         $("body").addClass("fluid_layout_width");
+        $(".column-middle-align").addClass("fluid_layout_width");
     } else {
         $("body").removeClass("fluid_layout_width");
+        $(".column-middle-align").removeClass("fluid_layout_width");
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -149,6 +149,10 @@ p.n-margin {
     display: none;
 }
 
+.column-middle-align.fluid_layout_width {
+    margin-left: 168px; 
+}
+
 .alert-zulip-logo,
 .top-messages-logo,
 .bottom-messages-logo {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -149,8 +149,8 @@ p.n-margin {
     display: none;
 }
 
-.column-middle-align.fluid_layout_width {
-    margin-left: 168px; 
+.column-align-middle.fluid_layout_width { 
+    margin-left: calc(var(--left-sidebar-width) - (10 * var(--left-sidebar-collapse-widget-gutter)));
 }
 
 .alert-zulip-logo,

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -10,7 +10,7 @@
                 <img id="realm-navbar-icon-logo" alt="" src="{{ realm_icon_url }}" class="nav-logo no-drag"/>
             </a>
         </div>
-        <div class="column-middle" id="navbar-middle">
+        <div class="column-middle column-middle-align" id="navbar-middle">
             <div class="column-middle-inner">
                 <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="show-left-sidebar-tooltip-template">
                     <a class="left-sidebar-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>


### PR DESCRIPTION
This PR solves the issue #30619. 

Before: 

<img width="805" alt="Screenshot 2024-06-28 at 11 59 39 PM" src="https://github.com/zulip/zulip/assets/113302312/c2619962-74b5-4350-8bd1-8d3b34d1b30a">

After: 

<img width="652" alt="Screenshot 2024-06-29 at 12 00 14 AM" src="https://github.com/zulip/zulip/assets/113302312/9ad89973-5645-4ca4-97fc-c69fc84d40fe">




Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
