### PR TITLE
navbar_search: Make search bar conform to short viewports.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -185,10 +185,6 @@
     --search-box-height: 28px;
     --search-box-width: 150px;
 
-    @media (height < $short_navbar_cutoff_height) {
-        --search-box-height: var(--header-height);
-    }
-
     @media (width < $md_min) {
         --search-box-width: 40px;
     }

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -216,6 +216,12 @@
         &.pill-container {
             /* Maintain only a column gap. */
             gap: 0 5px;
+
+            @media (height < $short_navbar_cutoff_height) {
+                /* Lose the luxury of padding in short navbar settings. */
+                padding-top: 0;
+                padding-bottom: 0;
+            }
         }
 
         .pill {
@@ -230,6 +236,10 @@
             .search-input-and-pills {
                 flex-wrap: nowrap;
                 overflow: hidden;
+
+                @media (height < $short_navbar_cutoff_height) {
+                    line-height: var(--base-line-height-unitless);
+                }
             }
         }
 
@@ -297,19 +307,15 @@
         #searchbox_form:not(.expanded) {
             margin: 0;
             /* Now that the header is shorter, the search box will take up the whole
-               height (which looks weird), so add 2px of space above and below it.
-               The extra pixel is to account for the header's bottom border (box shadow). */
-            margin-top: 2px;
-            height: calc(var(--header-height) - 5px);
-
-            #searchbox-input-container {
-                height: calc(var(--search-box-height) - 5px);
-            }
+               height (which looks weird), so add 1px of space above and below it
+               by manipulating the margin and the height. */
+            margin-top: 1px;
+            height: calc(var(--header-height) - 3px);
         }
 
         /* It looks fine to fill the navbar when the typeahead is open. */
         #searchbox_form.expanded {
-            margin-top: 0;
+            margin-top: 1px;
         }
     }
 

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -245,7 +245,6 @@
 
         &.focused .user-pill-container {
             flex-flow: row wrap;
-            height: unset;
         }
 
         .user-pill-container {
@@ -257,6 +256,8 @@
                 width: fit-content;
                 /* Replaced by the 5px gap. */
                 margin-right: 0;
+                /* Don't inherit large line-height for user pill labels. */
+                line-height: 1;
             }
 
             .pill {
@@ -271,6 +272,9 @@
                 max-width: none;
                 display: grid;
                 grid-template-columns: auto 1fr auto;
+
+                /* Don't inherit large line-height for user pills themselves, either. */
+                line-height: 1;
 
                 &:not(.deactivated-pill) {
                     background-color: var(--color-background-user-pill);


### PR DESCRIPTION
This PR makes the new, info-density-aware navbar play nicely with short viewports at both 16/140 and legacy sizes.

Also, it fixes a really subtle but nasty bug with user-pill alignment on short viewports containing a user pill when focused. Tall viewports were unaffected by the bug and the fix.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20navbar.20search.20text.20not.20middle.20aligned.20on.20small.20heights/near/1892365)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Closed search, before | Closed search, after |
| --- | --- |
| ![closed-search-before](https://github.com/user-attachments/assets/ee4cc8bd-a145-4d66-8890-d87a66fcc99e) | ![closed-search-after](https://github.com/user-attachments/assets/ae33ab59-6daa-498f-94d5-e9479e732fd6) |
| ![closed-search-legacy-before](https://github.com/user-attachments/assets/07df92c3-69eb-4a33-a016-d245241cdd8e) | ![closed-search-legacy-after](https://github.com/user-attachments/assets/3911ba74-1469-472f-a623-23ff70e5ec25) |

| Expanded search, before | Expanded search, after |
| --- | --- |
| ![expanded-search-before](https://github.com/user-attachments/assets/3b3ebbc8-644a-4d3e-aece-a2f44b5d29a2) | ![expanded-search-after](https://github.com/user-attachments/assets/66d07030-4597-446c-a8ae-5c8443378e21) |
| ![expanded-search-legacy-before](https://github.com/user-attachments/assets/851683c4-839d-4cd1-9c60-39ee4463d228) | ![expanded-search-legacy-after](https://github.com/user-attachments/assets/ecec38ab-ef61-479b-8b58-b46037c7d04e) |

| Focused search, before | Focused search, after (no change on taller viewports) |
| --- | --- |
| ![user-pill-alignment-bug](https://github.com/user-attachments/assets/97fec8ec-6c9e-4c91-b155-c89683f48147) | ![user-pill-alignment-fixed](https://github.com/user-attachments/assets/60c8faa1-444d-4490-8341-433a24921c47) |
| ![user-pill-alignment-before](https://github.com/user-attachments/assets/376be5be-dc01-4d9d-b597-6efc8c5aa56a) | ![user-pill-alignment-large-after-no-change](https://github.com/user-attachments/assets/2d90c143-616c-4ed1-8f6e-81594949d849) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>