### PR TITLE
Fix misaligning eye icon

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1169,6 +1169,11 @@ input[type="checkbox"] {
         .password-input-row {
             display: flex;
             margin-bottom: 10px;
+            /* This helps us in making sure that the
+               password_visibility_toggle does not look
+               misaligned in small screens where that component
+               increases in height on small screens. */
+            max-height: 2em;
 
             .modal_password_input {
                 /* The usual width of input is 206px, but we reduce

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1207,6 +1207,19 @@ input[type="checkbox"] {
                 opacity: 1;
             }
         }
+
+        .settings-forgot-password {
+            /* Make the link itself a flex container,
+               so we can perfectly center the text
+               in relation to the input box. */
+            display: flex;
+            align-items: center;
+            margin-left: 10px;
+            /* Make the bottom margin same as `.modal_password_input`
+               for proper centering, if the margin changes there,
+               it should also change here and vice versa. */
+            margin-bottom: 10px;
+        }
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1156,19 +1156,52 @@ input[type="checkbox"] {
 
 #api_key_form,
 #change_password_modal {
-    .password-div {
-        position: relative;
+    .settings-password-div {
+        display: flex;
+        flex-wrap: wrap;
 
-        & input[type="text"] {
-            margin-bottom: 10px;
+        .modal-field-label {
+            /* Keep the label to its own
+               line in the wrapping flexbox. */
+            flex: 0 0 100%;
+        }
+
+        .modal_password_input {
+            /* The usual width of input is 206px, but we reduce
+               it by 30px to make way for the padding. */
+            width: 176px;
+            padding-right: 30px;
         }
 
         .password_visibility_toggle {
-            position: absolute;
-            left: 194px;
-            top: 32px;
-            width: 14px;
+            /* We're going to use flexbox, not
+               positioning, to get the clear button
+               over top of the input. This -2em
+               margin accomplishes that, in tandem
+               with the 2em width of this element,
+               which is shared with the ending
+               anchor element in left sidebar header
+               rows. We're using em instead of pixels
+               so the whitespace between the input box
+               and the icon doesn't decrease when the
+               icon's font-size increases when switching
+               from 14px info density to 16px info density
+               mode. */
+            width: 2em;
+            margin-left: -2em;
+
+            /* Make the button itself a flex container,
+               so we can perfectly center the X icon. */
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
             opacity: 0.6;
+
+            /* Make the bottom margin same as `.modal_password_input`
+               for proper centering, if the margin changes there,
+               it should also change here and vice versa. */
+            margin-bottom: 10px;
 
             &:hover {
                 opacity: 1;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1166,59 +1166,58 @@ input[type="checkbox"] {
             flex: 0 0 100%;
         }
 
-        .modal_password_input {
-            /* The usual width of input is 206px, but we reduce
-               it by 30px to make way for the padding. */
-            width: 176px;
-            padding-right: 30px;
-        }
-
-        .password_visibility_toggle {
-            /* We're going to use flexbox, not
-               positioning, to get the clear button
-               over top of the input. This -2em
-               margin accomplishes that, in tandem
-               with the 2em width of this element,
-               which is shared with the ending
-               anchor element in left sidebar header
-               rows. We're using em instead of pixels
-               so the whitespace between the input box
-               and the icon doesn't decrease when the
-               icon's font-size increases when switching
-               from 14px info density to 16px info density
-               mode. */
-            width: 2em;
-            margin-left: -2em;
-
-            /* Make the button itself a flex container,
-               so we can perfectly center the X icon. */
+        .password-input-row {
             display: flex;
-            justify-content: center;
-            align-items: center;
-
-            opacity: 0.6;
-
-            /* Make the bottom margin same as `.modal_password_input`
-               for proper centering, if the margin changes there,
-               it should also change here and vice versa. */
             margin-bottom: 10px;
 
-            &:hover {
-                opacity: 1;
+            .modal_password_input {
+                /* The usual width of input is 206px, but we reduce
+                   it by 30px to make way for the padding. */
+                width: 176px;
+                padding-right: 30px;
+                /* Override the original 10px value so that we can
+                   set the margin-bottom in the parent div instead. */
+                margin-bottom: 0;
             }
-        }
 
-        .settings-forgot-password {
-            /* Make the link itself a flex container,
-               so we can perfectly center the text
-               in relation to the input box. */
-            display: flex;
-            align-items: center;
-            margin-left: 10px;
-            /* Make the bottom margin same as `.modal_password_input`
-               for proper centering, if the margin changes there,
-               it should also change here and vice versa. */
-            margin-bottom: 10px;
+            .password_visibility_toggle {
+                /* We're going to use flexbox, not
+                   positioning, to get the clear button
+                   over top of the input. This -2em
+                   margin accomplishes that, in tandem
+                   with the 2em width of this element,
+                   which is shared with the ending
+                   anchor element in left sidebar header
+                   rows. We're using em instead of pixels
+                   so the whitespace between the input box
+                   and the icon doesn't decrease when the
+                   icon's font-size increases when switching
+                   from 14px info density to 16px info density
+                   mode. */
+                width: 2em;
+                margin-left: -2em;
+
+                /* Make the button itself a flex container,
+                   so we can perfectly center the X icon. */
+                display: flex;
+                justify-content: center;
+                align-items: center;
+
+                opacity: 0.6;
+
+                &:hover {
+                    opacity: 1;
+                }
+            }
+
+            .settings-forgot-password {
+                /* Make the link itself a flex container,
+                   so we can perfectly center the text
+                   in relation to the input box. */
+                display: flex;
+                align-items: center;
+                margin-left: 10px;
+            }
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1028,13 +1028,6 @@ strong {
     font-size: 60%;
 }
 
-.settings-forgot-password {
-    display: inline-block;
-    position: relative;
-    color: hsl(0deg 0% 73%);
-    bottom: 4px;
-}
-
 div.message-list {
     border-collapse: separate;
     margin-left: auto;

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -3,9 +3,7 @@
         <label for="old_password" class="modal-field-label">{{t "Old password" }}</label>
         <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block modal_password_input" value="" />
         <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
-        <div class="settings-forgot-password">
-            <a href="/accounts/password/reset/" class="sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
-        </div>
+        <a href="/accounts/password/reset/" class="settings-forgot-password sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
     </div>
     <div class="settings-password-div">
         <label for="new_password" class="modal-field-label">{{t "New password" }}</label>

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -1,5 +1,5 @@
 <form id="change_password_container">
-    <div class="password-div">
+    <div class="settings-password-div">
         <label for="old_password" class="modal-field-label">{{t "Old password" }}</label>
         <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block modal_password_input" value="" />
         <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
@@ -7,7 +7,7 @@
             <a href="/accounts/password/reset/" class="sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
         </div>
     </div>
-    <div class="password-div">
+    <div class="settings-password-div">
         <label for="new_password" class="modal-field-label">{{t "New password" }}</label>
         <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="w-200 inline-block modal_password_input" value=""
           data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -1,15 +1,19 @@
 <form id="change_password_container">
     <div class="settings-password-div">
         <label for="old_password" class="modal-field-label">{{t "Old password" }}</label>
-        <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block modal_password_input" value="" />
-        <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
-        <a href="/accounts/password/reset/" class="settings-forgot-password sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
+        <div class="password-input-row">
+            <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block modal_password_input" value="" />
+            <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
+            <a href="/accounts/password/reset/" class="settings-forgot-password sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
+        </div>
     </div>
     <div class="settings-password-div">
         <label for="new_password" class="modal-field-label">{{t "New password" }}</label>
-        <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="w-200 inline-block modal_password_input" value=""
-          data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />
-        <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
+        <div class="password-input-row">
+            <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="w-200 inline-block modal_password_input" value=""
+              data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />
+            <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
+        </div>
         <div class="progress inline-block" id="pw_strength">
             <div class="bar bar-danger hide" style="width: 10%;"></div>
         </div>

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -14,8 +14,10 @@
                         <p>{{t "Please re-enter your password to confirm your identity." }}</p>
                         <div class="settings-password-div">
                             <label for="password" class="modal-field-label">{{t "Your password" }}</label>
-                            <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
-                            <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
+                            <div class="password-input-row">
+                                <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
+                                <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
+                            </div>
                         </div>
                         <p class="small">
                             {{#tr}}If you don't know your password, you can <z-link>reset it</z-link>.

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -12,7 +12,7 @@
                     <span class="alert-notification" id="api_key_status"></span>
                     <div id="api_key_form">
                         <p>{{t "Please re-enter your password to confirm your identity." }}</p>
-                        <div class="password-div">
+                        <div class="settings-password-div">
                             <label for="password" class="modal-field-label">{{t "Your password" }}</label>
                             <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
                             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes https://chat.zulip.org/#narrow/stream/9-issues/topic/Eye.20icon.20misaligned.20in.20Manage.20your.20API.20key/near/1890711.

Also fixes an additional issue of the `Forgot It` text not aligning properly. I've added 10px of left margin while I was at it so that text looks nicer.

The order of commits in this PR is not the nicest, but since I was not 100% sure of the approach taken in the third commit to introduce an extra div, I kept the order of commits this way so that it is easier to modify my approach if there's a better one without doing too much playing around with git history. While reading the first two commits, please note that the `margin-bottom: 10px` for each element in their respective commits is going to be removed.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Manage API key dialog

| 14px - before | 14px - after |
| -- | -- |
|   <img width="521" alt="manage_api_key_14px_old" src="https://github.com/user-attachments/assets/8b3afec5-d5be-4a21-b535-30d290e415c3">  |   <img width="521" alt="manage_api_key_14px_new" src="https://github.com/user-attachments/assets/57955962-bb5d-4dd8-9bd7-f5da94a1acd8">   |

| 16px - before | 16px - after |
| -- | -- |
|  <img width="521" alt="manage_api_key_16px_old" src="https://github.com/user-attachments/assets/4f037058-9145-487c-b450-746611539f90">   |   <img width="521" alt="manage_api_key_16px_new" src="https://github.com/user-attachments/assets/1b42551c-a5a2-4dcf-b03f-87dd217eb121">   |

Small screen:
<img width="358" alt="manage_api_key_small_screen" src="https://github.com/user-attachments/assets/68a78e15-60ac-4dc6-8e7e-8875491454eb">


### Change your password dialog (pay attention to forget it text also)

| 14px - before | 14px - after |
| -- | -- |
|  <img width="486" alt="settings_change_pass_14px_old" src="https://github.com/user-attachments/assets/1739f0e3-e6be-42c4-a6ea-80f0a8cd2b20">   |    <img width="486" alt="settings_change_pass_14px_new" src="https://github.com/user-attachments/assets/2eff991b-2b33-4e28-9047-1d7e76438cb6">  |

| 16px - before | 16px - after |
| -- | -- |
|  <img width="486" alt="settings_change_pass_16px_old" src="https://github.com/user-attachments/assets/cc365138-4c4b-4e8a-9f64-dac4b774bc33">   |  <img width="486" alt="settings_change_pass_16px_new" src="https://github.com/user-attachments/assets/093d7526-0c82-4a6c-9f56-7711d4d85242">  |

Small screen:
<img width="358" alt="settings_change_pass_small_screen" src="https://github.com/user-attachments/assets/664d4169-d1f8-4bcb-a96c-c1e2950996c6">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
