### PR TITLE
help: Add a note about unread count badge when testing notifications.

### DIFF
--- a/help/desktop-notifications.md
+++ b/help/desktop-notifications.md
@@ -67,6 +67,10 @@ and [mentions](/help/mention-a-user-or-group), or to include messages in
 
 ## Testing desktop notifications
 
+!!! warn ""
+
+    This does not make an unread count badge appear.
+
 {start_tabs}
 
 {tab|desktop-web}


### PR DESCRIPTION
Adding a clarification in response to https://github.com/zulip/zulip-desktop/issues/1376. Should this PR be marked as fixing it?

Current: https://zulip.com/help/desktop-notifications#testing-desktop-notifications

Updated:
![Screenshot 2024-07-08 at 00 52 46](https://github.com/zulip/zulip/assets/2090066/b2fc93be-15ad-4a8a-8f32-036c7bc9d55a)
