### PR TITLE
ListWidget: Fix sliding of actions column in tables.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -798,6 +798,10 @@ div.overlay {
         white-space: nowrap;
     }
 
+    th.actions {
+        padding-right: 1em;
+    }
+
     & th,
     td {
         padding: 4px 5px;


### PR DESCRIPTION
Added right padding to the actions heading in the table.

Fixes #29633.

<table>
<tr>
<th></th><th>Before</th><th>After 2em</th><th>After 1em</th><th>After 1em with data</th>
</tr>
<tr>
<td>Users</td>
<td>

![image](https://github.com/zulip/zulip/assets/29176437/902227e9-aea5-4fb6-8e36-3e06dff1f4fa)

</td>
<td>

![image](https://github.com/user-attachments/assets/e280eb0f-c4a8-406e-8148-69d452676814)

</td>
<td>

![image](https://github.com/user-attachments/assets/43996958-55d5-4d35-8d1f-80e0cd5a045e)


</td>
<td>

![image](https://github.com/user-attachments/assets/d4c69b00-2c5a-4487-ade1-38ca2768728d)


</td>
</tr>
<tr>
<td>Bots</td>
<td>

![image](https://github.com/zulip/zulip/assets/29176437/6a85c5fa-175f-4c22-a4b9-983067455b96)

</td><td>

![image](https://github.com/user-attachments/assets/a2df5f79-8216-44ef-b387-5a7545bce583)


</td><td>

![image](https://github.com/user-attachments/assets/97bda9f1-4648-4775-b2a4-ea256dec3085)

</td><td>

![image](https://github.com/user-attachments/assets/4ad98a73-31ab-489b-b2f0-e32c98d4f381)


</td>
</tr>
<tr>
<td>Default Channels</td>


<td>

![image](https://github.com/zulip/zulip/assets/29176437/da51a7a2-99f3-4e93-af58-45cea70108ce)


</td><td>

![image](https://github.com/user-attachments/assets/ed8c5c56-2e60-4796-bde9-12837117f51e)


</td><td>

![image](https://github.com/user-attachments/assets/2045f227-5d5a-49b4-9127-f048051b9abd)


</td><td>

![image](https://github.com/user-attachments/assets/46dc9535-1486-426a-8ab7-433ff9e51a2f)


</td>
</tr>

<tr>
<td>

Custom Emoji

</td>
<td>

![image](https://github.com/user-attachments/assets/643f05a7-5f83-4a31-8142-f5b6af0f44b7)


</td>
<td>

![image](https://github.com/user-attachments/assets/e4802eeb-9a8f-41b1-89a6-3eaf88176c5e)

</td>
<td>

![image](https://github.com/user-attachments/assets/dc82bb10-5689-4e7d-a905-009d6d6ae63b)


</td>
<td>

![image](https://github.com/user-attachments/assets/cba4bd12-fb1a-40d6-8c4f-a1d624b465e4)

</td>

<tr>
</table>
