### PR TITLE
Scale modal buttons when switching between 14px and 16px mode.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -112,10 +112,12 @@
 }
 
 .modal__btn {
-    font-size: 0.875rem;
-    padding: 0.5rem 1rem;
+    /* We need the backup value for billing related html files where
+       this variable is not defined. */
+    font-size: var(--base-font-size-px, 14px);
+    padding: 8px 16px;
     background-color: hsl(0deg 0% 90%);
-    border-radius: 0.25rem;
+    border-radius: 4px;
     border-width: 0;
     cursor: pointer;
     text-transform: none;


### PR DESCRIPTION
Fixes #30920.

This change affects all dialog boxes, so the impact is pretty widespread. I've added 1 screenshot of the dialog box for reference. But some regression testing would still be required by whoever tests this.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Add emoji dialog box:

| 14px - before                           | 14px -  after                          | 
| -- | -- |
|                <img width="522" alt="add_emoji_14px_old" src="https://github.com/user-attachments/assets/a443924d-12fc-4625-9437-6a3c9799f2fd">                  |               <img width="520" alt="dialog_14px_emoji" src="https://github.com/user-attachments/assets/22ec60b6-9c23-4465-8f83-495cb0e180b7">                  |

| 16px - before                           | 16px -  after                          | 
| -- | -- |
|      <img width="522" alt="add_emoji_16px_old" src="https://github.com/user-attachments/assets/3950d80e-ba41-4710-8e70-8a82ff60fc86">       |          <img width="519" alt="dialog_16px_emoji" src="https://github.com/user-attachments/assets/824b6387-af9b-4683-b955-929877399b6f">               |

### Billing page dialog box (no changes) 

| Before                         | After                          | 
| -- | -- |
|                <img width="522" alt="billing_before" src="https://github.com/user-attachments/assets/7ee088b1-a391-4b1d-a882-896619ebec4d">               |               <img width="520" alt="cancel_plan_new" src="https://github.com/user-attachments/assets/141159f5-1534-43dd-8dd0-9a39d0aef602">              |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
