### PR TITLE
left_sidebar: Present a wider left sidebar and scaling UI layout.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -237,8 +237,9 @@
     /* space direct message / stream / topic names from unread counters
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;
-    /* 334px at 15px/1em */
-    --left-sidebar-max-width: 22.6667em;
+    --left-sidebar-right-margin: 12px;
+    /* 287px at 14px/1em */
+    --left-sidebar-max-width: calc(20.5em - var(--left-sidebar-right-margin));
     /* Sidebar width is 1/3 of the screen at smaller
        sizes, but gets held to the left sidebar's max width.
        This is very useful for areas in the CSS codebase

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -237,7 +237,14 @@
     /* space direct message / stream / topic names from unread counters
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;
-    --left-sidebar-width: 270px;
+    /* 334px at 15px/1em */
+    --left-sidebar-max-width: 22.6667em;
+    /* Sidebar width is 1/3 of the screen at smaller
+       sizes, but gets held to the left sidebar's max width.
+       This is very useful for areas in the CSS codebase
+       that rely on this value, but not necessarily as
+       applied to `width:` or `max-width:`. */
+    --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
     --right-sidebar-width: 250px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -34,7 +34,7 @@
 
 #stream_filters,
 #left-sidebar-navigation-list {
-    margin-right: 12px;
+    margin-right: var(--left-sidebar-right-margin);
 }
 
 li.show-more-topics {
@@ -65,7 +65,6 @@ li.show-more-topics {
 #stream_filters {
     overflow: visible;
     margin-bottom: 5px;
-    margin-right: 12px;
     padding: 0;
     font-weight: normal;
 
@@ -176,15 +175,6 @@ li.show-more-topics {
     width: 100%;
 
     .direct-messages-container {
-        /* TODO: Clean up this value and the
-           analogous one on #stream-filters;
-           this could be done alongside the
-           --left-sidebar-collapse-widget-gutter
-           cleanup so that all of the left sidebar
-           space is better, more uniformly handled.
-           That will be an essential pre-condition
-           for a resizable left sidebar. */
-        margin-right: 12px;
         margin-left: 0;
     }
 }
@@ -232,7 +222,7 @@ li.show-more-topics {
 .direct-messages-container {
     /* Properly offset all the grid rows
        in the DM section. */
-    margin-right: 12px;
+    margin-right: var(--left-sidebar-right-margin);
 
     & ul.dm-list {
         list-style-type: none;
@@ -763,7 +753,7 @@ li.top_left_scheduled_messages {
 #views-label-container {
     grid-template-columns:
         0 15px minmax(0, 0.5fr) minmax(0, 1fr)
-        30px 12px;
+        30px var(--left-sidebar-right-margin);
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
        value and the styles dependent on it so that this kind of
@@ -1179,7 +1169,9 @@ li.topic-list-item {
 }
 
 #streams_header {
-    grid-template-columns: 0 0 minmax(0, 1fr) minmax(17px, max-content) 30px 12px;
+    grid-template-columns: 0 0 minmax(0, 1fr) minmax(17px, max-content) 30px var(
+            --left-sidebar-right-margin
+        );
     /* Keep the stream-search area rows collapsed. */
     grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
     cursor: pointer;
@@ -1324,7 +1316,9 @@ li.topic-list-item {
    one that reassigns the vdots space to markers and
    controls. */
 .spectator-view #streams_header {
-    grid-template-columns: 0 0 minmax(0, 1fr) minmax(30px, max-content) 0 12px;
+    grid-template-columns: 0 0 minmax(0, 1fr) minmax(30px, max-content) 0 var(
+            --left-sidebar-right-margin
+        );
 
     /* With markers and controls now sized the same
        as the ordinary vdots area (but allowed to grow,
@@ -1345,7 +1339,7 @@ li.topic-list-item {
     padding-left: var(--left-sidebar-far-left-gutter-size);
     cursor: pointer;
     text-align: center;
-    margin-right: 12px;
+    margin-right: var(--left-sidebar-right-margin);
     color: hsl(240deg 10% 50%);
 
     & span {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -39,7 +39,9 @@ body {
     .header-main,
     .app .app-main,
     #compose-container {
-        max-width: 1500px;
+        /* 1417px at 14px/1em; (14px * 20.5em) - 12px + 880 + 250px = 1417px */
+        max-width: 100.3571em;
+        max-width: calc(var(--left-sidebar-max-width) + 62.8571em + 250px);
     }
 
     &.fluid_layout_width {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -39,7 +39,7 @@ body {
     .header-main,
     .app .app-main,
     #compose-container {
-        max-width: 1400px;
+        max-width: 1500px;
     }
 
     &.fluid_layout_width {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1777,6 +1777,10 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         display: none;
 
         &.expanded {
+            /* In the extended state, we open the sidebar
+               to its maximum possible size (otherwise, it
+               would be unnecessarily too narrow). */
+            --left-sidebar-width: var(--left-sidebar-max-width);
             display: block;
             position: absolute;
             float: none;


### PR DESCRIPTION
This PR attempts to make the left sidebar more responsive to font size and available screen size, whose `max-width` is now calculated to scale with the font size as well:

* The left sidebar takes up 33.3333% of the screen
* The left sidebar will be no wider, however, than 20.5em minus the 12px of righthand margin on the left sidebar
* When the left sidebar is hidden at narrower viewports, it opens at its max-width size
* The max width of the UI (the left sidebar, the message column, and the right sidebar) is now calculated and appropriately scales with the font size

**Screenshots and screen captures:**

| 16/140, before | 16/140, after |
| --- | --- |
| ![16px-before](https://github.com/user-attachments/assets/10baa1b4-9044-4a5c-95a7-4ccbe6eee0c2) | ![16px-after](https://github.com/user-attachments/assets/416e2457-dce8-4626-a680-b219807cdd9e) |

| Compact mode, before | Compact mode, after |
| --- | --- |
| ![compact-mode-before](https://github.com/user-attachments/assets/ccc549d5-ae55-4e90-a24f-eb0e15e7e876) | ![compact-mode-after](https://github.com/user-attachments/assets/9e8356b3-29fb-4616-92b4-d5d505df06f3) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>