### PR TITLE
integration-docs: Update for new format (Wekan, Wordpress).

### DIFF
--- a/zerver/webhooks/wekan/doc.md
+++ b/zerver/webhooks/wekan/doc.md
@@ -1,18 +1,29 @@
+# Zulip Wekan integration
+
 Get Wekan notifications in Zulip!
+
+{start_tabs}
 
 1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-integration-url.md!}
+1. {!generate-webhook-url-basic.md!}
 
-    {!git-webhook-url-with-branches.md!}
+1. Go to Wekan, click the **Settings** icon, and select **Outgoing Webhooks**.
 
-1. Go to Wekan and click on the **Settings** icon.
-   Select **Outgoing Webhooks**.
+1. Set **URL** to the URL generated above, and click **Add Webhook**.
 
-1. Set **URL** to the URL constructed above and click **Add Webhook**.
+{end_tabs}
 
 {!congrats.md!}
 
 ![](/static/images/integrations/wekan/001.png)
+
+### Configuration options
+
+{!git-branches-additional-feature.md!}
+
+### Related documentation
+
+{!webhooks-url-specification.md!}

--- a/zerver/webhooks/wordpress/doc.md
+++ b/zerver/webhooks/wordpress/doc.md
@@ -1,33 +1,37 @@
+# Zulip WordPress integration
+
 Get WordPress notifications in Zulip!
 
-If you're hosting your WordPress blog yourself (i.e., not on WordPress.com),
-first install the
-[HookPress plugin](https://wordpress.org/plugins/hookpress/) (experimental).
+{start_tabs}
 
 1. {!create-channel.md!}
 
 1. {!create-an-incoming-webhook.md!}
 
-1. {!generate-integration-url.md!}
+1. {!generate-webhook-url-basic.md!}
 
-    **Important:** The HookPress plugin requires URL parameters to
-    be delimited by semicolons instead of ampersands. If you have a
-    self-hosted blog, replace every `&` with `;` in the URL above.
+1. Add `/wp-admin/options-general.php?page=webhooks` to the end of your
+   WordPress URL, and navigate to the site. Click **Add webhook**.
 
-1. Go to
-   `https://YOUR-WORDPRESS-BLOG/wp-admin/options-general.php?page=webhooks`,
-   after replacing `YOUR-WORDPRESS-BLOG` appropriately. Click **Add webhook**.
+1. Select an **Action** from the [supported
+   events](#filtering-incoming-events) that you'd like to be notified
+   about, along with these corresponding **Fields**: `post_title`,
+   `post_type`, and `post_url`.
 
-1. Select the **Action** that you'd like to be notified about, along with
-   the corresponding **Fields**. The list of currently supported actions is:
+1. Set **URL** to the URL generated above, and click **Add new webhook**.
 
-    * **publish_post**: Use fields *post_title*, *post_type*, and *post_url*
-    * **publish_page**: Use fields *post_title*, *post_type*, and *post_url*
-    * **user_register**: Use fields *display_name* and *user_email* (available on self-hosted blogs only)
-    * **wp_login**: Use field *user_login* (available on self-hosted blogs only)
-
-1. Set **URL** to the URL constructed above, and click **Add new webhook**.
+{end_tabs}
 
 {!congrats.md!}
 
 ![](/static/images/integrations/wordpress/wordpress_post_created.png)
+
+{!event-filtering-additional-feature.md!}
+
+### Related documentation
+
+- [WordPress webhooks documentation][1]
+
+{!webhooks-url-specification.md!}
+
+[1]: https://wordpress.com/support/webhooks/

--- a/zerver/webhooks/wordpress/fixtures/user_register.txt
+++ b/zerver/webhooks/wordpress/fixtures/user_register.txt
@@ -1,1 +1,0 @@
-stream=wordpress&topic=New%20Blog%20Users&post_type=post&hook=user_register&display_name=test_user&user_email=test_user@example.com

--- a/zerver/webhooks/wordpress/fixtures/wp_login.txt
+++ b/zerver/webhooks/wordpress/fixtures/wp_login.txt
@@ -1,1 +1,0 @@
-stream=wordpress&user_login=testuser&hook=wp_login&topic=New%20Login

--- a/zerver/webhooks/wordpress/tests.py
+++ b/zerver/webhooks/wordpress/tests.py
@@ -31,7 +31,7 @@ class WordPressHookTests(WebhookTestCase):
         )
 
     def test_publish_post_no_data_provided(self) -> None:
-        # Note: the fixture includes 'hook=publish_post' because it's always added by HookPress
+        # If the user forgot to configure the fields for the action in WordPress.
         expected_topic_name = "WordPress notification"
         expected_message = "New post published:\n* [New WordPress post](WordPress post URL)"
 
@@ -48,30 +48,6 @@ class WordPressHookTests(WebhookTestCase):
 
         self.check_webhook(
             "publish_page",
-            expected_topic_name,
-            expected_message,
-            content_type="application/x-www-form-urlencoded",
-        )
-
-    def test_user_register(self) -> None:
-        expected_topic_name = "New Blog Users"
-        expected_message = (
-            "New blog user registered:\n* **Name**: test_user\n* **Email**: test_user@example.com"
-        )
-
-        self.check_webhook(
-            "user_register",
-            expected_topic_name,
-            expected_message,
-            content_type="application/x-www-form-urlencoded",
-        )
-
-    def test_wp_login(self) -> None:
-        expected_topic_name = "New Login"
-        expected_message = "User testuser logged in."
-
-        self.check_webhook(
-            "wp_login",
             expected_topic_name,
             expected_message,
             content_type="application/x-www-form-urlencoded",

--- a/zerver/webhooks/wordpress/view.py
+++ b/zerver/webhooks/wordpress/view.py
@@ -13,17 +13,9 @@ PUBLISH_POST_OR_PAGE_TEMPLATE = """
 New {type} published:
 * [{title}]({url})
 """.strip()
-USER_REGISTER_TEMPLATE = """
-New blog user registered:
-* **Name**: {name}
-* **Email**: {email}
-""".strip()
-WP_LOGIN_TEMPLATE = "User {name} logged in."
 ALL_EVENT_TYPES = [
     "publish_post",
     "publish_page",
-    "user_register",
-    "wp_login",
 ]
 
 
@@ -37,22 +29,12 @@ def api_wordpress_webhook(
     post_title: str = "New WordPress post",
     post_type: str = "post",
     post_url: str = "WordPress post URL",
-    display_name: str = "New user name",
-    user_email: str = "New user email",
-    user_login: str = "Logged in user",
 ) -> HttpResponse:
     # remove trailing whitespace (issue for some test fixtures)
     hook = hook.rstrip()
 
     if hook in ("publish_post", "publish_page"):
         data = PUBLISH_POST_OR_PAGE_TEMPLATE.format(type=post_type, title=post_title, url=post_url)
-
-    elif hook == "user_register":
-        data = USER_REGISTER_TEMPLATE.format(name=display_name, email=user_email)
-
-    elif hook == "wp_login":
-        data = WP_LOGIN_TEMPLATE.format(name=user_login)
-
     else:
         raise JsonableError(_("Unknown WordPress webhook action: {hook}").format(hook=hook))
 


### PR DESCRIPTION
Apply integration-docs' new format for Wekan and Wordpress.

Fixes part of https://github.com/zulip/zulip/issues/29592.

Updates the following integration documentation pages:

**Screenshots and screen captures:**


<details>
<summary>Wekan</summary>

[Doc link](https://zulip.com/integrations/doc/wekan)
![image](https://github.com/zulip/zulip/assets/20315308/854358cf-0a0b-4042-bc0e-135f4fab5fdb)
</details>


<details>
<summary>Wordpress</summary>

[Doc link](https://zulip.com/integrations/doc/wordpress)
![image](https://github.com/user-attachments/assets/8ad8d07b-197a-4eff-b5e1-253d0c6e7fcb)
</details>



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
