### PR TITLE
user_groups: Add `is_empty_group` function to check for nobody group.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -259,8 +259,7 @@ function get_options_for_recipient_widget(): Option[] {
         name: $t({defaultMessage: "Direct message"}),
     };
 
-    const {name} = user_groups.get_user_group_from_id(realm.realm_direct_message_permission_group);
-    if (name !== "role:nobody") {
+    if (!user_groups.is_empty_group(realm.realm_direct_message_permission_group)) {
         options.unshift(direct_messages_option);
     } else {
         options.push(direct_messages_option);

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -114,10 +114,7 @@ export function needs_subscribe_warning(user_id: number, stream_id: number): boo
 
 export function check_dm_permissions_and_get_error_string(user_ids_string: string): string {
     if (!people.user_can_direct_message(user_ids_string)) {
-        const {name} = user_groups.get_user_group_from_id(
-            realm.realm_direct_message_permission_group,
-        );
-        if (name === "role:nobody") {
+        if (user_groups.is_empty_group(realm.realm_direct_message_permission_group)) {
             return $t({
                 defaultMessage: "Direct messages are disabled in this organization.",
             });

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -370,7 +370,7 @@ function set_create_web_public_stream_dropdown_visibility() {
 }
 
 export function check_disable_direct_message_initiator_group_dropdown(current_value) {
-    if (current_value === user_groups.get_user_group_from_name("role:nobody").id) {
+    if (user_groups.is_empty_group(current_value)) {
         $("#realm_direct_message_initiator_group_widget").prop("disabled", true);
     } else {
         $("#realm_direct_message_initiator_group_widget").prop("disabled", false);


### PR DESCRIPTION
Adds `is_empty_group` function in `user_groups.ts` to check for nobody group and removes hardcoded checks of `"role:nobody"`.
Follow-up for #28470.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
