### PR TITLE
privacy_icon: Raise lock icon throughout UI for better visual centering.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -938,6 +938,14 @@ div.overlay {
     }
 }
 
+.zulip-icon-lock {
+    /* The lock icon is bottom heavy, so to make it
+       appear better aligned, we pull it up by a
+       uniform margin throughout the UI. */
+    /* 3.5px at 16px/1em */
+    margin-top: -0.2188em !important;
+}
+
 /* This includes css needed to display messages in an overlay. */
 .overlay-messages-container {
     position: relative;


### PR DESCRIPTION
This PR introduces a negative top-margin adjustment on the icon lock, UI wide. Mathematical centering is just that: this adjustment goes for visual/perceptual centering instead. And it does so with an `em` value that works at legacy and 16/140.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20drooping.20left.20sidebar.20lock.20icons/near/1842926)

Fixes part of #30476

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Left sidebar detail, before | Left sidebar detail, after |
| --- | --- |
| ![lock-icons-before](https://github.com/zulip/zulip/assets/170719/e9b241b7-d213-4804-9851-1a25cbad520f) | ![lock-icons-after](https://github.com/zulip/zulip/assets/170719/430cca04-de7f-41b6-9fd3-580ddb4729df) |

| Recent conversations, before | Recent conversations, after |
| --- | --- |
| ![legacy-recent-view-before](https://github.com/zulip/zulip/assets/170719/714cc66c-38e1-4ca5-97cf-669cdab81f83) | ![legacy-recent-view-after](https://github.com/zulip/zulip/assets/170719/83b49eb4-90f0-46e0-b380-dd5128e1ef24) |
| ![recent-view-before](https://github.com/zulip/zulip/assets/170719/a26bb406-7669-46d4-b7db-224d1ed3a2c5) | ![recent-view-after](https://github.com/zulip/zulip/assets/170719/2e6881da-d594-45e9-8fb9-4b22e3c61aac) |

| Private stream, before | Private stream, after |
| --- | --- |
| ![private-stream-before](https://github.com/zulip/zulip/assets/170719/e54b1b42-424b-415e-a815-59f68f921ee9) | ![private-stream-after](https://github.com/zulip/zulip/assets/170719/233e8253-49ce-42b3-8ba4-74a0f5d74d77) |

_The righthand panel heading needs a layout rewrite, too much for this PR, to take advantage of the new icon positioning; but the icons appear better centered in the boxes to the right:_

| Stream settings, before | Stream settings, after |
| --- | --- |
| ![stream-settings-16-140-before](https://github.com/zulip/zulip/assets/170719/897627be-7e3f-475b-849b-cc98039df0e1) | ![stream-settings-16-140-after](https://github.com/zulip/zulip/assets/170719/ae917597-889a-474a-a1bf-98fe4eab2298) |
| ![stream-settings-after](https://github.com/zulip/zulip/assets/170719/bbfce4d4-0870-4a3e-9ab5-8f9715e1c861) | ![stream-settings-before](https://github.com/zulip/zulip/assets/170719/d93561e2-10ca-4f30-80eb-7d7190511b88) |




<details>
<summary>Self-review checklist</summary>



<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
