### PR TITLE
user_group_popover: Redesign popover using the new "popover-menu" theme.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -300,6 +300,7 @@ export function initialize(): void {
             "#filter_streams_tooltip",
             ".error-icon-message-recipient .zulip-icon",
             "#personal-menu-dropdown .status-circle",
+            ".popover-group-menu-member-list .popover_user_presence",
             "#copy_generated_invite_link",
         ].join(","),
         appendTo: () => document.body,

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -74,8 +74,8 @@ export function toggle_user_group_info_popover(
     popover_menus.toggle_popover_menu(
         element,
         {
+            theme: "popover-menu",
             placement: "right",
-            arrow: false,
             popperOptions: {
                 modifiers: [
                     {
@@ -92,8 +92,6 @@ export function toggle_user_group_info_popover(
                     message_lists.current.select_id(message_id);
                 }
                 user_group_popover_instance = instance;
-                const $popover = $(instance.popper);
-                $popover.addClass("user-group-popover-root");
                 const args = {
                     group_name: group.name,
                     group_description: group.description,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -101,6 +101,7 @@
     /* Tippy popover related values */
     --navbar-popover-menu-min-width: 230px;
     --message-actions-popover-min-width: 230px;
+    --user-group-info-popover-min-width: 16.4285em; /* 230px / 14px em */
     --topic-actions-popover-min-width: 200px;
 
     /* Information density and typography values */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -352,7 +352,6 @@ ul {
     }
 }
 
-.group-info-popover,
 .message-user-card-popover-root,
 .user-card-popover-root {
     /* 240px (width of avatar) + 2px (1px for each border) */
@@ -360,55 +359,54 @@ ul {
     padding: 0;
 }
 
-.group-info-popover {
-    .group-info-content {
-        padding: 5px 0;
+.popover-group-menu-info {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding: 3px 10px;
+}
+
+.popover-group-menu-name-container {
+    display: flex;
+    align-items: flex-start;
+    gap: 5px;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 20px;
+    color: var(--color-text-full-name);
+    word-break: break-word;
+}
+
+.popover-group-menu-description {
+    font-size: 15px;
+    line-height: 16px;
+}
+
+ul.popover-group-menu-member-list {
+    max-height: 300px;
+    display: flex;
+    flex-direction: column;
+
+    .simplebar-content {
+        width: unset;
     }
+}
 
-    .group-info {
-        padding-left: 11px;
-        padding-right: 11px;
+.popover-group-menu-member {
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+}
 
-        .group-name {
-            font-weight: bold;
+.popover-group-menu-member-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 
-            .zulip-icon-triple-users {
-                position: relative;
-                top: 2px;
-                margin-right: 5px;
-            }
-        }
-    }
-
-    .manage-group {
-        a {
-            display: flex;
-            align-items: center;
-            padding-left: 11px;
-
-            .zulip-icon {
-                position: relative;
-                top: -1px;
-                margin-right: 5px;
-            }
-        }
-    }
-
-    .member-list {
-        position: relative;
-        max-height: 300px;
-        overflow-y: auto;
-        list-style: none;
-        margin-left: 0;
-
-        .bot {
-            color: hsl(180deg 5% 74%);
-            vertical-align: top;
-            width: 20px;
-            padding-top: 3.5px;
-            text-align: center;
-        }
-    }
+.popover-group-menu-description,
+.popover-group-menu-member-name {
+    color: var(--color-text-popover-menu);
 }
 
 .user_profile_presence,
@@ -842,7 +840,6 @@ ul {
 
 .giphy-popover,
 .emoji-popover-root,
-.user-group-popover-root,
 .user-sidebar-popover-root,
 .message-user-card-popover-root,
 .user-card-popover-root {
@@ -859,23 +856,6 @@ ul {
     & ul.nav {
         /* TODO: Clean this logic up after drop Bootstrap styling */
         margin: 0;
-    }
-}
-
-.user-group-popover-root {
-    .group-info-popover ul.nav {
-        /* TODO: Clean this logic up after drop Bootstrap styling */
-        margin: 0;
-
-        &.member-list {
-            padding-left: 6px;
-        }
-    }
-
-    & .tippy-box {
-        box-shadow: 0 5px 10px hsl(0deg 0% 0% / 20%);
-        /* User group popover has a bigger border-radius than our usual popovers. */
-        border-radius: 6px;
     }
 }
 
@@ -1281,6 +1261,12 @@ ul {
 #topic-actions-menu-popover {
     .simplebar-content {
         min-width: var(--topic-actions-popover-min-width);
+    }
+}
+
+.user-group-info-popover {
+    .simplebar-content {
+        min-width: var(--user-group-info-popover-min-width);
     }
 }
 

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -1,35 +1,37 @@
-<div class="group-info-popover">
-    <div class="group-info-content">
-        <div class="group-info">
-            <div class="group-name">
-                <i class="zulip-icon zulip-icon-triple-users" aria-hidden="true"></i> {{group_name}}
+<div class="popover-menu user-group-info-popover" data-simplebar data-simplebar-tab-index="-1">
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item popover-menu-list-item">
+            <div class="popover-group-menu-info">
+                <div class="popover-group-menu-name-container">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-triple-users" aria-hidden="true"></i>
+                    <span class="popover-group-menu-name">{{group_name}}</span>
+                </div>
+                <div class="popover-group-menu-description">{{group_description}}</div>
             </div>
-            <div class="group-description">
-                {{group_description}}
-            </div>
-        </div>
-        <hr />
-        <ul class="nav nav-list member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-            {{#each members}}
-                <li>
-                    {{#if is_bot}}
-                    <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                    {{else}}
-                    <span class="user_circle {{user_circle_class}}  popover_user_presence" title="{{user_last_seen_time_status}}"></span>
-                    {{/if}}
-                    <span>{{full_name}}</span>
-                </li>
-            {{/each}}
-        </ul>
+        </li>
+        <li role="separator" class="popover-menu-separator"></li>
+        <li role="none" class="popover-menu-list-item">
+            <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                {{#each members}}
+                    <li class="popover-group-menu-member">
+                        {{#if is_bot}}
+                            <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                        {{else}}
+                            <span class="user_circle {{user_circle_class}} popover_user_presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
+                        {{/if}}
+                        <span class="popover-group-menu-member-name">{{full_name}}</span>
+                    </li>
+                {{/each}}
+            </ul>
+        </li>
         {{#unless is_guest}}
-        <hr />
-        <ul class="nav nav-list manage-group">
-            <li>
-                <a href="{{group_edit_url}}">
-                    <i class="zulip-icon zulip-icon-user-cog" aria-hidden="true"></i>{{t 'Group settings' }}
+            <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
+            <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+                <a href="{{group_edit_url}}" role="menuitem" class="navigate-link-on-enter popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-user-cog" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Group settings" }}</span>
                 </a>
             </li>
-        </ul>
         {{/unless}}
-    </div>
+    </ul>
 </div>


### PR DESCRIPTION
As part of the popover menu redesign, this PR redesigns the user group info popover using the new "popover-menu" tippy theme and improves accessibility by using appropriate ARIA attributes.

Fixes part of #28699.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Header | Header | Header |
|--------|--------|--------|
| Light Mode | <img width="480" alt="image" src="https://github.com/zulip/zulip/assets/82862779/37d87228-81ab-4323-a78f-34b8fa920ee5"> | <img width="480" alt="image" src="https://github.com/zulip/zulip/assets/82862779/4c556906-2337-4b56-af4f-451f59eae7c7"> |
| Dark Mode | <img width="480" alt="image" src="https://github.com/zulip/zulip/assets/82862779/0ec1c505-53eb-41b6-a169-00945aff1d70"> | <img width="480" alt="image" src="https://github.com/zulip/zulip/assets/82862779/940e9a49-eed8-426c-9aa3-bcbe2d825cde"> |
| Members list long enough to scroll | <img width="480" alt="image" src="https://github.com/zulip/zulip/assets/82862779/8182098e-693d-497e-a672-e3e9c8a1c4e1"> | <img width="480" alt="image" src="https://github.com/zulip/zulip/assets/82862779/fbc4539a-49d1-47cd-94d3-a5d5a52f8482"> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
