### PR TITLE
tippy: Add patch to avoid text Node as target in Firefox.

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     },
     "patchedDependencies": {
       "@uppy/core@3.13.0": "patches/@uppy__core@3.10.1.patch",
-      "source-sans@3.46.0": "patches/source-sans@3.46.0.patch"
+      "source-sans@3.46.0": "patches/source-sans@3.46.0.patch",
+      "tippy.js@6.3.7": "patches/tippy.js@6.3.7.patch"
     }
   },
   "nyc": {

--- a/patches/tippy.js@6.3.7.patch
+++ b/patches/tippy.js@6.3.7.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/tippy.esm.js b/dist/tippy.esm.js
+index 55346f57874b0af79fec3b6f9f0253f9d55bfee2..c7a4e1549dcc3e1815c908825d914d44467e60f3 100644
+--- a/dist/tippy.esm.js
++++ b/dist/tippy.esm.js
+@@ -1907,7 +1907,7 @@
+   var normalizedReturnValue = normalizeToArray(returnValue);
+ 
+   function onTrigger(event) {
+-    if (!event.target || disabled) {
++    if (!isElement(event.target) || disabled) {
+       return;
+     }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ patchedDependencies:
   source-sans@3.46.0:
     hash: 4n7ij66tzyhzaqnxsenbilrxr4
     path: patches/source-sans@3.46.0.patch
+  tippy.js@6.3.7:
+    hash: mlbmk5pq4q6iuwarqu6solgeeq
+    path: patches/tippy.js@6.3.7.patch
 
 importers:
 
@@ -243,7 +246,7 @@ importers:
         version: 4.1.1
       tippy.js:
         specifier: ^6.3.7
-        version: 6.3.7
+        version: 6.3.7(patch_hash=mlbmk5pq4q6iuwarqu6solgeeq)
       turndown:
         specifier: ^7.0.0
         version: 7.2.0
@@ -15105,7 +15108,7 @@ snapshots:
 
   tinyqueue@2.0.3: {}
 
-  tippy.js@6.3.7:
+  tippy.js@6.3.7(patch_hash=mlbmk5pq4q6iuwarqu6solgeeq):
     dependencies:
       '@popperjs/core': 2.11.8
 


### PR DESCRIPTION
In Firefox, event targets can be pseudo elements like text nodes which don't have .closest method. This results in error when delegate tries to handle trigger for a text node target.

Since https://github.com/atomiks/tippyjs/pull/1166 has no response from the developer, we decided to apply this patch ourselves.
