### PR TITLE
narrow_operators: Add `with` operator to `filter.is_conversation_view`.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1571,7 +1571,11 @@ export class Filter {
 
     is_conversation_view(): boolean {
         const term_type = this.sorted_term_types();
-        if (_.isEqual(term_type, ["channel", "topic"]) || _.isEqual(term_type, ["dm"])) {
+        if (
+            _.isEqual(term_type, ["channel", "topic", "with"]) ||
+            _.isEqual(term_type, ["channel", "topic"]) ||
+            _.isEqual(term_type, ["dm"])
+        ) {
             return true;
         }
         return false;

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -412,7 +412,7 @@ test("basics", () => {
     assert.ok(filter.includes_full_stream_history());
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
-    assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_conversation_view());
     assert.ok(filter.can_bucket_by("channel", "topic", "with"));
     assert.ok(!filter.is_conversation_view_with_near());
 


### PR DESCRIPTION
This commit updates `ilter.is_conversation_view` to be true for `with` operator. This is important because essentially, the `with` operator lands you in the same view as the channel-topic narrow or the `dm` narrow i.e., the last unread message of the narrow.

Hence, the `with` narrow should be handled in a similar way while determining whether to allow automatically marking messages as read, or displaying the unread banner, etc.

Fixes: #30863 and checkbox 1 of https://github.com/zulip/zulip/pull/30114#issuecomment-2226642678

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
