### PR TITLE
compose: Align multi-line text in compose box dropdown.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2285,9 +2285,10 @@ body:not(.hide-left-sidebar) {
 }
 
 .dropdown-list-container .dropdown-list .dropdown-list-item-common-styles {
-    display: block;
+    display: flex;
     color: var(--color-dropdown-item);
     padding: 3px 10px 3px 8px;
+    gap: 4px;
     font-weight: 400;
     line-height: 20px;
     white-space: normal;
@@ -2297,6 +2298,10 @@ body:not(.hide-left-sidebar) {
         width: 13px;
         height: 13px;
         padding-right: 2px;
+    }
+
+    .zulip-icon {
+        margin-top: 2px;
     }
 
     &:focus,


### PR DESCRIPTION
Using flexbox to left-align icon with the text on the first line in compose dropdowns.

Fixes part of #30469.

**Screenshots and screen captures:**

Before:
![image](https://github.com/zulip/zulip/assets/78212328/646b7147-2217-402c-8255-58aec0ac70da)

After:
![dropdown_fix](https://github.com/zulip/zulip/assets/78212328/9efd9af7-4276-4455-8196-13dd21e8067a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
