### PR TITLE
search: Update narrow when search bar contents change. 

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -91,7 +91,7 @@ export type InputPillContainer<T> = {
     onPillRemove: (callback: (pill: InputPill<T>) => void) => void;
     onTextInputHook: (callback: () => void) => void;
     createPillonPaste: (callback: () => void) => void;
-    clear: () => void;
+    clear: (quiet?: boolean) => void;
     clear_text: () => void;
     getCurrentText: () => string | null;
     is_pending: () => boolean;
@@ -592,7 +592,9 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             store.createPillonPaste = callback;
         },
 
-        clear: funcs.removeAllPills.bind(funcs),
+        clear(quiet?: boolean) {
+            funcs.removeAllPills.bind(funcs)(quiet);
+        },
         clear_text: funcs.clear_text.bind(funcs),
         is_pending: funcs.is_pending.bind(funcs),
         _get_pills_for_testing: funcs._get_pills_for_testing.bind(funcs),

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -1289,7 +1289,9 @@ function handle_post_view_change(msg_list, opts) {
     }
     compose_closed_ui.update_reply_recipient_label();
 
-    message_view_header.render_title_area();
+    if (!opts.prevent_message_header_render) {
+        message_view_header.render_title_area();
+    }
     narrow_title.update_narrow_title(filter);
     left_sidebar_navigation_area.handle_narrow_activated(filter);
     stream_list.handle_narrow_activated(filter, opts.change_hash, opts.show_more_topics);

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -317,7 +317,7 @@ export function show(raw_terms, opts) {
 
     // No operators is an alias for the Combined Feed view.
     if (raw_terms.length === 0) {
-        raw_terms = [{operator: "is", operand: "home"}];
+        raw_terms = [{operator: "in", operand: "home"}];
     }
     const filter = new Filter(raw_terms);
     filter.try_adjusting_for_moved_with_target();


### PR DESCRIPTION
Alya said on CZO:

> It used to be the case that selecting something from the typeahead immediately performed a search. Now, you have to press Enter again for the search to happen. Is this change intentional?

I said:

> Yes it is, because selecting from the typeahead is the main way to create a pill, and if you want a multi-pill search it can be annoying for the search bar to close and initiate a search after each pill you create.
>
> The first enter is for pill validation/creation, the second enter is for searching. When I was working on search pills I thought this might not feel great but couldn't think of a different way to go about it. Definitely open to ideas!

Alya said:

> it should leave the search open and your cursor in it, but navigate your view based on the current set of inputs.