### PR TITLE
recent_view: Set a shared column for filter icons.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -44,12 +44,6 @@
         display: flex;
         align-items: center;
 
-        .filter-icon {
-            /* Maintain righthand space between icon
-                and stream name. */
-            margin: 0 3px 0 -1px;
-        }
-
         & > * {
             outline: 0;
         }
@@ -97,9 +91,7 @@
     .fa-envelope {
         /* Legacy 11.2px size at 14px/1em. */
         font-size: 0.8em;
-        margin-right: 2px;
-        position: relative;
-        top: -1px;
+        text-align: center;
         opacity: 0.6;
     }
 
@@ -404,6 +396,17 @@
     .recent_topic_stream {
         padding: 8px 0 8px 8px;
 
+        .recent_view_focusable {
+            display: grid;
+            grid-template-areas: "starting-anchor-element row-content";
+            /* 14px at 14px/1em */
+            grid-template-columns: 1em minmax(0, 1fr);
+            /* Visually match the 8px of padding to
+               the left of the filter icon. */
+            gap: 7px;
+            place-content: center center;
+        }
+
         & a {
             word-break: break-word;
             hyphens: auto;
@@ -502,6 +505,7 @@
         /* Let flexbox handle vertical alignment by
            pushing back against inline-block display. */
         display: block;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
This provides a fixed, uniform but scalable column for filter icons in the Recent conversations view. Icons are now also more reliably centered related to their adjacent text content. 

Fixes part of #30476 

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/testing.20info.20density.20on.20CZO/near/1844325)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![recent-view-icons-legacy-before](https://github.com/zulip/zulip/assets/170719/f0f6a5cf-e9e1-429e-ade2-cdaaceea4d2d) | ![recent-view-icons-legacy-after](https://github.com/zulip/zulip/assets/170719/7104890f-ebc5-494c-b6a3-3e8588cc8ada) |
| ![recent-view-icons-before](https://github.com/zulip/zulip/assets/170719/496786da-e5c7-4cb6-8b2a-0c768428b468) | ![recent-view-icons-after](https://github.com/zulip/zulip/assets/170719/11ff7740-7582-47d6-bc02-dfb32d33af76) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>