### PR TITLE
topic permalinks follow ups

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -296,11 +296,13 @@ export class Filter {
     _predicate?: (message: Message) => boolean;
     _can_mark_messages_read?: boolean;
     requires_adjustment_for_moved_with_target?: boolean;
+    narrow_requires_hash_change: boolean;
 
     constructor(terms: NarrowTerm[]) {
         this._terms = terms;
         this.setup_filter(terms);
         this.requires_adjustment_for_moved_with_target = this.has_operator("with");
+        this.narrow_requires_hash_change = false;
     }
 
     static canonicalize_operator(operator: string): string {
@@ -1623,6 +1625,9 @@ export class Filter {
 
         const adjusted_terms = Filter.adjusted_terms_if_moved(this._terms, message);
         if (adjusted_terms) {
+            // If the narrow terms are adjusted, then we need to update the
+            // hash user entered, to point to the updated narrow.
+            this.narrow_requires_hash_change = true;
             this.setup_filter(adjusted_terms);
         }
         this.requires_adjustment_for_moved_with_target = false;

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1486,7 +1486,9 @@ export class Filter {
     }
 
     sorted_term_types(): string[] {
-        if (this._sorted_term_types === undefined) {
+        // We need to rebuild the sorted_term_types if at all our narrow
+        // is updated (through `with` operator).
+        if (this._sorted_term_types === undefined || this.narrow_requires_hash_change) {
             this._sorted_term_types = this._build_sorted_term_types();
         }
         return this._sorted_term_types;

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -535,6 +535,7 @@ export class Filter {
                 return ["home", "all"].includes(term.operand);
             case "id":
             case "near":
+            case "with":
                 return Number.isInteger(Number(term.operand));
             case "channel":
             case "stream":

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -666,6 +666,17 @@ export function show(raw_terms, opts) {
                             // filter.try_adjusting_for_moved_with_target, and
                             // should update the URL hash accordingly.
                             update_hash_to_match_filter(filter, "retarget topic location");
+                            // Since filter is updated, we need to handle various things
+                            // like updating the message view header title, unread banner
+                            // based on the updated filter.
+                            handle_post_message_list_change(
+                                id_info,
+                                message_lists.current,
+                                opts,
+                                select_immediately,
+                                select_opts,
+                                then_select_offset,
+                            );
                             filter.narrow_requires_hash_change = false;
                         }
                         if (!select_immediately) {

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -661,14 +661,12 @@ export function show(raw_terms, opts) {
                     validate_filter_topic_post_fetch:
                         filter.requires_adjustment_for_moved_with_target,
                     cont() {
-                        if (
-                            !filter.requires_adjustment_for_moved_with_target &&
-                            filter.has_operator("with")
-                        ) {
+                        if (filter.narrow_requires_hash_change) {
                             // We've already adjusted our filter via
                             // filter.try_adjusting_for_moved_with_target, and
                             // should update the URL hash accordingly.
                             update_hash_to_match_filter(filter, "retarget topic location");
+                            filter.narrow_requires_hash_change = false;
                         }
                         if (!select_immediately) {
                             render_message_list_with_selected_message({


### PR DESCRIPTION
Previously, while using "with" operator, even when the narrow was not updated by the operator, hash change requests were made.

This commit introduces a new variable - "narrow_requires_hash_change" which determines whether the narrow was updated and thus requires a hash change or not.

`commit 1`:
Fixes: #30862 and checkbox 4 of https://github.com/zulip/zulip/pull/30114#issuecomment-2226642678

`commit 2:`
This is from https://github.com/zulip/zulip/pull/30678#discussion_r1663279010. It is important because without this you won't be able to open search bar after using permalink.

`commit 3`:
Fixes incorrect rendering of message view header title when `with` adjusts the narrow.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
