### PR TITLE
search: Improve text about searching public channels.

### DIFF
--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -12,8 +12,10 @@ import {$t, $t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
 import * as markdown from "./markdown";
 import * as overlays from "./overlays";
+import {page_params} from "./page_params";
 import * as rendered_markdown from "./rendered_markdown";
 import * as scroll_util from "./scroll_util";
+import {current_user} from "./state_data";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
 
@@ -277,7 +279,11 @@ export function set_up_toggler(): void {
     });
     $(".informational-overlays .overlay-body").append($markdown_help);
 
-    const $search_operators = $(render_search_operator());
+    const $search_operators = $(
+        render_search_operator({
+            can_access_all_public_channels: !page_params.is_spectator && !current_user.is_guest,
+        }),
+    );
     $(".informational-overlays .overlay-body").append($search_operators);
 
     const $keyboard_shortcuts = $(render_keyboard_shortcut());

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -11,7 +11,7 @@ import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import type {User} from "./people";
-import type {NarrowTerm} from "./state_data";
+import {type NarrowTerm, current_user} from "./state_data";
 import * as stream_data from "./stream_data";
 import * as stream_topic_history from "./stream_topic_history";
 import * as stream_topic_history_util from "./stream_topic_history_util";
@@ -625,10 +625,16 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
     if (last.operator === "search" && common.phrase_match(last.operand, "streams")) {
         search_string = "streams:public";
     }
+    let description_html;
+    if (page_params.is_spectator || current_user.is_guest) {
+        description_html = "All public channels that you can view";
+    } else {
+        description_html = "All public channels";
+    }
     const suggestions: SuggestionAndIncompatiblePatterns[] = [
         {
             search_string,
-            description_html: "All public channels in organization",
+            description_html,
             is_people: false,
             incompatible_patterns: [
                 {operator: "is", operand: "dm"},

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -191,7 +191,11 @@ function initialize_compose_box() {
 }
 
 function initialize_message_feed_errors() {
-    $("#message_feed_errors_container").html(render_message_feed_errors());
+    $("#message_feed_errors_container").html(
+        render_message_feed_errors({
+            is_guest: current_user.is_guest,
+        }),
+    );
 }
 
 export function initialize_kitchen_sink_stuff() {

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -20,10 +20,17 @@
         {{/tr}}
         &nbsp;
         <span>
-            {{#tr}}
-            Consider <z-link>searching all public channels</z-link>.
-            {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
-            {{/tr}}
+            {{#if is_guest}}
+                {{#tr}}
+                    Consider <z-link>searching all public channels that you can view</z-link>.
+                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
+                {{/tr}}
+            {{else}}
+                {{#tr}}
+                    Consider <z-link>searching all public channels</z-link>.
+                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
+                {{/tr}}
+            {{/if}}
         </span>
     </p>
 </div>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -63,7 +63,11 @@
                     <tr>
                         <td class="operator">channels:public</td>
                         <td class="definition">
-                            {{t 'Search all public channels in the organization.'}}
+                            {{#if can_access_all_public_channels }}
+                            {{t 'Search all public channels.'}}
+                            {{else}}
+                            {{t 'Search all public channels that you can view.'}}
+                            {{/if}}
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
We use different text for guest users, specifying that they can only search in channels they can view.
The issue description suggests the same for spectators, but we already use different text for them.

The issue also specifies changing the "searching all public channels" link to use channels rather than streams in the URL.
But that is better done separately.

Fixes: #30902 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Screenshots and screen captures</summary>

### search typeahead:
- As guest:

![image](https://github.com/user-attachments/assets/827e4372-a845-47e2-a9d4-bfbf8b131239)

- Otherwise:
 
![image](https://github.com/user-attachments/assets/daaefa71-3371-4dad-9ca6-5a17291cb73c)


### Top of search results

- As guest:

![image](https://github.com/user-attachments/assets/47a986ca-81be-4f4b-af79-99a0ca726ec4)

- Otherwise:

![image](https://github.com/user-attachments/assets/dcb8cb4f-5c40-40ec-8d76-29320d5a4a37)




</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
