### PR TITLE
docs: Update docs for 3 way compose box resizing.

### DIFF
--- a/help/resize-the-compose-box.md
+++ b/help/resize-the-compose-box.md
@@ -4,34 +4,20 @@ When composing a long message, it can be helpful to expand the compose
 box to display more text and avoid distractions. Note that the compose
 box also stretches automatically when you type a long message.
 
-## Expand the compose box
-
 {start_tabs}
 
 {!start-composing.md!}
 
-1. Click on the **<i class="zulip-icon zulip-icon-expand-diagonal"></i> icon** in the top
-   right corner of the compose box, which is visible on hovering over the compose box.
+1. Move your mouse to the compose box area.
 
-{end_tabs}
+1. Click the <i class="zulip-icon zulip-icon-expand-diagonal"></i>, <i
+   class="zulip-icon zulip-icon-maximize-diagonal"></i>, or <i class="zulip-icon
+   zulip-icon-collapse-diagonal"></i> button in the top right corner of the text
+   box.
 
-## Collapse the compose box
+!!! tip ""
 
-{start_tabs}
-
-1. With the compose box in the expanded state, click on the **<i class="zulip-icon
-   zulip-icon-collapse-diagonal"></i> icon** in the top right corner of the compose box,
-   which is visible on hovering over the compose box.
-
-{end_tabs}
-
-## Stretch the compose box
-
-{start_tabs}
-
-{!start-composing.md!}
-
-1. Click and drag the bottom right corner of the compose box.
+    Which button you see depends on the current size of the compose box.
 
 {end_tabs}
 

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -110,18 +110,17 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
     const compose_non_textarea_height = compose_height - compose_textarea_height;
 
     // We ensure that the last message is not overlapped by compose box.
-    // TODO: Remove subtraction of 2 when we remove the margin in #29953
     $("textarea#compose-textarea").css(
         "max-height",
         // Because <textarea> max-height includes padding, we subtract
-        // 10 for the padding and 2 for the margin.
-        bottom_whitespace_height - compose_non_textarea_height - 2 - 10,
+        // 10 for the padding.
+        bottom_whitespace_height - compose_non_textarea_height - 10,
     );
     $("#preview_message_area").css(
         "max-height",
-        // Because <div> max-height doesn't include padding, we subtract
-        // 2 for the margin.
-        bottom_whitespace_height - compose_non_textarea_height - 2,
+        // Because <div> max-height doesn't include padding, we do not
+        // subtract anything.
+        bottom_whitespace_height - compose_non_textarea_height,
     );
     $("#scroll-to-bottom-button-container").css("bottom", compose_height);
     compose_ui.autosize_textarea($("#compose-textarea"));


### PR DESCRIPTION
Also,

compose: Fix the calculation of the compose box's max height.

This is a follow up to #30396, to remove consideration of the text box's margin after it's removal in #29953.

Fixes: [CZO message](https://chat.zulip.org/#narrow/stream/438-release-management/topic/zulip_updates.20items.20of.20note/near/1844022)

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/72a558ad-b380-485c-a05a-324b80b993aa)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
