### PR TITLE
settings: Allow tab switcher text to expand to show full text.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1,7 +1,7 @@
 /* The height of the settings header (including tab switcher). */
 $settings_header_height: 45px;
 /* The width of the settings sidebar. */
-$settings_sidebar_width: 250px;
+$settings_sidebar_width: 255px;
 
 label {
     margin: 0;
@@ -1297,6 +1297,31 @@ $option_title_width: 180px;
             height: $settings_header_height;
             padding: 6px;
             border-bottom: 1px solid hsl(0deg 0% 87%);
+
+            @media (width >= $md_min) {
+                .tab-switcher {
+                    position: absolute;
+                    display: flex;
+                    left: 10px;
+                    z-index: 1;
+
+                    .ind-tab {
+                        width: auto;
+                        min-width: 95px;
+                    }
+                }
+            }
+
+            @media (width < $md_min) {
+                .tab-switcher {
+                    display: flex;
+                    justify-content: center;
+
+                    .ind-tab {
+                        width: auto;
+                    }
+                }
+            }
         }
     }
 
@@ -1382,13 +1407,6 @@ $option_title_width: 180px;
         .normal-settings-list,
         .org-settings-list {
             position: relative;
-        }
-
-        .settings-sticky-bar {
-            position: sticky;
-            z-index: 1;
-            background-color: hsl(0deg 0% 100%);
-            top: 0;
         }
     }
 

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -8,7 +8,7 @@
         <div class="clear-float"></div>
     </div>
     <div class="sidebar-wrapper">
-        <div class="center tab-container settings-sticky-bar"></div>
+        <div class="center tab-container"></div>
         <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
             <div class="sidebar-list dark-grey small-text">
                 <ul class="normal-settings-list">


### PR DESCRIPTION
Instead of showing ellipsis if the content of the tab switcher is more than the width, we now allow it to take more width to show full text.

Increased 5px with of left sidebar:
<img width="418" alt="Screenshot 2024-07-08 at 1 46 07 PM" src="https://github.com/zulip/zulip/assets/25124304/f069aea4-ab96-453b-94ec-3594e320b171">

Mobile sizes:
<img width="418" alt="Screenshot 2024-07-08 at 1 48 34 PM" src="https://github.com/zulip/zulip/assets/25124304/4e3b0636-1dbd-4422-990f-45bc420b6133">

<img width="273" alt="Screenshot 2024-07-08 at 1 48 43 PM" src="https://github.com/zulip/zulip/assets/25124304/80858cb9-9d78-490b-9710-ed394424d53a">

