### PR TITLE
info_overlay: Render poll widget header without font size reduction.

### DIFF
--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -166,7 +166,7 @@ Tea
 Coffee`,
         output_html: `\
 <div class="poll-widget">
-    <h4 class="poll-question-header reduced-font-size">What did you drink this morning?</h4>
+    <h4 class="poll-question-header">What did you drink this morning?</h4>
     <i class="fa fa-pencil poll-edit-question"></i>
     <ul class="poll-widget">
     <li>

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -99,11 +99,6 @@
     & h4 {
         font-size: 18px;
         font-weight: 600;
-
-        /* for example in help `?` widget */
-        &.reduced-font-size {
-            font-size: 16px;
-        }
     }
 
     & li {


### PR DESCRIPTION
Since we more space now in info overlay after recent width increase and 40 / 60 split between columns, we have the space to show the poll header at its normal font size of `18px` without making it wrap to the next line at even medium width.

14px

| before | after |
| --- | --- |
| <img width="674" alt="Screenshot 2024-07-09 at 11 24 26 AM" src="https://github.com/zulip/zulip/assets/25124304/2c75c6f7-eba5-4ee5-a36f-0b9df1aa9e55"> | <img width="749" alt="Screenshot 2024-07-09 at 11 20 04 AM" src="https://github.com/zulip/zulip/assets/25124304/5744834b-dd61-4c8c-bd68-afb748e6ae81"> |

16px


| before | after |
| --- | --- |
| <img width="775" alt="Screenshot 2024-07-09 at 11 20 30 AM" src="https://github.com/zulip/zulip/assets/25124304/db7ed414-29bc-4e2e-a78d-e712d2da46b3"> | <img width="846" alt="Screenshot 2024-07-09 at 11 25 01 AM" src="https://github.com/zulip/zulip/assets/25124304/ecae5a79-27b9-45df-b227-32739eef279a"> |


Fixes this point in #30476

```quote
There’s a .reduced-font-size class on h4 in widgets.css that has a hard-coded value; that’s not shared with Today’s tasks (also in legacy)
```
