### PR TITLE
left_sidebar: Refactor nav rows for low-resolution screens.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -587,9 +587,18 @@ li.active-sub-filter {
     display: grid;
     grid-template-areas: "selected-home-view";
     line-height: var(--line-height-sidebar-row);
+    /* Explicitly ensure parity with the line-height
+       for the sake of low-resolution screens, whose
+       font-rendering and rounding may cause icons
+       to appear out of alignment. */
+    grid-auto-rows: var(--line-height-sidebar-row);
 
     .left-sidebar-navigation-label-container {
         .left-sidebar-navigation-label {
+            /* Again, for the sake of low-resolution screens,
+               we'll let the actual label take 1 as a line-height
+               value, and allow grid to handle the alignment. */
+            line-height: 1;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -641,17 +650,6 @@ li.top_left_scheduled_messages {
         /* Use display: grid to preserve the grid
            layout when visible. */
         display: grid;
-    }
-}
-
-.top_left_row {
-    /* The row grid for the outer .top_left_row
-       is chiefly for lefthand spacing and placing
-       the inner row content and vdots. */
-    grid-template-columns: 7px 0 minmax(0, 1fr) 0 30px 0;
-
-    .sidebar-menu-icon {
-        grid-area: ending-anchor-element;
     }
 }
 
@@ -729,6 +727,21 @@ li.top_left_scheduled_messages {
        (which alters the box size) or `margin` (which notoriously bleeds outside
        of the element it's defined on). */
     grid-template-areas: "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset";
+}
+
+.top_left_row {
+    /* We stretch the items on the overall
+       nav row, so there's no unclickable
+       gaps between nav rows. */
+    align-items: stretch;
+    /* The row grid for the outer .top_left_row
+       is chiefly for lefthand spacing and placing
+       the inner row content and vdots. */
+    grid-template-columns: 7px 0 minmax(0, 1fr) 0 30px 0;
+
+    .sidebar-menu-icon {
+        grid-area: ending-anchor-element;
+    }
 }
 
 #direct-messages-section-header,
@@ -974,6 +987,11 @@ li.top_left_scheduled_messages {
        so it remains hidden otherwise. */
     justify-content: center;
     text-align: center;
+    /* Ensure icons are vertically aligned, in
+       case they appear in a grid definition,
+       like the nav rows, that use a different
+       centering regime for the row. */
+    align-self: center;
     /* Set the icon size, which will be inherited
        by .zulip-icon */
     font-size: 17px;


### PR DESCRIPTION
This PR refactors the left sidebar navigation rows in a way that does not disturb high-res presentation of the labels and icons, but makes a big improvement to low-res display of navigation rows in Chrome.

The solution here effectively decouples the row height from the line-height, which was off in Chrome due to likely subpixel rounding errors in its font rendering engine. Instead, CSS Grid auto-generates rows as needed to the same `height` as would otherwise be specified on the `line-height`.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20icons.20sagging.20on.20.60main.60/near/1825390)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Chrome, low-res before | Chrome, low-res after |
| --- | --- |
| ![chrome-before](https://github.com/zulip/zulip/assets/170719/751256ab-e486-4be4-8e02-908319ce2cf5) | ![chrome-after](https://github.com/zulip/zulip/assets/170719/997817ca-3ccd-45aa-9a3f-0386a320f46e) |
| ![chrome-legacy-before](https://github.com/zulip/zulip/assets/170719/45a1c039-01c6-4545-b2ad-2e218196284c) | ![chrome-legacy-after](https://github.com/zulip/zulip/assets/170719/708a7571-72f2-4205-b9d8-3e352c38ec4e) |

| Chrome, high-res before | Chrome, high-res after (slight improvement?) |
| --- | --- |
| ![chrome-high-res-before](https://github.com/zulip/zulip/assets/170719/42f8e63d-4781-455e-ab59-1dda77ed088b) | ![chrome-high-res-after](https://github.com/zulip/zulip/assets/170719/d9be488c-53f3-414e-b1a9-372b01a920b3) |
| ![chrome-legacy-high-res-before](https://github.com/zulip/zulip/assets/170719/c9490a1e-e375-4f0a-bf94-761b6689aceb) | ![chrome-legacy-high-res-after](https://github.com/zulip/zulip/assets/170719/44247734-b0ea-4b06-a56e-72a775666d49) |

| Firefox, high-res before | Firefox, high-res after (no change) |
| --- | --- |
| ![firefox-high-res-before](https://github.com/zulip/zulip/assets/170719/07aacc51-f1f9-4c4e-8cbd-4a7608574aed) | ![firefox-high-res-after-no-change](https://github.com/zulip/zulip/assets/170719/61764531-9d7d-4e2c-af96-0e76cb617b68) |
| ![firefox-legacy-high-res-before](https://github.com/zulip/zulip/assets/170719/b8cf95e3-db46-4152-b62c-c74c3b0d03a0) | ![firefox-legacy-high-res-after-no-change](https://github.com/zulip/zulip/assets/170719/e61368c2-5bc6-46e8-a83f-d404d86ddd31) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>