### PR TITLE
stream_popover: Organize and improve the left sidebar channel menu.

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -1,3 +1,4 @@
+import ClipboardJS from "clipboard";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
@@ -99,11 +100,15 @@ function build_stream_popover(opts) {
         return;
     }
 
+    const stream_hash = hash_util.by_stream_url(stream_id);
     const show_go_to_channel_feed =
         user_settings.web_channel_default_view !==
         web_channel_default_view_values.channel_feed.code;
     const content = render_left_sidebar_stream_actions_popover({
-        stream: sub_store.get(stream_id),
+        stream: {
+            ...sub_store.get(stream_id),
+            url: browser_history.get_full_url(stream_hash),
+        },
         show_go_to_channel_feed,
     });
 
@@ -215,6 +220,10 @@ function build_stream_popover(opts) {
                 $colorpicker.parent().find(".sp-container").removeClass("sp-buttons-disabled");
                 $(e.currentTarget).hide();
                 e.stopPropagation();
+            });
+
+            new ClipboardJS($popper.find(".copy_stream_link")[0]).on("success", () => {
+                popover_menus.hide_current_popover_if_visible(instance);
             });
         },
         onHidden() {

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -21,6 +21,7 @@ import * as popover_menus from "./popover_menus";
 import {left_sidebar_tippy_options} from "./popover_menus";
 import {web_channel_default_view_values} from "./settings_config";
 import * as settings_data from "./settings_data";
+import {current_user} from "./state_data";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_settings_api from "./stream_settings_api";
@@ -150,7 +151,14 @@ function build_stream_popover(opts) {
                 const sub = stream_popover_sub(e);
                 hide_stream_popover();
 
-                const stream_edit_hash = hash_util.channels_settings_edit_url(sub, "general");
+                // Admin can change any stream's name & description either stream is public or
+                // private, subscribed or unsubscribed.
+                const can_change_name_description = current_user.is_admin;
+                const can_change_stream_permissions = stream_data.can_change_permissions(sub);
+                let stream_edit_hash = hash_util.channels_settings_edit_url(sub, "general");
+                if (!can_change_stream_permissions && !can_change_name_description) {
+                    stream_edit_hash = hash_util.channels_settings_edit_url(sub, "personal");
+                }
                 browser_history.go_to_location(stream_edit_hash);
             });
 

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -29,6 +29,12 @@
             </a>
         </li>
         {{/if}}
+        <li role="none" class="link-item popover-menu-inner-list-item">
+            <a role="menuitem" class="copy_stream_link popover-menu-link" data-clipboard-text="{{ stream.url }}" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Copy link to channel" }}</span>
+            </a>
+        </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
             <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -9,6 +9,18 @@
             <span class="popover-stream-name">{{stream.name}}</span>
         </li>
         <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="popover_new_topic_button popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "New topic"}}</span>
+            </a>
+        </li>
+        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
+            <a role="menuitem" class="mark_stream_as_read popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as read"}}</span>
+            </a>
+        </li>
         {{#if show_go_to_channel_feed}}
         <li role="none" class="link-item popover-menu-inner-list-item">
             <a role="menuitem" class="stream-popover-go-to-channel-feed popover-menu-link" tabindex="0">
@@ -17,6 +29,7 @@
             </a>
         </li>
         {{/if}}
+        <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
             <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
@@ -35,12 +48,6 @@
             </a>
         </li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
-            <a role="menuitem" class="mark_stream_as_read popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read"}}</span>
-            </a>
-        </li>
-        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
             <a role="menuitem" class="toggle_stream_muted popover-menu-link" tabindex="0">
                 {{#if stream.is_muted}}
                 <i class="popover-menu-icon zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
@@ -52,17 +59,12 @@
             </a>
         </li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
-            <a role="menuitem" class="popover_new_topic_button popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "New topic"}}</span>
-            </a>
-        </li>
-        <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
             <a role="menuitem" class="popover_sub_unsub_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-circle-x" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Unsubscribe"}}</span>
             </a>
         </li>
+        <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators no-auto-hide-left-sidebar-overlay">
             <span class="colorpicker-container">
                 <input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" />

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -35,7 +35,7 @@
                 <span class="popover-menu-label">{{t "Copy link to channel" }}</span>
             </a>
         </li>
-        <li role="separator" class="popover-menu-separator"></li>
+        <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators">
             <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
@@ -70,7 +70,7 @@
                 <span class="popover-menu-label">{{t "Unsubscribe"}}</span>
             </a>
         </li>
-        <li role="separator" class="popover-menu-separator"></li>
+        <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
         <li role="none" class="link-item popover-menu-inner-list-item hidden-for-spectators no-auto-hide-left-sidebar-overlay">
             <span class="colorpicker-container">
                 <input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" />


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Changes in this PR:
- Grouped related actions in the channel actions popover for better usability.
- Added a menu option to copy the channel feed link to the clipboard.
- Enabled the stream popover for spectators, showing only the "Copy link to channel" option.
- Added a conditional link to the "Personal" tab in channel settings if the user lacks permission to change channel permissions.

Fixes: #30529

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Desc | Before | After |
|--------|--------|--------|
| Channel settings | <img width="278" alt="Screenshot 2024-06-29 at 12 31 50 AM" src="https://github.com/zulip/zulip/assets/82862779/713fbba7-fab9-42a4-85e9-2396b8a15f86"> | <img width="278" alt="Screenshot 2024-06-28 at 11 34 01 PM" src="https://github.com/zulip/zulip/assets/82862779/014d9d8a-7998-4832-8ea4-f3a301613b40"> |
| Channel settings (spectators' view) | N/A | <img width="278" alt="Screenshot 2024-06-28 at 11 36 25 PM" src="https://github.com/zulip/zulip/assets/82862779/005a564b-2500-4ed6-a58c-6926512d3af1"> |

### Conditionally open "General" or "Personal" tab depending on the permissions available

https://github.com/zulip/zulip/assets/82862779/1a8ca8ed-2fcd-4b90-9b4f-0d279abdc18c

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
