### PR TITLE
5xx: Remove duplicate `error_page` class applied on page.

### DIFF
--- a/web/html/5xx.html
+++ b/web/html/5xx.html
@@ -6,7 +6,7 @@
         <meta http-equiv="refresh" content="60;URL='/'" />
         <!-- We use `error-styles` webpack assets to styles this page. -->
     </head>
-    <body class="error_page">
+    <body>
         <!-- TODO: Make nginx 5xx error page customizable -->
         <!-- This is tricky because it's not served by Django, -->
         <!-- so we can't use variables -->


### PR DESCRIPTION
We only want to apply this class on the actual content of the page.

| before | after |
| --- | --- |
| <img width="1139" alt="Screenshot 2024-07-04 at 1 20 51 AM" src="https://github.com/zulip/zulip/assets/25124304/b037eaa0-3313-4919-be62-8bd910ca44c7"> | <img width="1139" alt="Screenshot 2024-07-04 at 1 18 52 AM" src="https://github.com/zulip/zulip/assets/25124304/b8c6479a-c8fa-47f4-91dd-73504ad7f2a0"> |
