### PR TITLE
echo: Fix error during local echo while narrowed to search view.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -137,6 +137,7 @@ EXEMPT_FILES = make_set(
         "web/src/message_edit.js",
         "web/src/message_edit_history.ts",
         "web/src/message_events.js",
+        "web/src/message_events_util.js",
         "web/src/message_feed_loading.ts",
         "web/src/message_feed_top_notices.ts",
         "web/src/message_fetch.js",

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -296,7 +296,7 @@ export function notify_messages_outside_current_search(messages: Message[]): voi
             {message_recipient: get_message_header(message)},
         );
         notify_above_composebox(
-            $t({defaultMessage: "Sent! Your recent message is outside the current search."}),
+            $t({defaultMessage: "Sent! Your message is outside your current view."}),
             compose_banner.CLASSNAMES.narrow_to_recipient,
             above_composebox_narrow_url,
             message.id,

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -198,7 +198,7 @@ export function insert_local_message(message_request, local_id_float, insert_new
 
     message.display_recipient = build_display_recipient(message);
 
-    [message] = insert_new_messages([message], true);
+    [message] = insert_new_messages([message], true, true);
 
     waiting_for_id.set(message.local_id, message);
     waiting_for_ack.set(message.local_id, message);
@@ -432,6 +432,10 @@ export function process_from_server(messages) {
     if (msgs_to_rerender_or_add_to_narrow.length > 0) {
         for (const msg_list of message_lists.all_rendered_message_lists()) {
             if (!msg_list.data.filter.can_apply_locally()) {
+                // If this message list is a search filter that we
+                // cannot apply locally, we will not have locally
+                // echoed echoed the message at all originally, and
+                // must the server now whether to add it to the view.
                 message_events_util.maybe_add_narrowed_messages(
                     msgs_to_rerender_or_add_to_narrow,
                     msg_list,

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -3,8 +3,6 @@ import assert from "minimalistic-assert";
 
 import * as alert_words from "./alert_words";
 import {all_messages_data} from "./all_messages_data";
-import * as blueslip from "./blueslip";
-import * as channel from "./channel";
 import * as compose_fade from "./compose_fade";
 import * as compose_notifications from "./compose_notifications";
 import * as compose_state from "./compose_state";
@@ -13,6 +11,7 @@ import * as direct_message_group_data from "./direct_message_group_data";
 import * as drafts from "./drafts";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
+import * as message_events_util from "./message_events_util";
 import * as message_helper from "./message_helper";
 import * as message_lists from "./message_lists";
 import * as message_notifications from "./message_notifications";
@@ -35,86 +34,6 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
-function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) {
-    const ids = [];
-
-    for (const elem of messages) {
-        ids.push(elem.id);
-    }
-
-    channel.get({
-        url: "/json/messages/matches_narrow",
-        data: {
-            msg_ids: JSON.stringify(ids),
-            narrow: JSON.stringify(narrow_state.public_search_terms()),
-        },
-        timeout: 5000,
-        success(data) {
-            if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
-                // We unnarrowed or moved to Recent Conversations in the meantime.
-                return;
-            }
-
-            let new_messages = [];
-            const elsewhere_messages = [];
-
-            for (const elem of messages) {
-                if (Object.hasOwn(data.messages, elem.id)) {
-                    util.set_match_data(elem, data.messages[elem.id]);
-                    new_messages.push(elem);
-                } else {
-                    elsewhere_messages.push(elem);
-                }
-            }
-
-            // This second call to process_new_message in the
-            // insert_new_messages code path is designed to replace
-            // our slightly stale message object with the latest copy
-            // from the message_store. This helps in very rare race
-            // conditions, where e.g. the current user's name was
-            // edited in between when they sent the message and when
-            // we hear back from the server and can echo the new
-            // message.
-            new_messages = new_messages.map((message) =>
-                message_helper.process_new_message(message),
-            );
-
-            callback(new_messages, msg_list);
-            unread_ops.process_visible();
-            compose_notifications.notify_messages_outside_current_search(elsewhere_messages);
-        },
-        error(xhr) {
-            if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
-                return;
-            }
-            if (xhr.status === 400) {
-                // This narrow was invalid -- don't retry it, and don't display the message.
-                return;
-            }
-            if (attempt >= 5) {
-                // Too many retries -- bail out.  However, this means the `messages` are potentially
-                // missing from the search results view.  Since this is a very unlikely circumstance
-                // (Tornado is up, Django is down for 5 retries, user is in a search view that it
-                // cannot apply itself) and the failure mode is not bad (it will simply fail to
-                // include live updates of new matching messages), just log an error.
-                blueslip.error(
-                    "Failed to determine if new message matches current narrow, after 5 tries",
-                );
-                return;
-            }
-            // Backoff on retries, with full jitter: up to 2s, 4s, 8s, 16s, 32s
-            const delay = Math.random() * 2 ** attempt * 2000;
-            setTimeout(() => {
-                if (msg_list === message_lists.current) {
-                    // Don't actually try again if we un-narrowed
-                    // while waiting
-                    maybe_add_narrowed_messages(messages, msg_list, callback, attempt + 1);
-                }
-            }, delay);
-        },
-    });
-}
-
 export function insert_new_messages(messages, sent_by_this_client) {
     messages = messages.map((message) => message_helper.process_new_message(message));
 
@@ -133,7 +52,11 @@ export function insert_new_messages(messages, sent_by_this_client) {
             // new messages match the narrow, and use that to
             // determine which new messages to add to the current
             // message list (or display a notification).
-            maybe_add_narrowed_messages(messages, list, message_util.add_new_messages);
+            message_events_util.maybe_add_narrowed_messages(
+                messages,
+                list,
+                message_util.add_new_messages,
+            );
             continue;
         }
 
@@ -504,7 +427,7 @@ export function update_messages(events) {
                         updated_messages.map((msg) => msg.id),
                     );
                     // For filters that cannot be processed locally, ask server.
-                    maybe_add_narrowed_messages(
+                    message_events_util.maybe_add_narrowed_messages(
                         event_messages,
                         message_lists.current,
                         message_util.add_messages,

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -34,7 +34,7 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
-export function insert_new_messages(messages, sent_by_this_client) {
+export function insert_new_messages(messages, sent_by_this_client, deliver_locally) {
     messages = messages.map((message) => message_helper.process_new_message(message));
 
     const any_untracked_unread_messages = unread.process_loaded_messages(messages, false);
@@ -52,6 +52,17 @@ export function insert_new_messages(messages, sent_by_this_client) {
             // new messages match the narrow, and use that to
             // determine which new messages to add to the current
             // message list (or display a notification).
+
+            if (deliver_locally) {
+                // However, this is a local echo attempt, we can't ask
+                // the server about the match, since we don't have a
+                // final message ID. In that situation, we do nothing
+                // and echo.process_from_server will call
+                // message_events_util.maybe_add_narrowed_messages
+                // once the message is fully delivered.
+                continue;
+            }
+
             message_events_util.maybe_add_narrowed_messages(
                 messages,
                 list,

--- a/web/src/message_events_util.js
+++ b/web/src/message_events_util.js
@@ -1,0 +1,89 @@
+import * as blueslip from "./blueslip";
+import * as channel from "./channel";
+import * as compose_notifications from "./compose_notifications";
+import * as message_helper from "./message_helper";
+import * as message_lists from "./message_lists";
+import * as narrow_state from "./narrow_state";
+import * as unread_ops from "./unread_ops";
+import * as util from "./util";
+
+// TODO: Move this function to 'message_util.ts' once #30702 is merged.
+export function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) {
+    const ids = [];
+
+    for (const elem of messages) {
+        ids.push(elem.id);
+    }
+
+    channel.get({
+        url: "/json/messages/matches_narrow",
+        data: {
+            msg_ids: JSON.stringify(ids),
+            narrow: JSON.stringify(narrow_state.public_search_terms()),
+        },
+        timeout: 5000,
+        success(data) {
+            if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
+                // We unnarrowed or moved to Recent Conversations in the meantime.
+                return;
+            }
+
+            let new_messages = [];
+            const elsewhere_messages = [];
+
+            for (const elem of messages) {
+                if (Object.hasOwn(data.messages, elem.id)) {
+                    util.set_match_data(elem, data.messages[elem.id]);
+                    new_messages.push(elem);
+                } else {
+                    elsewhere_messages.push(elem);
+                }
+            }
+
+            // This second call to process_new_message in the
+            // insert_new_messages code path is designed to replace
+            // our slightly stale message object with the latest copy
+            // from the message_store. This helps in very rare race
+            // conditions, where e.g. the current user's name was
+            // edited in between when they sent the message and when
+            // we hear back from the server and can echo the new
+            // message.
+            new_messages = new_messages.map((message) =>
+                message_helper.process_new_message(message),
+            );
+
+            callback(new_messages, msg_list);
+            unread_ops.process_visible();
+            compose_notifications.notify_messages_outside_current_search(elsewhere_messages);
+        },
+        error(xhr) {
+            if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
+                return;
+            }
+            if (xhr.status === 400) {
+                // This narrow was invalid -- don't retry it, and don't display the message.
+                return;
+            }
+            if (attempt >= 5) {
+                // Too many retries -- bail out.  However, this means the `messages` are potentially
+                // missing from the search results view.  Since this is a very unlikely circumstance
+                // (Tornado is up, Django is down for 5 retries, user is in a search view that it
+                // cannot apply itself) and the failure mode is not bad (it will simply fail to
+                // include live updates of new matching messages), just log an error.
+                blueslip.error(
+                    "Failed to determine if new message matches current narrow, after 5 tries",
+                );
+                return;
+            }
+            // Backoff on retries, with full jitter: up to 2s, 4s, 8s, 16s, 32s
+            const delay = Math.random() * 2 ** attempt * 2000;
+            setTimeout(() => {
+                if (msg_list === message_lists.current) {
+                    // Don't actually try again if we un-narrowed
+                    // while waiting
+                    maybe_add_narrowed_messages(messages, msg_list, callback, attempt + 1);
+                }
+            }, delay);
+        },
+    });
+}

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -121,7 +121,7 @@ function get_events_success(events) {
                 // messages, only one of which was sent by this client,
                 // correctly.
 
-                message_events.insert_new_messages(messages, sent_by_this_client);
+                message_events.insert_new_messages(messages, sent_by_this_client, false);
             }
         } catch (error) {
             blueslip.error("Failed to insert new messages", undefined, error);

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -12,6 +12,7 @@ const {current_user} = require("./lib/zpage_params");
 const compose_notifications = mock_esm("../src/compose_notifications");
 const markdown = mock_esm("../src/markdown");
 const message_lists = mock_esm("../src/message_lists");
+const message_events_util = mock_esm("../src/message_events_util");
 
 let disparities = [];
 
@@ -39,12 +40,26 @@ message_lists.current = {
         rerender_messages: noop,
         change_message_id: noop,
     },
+    data: {
+        filter: {
+            can_apply_locally() {
+                return true;
+            },
+        },
+    },
     change_message_id: noop,
 };
 const home_msg_list = {
     view: {
         rerender_messages: noop,
         change_message_id: noop,
+    },
+    data: {
+        filter: {
+            can_apply_locally() {
+                return true;
+            },
+        },
     },
     preserver_rendered_state: true,
     change_message_id: noop,
@@ -113,6 +128,53 @@ run_test("process_from_server for differently rendered messages", ({override}) =
     assert.deepEqual(non_echo_messages, []);
     assert.equal(disparities.length, 1);
     assert.deepEqual(messages_to_rerender, [
+        {
+            content: server_messages[0].content,
+            timestamp: new_value,
+            is_me_message: new_value,
+            submessages: new_value,
+            topic_links: new_value,
+        },
+    ]);
+});
+
+run_test("process_from_server for messages to add to narrow", ({override}) => {
+    let messages_to_add_to_narrow = [];
+
+    override(message_lists.current.data.filter, "can_apply_locally", () => false);
+    override(message_events_util, "maybe_add_narrowed_messages", (msgs, msg_list) => {
+        messages_to_add_to_narrow = msgs;
+        assert.equal(msg_list, message_lists.current);
+    });
+
+    const old_value = "old_value";
+    const new_value = "new_value";
+    const waiting_for_ack = new Map([
+        [
+            "100.1",
+            {
+                content: "<p>rendered message</p>",
+                timestamp: old_value,
+                is_me_message: old_value,
+                submessages: old_value,
+                topic_links: old_value,
+            },
+        ],
+    ]);
+    const server_messages = [
+        {
+            local_id: "100.1",
+            content: "<p>rendered message</p>",
+            timestamp: new_value,
+            is_me_message: new_value,
+            submessages: new_value,
+            topic_links: new_value,
+        },
+    ];
+    echo._patch_waiting_for_ack(waiting_for_ack);
+    const non_echo_messages = echo.process_from_server(server_messages);
+    assert.deepEqual(non_echo_messages, []);
+    assert.deepEqual(messages_to_add_to_narrow, [
         {
             content: server_messages[0].content,
             timestamp: new_value,


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF400.20error.20on.20sending.20message.20while.20narrowed.20to.20search.20view/near/1851146)

* Commit 1: Fix message sent when narrowed to search view was not getting added to that view. 
* Commit 2: Fixes a 400 error during local echo while sender is narrowed to search view.
* Commit 3: Alya suggested -- https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF400.20error.20on.20sending.20message.20while.20narrowed.20to.20search.20view/near/1851376


**Screenshots and screen captures:**

<details><summary>Message sent when narrowed to search view (Sent message doesn't match narrow)</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/dd0139d4-4d4a-41e1-bb08-b7d7104b9405">
</img>
</details> 

<details><summary>Message sent when narrowed to search view (Sent message matches narrow)</summary>
<img src="https://github.com/user-attachments/assets/530e29a7-8873-497a-8575-1c24b0607dce">
</img>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
