### PR TITLE
ruff: Fix PLR6104 Use `+=` to perform an augmented assignment directly

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -158,7 +158,7 @@ def process_count_stat(stat: CountStat, fill_to_time: datetime, realm: Realm | N
                 return
             fill_to_time = min(fill_to_time, dependency_fill_time)
 
-    currently_filled = currently_filled + stat.time_increment
+    currently_filled += stat.time_increment
     while currently_filled <= fill_to_time:
         logger.info("START %s %s", stat.property, currently_filled)
         start = time.time()
@@ -166,7 +166,7 @@ def process_count_stat(stat: CountStat, fill_to_time: datetime, realm: Realm | N
         do_fill_count_stat_at_hour(stat, currently_filled, realm)
         do_update_fill_state(fill_state, currently_filled, FillState.DONE)
         end = time.time()
-        currently_filled = currently_filled + stat.time_increment
+        currently_filled += stat.time_increment
         logger.info("DONE %s (%dms)", stat.property, (end - start) * 1000)
 
 

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -337,7 +337,7 @@ class TestProcessCountStat(AnalyticsTestCase):
         self.assertEqual(InstallationCount.objects.filter(property=stat.property).count(), 1)
 
         # clean stat, with update
-        current_time = current_time + self.HOUR
+        current_time += self.HOUR
         stat = self.make_dummy_count_stat("test stat")
         process_count_stat(stat, current_time)
         self.assertFillStateEquals(stat, current_time)

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2412,7 +2412,7 @@ class BillingSession(ABC):
         if plan.fixed_price is None and flat_discounted_months > 0:
             flat_discounted_months = min(flat_discounted_months, num_months_next_cycle)
             discount = flat_discount * flat_discounted_months
-            renewal_cents = renewal_cents - discount
+            renewal_cents -= discount
 
         charge_automatically = plan.charge_automatically
         if customer.stripe_customer_id is not None:

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -224,7 +224,7 @@ def delete_existing_records(records: list[digitalocean.Record], record_name: str
             and record.type in ("AAAA", "A")
         ):
             record.destroy()
-            count = count + 1
+            count += 1
     if count:
         print(f"Deleted {count} existing A / AAAA records for {record_name}.zulipdev.org.")
 

--- a/zerver/actions/bots.py
+++ b/zerver/actions/bots.py
@@ -34,14 +34,14 @@ def send_bot_owner_update_events(
             {previous_owner_id},
         )
         # Do not send update event for previous bot owner.
-        update_users = update_users - {previous_owner.id}
+        update_users.discard(previous_owner.id)
 
     # Notify the new owner that the bot has been added.
     if not bot_owner.is_realm_admin:
         add_event = created_bot_event(user_profile)
         send_event_on_commit(user_profile.realm, add_event, {bot_owner.id})
         # Do not send update event for bot_owner.
-        update_users = update_users - {bot_owner.id}
+        update_users.discard(bot_owner.id)
 
     bot_event = dict(
         type="realm_bot",

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -958,9 +958,7 @@ def send_user_remove_events_on_removing_subscriptions(
     for user in altered_users:
         users_in_unsubscribed_streams: set[int] = set()
         for stream_id in altered_user_dict[user]:
-            users_in_unsubscribed_streams = (
-                users_in_unsubscribed_streams | subscribers_dict[stream_id]
-            )
+            users_in_unsubscribed_streams |= subscribers_dict[stream_id]
 
         users_who_can_access_altered_user = (
             set(non_guest_user_ids)

--- a/zerver/lib/compatibility.py
+++ b/zerver/lib/compatibility.py
@@ -34,7 +34,7 @@ def is_outdated_server(user_profile: UserProfile | None) -> bool:
 
     if user_profile is None or not user_profile.is_realm_admin:
         # Administrators get warned at the deadline; all users 30 days later.
-        deadline = deadline + timedelta(days=30)
+        deadline += timedelta(days=30)
 
     if timezone_now() > deadline:
         return True

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1211,7 +1211,7 @@ def fetch_usermessages(
     )
     if consent_message_id is not None:
         consented_user_ids = get_consented_user_ids(consent_message_id)
-        user_profile_ids = user_profile_ids & consented_user_ids
+        user_profile_ids = consented_user_ids & user_profile_ids
     user_message_chunk = []
     for user_message in user_message_query:
         if user_message.user_profile_id not in user_profile_ids:

--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -161,7 +161,7 @@ def add_md(mode: str, text: str) -> str:
     start = random.randrange(len(vals))
     end = random.randrange(len(vals) - start) + start
     vals[start] = mode + vals[start]
-    vals[end] = vals[end] + mode
+    vals[end] += mode
 
     return " ".join(vals).strip()
 

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1025,7 +1025,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         data = orjson.loads(f.read())
 
     # Merge in zerver_userprofile_mirrordummy
-    data["zerver_userprofile"] = data["zerver_userprofile"] + data["zerver_userprofile_mirrordummy"]
+    data["zerver_userprofile"] += data["zerver_userprofile_mirrordummy"]
     del data["zerver_userprofile_mirrordummy"]
     data["zerver_userprofile"].sort(key=lambda r: r["id"])
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -215,8 +215,8 @@ def get_web_link_regex() -> Pattern[str]:
                    """
     nested_paren_chunk = paren_group
     for i in range(6):
-        nested_paren_chunk = nested_paren_chunk % (paren_group,)
-    nested_paren_chunk = nested_paren_chunk % (inner_paren_contents,)
+        nested_paren_chunk %= (paren_group,)
+    nested_paren_chunk %= (inner_paren_contents,)
 
     file_links = r"| (?:file://(/[^/ ]*)+/?)" if settings.ENABLE_FILE_LINKS else r""
     REGEX = rf"""

--- a/zerver/lib/markdown/api_arguments_table_generator.py
+++ b/zerver/lib/markdown/api_arguments_table_generator.py
@@ -307,5 +307,5 @@ def generate_data_type(schema: Mapping[str, Any]) -> str:
     else:
         data_type = schema["type"]
         if schema.get("nullable", False):
-            data_type = data_type + " | null"
+            data_type += " | null"
     return data_type

--- a/zerver/migrations/0486_clear_old_data_for_unused_usermessage_flags.py
+++ b/zerver/migrations/0486_clear_old_data_for_unused_usermessage_flags.py
@@ -42,7 +42,7 @@ def clear_old_data_for_unused_usermessage_flags(
             )
 
         print(f"Processed {upper_id_bound} / {max_id}")
-        lower_id_bound = lower_id_bound + BATCH_SIZE
+        lower_id_bound += BATCH_SIZE
 
 
 class Migration(migrations.Migration):

--- a/zerver/migrations/0501_mark_introduce_zulip_view_modals_as_read.py
+++ b/zerver/migrations/0501_mark_introduce_zulip_view_modals_as_read.py
@@ -48,7 +48,7 @@ def mark_introduce_zulip_view_modals_as_read(
             )
 
         print(f"Processed {upper_id_bound} / {max_id}")
-        lower_id_bound = lower_id_bound + BATCH_SIZE
+        lower_id_bound += BATCH_SIZE
 
 
 def mark_introduce_zulip_view_modals_as_unread(

--- a/zerver/migrations/0513_copy_groups_data_to_named_user_group.py
+++ b/zerver/migrations/0513_copy_groups_data_to_named_user_group.py
@@ -42,7 +42,7 @@ def create_named_user_group_objects_for_groups(
             )
 
         print(f"Processed {upper_id_bound} / {max_id}")
-        lower_id_bound = lower_id_bound + BATCH_SIZE
+        lower_id_bound += BATCH_SIZE
 
 
 class Migration(migrations.Migration):

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -346,7 +346,7 @@ def generate_curl_example(
             lines.append("    -F " + shlex.quote("{}=@{}".format(key, property["example"])))
 
     for i in range(1, len(lines) - 1):
-        lines[i] = lines[i] + " \\"
+        lines[i] += " \\"
 
     lines.append("```")
 
@@ -378,7 +378,7 @@ def render_curl_example(
             kwargs["exclude"] = element["parameters"]["enum"]
         if "description" in element:
             rendered_example.extend(element["description"].splitlines())
-        rendered_example = rendered_example + generate_curl_example(endpoint, method, **kwargs)
+        rendered_example += generate_curl_example(endpoint, method, **kwargs)
     return rendered_example
 
 

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -361,9 +361,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
         key = generated_link[-24:]
         # Manually expire the link by changing the date of creation
         obj = RealmCreationKey.objects.get(creation_key=key)
-        obj.date_created = obj.date_created - timedelta(
-            days=settings.REALM_CREATION_LINK_VALIDITY_DAYS + 1
-        )
+        obj.date_created -= timedelta(days=settings.REALM_CREATION_LINK_VALIDITY_DAYS + 1)
         obj.save()
 
         result = self.client_get(generated_link)

--- a/zerver/tests/test_message_delete.py
+++ b/zerver/tests/test_message_delete.py
@@ -78,7 +78,7 @@ class DeleteMessageTest(ZulipTestCase):
         set_message_deleting_params(CommonMessagePolicyEnum.EVERYONE, "unlimited")
         msg_id = self.send_stream_message(hamlet, "Denmark")
         message = Message.objects.get(id=msg_id)
-        message.date_sent = message.date_sent - timedelta(seconds=600)
+        message.date_sent -= timedelta(seconds=600)
         message.save()
 
         result = test_delete_message_by_other_user(msg_id=msg_id)
@@ -91,12 +91,12 @@ class DeleteMessageTest(ZulipTestCase):
         set_message_deleting_params(CommonMessagePolicyEnum.EVERYONE, 240)
         msg_id_1 = self.send_stream_message(hamlet, "Denmark")
         message = Message.objects.get(id=msg_id_1)
-        message.date_sent = message.date_sent - timedelta(seconds=120)
+        message.date_sent -= timedelta(seconds=120)
         message.save()
 
         msg_id_2 = self.send_stream_message(hamlet, "Denmark")
         message = Message.objects.get(id=msg_id_2)
-        message.date_sent = message.date_sent - timedelta(seconds=360)
+        message.date_sent -= timedelta(seconds=360)
         message.save()
 
         result = test_delete_message_by_other_user(msg_id=msg_id_1)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -941,7 +941,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("iago"), "Denmark", content="content", topic_name="topic"
         )
         message = Message.objects.get(id=id_)
-        message.date_sent = message.date_sent - timedelta(seconds=180)
+        message.date_sent -= timedelta(seconds=180)
         message.save()
 
         # test the various possible message editing settings
@@ -1019,7 +1019,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("hamlet"), "Denmark", content="content", topic_name="topic"
         )
         message = Message.objects.get(id=id_)
-        message.date_sent = message.date_sent - timedelta(seconds=180)
+        message.date_sent -= timedelta(seconds=180)
         message.save()
 
         # Guest user must be subscribed to the stream to access the message.
@@ -1097,7 +1097,7 @@ class EditMessageTest(ZulipTestCase):
 
         # non-admin users cannot edit topics sent > 1 week ago including
         # sender of the message.
-        message.date_sent = message.date_sent - timedelta(seconds=604900)
+        message.date_sent -= timedelta(seconds=604900)
         message.save()
         set_message_editing_params(True, "unlimited", EditTopicPolicyEnum.EVERYONE)
         do_edit_message_assert_success(id_, "E", "iago")

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -118,15 +118,15 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         message = Message.objects.get(id=id1)
-        message.date_sent = message.date_sent - timedelta(days=10)
+        message.date_sent -= timedelta(days=10)
         message.save()
 
         message = Message.objects.get(id=id2)
-        message.date_sent = message.date_sent - timedelta(days=8)
+        message.date_sent -= timedelta(days=8)
         message.save()
 
         message = Message.objects.get(id=id3)
-        message.date_sent = message.date_sent - timedelta(days=5)
+        message.date_sent -= timedelta(days=5)
         message.save()
 
         verona = get_stream("Verona", user_profile.realm)
@@ -940,7 +940,7 @@ class MessageMoveStreamTest(ZulipTestCase):
         # non-admin and non-moderator users cannot move messages sent > 1 week ago
         # including sender of the message.
         message = Message.objects.get(id=msg_id)
-        message.date_sent = message.date_sent - timedelta(seconds=604900)
+        message.date_sent -= timedelta(seconds=604900)
         message.save()
         check_move_message_to_stream(
             cordelia,

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -1125,19 +1125,19 @@ class MessageMoveTopicTest(ZulipTestCase):
         self.send_stream_message(hamlet, "privatestream", topic_name="topic1")
 
         message = Message.objects.get(id=id1)
-        message.date_sent = message.date_sent - timedelta(days=10)
+        message.date_sent -= timedelta(days=10)
         message.save()
 
         message = Message.objects.get(id=id2)
-        message.date_sent = message.date_sent - timedelta(days=9)
+        message.date_sent -= timedelta(days=9)
         message.save()
 
         message = Message.objects.get(id=id3)
-        message.date_sent = message.date_sent - timedelta(days=8)
+        message.date_sent -= timedelta(days=8)
         message.save()
 
         message = Message.objects.get(id=id4)
-        message.date_sent = message.date_sent - timedelta(days=6)
+        message.date_sent -= timedelta(days=6)
         message.save()
 
         self.login("hamlet")

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -3274,7 +3274,7 @@ class CheckMessageTest(ZulipTestCase):
         # after; this should send an error to the bot owner that the
         # stream doesn't exist
         assert sender.last_reminder is not None
-        sender.last_reminder = sender.last_reminder - timedelta(hours=1)
+        sender.last_reminder -= timedelta(hours=1)
         sender.save(update_fields=["last_reminder"])
         ret = check_message(sender, client, addressee, message_content)
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1314,7 +1314,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         self.assert_length(tokens, 2)
 
         # Remove tokens
-        time_sent = time_sent + timedelta(minutes=1)
+        time_sent += timedelta(minutes=1)
         for endpoint, token, kind, appid in endpoints:
             with time_machine.travel(time_sent, tick=False):
                 result = self.client_delete(endpoint, {"token": token}, subdomain="zulip")
@@ -1353,7 +1353,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
             self.assert_length(tokens, 2)
 
         # Now we successfully remove them:
-        time_sent = time_sent + timedelta(minutes=1)
+        time_sent += timedelta(minutes=1)
         with time_machine.travel(time_sent, tick=False):
             do_regenerate_api_key(user, user)
         tokens = list(RemotePushDeviceToken.objects.filter(user_uuid=user.uuid, server=server))

--- a/zerver/worker/missedmessage_mobile_notifications.py
+++ b/zerver/worker/missedmessage_mobile_notifications.py
@@ -32,7 +32,7 @@ class PushNotificationsWorker(QueueProcessingWorker):
         worker_num: int | None = None,
     ) -> None:
         if settings.MOBILE_NOTIFICATIONS_SHARDS > 1 and worker_num is not None:  # nocoverage
-            self.queue_name = self.queue_name + f"_shard{worker_num}"
+            self.queue_name += f"_shard{worker_num}"
         super().__init__(threaded, disable_timeout, worker_num)
 
     @override


### PR DESCRIPTION
This is a preview rule, not yet enabled by default.

https://docs.astral.sh/ruff/rules/non-augmented-assignment/