### PR TITLE
Inbox and recent view multiple modal issue.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -212,6 +212,9 @@ export function show(): void {
             on_click() {
                 // Do nothing
             },
+            on_hidden() {
+                revive_current_focus();
+            },
             single_footer_button: true,
             focus_submit_on_open: true,
         });
@@ -831,6 +834,9 @@ function focus_clicked_list_element($elt: JQuery): void {
 }
 
 export function revive_current_focus(): void {
+    if (!is_in_focus()) {
+        return;
+    }
     if (is_list_focused()) {
         set_list_focus();
     } else {

--- a/web/src/modals.ts
+++ b/web/src/modals.ts
@@ -32,6 +32,11 @@ function call_hooks(func_list: Hook[]): void {
     }
 }
 
+export function any_active_or_animating(): boolean {
+    const $active_modal = $(".micromodal");
+    return $active_modal.hasClass("modal--open") || $active_modal.hasClass("modal--opening");
+}
+
 export function any_active(): boolean {
     return $(".micromodal").hasClass("modal--open");
 }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -1350,6 +1350,9 @@ export function show(): void {
             on_click() {
                 /* This widget is purely informational and clicking only closes it. */
             },
+            on_hidden() {
+                revive_current_focus();
+            },
             single_footer_button: true,
             focus_submit_on_open: true,
         });

--- a/web/src/user_deactivation_ui.ts
+++ b/web/src/user_deactivation_ui.ts
@@ -78,6 +78,7 @@ export function confirm_deactivation(
                 on_click: handle_confirm,
                 post_render: set_email_field_visibility,
                 loading_spinner,
+                focus_submit_on_open: true,
             });
         },
     });

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -145,7 +145,7 @@ export function is_in_focus(): boolean {
         !popovers.any_active() &&
         !sidebar_ui.any_sidebar_expanded_as_overlay() &&
         !overlays.any_active() &&
-        !modals.any_active() &&
+        !modals.any_active_or_animating() &&
         !$(".home-page-input").is(":focus") &&
         !$("#search_query").is(":focus")
     );


### PR DESCRIPTION
Earlier the focus was not being set to the modal when it was opened.
This was because `is_in_focus` checks if  `modals.any_active` which
checks `$(".micromodal").hasClass("modal--open")`.
But when `is_in_focus` is called
`$(".micromodal").hasClass("modal--opening")`.

This commit fixes the issue by creating a function
`is_active_or_animating` which checks if the modal has the class
`modal--open` or `modal--opening`.
[CZO Link](https://chat.zulip.org/#narrow/stream/6-frontend/topic/.F0.9F.8E.AF.20focus.20on.20dialog.20widget).

Also set `focus_submit_on_open` to true in the deactivate users modal.