### PR TITLE
polls: Fix transition issue for "Add" and "New" option in dark theme.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -126,12 +126,8 @@
     & input[type="text"] {
         /* Reset from zulip.css */
         height: unset;
-
         border: 1px solid hsl(0deg 0% 80%);
         box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
-        transition:
-            border-color linear 0.2s,
-            box-shadow linear 0.2s;
         border-radius: 4px;
         color: hsl(0deg 0% 33%);
 
@@ -140,6 +136,9 @@
             outline: 0;
             box-shadow: none;
             background-color: var(--color-background-widget-input);
+            transition:
+                border-color linear 0.2s,
+                box-shadow linear 0.2s;
         }
     }
 }
@@ -218,19 +217,20 @@ button {
         padding: 4px;
         padding-left: 14px;
         padding-right: 14px;
-        transition: none 0.2s ease;
         transition-property: background-color, border-color, color;
 
         &:hover,
         &:focus {
             outline: 0;
             border-color: hsl(156deg 30% 50%);
+            transition: none 0.2s ease;
         }
 
         &:active {
             border-color: hsl(156deg 30% 40%);
             color: hsl(156deg 44% 43%);
             background-color: hsl(154deg 33% 96%);
+            transition: none 0.2s ease;
         }
     }
 }


### PR DESCRIPTION
### PR Description
This PR resolves the transition problem for the "Add option" button and option field in polls to ensure proper synchronization when switching to the dark theme.


Fixes: #30628.

### Before: 
https://github.com/user-attachments/assets/4c4d8b3e-b229-44f1-894b-b09fd5adf076

### After: 
https://github.com/user-attachments/assets/02d89d98-7d25-4e88-885f-97eb2ebcd191

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>





