### PR TITLE
Remove instances of unnecessary `.small` classes

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -10,10 +10,11 @@
     align-items: stretch;
 
     .new_message_button {
-        .button.small {
+        .button {
             /* Keep the new message button sized to match
                adjacent buttons. */
             font-size: inherit;
+            min-width: inherit;
             line-height: var(--line-height-compose-buttons);
             padding: 3px 10px;
         }

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -14,7 +14,7 @@
         <div id="compose_buttons">
             <div class="new_message_button reply_button_container">
                 <div class="compose-reply-button-wrapper" data-reply-button-type="selected_message">
-                    <button type="button" class="button small compose_reply_button"
+                    <button type="button" class="button compose_reply_button"
                       id="left_bar_compose_reply_button_big">
                         {{t 'Compose message' }}
                     </button>
@@ -26,7 +26,7 @@
                 </button>
             </div>
             <span class="new_message_button mobile_button_container">
-                <button type="button" class="button small rounded compose_mobile_button"
+                <button type="button" class="button rounded compose_mobile_button"
                   id="left_bar_compose_mobile_button_big"
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
                     +
@@ -34,7 +34,7 @@
             </span>
             {{#unless embedded }}
             <span class="new_message_button new_direct_message_button_container">
-                <button type="button" class="button small rounded compose_new_direct_message_button"
+                <button type="button" class="button rounded compose_new_direct_message_button"
                   id="new_direct_message_button"
                   data-tooltip-template-id="new_direct_message_button_tooltip_template">
                     {{t 'New direct message' }}

--- a/web/templates/lightbox_overlay.hbs
+++ b/web/templates/lightbox_overlay.hbs
@@ -5,9 +5,9 @@
             <div class="user"></div>
         </div>
         <div class="media-actions">
-            <a class="button small lightbox-zoom-reset disabled">{{t "Reset zoom" }}</a>
-            <a class="button small open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>
-            <a class="button small download" download>{{t "Download" }}</a>
+            <a class="button lightbox-zoom-reset disabled">{{t "Reset zoom" }}</a>
+            <a class="button open" rel="noopener noreferrer" target="_blank">{{t "Open" }}</a>
+            <a class="button download" download>{{t "Download" }}</a>
         </div>
         <div class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">x</span></div>
     </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Preparatory PR for #30895.

I've checked most instances of `.small` class and removed `.small` class in 2 instances were it was being overriden. I've checked the buttons with text for getting their properties overriden, but the buttons with icons, since I noticed a pattern of them using the `.small` properties. The goal of this PR is not to remove `.small` for ALL possible cases, but just the ones that I noticed. 

This PR makes no visual changes, the screenshots are just for comparison b/w the before and after state.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary> Commit 1 (compose box): </summary>

Devtools screenshot showing the overriden properties:
<img width="583" alt="compose_box_devtools" src="https://github.com/user-attachments/assets/a2f9962d-9cd8-4aa1-a874-d0544eff5811">

| Compose box - full screen - 14px - before | Compose box - full screen - 14px -  after | Compose box - full screen - 16px before | Compose box - full screen - 16px after |
|-------------------------------------------|-------------------------------------------|-----------------------------------------|----------------------------------------|
|                 <img width="855" alt="compose_box_fullscreen_14px_before" src="https://github.com/user-attachments/assets/aae679a8-059e-41c9-975e-454e32a3937a">                        |               <img width="855" alt="compose_box_fullscreen_14px_after" src="https://github.com/user-attachments/assets/87b7638e-e2bb-40a1-8fad-d59821e1ff73">                       |               <img width="886" alt="compose_box_fullscreen_before" src="https://github.com/user-attachments/assets/6ae517ee-2fba-46fd-bd87-e9c6ba4efa0d">                          |                    <img width="886" alt="compose_box_fullscreen_after" src="https://github.com/user-attachments/assets/491fbac5-869f-47e5-8b1f-88ffff0784e6">                    |
| Compose box - plus sign - 14px - before   | Compose box - plus sign - 14px - after    | Compose box - plus sign - 16px - before | Compose box - plus sign - 16px - after |
|                     <img width="446" alt="compose_box_plus_14px_before" src="https://github.com/user-attachments/assets/a46e82c2-3be9-4fc0-abc2-f5dc270f8053">                      |                 <img width="446" alt="compose_box_plus_14px_after" src="https://github.com/user-attachments/assets/503becde-030d-416a-b3bb-4f72985c5da8">                          |                       <img width="416" alt="compose_box_plus_before" src="https://github.com/user-attachments/assets/06c3c077-0ae0-40eb-9e78-5f9057373019">                  |        <img width="416" alt="compose_box_plus_after" src="https://github.com/user-attachments/assets/c4a9b918-3835-401f-acea-039344b8b471">                      |

</details>

<details>
<summary> Commit 2 (lightbox): </summary>

Devtools screenshot:
<img width="364" alt="lightbox_before_devtools" src="https://github.com/user-attachments/assets/feae21f5-efc1-402d-a4fc-853ef1024571">

| Lightbox - 14px - before                | Lightbox - 14px -  after               | Lightbox - 16px before                  | Lightbox - 16px after                  |
|-----------------------------------------|----------------------------------------|-----------------------------------------|----------------------------------------|
|          <img width="320" alt="lightbox_14px_before" src="https://github.com/user-attachments/assets/d0c03b05-f3ef-4461-a9e7-2011c53f277e">                               |                        <img width="320" alt="lightbox_14px_after" src="https://github.com/user-attachments/assets/3ecba0bb-7038-493d-beff-a9727b708dff">               |                          <img width="333" alt="lightbox_before" src="https://github.com/user-attachments/assets/61cff022-16e2-46a6-bb6e-d64026aace4a">               |                        <img width="333" alt="lightbox_after" src="https://github.com/user-attachments/assets/bf641a0e-6a87-4939-83b0-1ccc76eaa7a3">                 |

</details>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

<details>
<summary> self review checklist </summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
