### PR TITLE
ruff: Fix SIM117 Use a single `with` statement with multiple contexts

### DIFF
--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -560,12 +560,15 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
         )
 
         # Try the case where the identity dict is simultaneously expired.
-        with time_machine.travel(
-            now + timedelta(seconds=REMOTE_BILLING_SESSION_VALIDITY_SECONDS + 30),
-            tick=False,
+        with (
+            time_machine.travel(
+                now + timedelta(seconds=REMOTE_BILLING_SESSION_VALIDITY_SECONDS + 30),
+                tick=False,
+            ),
+            self.assertLogs("django.request", "ERROR") as m,
+            self.assertRaises(AssertionError),
         ):
-            with self.assertLogs("django.request", "ERROR") as m, self.assertRaises(AssertionError):
-                self.client_get(final_url, subdomain="selfhosting")
+            self.client_get(final_url, subdomain="selfhosting")
         # The django.request log should be a traceback, mentioning the relevant
         # exceptions that occurred.
         self.assertIn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ ignore = [
     "SIM103", # Return the condition directly
     "SIM108", # Use ternary operator `action = "[commented]" if action == "created" else f"{action} a [comment]"` instead of if-else-block
     "SIM114", # Combine `if` branches using logical `or` operator
-    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
     "SIM401", # Use `d.get(key, default)` instead of an `if` block
     "TCH001", # Move application import into a type-checking block
     "TCH002", # Move third-party import into a type-checking block

--- a/tools/tail-ses
+++ b/tools/tail-ses
@@ -66,9 +66,11 @@ def main() -> None:
     args = parser.parse_args()
 
     sns_topic_arn = get_ses_arn(session, args)
-    with our_sqs_queue(session, sns_topic_arn) as (queue_arn, queue_url):
-        with our_sns_subscription(session, sns_topic_arn, queue_arn):
-            print_messages(session, queue_url)
+    with (
+        our_sqs_queue(session, sns_topic_arn) as (queue_arn, queue_url),
+        our_sns_subscription(session, sns_topic_arn, queue_arn),
+    ):
+        print_messages(session, queue_url)
 
 
 def get_ses_arn(session: boto3.session.Session, args: argparse.Namespace) -> str:

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -168,11 +168,13 @@ def get_failed_tests() -> list[str]:
 def block_internet() -> Iterator[None]:
     # Monkey-patching - responses library raises requests.ConnectionError when access to an unregistered URL
     # is attempted. We want to replace that with our own exception, so that it propagates all the way:
-    with mock.patch.object(responses, "ConnectionError", new=ZulipInternetBlockedError):
+    with (
+        mock.patch.object(responses, "ConnectionError", new=ZulipInternetBlockedError),
         # We'll run all tests in this context manager. It'll cause an error to be raised (see above comment),
         # if any code attempts to access the internet.
-        with responses.RequestsMock():
-            yield
+        responses.RequestsMock(),
+    ):
+        yield
 
 
 class ZulipInternetBlockedError(Exception):

--- a/tools/test-locked-requirements
+++ b/tools/test-locked-requirements
@@ -19,14 +19,13 @@ CACHE_FILE = os.path.join(CACHE_DIR, "requirements_hashes")
 
 
 def print_diff(path_file1: str, path_file2: str) -> None:
-    with open(path_file1) as file1:
-        with open(path_file2) as file2:
-            diff = difflib.unified_diff(
-                file1.readlines(),
-                file2.readlines(),
-                fromfile=path_file1,
-                tofile=path_file2,
-            )
+    with open(path_file1) as file1, open(path_file2) as file2:
+        diff = difflib.unified_diff(
+            file1.readlines(),
+            file2.readlines(),
+            fromfile=path_file1,
+            tofile=path_file2,
+        )
     sys.stdout.writelines(diff)
 
 

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1347,10 +1347,12 @@ def fetch_team_icons(
     )
 
     resized_icon_output_path = os.path.join(output_dir, str(realm_id), "icon.png")
-    with open(resized_icon_output_path, "wb") as output_file:
-        with open(original_icon_output_path, "rb") as original_file:
-            resized_data = resize_logo(original_file.read())
-            output_file.write(resized_data)
+    with (
+        open(resized_icon_output_path, "wb") as output_file,
+        open(original_icon_output_path, "rb") as original_file,
+    ):
+        resized_data = resize_logo(original_file.read())
+        output_file.write(resized_data)
     records.append(
         {
             "realm_id": realm_id,

--- a/zerver/lib/context_managers.py
+++ b/zerver/lib/context_managers.py
@@ -28,9 +28,8 @@ def lockfile(filename: str, shared: bool = False) -> Iterator[None]:
     If shared is True, use a LOCK_SH lock, otherwise LOCK_EX.
 
     The file is given by name and will be created if it does not exist."""
-    with open(filename, "w") as lock:
-        with flock(lock, shared=shared):
-            yield
+    with open(filename, "w") as lock, flock(lock, shared=shared):
+        yield
 
 
 @contextmanager

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -548,15 +548,17 @@ def custom_email_sender(
     rendered_input = render_markdown_path(plain_text_template_path.replace("templates/", ""))
 
     # And then extend it with our standard email headers.
-    with open(html_template_path, "w") as f:
-        with open(markdown_email_base_template_path) as base_template:
-            # We use an ugly string substitution here, because we want to:
-            #  1. Only run Jinja once on the supplied content
-            #  2. Allow the supplied content to have jinja interpolation in it
-            #  3. Have that interpolation happen in the context of
-            #     each individual email we send, so the contents can
-            #     vary user-to-user
-            f.write(base_template.read().replace("{{ rendered_input }}", rendered_input))
+    with (
+        open(html_template_path, "w") as f,
+        open(markdown_email_base_template_path) as base_template,
+    ):
+        # We use an ugly string substitution here, because we want to:
+        #  1. Only run Jinja once on the supplied content
+        #  2. Allow the supplied content to have jinja interpolation in it
+        #  3. Have that interpolation happen in the context of
+        #     each individual email we send, so the contents can
+        #     vary user-to-user
+        f.write(base_template.read().replace("{{ rendered_input }}", rendered_input))
 
     with open(subject_path, "w") as f:
         f.write(get_header(subject, parsed_email_template.get("subject"), "subject"))

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -2018,14 +2018,16 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
         # Some code might call process_notification using keyword arguments,
         # so mypy doesn't allow assigning lst.append to process_notification
         # So explicitly change parameter name to 'notice' to work around this problem
-        with mock.patch("zerver.tornado.event_queue.process_notification", lst.append):
+        with (
+            mock.patch("zerver.tornado.event_queue.process_notification", lst.append),
             # Some `send_event` calls need to be executed only after the current transaction
             # commits (using `on_commit` hooks). Because the transaction in Django tests never
             # commits (rather, gets rolled back after the test completes), such events would
             # never be sent in tests, and we would be unable to verify them. Hence, we use
             # this helper to make sure the `send_event` calls actually run.
-            with self.captureOnCommitCallbacks(execute=True):
-                yield lst
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            yield lst
 
         self.assert_length(lst, expected_num_events)
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -71,9 +71,11 @@ class MockLDAP(fakeldap.MockLDAP):
 def stub_event_queue_user_events(
     event_queue_return: Any, user_events_return: Any
 ) -> Iterator[None]:
-    with mock.patch("zerver.lib.events.request_event_queue", return_value=event_queue_return):
-        with mock.patch("zerver.lib.events.get_user_events", return_value=user_events_return):
-            yield
+    with (
+        mock.patch("zerver.lib.events.request_event_queue", return_value=event_queue_return),
+        mock.patch("zerver.lib.events.get_user_events", return_value=user_events_return),
+    ):
+        yield
 
 
 @contextmanager

--- a/zerver/migrations/0553_copy_emoji_images.py
+++ b/zerver/migrations/0553_copy_emoji_images.py
@@ -186,9 +186,11 @@ def thumbnail_local_emoji(apps: StateApps) -> None:
             )
             new_file_name = get_emoji_file_name("image/png", emoji.id)
             try:
-                with open(f"{settings.DEPLOY_ROOT}/static/images/bad-emoji.png", "rb") as f:
-                    with open(f"{base_path}/{new_file_name}", "wb") as new_f:
-                        new_f.write(f.read())
+                with (
+                    open(f"{settings.DEPLOY_ROOT}/static/images/bad-emoji.png", "rb") as f,
+                    open(f"{base_path}/{new_file_name}", "wb") as new_f,
+                ):
+                    new_f.write(f.read())
                 emoji.deactivated = True
                 emoji.is_animated = False
                 emoji.file_name = new_file_name

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3415,14 +3415,16 @@ class AppleIdAuthBackendTest(AppleAuthMixin, SocialAuthBase):
 
     def test_id_token_verification_failure(self) -> None:
         account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
-        with self.assertLogs(self.logger_string, level="INFO") as m:
-            with mock.patch("jwt.decode", side_effect=PyJWTError):
-                result = self.social_auth_test(
-                    account_data_dict,
-                    expect_choose_email_screen=True,
-                    subdomain="zulip",
-                    is_signup=True,
-                )
+        with (
+            self.assertLogs(self.logger_string, level="INFO") as m,
+            mock.patch("jwt.decode", side_effect=PyJWTError),
+        ):
+            result = self.social_auth_test(
+                account_data_dict,
+                expect_choose_email_screen=True,
+                subdomain="zulip",
+                is_signup=True,
+            )
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
         self.assertEqual(
@@ -4583,9 +4585,11 @@ class GoogleAuthBackendTest(SocialAuthBase):
                 "redirect_to": next,
             }
             user_profile = self.example_user("hamlet")
-            with mock.patch("zerver.views.auth.authenticate", return_value=user_profile):
-                with mock.patch("zerver.views.auth.do_login"):
-                    result = self.get_log_into_subdomain(data)
+            with (
+                mock.patch("zerver.views.auth.authenticate", return_value=user_profile),
+                mock.patch("zerver.views.auth.do_login"),
+            ):
+                result = self.get_log_into_subdomain(data)
             return result
 
         res = test_redirect_to_next_url()
@@ -5666,49 +5670,55 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_login_failure_due_to_wrong_subdomain(self) -> None:
         email = self.example_email("hamlet")
-        with self.settings(
-            AUTHENTICATION_BACKENDS=(
-                "zproject.backends.ZulipRemoteUserBackend",
-                "zproject.backends.ZulipDummyBackend",
-            )
-        ):
-            with mock.patch("zerver.views.auth.get_subdomain", return_value="acme"):
-                result = self.client_get(
-                    "http://testserver:9080/accounts/login/sso/", REMOTE_USER=email
-                )
-                self.assertEqual(result.status_code, 200)
-                self.assert_logged_in_user_id(None)
-                self.assert_in_response("You need an invitation to join this organization.", result)
-
-    def test_login_failure_due_to_empty_subdomain(self) -> None:
-        email = self.example_email("hamlet")
-        with self.settings(
-            AUTHENTICATION_BACKENDS=(
-                "zproject.backends.ZulipRemoteUserBackend",
-                "zproject.backends.ZulipDummyBackend",
-            )
-        ):
-            with mock.patch("zerver.views.auth.get_subdomain", return_value=""):
-                result = self.client_get(
-                    "http://testserver:9080/accounts/login/sso/", REMOTE_USER=email
-                )
-                self.assertEqual(result.status_code, 200)
-                self.assert_logged_in_user_id(None)
-                self.assert_in_response("You need an invitation to join this organization.", result)
-
-    def test_login_success_under_subdomains(self) -> None:
-        user_profile = self.example_user("hamlet")
-        email = user_profile.delivery_email
-        with mock.patch("zerver.views.auth.get_subdomain", return_value="zulip"):
-            with self.settings(
+        with (
+            self.settings(
                 AUTHENTICATION_BACKENDS=(
                     "zproject.backends.ZulipRemoteUserBackend",
                     "zproject.backends.ZulipDummyBackend",
                 )
-            ):
-                result = self.client_get("/accounts/login/sso/", REMOTE_USER=email)
-                self.assertEqual(result.status_code, 302)
-                self.assert_logged_in_user_id(user_profile.id)
+            ),
+            mock.patch("zerver.views.auth.get_subdomain", return_value="acme"),
+        ):
+            result = self.client_get(
+                "http://testserver:9080/accounts/login/sso/", REMOTE_USER=email
+            )
+            self.assertEqual(result.status_code, 200)
+            self.assert_logged_in_user_id(None)
+            self.assert_in_response("You need an invitation to join this organization.", result)
+
+    def test_login_failure_due_to_empty_subdomain(self) -> None:
+        email = self.example_email("hamlet")
+        with (
+            self.settings(
+                AUTHENTICATION_BACKENDS=(
+                    "zproject.backends.ZulipRemoteUserBackend",
+                    "zproject.backends.ZulipDummyBackend",
+                )
+            ),
+            mock.patch("zerver.views.auth.get_subdomain", return_value=""),
+        ):
+            result = self.client_get(
+                "http://testserver:9080/accounts/login/sso/", REMOTE_USER=email
+            )
+            self.assertEqual(result.status_code, 200)
+            self.assert_logged_in_user_id(None)
+            self.assert_in_response("You need an invitation to join this organization.", result)
+
+    def test_login_success_under_subdomains(self) -> None:
+        user_profile = self.example_user("hamlet")
+        email = user_profile.delivery_email
+        with (
+            mock.patch("zerver.views.auth.get_subdomain", return_value="zulip"),
+            self.settings(
+                AUTHENTICATION_BACKENDS=(
+                    "zproject.backends.ZulipRemoteUserBackend",
+                    "zproject.backends.ZulipDummyBackend",
+                )
+            ),
+        ):
+            result = self.client_get("/accounts/login/sso/", REMOTE_USER=email)
+            self.assertEqual(result.status_code, 302)
+            self.assert_logged_in_user_id(user_profile.id)
 
     @override_settings(SEND_LOGIN_EMAILS=True)
     @override_settings(
@@ -5974,30 +5984,34 @@ class TestJWTLogin(ZulipTestCase):
 
     def test_login_failure_due_to_wrong_subdomain(self) -> None:
         payload = {"email": "hamlet@zulip.com"}
-        with self.settings(JWT_AUTH_KEYS={"acme": {"key": "key", "algorithms": ["HS256"]}}):
-            with mock.patch("zerver.views.auth.get_realm_from_request", return_value=None):
-                key = settings.JWT_AUTH_KEYS["acme"]["key"]
-                [algorithm] = settings.JWT_AUTH_KEYS["acme"]["algorithms"]
-                web_token = jwt.encode(payload, key, algorithm)
+        with (
+            self.settings(JWT_AUTH_KEYS={"acme": {"key": "key", "algorithms": ["HS256"]}}),
+            mock.patch("zerver.views.auth.get_realm_from_request", return_value=None),
+        ):
+            key = settings.JWT_AUTH_KEYS["acme"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["acme"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
 
-                data = {"token": web_token}
-                result = self.client_post("/accounts/login/jwt/", data)
-                self.assert_json_error_contains(result, "Invalid subdomain", 404)
-                self.assert_logged_in_user_id(None)
+            data = {"token": web_token}
+            result = self.client_post("/accounts/login/jwt/", data)
+            self.assert_json_error_contains(result, "Invalid subdomain", 404)
+            self.assert_logged_in_user_id(None)
 
     def test_login_success_under_subdomains(self) -> None:
         payload = {"email": "hamlet@zulip.com"}
-        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key", "algorithms": ["HS256"]}}):
-            with mock.patch("zerver.views.auth.get_subdomain", return_value="zulip"):
-                key = settings.JWT_AUTH_KEYS["zulip"]["key"]
-                [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
-                web_token = jwt.encode(payload, key, algorithm)
+        with (
+            self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key", "algorithms": ["HS256"]}}),
+            mock.patch("zerver.views.auth.get_subdomain", return_value="zulip"),
+        ):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
 
-                data = {"token": web_token}
-                result = self.client_post("/accounts/login/jwt/", data)
-                self.assertEqual(result.status_code, 302)
-                user_profile = self.example_user("hamlet")
-                self.assert_logged_in_user_id(user_profile.id)
+            data = {"token": web_token}
+            result = self.client_post("/accounts/login/jwt/", data)
+            self.assertEqual(result.status_code, 302)
+            user_profile = self.example_user("hamlet")
+            self.assert_logged_in_user_id(user_profile.id)
 
 
 class DjangoToLDAPUsernameTests(ZulipTestCase):
@@ -6046,9 +6060,8 @@ class DjangoToLDAPUsernameTests(ZulipTestCase):
             self.backend.django_to_ldap_username("aaron@zulip.com"), self.ldap_username("aaron")
         )
 
-        with self.assertLogs(level="WARNING") as m:
-            with self.assertRaises(NoMatchingLDAPUserError):
-                self.backend.django_to_ldap_username("shared_email@zulip.com")
+        with self.assertLogs(level="WARNING") as m, self.assertRaises(NoMatchingLDAPUserError):
+            self.backend.django_to_ldap_username("shared_email@zulip.com")
         self.assertEqual(
             m.output,
             [
@@ -6641,9 +6654,11 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
 
     @override_settings(LDAP_EMAIL_ATTR="mail")
     def test_populate_user_returns_none(self) -> None:
-        with mock.patch.object(ZulipLDAPUser, "populate_user", return_value=None):
-            with self.assertRaises(PopulateUserLDAPError):
-                sync_user_from_ldap(self.example_user("hamlet"), mock.Mock())
+        with (
+            mock.patch.object(ZulipLDAPUser, "populate_user", return_value=None),
+            self.assertRaises(PopulateUserLDAPError),
+        ):
+            sync_user_from_ldap(self.example_user("hamlet"), mock.Mock())
 
     def test_update_full_name(self) -> None:
         self.change_ldap_user_attr("hamlet", "cn", "New Name")
@@ -6823,17 +6838,19 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
 
         self.change_ldap_user_attr("hamlet", "cn", "Second Hamlet")
         expected_call_args = [hamlet2, "Second Hamlet", None]
-        with self.settings(AUTH_LDAP_USER_ATTR_MAP={"full_name": "cn"}):
-            with mock.patch("zerver.actions.user_settings.do_change_full_name") as f:
-                self.perform_ldap_sync(hamlet2)
-                f.assert_called_once_with(*expected_call_args)
+        with (
+            self.settings(AUTH_LDAP_USER_ATTR_MAP={"full_name": "cn"}),
+            mock.patch("zerver.actions.user_settings.do_change_full_name") as f,
+        ):
+            self.perform_ldap_sync(hamlet2)
+            f.assert_called_once_with(*expected_call_args)
 
-                # Get the updated model and make sure the full name is changed correctly:
-                hamlet2 = get_user_by_delivery_email(email, test_realm)
-                self.assertEqual(hamlet2.full_name, "Second Hamlet")
-                # Now get the original hamlet and make he still has his name unchanged:
-                hamlet = self.example_user("hamlet")
-                self.assertEqual(hamlet.full_name, "King Hamlet")
+            # Get the updated model and make sure the full name is changed correctly:
+            hamlet2 = get_user_by_delivery_email(email, test_realm)
+            self.assertEqual(hamlet2.full_name, "Second Hamlet")
+            # Now get the original hamlet and make he still has his name unchanged:
+            hamlet = self.example_user("hamlet")
+            self.assertEqual(hamlet.full_name, "King Hamlet")
 
     def test_user_not_found_in_ldap(self) -> None:
         with self.settings(
@@ -7038,16 +7055,18 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
                 },
             ],
         ]
-        with self.settings(
-            AUTH_LDAP_USER_ATTR_MAP={
-                "full_name": "cn",
-                "custom_profile_field__birthday": "birthDate",
-                "custom_profile_field__phone_number": "homePhone",
-            }
+        with (
+            self.settings(
+                AUTH_LDAP_USER_ATTR_MAP={
+                    "full_name": "cn",
+                    "custom_profile_field__birthday": "birthDate",
+                    "custom_profile_field__phone_number": "homePhone",
+                }
+            ),
+            mock.patch("zproject.backends.do_update_user_custom_profile_data_if_changed") as f,
         ):
-            with mock.patch("zproject.backends.do_update_user_custom_profile_data_if_changed") as f:
-                self.perform_ldap_sync(self.example_user("hamlet"))
-                f.assert_called_once_with(*expected_call_args)
+            self.perform_ldap_sync(self.example_user("hamlet"))
+            f.assert_called_once_with(*expected_call_args)
 
     def test_update_custom_profile_field_not_present_in_ldap(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -7489,14 +7508,16 @@ class JWTFetchAPIKeyTest(ZulipTestCase):
             self.assert_json_error_contains(result, "Invalid subdomain", 404)
 
     def test_jwt_key_not_found_failure(self) -> None:
-        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
-            with mock.patch(
+        with (
+            self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}),
+            mock.patch(
                 "zerver.views.auth.get_realm_from_request", return_value=get_realm("zephyr")
-            ):
-                result = self.client_post("/api/v1/jwt/fetch_api_key")
-                self.assert_json_error_contains(
-                    result, "JWT authentication is not enabled for this organization", 400
-                )
+            ),
+        ):
+            result = self.client_post("/api/v1/jwt/fetch_api_key")
+            self.assert_json_error_contains(
+                result, "JWT authentication is not enabled for this organization", 400
+            )
 
     def test_missing_jwt_payload_failure(self) -> None:
         with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
@@ -7709,12 +7730,12 @@ class LDAPGroupSyncTest(ZulipTestCase):
             ),
             self.assertLogs("django_auth_ldap", "WARN") as django_ldap_log,
             self.assertLogs("zulip.ldap", "DEBUG") as zulip_ldap_log,
-        ):
-            with self.assertRaisesRegex(
+            self.assertRaisesRegex(
                 ZulipLDAPError,
                 "search_s.*",
-            ):
-                sync_user_from_ldap(cordelia, mock.Mock())
+            ),
+        ):
+            sync_user_from_ldap(cordelia, mock.Mock())
 
         self.assertEqual(
             zulip_ldap_log.output,

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -241,9 +241,8 @@ class TestDigestEmailMessages(ZulipTestCase):
             digest_user_ids = [user.id for user in digest_users]
 
             get_recent_topics.cache_clear()
-            with self.assert_database_query_count(16):
-                with self.assert_memcached_count(0):
-                    bulk_handle_digest_email(digest_user_ids, cutoff)
+            with self.assert_database_query_count(16), self.assert_memcached_count(0):
+                bulk_handle_digest_email(digest_user_ids, cutoff)
 
         self.assert_length(digest_users, mock_send_future_email.call_count)
 
@@ -441,9 +440,11 @@ class TestDigestEmailMessages(ZulipTestCase):
         tuesday = self.tuesday()
         cutoff = tuesday - timedelta(days=5)
 
-        with time_machine.travel(tuesday, tick=False):
-            with mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock:
-                enqueue_emails(cutoff)
+        with (
+            time_machine.travel(tuesday, tick=False),
+            mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock,
+        ):
+            enqueue_emails(cutoff)
         queue_mock.assert_not_called()
 
     @override_settings(SEND_DIGEST_EMAILS=True)
@@ -453,9 +454,11 @@ class TestDigestEmailMessages(ZulipTestCase):
         not_tuesday = datetime(year=2016, month=1, day=6, tzinfo=timezone.utc)
         cutoff = not_tuesday - timedelta(days=5)
 
-        with time_machine.travel(not_tuesday, tick=False):
-            with mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock:
-                enqueue_emails(cutoff)
+        with (
+            time_machine.travel(not_tuesday, tick=False),
+            mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock,
+        ):
+            enqueue_emails(cutoff)
         queue_mock.assert_not_called()
 
     @override_settings(SEND_DIGEST_EMAILS=True)

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -72,18 +72,20 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
 
     def test_embedded_bot_quit_exception(self) -> None:
         assert self.bot_profile is not None
-        with patch(
-            "zulip_bots.bots.helloworld.helloworld.HelloWorldHandler.handle_message",
-            side_effect=EmbeddedBotQuitError("I'm quitting!"),
+        with (
+            patch(
+                "zulip_bots.bots.helloworld.helloworld.HelloWorldHandler.handle_message",
+                side_effect=EmbeddedBotQuitError("I'm quitting!"),
+            ),
+            self.assertLogs(level="WARNING") as m,
         ):
-            with self.assertLogs(level="WARNING") as m:
-                self.send_stream_message(
-                    self.user_profile,
-                    "Denmark",
-                    content=f"@**{self.bot_profile.full_name}** foo",
-                    topic_name="bar",
-                )
-                self.assertEqual(m.output, ["WARNING:root:I'm quitting!"])
+            self.send_stream_message(
+                self.user_profile,
+                "Denmark",
+                content=f"@**{self.bot_profile.full_name}** foo",
+                topic_name="bar",
+            )
+            self.assertEqual(m.output, ["WARNING:root:I'm quitting!"])
 
 
 class TestEmbeddedBotFailures(ZulipTestCase):

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -86,12 +86,14 @@ class EventsEndpointTest(ZulipTestCase):
         test_event = dict(id=6, type=event_type, realm_emoji=empty_realm_emoji_dict)
 
         # Test that call is made to deal with a returning soft deactivated user.
-        with mock.patch("zerver.lib.events.reactivate_user_if_soft_deactivated") as fa:
-            with stub_event_queue_user_events(return_event_queue, return_user_events):
-                result = self.api_post(
-                    user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
-                )
-                self.assertEqual(fa.call_count, 1)
+        with (
+            mock.patch("zerver.lib.events.reactivate_user_if_soft_deactivated") as fa,
+            stub_event_queue_user_events(return_event_queue, return_user_events),
+        ):
+            result = self.api_post(
+                user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
+            )
+            self.assertEqual(fa.call_count, 1)
 
         with stub_event_queue_user_events(return_event_queue, return_user_events):
             result = self.api_post(
@@ -1171,9 +1173,11 @@ class FetchQueriesTest(ZulipTestCase):
         # count in production.
         realm = get_realm_with_settings(realm_id=user.realm_id)
 
-        with self.assert_database_query_count(43):
-            with mock.patch("zerver.lib.events.always_want") as want_mock:
-                fetch_initial_state_data(user, realm=realm)
+        with (
+            self.assert_database_query_count(43),
+            mock.patch("zerver.lib.events.always_want") as want_mock,
+        ):
+            fetch_initial_state_data(user, realm=realm)
 
         expected_counts = dict(
             alert_words=1,

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -298,12 +298,14 @@ class RateLimitTests(ZulipTestCase):
         # We need to reset the circuitbreaker before starting.  We
         # patch the .opened property to be false, then call the
         # function, so it resets to closed.
-        with mock.patch("builtins.open", mock.mock_open(read_data=orjson.dumps(["1.2.3.4"]))):
-            with mock.patch(
+        with (
+            mock.patch("builtins.open", mock.mock_open(read_data=orjson.dumps(["1.2.3.4"]))),
+            mock.patch(
                 "circuitbreaker.CircuitBreaker.opened", new_callable=mock.PropertyMock
-            ) as mock_opened:
-                mock_opened.return_value = False
-                get_tor_ips()
+            ) as mock_opened,
+        ):
+            mock_opened.return_value = False
+            get_tor_ips()
 
         # Having closed it, it's now cached.  Clear the cache.
         assert CircuitBreakerMonitor.get("get_tor_ips").closed
@@ -354,13 +356,15 @@ class RateLimitTests(ZulipTestCase):
         # An empty list of IPs is treated as some error in parsing the
         # input, and as such should not be cached; rate-limiting
         # should work as normal, per-IP
-        with self.tor_mock(read_data=[]) as tor_open:
-            with self.assertLogs("zerver.lib.rate_limiter", level="WARNING"):
-                self.do_test_hit_ratelimits(
-                    lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
-                )
-                resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
-                self.assertNotEqual(resp.status_code, 429)
+        with (
+            self.tor_mock(read_data=[]) as tor_open,
+            self.assertLogs("zerver.lib.rate_limiter", level="WARNING"),
+        ):
+            self.do_test_hit_ratelimits(
+                lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
+            )
+            resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
+            self.assertNotEqual(resp.status_code, 429)
 
         # Was not cached, so tried to read twice before hitting the
         # circuit-breaker, and stopping trying
@@ -372,15 +376,17 @@ class RateLimitTests(ZulipTestCase):
         for ip in ["1.2.3.4", "5.6.7.8", "tor-exit-node"]:
             RateLimitedIPAddr(ip, domain="api_by_ip").clear_history()
 
-        with self.tor_mock(side_effect=FileNotFoundError("File not found")) as tor_open:
+        with (
+            self.tor_mock(side_effect=FileNotFoundError("File not found")) as tor_open,
             # If we cannot get a list of TOR exit nodes, then
             # rate-limiting works as normal, per-IP
-            with self.assertLogs("zerver.lib.rate_limiter", level="WARNING") as log_mock:
-                self.do_test_hit_ratelimits(
-                    lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
-                )
-                resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
-                self.assertNotEqual(resp.status_code, 429)
+            self.assertLogs("zerver.lib.rate_limiter", level="WARNING") as log_mock,
+        ):
+            self.do_test_hit_ratelimits(
+                lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
+            )
+            resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
+            self.assertNotEqual(resp.status_code, 429)
 
         # Tries twice before hitting the circuit-breaker, and stopping trying
         tor_open.assert_has_calls(

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -261,10 +261,12 @@ class HomeTest(ZulipTestCase):
         self.client_post("/json/bots", bot_info)
 
         # Verify succeeds once logged-in
-        with self.assert_database_query_count(54):
-            with patch("zerver.lib.cache.cache_set") as cache_mock:
-                result = self._get_home_page(stream="Denmark")
-                self.check_rendered_logged_in_app(result)
+        with (
+            self.assert_database_query_count(54),
+            patch("zerver.lib.cache.cache_set") as cache_mock,
+        ):
+            result = self._get_home_page(stream="Denmark")
+            self.check_rendered_logged_in_app(result)
         self.assertEqual(
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
@@ -312,10 +314,9 @@ class HomeTest(ZulipTestCase):
         self.login("hamlet")
 
         # Verify succeeds once logged-in
-        with queries_captured():
-            with patch("zerver.lib.cache.cache_set"):
-                result = self._get_home_page(stream="Denmark")
-                self.check_rendered_logged_in_app(result)
+        with queries_captured(), patch("zerver.lib.cache.cache_set"):
+            result = self._get_home_page(stream="Denmark")
+            self.check_rendered_logged_in_app(result)
 
         page_params = self._get_page_params(result)
         self.assertCountEqual(page_params, self.expected_page_params_keys)
@@ -565,11 +566,13 @@ class HomeTest(ZulipTestCase):
     def test_num_queries_for_realm_admin(self) -> None:
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
-        with self.assert_database_query_count(54):
-            with patch("zerver.lib.cache.cache_set") as cache_mock:
-                result = self._get_home_page()
-                self.check_rendered_logged_in_app(result)
-                self.assert_length(cache_mock.call_args_list, 7)
+        with (
+            self.assert_database_query_count(54),
+            patch("zerver.lib.cache.cache_set") as cache_mock,
+        ):
+            result = self._get_home_page()
+            self.check_rendered_logged_in_app(result)
+            self.assert_length(cache_mock.call_args_list, 7)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -2547,9 +2547,11 @@ class MultiuseInviteTest(ZulipTestCase):
         email = self.nonreg_email("newuser")
         invite_link = "/join/invalid_key/"
 
-        with patch("zerver.views.registration.get_realm_from_request", return_value=self.realm):
-            with patch("zerver.views.registration.get_realm", return_value=self.realm):
-                self.check_user_able_to_register(email, invite_link)
+        with (
+            patch("zerver.views.registration.get_realm_from_request", return_value=self.realm),
+            patch("zerver.views.registration.get_realm", return_value=self.realm),
+        ):
+            self.check_user_able_to_register(email, invite_link)
 
     def test_multiuse_link_with_specified_streams(self) -> None:
         name1 = "newuser"

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -438,11 +438,10 @@ class PreviewTestCase(ZulipTestCase):
             self.create_mock_response(original_url)
             self.create_mock_response(edited_url)
 
-            with self.settings(TEST_SUITE=False):
-                with self.assertLogs(level="INFO") as info_logs:
-                    # Run the queue processor. This will simulate the event for original_url being
-                    # processed after the message has been edited.
-                    FetchLinksEmbedData().consume(event)
+            with self.settings(TEST_SUITE=False), self.assertLogs(level="INFO") as info_logs:
+                # Run the queue processor. This will simulate the event for original_url being
+                # processed after the message has been edited.
+                FetchLinksEmbedData().consume(event)
             self.assertTrue(
                 "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
                 in info_logs.output[0]
@@ -457,17 +456,16 @@ class PreviewTestCase(ZulipTestCase):
 
             self.assertTrue(responses.assert_call_count(edited_url, 0))
 
-            with self.settings(TEST_SUITE=False):
-                with self.assertLogs(level="INFO") as info_logs:
-                    # Now proceed with the original queue_json_publish and call the
-                    # up-to-date event for edited_url.
-                    queue_json_publish(*args, **kwargs)
-                    msg = Message.objects.select_related("sender").get(id=msg_id)
-                    assert msg.rendered_content is not None
-                    self.assertIn(
-                        f'<a href="{edited_url}" title="The Rock">The Rock</a>',
-                        msg.rendered_content,
-                    )
+            with self.settings(TEST_SUITE=False), self.assertLogs(level="INFO") as info_logs:
+                # Now proceed with the original queue_json_publish and call the
+                # up-to-date event for edited_url.
+                queue_json_publish(*args, **kwargs)
+                msg = Message.objects.select_related("sender").get(id=msg_id)
+                assert msg.rendered_content is not None
+                self.assertIn(
+                    f'<a href="{edited_url}" title="The Rock">The Rock</a>',
+                    msg.rendered_content,
+                )
             self.assertTrue(
                 "INFO:root:Time spent on get_link_embed_data for http://edited.org/: "
                 in info_logs.output[0]
@@ -503,11 +501,10 @@ class PreviewTestCase(ZulipTestCase):
         # We do still fetch the URL, as we don't want to incur the
         # cost of locking the row while we do the HTTP fetches.
         self.create_mock_response(url)
-        with self.settings(TEST_SUITE=False):
-            with self.assertLogs(level="INFO") as info_logs:
-                # Run the queue processor. This will simulate the event for original_url being
-                # processed after the message has been deleted.
-                FetchLinksEmbedData().consume(event)
+        with self.settings(TEST_SUITE=False), self.assertLogs(level="INFO") as info_logs:
+            # Run the queue processor. This will simulate the event for original_url being
+            # processed after the message has been deleted.
+            FetchLinksEmbedData().consume(event)
         self.assertTrue(
             "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
             in info_logs.output[0]
@@ -852,24 +849,26 @@ class PreviewTestCase(ZulipTestCase):
 
         self.create_mock_response(url, body=ConnectionError())
 
-        with mock.patch(
-            "zerver.lib.url_preview.preview.get_oembed_data",
-            side_effect=lambda *args, **kwargs: None,
-        ):
-            with mock.patch(
+        with (
+            mock.patch(
+                "zerver.lib.url_preview.preview.get_oembed_data",
+                side_effect=lambda *args, **kwargs: None,
+            ),
+            mock.patch(
                 "zerver.lib.url_preview.preview.valid_content_type", side_effect=lambda k: True
-            ):
-                with self.settings(TEST_SUITE=False):
-                    with self.assertLogs(level="INFO") as info_logs:
-                        FetchLinksEmbedData().consume(event)
-                    self.assertTrue(
-                        "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
-                        in info_logs.output[0]
-                    )
+            ),
+            self.settings(TEST_SUITE=False),
+        ):
+            with self.assertLogs(level="INFO") as info_logs:
+                FetchLinksEmbedData().consume(event)
+            self.assertTrue(
+                "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
+                in info_logs.output[0]
+            )
 
-                    # This did not get cached -- hence the lack of [0] on the cache_get
-                    cached_data = cache_get(preview_url_cache_key(url))
-                    self.assertIsNone(cached_data)
+            # This did not get cached -- hence the lack of [0] on the cache_get
+            cached_data = cache_get(preview_url_cache_key(url))
+            self.assertIsNone(cached_data)
 
         msg.refresh_from_db()
         self.assertEqual(
@@ -939,13 +938,15 @@ class PreviewTestCase(ZulipTestCase):
         )
         self.create_mock_response(url)
         with self.settings(TEST_SUITE=False):
-            with self.assertLogs(level="INFO") as info_logs:
-                with mock.patch(
+            with (
+                self.assertLogs(level="INFO") as info_logs,
+                mock.patch(
                     "zerver.lib.url_preview.preview.get_oembed_data",
                     lambda *args, **kwargs: mocked_data,
-                ):
-                    FetchLinksEmbedData().consume(event)
-                    cached_data = cache_get(preview_url_cache_key(url))[0]
+                ),
+            ):
+                FetchLinksEmbedData().consume(event)
+                cached_data = cache_get(preview_url_cache_key(url))[0]
             self.assertTrue(
                 "INFO:root:Time spent on get_link_embed_data for http://test.org/: "
                 in info_logs.output[0]
@@ -979,12 +980,14 @@ class PreviewTestCase(ZulipTestCase):
         )
         self.create_mock_response(url)
         with self.settings(TEST_SUITE=False):
-            with self.assertLogs(level="INFO") as info_logs:
-                with mock.patch(
+            with (
+                self.assertLogs(level="INFO") as info_logs,
+                mock.patch(
                     "zerver.worker.embed_links.url_preview.get_link_embed_data",
                     lambda *args, **kwargs: mocked_data,
-                ):
-                    FetchLinksEmbedData().consume(event)
+                ),
+            ):
+                FetchLinksEmbedData().consume(event)
             self.assertTrue(
                 "INFO:root:Time spent on get_link_embed_data for https://www.youtube.com/watch?v=eSJTXC7Ixgg:"
                 in info_logs.output[0]
@@ -1017,12 +1020,14 @@ class PreviewTestCase(ZulipTestCase):
         )
         self.create_mock_response(url)
         with self.settings(TEST_SUITE=False):
-            with self.assertLogs(level="INFO") as info_logs:
-                with mock.patch(
+            with (
+                self.assertLogs(level="INFO") as info_logs,
+                mock.patch(
                     "zerver.worker.embed_links.url_preview.get_link_embed_data",
                     lambda *args, **kwargs: mocked_data,
-                ):
-                    FetchLinksEmbedData().consume(event)
+                ),
+            ):
+                FetchLinksEmbedData().consume(event)
             self.assertTrue(
                 "INFO:root:Time spent on get_link_embed_data for [YouTube link](https://www.youtube.com/watch?v=eSJTXC7Ixgg):"
                 in info_logs.output[0]

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -29,11 +29,13 @@ from zerver.models.users import get_user_profile_by_email
 class TestCheckConfig(ZulipTestCase):
     def test_check_config(self) -> None:
         check_config()
-        with self.settings(REQUIRED_SETTINGS=[("asdf", "not asdf")]):
-            with self.assertRaisesRegex(
+        with (
+            self.settings(REQUIRED_SETTINGS=[("asdf", "not asdf")]),
+            self.assertRaisesRegex(
                 CommandError, "Error: You must set asdf in /etc/zulip/settings.py."
-            ):
-                check_config()
+            ),
+        ):
+            check_config()
 
     @override_settings(WARN_NO_EMAIL=True)
     def test_check_send_email(self) -> None:
@@ -210,9 +212,8 @@ class TestCommandsCanStart(ZulipTestCase):
     def test_management_commands_show_help(self) -> None:
         with stdout_suppressed():
             for command in self.commands:
-                with self.subTest(management_command=command):
-                    with self.assertRaises(SystemExit):
-                        call_command(command, "--help")
+                with self.subTest(management_command=command), self.assertRaises(SystemExit):
+                    call_command(command, "--help")
         # zerver/management/commands/runtornado.py sets this to True;
         # we need to reset it here.  See #3685 for details.
         settings.RUNNING_INSIDE_TORNADO = False

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1104,9 +1104,11 @@ class MarkdownTest(ZulipTestCase):
         )
 
     def test_fetch_tweet_data_settings_validation(self) -> None:
-        with self.settings(TEST_SUITE=False, TWITTER_CONSUMER_KEY=None):
-            with self.assertRaises(NotImplementedError):
-                fetch_tweet_data("287977969287315459")
+        with (
+            self.settings(TEST_SUITE=False, TWITTER_CONSUMER_KEY=None),
+            self.assertRaises(NotImplementedError),
+        ):
+            fetch_tweet_data("287977969287315459")
 
     def test_content_has_emoji(self) -> None:
         self.assertFalse(content_has_emoji_syntax("boring"))
@@ -1710,9 +1712,11 @@ class MarkdownTest(ZulipTestCase):
             self.assertEqual(linkifiers_for_realm(realm.id), [])
 
         # Verify that our in-memory cache avoids round trips.
-        with self.assert_database_query_count(0, keep_cache_warm=True):
-            with self.assert_memcached_count(0):
-                self.assertEqual(linkifiers_for_realm(realm.id), [])
+        with (
+            self.assert_database_query_count(0, keep_cache_warm=True),
+            self.assert_memcached_count(0),
+        ):
+            self.assertEqual(linkifiers_for_realm(realm.id), [])
 
         linkifier = RealmFilter(realm=realm, pattern=r"whatever", url_template="whatever")
         linkifier.save()
@@ -1724,12 +1728,14 @@ class MarkdownTest(ZulipTestCase):
         )
 
         # And the in-process cache works again.
-        with self.assert_database_query_count(0, keep_cache_warm=True):
-            with self.assert_memcached_count(0):
-                self.assertEqual(
-                    linkifiers_for_realm(realm.id),
-                    [{"id": linkifier.id, "pattern": "whatever", "url_template": "whatever"}],
-                )
+        with (
+            self.assert_database_query_count(0, keep_cache_warm=True),
+            self.assert_memcached_count(0),
+        ):
+            self.assertEqual(
+                linkifiers_for_realm(realm.id),
+                [{"id": linkifier.id, "pattern": "whatever", "url_template": "whatever"}],
+            )
 
     def test_alert_words(self) -> None:
         user_profile = self.example_user("othello")
@@ -3289,17 +3295,18 @@ class MarkdownApiTests(ZulipTestCase):
 
 class MarkdownErrorTests(ZulipTestCase):
     def test_markdown_error_handling(self) -> None:
-        with self.simulated_markdown_failure():
-            with self.assertRaises(MarkdownRenderingError):
-                markdown_convert_wrapper("")
+        with self.simulated_markdown_failure(), self.assertRaises(MarkdownRenderingError):
+            markdown_convert_wrapper("")
 
     def test_send_message_errors(self) -> None:
         message = "whatever"
-        with self.simulated_markdown_failure():
+        with (
+            self.simulated_markdown_failure(),
             # We don't use assertRaisesRegex because it seems to not
             # handle i18n properly here on some systems.
-            with self.assertRaises(JsonableError):
-                self.send_stream_message(self.example_user("othello"), "Denmark", message)
+            self.assertRaises(JsonableError),
+        ):
+            self.send_stream_message(self.example_user("othello"), "Denmark", message)
 
     @override_settings(MAX_MESSAGE_LENGTH=10)
     def test_ultra_long_rendering(self) -> None:
@@ -3310,9 +3317,9 @@ class MarkdownErrorTests(ZulipTestCase):
         with (
             mock.patch("zerver.lib.markdown.unsafe_timeout", return_value=msg),
             mock.patch("zerver.lib.markdown.markdown_logger"),
+            self.assertRaises(MarkdownRenderingError),
         ):
-            with self.assertRaises(MarkdownRenderingError):
-                markdown_convert_wrapper(msg)
+            markdown_convert_wrapper(msg)
 
     def test_curl_code_block_validation(self) -> None:
         processor = SimulatedFencedBlockPreprocessor(Markdown())

--- a/zerver/tests/test_message_delete.py
+++ b/zerver/tests/test_message_delete.py
@@ -301,12 +301,14 @@ class DeleteMessageTest(ZulipTestCase):
         self.send_stream_message(hamlet, "Denmark")
         message = self.get_last_message()
 
-        with self.capture_send_event_calls(expected_num_events=1):
-            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits."
-                )
-                do_delete_messages(hamlet.realm, [message])
+        with (
+            self.capture_send_event_calls(expected_num_events=1),
+            mock.patch("zerver.tornado.django_api.queue_json_publish") as m,
+        ):
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits."
+            )
+            do_delete_messages(hamlet.realm, [message])
 
     def test_delete_message_in_unsubscribed_private_stream(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -100,9 +100,11 @@ class EditMessageSideEffectsTest(ZulipTestCase):
             content=content,
         )
 
-        with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m:
-            with self.captureOnCommitCallbacks(execute=True):
-                result = self.client_patch(url, request)
+        with (
+            mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as m,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            result = self.client_patch(url, request)
 
         cordelia = self.example_user("cordelia")
         cordelia_calls = [

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -4203,14 +4203,13 @@ class GetOldMessagesTest(ZulipTestCase):
         request = HostRequestMock(query_params, user_profile)
 
         first_visible_message_id = first_unread_message_id + 2
-        with first_visible_id_as(first_visible_message_id):
-            with queries_captured() as all_queries:
-                get_messages_backend(
-                    request,
-                    user_profile,
-                    num_before=10,
-                    num_after=10,
-                )
+        with first_visible_id_as(first_visible_message_id), queries_captured() as all_queries:
+            get_messages_backend(
+                request,
+                user_profile,
+                num_before=10,
+                num_after=10,
+            )
 
         queries = [q for q in all_queries if "/* get_messages */" in q.sql]
         self.assert_length(queries, 1)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2118,9 +2118,11 @@ class StreamMessagesTest(ZulipTestCase):
         self.subscribe(cordelia, "test_stream")
         do_set_realm_property(cordelia.realm, "wildcard_mention_policy", 10, acting_user=None)
         content = "@**all** test wildcard mention"
-        with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=16):
-            with self.assertRaisesRegex(AssertionError, "Invalid wildcard mention policy"):
-                self.send_stream_message(cordelia, "test_stream", content)
+        with (
+            mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=16),
+            self.assertRaisesRegex(AssertionError, "Invalid wildcard mention policy"),
+        ):
+            self.send_stream_message(cordelia, "test_stream", content)
 
     def test_user_group_mention_restrictions(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -630,13 +630,15 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
             "https://bot.example.com/",
             body=requests.exceptions.Timeout("Time is up!"),
         )
-        with mock.patch(
-            "zerver.lib.outgoing_webhook.fail_with_message", side_effect=wrapped
-        ) as fail:
-            with self.assertLogs(level="INFO") as logs:
-                self.send_stream_message(
-                    bot_owner, "Denmark", content=f"@**{bot.full_name}** foo", topic_name="bar"
-                )
+        with (
+            mock.patch(
+                "zerver.lib.outgoing_webhook.fail_with_message", side_effect=wrapped
+            ) as fail,
+            self.assertLogs(level="INFO") as logs,
+        ):
+            self.send_stream_message(
+                bot_owner, "Denmark", content=f"@**{bot.full_name}** foo", topic_name="bar"
+            )
 
         self.assert_length(logs.output, 5)
         fail.assert_called_once()

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1054,12 +1054,14 @@ class ReactionAPIEventTest(EmojiReactionBase):
             "emoji_code": "1f354",
             "reaction_type": "unicode_emoji",
         }
-        with self.capture_send_event_calls(expected_num_events=1) as events:
-            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits!"
-                )
-                self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
+        with (
+            self.capture_send_event_calls(expected_num_events=1) as events,
+            mock.patch("zerver.tornado.django_api.queue_json_publish") as m,
+        ):
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits!"
+            )
+            self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])
@@ -1137,9 +1139,11 @@ class ReactionAPIEventTest(EmojiReactionBase):
             reaction_type="whatever",
         )
 
-        with self.capture_send_event_calls(expected_num_events=1):
-            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits."
-                )
-                notify_reaction_update(hamlet, message, reaction, "stuff")
+        with (
+            self.capture_send_event_calls(expected_num_events=1),
+            mock.patch("zerver.tornado.django_api.queue_json_publish") as m,
+        ):
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits."
+            )
+            notify_reaction_update(hamlet, message, reaction, "stuff")

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -95,13 +95,14 @@ class RealmTest(ZulipTestCase):
             )
 
     def test_realm_creation_on_special_subdomains_disallowed(self) -> None:
-        with self.settings(SOCIAL_AUTH_SUBDOMAIN="zulipauth"):
-            with self.assertRaises(AssertionError):
-                do_create_realm("zulipauth", "Test Realm")
+        with self.settings(SOCIAL_AUTH_SUBDOMAIN="zulipauth"), self.assertRaises(AssertionError):
+            do_create_realm("zulipauth", "Test Realm")
 
-        with self.settings(SELF_HOSTING_MANAGEMENT_SUBDOMAIN="zulipselfhosting"):
-            with self.assertRaises(AssertionError):
-                do_create_realm("zulipselfhosting", "Test Realm")
+        with (
+            self.settings(SELF_HOSTING_MANAGEMENT_SUBDOMAIN="zulipselfhosting"),
+            self.assertRaises(AssertionError),
+        ):
+            do_create_realm("zulipselfhosting", "Test Realm")
 
     def test_permission_for_education_non_profit_organization(self) -> None:
         realm = do_create_realm(

--- a/zerver/tests/test_send_email.py
+++ b/zerver/tests/test_send_email.py
@@ -132,15 +132,17 @@ class TestSendEmail(ZulipTestCase):
 
         for message, side_effect in errors.items():
             with mock.patch.object(EmailBackend, "send_messages", side_effect=side_effect):
-                with self.assertLogs(logger=logger) as info_log:
-                    with self.assertRaises(EmailNotDeliveredError):
-                        send_email(
-                            "zerver/emails/password_reset",
-                            to_emails=[hamlet.email],
-                            from_name=from_name,
-                            from_address=FromAddress.NOREPLY,
-                            language="en",
-                        )
+                with (
+                    self.assertLogs(logger=logger) as info_log,
+                    self.assertRaises(EmailNotDeliveredError),
+                ):
+                    send_email(
+                        "zerver/emails/password_reset",
+                        to_emails=[hamlet.email],
+                        from_name=from_name,
+                        from_address=FromAddress.NOREPLY,
+                        language="en",
+                    )
                 self.assert_length(info_log.records, 2)
                 self.assertEqual(
                     info_log.output[0],
@@ -151,15 +153,17 @@ class TestSendEmail(ZulipTestCase):
     def test_send_email_config_error_logging(self) -> None:
         hamlet = self.example_user("hamlet")
 
-        with self.settings(EMAIL_HOST_USER="test", EMAIL_HOST_PASSWORD=None):
-            with self.assertLogs(logger=logger, level="ERROR") as error_log:
-                send_email(
-                    "zerver/emails/password_reset",
-                    to_emails=[hamlet.email],
-                    from_name="From Name",
-                    from_address=FromAddress.NOREPLY,
-                    language="en",
-                )
+        with (
+            self.settings(EMAIL_HOST_USER="test", EMAIL_HOST_PASSWORD=None),
+            self.assertLogs(logger=logger, level="ERROR") as error_log,
+        ):
+            send_email(
+                "zerver/emails/password_reset",
+                to_emails=[hamlet.email],
+                from_name="From Name",
+                from_address=FromAddress.NOREPLY,
+                language="en",
+            )
 
         self.assertEqual(
             error_log.output,

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -273,9 +273,11 @@ class UserSoftDeactivationTests(ZulipTestCase):
         ).count()
         self.assertEqual(0, received_count)
 
-        with self.settings(AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS=False):
-            with self.assertLogs(logger_string, level="INFO") as m:
-                users_deactivated = do_auto_soft_deactivate_users(-1, realm)
+        with (
+            self.settings(AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS=False),
+            self.assertLogs(logger_string, level="INFO") as m,
+        ):
+            users_deactivated = do_auto_soft_deactivate_users(-1, realm)
         self.assertEqual(
             m.output,
             [

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -194,12 +194,14 @@ class TestBasics(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         message_id = self.send_stream_message(hamlet, "Denmark")
 
-        with self.capture_send_event_calls(expected_num_events=1):
-            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits."
-                )
-                do_add_submessage(hamlet.realm, hamlet.id, message_id, "whatever", "whatever")
+        with (
+            self.capture_send_event_calls(expected_num_events=1),
+            mock.patch("zerver.tornado.django_api.queue_json_publish") as m,
+        ):
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits."
+            )
+            do_add_submessage(hamlet.realm, hamlet.id, message_id, "whatever", "whatever")
 
     def test_fetch_message_containing_submessages(self) -> None:
         cordelia = self.example_user("cordelia")

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -176,9 +176,11 @@ class TypingHappyPathTestDirectMessages(ZulipTestCase):
             op="start",
         )
 
-        with self.assert_database_query_count(4):
-            with self.capture_send_event_calls(expected_num_events=1) as events:
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with (
+            self.assert_database_query_count(4),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
 
         self.assert_json_success(result)
         self.assert_length(events, 1)
@@ -212,9 +214,11 @@ class TypingHappyPathTestDirectMessages(ZulipTestCase):
             op="start",
         )
 
-        with self.assert_database_query_count(5):
-            with self.capture_send_event_calls(expected_num_events=1) as events:
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with (
+            self.assert_database_query_count(5),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 
@@ -406,9 +410,11 @@ class TypingHappyPathTestStreams(ZulipTestCase):
             topic=topic_name,
         )
 
-        with self.assert_database_query_count(6):
-            with self.capture_send_event_calls(expected_num_events=1) as events:
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with (
+            self.assert_database_query_count(6),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 
@@ -437,9 +443,11 @@ class TypingHappyPathTestStreams(ZulipTestCase):
             topic=topic_name,
         )
 
-        with self.assert_database_query_count(6):
-            with self.capture_send_event_calls(expected_num_events=1) as events:
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with (
+            self.assert_database_query_count(6),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 
@@ -470,9 +478,11 @@ class TypingHappyPathTestStreams(ZulipTestCase):
             topic=topic_name,
         )
         with self.settings(MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS=5):
-            with self.assert_database_query_count(5):
-                with self.capture_send_event_calls(expected_num_events=0) as events:
-                    result = self.api_post(sender, "/api/v1/typing", params)
+            with (
+                self.assert_database_query_count(5),
+                self.capture_send_event_calls(expected_num_events=0) as events,
+            ):
+                result = self.api_post(sender, "/api/v1/typing", params)
             self.assert_json_success(result)
             self.assert_length(events, 0)
 
@@ -501,9 +511,11 @@ class TypingHappyPathTestStreams(ZulipTestCase):
             topic=topic_name,
         )
 
-        with self.assert_database_query_count(6):
-            with self.capture_send_event_calls(expected_num_events=1) as events:
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with (
+            self.assert_database_query_count(6),
+            self.capture_send_event_calls(expected_num_events=1) as events,
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1390,9 +1390,11 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_avatar_upload_file_size_error(self) -> None:
         self.login("hamlet")
-        with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_AVATAR_FILE_SIZE_MIB=0):
-                result = self.client_post("/json/users/me/avatar", {"file": fp})
+        with (
+            get_test_image_file(self.correct_files[0][0]) as fp,
+            self.settings(MAX_AVATAR_FILE_SIZE_MIB=0),
+        ):
+            result = self.client_post("/json/users/me/avatar", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
 
@@ -1537,9 +1539,11 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_realm_icon_upload_file_size_error(self) -> None:
         self.login("iago")
-        with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_ICON_FILE_SIZE_MIB=0):
-                result = self.client_post("/json/realm/icon", {"file": fp})
+        with (
+            get_test_image_file(self.correct_files[0][0]) as fp,
+            self.settings(MAX_ICON_FILE_SIZE_MIB=0),
+        ):
+            result = self.client_post("/json/realm/icon", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
 
@@ -1743,11 +1747,13 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_logo_upload_file_size_error(self) -> None:
         self.login("iago")
-        with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_LOGO_FILE_SIZE_MIB=0):
-                result = self.client_post(
-                    "/json/realm/logo", {"file": fp, "night": orjson.dumps(self.night).decode()}
-                )
+        with (
+            get_test_image_file(self.correct_files[0][0]) as fp,
+            self.settings(MAX_LOGO_FILE_SIZE_MIB=0),
+        ):
+            result = self.client_post(
+                "/json/realm/logo", {"file": fp, "night": orjson.dumps(self.night).decode()}
+            )
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
 
@@ -1766,53 +1772,63 @@ class EmojiTest(UploadSerializeMixin, ZulipTestCase):
     def test_non_image(self) -> None:
         """Non-image is not resized"""
         self.login("iago")
-        with get_test_image_file("text.txt") as f:
-            with patch("zerver.lib.upload.resize_emoji", return_value=(b"a", None)) as resize_mock:
-                result = self.client_post("/json/realm/emoji/new", {"f1": f})
-                self.assert_json_error(result, "Invalid image format")
-                resize_mock.assert_not_called()
+        with (
+            get_test_image_file("text.txt") as f,
+            patch("zerver.lib.upload.resize_emoji", return_value=(b"a", None)) as resize_mock,
+        ):
+            result = self.client_post("/json/realm/emoji/new", {"f1": f})
+            self.assert_json_error(result, "Invalid image format")
+            resize_mock.assert_not_called()
 
     def test_upsupported_format(self) -> None:
         """Invalid format is not resized"""
         self.login("iago")
-        with get_test_image_file("img.bmp") as f:
-            with patch("zerver.lib.upload.resize_emoji", return_value=(b"a", None)) as resize_mock:
-                result = self.client_post("/json/realm/emoji/new", {"f1": f})
-                self.assert_json_error(result, "Invalid image format")
-                resize_mock.assert_not_called()
+        with (
+            get_test_image_file("img.bmp") as f,
+            patch("zerver.lib.upload.resize_emoji", return_value=(b"a", None)) as resize_mock,
+        ):
+            result = self.client_post("/json/realm/emoji/new", {"f1": f})
+            self.assert_json_error(result, "Invalid image format")
+            resize_mock.assert_not_called()
 
     def test_upload_too_big_after_resize(self) -> None:
         """Non-animated image is too big after resizing"""
         self.login("iago")
-        with get_test_image_file("img.png") as f:
-            with patch(
+        with (
+            get_test_image_file("img.png") as f,
+            patch(
                 "zerver.lib.upload.resize_emoji", return_value=(b"a" * (200 * 1024), None)
-            ) as resize_mock:
-                result = self.client_post("/json/realm/emoji/new", {"f1": f})
-                self.assert_json_error(result, "Image size exceeds limit")
-                resize_mock.assert_called_once()
+            ) as resize_mock,
+        ):
+            result = self.client_post("/json/realm/emoji/new", {"f1": f})
+            self.assert_json_error(result, "Image size exceeds limit")
+            resize_mock.assert_called_once()
 
     def test_upload_big_after_animated_resize(self) -> None:
         """A big animated image is fine as long as the still is small"""
         self.login("iago")
-        with get_test_image_file("animated_img.gif") as f:
-            with patch(
+        with (
+            get_test_image_file("animated_img.gif") as f,
+            patch(
                 "zerver.lib.upload.resize_emoji", return_value=(b"a" * (200 * 1024), b"aaa")
-            ) as resize_mock:
-                result = self.client_post("/json/realm/emoji/new", {"f1": f})
-                self.assert_json_success(result)
-                resize_mock.assert_called_once()
+            ) as resize_mock,
+        ):
+            result = self.client_post("/json/realm/emoji/new", {"f1": f})
+            self.assert_json_success(result)
+            resize_mock.assert_called_once()
 
     def test_upload_too_big_after_animated_resize_still(self) -> None:
         """Still of animated image is too big after resizing"""
         self.login("iago")
-        with get_test_image_file("animated_img.gif") as f:
-            with patch(
+        with (
+            get_test_image_file("animated_img.gif") as f,
+            patch(
                 "zerver.lib.upload.resize_emoji", return_value=(b"aaa", b"a" * (200 * 1024))
-            ) as resize_mock:
-                result = self.client_post("/json/realm/emoji/new", {"f1": f})
-                self.assert_json_error(result, "Image size exceeds limit")
-                resize_mock.assert_called_once()
+            ) as resize_mock,
+        ):
+            result = self.client_post("/json/realm/emoji/new", {"f1": f})
+            self.assert_json_error(result, "Image size exceeds limit")
+            resize_mock.assert_called_once()
 
 
 class SanitizeNameTests(ZulipTestCase):

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1156,9 +1156,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         munge = lambda obj: orjson.dumps(obj).decode()
         params = dict(add=munge(new_user_ids))
 
-        with mock.patch("zerver.views.user_groups.notify_for_user_group_subscription_changes"):
-            with self.assert_database_query_count(11):
-                result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
+        with (
+            mock.patch("zerver.views.user_groups.notify_for_user_group_subscription_changes"),
+            self.assert_database_query_count(11),
+        ):
+            result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
         self.assert_json_success(result)
 
         with self.assert_database_query_count(1):

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -338,10 +338,12 @@ class MutedTopicsTests(ZulipTestCase):
 
         mock_date_muted = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        with self.capture_send_event_calls(expected_num_events=2) as events:
-            with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
-                result = self.api_post(user, url, data)
-                self.assert_json_success(result)
+        with (
+            self.capture_send_event_calls(expected_num_events=2) as events,
+            time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False),
+        ):
+            result = self.api_post(user, url, data)
+            self.assert_json_success(result)
 
         self.assertTrue(
             topic_has_visibility_policy(
@@ -404,10 +406,12 @@ class MutedTopicsTests(ZulipTestCase):
 
         mock_date_mute_removed = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        with self.capture_send_event_calls(expected_num_events=2) as events:
-            with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
-                result = self.api_post(user, url, data)
-                self.assert_json_success(result)
+        with (
+            self.capture_send_event_calls(expected_num_events=2) as events,
+            time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False),
+        ):
+            result = self.api_post(user, url, data)
+            self.assert_json_success(result)
 
         self.assertFalse(
             topic_has_visibility_policy(
@@ -553,10 +557,12 @@ class UnmutedTopicsTests(ZulipTestCase):
 
         mock_date_unmuted = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        with self.capture_send_event_calls(expected_num_events=2) as events:
-            with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
-                result = self.api_post(user, url, data)
-                self.assert_json_success(result)
+        with (
+            self.capture_send_event_calls(expected_num_events=2) as events,
+            time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False),
+        ):
+            result = self.api_post(user, url, data)
+            self.assert_json_success(result)
 
         self.assertTrue(
             topic_has_visibility_policy(
@@ -619,10 +625,12 @@ class UnmutedTopicsTests(ZulipTestCase):
 
         mock_date_unmute_removed = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        with self.capture_send_event_calls(expected_num_events=2) as events:
-            with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
-                result = self.api_post(user, url, data)
-                self.assert_json_success(result)
+        with (
+            self.capture_send_event_calls(expected_num_events=2) as events,
+            time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False),
+        ):
+            result = self.api_post(user, url, data)
+            self.assert_json_success(result)
 
         self.assertFalse(
             topic_has_visibility_policy(

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -909,17 +909,19 @@ class QueryCountTest(ZulipTestCase):
 
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
-        with self.assert_database_query_count(84):
-            with self.assert_memcached_count(19):
-                with self.capture_send_event_calls(expected_num_events=10) as events:
-                    fred = do_create_user(
-                        email="fred@zulip.com",
-                        password="password",
-                        realm=realm,
-                        full_name="Fred Flintstone",
-                        prereg_user=prereg_user,
-                        acting_user=None,
-                    )
+        with (
+            self.assert_database_query_count(84),
+            self.assert_memcached_count(19),
+            self.capture_send_event_calls(expected_num_events=10) as events,
+        ):
+            fred = do_create_user(
+                email="fred@zulip.com",
+                password="password",
+                realm=realm,
+                full_name="Fred Flintstone",
+                prereg_user=prereg_user,
+                acting_user=None,
+            )
 
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
 
@@ -2404,9 +2406,8 @@ class GetProfileTest(ZulipTestCase):
         """
         realm = get_realm("zulip")
         email = self.example_user("hamlet").email
-        with self.assert_database_query_count(1):
-            with simulated_empty_cache() as cache_queries:
-                user_profile = get_user(email, realm)
+        with self.assert_database_query_count(1), simulated_empty_cache() as cache_queries:
+            user_profile = get_user(email, realm)
 
         self.assert_length(cache_queries, 1)
         self.assertEqual(user_profile.email, email)

--- a/zerver/webhooks/pivotal/tests.py
+++ b/zerver/webhooks/pivotal/tests.py
@@ -210,11 +210,11 @@ Try again next time
 
     def test_bad_payload(self) -> None:
         bad = ("foo", None, "bar")
-        with self.assertRaisesRegex(AssertionError, "Unable to handle Pivotal payload"):
-            with mock.patch(
-                "zerver.webhooks.pivotal.view.api_pivotal_webhook_v3", return_value=bad
-            ):
-                self.check_webhook("accepted", expect_topic="foo")
+        with (
+            self.assertRaisesRegex(AssertionError, "Unable to handle Pivotal payload"),
+            mock.patch("zerver.webhooks.pivotal.view.api_pivotal_webhook_v3", return_value=bad),
+        ):
+            self.check_webhook("accepted", expect_topic="foo")
 
     def test_bad_request(self) -> None:
         request = mock.MagicMock()
@@ -226,9 +226,11 @@ Try again next time
             self.assertEqual(result[0], "#0: ")
 
         bad = orjson.loads(self.get_body("bad_kind"))
-        with self.assertRaisesRegex(UnsupportedWebhookEventTypeError, "'unknown_kind'.* supported"):
-            with mock.patch("zerver.webhooks.pivotal.view.orjson.loads", return_value=bad):
-                api_pivotal_webhook_v5(request, hamlet)
+        with (
+            self.assertRaisesRegex(UnsupportedWebhookEventTypeError, "'unknown_kind'.* supported"),
+            mock.patch("zerver.webhooks.pivotal.view.orjson.loads", return_value=bad),
+        ):
+            api_pivotal_webhook_v5(request, hamlet)
 
     @override
     def get_body(self, fixture_name: str) -> str:

--- a/zerver/worker/base.py
+++ b/zerver/worker/base.py
@@ -276,9 +276,8 @@ class QueueProcessingWorker(ABC):
         fn = os.path.join(settings.QUEUE_ERROR_DIR, fname)
         line = f"{time.asctime()}\t{orjson.dumps(events).decode()}\n"
         lock_fn = fn + ".lock"
-        with lockfile(lock_fn):
-            with open(fn, "a") as f:
-                f.write(line)
+        with lockfile(lock_fn), open(fn, "a") as f:
+            f.write(line)
         check_and_send_restart_signal()
 
     def setup(self) -> None:


### PR DESCRIPTION
This was previously rejected in https://github.com/zulip/zulip/pull/24106#discussion_r1081730987. However, now that #30840 allows us to use the better [parenthesized syntax](https://docs.python.org/3/whatsnew/3.10.html#parenthesized-context-managers) for `with` with multiple context managers in Python 3.9/3.10, I think this is now an unambiguous improvement.