### PR TITLE
Fix subscribed bookend not displayed for newly subscribed stream.

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -373,20 +373,28 @@ export class MessageList {
     // Maintains a trailing bookend element explaining any changes in
     // your subscribed/unsubscribed status at the bottom of the
     // message list.
-    update_trailing_bookend() {
+    update_trailing_bookend(force_render = false) {
         this.view.clear_trailing_bookend();
         if (this.is_combined_feed_view) {
             return;
         }
+
         const stream_name = narrow_state.stream_name();
         if (stream_name === undefined) {
+            // Trailing bookends are only for channel views.
+            return;
+        }
+
+        // If user narrows to a stream, don't update
+        // trailing bookend if user is subscribed.
+        const sub = stream_data.get_sub(stream_name);
+        if (sub && sub.subscribed && !page_params.is_spectator && !force_render) {
             return;
         }
 
         let deactivated = false;
         let just_unsubscribed = false;
         const subscribed = stream_data.is_subscribed_by_name(stream_name);
-        const sub = stream_data.get_sub(stream_name);
         const invite_only = sub && sub.invite_only;
         const is_web_public = sub && sub.is_web_public;
         const can_toggle_subscription =

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -388,7 +388,13 @@ export class MessageList {
         // If user narrows to a stream, don't update
         // trailing bookend if user is subscribed.
         const sub = stream_data.get_sub(stream_name);
-        if (sub && sub.subscribed && !page_params.is_spectator && !force_render) {
+        if (
+            sub &&
+            sub.subscribed &&
+            !this.last_message_historical &&
+            !page_params.is_spectator &&
+            !force_render
+        ) {
             return;
         }
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1049,15 +1049,7 @@ export class MessageListView {
                 last_message_group.message_containers.at(-1).msg.historical;
         }
 
-        const stream_name = narrow_state.stream_name();
-        if (stream_name !== undefined) {
-            // If user narrows to a stream, doesn't update
-            // trailing bookend if user is subscribed.
-            const sub = stream_data.get_sub(stream_name);
-            if (sub === undefined || !sub.subscribed || page_params.is_spectator) {
-                list.update_trailing_bookend();
-            }
-        }
+        list.update_trailing_bookend();
 
         if (list === message_lists.current) {
             // Update the fade.

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -555,7 +555,7 @@ export function dispatch_normal_event(event) {
                         );
                         if (is_narrowed_to_stream) {
                             assert(message_lists.current !== undefined);
-                            message_lists.current.update_trailing_bookend();
+                            message_lists.current.update_trailing_bookend(true);
                         }
                         stream_data.delete_sub(stream.stream_id);
                         stream_settings_ui.remove_stream(stream.stream_id);

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -553,10 +553,6 @@ export function dispatch_normal_event(event) {
                         const is_narrowed_to_stream = narrow_state.is_for_stream_id(
                             stream.stream_id,
                         );
-                        if (is_narrowed_to_stream) {
-                            assert(message_lists.current !== undefined);
-                            message_lists.current.update_trailing_bookend(true);
-                        }
                         stream_data.delete_sub(stream.stream_id);
                         stream_settings_ui.remove_stream(stream.stream_id);
                         if (was_subscribed) {
@@ -581,6 +577,10 @@ export function dispatch_normal_event(event) {
                             settings_org.sync_realm_settings(
                                 "zulip_update_announcements_stream_id",
                             );
+                        }
+                        if (is_narrowed_to_stream) {
+                            assert(message_lists.current !== undefined);
+                            message_lists.current.update_trailing_bookend(true);
                         }
                     }
                     stream_list.update_subscribe_to_more_streams_link();

--- a/web/src/stream_events.js
+++ b/web/src/stream_events.js
@@ -148,7 +148,7 @@ export function mark_subscribed(sub, subscribers, color) {
 
     if (narrow_state.is_for_stream_id(sub.stream_id)) {
         assert(message_lists.current !== undefined);
-        message_lists.current.update_trailing_bookend();
+        message_lists.current.update_trailing_bookend(true);
         activity_ui.build_user_sidebar();
     }
 
@@ -181,7 +181,7 @@ export function mark_unsubscribed(sub) {
         // Update UI components if we just unsubscribed from the
         // currently viewed stream.
         assert(message_lists.current !== undefined);
-        message_lists.current.update_trailing_bookend();
+        message_lists.current.update_trailing_bookend(true);
 
         // This update would likely be better implemented by having it
         // disappear whenever no unread messages remain.

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -23,6 +23,7 @@ import * as keydown_util from "./keydown_util";
 import * as message_lists from "./message_lists";
 import * as message_live_update from "./message_live_update";
 import * as message_view_header from "./message_view_header";
+import * as narrow_state from "./narrow_state";
 import * as overlays from "./overlays";
 import * as resize from "./resize";
 import * as scroll_util from "./scroll_util";
@@ -150,7 +151,10 @@ export function update_stream_privacy(slim_sub, values) {
 
     // Update UI elements
     update_left_panel_row(sub);
-    message_lists.current?.update_trailing_bookend();
+    if (narrow_state.stream_sub().stream_id === sub.stream_id) {
+        // Rerender message list if we are narrowed to the stream.
+        message_lists.current?.rerender();
+    }
     stream_ui_updates.update_setting_element(sub, "stream_privacy");
     stream_ui_updates.enable_or_disable_permission_settings_in_edit_panel(sub);
     stream_ui_updates.update_stream_privacy_icon_in_settings(sub);


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20Missing.20subscribed.20bookends
<img width="885" alt="Screenshot 2024-07-05 at 10 07 07 AM" src="https://github.com/zulip/zulip/assets/25124304/7ef25d9f-bbfb-4770-b003-963c1e72c4ea">


Tested that subscribing to Denmark for Iago displays the subscribed bookend and updating the stream privacy works corretcly to only update the bookend if it displayed and not show one if it is not required.

Tested channel archieved booked is displayed when deleting a stream.
<img width="890" alt="Screenshot 2024-07-05 at 10 11 48 AM" src="https://github.com/zulip/zulip/assets/25124304/a094787a-d812-450f-9f23-6ffc61d27717">

Tested toggle subscribed button works in the trailing bookend.
