### PR TITLE
search: Fix outline of clear search button.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -163,6 +163,7 @@
     .input-append {
         position: relative;
         width: 100%;
+        box-sizing: border-box;
         margin-bottom: 0;
     }
 


### PR DESCRIPTION
Fixed by including the margin and padding in the
`width: 100%` calculation.
 
| before | after |
| --- | --- |
| <img width="756" alt="Screenshot 2024-07-22 at 9 48 37 AM" src="https://github.com/user-attachments/assets/e0f9e08a-a076-4610-ab19-3247b1d52fc7"> | <img width="756" alt="Screenshot 2024-07-22 at 9 46 47 AM" src="https://github.com/user-attachments/assets/aa228b02-3d6d-4eca-abd9-35d8a25d2856"> |
