### PR TITLE
Remove highlight for suggestions with empty query.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -43,9 +43,9 @@ export function build_highlight_regex(query: string): RegExp {
 }
 
 export function highlight_with_escaping_and_regex(regex: RegExp, item: string): string {
-    // if regex is empty return entire item highlighted and escaped
+    // if regex is empty return entire item escaped
     if (regex.source === "()") {
-        return "<strong>" + Handlebars.Utils.escapeExpression(item) + "</strong>";
+        return Handlebars.Utils.escapeExpression(item);
     }
 
     // We need to assemble this manually (as opposed to doing 'join') because we need to


### PR DESCRIPTION
Earlier in search typeaheads, empty query suggestions would highlight all the available suggestions for person name and channel name.

This PR changes the behaviour so that empty query doesn't give highlighted suggestions.

<!-- Describe your pull request here.-->

Fixes: [czo](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20bold.20in.20search.20typeahead)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**\
### Before:
![Screenshot-2024-07-03-at-15 26 27](https://github.com/zulip/zulip/assets/33497322/e2a3eb4e-5261-4802-8873-055cc547127e)


### After:

![Screenshot from 2024-07-04 17-07-33](https://github.com/zulip/zulip/assets/33497322/45f7b99c-3de1-4c41-a7b3-1a4e84a67888)
![Screenshot from 2024-07-04 17-07-41](https://github.com/zulip/zulip/assets/33497322/788f58bb-87b3-4c1b-a0a2-ae6d78d2d02f)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
