### PR TITLE
message_events: Fix moved messages not rendered if they are not cached.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -178,9 +178,11 @@ export function update_messages(events) {
     const messages_to_rerender = [];
     let any_topic_edited = false;
     let changed_narrow = false;
+    let refreshed_current_narrow = false;
     let changed_compose = false;
     let any_message_content_edited = false;
     let any_stream_changed = false;
+    let local_cache_missing_messages = false;
 
     for (const event of events) {
         const anchor_message = message_store.get(event.message_id);
@@ -290,6 +292,11 @@ export function update_messages(events) {
                 const message = message_store.get(message_id);
                 if (message !== undefined) {
                     event_messages.push(message);
+                } else {
+                    // If we don't have the message locally, we need to
+                    // refresh the current narrow after the update to fetch
+                    // the updated messages.
+                    local_cache_missing_messages = true;
                 }
             }
             // The event.message_ids received from the server are not in sorted order.
@@ -434,6 +441,33 @@ export function update_messages(events) {
                 }
             }
 
+            // If a message was moved to the current narrow and we don't have
+            // the message cached, we need to refresh the narrow to display the message.
+            if (!changed_narrow && local_cache_missing_messages && current_filter) {
+                let moved_message_stream = old_stream_name;
+                let moved_message_topic = orig_topic;
+                if (stream_changed) {
+                    moved_message_stream = sub_store.get(new_stream_id).name;
+                }
+
+                if (topic_edited) {
+                    moved_message_topic = new_topic;
+                }
+
+                if (
+                    current_filter.can_newly_match_moved_messages(
+                        moved_message_stream,
+                        moved_message_topic,
+                    )
+                ) {
+                    refreshed_current_narrow = true;
+                    message_view.show(current_filter.terms(), {
+                        then_select_id: current_selected_id,
+                        trigger: "stream/topic change",
+                    });
+                }
+            }
+
             // Ensure messages that are no longer part of this
             // narrow are deleted and messages that are now part
             // of this narrow are added to the message_list.
@@ -444,7 +478,7 @@ export function update_messages(events) {
             // this should be a loop over all valid message_list_data
             // objects, without the rerender (which will naturally
             // happen in the following code).
-            if (!changed_narrow && current_filter) {
+            if (!changed_narrow && !refreshed_current_narrow && current_filter) {
                 let message_ids_to_remove = [];
                 if (current_filter.can_apply_locally()) {
                     const predicate = current_filter.predicate();
@@ -544,7 +578,7 @@ export function update_messages(events) {
         // large organizations.
 
         for (const list of message_lists.all_rendered_message_lists()) {
-            if (changed_narrow && list === message_lists.current) {
+            if ((changed_narrow || refreshed_current_narrow) && list === message_lists.current) {
                 // Avoid updating current message list if user switched to a different narrow and
                 // we don't want to preserver the rendered state for the current one.
                 continue;

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -2429,3 +2429,30 @@ run_test("adjusted_terms_if_moved", () => {
     result = Filter.adjusted_terms_if_moved(raw_terms, message);
     assert.deepStrictEqual(result, expected);
 });
+
+run_test("can_newly_match_moved_messages", () => {
+    // Matches stream
+    let filter = new Filter([{operator: "channel", operand: "general"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("General", "test"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("random-stream", "test"), false);
+
+    // Matches topic
+    filter = new Filter([{operator: "topic", operand: "Test topic"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "Test topic"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test topic"), true);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "random topic"), false);
+
+    // Matches common narrows
+    filter = new Filter([{operator: "is", operand: "followed"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test"), true);
+
+    filter = new Filter([{operator: "is", operand: "starred"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test"), false);
+
+    filter = new Filter([{negated: true, operator: "channel", operand: "general"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("something-else", "test"), true);
+
+    filter = new Filter([{negated: true, operator: "is", operand: "followed"}]);
+    assert.deepEqual(filter.can_newly_match_moved_messages("general", "test"), true);
+});


### PR DESCRIPTION
We used to just drop moved messages from the list of messages to update if we didn't have them cached. So, if the user is in the narrow where messages were moved to, user will not see the moved message if they were not cached locally.

To fix this, we re-render the narrow after fetching messages from the server.

We don't want to use `fast_track_current_msg_list_to_anchor` here since that function assumes that current rendered state of the message list is correct which is not the case here.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20moved.20messages.20not.20with.20client.20locally