### PR TITLE
settings: Do not execute hotkey inside any users tab filter input.

### DIFF
--- a/web/src/settings_panel_menu.js
+++ b/web/src/settings_panel_menu.js
@@ -108,7 +108,7 @@ export class SettingsPanelMenu {
             // We need to re-register these handlers since they are
             // destroyed once the settings modal closes.
             this.org_user_settings_toggler.register_event_handlers();
-            this.set_key_handlers(this.org_user_settings_toggler, $("#admin-user-list"));
+            this.set_key_handlers(this.org_user_settings_toggler, $(".org-user-settings-switcher"));
         }
     }
 


### PR DESCRIPTION
We changed the scope of the selector to just the switcher. This means that the hotkeys will only run when the user focuses on that element. This follows the same pattern as the `Personal` and `Organization` tab switchers which limit the hotkey area to their tab list and not the content. If we want to use hotekeys inside the content, just filtering out INPUT elements in keydown_util might be better. 

Fixes https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20Org.20settings.20user.20search.20does.20not.20work.20with.20vim.20hotkeys.2E/near/1882313

<img width="760" alt="Screenshot 2024-07-12 at 10 26 03 AM" src="https://github.com/user-attachments/assets/c66d15d8-d163-421f-b309-3b62801eecbb">


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
