### PR TITLE
Recent view fix error when deleting the only message in a topic.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -806,7 +806,12 @@ export function update_topics_of_deleted_message_ids(message_ids: number[]): voi
         const msgs = message_util.get_messages_in_topic(stream_id, topic);
         msgs_to_process.push(...msgs);
     }
-    process_messages(msgs_to_process);
+
+    if (msgs_to_process.length > 0) {
+        process_messages(msgs_to_process);
+    } else {
+        complete_rerender();
+    }
 }
 
 export function filters_should_hide_row(topic_data: ConversationData): boolean {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -800,12 +800,13 @@ export function topic_in_search_results(
 
 export function update_topics_of_deleted_message_ids(message_ids: number[]): void {
     const topics_to_rerender = message_util.get_topics_for_message_ids(message_ids);
-
+    const msgs_to_process = [];
     for (const [stream_id, topic] of topics_to_rerender.values()) {
         recent_view_data.conversations.delete(recent_view_util.get_topic_key(stream_id, topic));
         const msgs = message_util.get_messages_in_topic(stream_id, topic);
-        process_messages(msgs);
+        msgs_to_process.push(...msgs);
     }
+    process_messages(msgs_to_process);
 }
 
 export function filters_should_hide_row(topic_data: ConversationData): boolean {


### PR DESCRIPTION
Looks like the error was only there when the topic had a single message which was deleted. 

Tested by having focus on the topic with a single unread message in recent view and deleting that message in another window. Couldn't reproduce the bug for topic with multiple unread messages.