### PR TITLE
register_server: Call crudini with --inplace when rotating secret key.

### DIFF
--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -128,6 +128,7 @@ class Command(ZulipBaseCommand):
                 subprocess.check_call(
                     [
                         "crudini",
+                        "--inplace",
                         "--set",
                         SECRETS_FILENAME,
                         "secrets",


### PR DESCRIPTION
This is needed for the command to work in docker-zulip, where the zulip user may not have write permissions to the parent directory of the secrets file. By default, crudini creates a temporary file, which makes the command fail under those conditions.
With --inplace, the secret file gets written to directly without creation of temporary files.

