### PR TITLE
message_box: Ensure emoji display correctly on messages with senders.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -339,11 +339,12 @@
         .message_content {
             /* Pull message content up closer to sender to
                let the text baseline sit adjacent the bottom
-               of the avatar. */
+               of the avatar. We also need to account for the
+               padding atop .message_content. */
             margin-top: calc(
-                var(--message-box-markdown-aligned-vertical-space) * 0.5 * -1
+                (var(--message-box-markdown-aligned-vertical-space) * 0.5 * -1) -
+                    var(--message-box-markdown-aligned-vertical-space)
             );
-            padding-top: 0;
             grid-area: message;
         }
 


### PR DESCRIPTION
This corrects a subtle regression introduced by #30579, which set `padding-top: 0` on `.message_content`, leading to larger emoji being cut off at the top of the message box in narrower line-heights, such as at legacy values.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/info.20density.3A.20inline.20emoji.20presentation/near/1847196)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy, before | Legacy, after |
| --- | --- |
| ![top-line-emoji-legacy-before](https://github.com/zulip/zulip/assets/170719/b3cb8660-7394-4cb2-bc92-99b12a46daa6) | ![top-line-emoji-legacy-after](https://github.com/zulip/zulip/assets/170719/60bd0e9f-3911-4a8c-b609-e310a266a932) |

| 16/140, before | 16/140, after (no change) |
| --- | --- |
| ![top-line-emoji-16-140-before](https://github.com/zulip/zulip/assets/170719/d8a17db5-dab9-4d18-b825-774b624385be) | ![top-line-emoji-16-140-after-no-change](https://github.com/zulip/zulip/assets/170719/bf171b91-814f-4e27-9f2b-3ea6a3eacbf4) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>