### PR TITLE
left_sidebar: Better present navigational, topic and topic-filter rows.

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -347,16 +347,16 @@ async function test_search_venice(page: Page): Promise<void> {
     await page.waitForSelector(await get_stream_li(page, "Verona"), {visible: true});
 
     await page.click("#streams_header .left-sidebar-title");
-    await page.waitForSelector(".input-append.notdisplayed");
+    await page.waitForSelector(".stream_search_section.notdisplayed");
 }
 
 async function test_stream_search_filters_stream_list(page: Page): Promise<void> {
     console.log("Filter streams using left side bar");
 
-    await page.waitForSelector(".input-append.notdisplayed"); // Stream filter box invisible initially
+    await page.waitForSelector(".stream_search_section.notdisplayed"); // Stream filter box invisible initially
     await page.click("#streams_header .left-sidebar-title");
 
-    await page.waitForSelector("#streams_list .input-append.notdisplayed", {hidden: true});
+    await page.waitForSelector("#streams_list .stream_search_section.notdisplayed", {hidden: true});
 
     // assert streams exist by waiting till they're visible
     await page.waitForSelector(await get_stream_li(page, "Denmark"), {visible: true});

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -385,6 +385,11 @@ div.overlay {
     margin: 0;
 }
 
+/* TODO: Once all layouts using this button
+   are modernized, the Font Awesome icon
+   should be replaced with a Zulip icon,
+   and its formatting should have no extra
+   space around its viewbox in SVG. */
 .clear_search_button {
     &:hover {
         color: hsl(0deg 0% 0%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -60,13 +60,21 @@
     /* This represents the space in the sidebar reserved for symbols like
        the #; labels like the stream name go to the right of this. */
     --left-sidebar-privacy-icon-column-size: 19px;
-    /* The full topic indentation includes 4px of indent in addition to
-       the above (and another 5px of padding not measured here) */
+    /* 13px at 14px/1em */
+    --left-sidebar-topic-resolve-width: 0.9286em;
+    /* At legacy sizes, the full indentation to the
+       left of the topic name was 25px of gutter,
+       plus 13px for the topic-resolution checkmark.
+       That works out to 38px (25px + 13px), which
+       we here express as pixels, as that is always
+       the amount of space to the left of the topic
+       name. However, CSS subtracts the em-unit width
+       of the topic-resolution checkmark to prevent
+       the the topic name from being shifted to the
+       right. */
     --left-sidebar-topic-indent: calc(
-        var(--left-sidebar-far-left-gutter-size) +
-            var(--left-sidebar-privacy-icon-column-size) + 4px
+        38px - var(--left-sidebar-topic-resolve-width)
     );
-    --left-sidebar-topic-resolve-width: 13px;
     /* space direct message / stream / topic names from unread counters
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -69,17 +69,15 @@ li.show-more-topics {
     padding: 0;
     font-weight: normal;
 
-    .input-append.topic_search_section {
-        padding: 2px 0 2px var(--left-sidebar-topic-indent);
-        margin-bottom: 3px;
-        margin-left: 3px;
-
-        & input {
-            width: calc(100% - 30px);
-        }
+    .topic_search_section {
+        margin: 3px 0;
 
         .clear_search_button {
-            margin-left: -1px;
+            grid-area: row-content;
+            justify-self: self-end;
+            /* Override app-component positioning. */
+            position: static;
+            padding-right: 4px;
         }
     }
 
@@ -714,7 +712,8 @@ li.top_left_scheduled_messages {
 .dm-box,
 .subscription_block,
 .topic-box,
-.searching-for-more-topics {
+.searching-for-more-topics,
+.topic_search_section {
     display: grid;
     align-items: center;
     /* This general pattern of elements applies to every single row in the left
@@ -873,9 +872,14 @@ li.top_left_scheduled_messages {
 .topic-box,
 .searching-for-more-topics {
     grid-template-columns:
-        var(--left-sidebar-topic-indent) var(
-            --left-sidebar-topic-resolve-width
-        ) minmax(0, 1fr) minmax(0, max-content)
+        var(--left-sidebar-topic-indent) var(--left-sidebar-topic-resolve-width)
+        minmax(0, 1fr) minmax(0, max-content)
+        30px 0;
+}
+
+.topic_search_section {
+    grid-template-columns:
+        var(--left-sidebar-topic-indent) 0 minmax(0, 1fr) minmax(0, max-content)
         30px 0;
 }
 
@@ -904,6 +908,10 @@ li.top_left_scheduled_messages {
     span.sidebar-topic-name-inner {
         white-space: pre;
     }
+}
+
+.topic-list-filter {
+    grid-area: row-content;
 }
 
 .searching-for-more-topics img {
@@ -1327,14 +1335,6 @@ li.topic-list-item {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-}
-
-.topic-list-filter {
-    /* Input width = 100% - 30px right-margin - 6px right-padding */
-    /* To keep the right edge of input along with its borders inline with other
-       topic items we consider to subtract the space given for right margin of
-       other items, and right padding of input element.  */
-    width: calc(100% - 36px);
 }
 
 .zero_count {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -70,16 +70,12 @@ li.show-more-topics {
     font-weight: normal;
 
     .input-append.topic_search_section {
-        padding: 2px 0 2px
-            calc(
-                var(--left-sidebar-topic-indent) -
-                    var(--left-sidebar-topic-resolve-width)
-            );
+        padding: 2px 0 2px var(--left-sidebar-topic-indent);
         margin-bottom: 3px;
         margin-left: 3px;
 
         & input {
-            width: calc(100% - 50px);
+            width: calc(100% - 30px);
         }
 
         .clear_search_button {
@@ -877,10 +873,9 @@ li.top_left_scheduled_messages {
 .topic-box,
 .searching-for-more-topics {
     grid-template-columns:
-        25px var(--left-sidebar-topic-resolve-width) minmax(0, 1fr) minmax(
-            0,
-            max-content
-        )
+        var(--left-sidebar-topic-indent) var(
+            --left-sidebar-topic-resolve-width
+        ) minmax(0, 1fr) minmax(0, max-content)
         30px 0;
 }
 
@@ -918,7 +913,8 @@ li.top_left_scheduled_messages {
 
 .sidebar-topic-check {
     grid-area: starting-anchor-element;
-    font-size: 15px;
+    /* 15px at 14px/1em */
+    font-size: 1.0714em;
 }
 
 .stream-markers-and-controls,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1185,7 +1185,7 @@ li.topic-list-item {
         width: var(--left-sidebar-header-icon-width);
     }
 
-    .input-append {
+    .stream_search_section {
         grid-area: filter-box;
         display: flex;
         justify-content: stretch;
@@ -1194,7 +1194,7 @@ li.topic-list-item {
         line-height: 20px;
         white-space: nowrap;
 
-        & input {
+        .stream-list-filter {
             /* Use the border-box model so flex
                can do its thing despite whatever
                padding and border we specify. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -39,7 +39,8 @@
 
 li.show-more-topics {
     & a {
-        font-size: 12px;
+        /* 12px at 14px/1em */
+        font-size: 0.8571em;
     }
 }
 
@@ -279,7 +280,8 @@ li.show-more-topics {
             align-items: baseline;
 
             & a {
-                font-size: 12px;
+                /* 12px at 14px/1em */
+                font-size: 0.8571em;
             }
 
             .unread_count {
@@ -1370,7 +1372,8 @@ li.topic-list-item {
         display: block;
         text-decoration: none;
         color: inherit;
-        font-size: 12px;
+        /* 12px at 14px/1em */
+        font-size: 0.8571em;
 
         & span {
             display: block;

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,4 +1,4 @@
-<div class="input-append topic_search_section filter-topics">
+<div class="topic_search_section filter-topics">
     <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
     <button type="button" class="btn clear_search_button" id="clear_search_topic_button">
         <i class="fa fa-remove" aria-hidden="true"></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -178,7 +178,7 @@
                     <span class="masked_unread_count"></span>
                 </div>
 
-                <div class="input-append notdisplayed stream_search_section">
+                <div class="notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>


### PR DESCRIPTION
This PR provides some polish to the left sidebar's participation in scalable information density.

1. It scales the resolved checkmark along with the rest of the UI, and does so in a way that preserves the space alloted topic names in the topic rows
2. It scales the font size on "show all topics," "more conversations" rows 
3. It rewrites the topic filter into a gridded row, achieving for the first time perfect alignment with the filtered topic rows below
4. It removes the `.input-append` class from stream and topic filter boxes, so that their text is sized identically as other parts of the UI, [as called for](https://chat.zulip.org/#narrow/stream/101-design/topic/font.20size.20on.20.3Cinput.3E.20elements/near/1824511) by @terpimost's redesign

Fixes parts of #30476 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy, before | Legacy, after (no change) |
| --- | --- |
| ![sidebar-subheads-legacy-before](https://github.com/zulip/zulip/assets/170719/87a11158-adf5-40f3-9d0c-1be29556155c) | ![sidebar-subheads-legacy-after](https://github.com/zulip/zulip/assets/170719/fc64fa47-e46a-4484-ad25-f08be6d5508f) |
| ![sidebar-dm-back-legacy-before](https://github.com/zulip/zulip/assets/170719/47f59c29-6895-4973-9192-e90431217d62) | ![sidebar-dm-back-legacy-after](https://github.com/zulip/zulip/assets/170719/75735031-8f20-4e6a-adb4-6289b0fc30d0) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![sidebar-subheads-and-check-before](https://github.com/zulip/zulip/assets/170719/78fa74dc-31a3-4b4d-949a-e069aead5f50) | ![sidebar-subheads-and-check-after](https://github.com/zulip/zulip/assets/170719/702b279b-e63b-4f5f-a566-bbb1b0f71e1f) |
| ![dm-back-to-channels-after](https://github.com/zulip/zulip/assets/170719/a13b42a9-d9a6-4ef6-965b-f386009d1e13) | ![dm-back-to-channels-before](https://github.com/zulip/zulip/assets/170719/a5dd4804-1d95-4ce3-b2c4-3118229030b3) |

| Legacy topic filter, before | Legacy topic filter, after |
| --- | --- |
| ![topic-filter-legacy-before](https://github.com/zulip/zulip/assets/170719/f5328481-f6dd-4c7c-80b6-a208d1c43957) | ![topic-filter-legacy-after](https://github.com/zulip/zulip/assets/170719/4b2ea723-c2b4-410a-ae64-f3c5b350e598) |
| ![topic-filter-legacy-grid-lines-before](https://github.com/zulip/zulip/assets/170719/d2ca8a92-af76-44c0-9ebf-3e1f73b23375) | ![topic-filter-legacy-grid-lines-after](https://github.com/zulip/zulip/assets/170719/b053ae34-2bd0-486f-bd6f-9c8f0b10179b) |

| 16/140 topic filter, before | 16/140 topic filter, after |
| --- | --- |
| ![topic-filter-before](https://github.com/zulip/zulip/assets/170719/a2df4be6-c778-45af-b844-e3afd2e67724) | ![topic-filter-after](https://github.com/zulip/zulip/assets/170719/564c41a9-03cc-426b-9977-951d6d96f917) |
| ![topic-filter-grid-lines-before](https://github.com/zulip/zulip/assets/170719/85898bf2-302c-4c06-8f32-5dac4612cd29) | ![topic-filter-grid-lines-after](https://github.com/zulip/zulip/assets/170719/718db6bf-c34b-4ff4-9656-1c86817656e5) |

