### PR TITLE
Scale typeaheads and dropdowns with font size.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -75,7 +75,7 @@
         0 2px 4px hsl(0deg 0% 0% / 10%);
 
     .tippy-content {
-        font-size: 14px;
+        font-size: var(--base-font-size-px);
         color: hsl(0deg 0% 75%);
         padding: 0;
     }

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -320,7 +320,7 @@
         }
     }
 
-    .typeahead-menu li a {
+    .typeahead-menu > li > a {
         padding: 3px 30px;
         /* Override white-space: nowrap from zulip.css */
         white-space: normal;

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -25,9 +25,15 @@
             font-weight: normal;
             /* We want to keep this `max-width` less than 320px. */
             max-width: 292px;
-            line-height: 20px;
+            line-height: var(--base-line-height-unitless);
             color: var(--color-dropdown-item);
             white-space: nowrap;
+
+            @media (width >= $ml_min) {
+                /* Scale up with font size on larger widths. */
+                /* 292px / 14px */
+                max-width: 20.86em;
+            }
 
             /* hidden text just to maintain line height for a blank option */
             strong:empty {
@@ -77,6 +83,7 @@
     }
 
     .autocomplete_secondary {
+        align-self: center;
         opacity: 0.8;
         font-size: 85%;
         flex: 1 1 0;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2156,7 +2156,8 @@ body:not(.hide-left-sidebar) {
     .dropdown-list-wrapper {
         /* Sync with `max-height` in dropdown_widget. */
         max-height: 210px;
-        min-width: 200px;
+        /* 200px/14px */
+        min-width: 14.285em;
 
         .dropdown-list {
             list-style: none;
@@ -2189,13 +2190,13 @@ body:not(.hide-left-sidebar) {
     padding: 3px 10px 3px 8px;
     gap: 4px;
     font-weight: 400;
-    line-height: 20px;
+    line-height: var(--base-line-height-unitless);
     white-space: normal;
 
     .stream-privacy-type-icon {
-        font-size: 13px;
-        width: 13px;
-        height: 13px;
+        font-size: 0.93em;
+        width: 0.93em;
+        height: 0.93em;
         padding-right: 2px;
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1958,14 +1958,6 @@ body:not(.hide-left-sidebar) {
             margin-left: 40px;
         }
 
-        .typeahead.dropdown-menu .typeahead-menu li {
-            width: 100%;
-
-            & a {
-                white-space: normal;
-            }
-        }
-
         #feedback_container {
             width: calc(90% - 30px);
             left: 5%;


### PR DESCRIPTION
Fixes #30780

| before | after |
| --- | --- |
| <img width="368" alt="Screenshot 2024-07-10 at 5 32 15 PM" src="https://github.com/zulip/zulip/assets/25124304/133d897e-c5ae-419a-ac3b-dd4707d5b2d9"> | <img width="394" alt="Screenshot 2024-07-10 at 5 31 00 PM" src="https://github.com/zulip/zulip/assets/25124304/22f4d47e-0e95-4a9b-a72e-bf1a3c052b24"> |
| <img width="371" alt="Screenshot 2024-07-10 at 5 32 10 PM" src="https://github.com/zulip/zulip/assets/25124304/20c2f327-e9a1-46a2-a6ad-6492e7feb5ee"> | <img width="384" alt="Screenshot 2024-07-10 at 5 31 09 PM" src="https://github.com/zulip/zulip/assets/25124304/eaa69da4-d7b6-44cd-88b6-14cc51f900ff"> |
| <img width="368" alt="Screenshot 2024-07-10 at 5 32 03 PM" src="https://github.com/zulip/zulip/assets/25124304/a7c4e02f-7624-4bf5-8e5b-a2df33384216">| <img width="368" alt="Screenshot 2024-07-10 at 5 30 50 PM" src="https://github.com/zulip/zulip/assets/25124304/74a9c888-1e2f-4f18-b0ed-25fb65d1c19c"> |
| <img width="368" alt="Screenshot 2024-07-10 at 5 31 49 PM" src="https://github.com/zulip/zulip/assets/25124304/97025ef7-5808-4254-9f41-29e004eacc46"> | <img width="368" alt="Screenshot 2024-07-10 at 5 31 24 PM" src="https://github.com/zulip/zulip/assets/25124304/174af452-c1f5-445a-a095-2d82d7babd70"> |
| <img width="368" alt="Screenshot 2024-07-10 at 5 31 57 PM" src="https://github.com/zulip/zulip/assets/25124304/2c557198-d086-4b02-8d8b-c40f06407490"> | <img width="368" alt="Screenshot 2024-07-10 at 5 30 44 PM" src="https://github.com/zulip/zulip/assets/25124304/1a4678c1-4c54-4b6c-997a-63499db55203"> |
