### PR TITLE
Settings:Added a new input field related to message deletion

### DIFF
--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -205,6 +205,9 @@ export function user_can_move_messages_to_another_topic(): boolean {
 export function user_can_delete_own_message(): boolean {
     return user_has_permission(realm.realm_delete_own_message_policy);
 }
+export function user_can_delete_other_message(): boolean {
+    return user_has_permission(realm.realm_delete_other_message_policy);
+}
 
 export function should_mask_unread_count(sub_muted: boolean): boolean {
     if (

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -282,6 +282,7 @@ const realm_schema = z.object({
         }),
     ),
     realm_default_language: z.string(),
+    realm_delete_other_message_policy: z.number(),
     realm_delete_own_message_policy: z.number(),
     realm_description: z.string(),
     realm_digest_emails_enabled: NOT_TYPED_YET,

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -237,9 +237,14 @@
                 {{> settings_save_discard_widget section_name="msg-deletion" }}
             </div>
             <div class="inline-block organization-settings-parent">
-                <label for="org-msg-deletion" class="inline-block">
-                    {{t "Administrators can delete any message." }}
-                </label>
+                <div class="input-group">
+                    <label for="realm_delete_other_message_policy" class="settings-field-label">
+                        {{t "Who can delete any message" }}
+                    </label>
+                    <select name="realm_delete_other_message_policy" id="id_realm_delete_other_message_policy" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="number">
+                        {{> dropdown_options_widget option_values=common_policy_values}}
+                    </select>
+                </div>
                 <div class="input-group">
                     <label for="realm_delete_own_message_policy" class="settings-field-label">
                         {{t "Who can delete their own messages" }}

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -228,7 +228,8 @@ def fetch_initial_state_data(
         # user_topic and muted_topics, and receive the duplicate
         # muted_topics data only from older servers that don't yet
         # support user_topic.
-        event_types is None or not want("user_topic")
+        event_types is None
+        or not want("user_topic")
     ):
         state["muted_topics"] = [] if user_profile is None else get_topic_mutes(user_profile)
 
@@ -324,6 +325,11 @@ def fetch_initial_state_data(
             EditTopicPolicyEnum.ADMINS_ONLY if user_profile is None else realm.edit_topic_policy
         )
         state["realm_delete_own_message_policy"] = (
+            CommonMessagePolicyEnum.ADMINS_ONLY
+            if user_profile is None
+            else realm.delete_own_message_policy
+        )
+        state["realm_delete_other_message_policy"] = (
             CommonMessagePolicyEnum.ADMINS_ONLY
             if user_profile is None
             else realm.delete_own_message_policy
@@ -470,12 +476,12 @@ def fetch_initial_state_data(
                 realm_user_default, property_name
             )
 
-        state["realm_user_settings_defaults"]["emojiset_choices"] = (
-            RealmUserDefault.emojiset_choices()
-        )
-        state["realm_user_settings_defaults"]["available_notification_sounds"] = (
-            get_available_notification_sounds()
-        )
+        state["realm_user_settings_defaults"][
+            "emojiset_choices"
+        ] = RealmUserDefault.emojiset_choices()
+        state["realm_user_settings_defaults"][
+            "available_notification_sounds"
+        ] = get_available_notification_sounds()
 
     if want("realm_domains"):
         state["realm_domains"] = get_realm_domains(realm)
@@ -726,9 +732,9 @@ def fetch_initial_state_data(
 
         state["user_settings"]["emojiset_choices"] = UserProfile.emojiset_choices()
         state["user_settings"]["timezone"] = canonicalize_timezone(settings_user.timezone)
-        state["user_settings"]["available_notification_sounds"] = (
-            get_available_notification_sounds()
-        )
+        state["user_settings"][
+            "available_notification_sounds"
+        ] = get_available_notification_sounds()
 
     if want("user_status"):
         # We require creating an account to access statuses.


### PR DESCRIPTION

<!-- Describe your pull request here.-->

Added ine input Field in the SETTINGS / ORGANIZATION PERMISSIONS > Message deletion section,

- [x] Remove: "Administrators can delete any message." As the first setting in this section, add a new setting, using the    groups permissions framework: "Who can delete any message"
 Options: Admins [default], Admins and moderators, Admins, moderators and full members, Admins, moderators and members.

Removed the Label Administrators and Added one input field related to message deletion of other and by default set the Value equal to Admin.

Fixes: <!-- Issue link, or clear description.-->
issue - https://github.com/zulip/zulip/issues/30717

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
