### PR TITLE
Fix Invite new users documentation

### DIFF
--- a/help/deactivate-or-reactivate-a-user.md
+++ b/help/deactivate-or-reactivate-a-user.md
@@ -82,8 +82,6 @@ bots will be deactivated until the user manually
 
 {settings_tab|deactivated}
 
-1. Select the **Deactivated** tab.
-
 1. Click the **Reactivate** button to the right of the user that you
    want to reactivate.
 

--- a/help/include/invite-users.md
+++ b/help/include/invite-users.md
@@ -1,6 +1,0 @@
-1. Click on the **gear** (<i class="zulip-icon zulip-icon-gear"></i>) icon in the upper
-   right corner of the web or desktop app.
-
-1. Select <i class="fa fa-user"></i> **Users**.
-
-1. Select the **Invitations** tab.

--- a/help/invite-new-users.md
+++ b/help/invite-new-users.md
@@ -29,9 +29,11 @@ permission to invite users.
 
 {start_tabs}
 
-{!invite-users.md!}
+{settings_tab|invitations}
 
-1. Click **Send an email**.
+1. Click on **Invite users to organization.**
+
+1. Select the **Send invite email** tab.
 
 1. Enter a list of email addresses.
 
@@ -60,9 +62,11 @@ permission to invite users.
 
 {start_tabs}
 
-{!invite-users.md!}
+{settings_tab|invitations}
 
-1. Click **Generate invite link**.
+1. Click on **Invite users to organization.**
+
+1. Select the **Create invite link** tab.
 
 1. Select when the invitation will expire.
 

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -65,7 +65,7 @@ link_mapping = {
     ],
     "deactivated": [
         "Organization settings",
-        "Users",
+        "Deactivated",
         "/#organization/users/deactivated",
     ],
     "bot-list-admin": [
@@ -120,7 +120,7 @@ def getMarkdown(setting_type_name: str, setting_name: str, setting_link: str) ->
         relative_link = f"[{setting_name}]({setting_link})"
         # The "Bots" label appears in both Personal and Organization settings
         # in the user interface so we need special text for this setting.
-        if setting_name in ["Bots", "Users", "Invitations"]:
+        if setting_name in ["Bots", "Users", "Invitations", "Deactivated"]:
             return f"1. Navigate to the {relative_link} \
                     tab of the **{setting_type_name}** menu."
         return f"1. Go to {relative_link}."

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -114,6 +114,17 @@ settings_markdown = """
 1. On the left, click {setting_reference}.
 """
 
+users_tab_markdown = """
+1. Click on the **gear** (<i class="zulip-icon zulip-icon-gear"></i>) icon in the upper
+   right corner of the web or desktop app.
+
+1. Select **{setting_type_name}**.
+
+1. On the left, click **Users**.
+
+1. Select the {setting_reference} tab.
+"""
+
 
 def getMarkdown(setting_type_name: str, setting_name: str, setting_link: str) -> str:
     if relative_settings_links:
@@ -124,6 +135,11 @@ def getMarkdown(setting_type_name: str, setting_name: str, setting_link: str) ->
             return f"1. Navigate to the {relative_link} \
                     tab of the **{setting_type_name}** menu."
         return f"1. Go to {relative_link}."
+    if setting_name in ["Users", "Deactivated", "Invitations"]:
+        return users_tab_markdown.format(
+            setting_type_name=setting_type_name,
+            setting_reference=f"**{setting_name}**",
+        )
     return settings_markdown.format(
         setting_type_name=setting_type_name,
         setting_reference=f"**{setting_name}**",

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -120,7 +120,7 @@ def getMarkdown(setting_type_name: str, setting_name: str, setting_link: str) ->
         relative_link = f"[{setting_name}]({setting_link})"
         # The "Bots" label appears in both Personal and Organization settings
         # in the user interface so we need special text for this setting.
-        if setting_name in ["Bots", "Users"]:
+        if setting_name in ["Bots", "Users", "Invitations"]:
             return f"1. Navigate to the {relative_link} \
                     tab of the **{setting_type_name}** menu."
         return f"1. Go to {relative_link}."

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -406,6 +406,26 @@ class HelpTest(ZulipTestCase):
         self.assertIn("<strong>Preferences</strong>", str(result.content))
         self.assertNotIn("/#settings", str(result.content))
 
+    def test_help_users_tab_links(self) -> None:
+        result = self.client_get("/help/invite-new-users")
+        self.assertEqual(result.status_code, 200)
+        # The full sentence hasn't been tested since there's a bunch of
+        # whitespace in the HTML after the invitations link and we
+        # don't want that whitespace to be part of the test since it
+        # might change in the future.
+        self.assertIn(
+            'Navigate to the <a href="/#organization/users/invitations">Invitations</a>',
+            str(result.content),
+        )
+        # Check that the sidebar was rendered properly.
+        self.assertIn("Getting started with Zulip", str(result.content))
+
+        with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
+            result = self.client_get("/help/invite-new-users", subdomain="")
+        self.assertEqual(result.status_code, 200)
+        self.assertIn("Select the <strong>Invitations</strong> tab.", str(result.content))
+        self.assertNotIn("/#settings", str(result.content))
+
     def test_help_relative_links_for_gear(self) -> None:
         result = self.client_get("/help/analytics")
         self.assertIn(


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/30715.

For the zulip cloud instructions, for the default `Users` tab also, we will show the instruction to select that tab, since there is a possibility that the user reading the documentation is not on the User tab. This will affect any places where the `settings_tab|users` link was present. 1 screenshot has been provided in this PR for reference but the change will affect multiple pages.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Send email invitations - self hosted | Send email invitations - cloud|
| -- | -- |
| <img width="891" alt="send_email_invitation_commit2_new" src="https://github.com/zulip/zulip/assets/13910561/fa997a3b-1f92-4baf-91ff-0631393fb93b"> | <img width="907" alt="send_email_invitation_cloud" src="https://github.com/zulip/zulip/assets/13910561/5d043d88-faa8-4b30-931d-1df2ec47d621">
| Reusable invitation link - self hosted | Reusable invitation link - cloud |
| <img width="895" alt="reusable_invitation_link_commit2_new" src="https://github.com/zulip/zulip/assets/13910561/750a61c5-fcd6-430d-9b50-e30ea2ed9967"> | <img width="914" alt="reusable_invitation_link_cloud" src="https://github.com/zulip/zulip/assets/13910561/9eadae18-43fd-43bf-a8e4-e45c3b6af167">
| Manage pending invitations - self hosted | Manage pending invitations - cloud |
| <img width="900" alt="manage_invitation_link_commit2_new" src="https://github.com/zulip/zulip/assets/13910561/d65b92a3-712f-4fbe-a60d-921f509f85fe"> | <img width="910" alt="manage_invitation_cloud" src="https://github.com/zulip/zulip/assets/13910561/a4d2edf4-2067-470a-9330-1ec5c3319a1a">
| Reactivate a user - self hosted | Reactivate a user - cloud |
| <img width="900" alt="Screenshot 2024-07-08 at 7 29 48 PM" src="https://github.com/zulip/zulip/assets/13910561/f78159bf-2b6d-4574-90b5-34b2968f1d25"> | <img width="899" alt="reactivate_a_user_cloud" src="https://github.com/zulip/zulip/assets/13910561/3a208b65-7029-4278-b2c6-8d9f69821e20">
| Deactivate a user - self hosted | Deactivate a user - cloud |
| <img width="903" alt="deactivate_a_user_self_hosted" src="https://github.com/zulip/zulip/assets/13910561/f6d84553-f512-4d78-ab2c-750f22eb31e3"> | <img width="912" alt="deactivate_a_user_cloud" src="https://github.com/zulip/zulip/assets/13910561/039cb1df-0940-4740-aecf-f8cca6ee9710">


**Self review checklist:**
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
