### PR TITLE
settings: Fix Add channel button relying on min-width for padding.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -770,9 +770,19 @@ input[type="checkbox"] {
     float: right;
 
     #show-add-default-streams-modal {
-        padding: 5px 0;
-        min-width: 100px;
-        margin-top: 11px;
+        /* We want this button to have the same height as the filter
+           button on its right. We're overriding the default vertical
+           padding of `.new-style` and setting it to 0. Having the
+           height fixed will mean that the vertical whitespace will
+           adjust itself for different font-sizes without changing the
+           height.
+           */
+        padding-top: 0;
+        padding-bottom: 0;
+        height: 30px;
+
+        min-width: 0;
+        margin-top: 12px;
         margin-right: 6px;
     }
 }


### PR DESCRIPTION
Fixes #30674.

The previous method was using `min-width` as a proxy for padding which led to unusually high padding for very short strings and no padding for long strings. It also had an issue where changing the font-size changed the alignment with the search filter. 

Another issue that you might notice is that the all these filters have a fixed height, which leads to a decrease in padding when changing the font size, the whitespace would become oh-so-slightly smaller on increasing the font size. This probably should be fixed but it is out of scope of this PR since it would apply to all the filters in settings panel. [CZO link](https://chat.zulip.org/#narrow/stream/9-issues/topic/Filters.20with.20fixed.20height.20in.20settings.20panels/near/1886187).

| Long button - 14px - before    | Long button - 14px -  after   | Long button - 16px before      | Long button - 16px after      |
|--------------------------------|-------------------------------|--------------------------------|-------------------------------|
|    <img width="371" alt="add_channel_long_14px_old" src="https://github.com/user-attachments/assets/a683c0ef-23ad-4a9d-9156-8712d20d6e91">           |           <img width="415" alt="add_channel_long_14px_new" src="https://github.com/user-attachments/assets/c2e40cd2-875e-40b9-ba77-e27d8b55f311">       |                 <img width="402" alt="add_channel_long_16px_old" src="https://github.com/user-attachments/assets/6ea3113e-a5c4-4c1e-9465-30362dbd334d">      |                    <img width="415" alt="add_channel_long_16px_new" src="https://github.com/user-attachments/assets/accadafb-c58a-4cdd-b801-2fb38b232558">  |
| Regular button - 14px - before | Regular button - 14px - after | Regular button - 16px - before | Regular button - 16px - after |
|           <img width="285" alt="add_channel_regular_14px_old" src="https://github.com/user-attachments/assets/05d0ab78-bd5f-4901-9188-4199894a4206">                     |          <img width="298" alt="add_channel_regular_14px_new" src="https://github.com/user-attachments/assets/f0bd4316-ce1f-4209-a120-10f999fd7a8a">                   |         <img width="298" alt="add_channel_regular_16px_old" src="https://github.com/user-attachments/assets/79ff82e9-812d-4c71-8a82-037f02229da6">                       |                  <img width="311" alt="add_channel_regular_16px_new" src="https://github.com/user-attachments/assets/38570b4e-e42e-40db-b88f-149fee79b48f">       |
| Short button - 14px - before   | Short button - 14px - after   | Short button - 16px - before   | Short button - 16px - after   |
|        <img width="285" alt="add_channel_short_14px_old" src="https://github.com/user-attachments/assets/72dfb287-cf29-4512-825d-478f0e7357e7">                        |            <img width="223" alt="add_channel_small_14px_new" src="https://github.com/user-attachments/assets/69caa0ca-0397-43bf-8665-7e06606ed605">                  |               <img width="298" alt="add_channel_short_16px_old" src="https://github.com/user-attachments/assets/e3ed220b-e9ed-4fbb-a1c2-604f9eddafd9">                 |                   <img width="237" alt="add_channel_small_16px_new" src="https://github.com/user-attachments/assets/ec29b1b3-d8ab-4e0e-9794-67814841bbe9">            |

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
