### PR TITLE
search pill refactor to only use `display_value` for display

### DIFF
--- a/docs/subsystems/input-pills.md
+++ b/docs/subsystems/input-pills.md
@@ -23,6 +23,7 @@ var pills = input_pill.create({
     $container: $pill_container,
     create_item_from_text: user_pill.create_item_from_email,
     get_text_from_item: user_pill.get_email_from_item,
+    // TODO documentation here
 });
 ```
 

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -1,18 +1,22 @@
 import * as blueslip from "./blueslip";
+import assert from "minimalistic-assert";
+
+import render_input_pill from "../templates/input_pill.hbs";
+
 import * as input_pill from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import type {User} from "./people";
 import * as pill_typeahead from "./pill_typeahead";
 import * as stream_pill from "./stream_pill";
-import type {CombinedPill, CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
 import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
 
 function create_item_from_text(
     text: string,
-    current_items: CombinedPillItem[],
-): CombinedPillItem | undefined {
+    current_items: CombinedPill[],
+): CombinedPill | undefined {
     const funcs = [
         stream_pill.create_item_from_stream_name,
         user_group_pill.create_item_from_group_name,
@@ -27,7 +31,7 @@ function create_item_from_text(
     return undefined;
 }
 
-function get_text_from_item(item: CombinedPillItem): string {
+function get_text_from_item(item: CombinedPill): string {
     let text: string;
     switch (item.type) {
         case "stream":
@@ -61,6 +65,31 @@ function set_up_pill_typeahead({
     pill_typeahead.set_up_combined($pill_container.find(".input"), pill_widget, opts);
 }
 
+function get_display_value_from_item(item: CombinedPill): string {
+    if (item.type === "user_group") {
+        return user_group_pill.display_pill(item.group_id);
+    } else if (item.type === "stream") {
+        return stream_pill.get_display_string_from_item(item);
+    }
+    assert(item.type === "user");
+    return user_pill.get_display_value_from_item(item);
+}
+
+function generate_pill_html(item: CombinedPill): string {
+    if (item.type === "user_group") {
+        return render_input_pill({
+            display_value: get_display_value_from_item(item),
+            group_id: item.group_id,
+        });
+    } else if (item.type === "user") {
+        return user_pill.generate_pill_html(item);
+    }
+
+    return render_input_pill({
+        display_value: get_display_value_from_item(item),
+    });
+}
+
 export function create({
     $pill_container,
     get_potential_subscribers,
@@ -72,6 +101,8 @@ export function create({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
+        get_display_value_from_item,
+        generate_pill_html,
     });
     function get_users(): User[] {
         const potential_subscribers = get_potential_subscribers();
@@ -116,6 +147,7 @@ export function create_without_add_button({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
+        get_display_value_from_item,
     });
     function get_users(): User[] {
         const potential_subscribers = get_potential_subscribers();

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -4,14 +4,13 @@ import type {InputPillConfig} from "./input_pill";
 import * as input_pill from "./input_pill";
 import type {User} from "./people";
 import * as people from "./people";
-import type {UserPillWidget} from "./user_pill";
+import type {UserPill, UserPillWidget} from "./user_pill";
 import * as user_pill from "./user_pill";
 import * as util from "./util";
 
 export let widget: UserPillWidget;
 
 const pill_config: InputPillConfig = {
-    show_user_status_emoji: true,
     exclude_inaccessible_users: true,
 };
 
@@ -23,6 +22,8 @@ export function initialize_pill(): UserPillWidget {
         pill_config,
         create_item_from_text: user_pill.create_item_from_email,
         get_text_from_item: user_pill.get_email_from_item,
+        get_display_value_from_item: user_pill.get_display_value_from_item,
+        generate_pill_html: (item: UserPill) => user_pill.generate_pill_html(item, true),
     });
 
     return pill;

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -1,7 +1,8 @@
-import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillConfig, InputPillContainer} from "./input_pill";
 import * as input_pill from "./input_pill";
 
 type EmailPill = {
+    type: "email";
     email: string;
 };
 
@@ -11,8 +12,8 @@ const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export function create_item_from_email(
     email: string,
-    current_items: InputPillItem<EmailPill>[],
-): InputPillItem<EmailPill> | undefined {
+    current_items: EmailPill[],
+): EmailPill | undefined {
     if (!email_regex.test(email)) {
         return undefined;
     }
@@ -24,12 +25,11 @@ export function create_item_from_email(
 
     return {
         type: "email",
-        display_value: email,
         email,
     };
 }
 
-export function get_email_from_item(item: InputPillItem<EmailPill>): string {
+export function get_email_from_item(item: EmailPill): string {
     return item.email;
 }
 
@@ -52,6 +52,7 @@ export function create_pills(
         pill_config,
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
+        get_display_value_from_item: get_email_from_item,
     });
     return pill_container;
 }

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -4,112 +4,89 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import render_input_pill from "../templates/input_pill.hbs";
-import render_search_user_pill from "../templates/search_user_pill.hbs";
 
 import * as blueslip from "./blueslip";
-import type {EmojiRenderingDetails} from "./emoji";
 import * as keydown_util from "./keydown_util";
 import type {SearchUserPill} from "./search_pill";
-import type {StreamSubscription} from "./sub_store";
 import * as ui_util from "./ui_util";
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html
 
-export type InputPillItem<T> = {
-    display_value: string;
-    type: string;
-    img_src?: string;
-    deactivated?: boolean;
-    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined; // TODO: Move this in user_status.js
-    should_add_guest_user_indicator?: boolean;
-    user_id?: number;
-    group_id?: number;
-    // Used for search pills
-    operator?: string;
-    stream?: StreamSubscription;
-} & T;
-
 export type InputPillConfig = {
-    show_user_status_emoji?: boolean;
+    // TODO: Put this in user-specific code instead of here.
     exclude_inaccessible_users?: boolean;
 };
 
-type InputPillCreateOptions<T> = {
+type InputPillCreateOptions<ItemType> = {
     $container: JQuery;
     pill_config?: InputPillConfig | undefined;
     split_text_on_comma?: boolean;
     convert_to_pill_on_enter?: boolean;
     create_item_from_text: (
         text: string,
-        existing_items: InputPillItem<T>[],
+        existing_items: ItemType[],
         pill_config?: InputPillConfig | undefined,
-    ) => InputPillItem<T> | undefined;
-    get_text_from_item: (item: InputPillItem<T>) => string;
+    ) => ItemType | undefined;
+    get_text_from_item: (item: ItemType) => string;
+    get_display_value_from_item: (item: ItemType) => string;
+    generate_pill_html?: (item: ItemType) => string;
 };
 
-type InputPill<T> = {
-    item: InputPillItem<T>;
+type InputPill<ItemType> = {
+    item: ItemType;
     $element: JQuery;
 };
 
-type InputPillStore<T> = {
+type InputPillStore<ItemType> = {
     onTextInputHook?: () => void;
-    pills: InputPill<T>[];
-    pill_config: InputPillCreateOptions<T>["pill_config"];
+    pills: InputPill<ItemType>[];
+    pill_config: InputPillCreateOptions<ItemType>["pill_config"];
     $parent: JQuery;
     $input: JQuery;
-    create_item_from_text: InputPillCreateOptions<T>["create_item_from_text"];
-    get_text_from_item: InputPillCreateOptions<T>["get_text_from_item"];
+    create_item_from_text: InputPillCreateOptions<ItemType>["create_item_from_text"];
+    get_text_from_item: InputPillCreateOptions<ItemType>["get_text_from_item"];
+    get_display_value_from_item: InputPillCreateOptions<ItemType>["get_display_value_from_item"];
+    generate_pill_html: InputPillCreateOptions<ItemType>["generate_pill_html"];
     onPillCreate?: () => void;
-    onPillRemove?: (pill: InputPill<T>) => void;
+    onPillRemove?: (pill: InputPill<ItemType>) => void;
     createPillonPaste?: () => void;
     split_text_on_comma: boolean;
     convert_to_pill_on_enter: boolean;
 };
 
-type InputPillRenderingDetails = {
-    display_value: string;
-    has_image: boolean;
-    img_src?: string | undefined;
-    deactivated: boolean | undefined;
-    has_status?: boolean;
-    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined;
-    should_add_guest_user_indicator: boolean | undefined;
-    user_id?: number | undefined;
-    group_id?: number | undefined;
-    has_stream?: boolean;
-    stream?: StreamSubscription;
-};
-
 // These are the functions that are exposed to other modules.
-export type InputPillContainer<T> = {
+export type InputPillContainer<ItemType> = {
     appendValue: (text: string) => void;
-    appendValidatedData: (item: InputPillItem<T>) => void;
-    getByElement: (element: HTMLElement) => InputPill<T> | undefined;
-    items: () => InputPillItem<T>[];
+    appendValidatedData: (item: ItemType) => void;
+    getByElement: (element: HTMLElement) => InputPill<ItemType> | undefined;
+    items: () => ItemType[];
     onPillCreate: (callback: () => void) => void;
-    onPillRemove: (callback: (pill: InputPill<T>) => void) => void;
+    onPillRemove: (callback: (pill: InputPill<ItemType>) => void) => void;
     onTextInputHook: (callback: () => void) => void;
     createPillonPaste: (callback: () => void) => void;
     clear: (quiet?: boolean) => void;
     clear_text: () => void;
     getCurrentText: () => string | null;
     is_pending: () => boolean;
-    _get_pills_for_testing: () => InputPill<T>[];
+    _get_pills_for_testing: () => InputPill<ItemType>[];
 };
 
-export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T> {
+export function create<ItemType extends {type: string}>(
+    opts: InputPillCreateOptions<ItemType>,
+): InputPillContainer<ItemType> {
     // a stateful object of this `pill_container` instance.
     // all unique instance information is stored in here.
-    const store: InputPillStore<T> = {
+    const store: InputPillStore<ItemType> = {
         pills: [],
         pill_config: opts.pill_config,
         $parent: opts.$container,
         $input: opts.$container.find(".input").expectOne(),
         create_item_from_text: opts.create_item_from_text,
         get_text_from_item: opts.get_text_from_item,
+        get_display_value_from_item: opts.get_display_value_from_item,
         split_text_on_comma: opts.split_text_on_comma ?? true,
         convert_to_pill_on_enter: opts.convert_to_pill_on_enter ?? true,
+        generate_pill_html: opts.generate_pill_html,
     };
 
     // a dictionary of internal functions. Some of these are exposed as well,
@@ -146,7 +123,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             const existing_items = funcs.items();
             const item = store.create_item_from_text(text, existing_items, store.pill_config);
 
-            if (!item?.display_value) {
+            if (!item) {
                 store.$input.addClass("shake");
                 return undefined;
             }
@@ -156,72 +133,21 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
         // This is generally called by typeahead logic, where we have all
         // the data we need (as opposed to, say, just a user-typed email).
-        appendValidatedData(item: InputPillItem<T>) {
-            if (!item.display_value) {
-                blueslip.error("no display_value returned");
+        appendValidatedData(item: ItemType) {
+            if (!item) {
+                blueslip.error("no value returned");
                 return;
             }
 
-            if (!item.type) {
-                blueslip.error("no type defined for the item");
-                return;
-            }
             let pill_html;
-            if (item.type === "search_user") {
-                pill_html = render_search_user_pill(item);
+            if (store.generate_pill_html !== undefined) {
+                pill_html = store.generate_pill_html(item);
             } else {
-                const has_image = item.img_src !== undefined;
-
-                let display_value = item.display_value;
-                // For search pills, we don't need to use + instead
-                // of spaces in the pill, since there is visual separation
-                // of pills. We also chose to add a space after the colon
-                // after the search operator.
-                //
-                // TODO: Ideally this code would live in search files, when
-                // we generate `item.display_value`, but we currently use
-                // `display_value` not only for visual representation but
-                // also for parsing the value a pill represents.
-                // In the future we should change all input pills to have
-                // a `value` as well as a `display_value`.
-                if (item.type === "search") {
-                    display_value = display_value.replaceAll("+", " ");
-                    display_value = display_value.replace(":", ": ");
-                }
-
-                const opts: InputPillRenderingDetails = {
-                    display_value,
-                    has_image,
-                    deactivated: item.deactivated,
-                    should_add_guest_user_indicator: item.should_add_guest_user_indicator,
-                };
-
-                if (item.user_id) {
-                    opts.user_id = item.user_id;
-                }
-                if (item.group_id) {
-                    opts.group_id = item.group_id;
-                }
-
-                if (has_image) {
-                    opts.img_src = item.img_src;
-                }
-
-                if (item.type === "stream" && item.stream) {
-                    opts.has_stream = true;
-                    opts.stream = item.stream;
-                }
-
-                if (store.pill_config?.show_user_status_emoji === true) {
-                    const has_status = item.status_emoji_info !== undefined;
-                    if (has_status) {
-                        opts.status_emoji_info = item.status_emoji_info;
-                    }
-                    opts.has_status = has_status;
-                }
-                pill_html = render_input_pill(opts);
+                pill_html = render_input_pill({
+                    display_value: store.get_display_value_from_item(item),
+                });
             }
-            const payload: InputPill<T> = {
+            const payload: InputPill<ItemType> = {
                 item,
                 $element: $(pill_html),
             };
@@ -298,7 +224,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             // TODO: Figure out how to get this typed correctly.
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             const user_pill_container = store.pills[container_idx]!
-                .item as unknown as InputPillItem<SearchUserPill>;
+                .item as unknown as SearchUserPill;
 
             // If there's only one user in this pill, delete the whole pill.
             if (user_pill_container.users.length === 1) {
@@ -316,13 +242,6 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
             }
             assert(user_idx !== undefined);
             user_pill_container.users.splice(user_idx, 1);
-            const sign = user_pill_container.negated ? "-" : "";
-            const search_string =
-                sign +
-                user_pill_container.operator +
-                ":" +
-                user_pill_container.users.map((user) => user.email).join(",");
-            user_pill_container.display_value = search_string;
 
             // Remove the user pill from the DOM.
             const $user_pill = $(store.pills[container_idx]!.$element.children(".pill")[user_idx]!);
@@ -566,7 +485,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
     }
 
     // the external, user-accessible prototype.
-    const prototype: InputPillContainer<T> = {
+    const prototype: InputPillContainer<ItemType> = {
         appendValue: funcs.appendPill.bind(funcs),
         appendValidatedData: funcs.appendValidatedData.bind(funcs),
 

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -346,6 +346,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             $container: $pill_container,
             create_item_from_text: email_pill.create_item_from_email,
             get_text_from_item: email_pill.get_email_from_item,
+            get_display_value_from_item: email_pill.get_email_from_item,
         });
 
         $("#invite-user-modal .dialog_submit_button").prop("disabled", true);

--- a/web/src/invite_stream_picker_pill.ts
+++ b/web/src/invite_stream_picker_pill.ts
@@ -2,7 +2,8 @@ import * as input_pill from "./input_pill";
 import {set_up_stream} from "./pill_typeahead";
 import * as stream_data from "./stream_data";
 import * as stream_pill from "./stream_pill";
-import type {CombinedPillItem} from "./typeahead_helper";
+import type {StreamPill} from "./stream_pill";
+import type {CombinedPill} from "./typeahead_helper";
 
 type SetUpPillTypeaheadConfig = {
     pill_widget: stream_pill.StreamPillWidget;
@@ -11,8 +12,8 @@ type SetUpPillTypeaheadConfig = {
 
 function create_item_from_stream_name(
     stream_name: string,
-    current_items: CombinedPillItem[],
-): input_pill.InputPillItem<stream_pill.StreamPill> | undefined {
+    current_items: CombinedPill[],
+): StreamPill | undefined {
     const stream_prefix_required = false;
     const get_allowed_streams = stream_data.get_invite_stream_data;
     const show_stream_sub_count = false;
@@ -48,6 +49,7 @@ export function create($stream_pill_container: JQuery): stream_pill.StreamPillWi
         $container: $stream_pill_container,
         create_item_from_text: create_item_from_stream_name,
         get_text_from_item: stream_pill.get_stream_name_from_item,
+        get_display_value_from_item: stream_pill.get_display_string_from_item,
     });
     add_default_stream_pills(pill_widget);
     set_up_pill_typeahead({pill_widget, $pill_container: $stream_pill_container});

--- a/web/src/stream_pill.ts
+++ b/web/src/stream_pill.ts
@@ -1,13 +1,16 @@
+import assert from "minimalistic-assert";
+
 import {$t} from "./i18n";
-import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillContainer} from "./input_pill";
 import * as peer_data from "./peer_data";
 import * as stream_data from "./stream_data";
 import type {StreamSubscription} from "./sub_store";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 
 export type StreamPill = {
     type: "stream";
     stream: StreamSubscription;
+    show_subscriber_count: boolean;
 };
 
 export type StreamPillWidget = InputPillContainer<StreamPill>;
@@ -24,11 +27,11 @@ function format_stream_name_and_subscriber_count(sub: StreamSubscription): strin
 
 export function create_item_from_stream_name(
     stream_name: string,
-    current_items: CombinedPillItem[],
+    current_items: CombinedPill[],
     stream_prefix_required = true,
     get_allowed_streams: () => StreamSubscription[] = stream_data.get_unsorted_subs,
     show_subscriber_count = true,
-): InputPillItem<StreamPill> | undefined {
+): StreamPill | undefined {
     stream_name = stream_name.trim();
     if (stream_prefix_required) {
         if (!stream_name.startsWith("#")) {
@@ -55,19 +58,14 @@ export function create_item_from_stream_name(
         return undefined;
     }
 
-    let display_value = sub.name;
-    if (show_subscriber_count) {
-        display_value = format_stream_name_and_subscriber_count(sub);
-    }
-
     return {
         type: "stream",
-        display_value,
+        show_subscriber_count,
         stream: sub,
     };
 }
 
-export function get_stream_name_from_item(item: InputPillItem<StreamPill>): string {
+export function get_stream_name_from_item(item: StreamPill): string {
     return item.stream.name;
 }
 
@@ -82,18 +80,23 @@ export function get_user_ids(pill_widget: StreamPillWidget | CombinedPillContain
     return user_ids;
 }
 
+export function get_display_string_from_item(item: StreamPill): string {
+    const stream = stream_data.get_sub_by_id(item.stream.stream_id);
+    assert(stream !== undefined);
+    if (item.show_subscriber_count) {
+        return format_stream_name_and_subscriber_count(stream);
+    }
+    return "#" + stream.name;
+}
+
 export function append_stream(
     stream: StreamSubscription,
     pill_widget: StreamPillWidget | CombinedPillContainer,
     show_subscriber_count = true,
 ): void {
-    let display_value = stream.name;
-    if (show_subscriber_count) {
-        display_value = format_stream_name_and_subscriber_count(stream);
-    }
     pill_widget.appendValidatedData({
         type: "stream",
-        display_value,
+        show_subscriber_count,
         stream,
     });
     pill_widget.clear_text();

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -10,7 +10,7 @@ import {MAX_ITEMS} from "./bootstrap_typeahead";
 import * as buddy_data from "./buddy_data";
 import * as compose_state from "./compose_state";
 import type {LanguageSuggestion, SlashCommandSuggestion} from "./composebox_typeahead";
-import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillContainer} from "./input_pill";
 import * as people from "./people";
 import type {PseudoMentionUser, User} from "./people";
 import * as pm_conversations from "./pm_conversations";
@@ -36,7 +36,6 @@ export type UserOrMentionPillData = UserOrMention & {
 
 export type CombinedPill = StreamPill | UserGroupPill | UserPill;
 export type CombinedPillContainer = InputPillContainer<CombinedPill>;
-export type CombinedPillItem = InputPillItem<CombinedPill>;
 
 export function build_highlight_regex(query: string): RegExp {
     const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,7 +1,7 @@
 import {$t_html} from "./i18n";
-import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillContainer} from "./input_pill";
 import * as people from "./people";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPillContainer, CombinedPill} from "./typeahead_helper";
 import type {UserGroup} from "./user_groups";
 import * as user_groups from "./user_groups";
 
@@ -18,7 +18,8 @@ export type UserGroupPillData = UserGroup & {
     is_silent?: boolean;
 };
 
-function display_pill(group: UserGroup): string {
+export function display_pill(group_id: number): string {
+    const group = user_groups.get_user_group_from_id(group_id);
     const group_members = get_group_members(group);
     return $t_html(
         {defaultMessage: "{group_name}: {group_size, plural, one {# user} other {# users}}"},
@@ -28,8 +29,8 @@ function display_pill(group: UserGroup): string {
 
 export function create_item_from_group_name(
     group_name: string,
-    current_items: CombinedPillItem[],
-): InputPillItem<UserGroupPill> | undefined {
+    current_items: CombinedPill[],
+): UserGroupPill | undefined {
     group_name = group_name.trim();
     const group = user_groups.get_user_group_from_name(group_name);
     if (!group) {
@@ -42,13 +43,12 @@ export function create_item_from_group_name(
 
     return {
         type: "user_group",
-        display_value: display_pill(group),
         group_id: group.id,
         group_name: group.name,
     };
 }
 
-export function get_group_name_from_item(item: InputPillItem<UserGroupPill>): string {
+export function get_group_name_from_item(item: UserGroupPill): string {
     return item.group_name;
 }
 
@@ -76,7 +76,6 @@ function get_group_members(user_group: UserGroup): number[] {
 export function append_user_group(group: UserGroup, pill_widget: CombinedPillContainer): void {
     pill_widget.appendValidatedData({
         type: "user_group",
-        display_value: display_pill(group),
         group_id: group.id,
         group_name: group.name,
     });

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -1,10 +1,13 @@
+import render_input_pill from "../templates/input_pill.hbs";
+
 import * as blueslip from "./blueslip";
-import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
+import type {EmojiRenderingDetails} from "./emoji";
+import type {InputPillConfig, InputPillContainer} from "./input_pill";
 import * as input_pill from "./input_pill";
 import type {User} from "./people";
 import * as people from "./people";
 import {realm} from "./state_data";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 import * as user_status from "./user_status";
 
 // This will be used for pills for things like composing
@@ -12,8 +15,13 @@ import * as user_status from "./user_status";
 
 export type UserPill = {
     type: "user";
-    user_id?: number;
     email: string;
+    full_name?: string;
+    img_src?: string;
+    deactivated?: boolean;
+    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined;
+    should_add_guest_user_indicator?: boolean;
+    user_id?: number;
 };
 
 export type UserPillWidget = InputPillContainer<UserPill>;
@@ -22,9 +30,9 @@ export type UserPillData = {type: "user"; user: User};
 
 export function create_item_from_email(
     email: string,
-    current_items: CombinedPillItem[],
+    current_items: CombinedPill[],
     pill_config?: InputPillConfig | undefined,
-): InputPillItem<UserPill> | undefined {
+): UserPill | undefined {
     // For normal Zulip use, we need to validate the email for our realm.
     const user = people.get_by_email(email);
 
@@ -39,7 +47,6 @@ export function create_item_from_email(
             // is the email itself.
             return {
                 type: "user",
-                display_value: email,
                 email,
             };
         }
@@ -60,13 +67,11 @@ export function create_item_from_email(
 
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
 
-    // We must supply display_value for the widget to work.  Everything
-    // else is for our own use in callbacks.
-    const item: InputPillItem<UserPill> = {
+    const item: UserPill = {
         type: "user",
-        display_value: user.full_name,
         user_id: user.user_id,
         email: user.email,
+        full_name: user.full_name,
         img_src: avatar_url,
         deactivated: false,
         status_emoji_info,
@@ -86,7 +91,7 @@ export function create_item_from_email(
     return item;
 }
 
-export function get_email_from_item(item: InputPillItem<UserPill>): string {
+export function get_email_from_item(item: UserPill): string {
     return item.email;
 }
 
@@ -99,9 +104,9 @@ export function append_person(opts: {
     const avatar_url = people.small_avatar_url_for_person(person);
     const status_emoji_info = user_status.get_status_emoji(opts.person.user_id);
 
-    const pill_data: InputPillItem<UserPill> = {
+    const pill_data: UserPill = {
         type: "user",
-        display_value: person.full_name,
+        full_name: person.full_name,
         user_id: person.user_id,
         email: person.email,
         img_src: avatar_url,
@@ -159,6 +164,31 @@ export function append_user(user: User, pills: UserPillWidget | CombinedPillCont
     }
 }
 
+export function get_display_value_from_item(item: UserPill): string {
+    return item.full_name ?? item.email;
+}
+
+export function generate_pill_html(item: UserPill, show_user_status_emoji = false): string {
+    let status_emoji_info;
+    let has_status;
+    if (show_user_status_emoji) {
+        const has_status = item.status_emoji_info !== undefined;
+        if (has_status) {
+            status_emoji_info = item.status_emoji_info;
+        }
+    }
+    return render_input_pill({
+        display_value: get_display_value_from_item(item),
+        has_image: item.img_src !== undefined,
+        deactivated: item.deactivated,
+        should_add_guest_user_indicator: item.should_add_guest_user_indicator,
+        user_id: item.user_id,
+        img_src: item.img_src,
+        has_status,
+        status_emoji_info,
+    });
+}
+
 export function create_pills(
     $pill_container: JQuery,
     pill_config?: InputPillConfig | undefined,
@@ -168,6 +198,8 @@ export function create_pills(
         pill_config,
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
+        get_display_value_from_item,
+        generate_pill_html: (item: UserPill) => generate_pill_html(item),
     });
     return pills;
 }

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -114,7 +114,7 @@ run_test("pills", ({override, override_rewire}) => {
             assert.ok(get_by_email_called);
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, iago.user_id);
-            assert.equal(res.display_value, iago.full_name);
+            assert.equal(res.full_name, iago.full_name);
         })();
 
         (function test_deactivated_pill() {
@@ -124,7 +124,7 @@ run_test("pills", ({override, override_rewire}) => {
             assert.ok(get_by_email_called);
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, iago.user_id);
-            assert.equal(res.display_value, iago.full_name);
+            assert.equal(res.full_name, iago.full_name);
             assert.ok(res.deactivated);
             people.add_active_user(iago);
         })();

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -50,6 +50,7 @@ const typeahead_helper = zrequire("typeahead_helper");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
+const user_pill = zrequire("user_pill");
 const stream_data = zrequire("stream_data");
 const stream_list_sort = zrequire("stream_list_sort");
 const compose_pm_pill = zrequire("compose_pm_pill");
@@ -846,7 +847,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         onPillCreate() {},
         onPillRemove() {},
         appendValidatedData(item) {
-            appended_names.push(item.display_value);
+            appended_names.push(user_pill.get_display_value_from_item(item));
         },
     }));
     compose_pm_pill.initialize({


### PR DESCRIPTION
This is a big refactor to store other data instead of `display_value` and generate `display_value` based on that.

Potentially there are performance issues here, and maybe we want to tweak it to only generate `display_value` once, but then still only rely on that value for display purposes.

This PR also needs rebasing.