### PR TITLE
tippy: Enable Tippies to scale with UI.

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -240,7 +240,8 @@ export function initialize(): void {
         // TODO: Might need to target just the Send button itself
         // in the new design
         target: ".disabled-message-send-controls",
-        maxWidth: 350,
+        // 350px at 14px/1em
+        maxWidth: "25em",
         content: () =>
             compose_recipient.get_posting_policy_error_message() ||
             compose_validate.get_disabled_send_tooltip(),

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -53,7 +53,8 @@ export const EXTRA_LONG_HOVER_DELAY: [number, number] = [1500, 20];
 // documentation for default properties.
 tippy.default.setDefaultProps({
     // Tooltips shouldn't take more space than mobile widths.
-    maxWidth: 300,
+    // 300px at 14px/1em
+    maxWidth: "21.4286em",
     delay: INSTANT_HOVER_DELAY,
     placement: "top",
     // Disable animations to make the tooltips feel snappy.

--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -27,6 +27,9 @@
             font-size: 1em;
             /* 20px at 14px/1em */
             line-height: 1.4286em;
+            /* Don't inherit font-weight when
+               a Tippy attaches to a parent */
+            font-weight: normal;
             color: hsl(0deg 0% 100%);
         }
 

--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -12,7 +12,10 @@
     .tippy-box:not([data-theme]) {
         background: hsl(0deg 0% 20%);
         border-radius: 5px;
-        min-height: 25px;
+        /* 14px at 14px/1em */
+        font-size: 1em;
+        /* 25px at 14px/1em */
+        min-height: 1.7857em;
         box-sizing: border-box;
 
         .tippy-content {
@@ -20,8 +23,10 @@
             display: flex;
             align-items: center;
             padding: 5px 10px;
-            font-size: 14px;
-            line-height: 20px;
+            /* 14px at 14px/1em */
+            font-size: 1em;
+            /* 20px at 14px/1em */
+            line-height: 1.4286em;
             color: hsl(0deg 0% 100%);
         }
 
@@ -34,7 +39,8 @@
         }
 
         .tooltip-inner-content {
-            line-height: 17px;
+            /* 17px at 14px/1em */
+            line-height: 1.2143em;
         }
 
         &[data-placement^="top"] > .tippy-arrow::before {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -779,7 +779,8 @@ strong {
 .buddy_list_tooltip_content {
     text-align: left;
     word-wrap: break-word;
-    max-width: 280px;
+    /* 280px at 14px/1em */
+    max-width: 20em;
 }
 
 #change_visibility_policy_button_tooltip {


### PR DESCRIPTION
This PR sets Tippies to scale with the UI, including initializing Tippies with em values for `maxWidth`. Additionally, a small commit here ensures that bold font-weights don't make their way into a Tippy when it's attached to a parent (as is the case in the Notifications UI.

Fixes part of #30476

<!-- Describe your pull request here.-->

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/maxWidth.20on.20Tippy.20tooltips/near/1845656)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| 16/140 Tippies, before | 16/140 Tippies, after |
| --- | --- |
| ![tippies-before](https://github.com/zulip/zulip/assets/170719/abc9848a-dc28-4536-acfb-24ecf2b33260) | ![tippies-after](https://github.com/zulip/zulip/assets/170719/c7075420-74fb-4bc1-a7ed-b0ac99d84ee7) |

| Legacy Tippies, before | Legacy Tippies, after (no apparent change) |
| --- | --- |
| ![legacy-tippies-before](https://github.com/zulip/zulip/assets/170719/94a07398-b888-44e0-8441-9da3c1158154) | ![legacy-tippies-after](https://github.com/zulip/zulip/assets/170719/0b1de094-6647-4baf-8c34-b08e85a8081b) |

| Bold-context Tippy, before | Bold-context Tippy, after |
| --- | --- |
| ![font-weight-before](https://github.com/zulip/zulip/assets/170719/347d2a4d-9202-4f9f-9e8f-2ccdb52b2596) | ![font-weight-after](https://github.com/zulip/zulip/assets/170719/844f9c22-1421-4d16-a47a-c7dacda04631) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>