### PR TITLE
onboarding: Update introductions to Inbox and Recent conversations.

### DIFF
--- a/web/templates/introduce_zulip_view_modal.hbs
+++ b/web/templates/introduce_zulip_view_modal.hbs
@@ -1,19 +1,11 @@
 <div id="introduce-zulip-view-modal">
     <p>
         {{#if (eq zulip_view "inbox")}}
-            {{#tr}}The <b>inbox</b> view provides an overview of your conversations with unread messages.{{/tr}}
+            {{#tr}}You’ll see a list of <b>conversations</b> where you have <b>unread messages</b>, organized by channel.{{/tr}}
         {{else if (eq zulip_view "recent_conversations")}}
-            {{#tr}}The <b>recent conversations</b> view provides an overview of all the ongoing conversations.{{/tr}}
+            {{#tr}}You’ll see a list of <b>ongoing conversations</b>.{{/tr}}
         {{/if}}
-        {{#tr}}
-            In Zulip, a conversation is either a <z-link-direct-message>direct message</z-link-direct-message>
-            thread, or a <z-link-channel-topic>topic in a channel</z-link-channel-topic>.
-            {{#*inline "z-link-direct-message"}}<a href="/help/direct-messages" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-            {{#*inline "z-link-channel-topic"}}<a href="/help/introduction-to-topics" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-        {{/tr}}
-        {{#if (eq zulip_view "inbox")}}
-            {{t 'The colored bars indicate which channel the conversation is in.' }}
-        {{/if}}
+        {{#tr}}Each conversation is <b>labeled with a topic</b> by the person started it.{{/tr}}
     </p>
     <p>
         {{t 'Click on a conversation to view it. To return here, you can:'}}


### PR DESCRIPTION
- Make more succinct; don't over-describe UI the user can't see yet.
- Remove links (there are help links in view descriptions now).
- Explain where topics come from.

|Before | After |
| --- | --- |
|![Screenshot 2024-07-09 at 14 25 09@2x](https://github.com/zulip/zulip/assets/2090066/354d00f2-4c9e-4842-8727-215e630952b5) | ![Screenshot 2024-07-09 at 14 55 47@2x](https://github.com/zulip/zulip/assets/2090066/b0aecdd8-ac2d-4c18-9477-d71a9994c5bc) |

| ![Screenshot 2024-07-09 at 14 33 53@2x](https://github.com/zulip/zulip/assets/2090066/075e58e0-e00c-42fa-940d-9e8d8170fbc3) | ![Screenshot 2024-07-09 at 14 58 12@2x](https://github.com/zulip/zulip/assets/2090066/e3bd8598-1068-46a2-9cc3-9ba1c6dd651e) |
| --- | --- |


Notes:
- I think it's actually a good feature that the content is basically the same after the first sentence. That means that wherever you end up second, you can stop reading after the first part. 
