### PR TITLE
settings: Convert name to pills in custom emoji section.

### DIFF
--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -126,12 +126,15 @@ export function populate_emoji(): void {
         name: "emoji_list",
         get_item: ListWidget.default_get_item,
         modifier_html(item) {
+            const author = item.author
+                ? {...item.author, is_active: people.is_person_active(item.author_id)}
+                : "";
             return render_admin_emoji_list({
                 emoji: {
                     name: item.name,
                     display_name: item.name.replaceAll("_", " "),
                     source_url: item.source_url,
-                    author: item.author ?? "",
+                    author,
                     can_delete_emoji: can_delete_emoji(item),
                 },
             });

--- a/web/templates/settings/admin_emoji_list.hbs
+++ b/web/templates/settings/admin_emoji_list.hbs
@@ -12,7 +12,9 @@
     </td>
     <td>
         {{#if author}}
-        <span class="emoji_author">{{author.full_name}}</span>
+        {{#with author}}
+        <span class="emoji_author panel_user_list">{{> ../user_display_only_pill display_value=full_name img_src=avatar_url}}</span>
+        {{/with}}
         {{else}}
         <span class="emoji_author">{{t "Unknown author" }}</span>
         {{/if}}


### PR DESCRIPTION
previously, author names are displayed in plain text, now they are converted to pills.

Fixes #30990.

| Dark | Light |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/126bf266-7d35-4d88-96a4-bd9fe2589d31) | ![image](https://github.com/user-attachments/assets/77dd1741-d2bc-48e4-bea5-89a4063073e1) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
