### PR TITLE
zcommand: Rename night->dark and day->light in the color scheme backend.

### DIFF
--- a/zerver/lib/zcommand.py
+++ b/zerver/lib/zcommand.py
@@ -26,18 +26,18 @@ def process_zcommands(content: str, user_profile: UserProfile) -> Dict[str, Any]
 
     if command == "ping":
         return {}
-    elif command == "night":
-        if user_profile.color_scheme == UserProfile.COLOR_SCHEME_NIGHT:
+    elif command == "dark":
+        if user_profile.color_scheme == UserProfile.COLOR_SCHEME_DARK:
             return dict(msg="You are still in dark theme.")
         return dict(
             msg=change_mode_setting(
                 setting_name="dark theme",
                 switch_command="light",
                 setting="color_scheme",
-                setting_value=UserProfile.COLOR_SCHEME_NIGHT,
+                setting_value=UserProfile.COLOR_SCHEME_DARK,
             )
         )
-    elif command == "day":
+    elif command == "light":
         if user_profile.color_scheme == UserProfile.COLOR_SCHEME_LIGHT:
             return dict(msg="You are still in light theme.")
         return dict(

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -73,9 +73,9 @@ class UserBaseSettings(models.Model):
     twenty_four_hour_time = models.BooleanField(default=False)
     starred_message_counts = models.BooleanField(default=True)
     COLOR_SCHEME_AUTOMATIC = 1
-    COLOR_SCHEME_NIGHT = 2
+    COLOR_SCHEME_DARK = 2
     COLOR_SCHEME_LIGHT = 3
-    COLOR_SCHEME_CHOICES = [COLOR_SCHEME_AUTOMATIC, COLOR_SCHEME_NIGHT, COLOR_SCHEME_LIGHT]
+    COLOR_SCHEME_CHOICES = [COLOR_SCHEME_AUTOMATIC, COLOR_SCHEME_DARK, COLOR_SCHEME_LIGHT]
     color_scheme = models.PositiveSmallIntegerField(default=COLOR_SCHEME_AUTOMATIC)
 
     # Information density is established through

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -474,11 +474,11 @@ class ChangeSettingsTest(ZulipTestCase):
         self.login("hamlet")
 
         result = self.client_patch(
-            "/json/settings/display", dict(color_scheme=UserProfile.COLOR_SCHEME_NIGHT)
+            "/json/settings/display", dict(color_scheme=UserProfile.COLOR_SCHEME_DARK)
         )
         self.assert_json_success(result)
         hamlet = self.example_user("hamlet")
-        self.assertEqual(hamlet.color_scheme, UserProfile.COLOR_SCHEME_NIGHT)
+        self.assertEqual(hamlet.color_scheme, UserProfile.COLOR_SCHEME_DARK)
 
     def test_changing_setting_using_notification_setting_endpoint(self) -> None:
         """

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1298,7 +1298,7 @@ class UserProfileTest(ZulipTestCase):
         do_change_user_setting(cordelia, "emojiset", "twitter", acting_user=None)
         do_change_user_setting(cordelia, "timezone", "America/Phoenix", acting_user=None)
         do_change_user_setting(
-            cordelia, "color_scheme", UserProfile.COLOR_SCHEME_NIGHT, acting_user=None
+            cordelia, "color_scheme", UserProfile.COLOR_SCHEME_DARK, acting_user=None
         )
         do_change_user_setting(
             cordelia, "enable_offline_email_notifications", False, acting_user=None
@@ -1342,8 +1342,8 @@ class UserProfileTest(ZulipTestCase):
         self.assertEqual(cordelia.timezone, "America/Phoenix")
         self.assertEqual(hamlet.timezone, "")
 
-        self.assertEqual(iago.color_scheme, UserProfile.COLOR_SCHEME_NIGHT)
-        self.assertEqual(cordelia.color_scheme, UserProfile.COLOR_SCHEME_NIGHT)
+        self.assertEqual(iago.color_scheme, UserProfile.COLOR_SCHEME_DARK)
+        self.assertEqual(cordelia.color_scheme, UserProfile.COLOR_SCHEME_DARK)
         self.assertEqual(hamlet.color_scheme, UserProfile.COLOR_SCHEME_AUTOMATIC)
 
         self.assertEqual(iago.enable_offline_email_notifications, False)

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -27,7 +27,7 @@ class ZcommandTest(ZulipTestCase):
         user.color_scheme = UserProfile.COLOR_SCHEME_LIGHT
         user.save()
 
-        payload = dict(command="/night")
+        payload = dict(command="/dark")
         result = self.client_post("/json/zcommand", payload)
         response_dict = self.assert_json_success(result)
         self.assertIn("Changed to dark theme", response_dict["msg"])
@@ -39,10 +39,10 @@ class ZcommandTest(ZulipTestCase):
     def test_day_zcommand(self) -> None:
         self.login("hamlet")
         user = self.example_user("hamlet")
-        user.color_scheme = UserProfile.COLOR_SCHEME_NIGHT
+        user.color_scheme = UserProfile.COLOR_SCHEME_DARK
         user.save()
 
-        payload = dict(command="/day")
+        payload = dict(command="/light")
         result = self.client_post("/json/zcommand", payload)
         response_dict = self.assert_json_success(result)
         self.assertIn("Changed to light theme", response_dict["msg"])


### PR DESCRIPTION
As a follow up for f49a11c810632cce6a94e679b2fb847dd2291c42, this PR standardizes the naming of the day and night themes to light and dark, respectively in the backend. This makes the backend consistent with the naming used in the frontend and UI.

This also solves a regression introduced in f49a11c810632cce6a94e679b2fb847dd2291c42, where the frontend was sending `/light` and `/dark` commands to the backend, but the backend was expecting `/day` and `/night` commands.

<!-- Describe your pull request here.-->

Fixes: [Issue reported on CZO
](https://chat.zulip.org/#narrow/stream/9-issues/topic/slash.20commands.20for.20theme.20switch.20are.20not.20working/near/1840977)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Kapture 2024-06-29 at 03 40 59](https://github.com/zulip/zulip/assets/82862779/70d70186-7b4e-4330-ad7a-65581eb35333)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
