### PR TITLE
Realm-typed-endpoint

### DIFF
--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
-from pydantic import AfterValidator, Json
+from pydantic import Json
 
 from corporate.lib.decorator import (
     authenticated_remote_realm_management_endpoint,
@@ -25,7 +25,7 @@ from corporate.models import CustomerPlan
 from zerver.decorator import require_organization_member, zulip_login_required
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import typed_endpoint
-from zerver.lib.typed_endpoint_validators import check_string_in
+from zerver.lib.typed_endpoint_validators import check_string_in_validator
 from zerver.models import UserProfile
 from zilencer.lib.remote_counts import MissingDataError
 
@@ -38,17 +38,11 @@ def upgrade(
     request: HttpRequest,
     user: UserProfile,
     *,
-    billing_modality: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_BILLING_MODALITY_VALUES))
-    ],
-    schedule: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_BILLING_SCHEDULE_VALUES))
-    ],
+    billing_modality: Annotated[str, check_string_in_validator(VALID_BILLING_MODALITY_VALUES)],
+    schedule: Annotated[str, check_string_in_validator(VALID_BILLING_SCHEDULE_VALUES)],
     signed_seat_count: str,
     salt: str,
-    license_management: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_LICENSE_MANAGEMENT_VALUES))
-    ]
+    license_management: Annotated[str, check_string_in_validator(VALID_LICENSE_MANAGEMENT_VALUES)]
     | None = None,
     licenses: Json[int] | None = None,
     tier: Json[int] = CustomerPlan.TIER_CLOUD_STANDARD,
@@ -94,17 +88,11 @@ def remote_realm_upgrade(
     request: HttpRequest,
     billing_session: RemoteRealmBillingSession,
     *,
-    billing_modality: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_BILLING_MODALITY_VALUES))
-    ],
-    schedule: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_BILLING_SCHEDULE_VALUES))
-    ],
+    billing_modality: Annotated[str, check_string_in_validator(VALID_BILLING_MODALITY_VALUES)],
+    schedule: Annotated[str, check_string_in_validator(VALID_BILLING_SCHEDULE_VALUES)],
     signed_seat_count: str,
     salt: str,
-    license_management: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_LICENSE_MANAGEMENT_VALUES))
-    ]
+    license_management: Annotated[str, check_string_in_validator(VALID_LICENSE_MANAGEMENT_VALUES)]
     | None = None,
     licenses: Json[int] | None = None,
     remote_server_plan_start_date: str | None = None,
@@ -149,17 +137,11 @@ def remote_server_upgrade(
     request: HttpRequest,
     billing_session: RemoteServerBillingSession,
     *,
-    billing_modality: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_BILLING_MODALITY_VALUES))
-    ],
-    schedule: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_BILLING_SCHEDULE_VALUES))
-    ],
+    billing_modality: Annotated[str, check_string_in_validator(VALID_BILLING_MODALITY_VALUES)],
+    schedule: Annotated[str, check_string_in_validator(VALID_BILLING_SCHEDULE_VALUES)],
     signed_seat_count: str,
     salt: str,
-    license_management: Annotated[
-        str, AfterValidator(lambda val: check_string_in(val, VALID_LICENSE_MANAGEMENT_VALUES))
-    ]
+    license_management: Annotated[str, check_string_in_validator(VALID_LICENSE_MANAGEMENT_VALUES)]
     | None = None,
     licenses: Json[int] | None = None,
     remote_server_plan_start_date: str | None = None,

--- a/zerver/lib/typed_endpoint_validators.py
+++ b/zerver/lib/typed_endpoint_validators.py
@@ -1,6 +1,9 @@
+from collections.abc import Collection
+
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.utils.translation import gettext as _
+from pydantic import AfterValidator
 from pydantic_core import PydanticCustomError
 
 # The Pydantic.StringConstraints does not have validation for the string to be
@@ -19,16 +22,24 @@ def check_string_fixed_length(string: str, length: int) -> str | None:
     return string
 
 
-def check_string_in(val: str, possible_values: list[str]) -> str:
+def check_string_in(val: str, possible_values: Collection[str]) -> str:
     if val not in possible_values:
         raise ValueError(_("Not in the list of possible values"))
     return val
 
 
-def check_int_in(val: int, possible_values: list[int]) -> int:
+def check_int_in(val: int, possible_values: Collection[int]) -> int:
     if val not in possible_values:
         raise ValueError(_("Not in the list of possible values"))
     return val
+
+
+def check_int_in_validator(possible_values: Collection[int]) -> AfterValidator:
+    return AfterValidator(lambda val: check_int_in(val, possible_values))
+
+
+def check_string_in_validator(possible_values: Collection[str]) -> AfterValidator:
+    return AfterValidator(lambda val: check_string_in(val, possible_values))
 
 
 def check_url(val: str) -> str:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2016,6 +2016,12 @@ class RealmAPITest(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid email batching period: 604810 seconds")
 
+    def test_invalid_emojiset_value(self) -> None:
+        result = self.client_patch("/json/realm/user_settings_defaults", {"emojiset": "invalid"})
+        self.assert_json_error(
+            result, "Invalid emojiset: Value error, Not in the list of possible values"
+        )
+
     def test_ignored_parameters_in_realm_default_endpoint(self) -> None:
         params = {"starred_message_counts": orjson.dumps(False).decode(), "emoji_set": "twitter"}
         result = self.client_patch("/json/realm/user_settings_defaults", params)

--- a/zerver/tests/test_typed_endpoint_validators.py
+++ b/zerver/tests/test_typed_endpoint_validators.py
@@ -1,5 +1,5 @@
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.typed_endpoint_validators import check_int_in, check_url
+from zerver.lib.typed_endpoint_validators import check_int_in, check_string_in, check_url
 
 
 class ValidatorTestCase(ZulipTestCase):
@@ -7,6 +7,11 @@ class ValidatorTestCase(ZulipTestCase):
         check_int_in(3, [1, 2, 3])
         with self.assertRaisesRegex(ValueError, "Not in the list of possible values"):
             check_int_in(3, [1, 2])
+
+    def test_check_string_in(self) -> None:
+        check_string_in("foo", ["foo", "bar"])
+        with self.assertRaisesRegex(ValueError, "Not in the list of possible values"):
+            check_string_in("foo", ["bar"])
 
     def test_check_url(self) -> None:
         check_url("https://example.com")

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -688,6 +688,26 @@ class UnmutedTopicsTests(ZulipTestCase):
         self.assert_json_error(result, "Invalid channel ID")
 
 
+class UserTopicsTests(ZulipTestCase):
+    def test_invalid_visibility_policy(self) -> None:
+        user = self.example_user("hamlet")
+        self.login_user(user)
+
+        stream = get_stream("Verona", user.realm)
+
+        url = "/api/v1/user_topics"
+        data = {
+            "stream_id": stream.id,
+            "topic": "Verona3",
+            "visibility_policy": 999,
+        }
+
+        result = self.api_post(user, url, data)
+        self.assert_json_error(
+            result, "Invalid visibility_policy: Value error, Not in the list of possible values"
+        )
+
+
 class AutomaticallyFollowTopicsTests(ZulipTestCase):
     def test_automatically_follow_topic_on_initiation(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -461,6 +461,14 @@ class PermissionTest(ZulipTestCase):
         result = self.client_patch("/json/users/{}".format(self.example_user("hamlet").id), req)
         self.assert_json_error(result, "Invalid format!")
 
+    def test_invalid_role(self) -> None:
+        self.login("iago")
+        req = dict(role=1000)
+        result = self.client_patch("/json/users/{}".format(self.example_user("hamlet").id), req)
+        self.assert_json_error(
+            result, "Invalid role: Value error, Not in the list of possible values"
+        )
+
     def test_admin_cannot_set_full_name_with_invalid_characters(self) -> None:
         new_name = "Opheli*"
         self.login("iago")

--- a/zerver/views/realm_emoji.py
+++ b/zerver/views/realm_emoji.py
@@ -7,8 +7,8 @@ from zerver.actions.realm_emoji import check_add_realm_emoji, do_remove_realm_em
 from zerver.decorator import require_member_or_admin
 from zerver.lib.emoji import check_remove_custom_emoji, check_valid_emoji_name, name_to_codepoint
 from zerver.lib.exceptions import JsonableError, ResourceNotFoundError
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.lib.upload import get_file_info
 from zerver.models import RealmEmoji, UserProfile
 from zerver.models.realm_emoji import get_all_custom_emoji_for_realm
@@ -23,9 +23,9 @@ def list_emoji(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
 
 
 @require_member_or_admin
-@has_request_variables
+@typed_endpoint
 def upload_emoji(
-    request: HttpRequest, user_profile: UserProfile, emoji_name: str = REQ(path_only=True)
+    request: HttpRequest, user_profile: UserProfile, *, emoji_name: PathOnly[str]
 ) -> HttpResponse:
     emoji_name = emoji_name.strip().replace(" ", "_")
     valid_built_in_emoji = name_to_codepoint.keys()

--- a/zerver/views/realm_linkifiers.py
+++ b/zerver/views/realm_linkifiers.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
+from pydantic import Json
 
 from zerver.actions.realm_linkifiers import (
     check_reorder_linkifiers,
@@ -10,9 +11,8 @@ from zerver.actions.realm_linkifiers import (
 )
 from zerver.decorator import require_realm_admin
 from zerver.lib.exceptions import JsonableError, ValidationFailureError
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_int, check_list
+from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.models import RealmFilter, UserProfile
 from zerver.models.linkifiers import linkifiers_for_realm
 
@@ -24,12 +24,13 @@ def list_linkifiers(request: HttpRequest, user_profile: UserProfile) -> HttpResp
 
 
 @require_realm_admin
-@has_request_variables
+@typed_endpoint
 def create_linkifier(
     request: HttpRequest,
     user_profile: UserProfile,
-    pattern: str = REQ(),
-    url_template: str = REQ(),
+    *,
+    pattern: str,
+    url_template: str,
 ) -> HttpResponse:
     try:
         linkifier_id = do_add_linkifier(
@@ -55,13 +56,14 @@ def delete_linkifier(
 
 
 @require_realm_admin
-@has_request_variables
+@typed_endpoint
 def update_linkifier(
     request: HttpRequest,
     user_profile: UserProfile,
-    filter_id: int,
-    pattern: str = REQ(),
-    url_template: str = REQ(),
+    *,
+    filter_id: PathOnly[int],
+    pattern: str,
+    url_template: str,
 ) -> HttpResponse:
     try:
         do_update_linkifier(
@@ -79,11 +81,12 @@ def update_linkifier(
 
 
 @require_realm_admin
-@has_request_variables
+@typed_endpoint
 def reorder_linkifiers(
     request: HttpRequest,
     user_profile: UserProfile,
-    ordered_linkifier_ids: list[int] = REQ(json_validator=check_list(check_int)),
+    *,
+    ordered_linkifier_ids: Json[list[int]],
 ) -> HttpResponse:
     check_reorder_linkifiers(user_profile.realm, ordered_linkifier_ids, acting_user=user_profile)
     return json_success(request)

--- a/zerver/views/realm_logo.py
+++ b/zerver/views/realm_logo.py
@@ -3,23 +3,23 @@ from django.core.files.uploadedfile import UploadedFile
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
+from pydantic import Json
 
 from zerver.actions.realm_logo import do_change_logo_source
 from zerver.decorator import require_realm_admin
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.realm_logo import get_realm_logo_url
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint
 from zerver.lib.upload import get_file_info, upload_logo_image
 from zerver.lib.url_encoding import append_url_query_string
-from zerver.lib.validator import check_bool
 from zerver.models import UserProfile
 
 
 @require_realm_admin
-@has_request_variables
+@typed_endpoint
 def upload_logo(
-    request: HttpRequest, user_profile: UserProfile, night: bool = REQ(json_validator=check_bool)
+    request: HttpRequest, user_profile: UserProfile, *, night: Json[bool]
 ) -> HttpResponse:
     user_profile.realm.ensure_not_on_limited_plan()
 
@@ -43,9 +43,9 @@ def upload_logo(
 
 
 @require_realm_admin
-@has_request_variables
+@typed_endpoint
 def delete_logo_backend(
-    request: HttpRequest, user_profile: UserProfile, night: bool = REQ(json_validator=check_bool)
+    request: HttpRequest, user_profile: UserProfile, *, night: Json[bool]
 ) -> HttpResponse:
     # We don't actually delete the logo because it might still
     # be needed if the URL was cached and it is rewritten
@@ -56,9 +56,9 @@ def delete_logo_backend(
     return json_success(request)
 
 
-@has_request_variables
+@typed_endpoint
 def get_logo_backend(
-    request: HttpRequest, user_profile: UserProfile, night: bool = REQ(json_validator=check_bool)
+    request: HttpRequest, user_profile: UserProfile, *, night: Json[bool]
 ) -> HttpResponse:
     url = get_realm_logo_url(user_profile.realm, night)
 

--- a/zerver/views/user_topics.py
+++ b/zerver/views/user_topics.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
-from pydantic import AfterValidator, Json, StringConstraints
+from pydantic import Json, StringConstraints
 
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.response import json_success
@@ -16,7 +16,7 @@ from zerver.lib.streams import (
     check_for_exactly_one_stream_arg,
 )
 from zerver.lib.typed_endpoint import typed_endpoint
-from zerver.lib.typed_endpoint_validators import check_int_in
+from zerver.lib.typed_endpoint_validators import check_int_in_validator
 from zerver.models import UserProfile, UserTopic
 from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 
@@ -100,10 +100,7 @@ def update_user_topic(
     stream_id: Json[int],
     topic: Annotated[str, StringConstraints(max_length=MAX_TOPIC_NAME_LENGTH)],
     visibility_policy: Json[
-        Annotated[
-            int,
-            AfterValidator(lambda x: check_int_in(x, UserTopic.VisibilityPolicy.values)),
-        ]
+        Annotated[int, check_int_in_validator(UserTopic.VisibilityPolicy.values)]
     ],
 ) -> HttpResponse:
     if visibility_policy == UserTopic.VisibilityPolicy.INHERIT:

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -57,7 +57,7 @@ from zerver.lib.typed_endpoint import (
     typed_endpoint,
     typed_endpoint_without_parameters,
 )
-from zerver.lib.typed_endpoint_validators import check_int_in, check_url
+from zerver.lib.typed_endpoint_validators import check_int_in_validator, check_url
 from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.url_encoding import append_url_query_string
@@ -98,11 +98,8 @@ from zproject.backends import check_password_strength
 
 RoleParamType: TypeAlias = Annotated[
     int,
-    AfterValidator(
-        lambda x: check_int_in(
-            x,
-            UserProfile.ROLE_TYPES,
-        )
+    check_int_in_validator(
+        UserProfile.ROLE_TYPES,
     ),
 ]
 


### PR DESCRIPTION
The first commit creates a function that returns an `AfterValidator`. This makes it possible to avoid using the lambda wrapper everywhere, making the code cleaner.

Migrate `realm.py`, `realm_domains.py`, `realm_emoji.py`,
`realm_linkifiers.py`, `realm_logo.py`, `realm_playgrounds.py`
to typed_endpoint.