### PR TITLE
Improvements in information density settings.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -461,17 +461,6 @@ export function dispatch_normal_event(event) {
                     realm_user_settings_defaults,
                 );
             }
-
-            if (
-                ["dense_mode", "web_font_size_px", "web_line_height_percent"].includes(
-                    event.property,
-                )
-            ) {
-                /* istanbul ignore next */
-                settings_preferences.update_information_density_settings_visibility(
-                    $(settings_realm_user_settings_defaults.realm_default_settings_panel.container),
-                );
-            }
             break;
         }
 
@@ -804,9 +793,6 @@ export function dispatch_normal_event(event) {
                 $("body").toggleClass("more-dense-mode");
                 information_density.set_base_typography_css_variables();
                 information_density.calculate_timestamp_widths();
-                settings_preferences.update_information_density_settings_visibility(
-                    $(settings_preferences.user_settings_panel.container),
-                );
             }
             if (
                 event.property === "web_font_size_px" ||
@@ -814,9 +800,6 @@ export function dispatch_normal_event(event) {
             ) {
                 information_density.set_base_typography_css_variables();
                 information_density.calculate_timestamp_widths();
-                settings_preferences.update_information_density_settings_visibility(
-                    $(settings_preferences.user_settings_panel.container),
-                );
             }
             if (event.property === "web_mark_read_on_scroll_policy") {
                 unread_ui.update_unread_banner();

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -254,6 +254,15 @@ export function set_up(settings_panel: SettingsPanel): void {
                     : NON_COMPACT_MODE_LINE_HEIGHT_PERCENT;
             }
 
+            if (
+                ((setting === "web_font_size_px" && setting_value !== LEGACY_FONT_SIZE_PX) ||
+                    (setting === "web_line_height_percent" &&
+                        setting_value !== LEGACY_LINE_HEIGHT_PERCENT)) &&
+                user_settings.dense_mode
+            ) {
+                data.dense_mode = false;
+            }
+
             const $status_element = $input_elem
                 .closest(".subsection-parent")
                 .find(".alert-notification");

--- a/web/src/settings_realm_user_settings_defaults.js
+++ b/web/src/settings_realm_user_settings_defaults.js
@@ -1,7 +1,12 @@
 import $ from "jquery";
 
 import * as audible_notifications from "./audible_notifications";
+import {
+    NON_COMPACT_MODE_FONT_SIZE_PX,
+    NON_COMPACT_MODE_LINE_HEIGHT_PERCENT,
+} from "./information_density";
 import * as overlays from "./overlays";
+import {page_params} from "./page_params";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings_notifications from "./settings_notifications";
 import * as settings_org from "./settings_org";
@@ -61,6 +66,25 @@ export function set_up() {
             notification_sound: sound,
         });
     });
+
+    if (!page_params.development_environment) {
+        $("#realm_dense_mode").on("change", (e) => {
+            const val = $(e.target).prop("checked");
+            if (val) {
+                $container.find(".information-density-settings").hide();
+                return;
+            }
+
+            if (
+                !realm_user_settings_defaults.dense_mode &&
+                (realm_user_settings_defaults.web_font_size_px !== NON_COMPACT_MODE_FONT_SIZE_PX ||
+                    realm_user_settings_defaults.web_line_height_percent !==
+                        NON_COMPACT_MODE_LINE_HEIGHT_PERCENT)
+            ) {
+                $container.find(".information-density-settings").show();
+            }
+        });
+    }
 
     settings_notifications.set_up(realm_default_settings_panel);
 

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -7,7 +7,7 @@ import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as ui_report from "./ui_report";
 
-type RequestOpts = {
+export type RequestOpts = {
     success_msg_html?: string | undefined;
     failure_msg_html?: string;
     success_continuation?: (response_data: unknown) => void;

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -961,13 +961,6 @@ run_test("user_settings", ({override}) => {
         container: "#user-preferences",
     };
     override(information_density, "set_base_typography_css_variables", noop);
-    override(
-        settings_preferences,
-        "update_information_density_settings_visibility",
-        ($container) => {
-            assert.equal($container, $("#user-preferences"));
-        },
-    );
     toggled = [];
     dispatch(event);
     assert_same(user_settings.dense_mode, true);

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -479,21 +479,6 @@ def do_set_realm_user_default_setting(
             },
         )
 
-        if name in {"web_font_size_px", "web_line_height_percent"}:
-            if (
-                realm_user_default.web_font_size_px != RealmUserDefault.WEB_FONT_SIZE_PX_LEGACY
-                or realm_user_default.web_line_height_percent
-                != RealmUserDefault.WEB_LINE_HEIGHT_PERCENT_LEGACY
-            ):
-                expected_dense_mode = False
-            else:
-                expected_dense_mode = True
-
-            if realm_user_default.dense_mode != expected_dense_mode:
-                do_set_realm_user_default_setting(
-                    realm_user_default, "dense_mode", expected_dense_mode, acting_user=acting_user
-                )
-
     event = dict(
         type="realm_user_settings_defaults",
         op="update",

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -472,6 +472,8 @@ def do_change_user_setting(
         assert isinstance(setting_value, str)
         event["language_name"] = get_language_name(setting_value)
 
+    transaction.on_commit(lambda: flush_user_profile(sender=UserProfile, instance=user_profile))
+
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
     if setting_name in {"web_font_size_px", "web_line_height_percent"}:
@@ -544,8 +546,6 @@ def do_change_user_setting(
 
         user_profile.email = get_display_email_address(user_profile)
         user_profile.save(update_fields=["email"])
-
-        transaction.on_commit(lambda: flush_user_profile(sender=UserProfile, instance=user_profile))
 
         send_user_email_update_event(user_profile)
         notify_avatar_url_change(user_profile)

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -476,20 +476,6 @@ def do_change_user_setting(
 
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
-    if setting_name in {"web_font_size_px", "web_line_height_percent"}:
-        if (
-            user_profile.web_font_size_px != UserProfile.WEB_FONT_SIZE_PX_LEGACY
-            or user_profile.web_line_height_percent != UserProfile.WEB_LINE_HEIGHT_PERCENT_LEGACY
-        ):
-            expected_dense_mode = False
-        else:
-            expected_dense_mode = True
-
-        if user_profile.dense_mode != expected_dense_mode:
-            do_change_user_setting(
-                user_profile, "dense_mode", expected_dense_mode, acting_user=acting_user
-            )
-
     if setting_name in UserProfile.notification_settings_legacy:
         # This legacy event format is for backwards-compatibility with
         # clients that don't support the new user_settings event type.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to flush cache after commiting to DB so that the cache data is not stale.
- Second commit is to change code to require clients to pass `dense_mode` field when needed instead of changing it in the server implicitly.
- Third commit is to pass `dense_mode` field when needed from webapp.
- Fourth commit is to fix flashing of text inputs.
- Fifth commit improves behavior for setting inputs in default user settings panel.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
