### PR TITLE
Change search suggestion string for has: operator.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -665,7 +665,7 @@ export class Filter {
 
             // Note: We hack around using this in "describe" below.
             case "has":
-                return verb + "messages with one or more";
+                return verb + "messages with";
 
             case "id":
                 return verb + "message ID";

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -720,25 +720,25 @@ function get_has_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
     const suggestions: SuggestionAndIncompatiblePatterns[] = [
         {
             search_string: "has:link",
-            description_html: "messages that contain links",
+            description_html: "messages with links",
             is_people: false,
             incompatible_patterns: [{operator: "has", operand: "link"}],
         },
         {
             search_string: "has:image",
-            description_html: "messages that contain images",
+            description_html: "messages with images",
             is_people: false,
             incompatible_patterns: [{operator: "has", operand: "image"}],
         },
         {
             search_string: "has:attachment",
-            description_html: "messages that contain attachments",
+            description_html: "messages with attachments",
             is_people: false,
             incompatible_patterns: [{operator: "has", operand: "attachment"}],
         },
         {
             search_string: "has:reaction",
-            description_html: "messages that contain reactions",
+            description_html: "messages with reactions",
             is_people: false,
             incompatible_patterns: [{operator: "has", operand: "reaction"}],
         },

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -12,7 +12,7 @@
         {{~!-- squash whitespace --~}}
     {{else if (eq this.type "prefix_for_operator")}}
         {{~!-- squash whitespace --~}}
-        {{this.prefix_for_operator}} {{this.operand}}
+        {{this.prefix_for_operator}} {{this.operand}}{{#if (or (eq this.operand "link") (eq this.operand "image") (eq this.operand "attachment") (eq this.operand "reaction"))}}s{{/if}}
         {{~!-- squash whitespace --~}}
     {{else if (eq this.type "user_pill")}}
         {{~!-- squash whitespace --~}}

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1500,7 +1500,7 @@ test("describe", ({mock_template}) => {
         {operator: "channel", operand: "devel"},
         {operator: "has", operand: "image", negated: true},
     ];
-    string = "channel devel, exclude messages with one or more image";
+    string = "channel devel, exclude messages with images";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [
@@ -1514,7 +1514,7 @@ test("describe", ({mock_template}) => {
         {operator: "has", operand: "image", negated: true},
         {operator: "channel", operand: "devel"},
     ];
-    string = "exclude messages with one or more image, channel devel";
+    string = "exclude messages with images, channel devel";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [];

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -381,9 +381,9 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
     assert.equal(describe("is:followed"), "Followed topics");
     assert.equal(describe("sender:myself@zulip.com"), "Sent by me");
-    assert.equal(describe("has:link"), "Messages that contain links");
-    assert.equal(describe("has:image"), "Messages that contain images");
-    assert.equal(describe("has:attachment"), "Messages that contain attachments");
+    assert.equal(describe("has:link"), "Messages with links");
+    assert.equal(describe("has:image"), "Messages with images");
+    assert.equal(describe("has:attachment"), "Messages with attachments");
 });
 
 test("has_suggestions", ({override, mock_template}) => {
@@ -404,17 +404,17 @@ test("has_suggestions", ({override, mock_template}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
 
-    assert.equal(describe("has:link"), "Messages that contain links");
-    assert.equal(describe("has:image"), "Messages that contain images");
-    assert.equal(describe("has:attachment"), "Messages that contain attachments");
+    assert.equal(describe("has:link"), "Messages with links");
+    assert.equal(describe("has:image"), "Messages with images");
+    assert.equal(describe("has:attachment"), "Messages with attachments");
 
     query = "-h";
     suggestions = get_suggestions(query);
     expected = ["-h", "-has:link", "-has:image", "-has:attachment", "-has:reaction"];
     assert.deepEqual(suggestions.strings, expected);
-    assert.equal(describe("-has:link"), "Exclude messages that contain links");
-    assert.equal(describe("-has:image"), "Exclude messages that contain images");
-    assert.equal(describe("-has:attachment"), "Exclude messages that contain attachments");
+    assert.equal(describe("-has:link"), "Exclude messages with links");
+    assert.equal(describe("-has:image"), "Exclude messages with images");
+    assert.equal(describe("-has:attachment"), "Exclude messages with attachments");
 
     // operand suggestions follow.
 


### PR DESCRIPTION
Earlier in search suggestion, has: operator returned two different suggestion string which were `messages with one or more links` and `messages that contain links`.

This PR changes this to a consistent suggestion string.

Fixes: zulip#30908

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
#### Before

![image](https://github.com/user-attachments/assets/51e9ea20-5598-4187-ad41-44f9abd36374)

![image](https://github.com/user-attachments/assets/43b50287-9454-403c-8726-c254d3b5a17c)

#### After
![Screenshot from 2024-07-16 05-17-46](https://github.com/user-attachments/assets/2afc0234-5bdf-4ea1-b11d-9f5f40ac771d)
![Screenshot from 2024-07-16 05-17-56](https://github.com/user-attachments/assets/31626c81-6ef5-475a-aa9b-25839b34b951)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
