### PR TITLE
navbar: Fix navbar heading alignment when using full width.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -42,6 +42,19 @@
     --navbar-content-righthand-offset: 5px;
 
     /*
+    Width of navbar left column
+    40px (Sidebar toggle icon) + 80px (wide logo).
+    */
+    --navbar-left-column-width: 120px;
+    /*
+    Both icon and logo change in width when height of header is reduced
+    30px (Sidebar toggle icon) + 60px (wide logo)
+    */
+    @media (height < $short_navbar_cutoff_height) {
+        --navbar-left-column-width: 90px;
+    }
+
+    /*
     We have a 10px gutter below the header,
     which often needs to be respected by both
     the elements above it and below it on

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1869,6 +1869,12 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     @extend %hide-left-sidebar;
 
     &.fluid_layout_width {
+        /* Since left sidebar is closed, update margin-left from --left-sidebar-width
+           to --navbar-left-column-width. Add sufficient space to the right of left column */
+        .column-middle {
+            margin-left: calc(var(--navbar-left-column-width) + 30px);
+        }
+
         #compose-content,
         .app-main .column-middle {
             margin-left: 7px;


### PR DESCRIPTION
Added CSS variable for left column width in the navbar.

Fixes: #30619.

**Screenshots and screen captures:**

| Before | After |
|--------|-------|
| ![image](https://github.com/zulip/zulip/assets/78212328/fadbe6ec-23bc-4d09-9cc9-dd01661694f5) | ![image](https://github.com/zulip/zulip/assets/78212328/fe6cbf07-31e3-4f90-b850-95389e014e3f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
