### PR TITLE
compose: Fix flashing effect on trying to send message that's too long.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -292,10 +292,10 @@
     &:has(.new_message_textarea.over_limit),
     &:has(.new_message_textarea.over_limit:focus) {
         box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
+    }
 
-        &.flash {
-            animation: message-limit-flash 0.5s ease-in-out infinite;
-        }
+    &:has(.new_message_textarea.over_limit.flash) {
+        animation: message-limit-flash 0.5s ease-in-out 3;
     }
 
     &:has(.new_message_textarea.invalid),


### PR DESCRIPTION
Due to a wrong CSS selector, the expected red outline flashing effect was not being applied to the compose box when the user tried to send a message that was longer than the maximum allowed length, which is fixed by this commit.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
