### PR TITLE
help: Document channel feed and new channel link setting.

### DIFF
--- a/help/channel-feed.md
+++ b/help/channel-feed.md
@@ -1,0 +1,34 @@
+# Channel feed
+
+The **Channel feed** is a feed of all the topics that you have not
+[muted](/help/mute-a-topic) in a particular channel. It's a great way to get a
+quick overview of recent messages in a channel.
+
+## Go to channel feed
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{!channel-actions.md!}
+
+1. Click **Go to channel feed**. If you do not see this option, Zulip is
+   [configured](#configure-where-channel-links-in-the-left-sidebar-go) so that
+   clicking on the channel name in the left sidebar will take you directly to
+   the channel feed.
+
+!!! keyboard_tip ""
+
+    Use <kbd>S</kbd> to go from a topic view to the channel feed.
+
+{end_tabs}
+
+## Configure where channel links in the left sidebar go
+
+{!configure-channel-links.md!}
+
+## Related articles
+
+* [Combined feed](/help/combined-feed)
+* [Reading strategies](/help/reading-strategies)
+* [Reading conversations](/help/reading-conversations)

--- a/help/combined-feed.md
+++ b/help/combined-feed.md
@@ -10,8 +10,11 @@
 
 
 ## Related articles
+
 * [Reading strategies](/help/reading-strategies)
 * [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
 * [Configure home view](/help/configure-home-view)
 * [Reading conversations](/help/reading-conversations)
+* [Channel feed](/help/channel-feed)
+

--- a/help/include/configure-channel-links.md
+++ b/help/include/configure-channel-links.md
@@ -1,0 +1,14 @@
+You can configure whether channel links in the [left
+sidebar](/help/left-sidebar) go to the channel feed, or to the top topic in the
+channel.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|preferences}
+
+1. Under **Advanced**, select your preferred option from the
+   **Channel links in the left sidebar go to** dropdown.
+
+{end_tabs}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -97,6 +97,7 @@
 * [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
 * [Combined feed](/help/combined-feed)
+* [Channel feed](/help/channel-feed)
 * [Left sidebar](/help/left-sidebar)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -94,7 +94,7 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Go to topic or DM conversation**: <kbd>S</kbd>
 
-* **Go to channel from topic view**: <kbd>S</kbd>
+* **Go to channel feed from topic view**: <kbd>S</kbd>
 
 * **Go to your direct message feed**: <kbd>Shift</kbd> + <kbd>P</kbd>
 

--- a/help/left-sidebar.md
+++ b/help/left-sidebar.md
@@ -17,6 +17,9 @@ section by:
 - [Configuring](/help/manage-inactive-channels) whether inactive channels are
   sorted at the bottom.
 
+You can also [configure](#configure-where-channel-links-in-the-left-sidebar-go)
+where clicking on channel links in the left sidebar takes you.
+
 ## Adjust what information is shown
 
 There are many ways you can adjust the left sidebar to help you focus on the
@@ -78,11 +81,16 @@ information you need in the moment.
 
 {end_tabs}
 
+## Configure where channel links in the left sidebar go
+
+{!configure-channel-links.md!}
+
 ## Related articles
 * [Reading strategies](/help/reading-strategies)
 * [Configuring unread message counters](/help/configure-unread-message-counters)
 * [Inbox](/help/inbox)
 * [Recent conversations](/help/recent-conversations)
 * [Combined feed](/help/combined-feed)
+* [Channel feed](/help/channel-feed)
 * [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -144,7 +144,7 @@
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to channel from topic view' }}</td>
+                    <td class="definition">{{t 'Go to channel feed from topic view' }}</td>
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>


### PR DESCRIPTION
**1st commit:**
<details>
<summary>
Channel -> channel feed in keyboard shortcuts docs
</summary>

![Screenshot 2024-07-08 at 15 03 52@2x](https://github.com/zulip/zulip/assets/2090066/c03a3f47-fba5-4629-9177-523dcbccfc0b)

![Screenshot 2024-07-08 at 15 05 56@2x](https://github.com/zulip/zulip/assets/2090066/3d25087c-4526-45ec-91bc-27cb1e35a286)
</details>

**2nd commit:**
<details>
<summary>
New channel feed page
</summary>

![Screenshot 2024-07-08 at 15 10 47@2x](https://github.com/zulip/zulip/assets/2090066/857b1333-7873-4657-8bae-6d92174a9bd8)
![Screenshot 2024-07-08 at 15 10 33@2x](https://github.com/zulip/zulip/assets/2090066/e57dad88-e5e4-499c-a605-76ca50d7780d)

</details>

**3rd commit:**
Current: https://zulip.com/help/left-sidebar

<details>
<summary>
Left sidebar page
</summary>

![Screenshot 2024-07-08 at 15 13 55@2x](https://github.com/zulip/zulip/assets/2090066/5fdafd8e-714f-4edb-85f1-9ca082296b52)
---

![Screenshot 2024-07-08 at 15 14 21@2x](https://github.com/zulip/zulip/assets/2090066/845223f6-5df0-4205-b2f5-762830b4798e)

</details>