### PR TITLE
auth: Migrate to @typed_endpoint.

### DIFF
--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -324,7 +324,7 @@ def has_request_variables(
 ) -> Callable[Concatenate[HttpRequest, ParamT], ReturnT]:
     num_params = req_func.__code__.co_argcount
     default_param_values = cast(FunctionType, req_func).__defaults__
-    if default_param_values is None:
+    if default_param_values is None:  # nocoverage # No users of this path.
         default_param_values = ()
     num_default_params = len(default_param_values)
     default_param_names = req_func.__code__.co_varnames[num_params - num_default_params :]
@@ -392,7 +392,7 @@ def has_request_variables(
                     if req_var in request.POST:
                         val = request.POST[req_var]
                         request_notes.processed_parameters.add(req_var)
-                    elif req_var in request.GET:
+                    elif req_var in request.GET:  # nocoverage # No users of this path
                         val = request.GET[req_var]
                         request_notes.processed_parameters.add(req_var)
                     else:


### PR DESCRIPTION
migrate the following endpoints from `@has_request_variables` to `@typed_endpoint` :

- `remote_user_sso()`
- `get_email_and_realm_from_jwt_authentication_request()`
- `remote_user_jwt()`
- `oauth_redirect_to_root()`
- `login_page()`
- `jwt_fetch_api_key()`
- `api_fetch_api_key()`
- `json_fetch_api_key()`
