### PR TITLE
search: Always reset the search bar when opening it.

### DIFF
--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -419,12 +419,7 @@ function exit_search(opts: {keep_search_narrow_open: boolean}): void {
 }
 
 export function open_search_bar_and_close_narrow_description(): void {
-    // Preserve user input if they've already started typing, but
-    // otherwise fill the input field with the text terms for
-    // the current narrow.
-    if (get_search_bar_text() === "") {
-        reset_searchbox();
-    }
+    reset_searchbox();
     $(".navbar-search").addClass("expanded");
     $("#message_view_header").addClass("hidden");
     popovers.hide_all();


### PR DESCRIPTION
Some time ago, I added a condition to not reset the search bar if the user had already started typing, so that we wouldn't erase what they'd started typing. But we encountered a situation where the search bar can be opened with text in it: clicking "searching all public channels" from a search view. We want to reset the searchbox to add the `channels: public` pill.

I tried to replicate original issue I encountered where the search box resetting was clearing user input and couldn't replicate it. So for now I'm just removing that if statement.

CZO thread: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20search.20pills.20don't.20update.20on.20hash.20change