### PR TITLE
docs: Replace `Advanced` with relevant section for user Preferences.

### DIFF
--- a/help/configure-home-view.md
+++ b/help/configure-home-view.md
@@ -39,7 +39,7 @@ organization settings:
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, click on the **Home view** dropdown
+1. Under **Navigation**, click on the **Home view** dropdown
    and select a view.
 
 1. To see your changes in action, open a new Zulip tab, or use a keyboard
@@ -71,7 +71,7 @@ shortcut.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, toggle **Escape key navigates to
+1. Under **Navigation**, toggle **Escape key navigates to
    home view**, as desired.
 
 {end_tabs}

--- a/help/configure-unread-message-counters.md
+++ b/help/configure-unread-message-counters.md
@@ -16,7 +16,7 @@ unread messages in a channel by moving your mouse over it in the left sidebar.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, select your preferred option from the
+1. Under **Information**, select your preferred option from the
    **Show unread counts for** dropdown.
 
 {end_tabs}

--- a/help/enable-full-width-display.md
+++ b/help/enable-full-width-display.md
@@ -13,6 +13,6 @@ You can instead configure Zulip to use the full width of wide screens.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, select **Use full width on wide screens**.
+1. Under **Information**, select **Use full width on wide screens**.
 
 {end_tabs}

--- a/help/include/configure-channel-links.md
+++ b/help/include/configure-channel-links.md
@@ -8,7 +8,7 @@ channel.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, select your preferred option from the
+1. Under **Navigation**, select your preferred option from the
    **Channel links in the left sidebar go to** dropdown.
 
 {end_tabs}

--- a/help/manage-inactive-channels.md
+++ b/help/manage-inactive-channels.md
@@ -15,7 +15,7 @@ is your first time using Zulip.
 
 {settings_tab|preferences}
 
-2. Under **Advanced**, configure **Demote inactive channels**.
+2. Under **Information**, configure **Demote inactive channels**.
 
 {end_tabs}
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -31,7 +31,7 @@ web/desktop app.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, click on the **Automatically mark messages as
+1. Under **Navigation**, click on the **Automatically mark messages as
    read** dropdown, and select **Always**, **Never** or **Only in
    [conversation](/help/reading-conversations) views**.
 

--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -68,7 +68,7 @@ currently composing to.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, toggle **Automatically go to conversation
+1. Under **Navigation**, toggle **Automatically go to conversation
 where you sent a message**, as desired.
 
 {end_tabs}

--- a/help/star-a-message.md
+++ b/help/star-a-message.md
@@ -93,7 +93,7 @@ can disable that feature.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, toggle **Show counts for starred messages**.
+1. Under **Information**, toggle **Show counts for starred messages**.
 
 {end_tabs}
 

--- a/help/status-and-availability.md
+++ b/help/status-and-availability.md
@@ -118,7 +118,7 @@ With the compact option, only status emoji are shown.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, select **Compact** or **Show status and text** for the
+1. Under **Information**, select **Compact** or **Show status and text** for the
    user list style.
 
 !!! tip ""

--- a/help/typing-notifications.md
+++ b/help/typing-notifications.md
@@ -39,7 +39,7 @@ If you'd prefer not to see notifications when others type, you can disable them.
 
 {settings_tab|preferences}
 
-1. Under **Advanced**, toggle **Show when other users are typing**.
+1. Under **Information**, toggle **Show when other users are typing**.
 
 {end_tabs}
 


### PR DESCRIPTION
This is a followup commit to #30824.
Fixes https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20help.20not.20updated.20for.20new.20preferences.20sections/near/1899330.

git grep in the help directory will still show up results for `Advanced` but those are mostly used in either plain english language instructions or refer to some other part of the app. At the point of writing this commit, there were 6 results for `Advanced`, 4 of which were plain english, 1 refers to the Advanced settings in chrome for desktop notifications, and another one refers to `Advanced configurations` for channel settings.

I've added one screenshot just for reference, but don't think we need screenshots for all changes.

<img width="926" alt="Screenshot 2024-07-23 at 11 12 31 AM" src="https://github.com/user-attachments/assets/f5a84166-c47a-4d27-80bc-d9c2f07c73f7">

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
