### PR TITLE
fetch_initial_state: Avoid doing one db query per announcement stream.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1681,8 +1681,11 @@ def do_events_register(
         event_types_set = None
 
     # Fetch the realm object again to prefetch all the
-    # group settings which support anonymous groups
+    # settings that will be used in 'fetch_initial_state_data'
     # to avoid unnecessary DB queries.
+    # The settings include:
+    # * group settings which support anonymous groups
+    # * announcements streams
     realm = get_realm_with_settings(realm_id=realm.id)
 
     if user_profile is None:

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -1102,10 +1102,12 @@ def get_realm_by_id(realm_id: int) -> Realm:
 
 
 def get_realm_with_settings(realm_id: int) -> Realm:
-    # Prefetch all the settings that can be set to anonymous groups.
+    # Prefetch the following settings:
+    # * All the settings that can be set to anonymous groups.
     # This also prefetches can_access_all_users_group setting,
     # even when it cannot be set to anonymous groups because
     # the setting is used when fetching users in the realm.
+    # * Announcements streams.
     return Realm.objects.select_related(
         "can_access_all_users_group",
         "can_access_all_users_group__named_user_group",
@@ -1117,6 +1119,9 @@ def get_realm_with_settings(realm_id: int) -> Realm:
         "direct_message_initiator_group__named_user_group",
         "direct_message_permission_group",
         "direct_message_permission_group__named_user_group",
+        "new_stream_announcements_stream",
+        "signup_announcements_stream",
+        "zulip_update_announcements_stream",
     ).get(id=realm_id)
 
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1174,7 +1174,7 @@ class FetchQueriesTest(ZulipTestCase):
         realm = get_realm_with_settings(realm_id=user.realm_id)
 
         with (
-            self.assert_database_query_count(43),
+            self.assert_database_query_count(41),
             mock.patch("zerver.lib.events.always_want") as want_mock,
         ):
             fetch_initial_state_data(user, realm=realm)
@@ -1190,7 +1190,7 @@ class FetchQueriesTest(ZulipTestCase):
             muted_users=1,
             onboarding_steps=1,
             presence=1,
-            realm=3,
+            realm=1,
             realm_bot=1,
             realm_domains=1,
             realm_embedded_bots=0,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -267,7 +267,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(54),
+            self.assert_database_query_count(52),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -572,7 +572,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(54),
+            self.assert_database_query_count(52),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -604,7 +604,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(49):
+        with self.assert_database_query_count(47):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/28720#discussion_r1486601441

In `fetch_initial_state_data` we were doing one database query per announcement stream.

This PR updates the logic to prefetch those streams using `select_related` hence avoiding the extra db queries.

Fixes: #28909.

Note: We can't use the first option suggested in #28909 because we need to check if `stream.deactivated`
> Just avoiding fetching the object if all we need for the API is the ID, i.e. .stream_id rather than .stream.id somewhere.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
