### PR TITLE
narrow: Migrate legacy SQLAlchemy select syntax

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -354,7 +354,7 @@ class NarrowBuilder:
                 # If the initial query doesn't use `zerver_usermessage`
                 check_col = literal_column("zerver_message.id", Integer)
             exists_cond = (
-                select([1])
+                select(1)
                 .select_from(table("zerver_reaction"))
                 .where(check_col == literal_column("zerver_reaction.message_id", Integer))
                 .exists()

--- a/zerver/lib/topic_sqlalchemy.py
+++ b/zerver/lib/topic_sqlalchemy.py
@@ -23,7 +23,7 @@ def topic_column_sa() -> ColumnElement[Text]:
 
 def get_followed_topic_condition_sa(user_id: int) -> ColumnElement[Boolean]:
     follow_topic_cond = (
-        select([1])
+        select(1)
         .select_from(table("zerver_usertopic"))
         .where(
             and_(


### PR DESCRIPTION
Fixes `sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0.` with warnings enabled.

https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#change-5284