### PR TITLE
help: Update documentation on linking to topics and channels.

### DIFF
--- a/help/link-to-a-message-or-conversation.md
+++ b/help/link-to-a-message-or-conversation.md
@@ -24,6 +24,11 @@ The easiest way to link to a channel or topic is:
 1. Choose the desired topic from the auto-complete menu. The link will be
    automatically formatted for you.
 
+!!! tip ""
+
+    When you paste a topic or channel link into Zulip, it is automatically
+    formatted for you.
+
 {end_tabs}
 
 Alternatively, it is possible to manually format channel and topic links:
@@ -98,14 +103,9 @@ message](/help/quote-and-reply).
 
 {tab|desktop-web}
 
-1. Right-click on a channel in the left sidebar.
+{!channel-actions.md!}
 
-1. Click **Copy Link**.
-
-!!! tip ""
-
-    If using Zulip in a browser, you can also click on a channel in the
-    left sidebar, and copy the URL from your browser's address bar.
+1. Click **Copy link to channel**.
 
 {tab|mobile}
 


### PR DESCRIPTION
Current: https://zulip.com/help/link-to-a-message-or-conversation

Updated:

![Screenshot 2024-07-12 at 15 42 25@2x](https://github.com/user-attachments/assets/f67609e2-2df2-43dd-be84-b69b1926f4b1)
![Screenshot 2024-07-12 at 15 42 33@2x](https://github.com/user-attachments/assets/d6d8c8fe-a651-46f2-81fd-39010c9f3ddb)
