### PR TITLE
left_sidebar: More carefully generate auto rows for expanded nav.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -590,7 +590,8 @@ li.active-sub-filter {
     /* Explicitly ensure parity with the line-height
        for the sake of low-resolution screens, whose
        font-rendering and rounding may cause icons
-       to appear out of alignment. */
+       to appear out of alignment. This grid feature should
+       only apply in the expanded-navigation view. */
     grid-auto-rows: var(--line-height-sidebar-row);
 
     .left-sidebar-navigation-label-container {
@@ -791,6 +792,10 @@ li.top_left_scheduled_messages {
        filter rows as needed, based on the narrow. */
     &.showing-condensed-navigation {
         + #left-sidebar-navigation-list {
+            /* In the condensed state, we don't want to generate
+               auto rows, or there will be a footprint where the
+               expanded nav sits. */
+            grid-auto-rows: unset;
             /* When the navigation area is condensed, hide all
                the rows in the full navigation list... */
             & .top_left_row {
@@ -800,6 +805,9 @@ li.top_left_scheduled_messages {
                that row should still be shown. */
             & .top_left_row.active-filter {
                 display: grid;
+                /* In the absence of auto rows in the condensed state,
+                   we set an explicit height on the active filter. */
+                height: var(--line-height-sidebar-row);
             }
         }
     }


### PR DESCRIPTION
This fixes a regression introduced in #30692; the use of `grid-auto-rows` set a non-zero auto-generated row height, which was applied even when the expanded nav list had no displayable children.

A clever use of `height` on the active filter ensures that that view remains undisturbed by this more targeted use of `grid-auto-rows`.
[
CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20left.20sidebar.20space.20between.20collapsed.20views.20and.20DMs/near/1845632)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Condensed nav, before | Condensed nav, after |
| --- | --- |
| ![condensed-nav-before](https://github.com/zulip/zulip/assets/170719/516e6f7b-4031-4238-9c94-b1b30ff22183) | ![condensed-nav-after](https://github.com/zulip/zulip/assets/170719/fa51ea76-cae3-453e-ba53-234b26f01855) |

| Condensed nav w/ active filter, before | Condensed nav w/ active filter, after (no change) |
| --- | --- |
| ![condensed-nav-active-filter-before](https://github.com/zulip/zulip/assets/170719/0dfac475-30a5-469a-bfad-c9b4bf7c5553) | ![condensed-nav-active-filter-after-no-change](https://github.com/zulip/zulip/assets/170719/0ae9199a-32c3-4c74-9df6-edca63b3bcf2) |

| Expanded nav, before | Expanded nav, after (no change) |
| --- | --- |
| ![expanded-nav-before](https://github.com/zulip/zulip/assets/170719/8e7a829a-c319-4468-954a-379153557249) | ![expanded-nav-after-no-change](https://github.com/zulip/zulip/assets/170719/8c983f20-0f7e-4950-bb44-a6e30d58ba37) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>