### PR TITLE
recent_view: Catch errors in trying to get message from id.

### DIFF
--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -606,7 +606,11 @@ export function initialize(finished_initial_fetch) {
     // which always contains the latest message, it makes sense for
     // Recent view to display the same data and be in sync.
     all_messages_data.set_add_messages_callback((messages, rows_order_changed) => {
-        recent_view_ui.process_messages(messages, rows_order_changed, all_messages_data);
+        try {
+            recent_view_ui.process_messages(messages, rows_order_changed, all_messages_data);
+        } catch (error) {
+            blueslip.error("Error in recent_view_ui.process_messages", undefined, error);
+        }
     });
 
     // TODO: Ideally we'd have loading indicators for Recent Conversations


### PR DESCRIPTION
This helps keep the app working and avoids functionalities like insert messages from breaking when we don't the message id cached which ideally we should have.
