### PR TITLE
confirm_dialog: Prevent multiple dialogs from opening.

### DIFF
--- a/web/src/confirm_dialog.ts
+++ b/web/src/confirm_dialog.ts
@@ -1,12 +1,17 @@
+import $ from "jquery";
+
 import * as dialog_widget from "./dialog_widget";
 import type {DialogWidgetConfig} from "./dialog_widget";
 import {$t_html} from "./i18n";
 
 export function launch(conf: DialogWidgetConfig): string {
-    return dialog_widget.launch({
-        close_on_submit: true,
-        focus_submit_on_open: true,
-        html_submit_button: $t_html({defaultMessage: "Confirm"}),
-        ...conf,
-    });
+    if ($(".modal__container[role='dialog']").length === 0) {
+        return dialog_widget.launch({
+            close_on_submit: true,
+            focus_submit_on_open: true,
+            html_submit_button: $t_html({defaultMessage: "Confirm"}),
+            ...conf,
+        });
+    }
+    return "Dialog already open";
 }


### PR DESCRIPTION
Add a check to see if an existing modal is open before opening
a new modal. This prevents multiple dialogs from opening.
Thus when the user presses the enter key multiple times,
only one dialog will open when `focus_submit_on_open` is set to false.

[CZO Link for context.](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20Duplicate.20confirmation.20modals.20merging.20topics)