### PR TITLE
invite-users: Use "invitation" instead of "invite" for strings.

### DIFF
--- a/help/invite-new-users.md
+++ b/help/invite-new-users.md
@@ -64,7 +64,7 @@ permission to invite users.
 
 {!invite-users.md!}
 
-1. Select **Create invite link**.
+1. Select **Invitation link**.
 
 1. Select when the invitation will expire.
 
@@ -72,7 +72,7 @@ permission to invite users.
 
 1. Configure which channels they will be added to.
 
-1. Click **Generate invite link**.
+1. Click **Create link**.
 
 1. Copy the link, and send it to anyone you'd like to invite.
 

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -240,9 +240,7 @@ function generate_multiuse_invite(): void {
             ui_report.error("", xhr, $invite_status);
         },
         complete() {
-            $("#invite-user-modal .dialog_submit_button").text(
-                $t({defaultMessage: "Generate invite link"}),
-            );
+            $("#invite-user-modal .dialog_submit_button").text($t({defaultMessage: "Create link"}));
             $("#invite-user-modal .dialog_submit_button").prop("disabled", false);
             $("#invite-user-modal .dialog_exit_button").prop("disabled", false);
             $invite_status[0]!.scrollIntoView();
@@ -387,10 +385,10 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             );
             if (selected_tab === "invite-email-tab") {
                 $button.text($t({defaultMessage: "Invite"}));
-                $button.attr("data-loading-text", $t({defaultMessage: "Inviting..."}));
+                $button.attr("data-loading-text", $t({defaultMessage: "Inviting…"}));
             } else {
-                $button.text($t({defaultMessage: "Generate invite link"}));
-                $button.attr("data-loading-text", $t({defaultMessage: "Generating link..."}));
+                $button.text($t({defaultMessage: "Create link"}));
+                $button.attr("data-loading-text", $t({defaultMessage: "Creating link…"}));
             }
         }
 
@@ -455,8 +453,8 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             selected: 0,
             child_wants_focus: true,
             values: [
-                {label: $t({defaultMessage: "Send invite email"}), key: "invite-email-tab"},
-                {label: $t({defaultMessage: "Create invite link"}), key: "invite-link-tab"},
+                {label: $t({defaultMessage: "Email invitation"}), key: "invite-email-tab"},
+                {label: $t({defaultMessage: "Invitation link"}), key: "invite-link-tab"},
             ],
             callback(_name, key) {
                 switch (key) {


### PR DESCRIPTION
Updates strings in the user invite modal to use "invitation" as the noun/adjective in strings, instead of "invite".

See [relevant CZO design discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/invite.20user.20modal.3A.20.22invite.22.20strings/near/1852874).

*Note that these are all internationalized strings and will need translation updates.*

**Screenshots and screen captures:**

<details>
<summary>Invite user modal - email invitations</summary>

![Screenshot from 2024-07-11 23-36-10](https://github.com/user-attachments/assets/90489bc0-708a-4da0-9acd-d9f0bce66a00)
</details>
<details>
<summary>Invite user modal - invitation link</summary>

*Before submitting*
![Screenshot from 2024-07-11 23-36-33](https://github.com/user-attachments/assets/9495eb1a-d70a-4490-9ca4-f93ec49132ce)

*After submitting*
![Screenshot from 2024-07-11 23-38-27](https://github.com/user-attachments/assets/4f082530-2203-4ba0-8b2e-c1002da7ec69)
</details>
<details>
<summary>Help center - create reusable invitation link instructions</summary>

[Current documentation](https://chat.zulip.org/help/invite-new-users#create-a-reusable-invitation-link)
![Screenshot from 2024-07-11 23-45-52](https://github.com/user-attachments/assets/94c71f1e-cfb0-4496-997d-526379b304ad)

</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
