### PR TITLE
recipient_row: Remove extra whitespace around recipient full name.

### DIFF
--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -88,11 +88,11 @@
         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
         <span class="private_message_header_name">
             {{#tr}}You and <z-user-names></z-user-names>
-            {{#*inline "z-user-names"}}
-                {{#each recipient_users}}
+            {{~#*inline "z-user-names"}}
+                {{~#each recipient_users}}
                     {{full_name}}{{#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{/if}}{{#unless @last}},{{/unless}}
-                {{/each}}
-            {{/inline}}
+                {{/each~}}
+            {{/inline~}}
             {{/tr}}
         </span>
         </a>

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -54,7 +54,7 @@ strip_whitespace_left = re.compile(
 )
 
 regexes = [
-    r"{{~?#tr}}([\s\S]*?)(?:~?{{/tr}}|{{#\*inline )",  # '.' doesn't match '\n' by default
+    r"{{~?#tr}}([\s\S]*?)(?:~?{{/tr}}|{{~?#\*inline )",  # '.' doesn't match '\n' by default
     r'{{~?\s*t "([\s\S]*?)"\W*~?}}',
     r"{{~?\s*t '([\s\S]*?)'\W*~?}}",
     r'\(t "([\s\S]*?)"\)',


### PR DESCRIPTION
Might fix the CI errors due to extra space between `You and` and the user full name.

discussion: https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1844222

No visual changes.