### PR TITLE
css: Scale font-size for .small buttons.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -149,7 +149,18 @@ input::placeholder {
         }
 
         &.small {
-            font-size: 0.8rem;
+            /* This value was 0.8rem in the past. When using rem,
+               the root font size was 16px when the base font-size was
+               14px. Now, we have two modes, one with 14px base
+               font-size and one with 16px base font-size. We multiply
+               by (16 / 14 * 0.8 = 0.9143) so rem equivalent value
+               will remain the same in the legacy 14px mode, while
+               scaling the size up for 16px mode. The font-size will
+               resolve in pixels.
+               TODO: Refactor this part to either use `em` or `rem`
+               and not this temporary hack of using calc() and
+               variables. */
+            font-size: calc(0.9143 * var(--base-font-size-px));
             min-width: inherit;
             padding: 6px 10px;
         }


### PR DESCRIPTION
Fixes zulip#30895. 

The root font-size for the app has always been 16px, and it remains the same when switching between 14px and 16px mode. This leads to `.small` buttons looking relatively smaller to their surroundings in 16px mode. So, if we use a unit that changes when switching between modes, we will have to multiple that value by (16/14) so that we don't change the existing behaviour for the 14px mode and make things smaller. This commit only affects `.small` buttons, the same named class is used in other places but does not use rem unit there and therefore does not require any changes. 

The original plan was to use em instead of rem and multiply it by (16/14 * 0.8), but since em depends on the parent element, there was a case in the poll button widget where 1em was equal to 16px in the dense 14px mode. While, the right thing to do might have been some refactor to make it work as desired, the safest thing to do right now might be to use the --base-font-size-px variable directly for the 9.0 release.

I've posted a bunch of screenshots and I've looked around all the possible occurrences manually for 16px mode for anything unusually off, and I could not find any. I've also included some screenshot for channel and user group settings since the usage for this class was higher there than other components. Screenshots for every occurrence might just take a lot of time to take, compare and document and not sure if it's worth the effort. Let me know if more screenshots are needed.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Drafts page 2 occurrences - Select all drafts & Delete all drafts</summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|     <img width="1003" alt="drafts_2_buttons_14px_old" src="https://github.com/user-attachments/assets/60bbc7fe-3d96-4a4d-a1d5-8d56edf1482f">                                    |                  <img width="1003" alt="drafts_2_buttons_14px_new" src="https://github.com/user-attachments/assets/9a673ff7-5e7c-4895-bf99-d8b9f9b4f700">                      |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|<img width="1003" alt="drafts_2_buttons_16px_old" src="https://github.com/user-attachments/assets/44bef730-1ea6-492e-b4ba-6c744de7962a">               | <img width="1003" alt="drafts_2_buttons_16px_new" src="https://github.com/user-attachments/assets/1c89df62-ab90-4597-aed4-9fa4844cfd55">                            |


</details>

<details>
<summary>Poll options 1 occurence - trash icon </summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|    <img width="520" alt="poll_options_14px_old" src="https://github.com/user-attachments/assets/10667a61-6c63-4718-aefd-08b1a80e5fd5">                                   |                 <img width="520" alt="poll_options_14px_new" src="https://github.com/user-attachments/assets/b8d40f2a-f025-4dd3-ae52-339567abd58a">                |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|     <img width="520" alt="poll_options_16px_old" src="https://github.com/user-attachments/assets/305b1acc-44cb-4c20-9f98-9a622a061805">   | <img width="520" alt="poll_options_16px_new" src="https://github.com/user-attachments/assets/f77daee7-398a-4af7-a504-787450d5d78c">                 |


</details>

<details>
<summary>User profile 2 occurrences - Subscribe & Unsubscribe </summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|     <img width="519" alt="user_profile_subscribe_14px_old" src="https://github.com/user-attachments/assets/7d93b45b-b5e7-4dc7-ac87-7ca345b3c324">                                  |                 <img width="519" alt="user_profile_subsribe_14px_new" src="https://github.com/user-attachments/assets/60951489-21b2-456b-998b-e52e851ea884">                       |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
| <img width="519" alt="user_profile_subscribe_16px_old" src="https://github.com/user-attachments/assets/5497fc84-34a6-4aea-b128-e1c02d84eea8">           | <img width="519" alt="user_profile_subscribe_16px_new" src="https://github.com/user-attachments/assets/3b86f5b7-acfb-422e-8c8c-2729cfdc8470">                        |


</details>

<details>
<summary>Add new bot - clear avatar icon - 1 occurence</summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|    <img width="518" alt="add_new_bot_14px_old" src="https://github.com/user-attachments/assets/80111ce2-3560-40e1-a070-ad6c42c43400">                                  |                 <img width="519" alt="add_new_bot_14px_new" src="https://github.com/user-attachments/assets/f156d322-a807-46fb-a256-6b8d45bceff5">              |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|     <img width="518" alt="add_new_bot_16px_old" src="https://github.com/user-attachments/assets/b6d80c13-925d-4c95-8c2e-78de89869bf9"> | <img width="518" alt="add_new_bot_16px_new" src="https://github.com/user-attachments/assets/0dd8eebe-e438-4485-bb63-17ab038369b0">|


</details>
<details>
<summary>Emoji list - delete trash icon button - 1 occurence</summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|    <img width="755" alt="emoji_delete_button_14px_old" src="https://github.com/user-attachments/assets/752d541f-d579-4231-bbe4-e89a10d4ca65">                            |                 <img width="755" alt="emoji_delete_button_14px_new" src="https://github.com/user-attachments/assets/56bca008-1a39-4eeb-89e6-f709abea532c">         |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|     <img width="755" alt="emoji_delete_button_16px_old" src="https://github.com/user-attachments/assets/dddf214a-dbb8-412c-b6f1-5f73767c40cc">| <img width="755" alt="emoji_delete_button_16px_new" src="https://github.com/user-attachments/assets/9a2dede4-13a1-4ae1-9729-360fefa61215">|


</details>

<details>
<summary> User group - multiple occurrences - almost all buttons</summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|    <img width="599" alt="group_14px_old" src="https://github.com/user-attachments/assets/fa1f95e2-beb6-428c-9972-82cbad6016b6">                 |            <img width="599" alt="group_14px_new" src="https://github.com/user-attachments/assets/d09e7515-4420-4da9-8e39-baa15a743f3f">          |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|    <img width="599" alt="group_16px_old" src="https://github.com/user-attachments/assets/b4a1b8ee-5104-4e10-ad20-a17aa18864b0"> |  <img width="599" alt="group_16px_new" src="https://github.com/user-attachments/assets/0858cad7-9c06-41dc-8906-3e6f1e3ea29d">|


</details>

<details>
<summary> Channel - multiple occurrences - almost all buttons (the 3 buttons on the right were skewed with each other before the change) </summary>

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|    <img width="599" alt="channel_14px_old" src="https://github.com/user-attachments/assets/3dac8315-dcd6-4d14-8162-d7fd47404c64">            |           <img width="599" alt="channel_16px_old" src="https://github.com/user-attachments/assets/421e6119-63cf-48a4-af60-27e3fe2af416">    |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|    <img width="599" alt="channel_16px_old" src="https://github.com/user-attachments/assets/83a2b237-b535-4607-b84b-1268965ee91b"> |  <img width="599" alt="channel_16px_new" src="https://github.com/user-attachments/assets/10408930-57ec-40eb-889f-b0cfd67608c4">|


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
