### PR TITLE
 #30044 removed the local time from the personal menu

### DIFF
--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -67,12 +67,6 @@
                                         <div class="name">{{t "Joined" }}</div>
                                         <div class="value">{{date_joined}}</div>
                                     </div>
-                                    {{#if user_time}}
-                                    <div class="default-field">
-                                        <div class="name">{{t "Local time" }}</div>
-                                        <div class="value">{{user_time}}</div>
-                                    </div>
-                                    {{/if}}
                                 </div>
                             </div>
                             <div class="col-wrap col-right">


### PR DESCRIPTION
Removed the local time from the personal menu of the user.

I removed the local time from the profile modal in zulips/web/templates/user_profile_modal.hbs.
which results in removal of local time in user modal

Fixes: [#30442](https://github.com/zulip/zulip/pull/30442)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [v ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [v ] Each commit is a coherent idea.
- [v ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [v ] Visual appearance of the changes.
- [ x] Responsiveness and internationalization.
- [ x] Strings and tooltips.
- [x ] End-to-end functionality of buttons, interactions and flows.
- [ x] Corner cases, error conditions, and easily imagined bugs.
</details>
