### PR TITLE
left_sidebar: Rewrite `back to channels` to use css grid.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -740,50 +740,42 @@ export function initialize() {
         stream_list.toggle_filter_displayed(e);
     });
 
-    $("body").on(
-        "click",
-        ".direct-messages-container.zoom-out #direct-messages-section-header",
-        (e) => {
-            if ($(e.target).closest("#show-all-direct-messages").length === 1) {
-                // Let the browser handle the "direct message feed" widget.
-                return;
-            }
+    $("body").on("click", "#direct-messages-section-header.zoom-out", (e) => {
+        if ($(e.target).closest("#show-all-direct-messages").length === 1) {
+            // Let the browser handle the "direct message feed" widget.
+            return;
+        }
 
-            e.preventDefault();
-            e.stopPropagation();
-            const $left_sidebar_scrollbar = $(
-                "#left_sidebar_scroll_container .simplebar-content-wrapper",
-            );
-            const scroll_position = $left_sidebar_scrollbar.scrollTop();
+        e.preventDefault();
+        e.stopPropagation();
+        const $left_sidebar_scrollbar = $(
+            "#left_sidebar_scroll_container .simplebar-content-wrapper",
+        );
+        const scroll_position = $left_sidebar_scrollbar.scrollTop();
 
-            if (stream_list.is_zoomed_in()) {
-                stream_list.zoom_out();
-            }
+        if (stream_list.is_zoomed_in()) {
+            stream_list.zoom_out();
+        }
 
-            // This next bit of logic is a bit subtle; this header
-            // button scrolls to the top of the direct messages
-            // section is uncollapsed but out of view; otherwise, we
-            // toggle its collapsed state.
-            if (scroll_position === 0 || pm_list.is_private_messages_collapsed()) {
-                pm_list.toggle_private_messages_section();
-            }
-            $left_sidebar_scrollbar.scrollTop(0);
-        },
-    );
+        // This next bit of logic is a bit subtle; this header
+        // button scrolls to the top of the direct messages
+        // section is uncollapsed but out of view; otherwise, we
+        // toggle its collapsed state.
+        if (scroll_position === 0 || pm_list.is_private_messages_collapsed()) {
+            pm_list.toggle_private_messages_section();
+        }
+        $left_sidebar_scrollbar.scrollTop(0);
+    });
 
     /* The DIRECT MESSAGES label's click behavior is complicated;
      * only when zoomed in does it have a navigation effect, so we need
      * this click handler rather than just a link. */
-    $("body").on(
-        "click",
-        ".direct-messages-container.zoom-in #direct-messages-section-header",
-        (e) => {
-            e.preventDefault();
-            e.stopPropagation();
+    $("body").on("click", "#direct-messages-section-header.zoom-in", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
 
-            window.location.hash = "narrow/is/dm";
-        },
-    );
+        window.location.hash = "narrow/is/dm";
+    });
 
     // disable the draggability for left-sidebar components
     $("#stream_filters, #left-sidebar-navigation-list").on("dragstart", (e) => {

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -23,7 +23,7 @@ let private_messages_collapsed = false;
 let zoomed = false;
 
 function get_private_messages_section_header(): JQuery {
-    return $(".direct-messages-container #direct-messages-section-header");
+    return $("#direct-messages-section-header");
 }
 
 export function set_count(count: number): void {

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -23,7 +23,7 @@ let private_messages_collapsed = false;
 let zoomed = false;
 
 function get_private_messages_section_header(): JQuery {
-    return $(".direct-messages-container #direct-messages-section #direct-messages-section-header");
+    return $(".direct-messages-container #direct-messages-section-header");
 }
 
 export function set_count(count: number): void {

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -30,7 +30,7 @@ function get_new_heights(): {
         Number.parseInt($("#left-sidebar-navigation-area").css("marginTop"), 10) -
         Number.parseInt($("#left-sidebar-navigation-area").css("marginBottom"), 10) -
         ($("#left-sidebar-navigation-list").outerHeight(true) ?? 0) -
-        ($("#direct-messages-sticky-header").outerHeight(true) ?? 0);
+        ($("#direct-messages-section-header").outerHeight(true) ?? 0);
 
     // Don't let us crush the stream sidebar completely out of view
     stream_filters_max_height = Math.max(80, stream_filters_max_height);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -313,7 +313,7 @@ li.show-more-topics {
 .active-direct-messages-section {
     background-color: var(--color-background-active-narrow-filter);
 
-    #direct-messages-section {
+    #direct-messages-section-header {
         border-radius: 4px 4px 0 0;
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -203,7 +203,7 @@ li.show-more-topics {
        in the DM section. */
     margin-right: 12px;
 
-    #direct-messages-section-header {
+    &#direct-messages-section-header {
         grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
         grid-template-rows: var(--line-height-sidebar-row-prominent);
         /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -711,6 +711,7 @@ li.top_left_scheduled_messages {
 
 /* New .topic-box grid definitions here. */
 #views-label-container,
+.zoom-in #hide-more-direct-messages,
 .top_left_row,
 .left-sidebar-navigation-label-container,
 .dm-box,
@@ -1396,29 +1397,21 @@ li.topic-list-item {
     }
 
     #hide-more-direct-messages {
-        display: block;
+        grid-template-columns: inherit;
+        grid-column: 1 / -1;
+        line-height: var(--line-height-sidebar-row);
         text-decoration: none;
         color: inherit;
         /* 12px at 14px/1em */
-        font-size: 0.8571em;
 
-        & span {
-            display: block;
-            /* TODO: Rewrite the show-more and show-less
-               buttons as grids alongside the left sidebar
-               header rewrites. The 12px left padding here
-               aligns the "back to channels" text with the
-               DIRECT MESSAGES heading above, which itself
-               is offset -3 px to the left, but reserves
-               15px for the arrow marker. 15px - 3px = 12px. */
-            padding: 2px 0 2px 12px;
+        .hide-more-direct-messages-text {
+            font-size: 0.8571em;
+            grid-area: row-content;
         }
 
         &:hover {
-            & span {
-                background-color: hsl(120deg 12.3% 71.4% / 38%);
-                border-radius: 4px;
-            }
+            background-color: hsl(120deg 12.3% 71.4% / 38%);
+            border-radius: 4px;
         }
     }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -144,20 +144,18 @@
     </div>
 
     <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
-        <div id="direct-messages-section">
-            <div id="direct-messages-section-header" class="zoom-out zoom-in-sticky">
-                <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-                <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
-                <div class="heading-markers-and-controls">
-                    <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
-                        <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
-                    </a>
-                    <span class="unread_count"></span>
-                </div>
-                <a class="zoom-out-hide" id="hide-more-direct-messages">
-                    <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
+        <div id="direct-messages-section-header" class="zoom-out zoom-in-sticky">
+            <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+            <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
+            <div class="heading-markers-and-controls">
+                <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
+                    <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
                 </a>
+                <span class="unread_count"></span>
             </div>
+            <a class="zoom-out-hide" id="hide-more-direct-messages">
+                <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
+            </a>
         </div>
     </div>
     {{~!-- squash whitespace --~}}

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -154,11 +154,11 @@
                     </a>
                     <span class="unread_count"></span>
                 </div>
+                <a class="zoom-out-hide" id="hide-more-direct-messages">
+                    <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
+                </a>
             </div>
         </div>
-        <a class="zoom-out-hide" id="hide-more-direct-messages">
-            <span> {{t 'back to channels' }}</span>
-        </a>
     </div>
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -143,20 +143,18 @@
         </ul>
     </div>
 
-    <div id="direct-messages-sticky-header" class="direct-messages-container zoom-out hidden-for-spectators">
-        <div id="direct-messages-section-header" class="zoom-out zoom-in-sticky">
-            <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
-            <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
-            <div class="heading-markers-and-controls">
-                <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
-                    <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
-                </a>
-                <span class="unread_count"></span>
-            </div>
-            <a class="zoom-out-hide" id="hide-more-direct-messages">
-                <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
+    <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
+        <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+        <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
+        <div class="heading-markers-and-controls">
+            <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
+                <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
             </a>
+            <span class="unread_count"></span>
         </div>
+        <a class="zoom-out-hide" id="hide-more-direct-messages">
+            <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
+        </a>
     </div>
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">

--- a/web/tests/pm_list.test.js
+++ b/web/tests/pm_list.test.js
@@ -12,9 +12,7 @@ run_test("update_dom_with_unread_counts", () => {
     let counts;
 
     const $total_count = $.create("total-count-stub");
-    const $private_li = $(
-        ".direct-messages-container #direct-messages-section #direct-messages-section-header",
-    );
+    const $private_li = $(".direct-messages-container #direct-messages-section-header");
     $private_li.set_find_results(".unread_count", $total_count);
 
     counts = {

--- a/web/tests/pm_list.test.js
+++ b/web/tests/pm_list.test.js
@@ -12,7 +12,7 @@ run_test("update_dom_with_unread_counts", () => {
     let counts;
 
     const $total_count = $.create("total-count-stub");
-    const $private_li = $(".direct-messages-container #direct-messages-section-header");
+    const $private_li = $("#direct-messages-section-header");
     $private_li.set_find_results(".unread_count", $total_count);
 
     counts = {


### PR DESCRIPTION
While the TODO comment we deleted in left_sidebar.css says we need to rewrite both show more and show less button to grids; show more was already a grid. There have been some very slight changes in the actual size of the back to channels row; those changes make the row more consistent with the rest of the left sidebar rows in terms of sizing.

We've introduced a new class called `.hide-more-direct-messages-text` that applies the same properties as the `span` selector used to. We are using a class because of better performance when selecting, see https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20performance/near/1845719 for more info on the why, The `font-size` was moved inside the above class, so that when setting the line-height of the anchor component, the `em` refers to the normal font size and not the smaller font size for `back to channels`.

We've moved the link inside `.direct-messages-section-header` and most of the grid properties are inherited from that element.

The second and third commit remove the unnecessary nesting of some divs.

The last commit has the potential to have regressions because of how the selectors were written. I've tried it out for regressions, but having a second set of eyes on it for manual testing would be great.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After (very slight change, should not be visible to naked eye)
-- | --
<img width="380" alt="before_back_to_channel" src="https://github.com/zulip/zulip/assets/13910561/ec802bc4-afdb-4bb2-8b11-b5bf9c004d2d"> |  <img width="351" alt="after_back_to_channel" src="https://github.com/zulip/zulip/assets/13910561/38f4c00f-344c-4c9e-8925-aa13f213d653">
<img width="477" alt="before_back_to_channel_size" src="https://github.com/zulip/zulip/assets/13910561/9852c093-16d5-43d4-9c0a-a49e12b528a2"> |  <img width="477" alt="after_back_to_channel_size" src="https://github.com/zulip/zulip/assets/13910561/adee738f-309b-466c-a8cb-e984b799242a">
Zoom out DM - before | Zoom out DM - after
<img width="359" alt="show_more_before" src="https://github.com/zulip/zulip/assets/13910561/970dcef9-025b-4c92-bcb1-86c97b9194af"> | <img width="359" alt="show_more_after" src="https://github.com/zulip/zulip/assets/13910561/05741232-6207-43c1-82a4-4988c0c0b2ec">
Zoom in DM - before | Zoom in DM - after
<img width="359" alt="show_less_before" src="https://github.com/zulip/zulip/assets/13910561/4d626233-a890-40a1-9820-3cbf6b0b20b2"> | <img width="359" alt="show_less_after" src="https://github.com/zulip/zulip/assets/13910561/20366f29-39a3-4aa9-8ffb-e2a704a7a390">







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
