### PR TITLE
subscription css: Fix cut off bottom border for subscriber list.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -452,6 +452,7 @@
     /* Settings table colors */
     --color-border-table-striped: hsl(0deg 0% 87%);
     --color-border-table-bordered: hsl(0deg 0% 87%);
+    --color-border-table-subscriber-list: hsl(0deg 0% 87%);
 
     /* Markdown code colors */
     --color-markdown-code-text: hsl(0deg 0% 0%);
@@ -835,6 +836,7 @@
     --color-border-table-striped: hsl(0deg 0% 0% / 20%);
     --color-border-table-bordered: hsl(0deg 0% 0% / 20%);
     --color-background-notification-table-thead: hsl(0deg 0% 0% / 20%);
+    --color-border-table-subscriber-list: hsl(0deg 0% 0% / 20%);
 
     /* Markdown code colors */
     /* Note that Markdown code-link colors are identical

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -137,6 +137,9 @@ h4.user_group_setting_subsection_title {
     .member_list_container,
     .subscriber_list_container {
         position: relative;
+        border-bottom: 1px solid hsl(0deg 0% 87%);
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
         max-height: var(--stream-subscriber-list-max-height);
         overflow: auto;
         text-align: left;
@@ -180,18 +183,6 @@ h4.user_group_setting_subsection_title {
                 position: sticky;
                 top: 0;
                 z-index: 1;
-            }
-
-            & tbody tr:last-child td {
-                border-bottom: 1px solid hsl(0deg 0% 87%);
-
-                &:first-of-type {
-                    border-bottom-left-radius: 4px;
-                }
-
-                &:last-of-type {
-                    border-bottom-right-radius: 4px;
-                }
             }
 
             .hidden-subscriber-email {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -137,7 +137,7 @@ h4.user_group_setting_subsection_title {
     .member_list_container,
     .subscriber_list_container {
         position: relative;
-        border-bottom: 1px solid hsl(0deg 0% 87%);
+        border-bottom: 1px solid var(--color-border-table-subscriber-list);
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
         max-height: var(--stream-subscriber-list-max-height);


### PR DESCRIPTION
## Overview
On some specific screen height, the `.subscriber-list` table will have its bottom border cut off by the `.subscriber_list_container` wrapper div around it.

This PR attempts to fix that issue by formatting the bottom border of the `.subscriber_list_container` wrapper div to act like the tables bottom border. 

[Screencast from 07-02-2024 02:16:25 PM.webm](https://github.com/zulip/zulip/assets/108744694/3c4f30e6-0304-43f8-a9cb-ef1c483dec2c)

`git grep "subscriber_list_container"`:
![image](https://github.com/zulip/zulip/assets/108744694/1103f1b4-4fbf-4049-8adf-07108d20e1c7)

<details>
<summary>
Screenshots & video:
</summary>

| Description | Before | After |
| --- | --- | --- |
| Create Channel | ![image](https://github.com/zulip/zulip/assets/108744694/8a5bba52-5fd3-4553-9709-6b5efb29508f) | ![image](https://github.com/zulip/zulip/assets/108744694/3b4970ed-78d0-48cb-8cf1-13fe272b03e2) |
| Channel with 3 subs | ![image](https://github.com/zulip/zulip/assets/108744694/f7990bec-412d-4cbe-8150-845988de025a) | ![image](https://github.com/zulip/zulip/assets/108744694/b6b17690-b08b-4719-b2a2-c6bd9fcc75ae) |
| Channel Setting with 13 subs | ![image](https://github.com/zulip/zulip/assets/108744694/39787b07-d721-46f3-a79c-c05c5c24e7e0) | ![image](https://github.com/zulip/zulip/assets/108744694/de33f151-7e0a-4069-ad85-89eff36b3009) |
| Group Settings | ![image](https://github.com/zulip/zulip/assets/108744694/b0cb9e5d-5121-493f-9ae7-7b2b9c94286e) | ![image](https://github.com/zulip/zulip/assets/108744694/de98ff67-d5eb-4e5b-8448-74edc58088aa) |

Dark theme:
![image](https://github.com/zulip/zulip/assets/108744694/519d4391-51f8-4890-b02b-9dd1c2944508)
![image](https://github.com/zulip/zulip/assets/108744694/9c02c708-fcec-4041-8d4d-d4bdf5cbead5)




</details>

CZO discussion: [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.93.82.20table's.20bottom.20border.20missing/near/1571062)

Fixes: https://github.com/zulip/zulip/issues/30677.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
