### PR TITLE
custom_profile_fields: improve check_valid_user_ids() efficiency.

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -718,7 +718,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         field_name = "Mentor"
         invalid_user_id = 1000
         self.assert_error_update_invalid_value(
-            field_name, [invalid_user_id], f"Invalid user ID: {invalid_user_id}"
+            field_name, [invalid_user_id], f"Invalid user IDs: {invalid_user_id}"
         )
 
     def test_update_profile_data_successfully(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1158,12 +1158,18 @@ class UserProfileTest(ZulipTestCase):
         othello = self.example_user("othello")
         bot = self.example_user("default_bot")
 
-        # Invalid user ID
+        # Invalid user IDs
         invalid_uid: object = 1000
+        another_invalid_uid: object = 1001
         with self.assertRaisesRegex(ValidationError, r"User IDs is not a list"):
             check_valid_user_ids(realm.id, invalid_uid)
-        with self.assertRaisesRegex(ValidationError, rf"Invalid user ID: {invalid_uid}"):
+        with self.assertRaisesRegex(ValidationError, rf"Invalid user IDs: {invalid_uid}"):
             check_valid_user_ids(realm.id, [invalid_uid])
+
+        with self.assertRaisesRegex(
+            ValidationError, rf"Invalid user IDs: {invalid_uid}, {another_invalid_uid}"
+        ):
+            check_valid_user_ids(realm.id, [invalid_uid, another_invalid_uid])
 
         invalid_uid = "abc"
         with self.assertRaisesRegex(ValidationError, r"User IDs\[0\] is not an integer"):
@@ -1174,7 +1180,7 @@ class UserProfileTest(ZulipTestCase):
             check_valid_user_ids(realm.id, [invalid_uid])
 
         # User is in different realm
-        with self.assertRaisesRegex(ValidationError, rf"Invalid user ID: {hamlet.id}"):
+        with self.assertRaisesRegex(ValidationError, rf"Invalid user IDs: {hamlet.id}"):
             check_valid_user_ids(get_realm("zephyr").id, [hamlet.id])
 
         # User is not active


### PR DESCRIPTION
bulk fetch query of `UserProfile` against which user_ids are validated, instead of looping over `user_ids` and fetching each `UserPfrofile` resulting in `O(n)` queries.

raises `ValidationError` showing all the invalid ids in one line instead of one exception per the first encountered invalid id.