### PR TITLE
Integrations-typed-endpoint

### DIFF
--- a/zerver/views/development/dev_login.py
+++ b/zerver/views/development/dev_login.py
@@ -15,9 +15,9 @@ from zerver.lib.exceptions import (
     RealmDeactivatedError,
     UserDeactivatedError,
 )
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.subdomains import get_subdomain
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.lib.users import get_api_key
 from zerver.lib.validator import validate_login_email
 from zerver.models import Realm, UserProfile
@@ -66,10 +66,11 @@ def add_dev_login_context(realm: Optional[Realm], context: Dict[str, Any]) -> No
 
 
 @csrf_exempt
-@has_request_variables
+@typed_endpoint
 def dev_direct_login(
     request: HttpRequest,
-    next: str = REQ(default="/"),
+    *,
+    next: str = "/",
 ) -> HttpResponse:
     # This function allows logging in without a password and should only be called
     # in development environments.  It may be called if the DevAuthBackend is included
@@ -106,8 +107,8 @@ def check_dev_auth_backend() -> None:
 
 @csrf_exempt
 @require_post
-@has_request_variables
-def api_dev_fetch_api_key(request: HttpRequest, username: str = REQ()) -> HttpResponse:
+@typed_endpoint
+def api_dev_fetch_api_key(request: HttpRequest, *, username: str) -> HttpResponse:
     """This function allows logging in without a password on the Zulip
     mobile apps when connecting to a Zulip development environment.  It
     requires DevAuthBackend to be included in settings.AUTHENTICATION_BACKENDS.

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -3,26 +3,28 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
+from pydantic import Json
 
 from zerver.actions.submessage import do_add_submessage, verify_submessage_sender
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_int, validate_poll_data, validate_todo_data
+from zerver.lib.typed_endpoint import typed_endpoint
+from zerver.lib.validator import validate_poll_data, validate_todo_data
 from zerver.lib.widget import get_widget_type
 from zerver.models import UserProfile
 
 
 # transaction.atomic is required since we use FOR UPDATE queries in access_message.
 @transaction.atomic
-@has_request_variables
+@typed_endpoint
 def process_submessage(
     request: HttpRequest,
     user_profile: UserProfile,
-    message_id: int = REQ(json_validator=check_int),
-    msg_type: str = REQ(),
-    content: str = REQ(),
+    *,
+    message_id: Json[int],
+    msg_type: str,
+    content: str,
 ) -> HttpResponse:
     message = access_message(user_profile, message_id, lock_message=True)
 

--- a/zerver/views/thumbnail.py
+++ b/zerver/views/thumbnail.py
@@ -7,8 +7,8 @@ from django.utils.translation import gettext as _
 
 from zerver.context_processors import get_valid_realm_from_request
 from zerver.lib.attachments import validate_attachment_request
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.thumbnail import generate_thumbnail_url
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.models import Realm, UserProfile
 
 
@@ -27,12 +27,13 @@ def validate_thumbnail_request(
     return True
 
 
-@has_request_variables
+@typed_endpoint
 def backend_serve_thumbnail(
     request: HttpRequest,
     maybe_user_profile: Union[UserProfile, AnonymousUser],
-    url: str = REQ(),
-    size_requested: str = REQ("size"),
+    *,
+    url: str,
+    size: str,
 ) -> HttpResponse:
     if not maybe_user_profile.is_authenticated:
         realm = get_valid_realm_from_request(request)

--- a/zerver/views/tutorial.py
+++ b/zerver/views/tutorial.py
@@ -1,15 +1,16 @@
 from django.http import HttpRequest, HttpResponse
+from typing_extensions import Literal
 
 from zerver.decorator import human_users_only
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.models import UserProfile
 
 
 @human_users_only
-@has_request_variables
+@typed_endpoint
 def set_tutorial_status(
-    request: HttpRequest, user_profile: UserProfile, status: str = REQ()
+    request: HttpRequest, user_profile: UserProfile, *, status: Literal["started", "finished"]
 ) -> HttpResponse:
     if status == "started":
         user_profile.tutorial_status = UserProfile.TUTORIAL_STARTED

--- a/zerver/views/zephyr.py
+++ b/zerver/views/zephyr.py
@@ -15,8 +15,8 @@ from zerver.decorator import authenticated_json_view
 from zerver.lib.ccache import make_ccache
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.pysa import mark_sanitized
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.lib.users import get_api_key
 from zerver.models import UserProfile
 
@@ -28,9 +28,9 @@ kerberos_alter_egos = {
 
 
 @authenticated_json_view
-@has_request_variables
+@typed_endpoint
 def webathena_kerberos_login(
-    request: HttpRequest, user_profile: UserProfile, cred: Optional[str] = REQ(default=None)
+    request: HttpRequest, user_profile: UserProfile, *, cred: Optional[str] = None
 ) -> HttpResponse:
     if cred is None:
         raise JsonableError(_("Could not find Kerberos credential"))

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -10,8 +10,8 @@ from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import JsonableError, UnsupportedWebhookEventTypeError
-from zerver.lib.request import has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint_without_parameters
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -177,7 +177,7 @@ def api_pivotal_webhook_v5(request: HttpRequest, user_profile: UserProfile) -> T
 
 
 @webhook_view("Pivotal", all_event_types=ALL_EVENT_TYPES)
-@has_request_variables
+@typed_endpoint_without_parameters
 def api_pivotal_webhook(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     topic_name = content = None
     try:


### PR DESCRIPTION
Migrate "submessage.py", "thumbnail.py", "tutorial.py", "zephyr.py" and
"dev_login.py" and "integrations.py" to `typed_endpoint`.
