### PR TITLE
playground_popover: Redesign popover using the new "popover-menu" theme.

### DIFF
--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -122,6 +122,10 @@ function register_click_handlers(): void {
                     url_template.expand({code: extracted_code}),
                 );
             } else {
+                // Remove the href attribute that was set when there was only
+                // one playground link, so that it doesn't interfere with the
+                // popover toggle when multiple playground links exist.
+                $view_in_playground_button.removeAttr("href");
                 const playground_store = new Map<number, RealmPlaygroundWithURL>();
                 for (const playground of playground_info) {
                     const url_template = url_template_lib.parse(playground.url_template);

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -12,7 +12,7 @@ import * as ui_util from "./ui_util";
 
 type RealmPlaygroundWithURL = RealmPlayground & {playground_url: string};
 
-let playground_links_popover_instance: tippy.Instance;
+let playground_links_popover_instance: tippy.Instance | null = null;
 
 // Playground_store contains all the data we need to generate a popover of
 // playground links for each code block. The element is the target element
@@ -63,16 +63,19 @@ export function is_open(): boolean {
 }
 
 export function hide(): void {
-    if (is_open()) {
-        $(playground_links_popover_instance.reference)
-            .parent()
-            .removeClass("active-playground-links-reference");
-        playground_links_popover_instance.destroy();
+    if (!playground_links_popover_instance) {
+        return;
     }
+
+    $(playground_links_popover_instance.reference)
+        .parent()
+        .removeClass("active-playground-links-reference");
+    playground_links_popover_instance.destroy();
+    playground_links_popover_instance = null;
 }
 
 function get_playground_links_popover_items(): JQuery | undefined {
-    if (!is_open()) {
+    if (!playground_links_popover_instance) {
         blueslip.error("Trying to get menu items when playground links popover is closed.");
         return undefined;
     }

--- a/web/src/playground_links_popover.ts
+++ b/web/src/playground_links_popover.ts
@@ -26,6 +26,7 @@ function toggle_playground_links_popover(
     }
 
     popover_menus.toggle_popover_menu(element, {
+        theme: "popover-menu",
         placement: "bottom",
         popperOptions: {
             modifiers: [

--- a/web/templates/popovers/playground_links_popover.hbs
+++ b/web/templates/popovers/playground_links_popover.hbs
@@ -1,11 +1,11 @@
-{{! Contents of "view code in playground" popover for code blocks}}
-<ul class="nav nav-list">
-    {{#each playground_info}}
-        <li>
-            <a href="{{this/playground_url}}" target="_blank" rel="noopener noreferrer" class="popover_playground_link">
-                {{t "View in {name}" }}
-            </a>
-        </li>
-    {{/each}}
-</ul>
-
+<div class="popover-menu playground-links-popover" data-simplebar data-simplebar-tab-index="-1">
+    <ul role="menu" class="popover-menu-list">
+        {{#each playground_info}}
+            <li role="none" class="link-item popover-menu-list-item">
+                <a href="{{this/playground_url}}" target="_blank" rel="noopener noreferrer" role="menuitem" class="popover_playground_link popover-menu-link" tabindex="0">
+                    <span class="popover-menu-label">{{t "View in {name}" }}</span>
+                </a>
+            </li>
+        {{/each}}
+    </ul>
+</div>


### PR DESCRIPTION
As part of the popover menu redesign, this PR redesigns the playground links popover using the new "popover-menu" tippy theme and improves accessibility by using appropriate ARIA attributes.

Additionally, this PR also contains the following fixes:
- Fixes a bug where the playground links popover doesn't reopen after it's closed.
- Removes the `href` attribute from the external code button when multiple code playground links are present for a language – prevents the bug where the external code button would always link to the previously set code playground link

Fixes part of #28699.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## Screenshots and screen captures:

<details><summary>Light Mode</summary>
<p>

| Before | After |
|--------|--------|
| <img width="897" alt="image" src="https://github.com/zulip/zulip/assets/82862779/9a294e77-7c1b-4bbe-a579-5fa4da9c1830"> | <img width="761" alt="image" src="https://github.com/zulip/zulip/assets/82862779/53e5bf74-2dbc-44af-9d8b-cfbcd10d8334"> | 

</p>
</details> 

<details><summary>Dark Mode</summary>
<p>

| Before | After |
|--------|--------|
| <img width="897" alt="image" src="https://github.com/zulip/zulip/assets/82862779/d5b1cc62-4a81-4d07-8b26-7436c3421e5f"> | <img width="761" alt="image" src="https://github.com/zulip/zulip/assets/82862779/d0dd739f-5e3c-4d02-bf0d-84d3d939301d"> | 

</p>
</details> 

<details><summary>Fix popover not reopening</summary>
<p>

| Before | After |
|--------|--------|
| ![Kapture 2024-07-04 at 03 54 44](https://github.com/zulip/zulip/assets/82862779/4757f87d-1d9f-4fc2-8305-faf5928cea26) | ![Kapture 2024-07-04 at 03 33 21](https://github.com/zulip/zulip/assets/82862779/adc92c95-4411-4ae1-8b02-f51e448c1583) | 

</p>
</details> 

<details><summary>Update external code button behavior on settings change</summary>
<p>

| Before | After |
|--------|--------|
| ![Kapture 2024-07-04 at 03 58 50](https://github.com/zulip/zulip/assets/82862779/63cce797-a9d9-4309-bb39-2be608d8ff9e) | ![Kapture 2024-07-04 at 03 38 05](https://github.com/zulip/zulip/assets/82862779/467134dd-f23a-4764-8cb9-528dd55696ae) | 

</p>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
