### PR TITLE
exceptions: Update DM permission error string.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -534,7 +534,7 @@ class DirectMessagePermissionError(JsonableError):
         if is_nobody_group:
             msg = _("Direct messages are disabled in this organization.")
         else:
-            msg = _("You do not have permission to send direct messages to this recipient.")
+            msg = _("This conversation does not include any users who can authorize it.")
         super().__init__(msg)
 
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2535,7 +2535,7 @@ class PersonalMessageSendTest(ZulipTestCase):
             self.send_personal_message(user_profile, cordelia)
         self.assertEqual(
             str(direct_message_permission_error.exception),
-            "You do not have permission to send direct messages to this recipient.",
+            "This conversation does not include any users who can authorize it.",
         )
 
         # We can send to this direct message group as it has administrator as one of the


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Changes `DirectMessagePermissionError` message to make it consistent with error message used in the web client.
Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
