### PR TITLE
help: Add search to documentation to pages on followed topics and resolved topics

### DIFF
--- a/help/follow-a-topic.md
+++ b/help/follow-a-topic.md
@@ -61,6 +61,36 @@ You can use followed topics for a variety of workflows:
 
 {end_tabs}
 
+## Search for messages in followed topics
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click the **search** (<i class="search_icon zulip-icon
+   zulip-icon-search"></i>) icon in the top bar to open the search box.
+
+1. Type `is:followed`, or start typing and select **Followed topics** from the
+   typeahead.
+
+1. _(optional)_ Enter additional search terms or
+   [filters](/help/search-for-messages).
+
+1. Press <kbd>Enter</kbd>.
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>
+    keyboard shortcut to start searching messages.
+
+{end_tabs}
+
+!!! tip ""
+
+    To get a feed of unread messages in all the topics you follow, search for
+    `is:followed is:unread`.
+
+
 ## Configure notifications for followed topics
 
 You can configure custom notifications for followed topics. You can also

--- a/help/resolve-a-topic.md
+++ b/help/resolve-a-topic.md
@@ -94,6 +94,59 @@ accident.
 
 {end_tabs}
 
+## Search for messages in unresolved topics
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click the **search** (<i class="search_icon zulip-icon
+   zulip-icon-search"></i>) icon in the top bar to open the search box.
+
+1. Type `-is:resolved`, or start typing and select **Exclude topics marked as
+   resolved** from the typeahead.
+
+1. _(optional)_ Enter additional search terms or
+   [filters](/help/search-for-messages).
+
+1. Press <kbd>Enter</kbd>.
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>
+    keyboard shortcut to start searching messages.
+
+{end_tabs}
+
+!!! tip ""
+
+    To get a feed of unread messages in all unresolved topics, search for
+    `is:unresolved is:unread`.
+
+## Search for messages in resolved topics
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click the **search** (<i class="search_icon zulip-icon
+   zulip-icon-search"></i>) icon in the top bar to open the search box.
+
+1. Type `is:resolved`, or start typing and select **Topics marked as resolved**
+   from the typeahead.
+
+1. _(optional)_ Enter additional search terms or
+   [filters](/help/search-for-messages).
+
+1. Press <kbd>Enter</kbd>.
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>
+    keyboard shortcut to start searching messages.
+
+{end_tabs}
+
 ## Details
 
 * Resolving a topic works by moving the messages to a new topic.

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -96,7 +96,6 @@ Zulip offers the following filters based on the location of the message.
 * `has:attachment`: Search messages that contain an [uploaded
   file](/help/share-and-upload-files).
 * `has:image`: Search messages that contain uploaded or linked images or videos.
-* `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
 
 !!! tip ""
 
@@ -120,6 +119,7 @@ Zulip offers the following filters based on the location of the message.
 * `is:resolved`: Search messages in [resolved topics](/help/resolve-a-topic).
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
 * `is:unread`: Search your unread messages.
+* `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
 
 ### Search by message ID
 


### PR DESCRIPTION
Notes:
- Repeated text could be extracted to /include. Not sure it's worth it at this stage?

Current: https://zulip.com/help/follow-a-topic
<details>
<summary>
Updated
</summary>

![Screenshot 2024-07-15 at 17 49 24@2x](https://github.com/user-attachments/assets/3bef07fa-077c-4772-90ee-142b2d4a3477)

</details>

Current: https://zulip.com/help/resolve-a-topic
<details>
<summary>
Updated
</summary>

![Screenshot 2024-07-15 at 17 50 16@2x](https://github.com/user-attachments/assets/065c280e-ad6d-452f-ba8e-67817ede42f1)

</details>


[CZO discussion ](https://chat.zulip.org/#narrow/stream/19-documentation/topic/.60has.3A.60.20search.20filter.20help.20section/near/1890436)(or just me talking to myself?)
Current: https://zulip.com/help/search-for-messages#search-for-attachments-or-links
<details>
<summary>
Moved `has:reaction` 
</summary>

![Screenshot 2024-07-15 at 18 04 24@2x](https://github.com/user-attachments/assets/77c56aa0-cdfd-455c-b3c0-d9bf18b4605f)

</details>
