### PR TITLE
integration-docs: Update Grafana for new doc format.

### DIFF
--- a/zerver/webhooks/grafana/doc.md
+++ b/zerver/webhooks/grafana/doc.md
@@ -1,48 +1,79 @@
+# Zulip Grafana integration
+
 See your Grafana dashboard alerts in Zulip!
+
+### Create Zulip bot for Grafana alerts
+
+{start_tabs}
 
 1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-integration-url.md!}
+1. {!generate-webhook-url-basic.md!}
+
+{end_tabs}
 
 ### Instructions for Grafana 8.3 and above
 
-1. In Grafana, go to **Alerting**. Click on **Contact points**, and
-   then **Add contact point**.  Configure the new contact point as
-   follows: set the name; under **Integration** choose Webhook, and
-   set **URL** to the URL constructed above; under **Optional Webhook
-   settings** choose **POST** as the **HTTP method**.  Click on
-   **Test** to send a test notification and if all is good, click on
-   **Save contact point**.
-1. Under **Notification policies** create a new policy (for example, a
-   **New nested policy** of the **Default policy**), setting the
-   **Matching label** as **Zulip** = 1, and selecting the **Contact
-   point** as the one created in the step above. Click on **Save
-   policy**.
-1. Under **Alert rules**, click on **Create alert rule**, where you
-   will specify the conditions to fire the alert. Make sure you set
-   the **Rule name**, and in the **Notifications** section add a label
-   that matches the label created in the step above. Customize the
-   **query and alert condition**, **alert evaluation behavior**, etc.
-   and click on **Save rule**.
+{start_tabs}
+
+1. In Grafana, go to **Alerting**. Click on **Contact points**, and then
+   **Add contact point**.
+
+1. Set a name for the contact point, such as `Zulip`. Under
+   **Integration**, choose  **Webhook**, and set **URL** to the URL
+   generated above. Under **Optional Webhook settings**, choose **POST**
+   as the **HTTP method**. Click on **Test** to send a test
+   notification, and if it's successful, click **Save contact point**.
+
+1. Go to **Notification policies**, and create a new policy, e.g., a
+   **New nested policy** of the **Default policy**. Set the **Matching
+   label** as **Zulip** = 1, and set the **Contact point** to the one
+   created above. Click **Save policy**.
+
+1. Go to **Alert rules**, and click **Create alert rule**. Make sure you
+   set a **Rule name**. In the **Notifications** section, add a label
+   that matches the label created for the notification policy above.
+   You can customize the **query and alert condition**, **alert
+   evaluation behavior**, and other conditions for your alerts. When
+   you're done, click **Save rule**.
+
+{end_tabs}
 
 ### Instructions for Grafana 8.2 and below
 
+{start_tabs}
+
 1. In Grafana, go to **Alerting**. Click on **Notification channels**.
-   Configure **Edit Notification Channel** as appropriate for your
-   alert notification. Set the name. Under **Type**, choose **webhook**.
-   In **Webhook Settings**, set **URL** to the URL constructed above.
-   Under **HTTP method**, choose **POST**. Click Save.
 
-1. Create an alert. Within your new alert rule, scroll down
-   to the **Notifications** section. Click on the button next to **Send to**
-   and select the webhook notification channel you just made. You can also
-   choose to write a message, which will be included in the Zulip notifications.
+1. Configure **Edit Notification Channel** as appropriate for your
+   alert notification. Set a name for the notification channel, such
+   as `Zulip`. Under **Type**, choose **webhook**. In **Webhook
+   Settings**, set **URL** to the URL generated above. Under **HTTP
+   method**, choose **POST**. Click **Save**.
 
-1. Return to **Notification channels**. You may now click **Send Test** and
-   you will see a Grafana test alert notification in Zulip.
+1. Create an alert. In your new alert rule, go to the **Notifications**
+   section. Click on the button next to **Send to** and select the
+   webhook notification channel you created above. You can also choose
+   to write a message, which will be included in your Zulip
+   notifications.
+
+1. Return to **Notification channels**, and click **Send Test**. You
+   should see a Grafana test alert notification in Zulip.
+
+{end_tabs}
 
 {!congrats.md!}
 
 ![](/static/images/integrations/grafana/001.png)
+
+{% if all_event_types is defined %}
+
+{!event-filtering-additional-feature.md!}
+
+{% endif %}
+
+### Related documentation
+
+{!webhooks-url-specification.md!}


### PR DESCRIPTION
Reformatted Grafana doc into 3 part sections. One for creating the Zulip bot and webhook URL. One for setting up Grafana version 8.3 and above and the last one for setting up Grafana version 8.2 and below.

Part of #29592.

**Screenshots and screen captures:**

<details>
<summary>

[Grafana](https://zulip.com/integrations/doc/grafana)
</summary>

![image](https://github.com/zulip/zulip/assets/108744694/9d74deb8-a146-46a4-8f8a-1ed1a4171fe5)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
