### PR TITLE
personal_menu: Don't show user local time.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -187,7 +187,6 @@ export function get_personal_menu_content_context() {
         show_placeholder_for_status_text: !status_text && status_emoji_info,
         status_text,
         status_emoji_info,
-        user_time: people.get_user_time(my_user_id),
 
         // user color scheme
         user_color_scheme: user_settings.color_scheme,

--- a/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
+++ b/web/templates/popovers/navbar/navbar_personal_menu_popover.hbs
@@ -16,13 +16,6 @@
         </header>
         <section class="dropdown-menu-list-section personal-menu-actions" data-user-id="{{user_id}}">
             <ul role="menu" class="popover-menu-list">
-                {{#if user_time}}
-                <li role="none" class="text-item hidden-for-spectators popover-menu-list-item">
-                    <i class="popover-menu-icon zulip-icon zulip-icon-clock" aria-hidden="true"></i>
-                    {{#tr}}{user_time} local time{{/tr}}
-                </li>
-                <li role="separator" class="popover-menu-separator"></li>
-                {{/if}}
                 {{#if status_content_available}}
                 <li role="none" class="text-item popover-menu-list-item">
                     <span class="personal-menu-status-wrapper">


### PR DESCRIPTION
Fixes #30044


<img width="460" alt="Screenshot 2024-07-14 at 8 09 42 PM" src="https://github.com/user-attachments/assets/3c5a9048-89a0-4b52-b251-fa0d2fed4607">
