### PR TITLE
i18n: Use user_notification_settings for tr_tag tests.

### DIFF
--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -85,49 +85,31 @@ run_test("t_tag", ({mock_template}) => {
     require("../templates/popovers/message_actions_popover.hbs")(args);
 });
 
-run_test("tr_tag", ({mock_template}) => {
+run_test("{{#tr}} to tag for translation", ({mock_template}) => {
     const args = {
-        botserverrc: "botserverrc",
-        date_joined_text: "Mar 21, 2022",
-        information_density_settings: {
-            settings: {},
-        },
-        information_section_checkbox_group: {
-            settings: {},
-        },
         notification_settings: {},
-        current_user: {
-            full_name: "John Doe",
-            delivery_email: "john@zulip.com",
-        },
-        page_params: {},
-        realm: {},
         settings_object: {},
         settings_label: {
             desktop_icon_count_display:
                 "Unread count badge (appears in desktop sidebar and browser tab)",
             realm_name_in_email_notifications_policy:
                 "Include organization name in subject of message notification emails",
-            twenty_four_hour_time: "Time format",
-            dense_mode: "Dense mode",
             automatically_follow_topics_policy: "Automatically follow topics",
             automatically_unmute_topics_in_muted_streams_policy:
                 "Automatically unmute topics in muted channels",
-            automatically_follow_topics_where_mentioned:
-                "Automatically follow topics where I'm mentioned",
         },
-        settings_render_only: {
-            dense_mode: true,
-        },
-        show_push_notifications_tooltip: false,
-        user_role_text: "Member",
     };
 
-    mock_template("settings_tab.hbs", true, (data, html) => {
+    // We're actually testing `notification_settings.hbs` here which
+    // is imported as a partial in the file below. We want to test
+    // the partial handling logic in `templates.js`, that's why we
+    // test the file below instead of directly testing
+    // `notification_settings.hbs`.
+    mock_template("settings/user_notification_settings.hbs", true, (data, html) => {
         assert.equal(data, args);
         assert.ok(html.includes("Déclencheurs de notification"));
     });
-    require("../templates/settings_tab.hbs")(args);
+    require("../templates/settings/user_notification_settings.hbs")(args);
 });
 
 run_test("language_list", () => {


### PR DESCRIPTION
Before this, settings_tab.hbs was being used to test the `{{#tr}}` syntax for tagging strings for translation. That was introduced in 82b5d9304b1b968f8be6f2d1e605360537eb3786, when the template in question was small enough to mock.

There are smaller templates than `user_notification_settings` but since none of them are used as a partial in another template, we can't use them for this test. This is because we can't test partial block handling part of the tr tag in templates.js with those templates. Since `user_notification_settings` has only 1 partial, it will atleast make it easier for us to know which arguments to pass to the template; in comparison to `settings_template` where it was hard to determine which arguments were supposed to be passed to the template.

I've also renamed the test to not say `tr_tag` since it confused me with the HTML <tr> tag when trying to read the test.

Fixes https://github.com/zulip/zulip/pull/30824#discussion_r1677204395

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
