### PR TITLE
Explicitly close memcached connections

### DIFF
--- a/puppet/kandra/files/memcached_exporter
+++ b/puppet/kandra/files/memcached_exporter
@@ -382,12 +382,13 @@ class MemcachedCollector(Collector):
 
         raw_stats = client.stats("sizes")
         sizes_stats = next(iter(raw_stats.values()))
-        if sizes_stats.get("sizes_status") == b"disabled" or sizes_stats == {}:
-            return
-        sizes = sorted([int(x) for x in sizes_stats])
-        yield gauge(
-            "item_max_bytes", "Largest item (rounded to 32 bytes) in bytes.", value=sizes[-1]
-        )
+        if sizes_stats.get("sizes_status") != b"disabled" and sizes_stats != {}:
+            sizes = sorted([int(x) for x in sizes_stats])
+            yield gauge(
+                "item_max_bytes", "Largest item (rounded to 32 bytes) in bytes.", value=sizes[-1]
+            )
+
+        client.disconnect_all()
 
 
 if __name__ == "__main__":

--- a/scripts/setup/flush-memcached
+++ b/scripts/setup/flush-memcached
@@ -15,4 +15,8 @@ from zproject import settings
 
 cache = settings.CACHES["default"]
 assert isinstance(cache, dict)  # for mypy
-bmemcached.Client((cache["LOCATION"],), **cache["OPTIONS"]).flush_all()
+client = bmemcached.Client((cache["LOCATION"],), **cache["OPTIONS"])
+try:
+    client.flush_all()
+finally:
+    client.disconnect_all()

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -109,10 +109,14 @@ def clear_database() -> None:
     # and; we only need to flush memcached if we're populating a
     # database that would be used with it (i.e. zproject.dev_settings).
     if default_cache["BACKEND"] == "zerver.lib.singleton_bmemcached.SingletonBMemcached":
-        bmemcached.Client(
+        memcached_client = bmemcached.Client(
             (default_cache["LOCATION"],),
             **default_cache["OPTIONS"],
-        ).flush_all()
+        )
+        try:
+            memcached_client.flush_all()
+        finally:
+            memcached_client.disconnect_all()
 
     model: Any = None  # Hack because mypy doesn't know these are model classes
 


### PR DESCRIPTION
Fixes warnings like `ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33332), raddr=('127.0.0.1', 11211)>` with warnings enabled.