### PR TITLE
help: Improve previews documentation.

### DIFF
--- a/help/allow-image-link-previews.md
+++ b/help/allow-image-link-previews.md
@@ -1,15 +1,31 @@
-# Block image and website previews
+# Image, video and website previews
+
+Zulip displays previews of images, videos and websites in your message feed. To
+avoid disrupting the flow of conversation, these previews are small. You can
+configure how animated images are previewed, and organization administrators can
+also disable previews altogether.
+
+## Configure how animated images are played
+
+In the desktop and web apps, you can configure previews of animated images to
+always show the animation, show it when you hover over the image with your
+mouse, or not show it at all. You can always see the animated image by opening
+it in the [image viewer](/help/view-images-and-videos).
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|preferences}
+
+1. Under **Information**, select the desired option from the **Play animated
+   images** dropdown.
+
+{end_tabs}
+
+## Configure whether image and video previews are shown
 
 {!admin-only.md!}
-
-By default, when a user links to an image or a website, a preview of the
-image or website content is shown. You can choose to disable previews of
-images and/or website links.
-
-Zulip proxies all external images in messages through the server, to
-prevent images from being used to track Zulip users.
-
-### Block image and website previews
 
 {start_tabs}
 
@@ -17,14 +33,32 @@ prevent images from being used to track Zulip users.
 
 1. Under **Other settings**, toggle **Show previews of uploaded and linked images and videos**.
 
+{!save-changes.md!}
+
+{end_tabs}
+
+## Configure whether website previews are shown
+
+{!admin-only.md!}
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
 1. Under **Other settings**, toggle **Show previews of linked websites**.
 
 {!save-changes.md!}
 
 {end_tabs}
 
+## Security
+
+To prevent images from being used to track Zulip users, Zulip proxies all
+external images in messages through the server.
+
 ## Related articles
 
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
 * [Share and upload files](/help/share-and-upload-files)
 * [View images and videos](/help/view-images-and-videos)
+* [Animated GIFs](/help/animated-gifs-from-giphy)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -224,7 +224,7 @@
 * [Restrict moving messages](/help/restrict-moving-messages)
 * [Restrict message editing](/help/restrict-message-editing-and-deletion)
 * [Disable message edit history](/help/disable-message-edit-history)
-* [Block image and link previews](/help/allow-image-link-previews)
+* [Image, video and website previews](/help/allow-image-link-previews)
 * [Hide message content in emails](/help/hide-message-content-in-emails)
 * [Message retention policy](/help/message-retention-policy)
 * [Weekly digest emails](/help/digest-emails)

--- a/help/manage-your-uploaded-files.md
+++ b/help/manage-your-uploaded-files.md
@@ -64,4 +64,4 @@ You can sort your uploaded files by name, upload date, message ID, and size.
 
 * [Share and upload files](/help/share-and-upload-files)
 * [View images and videos](/help/view-images-and-videos)
-* [Block image and link previews](/help/allow-image-link-previews)
+* [Image, video and website previews](/help/allow-image-link-previews)

--- a/help/share-and-upload-files.md
+++ b/help/share-and-upload-files.md
@@ -126,5 +126,5 @@ This limit can be changed by the server administrator.
 
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
 * [View images and videos](/help/view-images-and-videos)
-* [Block image and link previews](/help/allow-image-link-previews)
+* [Image, video and website previews](/help/allow-image-link-previews)
 * [Animated GIFs](/help/animated-gifs-from-giphy)

--- a/help/view-images-and-videos.md
+++ b/help/view-images-and-videos.md
@@ -135,4 +135,4 @@ images and videos in messages matching that search.
 
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
 * [Share and upload files](/help/share-and-upload-files)
-* [Block image and link previews](/help/allow-image-link-previews)
+* [Image, video and website previews](/help/allow-image-link-previews)


### PR DESCRIPTION
- Make page title more general.
- Document new option for animated image previews.
- Split instructions for showing different preview types.
- Update intro.

Current: https://zulip.com/help/allow-image-link-previews
<details>
<summary>
Updated
</summary>

![Screenshot 2024-07-22 at 14 58 13@2x](https://github.com/user-attachments/assets/f29b2572-2549-4b84-b99f-127d4142f3cf)

![Screenshot 2024-07-22 at 14 58 18@2x](https://github.com/user-attachments/assets/ba2e07d3-34bb-4396-85f7-6077b4c6618e)

</details>

Follow-ups:
- Change page URL to match the new title.
- Make the animate setting apply to GIPHY images. If this will be delayed a while, we can add a note to the documentation instead. 
