### PR TITLE
typeahead: Fix search typeahead open on `near` narrows.

### DIFF
--- a/web/third/bootstrap-typeahead/typeahead.css
+++ b/web/third/bootstrap-typeahead/typeahead.css
@@ -1,6 +1,7 @@
 /* CSS for Bootstrap typeahead */
 
 .dropdown-menu {
+  display: none;
   min-width: 160px;
   list-style: none;
 }


### PR DESCRIPTION
This css accidentally got removed in #29882. This bug fix was originally part of #30514.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Weird.20search.20state.20after.20clicking.20.60near.60.20view