### PR TITLE
css: Revert "css: Redefine `--color-outline-focus` for dark theme."

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -409,6 +409,7 @@
     --color-message-content-container-border: hsl(0deg 0% 0% / 10%);
     --color-message-content-container-border-focus: hsl(0deg 0% 57%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 0% / 5%);
+    --color-compose-focus-ring: var(--color-outline-focus);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -781,6 +782,7 @@
     --color-message-content-container-border: hsl(0deg 0% 0% / 80%);
     --color-message-content-container-border-focus: hsl(0deg 0% 100% / 27%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 100% / 5%);
+    --color-compose-focus-ring: hsl(0deg 0% 67%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -684,7 +684,6 @@
     --color-background-modal: hsl(212deg 28% 18%);
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 0% / 20%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
-    --color-outline-focus: hsl(0deg 0% 67%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);
     --color-background-search: hsl(0deg 0% 20%);
     --color-background-search-option-hover: hsl(0deg 0% 30%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -490,7 +490,7 @@
     }
 
     &:focus-visible {
-        outline-color: var(--color-outline-focus);
+        outline-color: var(--color-compose-focus-ring);
     }
 }
 
@@ -1096,7 +1096,7 @@ textarea.new_message_textarea {
         }
 
         &:focus-visible {
-            outline-color: var(--color-outline-focus);
+            outline-color: var(--color-compose-focus-ring);
         }
     }
 
@@ -1330,7 +1330,7 @@ textarea.new_message_textarea {
     }
 
     &:focus-visible {
-        outline-color: var(--color-outline-focus);
+        outline-color: var(--color-compose-focus-ring);
     }
 
     &:hover {
@@ -1376,7 +1376,7 @@ textarea.new_message_textarea {
            will handle the dimension change, so there won't
            be any movement of the vdots in this state. */
         outline: 0;
-        border: 2px solid var(--color-outline-focus);
+        border: 2px solid var(--color-compose-focus-ring);
     }
 
     @media ((width >= $sm_min) and (width < $mc_min)) {


### PR DESCRIPTION
Revert "css: Redefine `--color-outline-focus` for dark theme."

This reverts commit 5c1069872dff741ad8884b0bf6f9e438e90ff78c.

compose: Use same focus ring color for compose buttons in each theme.

A new css variable is created with the same blue color in light theme as `color-outline-focus`, and gray color in dark theme, and is used for the focus-visible state of the compose control buttons, the compose close button, and the send later vdots button.

(The revert fixes regressions mentioned in the linked CZO thread, and creates the need for a separate css variable for the color of focus rings of compose buttons.)

Fixes: [CZO issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20conversations.20underline.20color/near/1833310)

**Screenshots and screen captures:**
(regressions fixed on recent conversations page)
![image](https://github.com/zulip/zulip/assets/68962290/20231bd3-f131-4606-90e8-0a33604283a3)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
