### PR TITLE
typeahead: Rename huddle_message in the analytics to group_direct_mes…

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -259,21 +259,21 @@ class Command(ZulipBaseCommand):
         user_data = {
             "public_stream": self.generate_fixture_data(stat, 1.5, 1, 3, 0.6, 8),
             "private_message": self.generate_fixture_data(stat, 0.5, 0.3, 1, 0.6, 8),
-            "huddle_message": self.generate_fixture_data(stat, 0.2, 0.2, 2, 0.6, 8),
+            "group_direct_message": self.generate_fixture_data(stat, 0.2, 0.2, 2, 0.6, 8),
         }
         insert_fixture_data(stat, user_data, UserCount)
         realm_data = {
             "public_stream": self.generate_fixture_data(stat, 30, 8, 5, 0.6, 4),
             "private_stream": self.generate_fixture_data(stat, 7, 7, 5, 0.6, 4),
             "private_message": self.generate_fixture_data(stat, 13, 5, 5, 0.6, 4),
-            "huddle_message": self.generate_fixture_data(stat, 6, 3, 3, 0.6, 4),
+            "group_direct_message": self.generate_fixture_data(stat, 6, 3, 3, 0.6, 4),
         }
         insert_fixture_data(stat, realm_data, RealmCount)
         installation_data = {
             "public_stream": self.generate_fixture_data(stat, 300, 80, 5, 0.6, 4),
             "private_stream": self.generate_fixture_data(stat, 70, 70, 5, 0.6, 4),
             "private_message": self.generate_fixture_data(stat, 130, 50, 5, 0.6, 4),
-            "huddle_message": self.generate_fixture_data(stat, 60, 30, 3, 0.6, 4),
+            "group_direct_message": self.generate_fixture_data(stat, 60, 30, 3, 0.6, 4),
         }
         insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(


### PR DESCRIPTION
Title: Rename huddle_message to group_direct_message in analytics

Description:
This PR renames the huddle_message references in the analytics system to group_direct_message for consistency and clarity.

Fixes: #30771


<details>
<summary>No UI changes, screenshots not applicable.</summary>
</details>
<details>
<summary>Self-review checklist</summary>

 Self-reviewed: Ensured all changes are clear and maintainable.

 Explains differences from previous plans: (If applicable)

 Highlights technical choices and bugs encountered: (If applicable)

 Calls out remaining decisions and concerns: (If applicable)

 Automated tests verify logic where appropriate: (Describe testing details if relevant)

 Individual commits are ready for review: Each commit is a coherent idea.

 Commit message(s) explain reasoning and motivation for changes: Clear explanations provided.

 Completed manual review and testing of the following:

 Visual appearance of the changes (N/A)

 Responsiveness and internationalization (N/A)

 Strings and tooltips (N/A)

 End-to-end functionality of buttons, interactions and flows (N/A)

 Corner cases, error conditions, and easily imagined bugs (N/A)

</details>