### PR TITLE
message_edit: Fix compose tooltip not hidden on closing message edit form.

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -248,3 +248,11 @@ export function initialize(): void {
         },
     });
 }
+
+export function hide_compose_control_button_tooltips($row: JQuery): void {
+    $row.find(
+        ".compose_control_button[data-tooltip-template-id], .compose_control_button[data-tippy-content], .compose_control_button_container",
+    ).each(function (this: tippy.ReferenceElement) {
+        this._tippy?.hide();
+    });
+}

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -18,6 +18,7 @@ import * as compose_actions from "./compose_actions";
 import * as compose_banner from "./compose_banner";
 import * as compose_call from "./compose_call";
 import * as compose_state from "./compose_state";
+import * as compose_tooltips from "./compose_tooltips";
 import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";
 import * as composebox_typeahead from "./composebox_typeahead";
@@ -926,6 +927,8 @@ export function do_save_inline_topic_edit($row, message, new_topic) {
 }
 
 export function save_message_row_edit($row) {
+    compose_tooltips.hide_compose_control_button_tooltips($row);
+
     assert(message_lists.current !== undefined);
     const $banner_container = compose_banner.get_compose_banner_container(
         $row.find(".message_edit_form textarea"),

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import * as blueslip from "./blueslip";
+import * as compose_tooltips from "./compose_tooltips";
 import {MessageListData} from "./message_list_data";
 import * as message_list_tooltips from "./message_list_tooltips";
 import {MessageListView} from "./message_list_view";
@@ -456,6 +457,7 @@ export class MessageList {
     }
 
     hide_edit_message($row) {
+        compose_tooltips.hide_compose_control_button_tooltips($row);
         $row.find(".message_content, .status-message, .message_controls").show();
         $row.find(".message_edit_form").empty();
         $row.find(".messagebox-content").removeClass("content_edit_mode");


### PR DESCRIPTION
[CZO bug report](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20Tippy.20tooltips.20leaking.20when.20editing.20messages/near/1886541)

Bug:
A tooltip appears on hovering over a control button in the message edit form. Now when the form was closed either using Esc key (cancel) or Enter / Ctrl + Enter (save), the tooltip didn't disappear. This resulted in a random tooltip visible
in the message list view.

Fix:
Since `tippyjs` doesn't hide tooltip even after the element is hidden we need to explicitly hide the tooltip in those cases.
See https://github.com/atomiks/tippyjs/issues/938

This PR fixes the above mentioned bug by explicitly hiding the tooltip instance.

**Screenshots and screen captures:**

**Before**

[screen-capture (2).webm](https://github.com/user-attachments/assets/5173022d-37d9-4361-a462-b75bc781a13f)


**After**

[screen-capture (1).webm](https://github.com/user-attachments/assets/4aeeee22-0802-46e3-baef-1939fb06fb78)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
