### PR TITLE
Zerver-typed-endpoint-migrate

### DIFF
--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -30,7 +30,7 @@ for any particular type of object.
 
 import re
 import zoneinfo
-from collections.abc import Callable, Collection, Container, Iterator
+from collections.abc import Collection, Container, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, NoReturn, TypeVar, cast, overload
@@ -587,28 +587,6 @@ def to_non_negative_int(var_name: str, s: str, max_int_size: int = 2**32 - 1) ->
 
 def to_float(var_name: str, s: str) -> float:
     return float(s)
-
-
-def to_timezone_or_empty(var_name: str, s: str) -> str:
-    try:
-        s = canonicalize_timezone(s)
-        zoneinfo.ZoneInfo(s)
-    except (ValueError, zoneinfo.ZoneInfoNotFoundError):
-        return ""
-    else:
-        return s
-
-
-def to_converted_or_fallback(
-    sub_converter: Callable[[str, str], ResultT], default: ResultT
-) -> Callable[[str, str], ResultT]:
-    def converter(var_name: str, s: str) -> ResultT:
-        try:
-            return sub_converter(var_name, s)
-        except ValueError:
-            return default
-
-    return converter
 
 
 def check_string_or_int_list(var_name: str, val: object) -> str | list[int]:

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -731,7 +731,9 @@ class InviteUserTest(InviteUserBase):
         self.login("iago")
         invitee = self.nonreg_email("alice")
         response = self.invite(invitee, ["Denmark"], invite_as=10)
-        self.assert_json_error(response, "Invalid invite_as")
+        self.assert_json_error(
+            response, "Invalid invite_as: Value error, Not in the list of possible values"
+        )
 
     def test_successful_invite_user_as_guest_from_normal_account(self) -> None:
         self.login("hamlet")
@@ -2953,4 +2955,6 @@ class MultiuseInviteTest(ZulipTestCase):
                 "invite_expires_in_minutes": 2 * 24 * 60,
             },
         )
-        self.assert_json_error(result, "Invalid invite_as")
+        self.assert_json_error(
+            result, "Invalid invite_as: Value error, Not in the list of possible values"
+        )

--- a/zerver/tests/test_typed_endpoint_validators.py
+++ b/zerver/tests/test_typed_endpoint_validators.py
@@ -1,5 +1,10 @@
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.typed_endpoint_validators import check_int_in, check_string_in, check_url
+from zerver.lib.typed_endpoint_validators import (
+    check_int_in,
+    check_string_in,
+    check_url,
+    to_non_negative_int_or_none,
+)
 
 
 class ValidatorTestCase(ZulipTestCase):
@@ -17,3 +22,14 @@ class ValidatorTestCase(ZulipTestCase):
         check_url("https://example.com")
         with self.assertRaisesRegex(ValueError, "Not a URL"):
             check_url("https://127.0.0..:5000")
+
+    def test_to_non_negative_int_or_none(self) -> None:
+        self.assertEqual(to_non_negative_int_or_none("3"), 3)
+        self.assertEqual(to_non_negative_int_or_none("-3"), None)
+        self.assertEqual(to_non_negative_int_or_none("a"), None)
+        self.assertEqual(to_non_negative_int_or_none("3.5"), None)
+        self.assertEqual(to_non_negative_int_or_none("3.0"), None)
+        self.assertEqual(to_non_negative_int_or_none("3.1"), None)
+        self.assertEqual(to_non_negative_int_or_none("3.9"), None)
+        self.assertEqual(to_non_negative_int_or_none("3.5"), None)
+        self.assertEqual(to_non_negative_int_or_none("foo"), None)

--- a/zerver/views/email_mirror.py
+++ b/zerver/views/email_mirror.py
@@ -3,16 +3,17 @@ from django.http import HttpRequest, HttpResponse
 from zerver.decorator import internal_api_view
 from zerver.lib.email_mirror import mirror_email_message
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
+from zerver.lib.typed_endpoint import typed_endpoint
 
 
 @internal_api_view(False)
-@has_request_variables
+@typed_endpoint
 def email_mirror_message(
     request: HttpRequest,
-    rcpt_to: str = REQ(),
-    msg_base64: str = REQ(),
+    *,
+    rcpt_to: str,
+    msg_base64: str,
 ) -> HttpResponse:
     result = mirror_email_message(rcpt_to, msg_base64)
     if result["status"] == "error":

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -1,10 +1,11 @@
 import re
-from collections.abc import Sequence
+from typing import Annotated
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
+from pydantic import Json
 
 from confirmation import settings as confirmation_settings
 from zerver.actions.invites import (
@@ -17,10 +18,10 @@ from zerver.actions.invites import (
 )
 from zerver.decorator import require_member_or_admin
 from zerver.lib.exceptions import InvitationError, JsonableError, OrganizationOwnerRequiredError
-from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id
-from zerver.lib.validator import check_bool, check_int, check_int_in, check_list, check_none_or
+from zerver.lib.typed_endpoint import ApiParamConfig, PathOnly, typed_endpoint
+from zerver.lib.typed_endpoint_validators import check_int_in_validator
 from zerver.models import MultiuseInvite, PreregistrationUser, Stream, UserProfile
 
 # Convert INVITATION_LINK_VALIDITY_DAYS into minutes.
@@ -44,25 +45,20 @@ def check_role_based_permissions(
 
 
 @require_member_or_admin
-@has_request_variables
+@typed_endpoint
 def invite_users_backend(
     request: HttpRequest,
     user_profile: UserProfile,
-    invitee_emails_raw: str = REQ("invitee_emails"),
-    invite_expires_in_minutes: int | None = REQ(
-        json_validator=check_none_or(check_int), default=INVITATION_LINK_VALIDITY_MINUTES
-    ),
-    invite_as: int = REQ(
-        json_validator=check_int_in(
-            list(PreregistrationUser.INVITE_AS.values()),
-        ),
-        default=PreregistrationUser.INVITE_AS["MEMBER"],
-    ),
-    notify_referrer_on_join: bool = REQ(
-        "notify_referrer_on_join", json_validator=check_bool, default=True
-    ),
-    stream_ids: list[int] = REQ(json_validator=check_list(check_int)),
-    include_realm_default_subscriptions: bool = REQ(json_validator=check_bool, default=False),
+    *,
+    invitee_emails_raw: Annotated[str, ApiParamConfig("invitee_emails")],
+    invite_expires_in_minutes: Json[int | None] = INVITATION_LINK_VALIDITY_MINUTES,
+    invite_as: Annotated[
+        Json[int],
+        check_int_in_validator(list(PreregistrationUser.INVITE_AS.values())),
+    ] = PreregistrationUser.INVITE_AS["MEMBER"],
+    notify_referrer_on_join: Json[bool] = True,
+    stream_ids: Json[list[int]],
+    include_realm_default_subscriptions: Json[bool] = False,
 ) -> HttpResponse:
     if not user_profile.can_invite_users_by_email():
         # Guest users case will not be handled here as it will
@@ -140,9 +136,9 @@ def get_user_invites(request: HttpRequest, user_profile: UserProfile) -> HttpRes
 
 
 @require_member_or_admin
-@has_request_variables
+@typed_endpoint
 def revoke_user_invite(
-    request: HttpRequest, user_profile: UserProfile, invite_id: int
+    request: HttpRequest, user_profile: UserProfile, *, invite_id: PathOnly[int]
 ) -> HttpResponse:
     try:
         prereg_user = PreregistrationUser.objects.get(id=invite_id)
@@ -160,9 +156,9 @@ def revoke_user_invite(
 
 
 @require_member_or_admin
-@has_request_variables
+@typed_endpoint
 def revoke_multiuse_invite(
-    request: HttpRequest, user_profile: UserProfile, invite_id: int
+    request: HttpRequest, user_profile: UserProfile, *, invite_id: PathOnly[int]
 ) -> HttpResponse:
     try:
         invite = MultiuseInvite.objects.get(id=invite_id)
@@ -183,9 +179,9 @@ def revoke_multiuse_invite(
 
 
 @require_member_or_admin
-@has_request_variables
+@typed_endpoint
 def resend_user_invite_email(
-    request: HttpRequest, user_profile: UserProfile, invite_id: int
+    request: HttpRequest, user_profile: UserProfile, *, invite_id: PathOnly[int]
 ) -> HttpResponse:
     try:
         prereg_user = PreregistrationUser.objects.get(id=invite_id)
@@ -205,22 +201,21 @@ def resend_user_invite_email(
 
 
 @require_member_or_admin
-@has_request_variables
+@typed_endpoint
 def generate_multiuse_invite_backend(
     request: HttpRequest,
     user_profile: UserProfile,
-    invite_expires_in_minutes: int | None = REQ(
-        json_validator=check_none_or(check_int), default=INVITATION_LINK_VALIDITY_MINUTES
-    ),
-    invite_as: int = REQ(
-        json_validator=check_int_in(
-            list(PreregistrationUser.INVITE_AS.values()),
-        ),
-        default=PreregistrationUser.INVITE_AS["MEMBER"],
-    ),
-    stream_ids: Sequence[int] = REQ(json_validator=check_list(check_int), default=[]),
-    include_realm_default_subscriptions: bool = REQ(json_validator=check_bool, default=False),
+    *,
+    invite_expires_in_minutes: Json[int | None] = INVITATION_LINK_VALIDITY_MINUTES,
+    invite_as: Annotated[
+        Json[int],
+        check_int_in_validator(list(PreregistrationUser.INVITE_AS.values())),
+    ] = PreregistrationUser.INVITE_AS["MEMBER"],
+    stream_ids: Json[list[int]] | None = None,
+    include_realm_default_subscriptions: Json[bool] = False,
 ) -> HttpResponse:
+    if stream_ids is None:
+        stream_ids = []
     if not user_profile.can_create_multiuse_invite_to_realm():
         # Guest users case will not be handled here as it will
         # be handled by the decorator above.


### PR DESCRIPTION
Convert a few files from /zerver to typed_endpoint.

Removed unnecessary validators from `validators.py`.