### PR TITLE
narrow_banner: Fix search query overflowing from screen

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -72,6 +72,8 @@ function retrieve_search_query_data(): SearchData {
     const search_string_result: SearchData = {
         query_words: [],
         has_stop_word: false,
+        query_words_shortened: [],
+        size: 0,
     };
 
     // Add in stream:foo and topic:bar if present
@@ -100,6 +102,31 @@ function retrieve_search_query_data(): SearchData {
                 is_stop_word: false,
             });
         }
+    }
+
+    for (const query_word_entry of search_string_result.query_words) {
+        if (search_string_result.size + query_word_entry.query_word.length <= 50) {
+            search_string_result.query_words_shortened.push(query_word_entry);
+        } else {
+            const aux_query_word = query_word_entry.query_word.slice(
+                0,
+                50 - search_string_result.size,
+            );
+            search_string_result.query_words_shortened.push({
+                query_word: aux_query_word,
+                is_stop_word: query_word_entry.is_stop_word,
+            });
+            search_string_result.size += query_word_entry.query_word.length;
+            break;
+        }
+        search_string_result.size += query_word_entry.query_word.length;
+    }
+
+    if (search_string_result.size > 50) {
+        search_string_result.query_words_shortened.push({
+            query_word: "...",
+            is_stop_word: false,
+        });
     }
 
     return search_string_result;

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -10,6 +10,8 @@ export type SearchData = {
     has_stop_word: boolean;
     stream_query?: string;
     topic_query?: string;
+    query_words_shortened: QueryWord[];
+    size: number;
 };
 
 export type NarrowBannerData = {

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -9,7 +9,7 @@
             {{#if search_data.topic_query}}
             <span>topic: {{search_data.topic_query}}</span>
             {{/if}}
-            {{#each search_data.query_words}}
+            {{#each search_data.query_words_shortened}}
                 {{#if is_stop_word}}
                 <del>{{query_word}}</del>
                 {{else}}

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -122,6 +122,10 @@ run_test("empty_narrow_html", ({mock_template}) => {
             {query_word: "search", is_stop_word: false},
             {query_word: "a", is_stop_word: true},
         ],
+        query_words_shortened: [
+            {query_word: "search", is_stop_word: false},
+            {query_word: "a", is_stop_word: true},
+        ],
     };
     actual_html = empty_narrow_html(
         "This is a title",
@@ -147,6 +151,7 @@ run_test("empty_narrow_html", ({mock_template}) => {
         has_stop_word: false,
         stream_query: "hello world",
         query_words: [{query_word: "searchA", is_stop_word: false}],
+        query_words_shortened: [{query_word: "searchA", is_stop_word: false}],
     };
     actual_html = empty_narrow_html(
         "This is a title",
@@ -170,6 +175,7 @@ run_test("empty_narrow_html", ({mock_template}) => {
         has_stop_word: false,
         topic_query: "hello",
         query_words: [{query_word: "searchB", is_stop_word: false}],
+        query_words_shortened: [{query_word: "searchB", is_stop_word: false}],
     };
     actual_html = empty_narrow_html(
         "This is a title",
@@ -575,6 +581,37 @@ run_test("hide_empty_narrow_message", () => {
     assert.equal($(".empty_feed_notice").text(), "never-been-set");
 });
 
+run_test("show_search_long_word", ({mock_template}) => {
+    realm.stop_words = [];
+
+    mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
+
+    const expected_search_data_long_word = {
+        has_stop_word: false,
+        query_words: [
+            {
+                query_word: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                is_stop_word: false,
+            },
+        ],
+        query_words_shortened: [
+            {query_word: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", is_stop_word: false},
+            {query_word: "...", is_stop_word: false},
+        ],
+    };
+    message_lists.set_current(undefined);
+    set_filter([["search", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: No search results.",
+            undefined,
+            expected_search_data_long_word,
+        ),
+    );
+});
+
 run_test("show_search_stopwords", ({mock_template}) => {
     realm.stop_words = ["what", "about"];
 
@@ -583,6 +620,11 @@ run_test("show_search_stopwords", ({mock_template}) => {
     const expected_search_data = {
         has_stop_word: true,
         query_words: [
+            {query_word: "what", is_stop_word: true},
+            {query_word: "about", is_stop_word: true},
+            {query_word: "grail", is_stop_word: false},
+        ],
+        query_words_shortened: [
             {query_word: "what", is_stop_word: true},
             {query_word: "about", is_stop_word: true},
             {query_word: "grail", is_stop_word: false},
@@ -604,6 +646,11 @@ run_test("show_search_stopwords", ({mock_template}) => {
             {query_word: "about", is_stop_word: true},
             {query_word: "grail", is_stop_word: false},
         ],
+        query_words_shortened: [
+            {query_word: "what", is_stop_word: true},
+            {query_word: "about", is_stop_word: true},
+            {query_word: "grail", is_stop_word: false},
+        ],
     };
     set_filter([
         ["stream", "streamA"],
@@ -620,6 +667,11 @@ run_test("show_search_stopwords", ({mock_template}) => {
         stream_query: "streamA",
         topic_query: "topicA",
         query_words: [
+            {query_word: "what", is_stop_word: true},
+            {query_word: "about", is_stop_word: true},
+            {query_word: "grail", is_stop_word: false},
+        ],
+        query_words_shortened: [
             {query_word: "what", is_stop_word: true},
             {query_word: "about", is_stop_word: true},
             {query_word: "grail", is_stop_word: false},


### PR DESCRIPTION

<!-- Describe your pull request here.-->This commit fixes an issue where the error message overflows the screen when searching for an extremely long word. The error message now displays "No search results. You searched for: [the long word]" without overflowing the screen. If the complete word does not fit the entire screen, it is partially hidden with an ellipsis. For this implementation, I chose to add a new attribute to searchData and manipulate this attribute to retain the full information of the user's search. 
\
Fixes: <!-- Issue link, or clear description.-->(https://github.com/zulip/zulip/issues/29568)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| <img width="1440" alt="Captura de ecrã 2024-07-17, às 19 48 51" src="https://github.com/user-attachments/assets/e4d74e4a-088e-4944-a43c-1110f00b693d"> | <img width="1440" alt="Captura de ecrã 2024-07-17, às 19 47 21" src="https://github.com/user-attachments/assets/99ab3d92-4c1a-4792-93a9-9269ed7d679a">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
