### PR TITLE
travis_webhook: Removed the ignore_pull_requests from the CI integration

### DIFF
--- a/zerver/webhooks/travis/doc.md
+++ b/zerver/webhooks/travis/doc.md
@@ -27,12 +27,6 @@ See your Travis CI build notifications in Zulip!
 
 {!event-filtering-additional-feature.md!}
 
-### Configuration options
-
-- By default, pull request events are ignored since most people don't
-  want notifications for new pushes to pull requests. To enable
-  notifications for pull request builds, you can append
-  `&ignore_pull_requests=false` to the end of the generated URL.
 
 ### Related documentation
 

--- a/zerver/webhooks/travis/tests.py
+++ b/zerver/webhooks/travis/tests.py
@@ -31,16 +31,33 @@ Details: [changes](https://github.com/hl7-fhir/fhir-svn/compare/6dccb98bcfd9...6
             content_type="application/x-www-form-urlencoded",
         )
 
-    def test_ignore_travis_pull_request_by_default(self) -> None:
-        self.check_webhook(
-            "pull_request", content_type="application/x-www-form-urlencoded", expect_noop=True
-        )
-
-    def test_travis_pull_requests_are_not_ignored_when_applicable(self) -> None:
-        self.url = f"{self.build_webhook_url()}&ignore_pull_requests=false"
+    def test_travis_only_pull_request_event(self) -> None:
+        self.url = f'{self.build_webhook_url()}&only_events=["pull_request"]'
 
         self.check_webhook(
             "pull_request",
+            self.TOPIC_NAME,
+            self.EXPECTED_MESSAGE,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        self.check_webhook(
+            "build",
+            content_type="application/x-www-form-urlencoded",
+            expect_noop=True,
+        )
+
+    def test_travis_exclude_pull_request_event(self) -> None:
+        self.url = f'{self.build_webhook_url()}&exclude_events=["pull_request"]'
+
+        self.check_webhook(
+            "pull_request",
+            content_type="application/x-www-form-urlencoded",
+            expect_noop=True,
+        )
+
+        self.check_webhook(
+            "build",
             self.TOPIC_NAME,
             self.EXPECTED_MESSAGE,
             content_type="application/x-www-form-urlencoded",
@@ -55,9 +72,6 @@ Details: [changes](https://github.com/hl7-fhir/fhir-svn/compare/6dccb98bcfd9...6
             self.EXPECTED_MESSAGE,
             content_type="application/x-www-form-urlencoded",
         )
-
-    def test_travis_only_push_event_not_sent(self) -> None:
-        self.url = f'{self.build_webhook_url()}&only_events=["push"]&ignore_pull_requests=false'
 
         self.check_webhook(
             "pull_request",
@@ -74,9 +88,6 @@ Details: [changes](https://github.com/hl7-fhir/fhir-svn/compare/6dccb98bcfd9...6
             expect_noop=True,
         )
 
-    def test_travis_exclude_push_event_sent(self) -> None:
-        self.url = f'{self.build_webhook_url()}&exclude_events=["push"]&ignore_pull_requests=false'
-
         self.check_webhook(
             "pull_request",
             self.TOPIC_NAME,
@@ -85,7 +96,7 @@ Details: [changes](https://github.com/hl7-fhir/fhir-svn/compare/6dccb98bcfd9...6
         )
 
     def test_travis_include_glob_events(self) -> None:
-        self.url = f'{self.build_webhook_url()}&include_events=["*"]&ignore_pull_requests=false'
+        self.url = f'{self.build_webhook_url()}&include_events=["*"]'
 
         self.check_webhook(
             "pull_request",
@@ -102,7 +113,7 @@ Details: [changes](https://github.com/hl7-fhir/fhir-svn/compare/6dccb98bcfd9...6
         )
 
     def test_travis_exclude_glob_events(self) -> None:
-        self.url = f'{self.build_webhook_url()}&exclude_events=["*"]&ignore_pull_requests=false'
+        self.url = f'{self.build_webhook_url()}&exclude_events=["*"]'
 
         self.check_webhook(
             "pull_request",

--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -40,12 +40,9 @@ def api_travis_webhook(
     user_profile: UserProfile,
     *,
     message: Annotated[Json[TravisPayload], ApiParamConfig("payload")],
-    ignore_pull_requests: Json[bool] = True,
 ) -> HttpResponse:
     event = message.type
     message_status = message.status_message
-    if ignore_pull_requests and message.type == "pull_request":
-        return json_success(request)
 
     if message_status in GOOD_STATUSES:
         emoji = ":thumbs_up:"


### PR DESCRIPTION
Description: 
Removed the ignore_pull_request form the CI integration. As this functionality is now fully covered by zulip's standard event filtering framework.

Fixes: #30934

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
