### PR TITLE
 stream_settings: Fix channel subscription jitter.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -581,7 +581,8 @@ export function initialize() {
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.
     $("#channels_overlay_container").on("click", ".sub_unsub_button", (e) => {
-        if ($(e.currentTarget).hasClass("disabled")) {
+        const $target = $(e.currentTarget);
+        if ($target.hasClass("disabled")) {
             // We do not allow users to subscribe themselves to private streams.
             return;
         }
@@ -593,7 +594,14 @@ export function initialize() {
                 sub.stream_id,
             )}']`,
         );
-        stream_settings_components.sub_or_unsub(sub, $stream_row);
+
+        // If subscribe button on right-side panel is clicked, prevent
+        // displaying loading spinner in the stream row.
+        if ($target.hasClass("subscribe-button")) {
+            stream_settings_components.sub_or_unsub(sub);
+        } else {
+            stream_settings_components.sub_or_unsub(sub, $stream_row);
+        }
 
         if (!sub.subscribed) {
             open_edit_panel_for_row($stream_row);

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -114,7 +114,7 @@ export function dropdown_setup() {
 }
 
 /* For the given stream_row, remove the tick and replace by a spinner. */
-function display_subscribe_toggle_spinner(stream_row) {
+export function display_subscribe_toggle_spinner(stream_row) {
     /* Prevent sending multiple requests by removing the button class. */
     $(stream_row).find(".check").removeClass("sub_unsub_button");
 
@@ -129,7 +129,7 @@ function display_subscribe_toggle_spinner(stream_row) {
 }
 
 /* For the given stream_row, add the tick and delete the spinner. */
-function hide_subscribe_toggle_spinner(stream_row) {
+export function hide_subscribe_toggle_spinner(stream_row) {
     /* Re-enable the button to handle requests. */
     $(stream_row).find(".check").addClass("sub_unsub_button");
 
@@ -170,15 +170,8 @@ export function ajaxSubscribe(stream, color, $stream_row) {
                 );
             }
             // The rest of the work is done via the subscribe event we will get
-
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
         },
         error(xhr) {
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
             ui_report.error(
                 $t_html({defaultMessage: "Error adding subscription"}),
                 xhr,
@@ -199,15 +192,8 @@ function ajaxUnsubscribe(sub, $stream_row) {
         success() {
             $(".stream_change_property_info").hide();
             // The rest of the work is done via the unsubscribe event we will get
-
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
         },
         error(xhr) {
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
             ui_report.error(
                 $t_html({defaultMessage: "Error removing subscription"}),
                 xhr,

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -67,6 +67,16 @@ export function update_left_panel_row(sub) {
         $new_row.addClass("active");
     }
 
+    // Show spinner in $new_row if $row contains spinner.
+    const show_spinner = $($row).find(".sub_unsub_status").children().length !== 0;
+    if (show_spinner) {
+        stream_settings_components.display_subscribe_toggle_spinner($new_row);
+        // Hide toggle spinner for after 300ms.
+        setTimeout(() => {
+            stream_settings_components.hide_subscribe_toggle_spinner($new_row);
+        }, 300);
+    }
+
     $row.replaceWith($new_row);
 }
 

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -448,7 +448,13 @@ export function enable_or_disable_add_subscribers_elements(
         const $add_subscribers_button = $container_elem
             .find('button[name="add_subscriber"]')
             .expectOne();
-        $add_subscribers_button.prop("disabled", !enable_elem);
+
+        if ($input_element.text().length === 0) {
+            $add_subscribers_button.prop("disabled", true);
+        } else {
+            $add_subscribers_button.prop("disabled", !enable_elem);
+        }
+
         if (enable_elem) {
             $add_subscribers_button.css("pointer-events", "");
         }


### PR DESCRIPTION
Previously, we were showing loading spinner in each stream's row
on clicking the sub_unsub button which feels like jitter.

Now we are showing plus or checkmark icon directly instead of loading spinner.

Also the `Add` button remains unchanged on clicking subscribe/unsubscribe.

Based on #30557.

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/jitter.20when.20subscribing.2Funsubscribing.20to.20a.20channel/near/1814234)

<details>
<summary>Screenshots and screen captures:</summary>

Before:

![jitter-fix-before](https://github.com/user-attachments/assets/99ec67ca-6a96-44ba-b0e8-d78c73bad012)

After:

![jitter-fix-after](https://github.com/user-attachments/assets/956a15e6-3de6-418f-bbb1-4e4126f6e5b9)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
