### PR TITLE
Change inconsistent tooltip for topic menu option.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -436,6 +436,7 @@ function format_topic(
         is_topic: true,
         stream_id,
         topic_name: topic,
+        stream_name: stream_data.get_stream_name_from_id(stream_id),
         unread_count: topic_unread_count,
         conversation_key: get_topic_key(stream_id, topic),
         topic_url: hash_util.by_stream_topic_url(stream_id, topic),

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -292,6 +292,7 @@ function populate_group_from_message_container(group, message_container) {
         } else {
             group.stream_id = sub.stream_id;
         }
+        group.stream_name = stream_data.get_stream_name_from_id(sub.stream_id);
         group.is_subscribed = stream_data.is_subscribed(group.stream_id);
         group.topic_is_resolved = resolved_topic.is_resolved(group.topic);
         group.visibility_policy = user_topics.get_topic_visibility_policy(

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -11,6 +11,7 @@ import {$t} from "./i18n";
 import * as people from "./people";
 import * as popovers from "./popovers";
 import * as settings_config from "./settings_config";
+import * as stream_data from "./stream_data";
 import * as ui_util from "./ui_util";
 import {user_settings} from "./user_settings";
 
@@ -83,11 +84,27 @@ export const topic_visibility_policy_tooltip_props = {
     appendTo: () => document.body,
     onShow(instance: tippy.Instance) {
         const $elem = $(instance.reference);
-        const current_visibility_policy_str = $elem.attr("data-tippy-content");
+        let should_render_privacy_icon;
+        let current_visibility_policy_str;
+        if ($elem.hasClass("zulip-icon-inherit")) {
+            should_render_privacy_icon = true;
+        } else {
+            should_render_privacy_icon = false;
+            current_visibility_policy_str = $elem.attr("data-tippy-content");
+        }
+        let current_stream_obj;
+        if (should_render_privacy_icon) {
+            current_stream_obj = stream_data.get_sub_by_id(
+                Number($elem.parent().attr("data-stream-id")),
+            );
+        }
+        const tooltip_context = {
+            ...current_stream_obj,
+            current_visibility_policy_str,
+            should_render_privacy_icon,
+        };
         instance.setContent(
-            ui_util.parse_html(
-                render_change_visibility_policy_button_tooltip({current_visibility_policy_str}),
-            ),
+            ui_util.parse_html(render_change_visibility_policy_button_tooltip(tooltip_context)),
         );
     },
     onHidden(instance: tippy.Instance) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -786,7 +786,25 @@ strong {
 }
 
 #change_visibility_policy_button_tooltip {
-    text-align: center;
+    text-align: left;
+
+    .tooltip-privacy-icon {
+        position: relative;
+        display: inline-block;
+    }
+
+    .tooltip-privacy-icon .zulip-icon-lock {
+        margin-top: -0.15em !important;
+    }
+
+    .tooltip-privacy-icon i {
+        position: absolute;
+        top: 0.1667em;
+    }
+
+    .tooltip-privacy-icon span {
+        margin-left: 1.25em;
+    }
 }
 
 .narrow-filter {

--- a/web/templates/change_visibility_policy_button_tooltip.hbs
+++ b/web/templates/change_visibility_policy_button_tooltip.hbs
@@ -1,4 +1,15 @@
 <div id="change_visibility_policy_button_tooltip">
     <strong>{{t 'Configure topic notifications' }}</strong>
-    <div class="tooltip-inner-content italic">{{current_visibility_policy_str}}</div>
+    <div class="tooltip-inner-content italic">
+        <span>
+            {{#if should_render_privacy_icon}}
+                {{#tr}}
+                    Notifications are based on your configuration for <z-stream-name></z-stream-name>.
+                    {{#*inline "z-stream-name"}}<span class="tooltip-privacy-icon">{{> stream_privacy }}<span>{{name}}</span></span>{{/inline}}
+                {{/tr}}
+            {{else}}
+                {{current_visibility_policy_str}}
+            {{/if}}
+        </span>
+    </div>
 </div>

--- a/web/templates/change_visibility_policy_button_tooltip.hbs
+++ b/web/templates/change_visibility_policy_button_tooltip.hbs
@@ -1,4 +1,4 @@
 <div id="change_visibility_policy_button_tooltip">
-    <strong>{{current_visibility_policy_str}}</strong>
-    <div class="tooltip-inner-content italic">{{t 'Click to change notifications for this topic.' }}</div>
+    <strong>{{t 'Configure topic notifications' }}</strong>
+    <div class="tooltip-inner-content italic">{{current_visibility_policy_str}}</div>
 </div>

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -50,17 +50,17 @@
                         <span class="visibility-policy-indicator change_visibility_policy hidden-for-spectators{{#if (eq visibility_policy all_visibility_policies.INHERIT)}} inbox-row-visibility-policy-inherit{{/if}}"
                           data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}" tabindex="0" data-col-index="{{ column_indexes.TOPIC_VISIBILITY }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
-                                <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
+                                <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic.'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
                             {{else if (eq visibility_policy all_visibility_policies.UNMUTED)}}
-                                <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic'}}"
+                                <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic.'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You have unmuted this topic' }}"></i>
                             {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
-                                <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic'}}"
+                                <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
                             {{else if (eq visibility_policy all_visibility_policies.INHERIT)}}
-                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'Default'}}"
-                                  role="button" aria-haspopup="true" aria-label="{{t 'Default' }}"></i>
+                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic.'}}"
+                                  role="button" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
                             {{/if}}
                         </span>
                     {{/if}}

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -59,8 +59,8 @@
                                 <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
                                   role="button" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
                             {{else if (eq visibility_policy all_visibility_policies.INHERIT)}}
-                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic.'}}"
-                                  role="button" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
+                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon"
+                                  role="button" aria-haspopup="true" aria-label="{{t 'Notifications are based on your configuration for #{stream_name}' }}"></i>
                             {{/if}}
                         </span>
                     {{/if}}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -62,16 +62,16 @@
                     <div class="hidden-for-spectators">
                         <span class="recent_view_focusable change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-col-index="{{ column_indexes.mute }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
-                                <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
+                                <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic.'}}"
                                   role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
                             {{else if (eq visibility_policy all_visibility_policies.UNMUTED)}}
-                                <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic'}}"
+                                <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic.'}}"
                                   role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have unmuted this topic' }}"></i>
                             {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
-                                <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic'}}"
+                                <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
                                   role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
                             {{else}}
-                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic'}}"
+                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic.'}}"
                                   role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
                             {{/if}}
                         </span>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -71,8 +71,8 @@
                                 <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
                                   role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
                             {{else}}
-                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic.'}}"
-                                  role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
+                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon"
+                                  role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'Notifications are based on your configuration for #{stream_name}' }}"></i>
                             {{/if}}
                         </span>
                     </div>

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -70,8 +70,8 @@
                         <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
                           role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
                     {{else}}
-                        <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic.'}}"
-                          role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
+                        <i class="zulip-icon zulip-icon-inherit recipient_bar_icon"
+                          role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'Notifications are based on your configuration for #{stream_name}' }}"></i>
                     {{/if}}
                 </span>
             {{/if}}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -61,16 +61,16 @@
             {{#if is_subscribed}}
                 <span class="change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
                     {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
-                        <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic'}}"
+                        <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic.'}}"
                           role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic' }}"></i>
                     {{else if (eq visibility_policy all_visibility_policies.UNMUTED)}}
-                        <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic'}}"
+                        <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic.'}}"
                           role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have unmuted this topic' }}"></i>
                     {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
-                        <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic'}}"
+                        <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
                           role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic' }}"></i>
                     {{else}}
-                        <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic'}}"
+                        <i class="zulip-icon zulip-icon-inherit recipient_bar_icon" data-tippy-content="{{t 'You will get default notifications for this topic.'}}"
                           role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You will get default notifications for this topic' }}"></i>
                     {{/if}}
                 </span>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -12,7 +12,7 @@
                     @
                 </span>
             {{else if is_followed}}
-                <i class="zulip-icon zulip-icon-follow visibility-policy-icon" role="button" aria-hidden="true" data-tippy-content="{{t 'You follow this topic'}}"></i>
+                <i class="zulip-icon zulip-icon-follow visibility-policy-icon" role="button" aria-hidden="true" data-tippy-content="{{t 'You follow this topic.'}}"></i>
             {{/if}}
             <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
                 {{unread}}


### PR DESCRIPTION
Earlier tooltips for topic menu button had inconsistent context with that of other tooltips. In topic menu tooltip, action was described in first line which different from that of other tooltips.

This PR changes the tooltip context and rearranges them to match the format of action on first line and more context on second line.

<!-- Describe your pull request here.-->

Fixes: [czo](https://chat.zulip.org/#narrow/stream/101-design/topic/follow.20topic.20menu.20tooltips)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-07-13 02-21-52](https://github.com/user-attachments/assets/5ad00ede-075b-4ec5-90b5-1bd2840fc171)

![Screenshot from 2024-07-13 02-22-09](https://github.com/user-attachments/assets/141d0061-cc2b-44f7-abf7-801e30701292)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
