### PR TITLE
help: Fix help center loading scrolled down.

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -122,7 +122,6 @@ $(".markdown").on("click", () => {
 render_tabbed_sections();
 
 if ($(window).width() > 800) {
-    $(".highlighted")[0]?.scrollIntoView({block: "center"});
     $(".highlighted").eq(0).trigger("focus");
     $(".highlighted")
         .eq(0)


### PR DESCRIPTION
We were trying scroll the highlighted element but it also scrolls the parent elements leading to scrolling of the help doc.

We don't need to scroll here at all actually since focused element is scrolled to be visible by default. Tested in chrome, firefox and safari on mac by going to http://aman.zulipdev.org:9991/help/support-zulip-project

fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20landing.20low.20on.20help.20pages

dones't fix: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20anchor.20link.20partially.20hidden.20in.20help.20center (which I still cannot reproduce)