### PR TITLE
Increase max width of information overlay.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -267,9 +267,7 @@
     /* .settings-sticky-footer */
     --subscriptions-overlay-sticky-footer-height: 60px;
     /* Informational overlay */
-    /* Because zoom breaks at 525px perhaps due to rounding errors, we add a
-       trivial amount of width so the overlay doesn't break. */
-    --informational-overlay-max-width: 550px;
+    --informational-overlay-max-width: 43.75em;
 
     /*
     Maximum height of the compose box when it is not in maximised state. This

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -125,3 +125,8 @@
         }
     }
 }
+
+#message-formatting-first-header,
+#search-operators-first-header {
+    width: 40%;
+}

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -49,6 +49,10 @@
     & td.operator {
         font-size: 0.9em;
     }
+
+    .poll-question-header {
+        display: inline;
+    }
 }
 
 .hotkeys_table {

--- a/web/templates/markdown_help.hbs
+++ b/web/templates/markdown_help.hbs
@@ -5,7 +5,7 @@
             <table class="table table-striped table-rounded table-bordered help-table">
                 <thead>
                     <tr>
-                        <th>{{t "You type" }}</th>
+                        <th id="message-formatting-first-header">{{t "You type" }}</th>
                         <th>{{t "You get" }}</th>
                     </tr>
                 </thead>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -4,7 +4,7 @@
             <table class="table table-striped table-rounded table-bordered help-table">
                 <thead>
                     <tr>
-                        <th>{{t "Filter" }}</th>
+                        <th id="search-operators-first-header">{{t "Filter" }}</th>
                         <th>{{t "Effect" }}</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/.F0.9F.8E.AF.20info.20density.3A.20help.20modal

| before | after |
| --- | --- |
| <img width="866" alt="Screenshot 2024-07-03 at 7 47 42 AM" src="https://github.com/zulip/zulip/assets/25124304/c7c01648-a279-4ce2-a099-d2472e5406fa"> | <img width="780" alt="Screenshot 2024-07-03 at 7 44 52 AM" src="https://github.com/zulip/zulip/assets/25124304/3145c1b9-5fe9-4d3a-8431-c295b59eaac8"> |

| before | after |
| --- | --- |
| <img width="592" alt="Screenshot 2024-07-02 at 10 15 43 PM" src="https://github.com/zulip/zulip/assets/25124304/f40c0db4-1e69-45f5-a941-7d68b60f681a"> | <img width="602" alt="Screenshot 2024-07-02 at 10 15 50 PM" src="https://github.com/zulip/zulip/assets/25124304/638844ad-6621-480d-a31d-0b350ea278ed"> |

Tested at different breakpoints and zoom levels to ensure we are not breaking anything.