### PR TITLE
settings: Remove max-height for bots box container.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -971,7 +971,6 @@ input[type="checkbox"] {
         position: relative;
         display: inline-block;
         width: calc(50% - 10px);
-        max-height: 220px;
         margin: 5px;
 
         border-radius: 4px;
@@ -1868,7 +1867,6 @@ $option_title_width: 180px;
        information box */
     .bots_list .bot-information-box {
         width: calc(100% - 10px);
-        max-height: unset;
     }
 }
 


### PR DESCRIPTION
This helps us in avoiding the scrollbar inside the box if the information density setting
is set to 16/140 by allowing the box to set its height as per the content.

There is no need for max-height since the height of the box was anyways less than
the max-height value set before at normal font size and screen widths.

For narrow screens, the max-height property was set to unset, so removing the max-height
property does not have any effect on how the bots are shown on narrow screens.

Fixes #30669.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**For 14px**

![bots-14px](https://github.com/zulip/zulip/assets/35494118/61977074-6b62-481a-a426-a2a0baeb384c)

**For 16px**

![bots-16px](https://github.com/zulip/zulip/assets/35494118/f0be0d5c-897f-48dc-adb5-add39fe1b9bf)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
