### PR TITLE
Direct messages code cleanup followups

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -774,13 +774,14 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
 
-        if (!$(e.target).hasClass("direct-messages-list-filter")) {
-            // Avoiding having clicks on the filter input.
-            //
-            // TODO: Refactor to use more precise selectors for this
-            // click handler in general; this is a fragile pattern.
-            window.location.hash = "narrow/is/dm";
-        }
+        window.location.hash = "narrow/is/dm";
+    });
+
+    $("body").on("click", ".direct-messages-list-filter", (e) => {
+        // We don't want clicking on the filter to trigger the DM
+        // narrow defined on click for
+        // `#direct-messages-section-header.zoom-in`.
+        e.stopPropagation();
     });
 
     // disable the draggability for left-sidebar components

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -198,50 +198,50 @@ li.show-more-topics {
     }
 }
 
+#direct-messages-section-header {
+    grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
+    grid-template-rows: var(--line-height-sidebar-row-prominent);
+    /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
+       value and the styles dependent on it so that this kind of
+       1990s layout shenanigans is made unnecessary. */
+    margin-left: -3px;
+    cursor: pointer;
+    white-space: nowrap;
+
+    #toggle-direct-messages-section-icon {
+        grid-area: starting-anchor-element;
+    }
+
+    .left-sidebar-title {
+        grid-area: row-content;
+    }
+
+    .heading-markers-and-controls {
+        grid-area: markers-and-controls;
+        display: flex;
+        gap: 5px;
+        align-items: center;
+    }
+
+    #show-all-direct-messages {
+        width: var(--left-sidebar-header-icon-width);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0.7;
+        text-decoration: none;
+        color: inherit;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+}
+
 .direct-messages-container {
     /* Properly offset all the grid rows
        in the DM section. */
     margin-right: 12px;
-
-    &#direct-messages-section-header {
-        grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
-        grid-template-rows: var(--line-height-sidebar-row-prominent);
-        /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
-           value and the styles dependent on it so that this kind of
-           1990s layout shenanigans is made unnecessary. */
-        margin-left: -3px;
-        cursor: pointer;
-        white-space: nowrap;
-
-        #toggle-direct-messages-section-icon {
-            grid-area: starting-anchor-element;
-        }
-
-        .left-sidebar-title {
-            grid-area: row-content;
-        }
-
-        .heading-markers-and-controls {
-            grid-area: markers-and-controls;
-            display: flex;
-            gap: 5px;
-            align-items: center;
-        }
-
-        #show-all-direct-messages {
-            width: var(--left-sidebar-header-icon-width);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            opacity: 0.7;
-            text-decoration: none;
-            color: inherit;
-
-            &:hover {
-                opacity: 1;
-            }
-        }
-    }
 
     & ul.dm-list {
         list-style-type: none;


### PR DESCRIPTION
<!-- Describe your pull request here.-->

First commit fixes https://github.com/zulip/zulip/pull/30707#discussion_r1669110661.
Second commit fixes https://github.com/zulip/zulip/pull/30332#discussion_r1669198527. 
For the second commit, I considered changing the HTML structure have a selector that will encapsulate all elements of the section header except the filter. But in that case also, we need the DM filter to narrow on click around the edge of the DM list filter in the empty space, which might not happen after changing the HTML structure. I'm not committed to the current approach in the PR, so suggestions are welcome!

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change) |
| -- | -- |
| <img width="285" alt="Screenshot 2024-07-10 at 2 49 48 PM" src="https://github.com/zulip/zulip/assets/13910561/96925503-ed63-467a-8f8e-487fdbd3cfae"> | <img width="285" alt="Screenshot 2024-07-10 at 2 49 17 PM" src="https://github.com/zulip/zulip/assets/13910561/564c45bb-d80f-4a85-a869-6e06506cda50"> |
| <img width="285" alt="Screenshot 2024-07-10 at 2 49 44 PM" src="https://github.com/zulip/zulip/assets/13910561/cf1044d6-b3e3-45ec-aebd-fa4319ccd7b7"> | <img width="285" alt="Screenshot 2024-07-10 at 2 49 23 PM" src="https://github.com/zulip/zulip/assets/13910561/b1bb6cba-8ec3-4def-889b-3b6bc595c1b5">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
