### PR TITLE
ui: Fix overflowing time tag in spoiler block.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -272,6 +272,13 @@
                    spoiler messages to wrap. */
                 flex: 1 1 auto;
             }
+
+            time {
+                /* Time tag pushes the arrow out of view when overflow,
+                   adding white-space property prevents this by wrapping
+                   the element */
+                white-space: normal;
+            }
         }
 
         .spoiler-content {


### PR DESCRIPTION

<!-- Describe your pull request here.-->
When rendering a spoiler block that includes a datetime format, the dropdown button was pushed out of view on smaller devices. This happened because the time tag was overflowing past the spoiler blocks width.

This commit intends to fix this problem by adding a `white-space` attribute to the rendered time tags which will stop it from overflowing.

Fixes: #30641.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
After fix screenshot

![image](https://github.com/zulip/zulip/assets/53932029/81ec752f-3372-48c2-a33b-a89553649988)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
