### PR TITLE
Zulip Updates + help center tweak

### DIFF
--- a/help/moderating-open-organizations.md
+++ b/help/moderating-open-organizations.md
@@ -54,7 +54,8 @@ problematic behavior.
 * Create a [default channel](/help/set-default-channels-for-new-users)
   for announcements where [only admins can
   post](/help/channel-posting-policy).
-* Restrict who can [send direct messages](/help/restrict-direct-messages).
+* Configure who can [authorize and start](/help/restrict-direct-messages) direct
+  message conversations.
 
 ## Response
 

--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -119,6 +119,26 @@ topic or go back to your [home view]({configure_home_view_help_url}).
             search_by_message_status_help_url="/help/search-for-messages#search-by-message-status",
         ),
     ),
+    ZulipUpdateAnnouncement(
+        level=6,
+        message="""
+**Web and desktop updates**
+- You can now configure whether channel links in the left sidebar go to the most
+recent topic (default option), or to the channel feed. With the default
+configuration, you can access the feed from the channel menu.
+[Learn more]({channel_feed_help_url}).
+- You can also [configure]({automatically_go_to_conversation_help_url}) whether Zulip
+automatically takes you to the conversation to which you sent a message, if you
+aren't already viewing it.
+- You can now [filter]({find_a_dm_conversation_help_url}) direct message
+conversations in the left sidebar to conversations that include a specific
+person.
+""".format(
+            channel_feed_help_url="/help/channel-feed",
+            automatically_go_to_conversation_help_url="/help/mastering-the-compose-box#automatically-go-to-conversation-where-you-sent-a-message",
+            find_a_dm_conversation_help_url="/help/direct-messages#find-a-direct-message-conversation",
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/stream/438-release-management/topic/zulip_updates.20items.20of.20note/near/1884247)

Message (links work):

![Screenshot 2024-07-12 at 16 16 47@2x](https://github.com/user-attachments/assets/d5ccac6a-e4c4-4793-afa0-2d314da09fc7)

--
Help center commit:
Before: https://zulip.com/help/moderating-open-organizations#minimize-spam
After:
![Screenshot 2024-07-11 at 14 24 14@2x](https://github.com/user-attachments/assets/81296f13-f98f-4ff9-9235-842f3a8e387b)

