### PR TITLE
Fix incorrect user count in sidebar with bot as recipient.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -36,11 +36,12 @@ function get_formatted_sub_count(sub_count: number): string {
     );
 }
 
-function total_subscriber_count(
+function get_total_human_subscriber_count(
     current_sub: StreamSubscription | undefined,
     pm_ids_set: Set<number>,
 ): number {
-    // Includes inactive users who might not show up in the buddy list.
+    // Excludes human users, but may include long-inactive users who
+    // might not show up in the buddy list.
     if (current_sub) {
         return peer_data.get_subscriber_count(current_sub.stream_id, false);
     } else if (pm_ids_set.size) {
@@ -82,7 +83,7 @@ function get_render_data(): BuddyListRenderData {
     const current_sub = narrow_state.stream_sub();
     const pm_ids_set = narrow_state.pm_ids_set();
 
-    const total_human_subscribers_count = total_subscriber_count(current_sub, pm_ids_set);
+    const total_human_subscribers_count = get_total_human_subscriber_count(current_sub, pm_ids_set);
     const total_human_users = people.get_active_human_count();
     const other_users_count = total_human_users - total_human_subscribers_count;
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
@@ -192,7 +193,7 @@ export class BuddyList extends BuddyListConf {
                         let tooltip_text;
                         const current_sub = narrow_state.stream_sub();
                         const pm_ids_set = narrow_state.pm_ids_set();
-                        const total_human_subscribers_count = total_subscriber_count(
+                        const total_human_subscribers_count = get_total_human_subscriber_count(
                             current_sub,
                             pm_ids_set,
                         );

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -44,6 +44,7 @@ function total_subscriber_count(
         return peer_data.get_subscriber_count(current_sub.stream_id, false);
     } else if (pm_ids_set.size) {
         const pm_ids_list = [...pm_ids_set];
+        let bot_count = 0;
         // Plus one for the "me" user, who isn't in the recipients list (except
         // for when it's a private message conversation with only "me" in it).
         if (
@@ -53,7 +54,13 @@ function total_subscriber_count(
         ) {
             return 1;
         }
-        return pm_ids_list.length + 1;
+
+        for (const pm_id of pm_ids_list) {
+            if (people.is_valid_bot_user(pm_id)) {
+                bot_count += 1;
+            }
+        }
+        return pm_ids_list.length - bot_count + 1;
     }
     return 0;
 }
@@ -71,9 +78,9 @@ function should_hide_headers(
 type BuddyListRenderData = {
     current_sub: StreamSubscription | undefined;
     pm_ids_set: Set<number>;
-    subscriber_count: number;
+    total_human_subscribers_count: number;
     other_users_count: number;
-    total_user_count: number;
+    total_human_users: number;
     hide_headers: boolean;
 };
 
@@ -81,17 +88,17 @@ function get_render_data(): BuddyListRenderData {
     const current_sub = narrow_state.stream_sub();
     const pm_ids_set = narrow_state.pm_ids_set();
 
-    const subscriber_count = total_subscriber_count(current_sub, pm_ids_set);
-    const total_user_count = people.get_active_human_count();
-    const other_users_count = total_user_count - subscriber_count;
+    const total_human_subscribers_count = total_subscriber_count(current_sub, pm_ids_set);
+    const total_human_users = people.get_active_human_count();
+    const other_users_count = total_human_users - total_human_subscribers_count;
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
 
     return {
         current_sub,
         pm_ids_set,
-        subscriber_count,
+        total_human_subscribers_count,
         other_users_count,
-        total_user_count,
+        total_human_users,
         hide_headers,
     };
 }
@@ -191,7 +198,10 @@ export class BuddyList extends BuddyListConf {
                         let tooltip_text;
                         const current_sub = narrow_state.stream_sub();
                         const pm_ids_set = narrow_state.pm_ids_set();
-                        const subscriber_count = total_subscriber_count(current_sub, pm_ids_set);
+                        const total_human_subscribers_count = total_subscriber_count(
+                            current_sub,
+                            pm_ids_set,
+                        );
                         const elem_id = $elem.attr("id");
                         if (elem_id === "buddy-list-users-matching-view-section-heading") {
                             if (current_sub) {
@@ -200,7 +210,7 @@ export class BuddyList extends BuddyListConf {
                                         defaultMessage:
                                             "{N, plural, one {# subscriber} other {# subscribers}}",
                                     },
-                                    {N: subscriber_count},
+                                    {N: total_human_subscribers_count},
                                 );
                             } else {
                                 tooltip_text = $t(
@@ -208,12 +218,13 @@ export class BuddyList extends BuddyListConf {
                                         defaultMessage:
                                             "{N, plural, one {# participant} other {# participants}}",
                                     },
-                                    {N: subscriber_count},
+                                    {N: total_human_subscribers_count},
                                 );
                             }
                         } else {
-                            const total_user_count = people.get_active_human_count();
-                            const other_users_count = total_user_count - subscriber_count;
+                            const total_human_users = people.get_active_human_count();
+                            const other_users_count =
+                                total_human_users - total_human_subscribers_count;
                             tooltip_text = $t(
                                 {
                                     defaultMessage:
@@ -270,9 +281,9 @@ export class BuddyList extends BuddyListConf {
     }
 
     update_empty_list_placeholders(): void {
-        const {subscriber_count, other_users_count} = this.render_data;
+        const {total_human_subscribers_count, other_users_count} = this.render_data;
         const has_inactive_users_matching_view =
-            subscriber_count > this.users_matching_view_ids.length;
+            total_human_subscribers_count > this.users_matching_view_ids.length;
         const has_inactive_other_users = other_users_count > this.other_user_ids.length;
 
         let matching_view_empty_list_message;
@@ -319,8 +330,13 @@ export class BuddyList extends BuddyListConf {
     }
 
     render_section_headers(): void {
-        const {current_sub, subscriber_count, other_users_count, total_user_count, hide_headers} =
-            this.render_data;
+        const {
+            current_sub,
+            total_human_subscribers_count,
+            other_users_count,
+            total_human_users,
+            hide_headers,
+        } = this.render_data;
         $("#buddy-list-users-matching-view-container .buddy-list-subsection-header").empty();
         $("#buddy-list-other-users-container .buddy-list-subsection-header").empty();
 
@@ -330,7 +346,7 @@ export class BuddyList extends BuddyListConf {
         // those headers then we show the total user count in the main title.
         const default_userlist_title = $t({defaultMessage: "USERS"});
         if (hide_headers) {
-            const formatted_count = get_formatted_sub_count(total_user_count);
+            const formatted_count = get_formatted_sub_count(total_human_users);
             const userlist_title = `${default_userlist_title} (${formatted_count})`;
             $("#userlist-title").text(userlist_title);
             return;
@@ -349,7 +365,7 @@ export class BuddyList extends BuddyListConf {
                 render_section_header({
                     id: "buddy-list-users-matching-view-section-heading",
                     header_text,
-                    user_count: get_formatted_sub_count(subscriber_count),
+                    user_count: get_formatted_sub_count(total_human_subscribers_count),
                     toggle_class: "toggle-users-matching-view",
                     is_collapsed: this.users_matching_view_is_collapsed,
                 }),
@@ -474,9 +490,9 @@ export class BuddyList extends BuddyListConf {
     }
 
     render_view_user_list_links(): void {
-        const {current_sub, subscriber_count, other_users_count} = this.render_data;
+        const {current_sub, total_human_subscribers_count, other_users_count} = this.render_data;
         const has_inactive_users_matching_view =
-            subscriber_count > this.users_matching_view_ids.length;
+            total_human_subscribers_count > this.users_matching_view_ids.length;
         const has_inactive_other_users = other_users_count > this.other_user_ids.length;
 
         // For stream views, we show a link at the bottom of the list of subscribed users that


### PR DESCRIPTION
Earlier in right sidebar user count, it would show less user count when a bot was present as a recipient in the conversation. Since the sidebar shows active human users only, user count should not consider bots in the conversation.

This PR fixes the behaviour by adding all the subtracted bots from user count.

<!-- Describe your pull request here.-->

Fixes: [czo](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20incorrect.20user.20counts.20in.20right.20sidebar.20in.20bot.20DMs)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
#### Before:
![Screenshot from 2024-07-09 22-08-51](https://github.com/zulip/zulip/assets/33497322/f4bc498a-b626-42fc-a5c5-04bc3f1311cb)

#### After:
![Screenshot from 2024-07-09 22-08-23](https://github.com/zulip/zulip/assets/33497322/28f0a7f5-1080-4877-b447-fe5810a5a098)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
