### PR TITLE
tests: Remove deprecated SHA1PasswordHasher

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -367,15 +367,15 @@ class AuthBackendTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         password = "a_password_of_22_chars"
 
-        with self.settings(PASSWORD_HASHERS=("django.contrib.auth.hashers.SHA1PasswordHasher",)):
+        with self.settings(PASSWORD_HASHERS=("django.contrib.auth.hashers.MD5PasswordHasher",)):
             user_profile.set_password(password)
             user_profile.save()
 
         with (
             self.settings(
                 PASSWORD_HASHERS=(
+                    "django.contrib.auth.hashers.PBKDF2PasswordHasher",
                     "django.contrib.auth.hashers.MD5PasswordHasher",
-                    "django.contrib.auth.hashers.SHA1PasswordHasher",
                 ),
                 PASSWORD_MIN_LENGTH=30,
             ),
@@ -5040,15 +5040,15 @@ class FetchAPIKeyTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         password = "a_password_of_22_chars"
 
-        with self.settings(PASSWORD_HASHERS=("django.contrib.auth.hashers.SHA1PasswordHasher",)):
+        with self.settings(PASSWORD_HASHERS=("django.contrib.auth.hashers.MD5PasswordHasher",)):
             user_profile.set_password(password)
             user_profile.save()
 
         with (
             self.settings(
                 PASSWORD_HASHERS=(
+                    "django.contrib.auth.hashers.PBKDF2PasswordHasher",
                     "django.contrib.auth.hashers.MD5PasswordHasher",
-                    "django.contrib.auth.hashers.SHA1PasswordHasher",
                 ),
                 PASSWORD_MIN_LENGTH=30,
             ),

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -967,15 +967,15 @@ class LoginTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         password = "a_password_of_22_chars"
 
-        with self.settings(PASSWORD_HASHERS=("django.contrib.auth.hashers.SHA1PasswordHasher",)):
+        with self.settings(PASSWORD_HASHERS=("django.contrib.auth.hashers.MD5PasswordHasher",)):
             user_profile.set_password(password)
             user_profile.save()
 
         with (
             self.settings(
                 PASSWORD_HASHERS=(
+                    "django.contrib.auth.hashers.PBKDF2PasswordHasher",
                     "django.contrib.auth.hashers.MD5PasswordHasher",
-                    "django.contrib.auth.hashers.SHA1PasswordHasher",
                 ),
                 PASSWORD_MIN_LENGTH=30,
             ),

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -419,7 +419,6 @@ if DEVELOPMENT:
     # PRODUCTION.  Saves a bunch of time.
     PASSWORD_HASHERS = [
         "django.contrib.auth.hashers.MD5PasswordHasher",
-        "django.contrib.auth.hashers.SHA1PasswordHasher",
         "django.contrib.auth.hashers.PBKDF2PasswordHasher",
     ]
     # Also we auto-generate passwords for the default users which you


### PR DESCRIPTION
`SHA1PasswordHasher` will be removed in Django 5.1. `MD5PasswordHasher` will remain for the purpose of speeding up tests.

- Followup to commit ac5161f4397eb6d984cdc27f56fba52f6a220af2 (#29620).