### PR TITLE
compose: Ensure color concord across compose and edit boxes.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -352,6 +352,7 @@
 #preview_message_area {
     margin-right: calc(var(--composebox-buttons-width) * -1);
     padding-right: var(--composebox-buttons-width);
+    color: var(--color-text-default);
 }
 
 .surround-formatting-buttons-row {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -560,7 +560,7 @@
     /* Setting resize as none hides the bottom right diagonal box
        (which even has a background color of its own!). */
     resize: none !important;
-    color: hsl(0deg 0% 33%);
+    color: var(--color-text-default);
     background-color: hsl(0deg 0% 100%);
     border-radius: 3px;
     vertical-align: middle;


### PR DESCRIPTION
This PR removes a one-off color declaration from the message-edit box to ensure that `--color-text-default` appears when editing a message.

Additionally, this corrects for an even subtler bug: it fixes the browser-default `#000`-equivalent on the compose textarea in light mode by specifying that the textarea there also takes `--color-text-default` (that was already handled correctly in dark mode, thanks to a `color: inherit` declaration in dark theme that picked up `--color-text-default).

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20text.20greyed.20out.20when.20editing.20message/near/1883076)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Compose/edit mode, before | Compose/edit mode, after (no change in dark theme) |
| --- | --- |
| ![light-edit-before](https://github.com/user-attachments/assets/3b73779d-6bb0-462f-84d9-6b0c9cf6d9c3) | ![light-edit-after](https://github.com/user-attachments/assets/af045c21-4521-4d07-8582-b798c7e78fd0) |
| ![dark-edit-before](https://github.com/user-attachments/assets/ac46fc59-9043-425b-9b0a-e65387f78f05) | ![dark-edit-after](https://github.com/user-attachments/assets/b2954502-01e7-4c71-b0e7-f72e3c2fecf3) |

| Preview mode, before | Preview mode, after (no change in light or dark theme) |
| --- | --- |
| ![light-preview-before](https://github.com/user-attachments/assets/5cae3dd3-f0f3-45d0-b3ed-90d295931515) | ![light-preview-after](https://github.com/user-attachments/assets/071f7b3b-6df2-4b79-bb1b-0826e6f3d30f) |
| ![dark-preview-before](https://github.com/user-attachments/assets/f858d693-6da0-493a-96ed-def525ae560b) | ![dark-preview-after](https://github.com/user-attachments/assets/77a3d6e3-15db-4587-8735-7dde8136b141) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>