### PR TITLE
search pills: Align typeahead text with pills.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -332,7 +332,7 @@
     }
 
     .typeahead-menu .simplebar-content > li > a {
-        padding: 3px 30px;
+        padding: 3px 40px;
         /* Override white-space: nowrap from zulip.css */
         white-space: normal;
 


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/d801ddc8-3e3b-44b1-8139-530da7809ca7)


after:

<img width="633" alt="image" src="https://github.com/user-attachments/assets/0515d262-549e-481e-8e66-cf412f20fb7e">

CZO: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20search.20pills.20alignment