### PR TITLE
Allow only system groups to be used as setting in production.

### DIFF
--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -4,6 +4,7 @@ import * as blueslip from "./blueslip";
 import {FoldDict} from "./fold_dict";
 import * as group_permission_settings from "./group_permission_settings";
 import {$t} from "./i18n";
+import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import type {StateData, user_group_schema} from "./state_data";
 import {current_user} from "./state_data";
@@ -291,7 +292,10 @@ export function get_realm_user_groups_for_dropdown_list_widget(
             };
         });
 
-    if (require_system_group) {
+    if (
+        (setting_name !== "can_mention_group" && !page_params.development_environment) ||
+        require_system_group
+    ) {
         return system_user_groups;
     }
 

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -53,6 +53,7 @@ class ErrorCode(Enum):
     REMOTE_REALM_SERVER_MISMATCH_ERROR = auto()
     PUSH_NOTIFICATIONS_DISALLOWED = auto()
     EXPECTATION_MISMATCH = auto()
+    SYSTEM_GROUP_REQUIRED = auto()
 
 
 class JsonableError(Exception):
@@ -688,3 +689,16 @@ class PreviousSettingValueMismatchedError(JsonableError):
     @override
     def msg_format() -> str:
         return _("'old' value does not match the expected value.")
+
+
+class SystemGroupRequiredError(JsonableError):
+    code = ErrorCode.SYSTEM_GROUP_REQUIRED
+    data_fields = ["setting_name"]
+
+    def __init__(self, setting_name: str) -> None:
+        self.setting_name = setting_name
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("'{setting_name}' must be a system user group.")

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -571,7 +571,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_post("/json/user_groups/create", info=params)
         self.assert_json_error(result, "Invalid user group ID: 1111")
 
-        with self.settings(ALLOW_ANONYMOUS_GROUP_VALUED_SETTINGS=False):
+        with self.settings(ALLOW_GROUP_VALUED_SETTINGS=False):
             params = {
                 "name": "frontend",
                 "members": orjson.dumps([hamlet.id]).decode(),
@@ -584,9 +584,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
                 ).decode(),
             }
             result = self.client_post("/json/user_groups/create", info=params)
-            self.assert_json_error(
-                result, "can_mention_group can only be set to a single named user group."
-            )
+            self.assert_json_error(result, "'can_mention_group' must be a system user group.")
 
             params = {
                 "name": "frontend",
@@ -608,12 +606,12 @@ class UserGroupAPITestCase(UserGroupTestCase):
                 "name": "devops",
                 "members": orjson.dumps([hamlet.id]).decode(),
                 "description": "Devops team",
-                "can_mention_group": orjson.dumps(moderators_group.id).decode(),
+                "can_mention_group": orjson.dumps(leadership_group.id).decode(),
             }
             result = self.client_post("/json/user_groups/create", info=params)
             self.assert_json_success(result)
             devops_group = NamedUserGroup.objects.get(name="devops", realm=hamlet.realm)
-            self.assertEqual(devops_group.can_mention_group_id, moderators_group.id)
+            self.assertEqual(devops_group.can_mention_group_id, leadership_group.id)
 
     def test_user_group_get(self) -> None:
         # Test success
@@ -868,8 +866,8 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_patch(f"/json/user_groups/{support_group.id}", info=params)
         self.assert_json_error(result, "Invalid user group ID: 1111")
 
-        # Test case when ALLOW_ANONYMOUS_GROUP_VALUED_SETTINGS is False.
-        with self.settings(ALLOW_ANONYMOUS_GROUP_VALUED_SETTINGS=False):
+        # Test case when ALLOW_GROUP_VALUED_SETTINGS is False.
+        with self.settings(ALLOW_GROUP_VALUED_SETTINGS=False):
             params = {
                 "can_mention_group": orjson.dumps(
                     {
@@ -881,9 +879,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
                 ).decode()
             }
             result = self.client_patch(f"/json/user_groups/{support_group.id}", info=params)
-            self.assert_json_error(
-                result, "can_mention_group can only be set to a single named user group."
-            )
+            self.assert_json_error(result, "'can_mention_group' must be a system user group.")
 
             params = {
                 "can_mention_group": orjson.dumps(

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -642,7 +642,7 @@ CUSTOM_AUTHENTICATION_WRAPPER_FUNCTION: Optional[Callable[..., Any]] = None
 # groups as described in api_docs/group-setting-values.md. Set to
 # False in production, as we can only handle named user groups in the
 # web app settings UI.
-ALLOW_ANONYMOUS_GROUP_VALUED_SETTINGS = False
+ALLOW_GROUP_VALUED_SETTINGS = False
 
 # Grace period during which we don't send a resolve/unresolve
 # notification to a stream and also delete the previous counter

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -209,7 +209,7 @@ DEVELOPMENT_DISABLE_PUSH_BOUNCER_DOMAIN_CHECK = True
 PUSH_NOTIFICATION_BOUNCER_URL = f"http://push.{EXTERNAL_HOST}"
 
 # Breaks the UI if used, but enabled for development environment testing.
-ALLOW_ANONYMOUS_GROUP_VALUED_SETTINGS = True
+ALLOW_GROUP_VALUED_SETTINGS = True
 
 # This value needs to be lower in development than usual to allow
 # for quicker testing of the feature.

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -269,7 +269,7 @@ SCIM_CONFIG: Dict[str, SCIMConfigDict] = {
     }
 }
 
-ALLOW_ANONYMOUS_GROUP_VALUED_SETTINGS = True
+ALLOW_GROUP_VALUED_SETTINGS = True
 
 # This override disables the grace period for undoing resolving/unresolving
 # a topic in tests.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is for the backend changes to allow only system groups.
- Second commit is to not show user defined groups in webapp UI.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
