### PR TITLE
thumbnail: Add a data-original-dimensions attribute

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 9.0
 
+**Feature level 276**
+
+* [Markdown message formatting](/api/message-formatting#image-previews):
+  Image preview elements not contain a `data-original-dimensions`
+  attribute containing the dimensions of the original image.
+
 **Feature level 275**
 
 * [`POST /register`](/api/register-queue), [`PATCH

--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -23,6 +23,102 @@ for syntax highlighting. This field is used in the
 mentions][help-global-time] to supported Markdown message formatting
 features.
 
+## Image previews
+
+When a Zulip message is sent linking to an uploaded image, Zulip will
+generate an image preview element with the following format.
+
+``` html
+<div class="message_inline_image">
+    <a href="/user_uploads/path/to/image.png" title="image.png">
+        <img data-original-dimensions="1920x1080"
+          src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">
+    </a>
+</div>
+```
+
+If the server has not yet generated thumbnails for the image yet at
+the time the message is sent, the `img` element will be a temporary
+loading indicator image and have the `image-loading-placeholder`
+class, which clients can use to identify loading indicators and
+replace them with a more native loading indicator element if
+desired. For example:
+
+``` html
+<div class="message_inline_image">
+    <a href="/user_uploads/path/to/image.png" title="image.png">
+        <img class="image-loading-placeholder" src="/path/to/spinner.png">
+    </a>
+</div>
+```
+
+Once the server has a working thumbnail, such messages will be updated
+via an `update_message` event, with the `rendering_only: true` flag
+(telling clients not to adjust message edit history), with appropriate
+adjusted `rendered_content`. A client should process those events by
+just using the updated rendering. If thumbnailing failed, the same
+type of event will edit the message's rendered form to remove the
+image preview element, so no special client-side logic should be
+required to process such errors.
+
+Note that in the uncommon situation that the thumbnailing system is
+backlogged, an individual message containing multiple image previews
+may be re-rendered multiple times as each image finishes thumbnailing
+and triggers a message update.
+
+Clients are recommended to do the following when processing image
+previews:
+
+- If the client would like to control the thumbnail resolution used,
+  it can replace the final section of the URL (`840x560.webp` in the
+  example above) with the `name` of its preferred format from the set
+  of supported formats provided by the server in the
+  `server_thumbnail_formats` portion of the `register`
+  response. Clients should not make any assumptions about what format
+  the server will use as the "default" thumbnail resolution, as it may
+  change over time.
+- Download button type elements should provide the original image
+  (encoded via the `href` of the containing `a` tag).
+- Lightbox elements for viewing an image should be designed to
+  immediately display any already-downloaded thumbnail while fetching
+  the original-quality image or an appropriate higher-quality
+  thumbnail from the server, to be transparently swapped in once it is
+  available. Clients that would like to size the lightbox based on the
+  size of the original image can use the `data-original-dimensions`
+  attribute, which encodes the dimensions of the original image as
+  `{width}x{height}`, to do so.
+- Animated images will have a `data-animated` attribute on the `img`
+  tag. As detailed in `server_thumbnail_formats`, both animated and
+  still images are available for clients to use, depending on their
+  preference. See, for example, the [web
+  setting](/help/allow-image-link-previews#configure-how-animated-images-are-played)
+  to control whether animated images are autoplayed in the message
+  feed.
+- Clients should not assume that the requested format is the format
+  that they will receive; in rare cases where the client has an
+  out-of-date list of `server_thumbnail_formats`, the server will
+  provide an approximation of the client's requested format.  Because
+  of this, clients should not assume that the pixel dimensions or file
+  format match what they requested.
+- No other processing of the URLs is recommended.
+
+**Changes**: In Zulip 9.0 (feature level 276), added
+`data-original-dimensions` attribute to images that have been
+thumbnailed, containing the dimensions of the full-size version of the
+image. Thumbnailing itself was reintroduced at feature level 275.
+
+Previously, with the exception of Zulip servers that used the beta
+Thumbor-based implementation years ago, all image previews in Zulip
+messages were not thumbnailed; the `a` tag and the `img` tag would both
+point to the original image.
+
+Clients that correctly implement the current API should handle
+Thumbor-based older thumbnails correctly, as long as they do not
+assume that `data-original-dimension` is present. Clients should not
+assume that messages sent prior to the introduction of thumbnailing
+have been re-rendered to use the new format or have thumbnails
+available.
+
 ## Mentions
 
 **Changes**: In Zulip 9.0 (feature level 247), `channel` was added

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 275  # Last bumped for `web_animate_image_previews` setting.
+API_FEATURE_LEVEL = 276  # Last bumped for data-original-dimensions
 
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -55,7 +55,11 @@ from zerver.lib.mention import (
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.subdomains import is_static_or_current_realm_url
 from zerver.lib.tex import render_tex
-from zerver.lib.thumbnail import get_user_upload_previews, rewrite_thumbnailed_images
+from zerver.lib.thumbnail import (
+    MarkdownImageMetadata,
+    get_user_upload_previews,
+    rewrite_thumbnailed_images,
+)
 from zerver.lib.timeout import unsafe_timeout
 from zerver.lib.timezone import common_timezones
 from zerver.lib.types import LinkifierDict
@@ -125,7 +129,7 @@ class DbData:
     sent_by_bot: bool
     stream_names: dict[str, int]
     translate_emoticons: bool
-    user_upload_previews: dict[str, tuple[str, bool] | None]
+    user_upload_previews: dict[str, MarkdownImageMetadata | None]
 
 
 # Format version of the Markdown rendering; stored along with rendered

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -325,9 +325,17 @@ def split_thumbnail_path(file_path: str) -> tuple[str, BaseThumbnailFormat]:
     return path_id, thumbnail_format
 
 
-def get_user_upload_previews(realm_id: int, content: str) -> dict[str, tuple[str, bool] | None]:
+@dataclass
+class MarkdownImageMetadata:
+    url: str
+    is_animated: bool
+
+
+def get_user_upload_previews(
+    realm_id: int, content: str
+) -> dict[str, MarkdownImageMetadata | None]:
     matches = re.findall(r"/user_uploads/(\d+/[/\w.-]+)", content)
-    upload_preview_data: dict[str, tuple[str, bool] | None] = {}
+    upload_preview_data: dict[str, MarkdownImageMetadata | None] = {}
     for image_attachment in ImageAttachment.objects.filter(realm_id=realm_id, path_id__in=matches):
         if image_attachment.thumbnail_metadata == []:
             # Image exists, and header of it parsed as a valid image,
@@ -335,8 +343,10 @@ def get_user_upload_previews(realm_id: int, content: str) -> dict[str, tuple[str
             # spinner.
             upload_preview_data[image_attachment.path_id] = None
         else:
-            upload_preview_data[image_attachment.path_id] = get_default_thumbnail_url(
-                image_attachment
+            url, is_animated = get_default_thumbnail_url(image_attachment)
+            upload_preview_data[image_attachment.path_id] = MarkdownImageMetadata(
+                url=url,
+                is_animated=is_animated,
             )
     return upload_preview_data
 
@@ -364,7 +374,7 @@ def get_default_thumbnail_url(image_attachment: ImageAttachment) -> tuple[str, b
 
 def rewrite_thumbnailed_images(
     rendered_content: str,
-    images: dict[str, tuple[str, bool] | None],
+    images: dict[str, MarkdownImageMetadata | None],
     to_delete: set[str] | None = None,
 ) -> str | None:
     if not images and not to_delete:
@@ -410,8 +420,8 @@ def rewrite_thumbnailed_images(
         else:
             changed = True
             del image_tag["class"]
-            image_tag["src"], is_animated = image_data
-            if is_animated:
+            image_tag["src"] = image_data.url
+            if image_data.is_animated:
                 image_tag["data-animated"] = "true"
 
     if changed:

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -329,6 +329,8 @@ def split_thumbnail_path(file_path: str) -> tuple[str, BaseThumbnailFormat]:
 class MarkdownImageMetadata:
     url: str
     is_animated: bool
+    original_width_px: int
+    original_height_px: int
 
 
 def get_user_upload_previews(
@@ -347,6 +349,8 @@ def get_user_upload_previews(
             upload_preview_data[image_attachment.path_id] = MarkdownImageMetadata(
                 url=url,
                 is_animated=is_animated,
+                original_width_px=image_attachment.original_width_px,
+                original_height_px=image_attachment.original_height_px,
             )
     return upload_preview_data
 
@@ -421,6 +425,9 @@ def rewrite_thumbnailed_images(
             changed = True
             del image_tag["class"]
             image_tag["src"] = image_data.url
+            image_tag["data-original-dimensions"] = (
+                f"{image_data.original_width_px}x{image_data.original_height_px}"
+            )
             if image_data.is_animated:
                 image_tag["data-animated"] = "true"
 

--- a/zerver/tests/test_markdown_thumbnail.py
+++ b/zerver/tests/test_markdown_thumbnail.py
@@ -73,15 +73,15 @@ class MarkdownThumbnailTest(ZulipTestCase):
                 "<p>Test 1<br>\n"
                 f'<a href="/user_uploads/{path_ids[0]}">{image_names[0]}</a> </p>\n'
                 f'<div class="message_inline_image"><a href="/user_uploads/{path_ids[0]}" title="{image_names[0]}">'
-                f'<img src="/user_uploads/thumbnail/{path_ids[0]}/840x560.webp"></a></div>'
+                f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_ids[0]}/840x560.webp"></a></div>'
                 "<p>Next image<br>\n"
                 f'<a href="/user_uploads/{path_ids[1]}">{image_names[1]}</a> </p>\n'
                 f'<div class="message_inline_image"><a href="/user_uploads/{path_ids[1]}" title="{image_names[1]}">'
-                f'<img src="/user_uploads/thumbnail/{path_ids[1]}/840x560.webp"></a></div>'
+                f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_ids[1]}/840x560.webp"></a></div>'
                 "<p>Another screenshot<br>\n"
                 f'<a href="/user_uploads/{path_ids[2]}">{image_names[2]}</a></p>\n'
                 f'<div class="message_inline_image"><a href="/user_uploads/{path_ids[2]}" title="{image_names[2]}">'
-                f'<img src="/user_uploads/thumbnail/{path_ids[2]}/840x560.webp"></a></div>'
+                f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_ids[2]}/840x560.webp"></a></div>'
             ),
         )
 
@@ -124,7 +124,7 @@ class MarkdownThumbnailTest(ZulipTestCase):
         expected = (
             f'<p><a href="/user_uploads/{path_id}">image</a></p>\n'
             f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="image">'
-            f'<img src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
+            f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
         )
         self.assert_message_content_is(message_id, expected)
 
@@ -142,7 +142,8 @@ class MarkdownThumbnailTest(ZulipTestCase):
         message_id = self.send_message_content(f"[I am 95% ± 5% certain!](/user_uploads/{path_id})")
         expected = (
             f'<p><a href="/user_uploads/{path_id}">I am 95% &plusmn; 5% certain!</a></p>\n'
-            f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="I am 95% &plusmn; 5% certain!"><img src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
+            f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="I am 95% &plusmn; 5% certain!">'
+            f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
         )
         self.assert_message_content_is(message_id, expected)
 
@@ -157,12 +158,13 @@ class MarkdownThumbnailTest(ZulipTestCase):
             ThumbnailFormat("webp", 100, 75, animated=True),
             ThumbnailFormat("webp", 100, 75, animated=False),
         ):
-            path_id = self.upload_and_thumbnail_image("animated_img.gif")
-            content = f"[animated_img.gif](/user_uploads/{path_id})"
+            path_id = self.upload_and_thumbnail_image("animated_unequal_img.gif")
+            content = f"[animated_unequal_img.gif](/user_uploads/{path_id})"
             expected = (
-                f'<p><a href="/user_uploads/{path_id}">animated_img.gif</a></p>\n'
-                f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="animated_img.gif">'
-                f'<img data-animated="true" src="/user_uploads/thumbnail/{path_id}/100x75-anim.webp"></a></div>'
+                f'<p><a href="/user_uploads/{path_id}">animated_unequal_img.gif</a></p>\n'
+                f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="animated_unequal_img.gif">'
+                '<img data-animated="true" data-original-dimensions="128x56"'
+                f' src="/user_uploads/thumbnail/{path_id}/100x75-anim.webp"></a></div>'
             )
             message_id = self.send_message_content(content, do_thumbnail=True)
         self.assert_message_content_is(message_id, expected)
@@ -208,7 +210,7 @@ class MarkdownThumbnailTest(ZulipTestCase):
                 f'<div class="message_inline_image"><a href="/user_uploads/{first_path_id}" title="first image">'
                 '<img class="image-loading-placeholder" src="/static/images/loading/loader-black.svg"></a></div>'
                 f'<div class="message_inline_image"><a href="/user_uploads/{second_path_id}" title="second image">'
-                f'<img src="/user_uploads/thumbnail/{second_path_id}/840x560.webp"></a></div>'
+                f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{second_path_id}/840x560.webp"></a></div>'
             ),
         )
 
@@ -220,9 +222,9 @@ class MarkdownThumbnailTest(ZulipTestCase):
                 f'<p><a href="/user_uploads/{first_path_id}">first image</a><br>\n'
                 f'<a href="/user_uploads/{second_path_id}">second image</a></p>\n'
                 f'<div class="message_inline_image"><a href="/user_uploads/{first_path_id}" title="first image">'
-                f'<img src="/user_uploads/thumbnail/{first_path_id}/840x560.webp"></a></div>'
+                f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{first_path_id}/840x560.webp"></a></div>'
                 f'<div class="message_inline_image"><a href="/user_uploads/{second_path_id}" title="second image">'
-                f'<img src="/user_uploads/thumbnail/{second_path_id}/840x560.webp"></a></div>'
+                f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{second_path_id}/840x560.webp"></a></div>'
             ),
         )
 
@@ -247,7 +249,7 @@ class MarkdownThumbnailTest(ZulipTestCase):
         expected = (
             f'<p><a href="/user_uploads/{path_id}">image</a></p>\n'
             f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="image">'
-            f'<img src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
+            f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
         )
         self.assertEqual(
             ArchivedMessage.objects.get(id=message_id).rendered_content,
@@ -320,7 +322,7 @@ class MarkdownThumbnailTest(ZulipTestCase):
 
         rendered_thumb = (
             f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="image">'
-            f'<img src="/user_uploads/thumbnail/{path_id}/100x75.webp"></a></div>'
+            f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_id}/100x75.webp"></a></div>'
         )
 
         self.assert_message_content_is(

--- a/zerver/worker/thumbnail.py
+++ b/zerver/worker/thumbnail.py
@@ -147,6 +147,8 @@ def ensure_thumbnails(image_attachment: ImageAttachment) -> int:
         MarkdownImageMetadata(
             url=url,
             is_animated=is_animated,
+            original_width_px=image_attachment.original_width_px,
+            original_height_px=image_attachment.original_height_px,
         ),
     )
     return written_images

--- a/zerver/worker/thumbnail.py
+++ b/zerver/worker/thumbnail.py
@@ -11,6 +11,7 @@ from typing_extensions import override
 from zerver.actions.message_edit import do_update_embedded_data
 from zerver.lib.mime_types import guess_type
 from zerver.lib.thumbnail import (
+    MarkdownImageMetadata,
     StoredThumbnailFormat,
     get_default_thumbnail_url,
     get_image_thumbnail_path,
@@ -139,16 +140,20 @@ def ensure_thumbnails(image_attachment: ImageAttachment) -> int:
             pass
 
     image_attachment.save(update_fields=["thumbnail_metadata"])
+    url, is_animated = get_default_thumbnail_url(image_attachment)
     update_message_rendered_content(
         image_attachment.realm_id,
         image_attachment.path_id,
-        get_default_thumbnail_url(image_attachment),
+        MarkdownImageMetadata(
+            url=url,
+            is_animated=is_animated,
+        ),
     )
     return written_images
 
 
 def update_message_rendered_content(
-    realm_id: int, path_id: str, image_data: tuple[str, bool] | None
+    realm_id: int, path_id: str, image_data: MarkdownImageMetadata | None
 ) -> None:
     for message_class in [Message, ArchivedMessage]:
         messages_with_image = (


### PR DESCRIPTION
This allows clients to potentially lay out the thumbnails more intelligently, or to provide a better "progressive-load" experience when enlarging the thumbnail.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
