### PR TITLE
fix(settings.css): adjust padding for 'Add channel' button

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -761,8 +761,6 @@ input[type="checkbox"] {
     float: right;
 
     #show-add-default-streams-modal {
-        padding: 5px 0;
-        min-width: 100px;
         margin-top: 11px;
         margin-right: 6px;
     }

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -5,7 +5,7 @@
         <h3>{{t "Default channels"}}</h3>
         <div class="add_default_streams_button_container">
             {{#if is_admin}}
-                <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
+                <button type="submit" id="show-add-default-streams-modal" class="button small rounded sea-green">{{t "Add channel" }}</button>
             {{/if}}
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default channels' }}" aria-label="{{t 'Filter channels' }}"/>
         </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
### Issue Description
This PR addresses the issue where the button is not wide enough for text in certain languages, like Russian or Belarussian.

### Solution
After testing different approaches, I found that adjusting the padding resolves the issue effectively without needing to change the min-width. The updated CSS is:

```css
#show-add-default-streams-modal {
    padding: 5px 10px;
    min-width: 100px;
    margin-top: 11px;
    margin-right: 6px;
}
```

Fixes:  #30674 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<table>
  <tr >
    <th>Russian Before</th>
    <th>Russian After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/zulip/zulip/assets/77602579/6de8708f-3d52-4998-9b04-f04a677fde17" width="400"></td>
    <td><img src="https://github.com/zulip/zulip/assets/77602579/dccbab6f-fa49-43a9-b8d1-62d73978200a" width="400"></td>
  </tr>
  <tr>
    <th>English Before</th>
    <th>English After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/zulip/zulip/assets/77602579/a28b5181-7602-463c-9d5c-73842c3ee702" width="400"></td>
    <td><img src="https://github.com/zulip/zulip/assets/77602579/2fd93c65-19ce-474a-a32f-074057a4a336" width="400"></td>
  </tr>
</table>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
