### PR TITLE
Fix topics with 0 message count not updated correctly.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -288,6 +288,7 @@ export function update_messages(events) {
                 }
             }
             // The event.message_ids received from the server are not in sorted order.
+            // Sorts in ascending order.
             event_messages.sort((a, b) => a.id - b.id);
 
             if (
@@ -305,6 +306,18 @@ export function update_messages(events) {
 
             if (going_forward_change) {
                 drafts.rename_stream_recipient(old_stream_id, orig_topic, new_stream_id, new_topic);
+            }
+
+            // Remove the stream_topic_entry for the old topics;
+            // must be called before we call set message topic.
+            const num_messages = event_messages.length;
+            if (num_messages > 0) {
+                stream_topic_history.remove_messages({
+                    stream_id: old_stream_id,
+                    topic_name: orig_topic,
+                    num_messages,
+                    max_removed_msg_id: event_messages[num_messages - 1].id,
+                });
             }
 
             for (const moved_message of event_messages) {
@@ -334,23 +347,6 @@ export function update_messages(events) {
                     ];
                 }
                 moved_message.last_edit_timestamp = event.edit_timestamp;
-
-                // Remove the stream_topic_entry for the old topics;
-                // must be called before we call set message topic.
-                //
-                // TODO: Use a single bulk request to do this removal.
-                // Note that we need to be careful to only remove IDs
-                // that were present in stream_topic_history data.
-                // This may not be possible to do correctly without extra
-                // complexity; the present loop assumes stream_topic_history has
-                // only messages in message_store, but that's been false
-                // since we added the server_history feature.
-                stream_topic_history.remove_messages({
-                    stream_id: moved_message.stream_id,
-                    topic_name: moved_message.topic,
-                    num_messages: 1,
-                    max_removed_msg_id: moved_message.id,
-                });
 
                 // Update the unread counts; again, this must be called
                 // before we modify the topic field on the message.

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -335,8 +335,8 @@ export function update_messages(events) {
                 }
                 moved_message.last_edit_timestamp = event.edit_timestamp;
 
-                // Remove the Recent Conversations entry for the old topics;
-                // must be called before we call set_message_topic.
+                // Remove the stream_topic_entry for the old topics;
+                // must be called before we call set message topic.
                 //
                 // TODO: Use a single bulk request to do this removal.
                 // Note that we need to be careful to only remove IDs

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -185,18 +185,14 @@ export class PerStreamHistory {
     maybe_remove(topic_name: string, num_messages: number): void {
         const existing = this.topics.get(topic_name);
 
-        if (!existing || existing.count === 0) {
+        if (!existing) {
             return;
         }
 
         if (existing.count <= num_messages) {
             this.topics.delete(topic_name);
-            if (!is_complete_for_stream_id(this.stream_id)) {
-                // Request server for latest message in topic if we
-                // cannot be sure that we have all messages in the topic.
-                update_topic_last_message_id(this.stream_id, topic_name);
-                return;
-            }
+            // Verify if this topic still has messages from the server.
+            update_topic_last_message_id(this.stream_id, topic_name);
         }
 
         existing.count -= num_messages;

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -214,15 +214,23 @@ test("server_history", () => {
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["hist2", "hist1"]);
 
-    // We can try to remove a historical message, but it should
-    // have no effect.
+    // Removing message from a topic fetched from server history, will send
+    // query to the server to get the latest message id in the topic.
+    let update_topic_called = false;
+    stream_topic_history.set_update_topic_last_message_id((stream_id, topic_name) => {
+        assert.equal(stream_id, 66);
+        assert.equal(topic_name, "hist2");
+        update_topic_called = true;
+    });
     stream_topic_history.remove_messages({
         stream_id,
         topic_name: "hist2",
         num_messages: 1,
     });
+    assert.equal(update_topic_called, true);
     history = stream_topic_history.get_recent_topic_names(stream_id);
-    assert.deepEqual(history, ["hist2", "hist1"]);
+    assert.deepEqual(history, ["hist1"]);
+    stream_topic_history.set_update_topic_last_message_id(noop);
 
     // If we call back to the server for history, the
     // effect is always additive.  We may decide to prune old


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/topic.20list.20order

Testing:
* Set message_fetch constants to 1.
* Click on show all in a stream and go to a topic
* Open the same stream in other tab and checking if live update works correctly in both the tabs when moving / deleting messages.