### PR TITLE
ui_init: Initialize `timerender` before `information_density`

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -420,13 +420,12 @@ export function initialize_everything(state_data) {
        density is so fundamental, we initialize that first, however. */
     initialize_user_settings(state_data.user_settings);
     sidebar_ui.restore_sidebar_toggle_status();
+    i18n.initialize({language_list: page_params.language_list});
+    timerender.initialize();
     information_density.initialize();
     if (page_params.is_spectator) {
         theme.initialize_theme_for_spectator();
     }
-
-    i18n.initialize({language_list: page_params.language_list});
-    timerender.initialize();
     widgets.initialize();
     tippyjs.initialize();
     compose_tooltips.initialize();


### PR DESCRIPTION
`information_density.initialize` uses `timerender.stringify_time`, and thus requires `timerender.initialize` to have been called first.

Cc @karlstolley (7291f0a9192c3bc114f0e5a73c27a83e033a4c22, #29569).