### PR TITLE
Preparatory commit for #28470.

### DIFF
--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -90,6 +90,13 @@ class RecentDirectMessages {
             .map((conversation) => conversation.user_ids_string);
     }
 
+    has_conversation(user_ids_string: string): boolean {
+        // Returns a boolean indicating whether we have a record proving
+        // this particular direct message conversation exists.
+        const recipient_ids_string = people.pm_lookup_key(user_ids_string);
+        return this.recent_message_ids.get(recipient_ids_string) !== undefined;
+    }
+
     initialize(params: StateData["pm_conversations"]): void {
         for (const conversation of params.recent_private_conversations) {
             this.insert(conversation.user_ids, conversation.max_message_id);


### PR DESCRIPTION
Adds `has_conversation` function in `pm_conversation.RecentDirectMessages` for checking previous messages in the DM conversations.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
