### PR TITLE
user_group_settings: Disable dropdown if no permission to update it.

### DIFF
--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -101,6 +101,34 @@ function update_add_members_elements(group) {
     }
 }
 
+function update_general_settings_elements(group) {
+    if (!is_editing_group(group.id)) {
+        return;
+    }
+
+    // We are concerend with the General tab for changing group permissions.
+    const $group_permission_settings = $("#group_permission_settings");
+
+    // Otherwise, we adjust whether the widgets are disabled based on
+    // whether this user is authorized to change the group settings.
+    const $permission_dropdown_elements =
+        $group_permission_settings.find(".dropdown-widget-button");
+
+    if (settings_data.can_edit_user_group(group.id)) {
+        $permission_dropdown_elements.prop("disabled", false);
+        $permission_dropdown_elements
+            .closest(".dropdown_widget_with_label_wrapper")
+            ._tippy?.destroy();
+    } else {
+        $permission_dropdown_elements.prop("disabled", true);
+
+        settings_components.initialize_disable_btn_hint_popover(
+            $permission_dropdown_elements.closest(".dropdown_widget_with_label_wrapper"),
+            $t({defaultMessage: "You do not have permission to edit this setting."}),
+        );
+    }
+}
+
 function show_membership_settings(group) {
     const $edit_container = get_edit_container(group);
     update_add_members_elements(group);
@@ -110,6 +138,11 @@ function show_membership_settings(group) {
         group,
         $parent_container: $member_container,
     });
+}
+
+function show_general_settings(group) {
+    user_group_components.setup_permissions_dropdown(group, false);
+    update_general_settings_elements(group);
 }
 
 function enable_group_edit_settings(group) {
@@ -285,7 +318,7 @@ export function show_settings_for(group) {
 
     $edit_container.show();
     show_membership_settings(group);
-    user_group_components.setup_permissions_dropdown(group, false);
+    show_general_settings(group);
 }
 
 export function setup_group_settings(group) {

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1145,6 +1145,10 @@ div.overlay {
     }
 }
 
+.dropdown_widget_with_label_wrapper {
+    margin-top: 0 !important;
+}
+
 .dropdown-current-value-not-in-options,
 .setting-disabled-option {
     color: hsl(38deg 46% 54%);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1087,6 +1087,11 @@ div.settings-radio-input-parent {
     }
 }
 
+.group-permissions .dropdown_widget_with_label_wrapper {
+    display: inline-block;
+    height: 30px;
+}
+
 #stream-advanced-configurations {
     .dropdown-widget-button {
         color: hsl(0deg 0% 33%);

--- a/web/templates/dropdown_widget_with_label.hbs
+++ b/web/templates/dropdown_widget_with_label.hbs
@@ -3,5 +3,7 @@
         {{#if help_link}}{{> help_link_widget link=help_link }}{{/if}}
     </label>
     <span class="prop-element hide" id="id_{{widget_name}}" data-setting-widget-type="dropdown-list-widget" {{#if value_type}}data-setting-value-type="{{value_type}}"{{/if}}></span>
-    {{> dropdown_widget}}
+    <div class="dropdown_widget_with_label_wrapper">
+        {{> dropdown_widget}}
+    </div>
 </div>


### PR DESCRIPTION
Previously, even when a user doesn't have permission to edit a user group, the dropdown for the group permission settings was not disabled, and is possible for a user to change the values.

This commit adds a property `is_disabled` to the `dropdown_widget`, which can be used to disable the dropdown in cases of no permission  to update the widget, and the same is reflected in the user group permission settings.

<!-- Describe your pull request here.-->

[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/group.20permissions.20dropdown.20not.20disabled/near/1886217)



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/d36f2eb0-9f8c-4e49-a51d-c955950ee4dd)
![image](https://github.com/user-attachments/assets/06c74821-9157-4442-8f80-c5a5c639506d)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
