### PR TITLE
documentation: Fix "you you" typos in docs/comments/logs.

### DIFF
--- a/puppet/kandra/templates/nagios4/cgi.cfg.template.erb
+++ b/puppet/kandra/templates/nagios4/cgi.cfg.template.erb
@@ -177,7 +177,7 @@ authorized_for_all_hosts=*
 # can issue host or service related commands via the command
 # CGI (cmd.cgi) for all hosts and services that are being monitored.
 # By default, users can only issue commands for hosts or services
-# that they are contacts for (unless you you choose to not use
+# that they are contacts for (unless you choose to not use
 # authorization).  You may use an asterisk (*) to authorize any
 # user who has authenticated to the web server.
 

--- a/scripts/setup/initialize-database
+++ b/scripts/setup/initialize-database
@@ -57,6 +57,6 @@ if [ -z "$QUIET" ]; then
     echo
     echo "    /home/zulip/deployments/current/manage.py generate_realm_creation_link"
     echo
-    echo "This generates a secure, single-use link that you you can use to set up "
+    echo "This generates a secure, single-use link that you can use to set up "
     echo "a Zulip organization from the convenience of your web browser."
 fi

--- a/zerver/webhooks/gitlab/doc.md
+++ b/zerver/webhooks/gitlab/doc.md
@@ -14,7 +14,7 @@ Receive GitLab notifications in Zulip!
    sidebar.  Click on **Integrations**.
 
 1. Set **URL** to the URL you generated. Select the
-   [events](#filtering-incoming-events) you you would like to receive
+   [events](#filtering-incoming-events) you would like to receive
    notifications for, and click **Add Webhook**.
 
 !!! warn ""


### PR DESCRIPTION
Noticed the "you you" typo in the documentation for the [GitLab integration](https://zulip.com/integrations/doc/gitlab), and then did `git-grep "you you"` to fix any other instances of this same typo in docs.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
