### PR TITLE
topic permalinks follow up commits

### DIFF
--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -282,13 +282,8 @@ export function _possible_unread_message_ids(
     assert(!current_filter.requires_adjustment_for_moved_with_target);
 
     if (current_filter.can_bucket_by("channel", "topic", "with")) {
-        sub = stream_sub(current_filter);
-        topic_name = topic(current_filter);
-
-        if (sub === undefined || topic_name === undefined) {
-            /* istanbul ignore next */
-            return [];
-        }
+        sub = stream_sub(current_filter)!;
+        topic_name = topic(current_filter)!;
         return unread.get_msg_ids_for_topic(sub.stream_id, topic_name);
     }
 

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -3,7 +3,6 @@ import assert from "minimalistic-assert";
 import * as blueslip from "./blueslip";
 import {Filter} from "./filter";
 import * as message_lists from "./message_lists";
-import * as message_store from "./message_store";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import type {NarrowTerm} from "./state_data";
@@ -286,18 +285,6 @@ export function _possible_unread_message_ids(
         sub = stream_sub(current_filter);
         topic_name = topic(current_filter);
 
-        const with_operand = current_filter.operands("with")[0]!;
-        const target_id = Number.parseInt(with_operand, 10);
-        const target_message = message_store.get(target_id)!;
-
-        if (target_message?.type === "private") {
-            // BUG: In theory, the fact that we've asserted
-            // !current_filter.requires_adjustment_for_moved_with_target
-            // should mean this is not possible; but
-            // filter.adjusted_terms_if_moved incorrectly does not
-            // ensure this. Once that bug is fixed, we can delete this case.
-            return [];
-        }
         if (sub === undefined || topic_name === undefined) {
             /* istanbul ignore next */
             return [];

--- a/web/tests/narrow_unread.test.js
+++ b/web/tests/narrow_unread.test.js
@@ -76,7 +76,7 @@ run_test("get_unread_ids", () => {
         id: 102,
         type: "private",
         unread: true,
-        display_recipient: [{id: alice.user_id}],
+        display_recipient: [{id: alice.user_id, email: alice.email}],
     };
 
     const other_topic_message = {
@@ -249,7 +249,7 @@ run_test("get_unread_ids", () => {
     ];
     set_filter(terms);
     unread_ids = candidate_ids();
-    assert.deepEqual(unread_ids, []);
+    assert.deepEqual(unread_ids, [private_msg.id]);
 
     message_lists.set_current(undefined);
     blueslip.expect("error", "unexpected call to get_first_unread_info");


### PR DESCRIPTION
Previously, when "adjusted_terms_if_moved" was called for non stream messages, it used to return "null" for adjusted terms. This is true for some extent since the non stream messages can not be moved.

However, in case of narrow containing "with" operator, this would be buggy since there, we want the narrow terms to be adjusted according to the "with" operand to point to the current narrow, rather than returning null.

This commit updates the method to return null only if  the "raw_terms" dont contain "with" operator. Else, adjust the "raw_terms" according to the message.

<!-- Describe your pull request here.-->

`commit 1`: Fixes checkbox 6 of https://github.com/zulip/zulip/pull/30114#issuecomment-2226642678
`commit 2`: Fixes checkbox 7 of https://github.com/zulip/zulip/pull/30114#issuecomment-2226642678

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
