### PR TITLE
ruff: Fix FURB180 Use of `metaclass=abc.ABCMeta`

### DIFF
--- a/zerver/lib/notes.py
+++ b/zerver/lib/notes.py
@@ -1,5 +1,5 @@
 import weakref
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import MutableMapping
 from typing import Any, ClassVar, Generic, TypeVar
 
@@ -9,7 +9,7 @@ _KeyT = TypeVar("_KeyT")
 _DataT = TypeVar("_DataT")
 
 
-class BaseNotes(Generic[_KeyT, _DataT], metaclass=ABCMeta):
+class BaseNotes(Generic[_KeyT, _DataT], ABC):
     """This class defines a generic type-safe mechanism for associating
     additional data with an object (without modifying the original
     object via subclassing or monkey-patching).

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -25,7 +25,7 @@ from zerver.models.clients import get_client
 from zerver.models.users import get_user_profile_by_id
 
 
-class OutgoingWebhookServiceInterface(metaclass=abc.ABCMeta):
+class OutgoingWebhookServiceInterface(abc.ABC):
     def __init__(self, token: str, user_profile: UserProfile, service_name: str) -> None:
         self.token: str = token
         self.user_profile: UserProfile = user_profile

--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -3,7 +3,7 @@ import random
 import ssl
 import threading
 import time
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from typing import Any, Generic, TypeAlias, TypeVar
@@ -32,7 +32,7 @@ Consumer: TypeAlias = Callable[[ChannelT, Basic.Deliver, pika.BasicProperties, b
 # RabbitMQ/Pika's queuing system; its purpose is to just provide an
 # interface for external files to put things into queues and take them
 # out from bots without having to import pika code all over our codebase.
-class QueueClient(Generic[ChannelT], metaclass=ABCMeta):
+class QueueClient(Generic[ChannelT], ABC):
     def __init__(
         self,
         # Disable RabbitMQ heartbeats by default because BlockingConnection can't process them


### PR DESCRIPTION
This is a preview rule, not yet enabled by default.

https://docs.astral.sh/ruff/rules/meta-class-abc-meta/