### PR TITLE
test_stream: Setup make_stream function to create streams in node tests.

### DIFF
--- a/web/tests/example1.test.js
+++ b/web/tests/example1.test.js
@@ -11,6 +11,7 @@ const {strict: assert} = require("assert");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
+const {make_stream} = require("./lib/test_stream");
 
 // We will use our special zrequire helper to import the
 // Zulip code. We use zrequire instead of require,
@@ -52,12 +53,14 @@ assert.ok(people.is_known_user_id(isaac.user_id));
 // some data at module scope. (You could also declare this inside
 // the test, if you prefer.)
 
-const denmark_stream = {
-    color: "blue",
+// We use make_stream to create a complete stream object with select
+// fields explicitly specified, and all other fields populated with
+// reasonable defaults.
+const denmark_stream = make_stream({
+    color: "a1a1a1",
     name: "Denmark",
-    stream_id: 101,
     subscribed: false,
-};
+});
 
 // We introduce the run_test helper, which mostly just causes
 // a line of output to go to the console. It does a little more than
@@ -68,6 +71,6 @@ run_test("verify stream_data persists stream color", () => {
     assert.equal(stream_data.get_sub_by_name("Denmark"), undefined);
     stream_data.add_sub(denmark_stream);
     const sub = stream_data.get_sub_by_name("Denmark");
-    assert.equal(sub.color, "blue");
+    assert.equal(sub.color, "a1a1a1");
 });
 // See example2.test.js in this directory.

--- a/web/tests/example2.test.js
+++ b/web/tests/example2.test.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
+const {make_stream} = require("./lib/test_stream");
 
 // Hopefully the basic patterns for testing data-oriented modules
 // are starting to become apparent.  To reinforce that, we will present
@@ -28,12 +29,12 @@ const isaac = {
     full_name: "Isaac Newton",
 };
 
-const denmark_stream = {
+const denmark_stream = make_stream({
     color: "blue",
     name: "Denmark",
     stream_id: 101,
     subscribed: false,
-};
+});
 
 const messages = {
     isaac_to_denmark_stream: {

--- a/web/tests/example3.test.js
+++ b/web/tests/example3.test.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
+const {make_stream} = require("./lib/test_stream");
 const {realm} = require("./lib/zpage_params");
 
 // In the Zulip app you can narrow your message stream by topic, by
@@ -21,12 +22,12 @@ const stream_data = zrequire("stream_data");
 // realm, since we want to test the "normal" codepath.
 realm.realm_is_zephyr_mirror_realm = false;
 
-const denmark_stream = {
+const denmark_stream = make_stream({
     color: "blue",
     name: "Denmark",
     stream_id: 101,
     subscribed: false,
-};
+});
 
 run_test("filter", () => {
     stream_data.clear_subscriptions();

--- a/web/tests/example7.test.js
+++ b/web/tests/example7.test.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
+const {make_stream} = require("./lib/test_stream");
 const $ = require("./lib/zjquery");
 
 /*
@@ -66,12 +67,12 @@ const stream_data = zrequire("stream_data");
 const unread = zrequire("unread");
 const unread_ops = zrequire("unread_ops");
 
-const denmark_stream = {
+const denmark_stream = make_stream({
     color: "blue",
     name: "Denmark",
     stream_id: 101,
     subscribed: false,
-};
+});
 
 run_test("unread_ops", ({override}) => {
     stream_data.clear_subscriptions();

--- a/web/tests/lib/test_stream.js
+++ b/web/tests/lib/test_stream.js
@@ -1,0 +1,54 @@
+"use strict";
+
+let last_issued_stream_id = 20000;
+
+const get_stream_id = () => {
+    last_issued_stream_id += 1 + Math.floor(Math.random() * 10);
+    return last_issued_stream_id;
+};
+
+exports.make_stream = (opts = {}) => {
+    // Since other fields are computed from these, we need to
+    // pull these out of opts early.
+    const stream_id = opts.stream_id ?? get_stream_id();
+    const name = opts.name ?? `stream-${stream_id}`;
+
+    const default_channel = {
+        audible_notifications: false,
+        /* BUG: This should always be a group ID. But it's annoying to
+         * fix without assuming groups exist in the data set. */
+        can_remove_subscribers_group: 0,
+        color: "abcd12",
+        /* This is rarely going to be the case, but a valid possibility. */
+        creator_id: null,
+        date_created: Date.now(),
+        description: `Description of ${name}`,
+        desktop_notifications: false,
+        email_address: "channel-email-address@example.com",
+        email_notifications: false,
+        /* This will rarely be the case, but is a valid possibility*/
+        first_message_id: null,
+        history_public_to_subscribers: true,
+        invite_only: false,
+        is_announcement_only: false,
+        is_muted: false,
+        is_web_public: false,
+        message_retention_days: null,
+        name,
+        newly_subscribed: false,
+        pin_to_top: false,
+        previously_subscribed: false,
+        push_notifications: false,
+        render_subscribers: false,
+        rendered_description: `<p>Description of ${name}</p>`,
+        stream_id,
+        /* STREAM_POST_POLICY_EVERYONE */
+        stream_post_policy: 1,
+        stream_weekly_traffic: 0,
+        /* Most tests want to work with a channel the current user is subscribed to. */
+        subscribed: true,
+        wildcard_mentions_notify: false,
+    };
+
+    return {...default_channel, ...opts};
+};


### PR DESCRIPTION
The PR introduces a new function make_stream to make test streams in node tests with accurate types instead of dummy objects.
I've currently modified `example${i}.test.js` files only.

I've used dummy data in `make_stream` function.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
