### PR TITLE
[DRAFT] Scale compose formatting and send buttons with info density.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -183,7 +183,14 @@
     flex item. 2.1786em is 30.5px at 14px/1em.
     */
     --compose-recipient-box-min-height: 2.1786em;
-    --compose-formatting-buttons-row-height: 28px;
+    /* 28px at 14px/1em */
+    /* Note that this variable can only be used in contexts where
+       the font-size doesn't deviate from the base font-size;
+       that excludes contexts like .compose_control_button, which
+       uses font-sizing to adjust the size of the icon. Related
+       values have been noted in comments with this variable name,
+       to make their coordination a little less painful. */
+    --compose-formatting-buttons-row-height: 2em;
 
     /*
     Width of the area where the compose box buttons are placed, "inside"

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -969,7 +969,7 @@ textarea.new_message_textarea {
 
 #compose-send-button {
     width: 74px;
-    height: 28px;
+    height: var(--compose-formatting-buttons-row-height);
     /* Allow to grow but not shrink */
     flex: 1 0 auto;
     /* Override inherited styles
@@ -1367,9 +1367,7 @@ textarea.new_message_textarea {
     width: 40px;
     /* Allow to grow but not shrink */
     flex: 1 0 auto;
-    /* TODO: Set this as a variable shared with
-       the send button. */
-    height: 28px;
+    height: var(--compose-formatting-buttons-row-height);
     /* Make the vdots appear to extend from
        beneath the send button when an
        interactive background is present.
@@ -1411,7 +1409,8 @@ textarea.new_message_textarea {
 
     .zulip-icon {
         padding: 5px 0 5px 4px;
-        font-size: 17px;
+        /* 17px at 14px/1em */
+        font-size: 1.2143em;
         flex-grow: 1;
 
         @media (width < $sm_min) {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1074,15 +1074,20 @@ textarea.new_message_textarea {
     align-items: center;
 
     .compose_control_button {
-        height: var(--compose-formatting-buttons-row-height);
-        width: 30px;
+        /* 22px at 14px/1em */
+        font-size: 1.5714em;
+        /* Coordinate with the value of
+           --compose-formatting-buttons-row-height */
+        /* 28px at 22px/1em */
+        height: 1.2727em;
+        /* 30px at 22px/1em */
+        width: 1.3636em;
         display: flex;
         align-items: center;
         justify-content: center;
         opacity: 0.7;
         color: inherit;
         text-decoration: none;
-        font-size: 22px;
 
         &:hover {
             opacity: 1;
@@ -1116,7 +1121,12 @@ textarea.new_message_textarea {
 
     .compose_control_menu {
         padding: 0 1px;
-        font-size: 18px;
+        /* 18px at 14px/1em */
+        font-size: 1.2957em;
+        /* Coordinate with the value of
+           --compose-formatting-buttons-row-height */
+        /* 28px at 18px/1em */
+        height: 1.5556em;
     }
 
     .compose_control_menu_wrapper {
@@ -1152,9 +1162,13 @@ textarea.new_message_textarea {
 
     .divider {
         color: hsl(0deg 0% 75%);
-        font-size: 20px;
+        /* 20px at 14px/1em */
+        font-size: 1.4286em;
         margin: 0 3px;
-        height: var(--compose-formatting-buttons-row-height);
+        /* Coordinate with the value of
+           --compose-formatting-buttons-row-height */
+        /* 28px at 20px/1em */
+        height: 1.4em;
     }
 
     .compose_draft_button {


### PR DESCRIPTION
This PR allows compose formatting buttons to scale up with the font size.

Work remains to fix the display of buttons at certain viewport widths:

* Less than 360px wide viewports
* Near 750px wide viewports
* Near 1070px wide viewports
* Near 1315px wide viewports

**Screenshots and screen captures:**

| Legacy, before | Legacy, after (no change) |
| --- | --- |
| ![compose-buttons-legacy-before](https://github.com/zulip/zulip/assets/170719/5bbc9ec4-ea6e-482b-8e68-b5c877b21d7e) | ![compose-buttons-legacy-after](https://github.com/zulip/zulip/assets/170719/81e92ab1-b8b6-467d-b38a-9bd9df37c48e) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![compose-buttons-16-140-before](https://github.com/zulip/zulip/assets/170719/ad55e4fe-7cf3-40fa-b08f-97127a093310) | ![compose-buttons-16-140-after](https://github.com/zulip/zulip/assets/170719/5405f3be-8c04-4956-b8e3-67e662ed73c9) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
