### PR TITLE
popovers: Allow popover menus to scale with font-size.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1186,7 +1186,8 @@ div.overlay {
     min-width: max-content;
     padding: 1px;
     background-color: var(--color-background-tab-picker-container);
-    font-size: 16px;
+    /* 16px at 15px/1em */
+    font-size: 1.0666em;
 
     input[type="radio"] {
         display: none;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -861,6 +861,7 @@ li.top_left_scheduled_messages {
     .unread_count {
         margin: 1px 0 0 6px;
         border-color: var(--color-border-unread-counter-popover-menu);
+        width: max-content;
     }
 }
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -100,7 +100,8 @@
 .modal__content {
     display: flex;
     flex-direction: column;
-    font-size: 1rem;
+    /* 16px at 14px/1em */
+    font-size: 1.1429em;
     overflow-y: auto;
     padding: 2px 24px;
     line-height: 1.5;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1166,7 +1166,7 @@ ul.popover-group-menu-member-list {
         flex-flow: row nowrap;
         align-items: flex-start;
         gap: 5px;
-        padding: 3px 10px;
+        padding: 0.2em 0.6666em;
         /* 15px at 15px/1em */
         font-size: 1em;
         /* 16px at 15px/1em */

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -472,13 +472,13 @@ ul.popover-group-menu-member-list {
     .user-profile-manage-own-edit-button,
     .user-profile-manage-others-edit-button {
         text-decoration: none;
-        /* 15px at 14px/1em */
-        font-size: 1.0714em;
+        /* 15px at 22px/1em */
+        font-size: 0.6818em;
     }
 
     .user-profile-manage-own-copy-link-button {
-        /* 19px at 14px/1em */
-        font-size: 1.3571em;
+        /* 19px at 22px/1em */
+        font-size: 0.8638em;
         text-decoration: none;
     }
 
@@ -951,8 +951,8 @@ ul.popover-group-menu-member-list {
 
 .recipient-bar-topic-visibility-switcher {
     .tab-option-content {
-        /* 15px at 14px/1em */
-        font-size: 1.0714em;
+        /* 15px at 16px/1em */
+        font-size: 0.9375em;
         color: var(--color-text-popover-menu);
         gap: 10px;
         justify-content: flex-start;
@@ -1105,8 +1105,8 @@ ul.popover-group-menu-member-list {
     }
 
     .full-name {
-        /* 18px at 14px/1em */
-        font-size: 1.2857;
+        /* 18px at 15px/1em */
+        font-size: 1.2em;
         font-weight: 600;
         /* 20px at 18px/1em */
         line-height: 1.1111em;
@@ -1116,6 +1116,8 @@ ul.popover-group-menu-member-list {
     }
 
     .user-type {
+        /* 14px at 15px/1em */
+        font-size: 0.9333em;
         font-weight: 400;
         /* 16px at 14px/1em */
         line-height: 1.1429em;
@@ -1338,8 +1340,6 @@ ul.popover-group-menu-member-list {
         .org-info {
             display: flex;
             justify-content: flex-start;
-            /* 15px at 14px/1em */
-            font-size: 1.0714em;
             font-style: normal;
             font-weight: 400;
             /* 16px at 15px/1em */
@@ -1395,6 +1395,8 @@ ul.popover-group-menu-member-list {
         .org-upgrade {
             /* 14px at 15px/1em */
             font-size: 0.9333em;
+            /* 16px at 14px/1em */
+            line-height: 1.1428em;
         }
 
         .org-upgrade,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -236,6 +236,8 @@
         margin-right: 10px;
 
         .sp-container {
+            /* The base-font size for the color container is 12px,
+               inherited from the upstream spectrum.css file. */
             background-color: hsl(0deg 0% 100%);
             cursor: pointer;
             border: none;
@@ -257,7 +259,8 @@
                 border: 1px solid hsl(0deg 0% 80%);
                 border-radius: 4px;
                 color: hsl(0deg 0% 25%);
-                font-size: 12px;
+                /* 12px at 12px/1em */
+                font-size: 1em;
                 padding: 6px;
                 text-transform: capitalize;
                 text-align: center;
@@ -428,7 +431,8 @@ ul.popover-group-menu-member-list {
     }
 
     #exit-sign {
-        font-size: 1.5rem;
+        /* 24px at 14px/1em */
+        font-size: 1.7143em;
         line-height: 1;
     }
 
@@ -468,11 +472,13 @@ ul.popover-group-menu-member-list {
     .user-profile-manage-own-edit-button,
     .user-profile-manage-others-edit-button {
         text-decoration: none;
-        font-size: 15px;
+        /* 15px at 14px/1em */
+        font-size: 1.0714em;
     }
 
     .user-profile-manage-own-copy-link-button {
-        font-size: 19px;
+        /* 19px at 14px/1em */
+        font-size: 1.3571em;
         text-decoration: none;
     }
 
@@ -542,7 +548,8 @@ ul.popover-group-menu-member-list {
         margin: 0;
         display: inline-block;
         font-weight: inherit;
-        font-size: 21px;
+        /* 21px at 14px/1em */
+        font-size: 1.5em;
     }
 
     #user-profile-streams-tab {
@@ -842,6 +849,7 @@ ul.popover-group-menu-member-list {
 }
 
 #move_topic_modal {
+    /* Modals have a 16px/1em base font-size. */
     & form {
         margin: 0;
     }
@@ -852,7 +860,8 @@ ul.popover-group-menu-member-list {
 
         .dropdown-widget-button {
             outline: none;
-            line-height: 24px;
+            /* 24px at 16px/1em */
+            line-height: 1.5em;
             width: auto;
             max-width: 206px;
         }
@@ -864,9 +873,11 @@ ul.popover-group-menu-member-list {
             color: var(--color-text-default);
 
             .stream-privacy-type-icon {
-                font-size: 13px;
-                width: 13px;
-                height: 13px;
+                /* 13px at 16px/1em */
+                font-size: 0.8125em;
+                /* 13px at 13px/1em */
+                width: 1em;
+                height: 1em;
                 position: relative;
                 top: 2px;
             }
@@ -940,7 +951,8 @@ ul.popover-group-menu-member-list {
 
 .recipient-bar-topic-visibility-switcher {
     .tab-option-content {
-        font-size: 15px;
+        /* 15px at 14px/1em */
+        font-size: 1.0714em;
         color: var(--color-text-popover-menu);
         gap: 10px;
         justify-content: flex-start;
@@ -1093,18 +1105,20 @@ ul.popover-group-menu-member-list {
     }
 
     .full-name {
-        font-size: 18px;
+        /* 18px at 14px/1em */
+        font-size: 1.2857;
         font-weight: 600;
-        line-height: 20px;
+        /* 20px at 18px/1em */
+        line-height: 1.1111em;
         color: var(--color-text-full-name) !important;
         max-width: 150px;
         word-break: break-word;
     }
 
     .user-type {
-        font-size: 14px;
         font-weight: 400;
-        line-height: 16px;
+        /* 16px at 14px/1em */
+        line-height: 1.1429em;
         color: var(--color-text-item) !important;
     }
 }
@@ -1151,14 +1165,18 @@ ul.popover-group-menu-member-list {
         align-items: flex-start;
         gap: 5px;
         padding: 3px 10px;
-        font-size: 15px;
-        line-height: 16px;
+        /* 15px at 15px/1em */
+        font-size: 1em;
+        /* 16px at 15px/1em */
+        line-height: 1.0667em;
         min-height: 26px;
 
         .popover-menu-icon {
-            width: 16px;
-            height: 16px;
-            font-size: 16px;
+            /* 16px at 15px/1em */
+            font-size: 1.0667em;
+            /* 16px at 16px/1em */
+            width: 1em;
+            height: 1em;
             text-align: center;
         }
     }
@@ -1224,8 +1242,9 @@ ul.popover-group-menu-member-list {
     .status_emoji {
         align-self: flex-start;
         flex-shrink: 0;
-        width: 16px;
-        height: 16px;
+        /* 16px at 15px/1em */
+        width: 1.0667em;
+        height: 1.0667em;
     }
 
     .zulip-icon {
@@ -1319,10 +1338,12 @@ ul.popover-group-menu-member-list {
         .org-info {
             display: flex;
             justify-content: flex-start;
-            font-size: 15px;
+            /* 15px at 14px/1em */
+            font-size: 1.0714em;
             font-style: normal;
             font-weight: 400;
-            line-height: 16px; /* 114.286% */
+            /* 16px at 15px/1em */
+            line-height: 1.0667em;
             letter-spacing: 0.28px;
 
             &:focus-within {
@@ -1363,14 +1384,17 @@ ul.popover-group-menu-member-list {
         }
 
         .org-name {
-            font-size: 17px;
+            /* 17px at 15px/1em */
+            font-size: 1.1333em;
             font-weight: 600;
-            line-height: 22px;
+            /* 22px at 17px/1em */
+            line-height: 1.2941em;
             padding: 0 10px;
         }
 
         .org-upgrade {
-            font-size: 14px;
+            /* 14px at 15px/1em */
+            font-size: 0.9333em;
         }
 
         .org-upgrade,
@@ -1406,10 +1430,12 @@ ul.popover-menu-list {
         box-sizing: border-box;
         color: var(--color-popover-hotkey-hint);
         text-align: center;
-        font-size: 14px;
+        /* 14px at 15px/1em */
+        font-size: 0.9333em;
         font-style: normal;
         font-weight: 500;
-        line-height: 14px;
+        /* 14px at 14px/1em */
+        line-height: 1em;
         min-width: 1.25rem;
         padding: 2px 4px;
         border-radius: 3px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1264,7 +1264,8 @@ ul.popover-group-menu-member-list {
 }
 
 #message-actions-menu-dropdown {
-    --popover-menu-max-width: 350px;
+    /* 350px at 15px/1em */
+    --popover-menu-max-width: 23.3333em;
 
     .simplebar-content {
         min-width: var(--message-actions-popover-min-width);

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1438,7 +1438,8 @@ ul.popover-menu-list {
         font-weight: 500;
         /* 14px at 14px/1em */
         line-height: 1em;
-        min-width: 1.25rem;
+        /* 20px at 14px/1em */
+        min-width: 1.4285em;
         padding: 2px 4px;
         border-radius: 3px;
         border: 1px solid var(--color-border-popover-hotkey-hint);

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -5,6 +5,8 @@
 */
 .tippy-box[data-theme="light-border"] {
     background-color: var(--color-background-popover);
+    /* Basic Tippy popovers scale with the base font-size. */
+    font-size: var(--base-font-size-px);
 
     .sp-input {
         /* Override incorrect color for text in dark theme. */
@@ -12,7 +14,10 @@
     }
 
     .tippy-content {
-        font-size: 14px;
+        /* We set the font-size here to override the
+           default value in the upstream tippy.css */
+        /* 14px at 14px/1em */
+        font-size: 1em;
     }
 
     /* TODO: Clean this logic up after drop Bootstrap styling */
@@ -73,9 +78,14 @@
         0 7px 13px hsl(0deg 0% 0% / 15%),
         0 5px 8px hsl(0deg 0% 0% / 12%),
         0 2px 4px hsl(0deg 0% 0% / 10%);
+    /* Tippy dropdown widgets scale with the base font-size. */
+    font-size: var(--base-font-size-px);
 
     .tippy-content {
-        font-size: var(--base-font-size-px);
+        /* We set the font-size here to override the
+           default value in the upstream tippy.css */
+        /* 14px at 14px/1em */
+        font-size: 1em;
         color: hsl(0deg 0% 75%);
         padding: 0;
     }
@@ -86,10 +96,16 @@
     border: 1px solid var(--color-border-popover-menu);
     border-radius: 6px;
     box-shadow: var(--box-shadow-popover-menu);
+    /* Popover menus should scale no smaller than 15px,
+       but scale up with the base font-size. */
+    font-size: max(15px, var(--base-font-size-px));
 
     > .tippy-content {
         padding: 0;
-        font-size: 14px;
+        /* We set the font-size here to override the
+           default value in the upstream tippy.css */
+        /* 15 at 15px/1em */
+        font-size: 1em;
     }
 
     > .tippy-arrow {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -998,17 +998,21 @@ ul.popover-group-menu-member-list {
     }
 
     .popover-menu-user-full-name {
-        font-size: 18px;
+        /* 18px at 15px/1em */
+        font-size: 1.2em;
         font-weight: 600;
-        line-height: 20px;
+        /* 20px at 18px/1em */
+        line-height: 1.1111em;
         color: var(--color-text-full-name);
         word-break: break-word;
     }
 
     .popover-menu-user-type {
-        font-size: 14px;
+        /* 14px at 15px/1em */
+        font-size: 0.9333em;
         font-weight: 400;
-        line-height: 16px;
+        /* 16px at 14px/1em */
+        line-height: 1.1428em;
         color: var(--color-text-item);
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -295,16 +295,20 @@
     display: flex;
     align-items: flex-start;
     gap: 5px;
-    font-size: 18px;
+    /* 18px at 15px/1em */
+    font-size: 1.2em;
     font-weight: 600;
-    line-height: 20px;
+    /* 20px at 18px/1em */
+    line-height: 1.1111em;
     color: var(--color-text-full-name);
     word-break: break-word;
 }
 
 .popover-group-menu-description {
-    font-size: 15px;
-    line-height: 16px;
+    /* 15px at 15px/1em */
+    font-size: 1em;
+    /* 16px at 15px/1em */
+    line-height: 1.0667em;
 }
 
 ul.popover-group-menu-member-list {


### PR DESCRIPTION
As part of the efforts to allow the UI to scale with the font-size, this PR makes changes in the popover-related css to allow for font-scaling in the popovers.

The base work for this was done by @karlstolley in #30745.

Fixes: Part of #30476.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![add-channel-before](https://github.com/user-attachments/assets/9d1b5d55-d10f-49cb-b10b-04fbb33b3df9) | ![add-channel-after](https://github.com/user-attachments/assets/29946551-1cb4-4c1f-a797-7ba8957923fa) |
| ![group-info-before](https://github.com/user-attachments/assets/9ed71926-2a7f-46cd-a626-318fa4c6cc04) | ![group-info-after](https://github.com/user-attachments/assets/e3f927e3-012f-4279-b960-8ef4fb9586be) |
| ![help-menu-before](https://github.com/user-attachments/assets/64c7cbbd-6641-4e69-8b0a-808bbf97bd69) | ![help-menu-after](https://github.com/user-attachments/assets/5d8be03c-866d-4d4d-abc5-4f587d36da6d) |
| ![left-sidebar-before](https://github.com/user-attachments/assets/bd05500b-3324-45bc-87ab-aebfe4d72ef2) | ![left-sidebar-after](https://github.com/user-attachments/assets/0827e9f1-22fd-461b-a747-e1d7f5405736) |
| ![mobile-send-before](https://github.com/user-attachments/assets/723b2ba7-dc03-4a24-b3a6-5efb7ea0351a) | ![mobile-send-after](https://github.com/user-attachments/assets/caeb2d2f-acb6-49a8-881c-23a5f1d81b0a) | 
| ![msg-actions-before](https://github.com/user-attachments/assets/cbf3f2a3-04f0-468c-b24b-7e6f17cdd091) | ![msg-actions-after](https://github.com/user-attachments/assets/9df69214-c4e5-4652-bdd0-e3d544440d6b) | 
| ![personal-menu-before](https://github.com/user-attachments/assets/f76e789f-74cc-45e4-9a2e-5b4efa8bfca9) | ![personal-menu-after](https://github.com/user-attachments/assets/3042036e-1c8a-4419-8244-ebe4aa916d6d) | 
| ![send-opts-before](https://github.com/user-attachments/assets/5fccf24d-9581-415a-89dd-2c3c9045dc69) | ![send-opts-after](https://github.com/user-attachments/assets/9f0b67ad-348c-443a-ab72-b6b147b0056c) | 
| ![stream-actions-before](https://github.com/user-attachments/assets/ddb516b0-83b4-4fed-a7ad-11b98f610301) | ![stream-actions-after](https://github.com/user-attachments/assets/1a9e802e-c42a-49c8-a6b0-297554b703dc) | 
| ![topic-actions-before](https://github.com/user-attachments/assets/ad7fa7a9-5c4e-43f2-bb1a-69b99ea83eb9) | ![topic-actions-after](https://github.com/user-attachments/assets/3fdd4f43-a09b-4b98-b52f-abef3fbe126a) | 
| ![topic-vis-before](https://github.com/user-attachments/assets/47a445c9-b0d7-4a5d-b3cf-279af92fa20e) | ![topic-vis-after](https://github.com/user-attachments/assets/cec68198-0536-4f16-939d-3cd95ce4b02c) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
