### PR TITLE
navbar_search: Explicitly specify search input background color.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -214,6 +214,9 @@
 
         /* Override styles for .pill-container that aren't relevant for search. */
         &.pill-container {
+            /* Pill container should display the same background
+               color as the search typeahead. */
+            background-color: var(--color-background-search);
             /* Maintain only a column gap. */
             gap: 0 5px;
 


### PR DESCRIPTION
The pill-container background color has been displaying erroneously on the search input in dark mode. This PR explicitly calls up the search background color; while those match in light mode, they do not in dark mode.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20search.20typeahead.20color/near/1893907)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change in light mode) |
| --- | --- |
| ![search-background-dark-before](https://github.com/user-attachments/assets/cc1e247f-72b9-458e-8e48-1a38e196ff7e) | ![search-background-dark-after](https://github.com/user-attachments/assets/ebffe374-3226-47f0-855e-9dc5d39a2522) |
| ![search-background-light-before](https://github.com/user-attachments/assets/965cfceb-62cc-4a91-be44-f4a0e35ad089) | ![search-background-light-after-no-change](https://github.com/user-attachments/assets/a91e2899-f1f8-4321-8c05-c9c7c48ad85f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>