### PR TITLE
Adjusted the min width for russian language for "Add Channel"

### DIFF
--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -5,8 +5,10 @@ import {user_settings} from "./user_settings";
 export function set_layout_width(): void {
     if (user_settings.fluid_layout_width) {
         $("body").addClass("fluid_layout_width");
+        $(".column-middle-align").addClass("fluid_layout_width");
     } else {
         $("body").removeClass("fluid_layout_width");
+        $(".column-middle-align").removeClass("fluid_layout_width");
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -753,7 +753,7 @@ input[type="checkbox"] {
 
     #show-add-default-streams-modal {
         padding: 5px 0;
-        min-width: 100px;
+        min-width: 110px;
         margin-top: 11px;
         margin-right: 6px;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -149,6 +149,10 @@ p.n-margin {
     display: none;
 }
 
+.column-middle-align.fluid_layout_width {
+    margin-left: 168px; 
+}
+
 .alert-zulip-logo,
 .top-messages-logo,
 .bottom-messages-logo {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -149,8 +149,8 @@ p.n-margin {
     display: none;
 }
 
-.column-middle-align.fluid_layout_width {
-    margin-left: 168px; 
+.column-align-middle.fluid_layout_width { 
+    margin-left: calc(var(--left-sidebar-width) - (10 * var(--left-sidebar-collapse-widget-gutter)));
 }
 
 .alert-zulip-logo,

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -10,7 +10,7 @@
                 <img id="realm-navbar-icon-logo" alt="" src="{{ realm_icon_url }}" class="nav-logo no-drag"/>
             </a>
         </div>
-        <div class="column-middle" id="navbar-middle">
+        <div class="column-middle column-middle-align" id="navbar-middle">
             <div class="column-middle-inner">
                 <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="show-left-sidebar-tooltip-template">
                     <a class="left-sidebar-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>


### PR DESCRIPTION
Adjusted the min-width for add option button as mentioned in 

"Add channel" should widen as needed #30674

Before: 

<img width="322" alt="Screenshot 2024-07-02 at 2 26 40 PM" src="https://github.com/zulip/zulip/assets/113302312/3c28dd39-ec59-4f47-9835-a59f70d9ffd3">


After: 

<img width="473" alt="Screenshot 2024-07-02 at 2 26 56 PM" src="https://github.com/zulip/zulip/assets/113302312/6d2a87ef-3183-493f-925e-33abc6756d16">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
