### PR TITLE
search pills: Fix some UI bugs with long pills.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -35,6 +35,7 @@
         .pill-image {
             height: var(--length-input-pill-image);
             width: var(--length-input-pill-image);
+            min-width: var(--length-input-pill-image);
             border-radius: 4px 0 0 4px;
         }
 

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -223,7 +223,7 @@
                 var(--search-box-height),
                 auto
             )
-            / auto minmax(0, 1fr) auto;
+            / auto minmax(0, 1fr) 28px;
         align-items: start;
         cursor: pointer;
 
@@ -244,7 +244,6 @@
         }
 
         .user-pill-container {
-            min-width: fit-content;
             gap: 5px;
 
             > .pill-label {
@@ -259,12 +258,19 @@
                 height: var(--height-input-pill);
                 border: none;
                 border-radius: 3px;
+                max-width: none;
+                display: grid;
+                grid-template-columns: auto 1fr auto;
 
                 &:not(.deactivated-pill) {
                     background-color: var(--color-background-user-pill);
                 }
             }
         }
+    }
+
+    .pill-label {
+        min-width: 30px;
     }
 
     @media (width >= $md_min) {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -243,6 +243,11 @@
             }
         }
 
+        &.focused .user-pill-container {
+            flex-flow: row wrap;
+            height: unset;
+        }
+
         .user-pill-container {
             gap: 5px;
 

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -331,12 +331,17 @@
         /* Override white-space: nowrap from zulip.css */
         white-space: normal;
 
+        .search_list_item {
+            max-width: 100%;
+        }
+
         .search_list_item .pill-container {
             margin-left: 5px;
             /* This contains only one pill, which handles its own border */
             border: none;
             cursor: pointer;
             padding: 0;
+            max-width: 100%;
         }
 
         .pill {


### PR DESCRIPTION
**in the search bar**

before:

<img width="444" alt="image" src="https://github.com/zulip/zulip/assets/5634097/d7ad74cc-58a2-4d80-ad8a-7f5b238d8690">


after:

<img width="434" alt="image" src="https://github.com/zulip/zulip/assets/5634097/c92117dd-4fd9-43ed-8fb8-c7a6198fd3c4">

------

**in the typeahead**

before:

<img width="386" alt="image" src="https://github.com/zulip/zulip/assets/5634097/3462b35a-6ee8-4bcb-9fb6-5bc6f8b9f870">


after:

<img width="393" alt="image" src="https://github.com/zulip/zulip/assets/5634097/2b6671e7-13c2-4194-9780-36a5908a6b62">
