### PR TITLE
Fix typeahead spacing and alignment issue.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -83,12 +83,14 @@
     }
 
     .autocomplete_secondary {
-        align-self: center;
+        align-self: end;
         opacity: 0.8;
         font-size: 85%;
         flex: 1 1 0;
         overflow: hidden;
         text-overflow: ellipsis;
+        position: relative;
+        top: -1px;
     }
 
     .active .autocomplete_secondary {

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -25,7 +25,7 @@
             font-weight: normal;
             /* We want to keep this `max-width` less than 320px. */
             max-width: 292px;
-            line-height: var(--base-line-height-unitless);
+            line-height: 1.43; /* 20px / 14px */
             color: var(--color-dropdown-item);
             white-space: nowrap;
 


### PR DESCRIPTION
16px
<img width="460" alt="Screenshot 2024-07-13 at 12 24 52 PM" src="https://github.com/user-attachments/assets/6cd6e0ad-3013-4cdf-b162-59637cc1f229">
<img width="460" alt="Screenshot 2024-07-13 at 12 24 49 PM" src="https://github.com/user-attachments/assets/fa8373c0-78dc-4e8f-82af-3cb3efbed8a2">

<img width="460" alt="Screenshot 2024-07-13 at 12 24 46 PM" src="https://github.com/user-attachments/assets/73f7beed-2e62-409b-9c7c-fc7bc5ab2d03">



14px
<img width="460" alt="Screenshot 2024-07-13 at 12 24 20 PM" src="https://github.com/user-attachments/assets/6d64d3b4-3e9c-4328-9c98-3f13fa63aac8">
<img width="460" alt="Screenshot 2024-07-13 at 12 24 14 PM" src="https://github.com/user-attachments/assets/5890493c-5d1d-4f32-9fba-4ff1d657fe57">
<img width="460" alt="Screenshot 2024-07-13 at 12 24 09 PM" src="https://github.com/user-attachments/assets/cbdc740f-7a16-4a7e-a516-c309e9edd903">

