### PR TITLE
topic: Focus on confirm dialog when merging topics.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -850,7 +850,6 @@ export function try_save_inline_topic_edit($row) {
             html_body: render_confirm_merge_topics_with_rename({
                 topic_name: new_topic,
             }),
-            focus_submit_on_open: false,
             on_click: () => do_save_inline_topic_edit($row, message, new_topic),
         });
     } else {


### PR DESCRIPTION
[CZO link for this issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/Duplicate.20confirmation.20modals.20merging.20topics).

Earlier `focus_submit_on_open` was set to `false` so even when the
`confirm_dialog` is open the `topic_edit_save` button is still in focus.
Therefore pressing enter causes the `topic_edit_save` button to be
pressed causing multiple `confirm_dialog` modals to be created.

This commit sets `focus_submit_on_open` to `true` so that the
`confirm_dialog` is in focus when it is opened and pressing enter
will cause the `confirm_dialog` to be closed.