### PR TITLE
ruff: Fix FURB154 Use of repeated consecutive `global`, `nonlocal`

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -534,10 +534,7 @@ def channels_to_zerver_stream(
     direct_message_group_id_count = 0
 
     def process_channels(channels: list[dict[str, Any]], invite_only: bool = False) -> None:
-        nonlocal stream_id_count
-        nonlocal recipient_id_count
-        nonlocal defaultstream_id
-        nonlocal subscription_id_count
+        nonlocal stream_id_count, recipient_id_count, defaultstream_id, subscription_id_count
 
         for channel in channels:
             # map Slack's topic and purpose content into Zulip's stream description.
@@ -606,9 +603,7 @@ def channels_to_zerver_stream(
 
     # mpim is the Slack equivalent of direct message group.
     def process_mpims(mpims: list[dict[str, Any]]) -> None:
-        nonlocal direct_message_group_id_count
-        nonlocal recipient_id_count
-        nonlocal subscription_id_count
+        nonlocal direct_message_group_id_count, recipient_id_count, subscription_id_count
 
         for mpim in mpims:
             direct_message_group = build_direct_message_group(direct_message_group_id_count)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -49,8 +49,7 @@ def remote_cache_stats_start() -> None:
 
 
 def remote_cache_stats_finish() -> None:
-    global remote_cache_total_time
-    global remote_cache_total_requests
+    global remote_cache_total_time, remote_cache_total_requests
     remote_cache_total_requests += 1
     remote_cache_total_time += time.time() - remote_cache_time_start
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2709,8 +2709,7 @@ def markdown_stats_start() -> None:
 
 
 def markdown_stats_finish() -> None:
-    global markdown_total_time
-    global markdown_total_requests
+    global markdown_total_time, markdown_total_requests
     markdown_total_requests += 1
     markdown_total_time += time.time() - markdown_time_start
 

--- a/zerver/lib/templates.py
+++ b/zerver/lib/templates.py
@@ -103,8 +103,7 @@ def render_markdown_path(
 
     set_relative_help_links(bool(context is not None and context.get("html_settings_links")))
 
-    global md_extensions
-    global md_macro_extension
+    global md_extensions, md_macro_extension
     if md_extensions is None:
         md_extensions = [
             markdown.extensions.extra.makeExtension(),

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -7740,8 +7740,7 @@ class TestCustomAuthDecorator(ZulipTestCase):
         def custom_auth_wrapper(
             auth_func: AuthFuncT, *args: Any, **kwargs: Any
         ) -> UserProfile | None:
-            nonlocal call_count
-            nonlocal backends_with_restriction
+            nonlocal call_count, backends_with_restriction
             call_count += 1
 
             backend = args[0]


### PR DESCRIPTION
This is a preview rule, not yet enabled by default.

https://docs.astral.sh/ruff/rules/repeated-global/