### PR TITLE
stream_popover: Fix stream lock icon position in stream actions popover.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -215,6 +215,13 @@
         margin-top: 4px;
     }
 
+    .zulip-icon-lock {
+        /* Override the margin-top set on the stream lock icon
+           at the top-level, since we don't need to pull up this
+           icon for the stream actions popover header.  */
+        margin: 0 !important;
+    }
+
     .colorpicker-container {
         display: none;
         margin-right: 10px;


### PR DESCRIPTION
As noted in PR #30849, the stream lock icon was not positioned correctly in the stream actions popover and this was being exaggerated at 16/140.

This commit overrides the margin-top set on the stream lock icon at the top-level in `app_components.css`, since we don't need to pull up this icon for the stream actions popover header.

<!-- Describe your pull request here.-->

Fixes: [Issue mentioned in #30849 comments](https://github.com/zulip/zulip/pull/30849#issuecomment-2229023244)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-07-16 at 2 54 29 PM](https://github.com/user-attachments/assets/a74ad3b9-8700-475d-b1e7-147fd1dbc680) | ![Screenshot 2024-07-16 at 2 52 52 PM](https://github.com/user-attachments/assets/27b07fa4-2f34-4f85-978f-697987e2fdc3) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
