### PR TITLE
settings_components: Keep saved button displayed a little longer.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -553,7 +553,12 @@ export function change_save_button_state($element: JQuery, state: string): void 
     }
 
     if (state === "discarded") {
-        show_hide_element($element, false, 0, () => {
+        let hide_delay = 0;
+        if ($saveBtn.attr("data-status") === "saved") {
+            // Keep saved button displayed a little longer.
+            hide_delay = 500;
+        }
+        show_hide_element($element, false, hide_delay, () => {
             enable_or_disable_save_button($element.closest(".settings-subsection-parent"));
         });
         return;


### PR DESCRIPTION
It's unlikely that the saved button didn't appear. So, we were too late in calling the waitForSelector method, so having a delay would help in that case.

discussion: https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1892339

This is an attempt to fix this CI failure:

```
TimeoutError: Waiting for selector `#org-notifications .save-button[data-status="saved"]` failed: Waiting failed: 30000ms exceeded
    at new WaitTask (/__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@22.12.0/node_modules/puppeteer-core/src/common/WaitTask.ts:82:28)
    at IsolatedWorld.waitForFunction (/__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@22.12.0/node_modules/puppeteer-core/src/api/Realm.ts:74:22)
    at Function.waitFor (/__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@22.12.0/node_modules/puppeteer-core/src/common/QueryHandler.ts:172:50)
    at async CdpFrame.waitForSelector (/__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@22.12.0/node_modules/puppeteer-core/src/api/Frame.ts:738:13)
    at async CdpPage.waitForSelector (/__w/zulip/zulip/node_modules/.pnpm/puppeteer-core@22.12.0/node_modules/puppeteer-core/src/api/Page.ts:2849:12)
    at async submit_announcements_stream_settings (/__w/zulip/zulip/web/e2e-tests/admin.test.ts:20:5)
    at async test_change_new_stream_announcements_stream (/__w/zulip/zulip/web/e2e-tests/admin.test.ts:47:5)
    at async admin_test (/__w/zulip/zulip/web/e2e-tests/admin.test.ts:284:5)
    at async run_test_async (/__w/zulip/zulip/web/e2e-tests/lib/common.ts:691:9)

```