### PR TITLE
help_modal: Fix the placement issue of emoji and time layout.

### DIFF
--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -65,6 +65,10 @@
         /* keeps dividing line at same width for all tables in model. */
         width: calc(50% - 11px);
         text-align: right;
+
+        .emoji {
+            margin-bottom: 6px;
+        }
     }
 
     .hotkey {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -227,7 +227,7 @@
         margin-left: 2px;
         margin-right: 2px;
         display: inline-block;
-        margin-bottom: 1px;
+        margin-top: 5px;
     }
 
     /* LaTeX styling */


### PR DESCRIPTION
<!-- Describe your pull request here.-->
**Description :** 
This pull request solves the issue where the thumbs up emoji was not centered properly with the test and the position of time display was also not centered as per the modal.

**Fixes: <!-- Issue link, or clear description.--> Layout bugs in the help modal #30781**
- [x] The thumb-up emoji is too low on “React to selected message with 👍”.
- [x] The Time example output sits too high in its table row.

To solve the thumbs up emoji issue, I added the margin from bottom as other properties weren't working.
To solve the date issue, I removed the unnecessary margin-bottom and applid some margin from top.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After 
--- | --- 
![before emoji](https://github.com/zulip/zulip/assets/135590545/798e3758-d45e-4b41-8a53-a65cd190a282) | ![after emoji](https://github.com/zulip/zulip/assets/135590545/6c783114-4f6f-4a98-be8e-13fa0682ee74)  
![before emoji dark](https://github.com/zulip/zulip/assets/135590545/febcc073-fff3-4782-90a5-b1cedc0ddaab) | ![after emoji dark](https://github.com/zulip/zulip/assets/135590545/b54a13cf-e880-4549-b806-2458a650c93e)  
![before date](https://github.com/zulip/zulip/assets/135590545/6e48abe1-5d0e-4437-b85b-8d77091b90d3) | ![after date](https://github.com/zulip/zulip/assets/135590545/f8aa0139-6fdc-4107-a823-d3b9ccfb9555)  
![before date dark](https://github.com/zulip/zulip/assets/135590545/1aeccdb4-2e2e-4ef4-8c96-e741ab057602) | ![after date dark](https://github.com/zulip/zulip/assets/135590545/202362e1-5f6f-490b-a86c-b7c3efc32dc6)





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
