### PR TITLE
compose: Scale compose formatting buttons and send area elements with info density.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -202,7 +202,14 @@
     flex item. 2.1786em is 30.5px at 14px/1em.
     */
     --compose-recipient-box-min-height: 2.1786em;
-    --compose-formatting-buttons-row-height: 28px;
+    /* 28px at 14px/1em */
+    /* Note that this variable can only be used in contexts where
+       the font-size doesn't deviate from the base font-size;
+       that excludes contexts like .compose_control_button, which
+       uses font-sizing to adjust the size of the icon. Related
+       values have been noted in comments with this variable name,
+       to make their coordination a little less painful. */
+    --compose-formatting-buttons-row-height: 2em;
 
     /*
     Width of the area where the compose box buttons are placed, "inside"

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1071,15 +1071,20 @@ textarea.new_message_textarea {
     align-items: center;
 
     .compose_control_button {
-        height: var(--compose-formatting-buttons-row-height);
-        width: 30px;
+        /* 22px at 14px/1em */
+        font-size: 1.5714em;
+        /* Coordinate with the value of
+           --compose-formatting-buttons-row-height */
+        /* 28px at 22px/1em */
+        height: 1.2727em;
+        /* 30px at 22px/1em */
+        width: 1.3636em;
         display: flex;
         align-items: center;
         justify-content: center;
         opacity: 0.7;
         color: inherit;
         text-decoration: none;
-        font-size: 22px;
 
         &:hover {
             opacity: 1;
@@ -1113,7 +1118,12 @@ textarea.new_message_textarea {
 
     .compose_control_menu {
         padding: 0 1px;
-        font-size: 18px;
+        /* 18px at 14px/1em */
+        font-size: 1.2957em;
+        /* Coordinate with the value of
+           --compose-formatting-buttons-row-height */
+        /* 28px at 18px/1em */
+        height: 1.5556em;
     }
 
     .compose_control_menu_wrapper {
@@ -1149,9 +1159,13 @@ textarea.new_message_textarea {
 
     .divider {
         color: hsl(0deg 0% 75%);
-        font-size: 20px;
+        /* 20px at 14px/1em */
+        font-size: 1.4286em;
         margin: 0 3px;
-        height: var(--compose-formatting-buttons-row-height);
+        /* Coordinate with the value of
+           --compose-formatting-buttons-row-height */
+        /* 28px at 20px/1em */
+        height: 1.4em;
     }
 
     .compose_draft_button {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -966,7 +966,7 @@ textarea.new_message_textarea {
 
 #compose-send-button {
     width: 74px;
-    height: 28px;
+    height: var(--compose-formatting-buttons-row-height);
     /* Allow to grow but not shrink */
     flex: 1 0 auto;
     /* Override inherited styles
@@ -1364,9 +1364,7 @@ textarea.new_message_textarea {
     width: 40px;
     /* Allow to grow but not shrink */
     flex: 1 0 auto;
-    /* TODO: Set this as a variable shared with
-       the send button. */
-    height: 28px;
+    height: var(--compose-formatting-buttons-row-height);
     /* Make the vdots appear to extend from
        beneath the send button when an
        interactive background is present.
@@ -1408,7 +1406,8 @@ textarea.new_message_textarea {
 
     .zulip-icon {
         padding: 5px 0 5px 4px;
-        font-size: 17px;
+        /* 17px at 14px/1em */
+        font-size: 1.2143em;
         flex-grow: 1;
 
         @media (width < $sm_min) {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1154,6 +1154,12 @@ textarea.new_message_textarea {
            --compose-formatting-buttons-row-height */
         /* 28px at 20px/1em */
         height: 1.4em;
+
+        @media (width < 400px) {
+            /* Remove at mobile widths to make more space
+               for compose buttons */
+            display: none;
+        }
     }
 
     .compose_draft_button {
@@ -1229,6 +1235,14 @@ textarea.new_message_textarea {
             they are hidden in the main row below the compose box. */
             @media ((width < 596px) or ((width < 919px) and (width >= $md_min))) {
                 display: flex;
+            }
+        }
+
+        .compose_control_button {
+            /* Slightly reduce width so that buttons don't overflow the available
+            space at mobile widths */
+            @media (width < 400px) {
+                width: 1.28em;
             }
         }
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1143,18 +1143,6 @@ textarea.new_message_textarea {
             opacity: 1;
             display: none;
         }
-
-        /* The media query below handles the hiding and showing of the
-        vdot menu icon, so that it is hidden when all compose buttons fit
-        in the main row below the compose box. So, this is the same as
-        the media query for .show_popover_buttons. */
-        @media (((width < $cb1_min) and (width >= $xl_min)) or ((width < $cb2_min) and (width >= $md_min)) or (width < $cb4_min)) {
-            display: block;
-
-            .compose_control_menu {
-                display: flex;
-            }
-        }
     }
 
     .divider {
@@ -1187,15 +1175,6 @@ textarea.new_message_textarea {
         align-items: center;
         padding: 0;
         margin: 0;
-
-        /* We use this class for the div containing those compose buttons, which
-        we hide and show in a popover instead when they no longer fit in a
-        single row. The media query below handles the hiding and showing of the
-        buttons from the main row of compose buttons below the compose box. */
-
-        @media (((width < $cb1_min) and (width >= $xl_min)) or ((width < $cb2_min) and (width >= $md_min)) or (width < $cb4_min)) {
-            display: none;
-        }
     }
 
     .show_popover_buttons_2 {
@@ -1203,24 +1182,86 @@ textarea.new_message_textarea {
         align-items: center;
         padding: 0;
         margin: 0;
-
-        /* This is similar to show_popover_buttons, but it's only for those
-        compose buttons that we hide, and show in the popover only when the
-        screen gets extremely narrow. */
-
-        @media ((width < $cb5_min) or ((width < $cb3_min) and (width >= $md_min))) {
-            display: none;
-        }
     }
 
     &.show_in_popover {
         display: none;
+    }
+}
 
-        /* This is to show the popover 2 buttons in the popover, only when
-        they are hidden in the main row below the compose box. */
+.less-dense-mode {
+    .compose-control-buttons-container {
+        .compose_control_menu_wrapper {
+            /* The media query below handles the hiding and showing of the
+            vdot menu icon, so that it is hidden when all compose buttons fit
+            in the main row below the compose box. So, this is the same as
+            the media query for .show_popover_buttons. */
+            @media (((width < 1398px) and (width >= $xl_min)) or (width < 1158px)) {
+                display: block;
 
-        @media ((width < $cb5_min) or ((width < $cb3_min) and (width >= $md_min))) {
-            display: flex;
+                .compose_control_menu {
+                    display: flex;
+                }
+            }
+        }
+
+        .show_popover_buttons {
+            /* We use this class for the div containing those compose buttons, which
+            we hide and show in a popover instead when they no longer fit in a
+            single row. The media query below handles the hiding and showing of the
+            buttons from the main row of compose buttons below the compose box. */
+            @media (((width < 1398px) and (width >= $xl_min)) or (width < 1158px)) {
+                display: none;
+            }
+        }
+
+        .show_popover_buttons_2 {
+            /* This is similar to show_popover_buttons, but it's only for those
+            compose buttons that we hide, and show in the popover only when the
+            screen gets extremely narrow. */
+            @media ((width < 596px) or ((width < 919px) and (width >= $md_min))) {
+                display: none;
+            }
+        }
+
+        &.show_in_popover {
+            /* This is to show the popover 2 buttons in the popover, only when
+            they are hidden in the main row below the compose box. */
+            @media ((width < 596px) or ((width < 919px) and (width >= $md_min))) {
+                display: flex;
+            }
+        }
+    }
+}
+
+.more-dense-mode {
+    .compose-control-buttons-container {
+        .compose_control_menu_wrapper {
+            @media (((width < $cb1_min) and (width >= $xl_min)) or ((width < $cb2_min) and (width >= $md_min)) or (width < $cb4_min)) {
+                display: block;
+
+                .compose_control_menu {
+                    display: flex;
+                }
+            }
+        }
+
+        .show_popover_buttons {
+            @media (((width < $cb1_min) and (width >= $xl_min)) or ((width < $cb2_min) and (width >= $md_min)) or (width < $cb4_min)) {
+                display: none;
+            }
+        }
+
+        .show_popover_buttons_2 {
+            @media ((width < $cb5_min) or ((width < $cb3_min) and (width >= $md_min))) {
+                display: none;
+            }
+        }
+
+        &.show_in_popover {
+            @media ((width < $cb5_min) or ((width < $cb3_min) and (width >= $md_min))) {
+                display: flex;
+            }
         }
     }
 }


### PR DESCRIPTION
compose: Remove dividers and reduce button width at narrow mobile sizes.

At widths under 400px, buttons in the popover were running off the edge, which is fixed by removing the dividers between them.

For the new info density, buttons in the original row, even despite removing the dividers, were still not fitting, so their width has been slightly reduced.

compose: Adjust media queries for the buttons row as per info density.

compose_box: Scale send buttons with info density.

Because the formatting buttons are integrated with the message box, the send button and its accompanying vdots now share the same button dimensions.

compose_box: Scale formatting buttons with info density.

Fixes: [one of the 2 issues mentioned in this CZO message](https://chat.zulip.org/#narrow/stream/101-design/topic/testing.20info.20density.20on.20CZO/near/1836901)

**Screenshots and screen captures:**
Breakpoint viewport widths with 16px/120px density:
- around 1400px
![image](https://github.com/zulip/zulip/assets/68962290/cae383fd-bc95-47f6-8fd9-09f0ea31a3e6)
and
![image](https://github.com/zulip/zulip/assets/68962290/8cc85086-356e-4b0d-8948-742a3f5a94ed)
- around 1200px
![image](https://github.com/zulip/zulip/assets/68962290/8ed6dd78-5970-4229-a6d9-bad9a4b298b5)
- around 1150px
![image](https://github.com/zulip/zulip/assets/68962290/3ce45233-90c7-41c5-b778-b673179a27d4)
- around 915px
![image](https://github.com/zulip/zulip/assets/68962290/66b53514-3779-4a57-82d1-e2f55e137cb8)
- around 750px
![image](https://github.com/zulip/zulip/assets/68962290/456efd5b-0040-4c00-a201-0b42b261b520)
- around 580px
![image](https://github.com/zulip/zulip/assets/68962290/b394eb7f-1281-4e28-905a-50acdb1308ef)
- 360px
![image](https://github.com/zulip/zulip/assets/68962290/d77cfd1d-43cc-462b-b6f4-b972809557a6)


360px width with original info density:
![image](https://github.com/zulip/zulip/assets/68962290/c34bc8d6-7ee2-4e99-abaa-2fd4cf3e2419)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
