### PR TITLE
Added Alt + P shortcut to toggle preview for message editing solved #30851

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -78,6 +78,40 @@ export function show_preview_area() {
     );
 }
 
+export function edit_mode_preview() {
+    const $row = $(".message_edit_form");
+    const $msg_edit_content = $row.find(".message_edit_content");
+    const content = $msg_edit_content.val();
+
+    // Disable unneeded compose_control_buttons as we don't
+    // need them in preview mode.
+    $row.addClass("preview_mode");
+    $row.find(".preview_mode_disabled .compose_control_button").attr("tabindex", -1);
+
+    $msg_edit_content.hide();
+    $row.find(".markdown_preview").hide();
+    $row.find(".undo_markdown_preview").show();
+    $row.find(".preview_message_area").show();
+
+    render_and_show_preview(
+        $row.find(".markdown_preview_spinner"),
+        $row.find(".preview_content"),
+        content,
+    );
+}
+
+export function edit_mode_hide_preview() {
+    const $row = $(".message_edit_form");
+    $row.removeClass("preview_mode");
+    $row.find(".preview_mode_disabled .compose_control_button").attr("tabindex", 0);
+
+    $row.find(".message_edit_content").show();
+    $row.find(".undo_markdown_preview").hide();
+    $row.find(".preview_message_area").hide();
+    $row.find(".preview_content").empty();
+    $row.find(".markdown_preview").show();
+}
+
 export function create_message_object(message_content = compose_state.message_content()) {
     // Topics are optional, and we provide a placeholder if one isn't given.
     let topic = compose_state.topic();

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -798,6 +798,15 @@ export function process_hotkey(e, hotkey) {
         return true;
     }
 
+    if (event_name === "toggle_compose_preview" && $(".message_edit").is(":visible")) {
+        if ($(".compose-control-buttons-container .markdown_preview").is(":visible")) {
+            compose.edit_mode_preview();
+        } else {
+            compose.edit_mode_hide_preview();
+        }
+        return true;
+    }
+
     if (event_name === "toggle_compose_preview" && compose_state.composing()) {
         if ($("#compose .markdown_preview").is(":visible")) {
             compose.show_preview_area();


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR is same as https://github.com/zulip/zulip/pull/30860 , but with clean commit history

Fixes: #30851 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 2024-07-13 04-01-11.webm](https://github.com/user-attachments/assets/9282d73c-23ef-4133-8175-b839eb091f3c)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
