### PR TITLE
Fix property name starred_message_counts.

### DIFF
--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -67,7 +67,7 @@ export function initialize(): void {
             $popper.one("click", "#toggle_display_starred_msg_count", () => {
                 const starred_msg_counts = user_settings.starred_message_counts;
                 const data = {
-                    starred_messages_counts: JSON.stringify(!starred_msg_counts),
+                    starred_message_counts: JSON.stringify(!starred_msg_counts),
                 };
                 void channel.patch({
                     url: "/json/settings",


### PR DESCRIPTION

The bug was introduced in 22a58c739c7d1c30845dc40ebb646ccebd35f089


**Screenshots and screen captures:**
## Before


https://github.com/user-attachments/assets/4acba720-e65b-44cb-8bac-6d029bb158e2



## After

https://github.com/user-attachments/assets/1b069d10-f50d-464a-b45e-9d60d44dd9af



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- x ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
