### PR TITLE
settings: Use box buttons for download and delete.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -566,15 +566,24 @@ input[type="checkbox"] {
     }
 }
 
-.remove-attachment {
-    margin-right: 5px !important;
-    font-size: 1.1em !important;
-    padding-left: 0 !important;
+.edit-attachment-buttons {
+    display: inline-block;
+    vertical-align: middle;
+    height: 32px;
 }
 
-#download_attachment {
-    padding-left: 0;
-    border-left: 0;
+.edit-attachment-buttons .remove-attachment {
+    margin-left: 5px;
+}
+
+.edit-attachment-buttons #download_attachment {
+    display: block;
+    padding: 6px 9px;
+    text-decoration: none;
+
+    &:hover {
+        color: hsl(156deg 41% 40%);
+    }
 }
 
 .remove-alert-word {

--- a/web/templates/settings/uploaded_files_list.hbs
+++ b/web/templates/settings/uploaded_files_list.hbs
@@ -20,14 +20,14 @@
     <td class="upload-size" >{{ size_str }}</td>
     <td class="actions">
         <span class="edit-attachment-buttons">
-            <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" title="{{t 'Download file' }}" id="download_attachment" download>
+            <a type="submit" href="/user_uploads/{{path_id}}" class="button rounded small sea-green tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download' }}" id="download_attachment" download>
                 <i class="fa fa-download sea-green" aria-hidden="true"></i>
             </a>
         </span>
         <span class="edit-attachment-buttons">
             <button type="submit"
-              class="button small no-style remove-attachment"
-              title="{{t 'Delete file' }}" data-attachment="{{id}}">
+              class="button rounded small delete btn-danger remove-attachment tippy-zulip-delayed-tooltip"
+              data-tippy-content="{{t 'Delete' }}" data-attachment="{{id}}">
                 <i class="fa fa-trash-o" aria-hidden="true"></i>
             </button>
         </span>


### PR DESCRIPTION
| before | after |
| --- | --- |
| <img width="710" alt="Screenshot 2024-07-01 at 11 04 34 PM" src="https://github.com/zulip/zulip/assets/25124304/0aa5c823-fbd8-4a61-a27e-0e78978110e0"> | <img width="710" alt="Screenshot 2024-07-01 at 11 03 43 PM" src="https://github.com/zulip/zulip/assets/25124304/ee4e1644-aafe-4575-9e71-07ed2dbf9277"> |

<img width="160" alt="Screenshot 2024-07-01 at 11 08 58 PM" src="https://github.com/zulip/zulip/assets/25124304/ec3323d8-d64b-4033-85ca-76a99b2e3e0f">
<img width="369" alt="Screenshot 2024-07-01 at 11 09 02 PM" src="https://github.com/zulip/zulip/assets/25124304/ca170a71-bee4-4fa3-b859-48c816dd932d">


Most changes are from this commit - https://github.com/zulip/zulip/pull/28653/commits/ae05c92ae714ae65bc23daea4f36c37447675e8e

