### PR TITLE
navbar_description: Refactor help-widget icon display.

### DIFF
--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -97,5 +97,20 @@
         .fa {
             margin: 0;
         }
+
+        .fa-question-circle-o {
+            /* Override relative position for sake of
+               Chrome paint bug that keeps the circle
+               visible when ellipses are showing. */
+            position: static;
+        }
+
+        .help_link_widget {
+            /* With relative positioning no longer
+               in effect, we vertically align the
+               help icon with an inline-block assist,
+               which is present on the .fa class. */
+            vertical-align: middle;
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a minor refactor of how the help widget is displayed and aligned; it causes no changes to Firefox, but works around a paint bug present in Chrome where the icon remains visible when there is an ellipsis on the description.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20space.20between.20channel.20description.20and.20search/near/1893064)

**Screenshots and screen captures:**

| Chrome, before | Chrome, after |
| --- | --- |
| ![chrome-help-widget-before](https://github.com/user-attachments/assets/d22f1f08-9259-48ce-8d07-cf95ecae7820) | ![chrome-help-widget-after](https://github.com/user-attachments/assets/1825bcab-2373-4737-a8d8-6651e3f6da86) |

| Before | After (no change) |
| --- | --- |
| ![help-widget-before](https://github.com/user-attachments/assets/4f89f75f-e01a-4cd9-9ed4-a4b25743110b) | ![help-widget-after-no-change](https://github.com/user-attachments/assets/4b5cffe8-2e4d-42bc-9502-a189c39a3bfb) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>