### PR TITLE
narrow: Update `with` operator behaviour when message not accessible.

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -106,14 +106,21 @@ number or a string.
 The `id` operator returns the message with the specified ID if it exists,
 and if it can be accessed by the user.
 
-The `with` operator is designed to be used for permanent links to topics,
-which means they should continue to work when the topic is
+The `with` operator is designed to be used for permanent links to
+topics, which means they should continue to work when the topic is
 [moved](/help/move-content-to-another-topic) or
-[resolved](/help/resolve-a-topic). If the message with the specified ID
-exists, and can be accessed by the user, then it will return messages
-with the `channel`/`topic`/`dm` operators corresponding to the current
-conversation containing that message, and replacing any such filters
-included in the narrow.
+[resolved](/help/resolve-a-topic). If the message with the specified
+ID exists, and can be accessed by the user, then it will return
+messages with the `channel`/`topic`/`dm` operators corresponding to
+the current conversation containing that message, replacing any such
+operators included in the original narrow query.
+
+If no such message exists, or the message ID represents a message that
+is inaccessible to the user, this operator will be ignored (rather
+than throwing an error) if the remaining operators uniquely identify a
+conversation (i.e., they contain `channel` and `topic` terms or `dm`
+term). This behavior is intended to provide the best possible
+experience for links to private channels with protected history.
 
 The [help center](/help/search-for-messages#search-by-message-id) also
 documents the `near` operator for searching for messages by ID, but


### PR DESCRIPTION
Previously, when the message of the "with" operator can not be accessed by the user, it used to return messages in combined feed or stream feed.

This commit updates it to rather raise a BadNarrowOperator error if the message of "with" operand is not accessible to user, and the narrow terms present can not define a conversation. However, if the narrow terms can define a conversation, then the narrow falls back to that of without the "with" operator.

<!-- Describe your pull request here.-->

Fixes: [approach suggested in CZO](https://chat.zulip.org/#narrow/stream/378-api-design/topic/topic.20permalinks/near/1888408) and checkbox 2 of https://github.com/zulip/zulip/pull/30114#issuecomment-2226642678

This would be a really important detail because of how the web app currently handles the updating of narrow based on fetched messages -- Currently in the web app we use:
```ts
if (opts.validate_filter_topic_post_fetch) {
         opts.msg_list.data.filter.try_adjusting_for_moved_with_target(messages[0]);
}
```
which basically takes the first of the fetched messages, and updates the narrow terms accordingly. This would make sense if that `with` operand message is accessible/exists.

However, if we consider cases like when you don't have that message id, then rather than displaying the combined feed or stream feed, it goes to the narrow of the first message fetched (from the stream or combined feed).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
