### PR TITLE
user_circles: Adjust circles top margin on low-res screens.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1095,6 +1095,16 @@ li.topic-list-item {
     .user_circle {
         width: var(--length-user-status-circle);
         height: var(--length-user-status-circle);
+
+        @media screen and (resolution <= 1x) {
+            /* User circles appear to sag a bit on
+               low-resolution screens, so this fix
+               targets them without disrupting
+               line-height values that may become
+               important in multi-line DM groups, etc.
+               in the future. */
+            margin-top: -2.5px;
+        }
     }
 
     .zulip-icon.zulip-icon-bot {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -121,6 +121,14 @@ $user_status_emoji_width: 24px;
         height: var(--length-user-status-circle);
         grid-area: starting-anchor-element;
         place-self: center center;
+
+        @media screen and (resolution <= 1x) {
+            /* User circles appear to sag a bit on
+               low-resolution screens, so this fix
+               targets them without disrupting
+               line-height values. */
+            margin-top: -2.5px;
+        }
     }
 
     .empty-list-message {


### PR DESCRIPTION
This PR uses a resolution-based media query to adjust the top margin on user-presence circles on low-resolution screens.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20.E2.9D.93.20sagging.20presence.20icons.20in.20the.20left.20sidebar/near/1851356)

Because things like multiline DM groups are in the future (as well as non-CSS presence icons), it doesn't make sense to engage in a more drastic reworking of this area in quite the same way as a similar PR, #30692, did for the comparatively simpler, one-line elements in the navigation area.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Low-res, before | Low-res, after |
| --- | --- |
| ![low-res-circles-legacy-before](https://github.com/user-attachments/assets/aa080d68-f1d7-4d57-aca7-831c12bbc027) | ![low-res-circles-legacy-after](https://github.com/user-attachments/assets/d2e98716-8dca-46ab-8bd8-c16d5964c85f) |
| ![low-res-circles-before](https://github.com/user-attachments/assets/212781c4-578b-4a2f-92f3-ff7ad17455ed) | ![low-res-circles-after](https://github.com/user-attachments/assets/a46d722b-9d0f-4db0-bcb5-7637db1b4016) |

| High-res, before | High-res, after (no change) |
| --- | --- |
| ![high-res-circles-before](https://github.com/user-attachments/assets/758350a3-2d50-444e-98f1-6ed074e8f588) | ![high-res-circles-after-no-change](https://github.com/user-attachments/assets/56edf8f7-7952-4e3b-9d94-1b216dea325c) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>