### PR TITLE
search pills: Ensure correct narrow/header when search content changes.

### DIFF
--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -1289,9 +1289,8 @@ function handle_post_view_change(msg_list, opts) {
     }
     compose_closed_ui.update_reply_recipient_label();
 
-    if (!opts.prevent_message_header_render) {
-        message_view_header.render_title_area();
-    }
+    message_view_header.render_title_area();
+
     narrow_title.update_narrow_title(filter);
     left_sidebar_navigation_area.handle_narrow_activated(filter);
     stream_list.handle_narrow_activated(filter, opts.change_hash, opts.show_more_topics);

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -77,6 +77,12 @@ function narrow_or_search_for_term({on_narrow_search}: {on_narrow_search: OnNarr
     return get_search_bar_text();
 }
 
+function focus_search_input_at_end(): void {
+    $("#search_query").trigger("focus");
+    // Move cursor to the end of the input text.
+    window.getSelection()!.modify("move", "forward", "line");
+}
+
 function narrow_to_search_contents_with_search_bar_open(): void {
     // We skip validation when we're dealing with partial pills
     // since we don't want to do the shake animation for e.g. "dm:"
@@ -215,7 +221,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
                     set_search_bar_text,
                 );
                 narrow_to_search_contents_with_search_bar_open();
-                $search_query_box.trigger("focus");
+                focus_search_input_at_end();
             }
             return get_search_bar_text();
         },
@@ -381,7 +387,7 @@ export function initiate_search(): void {
     // or clicks on the search input instead, the selection goes away and
     // the user can add new search input to the existing pills.
     $(".search-input-and-pills").addClass("freshly-opened");
-    $("#search_query").trigger("focus");
+    focus_search_input_at_end();
 
     // Open the typeahead after opening the search bar, so that we don't
     // get a weird visual jump where the typeahead results are narrow

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -298,20 +298,19 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
 
             if (e.key === "Escape" && $search_query_box.is(":focus")) {
                 exit_search({keep_search_narrow_open: false});
-            } else if (keydown_util.is_enter_event(e) && $search_query_box.is(":focus")) {
+            } else if (
+                keydown_util.is_enter_event(e) &&
+                $search_query_box.is(":focus") &&
+                !typeahead_was_open_on_enter
+            ) {
                 // If the typeahead was just open, the Enter event was selecting an item
-                // from the typeahead. When that's the case, we don't want to exit the
-                // search bar since the user might have more terms to add still. But we
-                // do trigger a search to update the message feed to match the current
-                // set of terms in the search bar.
-                if (typeahead_was_open_on_enter) {
-                    narrow_to_search_contents_with_search_bar_open();
-                } else {
-                    if (!validate_text_terms()) {
-                        return;
-                    }
-                    narrow_or_search_for_term({on_narrow_search});
+                // from the typeahead. When that's the case, we don't want to call
+                // narrow_or_search_for_term which exits the search bar, since the user
+                // might have more terms to add still.
+                if (!validate_text_terms()) {
+                    return;
                 }
+                narrow_or_search_for_term({on_narrow_search});
             }
         });
 

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -35,7 +35,6 @@ function get_search_bar_text(): string {
 // TODO/typescript: Add the rest of the options when converting narrow.js to typescript.
 type NarrowSearchOptions = {
     trigger: string;
-    prevent_message_header_render?: boolean;
 };
 
 type OnNarrowSearch = (terms: NarrowTerm[], options: NarrowSearchOptions) => void;
@@ -102,7 +101,18 @@ function narrow_to_search_contents_with_search_bar_open(): void {
         .join(" ")
         .trim();
     const terms = Filter.parse(search_query);
-    on_narrow_search(terms, {trigger: "search", prevent_message_header_render: true});
+    on_narrow_search(terms, {trigger: "search"});
+
+    // We want to keep the search bar open here, not show the
+    // message header. But here we'll let the message header
+    // get rendered first, so that it's up to date with the
+    // new narrow, and then reopen search if it got closed.
+    if ($(".navbar-search.expanded").length === 0) {
+        open_search_bar_and_close_narrow_description();
+        focus_search_input_at_end();
+        search_typeahead.lookup(false);
+        search_input_has_changed = true;
+    }
 }
 
 // When a pill is added, or when text input is changed, we set

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -245,6 +245,7 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             _setup(terms);
             input_pill_displayed = false;
             mock_pill_removes(search.search_pill_widget);
+            $(".navbar-search.expanded").length = 1;
             assert.equal(opts.updater("ver"), "ver");
             assert.ok(!input_pill_displayed);
 


### PR DESCRIPTION
The first commit is a bug I noticed while working on this.

The second and third commits are two parts of the solution to [this reported issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20search.20suggestion.20narrow.20from.20recent.20and.20inbox/near/1890604)