### PR TITLE
user_group_popovers: Add display message when group is empty.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -317,7 +317,8 @@ ul.popover-group-menu-member-list {
     }
 }
 
-.popover-group-menu-member {
+.popover-group-menu-member,
+.popover-group-menu-placeholder {
     display: flex;
     align-items: center;
     padding: 0 10px;
@@ -330,7 +331,8 @@ ul.popover-group-menu-member-list {
 }
 
 .popover-group-menu-description,
-.popover-group-menu-member-name {
+.popover-group-menu-member-name,
+.popover-group-menu-placeholder {
     color: var(--color-text-popover-menu);
 }
 

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -11,18 +11,22 @@
         </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item">
-            <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                {{#each members}}
-                    <li class="popover-group-menu-member">
-                        {{#if is_bot}}
-                            <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
-                        {{else}}
-                            <span class="user_circle {{user_circle_class}} popover_user_presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
-                        {{/if}}
-                        <span class="popover-group-menu-member-name">{{full_name}}</span>
-                    </li>
-                {{/each}}
-            </ul>
+            {{#if members.length}}
+                <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                    {{#each members}}
+                        <li class="popover-group-menu-member">
+                            {{#if is_bot}}
+                                <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                            {{else}}
+                                <span class="user_circle {{user_circle_class}} popover_user_presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
+                            {{/if}}
+                            <span class="popover-group-menu-member-name">{{full_name}}</span>
+                        </li>
+                    {{/each}}
+                </ul>
+            {{else}}
+                <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>
+            {{/if}}
         </li>
         {{#unless (or is_guest is_system_group)}}
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>


### PR DESCRIPTION
Previously no message was being shown in the group popover, when group had no members, this commit intends to fix this by displaying an approriate message when group is empty. 
Fixes #30830.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
DARK
<img width="247" alt="Screenshot 2024-07-19 at 12 26 22 AM" src="https://github.com/user-attachments/assets/80e7341c-d1d6-4361-ad55-928caa309c8f">

LIGHT
<img width="247" alt="Screenshot 2024-07-19 at 12 27 39 AM" src="https://github.com/user-attachments/assets/ae4618c5-cb38-4f66-b5b6-9e55e02fbaeb">




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
