### PR TITLE
exceptions: Add new error class to be used for invalid parameter values.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -702,3 +702,16 @@ class SystemGroupRequiredError(JsonableError):
     @override
     def msg_format() -> str:
         return _("'{setting_name}' must be a system user group.")
+
+
+class IncompatibleParameterValuesError(JsonableError):
+    data_fields = ["first_parameter", "second_parameter"]
+
+    def __init__(self, first_parameter: str, second_parameter: str) -> None:
+        self.first_parameter = first_parameter
+        self.second_parameter = second_parameter
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Incompatible values for '{first_parameter}' and '{second_parameter}'.")

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2010,7 +2010,7 @@ class RealmAPITest(ZulipTestCase):
         result = self.client_patch("/json/realm/user_settings_defaults", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_font_size_px' settings.",
+            "Incompatible values for 'dense_mode' and 'web_font_size_px'.",
         )
 
         data = {"web_font_size_px": 16, "dense_mode": orjson.dumps(False).decode()}
@@ -2048,7 +2048,7 @@ class RealmAPITest(ZulipTestCase):
         result = self.client_patch("/json/realm/user_settings_defaults", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_line_height_percent' settings.",
+            "Incompatible values for 'dense_mode' and 'web_line_height_percent'.",
         )
 
         data = {"web_line_height_percent": 140, "dense_mode": orjson.dumps(False).decode()}
@@ -2079,14 +2079,14 @@ class RealmAPITest(ZulipTestCase):
         result = self.client_patch("/json/realm/user_settings_defaults", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_font_size_px' settings.",
+            "Incompatible values for 'dense_mode' and 'web_font_size_px'.",
         )
 
         data = {"dense_mode": orjson.dumps(True).decode(), "web_line_height_percent": 140}
         result = self.client_patch("/json/realm/user_settings_defaults", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_line_height_percent' settings.",
+            "Incompatible values for 'dense_mode' and 'web_line_height_percent'.",
         )
 
         data = {

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -518,7 +518,7 @@ class ChangeSettingsTest(ZulipTestCase):
         result = self.client_patch("/json/settings", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_font_size_px' settings.",
+            "Incompatible values for 'dense_mode' and 'web_font_size_px'.",
         )
 
         data = {"web_font_size_px": 16, "dense_mode": orjson.dumps(False).decode()}
@@ -556,7 +556,7 @@ class ChangeSettingsTest(ZulipTestCase):
         result = self.client_patch("/json/settings", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_line_height_percent' settings.",
+            "Incompatible values for 'dense_mode' and 'web_line_height_percent'.",
         )
 
         data = {"web_line_height_percent": 140, "dense_mode": orjson.dumps(False).decode()}
@@ -587,14 +587,14 @@ class ChangeSettingsTest(ZulipTestCase):
         result = self.client_patch("/json/settings", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_font_size_px' settings.",
+            "Incompatible values for 'dense_mode' and 'web_font_size_px'.",
         )
 
         data = {"dense_mode": orjson.dumps(True).decode(), "web_line_height_percent": 140}
         result = self.client_patch("/json/settings", data)
         self.assert_json_error(
             result,
-            "Incompatible values for 'dense_mode' and 'web_line_height_percent' settings.",
+            "Incompatible values for 'dense_mode' and 'web_line_height_percent'.",
         )
 
         data = {

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -37,7 +37,12 @@ from zerver.lib.email_validation import (
     validate_email_is_valid,
     validate_email_not_already_in_realm,
 )
-from zerver.lib.exceptions import JsonableError, RateLimitedError, UserDeactivatedError
+from zerver.lib.exceptions import (
+    IncompatibleParameterValuesError,
+    JsonableError,
+    RateLimitedError,
+    UserDeactivatedError,
+)
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.rate_limiter import RateLimitedUser
 from zerver.lib.request import REQ, has_request_variables
@@ -210,14 +215,10 @@ def check_information_density_setting_values(
 
     if dense_mode:
         if web_font_size_px != UserBaseSettings.WEB_FONT_SIZE_PX_COMPACT:
-            raise JsonableError(
-                _("Incompatible values for 'dense_mode' and 'web_font_size_px' settings.")
-            )
+            raise IncompatibleParameterValuesError("dense_mode", "web_font_size_px")
 
         if web_line_height_percent != UserBaseSettings.WEB_LINE_HEIGHT_PERCENT_COMPACT:
-            raise JsonableError(
-                _("Incompatible values for 'dense_mode' and 'web_line_height_percent' settings.")
-            )
+            raise IncompatibleParameterValuesError("dense_mode", "web_line_height_percent")
 
 
 @human_users_only


### PR DESCRIPTION
This would help us in avoiding adding translation everytime we use this error for a new pair of parameters.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
