### PR TITLE
help: Document left sidebar actions.

### DIFF
--- a/help/direct-messages.md
+++ b/help/direct-messages.md
@@ -34,7 +34,10 @@ If using Zulip in a browser or desktop, there are several ways to access an exis
 
 {tab|desktop-web}
 
-{relative|message|direct}
+1. In the left sidebar, click the **Direct message feed**
+   (<i class="fa fa-align-right"></i>) icon to the right of the
+   **Direct messages** label, or use the <kbd>Shift</kbd> + <kbd>P</kbd>
+   keyboard shortcut.
 
 {tab|mobile}
 

--- a/help/left-sidebar.md
+++ b/help/left-sidebar.md
@@ -9,22 +9,74 @@ conversations. It has three main sections:
 - The **channels** section shows the [channels](/help/introduction-to-channels)
   you are subscribed to.
 
-You can adjust the left sidebar to focus on the information you need right now
-by:
-
-- Expanding or collapsing the **Views** section.
-- Expanding or collapsing the **Direct messages** section.
-- Showing all topics in a channel.
-- [Configuring unread message counters](/help/configure-unread-message-counters).
-- Hiding the left sidebar altogether.
-
-You can also customize how channels are organized within the **channels**
+You can customize how channels are organized within the **channels**
 section by:
 
 - [Pinning channels](/help/pin-a-channel) so that they appear in the top section.
 - [Changing channel colors](/help/change-the-color-of-a-channel).
 - [Configuring](/help/manage-inactive-channels) whether inactive channels are
   sorted at the bottom.
+
+## Adjust what information is shown
+
+There are many ways you can adjust the left sidebar to help you focus on the
+information you need in the moment.
+
+### Expand or collapse the views section
+
+{start_tabs}
+
+1. Click the triangle to the left of **VIEWS** in the left sidebar.
+
+{end_tabs}
+
+### Expand or collapse the direct messages section
+
+{start_tabs}
+
+1. Click the triangle to the left of **DIRECT MESSAGES** in the left sidebar.
+
+{end_tabs}
+
+### Show all direct message conversations
+
+{start_tabs}
+
+1. If the **DIRECT MESSAGES** section in the left sidebar is collapsed, click the triangle to the
+   left of **DIRECT MESSAGES** to expand it.
+
+1. Click **more conversations** at the bottom of the list of recent DM conversations.
+
+!!! tip ""
+
+    To return to the channel list in the left sidebar, click **back to channels**.
+
+{end_tabs}
+
+
+### Show all topics in a channel
+
+{start_tabs}
+
+1. Click on a channel in the left sidebar.
+
+1. Click **show all topics** at the bottom of the list of recent topics in the
+   selected channel.
+
+!!! tip ""
+
+     To return to the channel list in the left sidebar, click **BACK TO
+     CHANNELS**.
+
+{end_tabs}
+
+### Hide or show the left sidebar
+
+{start_tabs}
+
+1. Above the left sidebar, click the <i class="fa fa-reorder"></i> icon.
+
+{end_tabs}
 
 ## Related articles
 * [Reading strategies](/help/reading-strategies)

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -165,13 +165,6 @@ starred_instructions = """
    sidebar, or by [searching](/help/search-for-messages) for `is:starred`.
 """
 
-direct_instructions = """
-1. In the left sidebar, click the **Direct message feed**
-   (<i class="fa fa-align-right"></i>) icon to the right of the
-   **Direct messages** label, or use the <kbd>Shift</kbd> + <kbd>P</kbd>
-   keyboard shortcut.
-"""
-
 inbox_instructions = """
 1. Click on <i class="zulip-icon zulip-icon-inbox"></i> **Inbox** in the left
    sidebar, or use the <kbd>Shift</kbd> + <kbd>I</kbd> keyboard shortcut.
@@ -183,7 +176,6 @@ message_info = {
     "recent": ["Recent conversations", "/#recent", recent_instructions],
     "all": ["Combined feed", "/#feed", all_instructions],
     "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
-    "direct": ["Direct message feed", "/#narrow/is/dm", direct_instructions],
     "inbox": ["Inbox", "/#inbox", inbox_instructions],
 }
 


### PR DESCRIPTION
**Notes on updates**:
- Removed the bulleted list of these actions in the main description.
- The information about configuring unread markers is just in the related articles section now. I didn't see a good way to include it with the left sidebar actions that can all be done/undone during your work session since it's a general setting that a user decides on.
- Added a section titled "Adjust the left sidebar for your focus" under which all the actions have their own sections. This seemed like a nice general section to be able to link to from blog posts or landing pages.
- Added some tips that seemed useful as I was manually testing the new instructions.

Fixes #30411.

---

**Screenshots and screen captures:**

[Current documentation](https://zulip.com/help/left-sidebar)
<details>
<summary>New sections and instructions for left sidebar actions</summary>

![Screenshot from 2024-07-03 19-45-45](https://github.com/zulip/zulip/assets/63245456/8b6f622c-4d79-466a-84d7-8c58f67cfa33)
</details>
<details>
<summary>Screenshot of full article with updates</summary>

![Screenshot from 2024-07-03 19-45-19](https://github.com/zulip/zulip/assets/63245456/37815a80-f162-4e10-a8f4-2048fd46877f)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
