### PR TITLE
django: Switch to .alias() instead .annotate() where possible.

### DIFF
--- a/corporate/views/remote_billing_page.py
+++ b/corporate/views/remote_billing_page.py
@@ -662,7 +662,7 @@ def has_live_plan_for_any_remote_realm_on_server(server: RemoteZulipServer) -> b
 
     return (
         RemoteRealm.objects.filter(server=server)
-        .annotate(has_plan=Exists(has_plan_with_status_lt_live_threshold))
+        .alias(has_plan=Exists(has_plan_with_status_lt_live_threshold))
         .filter(has_plan=True)
         .exists()
     )

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -176,7 +176,7 @@ def get_old_unclaimed_attachments(
 
     # The Attachment vs ArchivedAttachment queries are asymmetric because only
     # Attachment has the scheduled_messages relation.
-    old_attachments = Attachment.objects.annotate(
+    old_attachments = Attachment.objects.alias(
         has_other_messages=Exists(
             ArchivedAttachment.objects.filter(id=OuterRef("id")).exclude(messages=None)
         )
@@ -186,7 +186,7 @@ def get_old_unclaimed_attachments(
         create_time__lt=delta_weeks_ago,
         has_other_messages=False,
     )
-    old_archived_attachments = ArchivedAttachment.objects.annotate(
+    old_archived_attachments = ArchivedAttachment.objects.alias(
         has_other_messages=Exists(
             Attachment.objects.filter(id=OuterRef("id")).exclude(
                 messages=None, scheduled_messages=None

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1359,7 +1359,7 @@ def export_partial_message_files(
                     user_profile_id__in=consented_user_ids, message_id=OuterRef("id")
                 )
             )
-            messages_we_received_in_protected_history_streams = Message.objects.annotate(
+            messages_we_received_in_protected_history_streams = Message.objects.alias(
                 has_usermessage=has_usermessage_expression
             ).filter(
                 # Uses index: zerver_message_realm_sender_recipient

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -491,13 +491,13 @@ def bulk_access_stream_messages_query(
     ).exists():
         return Message.objects.none()
     if not stream.is_history_public_to_subscribers():
-        messages = messages.annotate(
+        messages = messages.alias(
             has_usermessage=Exists(
                 UserMessage.objects.filter(
                     user_profile_id=user_profile.id, message_id=OuterRef("id")
                 )
             )
-        ).filter(has_usermessage=1)
+        ).filter(has_usermessage=True)
     return messages
 
 

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -25,7 +25,7 @@ def missing_any_realm_internal_bots() -> bool:
         for bot in settings.REALM_INTERNAL_BOTS
     ]
     realm_count = Realm.objects.count()
-    return UserProfile.objects.filter(email__in=bot_emails).values("email").annotate(
+    return UserProfile.objects.filter(email__in=bot_emails).values("email").alias(
         count=Count("id")
     ).filter(count=realm_count).count() != len(bot_emails)
 

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -203,7 +203,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
         recipient_ids.append(sub["recipient_id"])
 
     new_stream_msgs = (
-        Message.objects.annotate(
+        Message.objects.alias(
             has_user_message=Exists(
                 UserMessage.objects.filter(
                     user_profile_id=user_profile,
@@ -213,7 +213,7 @@ def add_missing_messages(user_profile: UserProfile) -> None:
         )
         .filter(
             # Uses index: zerver_message_realm_recipient_id
-            has_user_message=0,
+            has_user_message=False,
             realm_id=user_profile.realm_id,
             recipient_id__in=recipient_ids,
             id__gt=user_profile.last_active_message_id,

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -845,7 +845,7 @@ def get_occupied_streams(realm: Realm) -> QuerySet[Stream]:
     )
     occupied_streams = (
         Stream.objects.filter(realm=realm, deactivated=False)
-        .annotate(occupied=exists_expression)
+        .alias(occupied=exists_expression)
         .filter(occupied=True)
     )
     return occupied_streams
@@ -1002,7 +1002,7 @@ def get_subscribed_private_streams_for_user(user_profile: UserProfile) -> QueryS
     )
     subscribed_private_streams = (
         Stream.objects.filter(realm=user_profile.realm, invite_only=True, deactivated=False)
-        .annotate(subscribed=exists_expression)
+        .alias(subscribed=exists_expression)
         .filter(subscribed=True)
     )
     return subscribed_private_streams


### PR DESCRIPTION
When using the sub-expression purely for filtering, and not for accessing the value in the resultset, .alias() is potentially faster since it does not pull the value in as well.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
