### PR TITLE
typeahead: Fix typeahead position not updating on pill remove.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -505,7 +505,8 @@ export class Typeahead<ItemType extends string | object> {
             .on("keypress", this.keypress.bind(this))
             .on("keyup", this.keyup.bind(this))
             .on("click", this.element_click.bind(this))
-            .on("keydown", this.keydown.bind(this));
+            .on("keydown", this.keydown.bind(this))
+            .on("typeahead.refreshPosition", this.refreshPosition.bind(this));
 
         this.$menu
             .on("click", "li", this.click.bind(this))
@@ -735,6 +736,14 @@ export class Typeahead<ItemType extends string | object> {
         }
         this.$menu.find(".active").removeClass("active");
         $(e.currentTarget).addClass("active");
+    }
+
+    refreshPosition(e: JQuery.Event): void {
+        e.stopPropagation();
+        // Refresh the typeahead menu to account for any changes in the
+        // input position by asking popper to recompute your tooltip's position.
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.instance?.popperInstance?.update();
     }
 }
 

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -440,6 +440,9 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             const $next = $pill.next();
 
             funcs.removePill($pill[0]!);
+            // Since removing a pill moves the $input, typeahead needs to refresh
+            // to appear at the correct position.
+            store.$input.trigger(new $.Event("typeahead.refreshPosition"));
             $next.trigger("focus");
         });
 


### PR DESCRIPTION
On the pressing the 'X' button on a pill, the input was moving without repositioning the typeahead. Fixed it by:

Calling popper instance update method to refresh the position of the typeahead menu.

Before:

![before](https://github.com/zulip/zulip/assets/78212328/181e4e9b-ca2d-4d3d-b2d5-0b6ba07d7b42)

After:

![after](https://github.com/zulip/zulip/assets/78212328/08f154a9-f90b-4f64-a0dc-0dab38904416)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
