### PR TITLE
typeahead: Ignore mouse position once user uses keyboard.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -707,6 +707,7 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keyup(e: JQuery.KeyUpEvent): void {
+        this.mouse_moved_since_typeahead = false;
         // NOTE: Ideally we can ignore meta keyup calls here but
         // it's better to just trigger the lookup call to update the list in case
         // it did modify the query. For example, `Command + delete` on Mac


### PR DESCRIPTION
This keeps the first item focused when user uses keyboard. User can still move the focused item using mouse and click to select it. Highlighting an item via mouse and then pressing enter would select the highlighted item.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20unexpected.20selection.20from.20search.20typeahead