### PR TITLE
search: Vertically center search pills in search bar.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -219,8 +219,11 @@
         /* Override style for .pill-container that isn't relevant for search. */
         border: none;
         grid-template:
-            "search-icon search-pills search-close" var(--search-box-height)
-            ". search-pills ." auto / auto minmax(0, 1fr) auto;
+            "search-icon search-pills search-close" minmax(
+                var(--search-box-height),
+                auto
+            )
+            / auto minmax(0, 1fr) auto;
         align-items: start;
         cursor: pointer;
 


### PR DESCRIPTION
before:

<img width="684" alt="image" src="https://github.com/zulip/zulip/assets/5634097/c0c5e4c2-a9bd-4e90-b100-81c62182be0d">

after:

<img width="674" alt="image" src="https://github.com/zulip/zulip/assets/5634097/217cb986-fc05-4946-a29a-f25367bb7c5b">
