### PR TITLE
Add support to export and import `OnboardingUserMessage` table.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -514,7 +514,7 @@ def re_map_foreign_keys(
     """
 
     # See comments in bulk_import_user_message_data.
-    assert "usermessage" not in related_table
+    assert related_table != "usermessage"
 
     re_map_foreign_keys_internal(
         data[table],
@@ -692,7 +692,7 @@ def update_model_ids(model: Any, data: TableData, related_table: TableName) -> N
     # Important: remapping usermessage rows is
     # not only unnecessary, it's expensive and can cause
     # memory errors. We don't even use ids from ID_MAP.
-    assert "usermessage" not in table
+    assert table != "usermessage"
 
     old_id_list = current_table_ids(data, table)
     allocated_id_list = allocate_ids(model, len(data[table]))

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -56,6 +56,7 @@ from zerver.models import (
     MutedUser,
     NamedUserGroup,
     OnboardingStep,
+    OnboardingUserMessage,
     Reaction,
     Realm,
     RealmAuditLog,
@@ -148,6 +149,7 @@ ID_MAP: dict[str, dict[int, int]] = {
     "analytics_usercount": {},
     "realmuserdefault": {},
     "scheduledmessage": {},
+    "onboardingusermessage": {},
 }
 
 id_map_to_list: dict[str, dict[int, list[int]]] = {
@@ -1493,6 +1495,15 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
 
     # Import zerver_message and zerver_usermessage
     import_message_data(realm=realm, sender_map=sender_map, import_dir=import_dir)
+
+    if "zerver_onboardingusermessage" in data:
+        fix_bitfield_keys(data, "zerver_onboardingusermessage", "flags")
+        re_map_foreign_keys(data, "zerver_onboardingusermessage", "realm", related_table="realm")
+        re_map_foreign_keys(
+            data, "zerver_onboardingusermessage", "message", related_table="message"
+        )
+        update_model_ids(OnboardingUserMessage, data, "onboardingusermessage")
+        bulk_import_model(data, OnboardingUserMessage)
 
     if "zerver_scheduledmessage" in data:
         fix_datetime_fields(data, "zerver_scheduledmessage")


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20No.20data.20exported.20for.20table.20zerver_onboardingusermessage/near/1885788)

https://github.com/zulip/zulip/pull/30142#issuecomment-2220901079


> @prakhar1144: Our export tool is mildly unhappy with the new table:

> 2024-07-10 15:54:20.993 WARN [] ??? NO DATA EXPORTED FOR TABLE zerver_onboardingusermessage!!!

PR to add support to export and import `OnboardingUserMessage` table properly.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
