### PR TITLE
search pills: Align icons on top row.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -215,11 +215,8 @@
         /* Override style for .pill-container that isn't relevant for search. */
         border: none;
         grid-template:
-            "search-icon search-pills search-close" minmax(
-                var(--search-box-height),
-                auto
-            )
-            / auto minmax(0, 1fr) 28px;
+            "search-icon search-pills search-close" var(--search-box-height)
+            ". search-pills ." auto / auto minmax(0, 1fr) 28px;
         align-items: start;
         cursor: pointer;
 


### PR DESCRIPTION
This reverts #30804. We need a followup PR to address the issue that PR was trying to solve without breaking icon alignment.

https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20buggy.20.60x.60.20button.20in.202-line.20search.20box/near/1886781