### PR TITLE
stream_create: Add "all users: N" pill to input on clicking `Add all users`

### DIFF
--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -1,3 +1,4 @@
+import * as blueslip from "./blueslip";
 import * as input_pill from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import type {User} from "./people";
@@ -5,6 +6,7 @@ import * as pill_typeahead from "./pill_typeahead";
 import * as stream_pill from "./stream_pill";
 import type {CombinedPill, CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
+import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
 
 function create_item_from_text(
@@ -130,6 +132,21 @@ export function create_without_add_button({
     set_up_pill_typeahead({pill_widget, $pill_container, get_users});
 
     return pill_widget;
+}
+
+export function append_user_group_from_name(
+    user_group_name: string,
+    pill_widget: CombinedPillContainer,
+): void {
+    const user_group = user_groups.get_user_group_from_name(user_group_name);
+    if (user_group === undefined) {
+        // This shouldn't happen, but we'll give a warning for now if it
+        // does.
+        blueslip.error("User group with the given name does not exist.");
+        return;
+    }
+
+    user_group_pill.append_user_group(user_group, pill_widget);
 }
 
 function get_pill_user_ids(pill_widget: CombinedPillContainer): number[] {

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -9,8 +9,10 @@ import type {ListWidget as ListWidgetType} from "./list_widget";
 import * as people from "./people";
 import {current_user} from "./state_data";
 import * as stream_create_subscribers_data from "./stream_create_subscribers_data";
+import type {CombinedPillContainer} from "./typeahead_helper";
 import * as user_sort from "./user_sort";
 
+let pill_widget: CombinedPillContainer;
 let all_users_list_widget: ListWidgetType<number, people.User>;
 
 export function get_principals(): number[] {
@@ -27,8 +29,7 @@ function add_user_ids(user_ids: number[]): void {
 }
 
 function add_all_users(): void {
-    const user_ids = stream_create_subscribers_data.get_all_user_ids();
-    add_user_ids(user_ids);
+    add_subscribers_pill.append_user_group_from_name("role:everyone", pill_widget!);
 }
 
 function soft_remove_user_id(user_id: number): void {
@@ -46,10 +47,14 @@ function sync_user_ids(user_ids: number[]): void {
     redraw_subscriber_list();
 }
 
-function build_pill_widget({$parent_container}: {$parent_container: JQuery}): void {
+function build_pill_widget({
+    $parent_container,
+}: {
+    $parent_container: JQuery;
+}): CombinedPillContainer {
     const $pill_container = $parent_container.find(".pill-container");
     const get_potential_subscribers = stream_create_subscribers_data.get_potential_subscribers;
-    add_subscribers_pill.create_without_add_button({
+    return add_subscribers_pill.create_without_add_button({
         $pill_container,
         get_potential_subscribers,
         onPillCreateAction: add_user_ids,
@@ -90,7 +95,7 @@ export function build_widgets(): void {
 
     const $simplebar_container = $add_people_container.find(".subscriber_list_container");
 
-    build_pill_widget({$parent_container: $add_people_container});
+    pill_widget = build_pill_widget({$parent_container: $add_people_container});
 
     stream_create_subscribers_data.initialize_with_current_user();
     const current_user_id = current_user.user_id;

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -17,7 +17,8 @@ export type UserGroupPillData = UserGroup & {
 };
 
 function display_pill(group: UserGroup): string {
-    return `${group.name}: ${group.members.size} users`;
+    const group_members = user_groups.get_recursive_group_members(group);
+    return `${group.name}: ${group_members.size} users`;
 }
 
 export function create_item_from_group_name(
@@ -47,13 +48,15 @@ export function get_group_name_from_item(item: InputPillItem<UserGroupPill>): st
 }
 
 export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillContainer): number[] {
-    let user_ids = pill_widget
-        .items()
-        .flatMap((item) =>
-            item.type === "user_group"
-                ? [...user_groups.get_user_group_from_id(item.group_id).members]
-                : [],
-        );
+    let user_ids: number[] = [];
+    for (const user_group_item of pill_widget.items()) {
+        if (user_group_item.type === "user_group") {
+            const user_group = user_groups.get_user_group_from_id(user_group_item.group_id);
+            const group_members = user_groups.get_recursive_group_members(user_group);
+            user_ids.push(...group_members);
+        }
+    }
+
     user_ids = [...new Set(user_ids)];
     user_ids.sort((a, b) => a - b);
 

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -18,7 +18,7 @@ export type UserGroupPillData = UserGroup & {
 
 function display_pill(group: UserGroup): string {
     const group_members = user_groups.get_recursive_group_members(group);
-    return `${group.name}: ${group_members.size} users`;
+    return `${user_groups.get_display_group_name(group)}: ${group_members.size} users`;
 }
 
 export function create_item_from_group_name(

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,3 +1,4 @@
+import {$t_html} from "./i18n";
 import type {InputPillContainer, InputPillItem} from "./input_pill";
 import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
 import type {UserGroup} from "./user_groups";
@@ -18,7 +19,10 @@ export type UserGroupPillData = UserGroup & {
 
 function display_pill(group: UserGroup): string {
     const group_members = user_groups.get_recursive_group_members(group);
-    return `${user_groups.get_display_group_name(group)}: ${group_members.size} users`;
+    return $t_html(
+        {defaultMessage: "{group_name}: {group_size, plural, one {# user} other {# users}}"},
+        {group_name: user_groups.get_display_group_name(group), group_size: group_members.size},
+    );
 }
 
 export function create_item_from_group_name(

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -57,7 +57,6 @@ export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillCont
     user_ids = [...new Set(user_ids)];
     user_ids.sort((a, b) => a - b);
 
-    user_ids = user_ids.filter(Boolean);
     return user_ids;
 }
 

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,5 +1,6 @@
 import {$t_html} from "./i18n";
 import type {InputPillContainer, InputPillItem} from "./input_pill";
+import * as people from "./people";
 import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
 import type {UserGroup} from "./user_groups";
 import * as user_groups from "./user_groups";
@@ -18,10 +19,10 @@ export type UserGroupPillData = UserGroup & {
 };
 
 function display_pill(group: UserGroup): string {
-    const group_members = user_groups.get_recursive_group_members(group);
+    const group_members = get_group_members(group);
     return $t_html(
         {defaultMessage: "{group_name}: {group_size, plural, one {# user} other {# users}}"},
-        {group_name: user_groups.get_display_group_name(group), group_size: group_members.size},
+        {group_name: user_groups.get_display_group_name(group), group_size: group_members.length},
     );
 }
 
@@ -56,7 +57,7 @@ export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillCont
     for (const user_group_item of pill_widget.items()) {
         if (user_group_item.type === "user_group") {
             const user_group = user_groups.get_user_group_from_id(user_group_item.group_id);
-            const group_members = user_groups.get_recursive_group_members(user_group);
+            const group_members = get_group_members(user_group);
             user_ids.push(...group_members);
         }
     }
@@ -65,6 +66,11 @@ export function get_user_ids(pill_widget: UserGroupPillWidget | CombinedPillCont
     user_ids.sort((a, b) => a - b);
 
     return user_ids;
+}
+
+function get_group_members(user_group: UserGroup): number[] {
+    const user_ids = [...user_groups.get_recursive_group_members(user_group)];
+    return user_ids.filter((user_id) => people.is_person_active(user_id));
 }
 
 export function append_user_group(group: UserGroup, pill_widget: CombinedPillContainer): void {

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -93,9 +93,11 @@ export function toggle_user_group_info_popover(
                 }
                 user_group_popover_instance = instance;
                 const args = {
-                    group_name: group.name,
+                    group_name: user_groups.get_display_group_name(group),
                     group_description: group.description,
-                    members: sort_group_members(fetch_group_members([...group.members])),
+                    members: sort_group_members(
+                        fetch_group_members([...user_groups.get_recursive_group_members(group)]),
+                    ),
                     group_edit_url: hash_util.group_edit_url(group, "general"),
                     is_guest: current_user.is_guest,
                 };

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -100,6 +100,7 @@ export function toggle_user_group_info_popover(
                     ),
                     group_edit_url: hash_util.group_edit_url(group, "general"),
                     is_guest: current_user.is_guest,
+                    is_system_group: group.is_system_group,
                 };
                 instance.setContent(ui_util.parse_html(render_user_group_info_popover(args)));
             },

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -1,3 +1,4 @@
+import assert from "minimalistic-assert";
 import type {z} from "zod";
 
 import * as blueslip from "./blueslip";
@@ -201,6 +202,24 @@ export function get_recursive_subgroups(target_user_group: UserGroup): Set<numbe
         }
     }
     return subgroup_ids;
+}
+
+export function get_recursive_group_members(target_user_group: UserGroup): Set<number> {
+    const members = new Set(target_user_group.members);
+    const subgroup_ids = get_recursive_subgroups(target_user_group);
+
+    if (subgroup_ids === undefined) {
+        return members;
+    }
+
+    for (const subgroup_id of subgroup_ids) {
+        const subgroup = user_group_by_id_dict.get(subgroup_id);
+        assert(subgroup !== undefined);
+        for (const member of subgroup.members) {
+            members.add(member);
+        }
+    }
+    return members;
 }
 
 export function is_user_in_group(user_group_id: number, user_id: number): boolean {

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -321,3 +321,15 @@ export function get_realm_user_groups_for_dropdown_list_widget(
 
     return [...system_user_groups, ...user_groups_excluding_system_groups];
 }
+
+// Group name for user-facing display. For settings, we already use
+// description strings for system groups. But those description strings
+// might not be suitable for every case, e.g. we want the name for
+// `role:everyone` to be `Everyone` instead of
+// `Admins, moderators, members and guests` from `settings_config`.
+// Right now, we only change the name for `role:everyone`, that's why
+// we don't store the values in a structured way like
+// `settings_config` yet.
+export function get_display_group_name(user_group: UserGroup): string {
+    return user_group.name === "role:everyone" ? $t({defaultMessage: "Everyone"}) : user_group.name;
+}

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -24,7 +24,7 @@
                 {{/each}}
             </ul>
         </li>
-        {{#unless is_guest}}
+        {{#unless (or is_guest is_system_group)}}
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
             <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
                 <a href="{{group_edit_url}}" role="menuitem" class="navigate-link-on-enter popover-menu-link" tabindex="0">

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -47,7 +47,7 @@ const everyone_pill = {
     // While we can programmatically set the user count below,
     // calculating it would almost mimic the entire display function
     // here, reducing the usefulness of the test.
-    display_value: everyone.name + ": 5 users",
+    display_value: "translated: Everyone: 5 users",
 };
 
 const groups = [admins, testers, everyone];

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -7,6 +7,42 @@ const {run_test} = require("./lib/test");
 
 const user_groups = zrequire("user_groups");
 const user_group_pill = zrequire("user_group_pill");
+const people = zrequire("people");
+
+const user1 = {
+    user_id: 10,
+    email: "user1@example.com",
+    full_name: "User One",
+};
+people.add_active_user(user1);
+
+const user2 = {
+    user_id: 20,
+    email: "user2@example.com",
+    full_name: "User Two",
+};
+people.add_active_user(user2);
+
+const user3 = {
+    user_id: 30,
+    email: "user3@example.com",
+    full_name: "User Three",
+};
+people.add_active_user(user3);
+
+const user4 = {
+    user_id: 40,
+    email: "user4@example.com",
+    full_name: "User Four",
+};
+people.add_active_user(user4);
+
+const user5 = {
+    user_id: 50,
+    email: "user5@example.com",
+    full_name: "User Five",
+};
+people.add_active_user(user5);
 
 const admins = {
     name: "Admins",
@@ -83,6 +119,12 @@ run_test("get_user_ids", () => {
     items = [everyone_pill];
     user_ids = user_group_pill.get_user_ids(widget);
     assert.deepEqual(user_ids, [10, 20, 30, 40, 50]);
+
+    // Deactivated users should be excluded.
+    people.deactivate(user5);
+    user_ids = user_group_pill.get_user_ids(widget);
+    assert.deepEqual(user_ids, [10, 20, 30, 40]);
+    people.add_active_user(user5);
 });
 
 run_test("get_group_ids", () => {

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -32,13 +32,13 @@ const admins_pill = {
     group_id: admins.id,
     group_name: admins.name,
     type: "user_group",
-    display_value: admins.name + ": " + admins.members.length + " users",
+    display_value: "translated HTML: " + admins.name + ": " + admins.members.length + " users",
 };
 const testers_pill = {
     group_id: testers.id,
     group_name: testers.name,
     type: "user_group",
-    display_value: testers.name + ": " + testers.members.length + " users",
+    display_value: "translated HTML: " + testers.name + ": " + testers.members.length + " users",
 };
 const everyone_pill = {
     group_id: everyone.id,
@@ -47,7 +47,7 @@ const everyone_pill = {
     // While we can programmatically set the user count below,
     // calculating it would almost mimic the entire display function
     // here, reducing the usefulness of the test.
-    display_value: "translated: Everyone: 5 users",
+    display_value: "translated HTML: translated: Everyone: 5 users",
 };
 
 const groups = [admins, testers, everyone];

--- a/web/tests/user_groups.test.js
+++ b/web/tests/user_groups.test.js
@@ -190,6 +190,66 @@ run_test("get_recursive_subgroups", () => {
     assert.deepEqual(user_groups.get_recursive_subgroups(test), undefined);
 });
 
+run_test("get_recursive_group_members", () => {
+    const admins = {
+        name: "Admins",
+        description: "foo",
+        id: 1,
+        members: new Set([1]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([4]),
+    };
+    const all = {
+        name: "Everyone",
+        id: 2,
+        members: new Set([2, 3]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([1, 3]),
+    };
+    const test = {
+        name: "Test",
+        id: 3,
+        members: new Set([3, 4, 5]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([2]),
+    };
+    const foo = {
+        name: "Foo",
+        id: 4,
+        members: new Set([6, 7]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([]),
+    };
+
+    user_groups.add(admins);
+    user_groups.add(all);
+    user_groups.add(test);
+    user_groups.add(foo);
+
+    // This test setup has a state that won't appear in real data: Groups 2 and 3
+    // each contain the other. We test this corner case because it is a simple way
+    // to verify whether our algorithm correctly avoids visiting groups multiple times
+    // when determining recursive subgroups.
+    // A test case that can occur in practice and would be problematic without this
+    // optimization is a tree where each layer connects to every node in the next layer.
+    assert.deepEqual([...user_groups.get_recursive_group_members(admins)].sort(), [1, 6, 7]);
+    assert.deepEqual(
+        [...user_groups.get_recursive_group_members(all)].sort(),
+        [1, 2, 3, 4, 5, 6, 7],
+    );
+    assert.deepEqual(
+        [...user_groups.get_recursive_group_members(test)].sort(),
+        [1, 2, 3, 4, 5, 6, 7],
+    );
+    assert.deepEqual([...user_groups.get_recursive_group_members(foo)].sort(), [6, 7]);
+
+    user_groups.add_subgroups(foo.id, [9999]);
+    const foo_group = user_groups.get_user_group_from_id(foo.id);
+    blueslip.expect("error", "Could not find subgroup", 2);
+    assert.deepEqual([...user_groups.get_recursive_group_members(foo_group)].sort(), [6, 7]);
+    assert.deepEqual([...user_groups.get_recursive_group_members(test)].sort(), [3, 4, 5]);
+});
+
 run_test("is_user_in_group", () => {
     const admins = {
         name: "Admins",

--- a/web/tests/user_groups.test.js
+++ b/web/tests/user_groups.test.js
@@ -470,3 +470,24 @@ run_test("get_realm_user_groups_for_dropdown_list_widget", () => {
         },
     );
 });
+
+run_test("get_display_group_name", () => {
+    const admins = {
+        name: "Admins",
+        description: "foo",
+        id: 1,
+        members: new Set([1]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([4]),
+    };
+    const all = {
+        name: "role:everyone",
+        id: 2,
+        members: new Set([2, 3]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([1]),
+    };
+
+    assert.equal(user_groups.get_display_group_name(admins), "Admins");
+    assert.equal(user_groups.get_display_group_name(all), "translated: Everyone");
+});


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #30690 . This PR implements the second remaining part of #30690.

Changes in addition to the original issue description:

1. For the user group popover, the `group settings` link is not shown for system groups after this PR since they are immutable.
2. For user group popover, it only showed the direct members of the group before this PR. Now, we should all members of a group including subgroup members. This will change the behaviour everywhere where the user group popover is being used, but since that might the desired behaviour, that shouldn't be an issue hopefully.
3. User group pill did not count subgroup members as part of its count before, now it does. This will affect all user group pills, but since that might be the desired behaviour, that shouldn't be an issue hopefully.

For system groups, the directive is that we should use the description as the display name. But in case of `role:everyone`, the description is `Admins, moderators, members and guests`, while for the `user_group_pill`, we want to display a simpler and succinct message: `Everyone`. We've only hardcoded this for user_group_pill since we don't want to display the name as `Everyone` anywhere else yet.

`Everyone` cannot be searched on the typeahead and only way to add it is to click the `Add all users` button.

On the technical side, please refer to the commit messages and the PR comments for more details.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="730" alt="Screenshot 2024-07-09 at 7 02 41 PM" src="https://github.com/zulip/zulip/assets/13910561/03fd86c7-a28a-424a-a125-3764a5e66c75">

<details>
<summary> Everyone user group popover (no settings link) </summary>
<img width="461" alt="Screenshot 2024-07-09 at 7 25 28 PM" src="https://github.com/zulip/zulip/assets/13910561/ed543571-0138-408f-942d-8ea32a9a4752">


</details>

<details>
<summary> Non system user group popover (settings link is present) </summary>
<img width="731" alt="Screenshot 2024-07-09 at 7 25 45 PM" src="https://github.com/zulip/zulip/assets/13910561/2a495edd-0251-40df-85e0-31032bdaccbc">


</details>

<details>
<summary> All users popover with deactivated users (12 instead of the usual 16 users) </summary>

<img width="412" alt="Screenshot 2024-07-11 at 4 22 54 PM" src="https://github.com/zulip/zulip/assets/13910561/6c41d9b9-0ecc-4423-b729-51bc89c397eb">


</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
