### PR TITLE
sidebars: Correct placement of browse more streams, invite more users links.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -85,7 +85,11 @@
     --left-sidebar-header-icon-width: 15px;
     /* Space between section in the left sidebar. */
     --left-sidebar-sections-vertical-gutter: 8px;
-    --left-sidebar-bottom-scrolling-buffer: 25px;
+    /* The legacy value here is 25px; that's the unitless legacy line-height
+       of 20px, plus 5px at 14px/1em */
+    --left-sidebar-bottom-scrolling-buffer: calc(
+        (var(--legacy-body-line-height-unitless) * 1em) + 0.3571em
+    );
 
     /* We base sidebar row heights on their line heights.
        Prominent rows include things like headers (e.g., VIEWS)

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -341,7 +341,11 @@ $user_status_emoji_width: 24px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    margin-top: 5px;
+    /* The margin top is calculated from a legacy 25px height,
+       from a 20px line of text and 5px of margin top. We calculate
+       a scaling margin-top by subtracting the em-unit line height
+       from the legacy value. */
+    margin-top: calc(25px - (var(--legacy-body-line-height-unitless) * 1em));
 }
 
 #user_search_section {


### PR DESCRIPTION
This PR computes legacy values using different but context-appropriate methods for the left and right sidebar, so that links at the bottom of each sidebar scales up and preserves the legacy space from the bottom of the viewport.

Fixes parts of #30476.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy, before | Legacy, after (no change) |
| --- | --- |
| ![sidebars-legacy-before](https://github.com/zulip/zulip/assets/170719/b9d7badd-d8d5-40a0-a3f7-ad133cde3149) | ![sidebars-legacy-after-no-change](https://github.com/zulip/zulip/assets/170719/3ff7c405-16fd-4188-9277-720d3ee912c2) |

| 16/140, before | 16/140, after |
| --- | --- |
| ![sidebars-16-140-before](https://github.com/zulip/zulip/assets/170719/e72dc87f-3cee-4848-a68d-c8875ef9bc07) | ![sidebars-16-140-after](https://github.com/zulip/zulip/assets/170719/f7207c9a-4e37-4273-8c80-0f3849580883) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
