### PR TITLE
corporate: Set assume_scheme="https" for django.forms.URLField

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -690,7 +690,9 @@ class UpgradePageContext(TypedDict):
 
 
 class SponsorshipRequestForm(forms.Form):
-    website = forms.URLField(max_length=ZulipSponsorshipRequest.MAX_ORG_URL_LENGTH, required=False)
+    website = forms.URLField(
+        max_length=ZulipSponsorshipRequest.MAX_ORG_URL_LENGTH, required=False, assume_scheme="https"
+    )
     organization_type = forms.IntegerField()
     description = forms.CharField(widget=forms.Textarea)
     expected_total_users = forms.CharField(widget=forms.Textarea)

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -104,7 +104,7 @@ class DemoRequestForm(forms.Form):
     role = forms.CharField(max_length=MAX_INPUT_LENGTH)
     organization_name = forms.CharField(max_length=MAX_INPUT_LENGTH)
     organization_type = forms.CharField()
-    organization_website = forms.URLField(required=True)
+    organization_website = forms.URLField(required=True, assume_scheme="https")
     expected_user_count = forms.CharField(max_length=MAX_INPUT_LENGTH)
     message = forms.CharField(widget=forms.Textarea)
 


### PR DESCRIPTION
The previous default of `"http"` is deprecated and will change to `"https"` in Django 6.0.

https://docs.djangoproject.com/en/5.0/releases/5.0/#id2
https://docs.djangoproject.com/en/5.0/ref/forms/fields/#django.forms.URLField.assume_scheme