### PR TITLE
css: Exclude lock icons in dropdowns from being unnecessarily pulled up.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -946,6 +946,16 @@ div.overlay {
     margin-top: -0.2188em !important;
 }
 
+.dropdown-list-container
+    .dropdown-list
+    .dropdown-list-item-common-styles
+    .zulip-icon-lock {
+    /* We do not need to pull up lock icons in dropdowns
+       so we reset their margin-top to the original value
+       for a dropdown's .zulip-icon */
+    margin-top: 2px !important;
+}
+
 /* This includes css needed to display messages in an overlay. */
 .overlay-messages-container {
     position: relative;


### PR DESCRIPTION
This fixes the issue where the lock icon, most noticeably in the compose recipient stream dropdown, was placed too high.

Fixes: [CZO issue report](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20channel.20privacy.20icons.20in.20typeahead/near/1882568)

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/4ace0356-2d30-4709-8543-89ef2495bccd)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
