### PR TITLE
analytics: Migrate to @typed_endpoint.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -964,7 +964,7 @@ def internal_api_view(
     return _wrapped_view_func
 
 
-def to_utc_datetime(var_name: str, timestamp: str) -> datetime:
+def to_utc_datetime(timestamp: str) -> datetime:
     return timestamp_to_datetime(float(timestamp))
 
 


### PR DESCRIPTION
Migrate `analytics.views.stats` from `@has_request_variables` endpoint decorator to `@typed_endpoint`.