### PR TITLE
search pills: Fix bug closing multiple pills on fresh open.

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -75,8 +75,8 @@ function narrow_or_search_for_term({on_narrow_search}: {on_narrow_search: OnNarr
     return get_search_bar_text();
 }
 
-// When a pill is added or removed, or when text input is changed,
-// we set `search_input_has_changed` to `false`. We also remove the
+// When a pill is added, or when text input is changed, we set
+// `search_input_has_changed` to `false`. We also remove the
 // `freshly-opened` styling on the search pills (which is added in
 // `initiate_search` but not every time we open the search bar) after
 // the first input change.
@@ -106,7 +106,8 @@ export function initialize({on_narrow_search}: {on_narrow_search: OnNarrowSearch
 
     search_pill_widget = search_pill.create_pills($pill_container);
     search_pill_widget.onPillRemove(() => {
-        on_search_contents_changed();
+        $(".search-input-and-pills").removeClass("freshly-opened");
+        search_input_has_changed = true;
     });
 
     $search_query_box.on("change", () => {


### PR DESCRIPTION
`on_search_contents_changed` resets the search bar on input change in the "freshly opened" state. We shouldn't be calling this when removing pills, since removing pills should always remove the freshly opened state, not reset the search bar.

This bug was reported on CZO:
https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20message.20search.20'x'.2Fdelete/near/1883828

Note: After deleting a pill, the next pill will be highlighted. This is a feature of input pill and happens for all input pills, so I didn't bother changing it here even though I think it would be better to put focus in the text area.