### PR TITLE
scroll: Set outline as none for `.simplebar-content-wrapper`.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2214,6 +2214,13 @@ body:not(.hide-left-sidebar) {
 }
 
 .simplebar-content-wrapper {
+    /* `simplebar-content-wrapper` has `tabindex=-1` set, which makes sure
+       that it does not get focus when navigating via a keyboard.
+
+       But in a few situations, we programmatically focus this
+       element, and in this case, we don't want to see the outline. */
+    outline: none;
+
     /* This prevents the popover from closing once the top/bottom is reached */
     overscroll-behavior: contain;
 }


### PR DESCRIPTION
We're reverting removing `outline: none` from commit fe11f3be7c21c649e21702b9afbbb63fb70879d6. While we set tabIndex to -1 in that commit, which makes sure that it does not get focus when navigating via a keyboard. But it does not prevent us from programmatically focusing on the element. In this case, we don't want to see the outline. 

Fixes https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20weird.20left.20sidebar.20outline/near/1834137

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Screenshots and screen captures:
| Before | After |
| --- | --- |
|  <img width="1351" alt="Screenshot 2024-07-03 at 1 58 31 AM" src="https://github.com/zulip/zulip/assets/13910561/f9983fd8-ff73-4146-99fc-aa4284149f74"> |  <img width="1351" alt="Screenshot 2024-07-03 at 1 58 12 AM" src="https://github.com/zulip/zulip/assets/13910561/b0387c52-7f49-43e7-adc8-c69215c43efa">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
