### PR TITLE
import_realm: Update incorrect comment about emoji dir in exported data.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -1458,9 +1458,8 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         default_user_profile_id=None,  # Fail if there is no user set
     )
 
-    # We need to have this check as the emoji files are only present in the data
-    # importer from Slack
-    # For Zulip export, this doesn't exist
+    # We need to have this check as the emoji files may not
+    # be present in import data from other services.
     if os.path.exists(os.path.join(import_dir, "emoji")):
         import_uploads(
             realm,


### PR DESCRIPTION
The emoji dir is present in the data from our export tool. This was added in 468afe4840fbac0ca93643d1c8fc11c31a687528.

This comment hasn't been updated since
c4b886d8aee2503a03cfbffd30676ee0d4aba933, so probably we just forgot to refresh it when custom emoji export was added.
