### PR TITLE
settings: Don't show last active in deactivated users table. 

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -276,12 +276,11 @@ function human_info(person) {
     info.cannot_deactivate = info.is_current_user || (person.is_owner && !current_user.is_owner);
     info.display_email = person.delivery_email;
 
-    if (info.is_active) {
-        // TODO: We might just want to show this
-        // for deactivated users, too, even though
-        // it might usually just be undefined.
-        info.last_active_date = get_last_active(person);
-    }
+    // TODO: This is not shown in deactivated users table and it is
+    // controlled by `display_last_active_column` We might just want
+    // to show this for deactivated users, too, even though it might
+    // usually just be undefined.
+    info.last_active_date = get_last_active(person);
 
     return info;
 }
@@ -336,6 +335,7 @@ section.active.create_table = (active_users) => {
         get_item: people.get_by_user_id,
         modifier_html(item) {
             const info = human_info(item);
+            info.display_last_active_column = true;
             return render_admin_user_list(info);
         },
         filter: {
@@ -370,6 +370,7 @@ section.deactivated.create_table = (deactivated_users) => {
             get_item: people.get_by_user_id,
             modifier_html(item) {
                 const info = human_info(item);
+                info.display_last_active_column = false;
                 return render_admin_user_list(info);
             },
             filter: {

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -97,7 +97,7 @@ export function update_view_on_deactivate(user_id) {
     $button.addClass("btn-warning reactivate");
     $button.removeClass("deactivate btn-danger");
     $button.empty().append($("<i>").addClass(["fa", "fa-user-plus"]).attr("aria-hidden", "true"));
-    $row.removeClass("reactivated_user");
+    $row.removeClass("active-user");
     $row.addClass("deactivated_user");
 
     should_redraw_active_users_list = true;
@@ -116,7 +116,7 @@ export function update_view_on_reactivate(user_id) {
     $button.removeClass("btn-warning reactivate");
     $button.empty().append($("<i>").addClass(["fa", "fa-user-times"]).attr("aria-hidden", "true"));
     $row.removeClass("deactivated_user");
-    $row.addClass("reactivated_user");
+    $row.addClass("active-user");
 
     should_redraw_active_users_list = true;
     should_redraw_deactivated_users_list = true;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1960,7 +1960,7 @@ $option_title_width: 180px;
 }
 
 #admin_users_table .deactivated_user,
-#admin_deactivated_users_table .reactivated_user {
+#admin_deactivated_users_table .active-user {
     color: hsl(0deg 0% 64%);
 
     & a {

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -1,4 +1,4 @@
-<tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
+<tr class="user_row{{#if is_active}} active-user{{else}} deactivated_user{{/if}}" data-user-id="{{user_id}}">
     <td>
         <span class="user_name" >
             <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{full_name}}</a>

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -34,7 +34,7 @@
     <td class="bot_type">
         <span class="bot type">{{bot_type}}</span>
     </td>
-    {{else if is_active}}
+    {{else if display_last_active_column}}
     <td class="last_active">
         {{ last_active_date }}
     </td>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #29894

> One small bug that I noticed - when I reactivate a user in "Deactivated users" list, the row of the reactivated user becomes faded, but when I click on any of the column heading to change the sorting, the row is not faded. I think it should still be faded like it is when sorting changes after deactivating a user in "Users" list.

This is fixed by the second commit.

#29986 was mostly correct in its underlying implementation, it was missing the fix for a case noted during testing, for which I've added the second commit. 

In terms of changes to the original PR, the variable name has been changed from `display_last_active_in_table` to `display_last_active_column` since `in_table` part was redundant in that context. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Active users table - screen capture </summary>

![active_users_table_sort](https://github.com/zulip/zulip/assets/13910561/45106664-3d19-4dc1-a603-69ba48b4b105)

</details>

<details>
<summary>Deactivated users table - screen capture </summary>

![bots_deactivate_sort](https://github.com/zulip/zulip/assets/13910561/fcb5e5ec-61d5-4542-817e-cfb27549ddd2)


</details>


<details>
<summary> Bots page - screen capture - unchanged - No greying out on deactivate there since the page contains both active and deactivated users. </summary>

![bots_table_sort](https://github.com/zulip/zulip/assets/13910561/25397b3f-a9fc-49c4-9fca-a9cd1108d34e)

</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
