### PR TITLE
subscriptions: Keep individual tabs in the same row.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -379,10 +379,16 @@ h4.user_group_setting_subsection_title {
         border-right: 1px solid hsl(0deg 0% 87%);
 
         .list-toggler-container {
+            align-items: center;
             padding: 6px 8px;
             border-bottom: 1px solid hsl(0deg 0% 87%);
             display: flex;
             justify-content: space-between;
+
+            #add_new_subscription {
+                position: relative;
+                top: -2px;
+            }
         }
     }
 
@@ -698,6 +704,11 @@ h4.user_group_setting_subsection_title {
 
 #groups_overlay,
 #subscription_overlay {
+    .tab-switcher {
+        display: flex;
+        flex-wrap: nowrap;
+    }
+
     #user-group-creation,
     #stream-creation {
         overflow: auto;


### PR DESCRIPTION
Fixes #30675

This PR doesn't completely fix the issue but does a reasonably good job at it. I think we need to add icons here and use ellipsis for text overflow to completely fix the issue.

| before | after |
| --- | --- |
| <img width="849" alt="Screenshot 2024-07-15 at 11 42 38 AM" src="https://github.com/user-attachments/assets/e219b972-601f-4f65-b563-aa73238f4c16"> | <img width="902" alt="Screenshot 2024-07-15 at 11 43 35 AM" src="https://github.com/user-attachments/assets/39aa4aba-00ab-4185-a2e2-ce23d1021068"> |

Some other screen sizes:
<img width="849" alt="Screenshot 2024-07-15 at 11 41 49 AM" src="https://github.com/user-attachments/assets/21e67882-cea3-4d6b-a3e1-0abf9724792e">
<img width="566" alt="Screenshot 2024-07-15 at 11 41 36 AM" src="https://github.com/user-attachments/assets/0327d0ff-a066-49c4-85ac-5705761bc4d3">

