### PR TITLE
edit_stream_status: Removed the word channel from the stream_status

### DIFF
--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -10,17 +10,17 @@
                 {{t "This channel has been archived." }}
             {{else if subscribed }}
                 {{#tr}}
-                    You subscribed to channel <z-stream-name></z-stream-name>.
+                    You subscribed to <z-stream-name></z-stream-name>.
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
                 {{/tr}}
             {{else if just_unsubscribed }}
                 {{#tr}}
-                    You unsubscribed from channel <z-stream-name></z-stream-name>.
+                    You unsubscribed from <z-stream-name></z-stream-name>.
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
                 {{/tr}}
             {{else}}
                 {{#tr}}
-                    You are not subscribed to channel <z-stream-name></z-stream-name>.
+                    You are not subscribed to <z-stream-name></z-stream-name>.
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
                 {{/tr}}
             {{/if}}


### PR DESCRIPTION
Description:
This PR removes the word "channel" from the stream status to streamline the messaging and improve clarity. The changes ensure that the status messages are concise and focused.

Fixes: #30803

| Before | After |
|----|-----|
|<img width="617" alt="Screenshot 2024-07-10 at 12 37 36 PM" src="https://github.com/zulip/zulip/assets/113302312/2365c544-85ec-431f-920a-6d933dcb4503">| You unsubscribed from #fsad|
<img width="452" alt="Screenshot 2024-07-10 at 12 40 36 PM" src="https://github.com/zulip/zulip/assets/113302312/0dbb97cc-15af-4a91-91fc-4f67501fbf18"> | You subscribed to #fsad|

The screenshot is not provided for the after because using the localhost (via vagrant ssh) is not giving any log in the new channel. This might be an issue that only I'm facing as I have done some changes in the past for other issues. If this is an issue and I'm able to fix this then I will upload the picture for the after.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
