### PR TITLE
ruff: Fix FURB148 `enumerate` index or value is unused

### DIFF
--- a/corporate/views/remote_activity.py
+++ b/corporate/views/remote_activity.py
@@ -226,7 +226,7 @@ def get_remote_server_activity(request: HttpRequest) -> HttpResponse:
             row.append(user_counts.guest_user_count)
 
     # Format column data and add total row
-    for i, col in enumerate(cols):
+    for i in range(len(cols)):
         if i == LAST_AUDIT_LOG_DATE:
             fix_rows(rows, i, format_optional_datetime)
         if i in [MOBILE_USER_COUNT, MOBILE_PUSH_COUNT]:

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -740,8 +740,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         data: list[ProfileDataElementUpdateDict] = []
         expected_value: dict[int, ProfileDataElementValue] = {}
         expected_rendered_value: dict[int, str | None] = {}
-        for i, field_value in enumerate(fields):
-            name, value = field_value
+        for name, value in fields:
             field = CustomProfileField.objects.get(name=name, realm=realm)
             data.append(
                 {


### PR DESCRIPTION
This is a preview rule, not yet enabled by default.

https://docs.astral.sh/ruff/rules/unnecessary-enumerate/