### PR TITLE
user_card_popover: Focus on menu options first when opened with keyboard.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -602,9 +602,19 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: [".personal-menu-clear-status", ".user-card-clear-status-button"].join(","),
+        target: [
+            ".custom-profile-field-value",
+            ".copy-custom-profile-field-link",
+            "#popover-menu-copy-email",
+            ".personal-menu-clear-status",
+            ".user-card-clear-status-button",
+        ].join(","),
         placement: "top",
+        delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
+        onHidden(instance: tippy.Instance) {
+            instance.destroy();
+        },
     });
 
     tippy.delegate("body", {

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -480,7 +480,9 @@ function get_user_card_popover_for_message_items() {
         return undefined;
     }
 
-    return $("li:not(.divider):visible a:not(.hide_copy_icon)", $popover);
+    // Return only the popover menu options that are visible, and not the
+    // copy buttons or the link items in the custom profile fields.
+    return $(".link-item .popover-menu-link", $popover).filter(":visible");
 }
 
 // Functions related to the user card popover in the user sidebar.

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -127,7 +127,7 @@
             {{#if user_email}}
                 <li role="none" class="popover-menu-list-item text-item user-card-popover-email-field hidden-for-spectators">
                     <span class="user_popover_email">{{ user_email }}</span>
-                    <a role="menuitem" tabindex="0" id="popover-menu-copy-email" class="popover-menu-link tippy-zulip-tooltip hide_copy_icon" aria-label="{{t 'Copy email'}}" data-tippy-content="{{t 'Copy email' }}" data-clipboard-text="{{ user_email }}">
+                    <a role="menuitem" tabindex="0" id="popover-menu-copy-email" class="popover-menu-link hide_copy_icon" aria-label="{{t 'Copy email'}}" data-tippy-content="{{t 'Copy email' }}" data-clipboard-text="{{ user_email }}">
                         <i class="popover-menu-icon zulip-icon zulip-icon-copy hide" aria-hidden="true"></i>
                     </a>
                 </li>

--- a/web/templates/popovers/user_card/user_card_popover_custom_fields.hbs
+++ b/web/templates/popovers/user_card/user_card_popover_custom_fields.hbs
@@ -1,14 +1,14 @@
 {{#each profile_fields}}
     <li role="none" class="popover-menu-list-item text-item custom_user_field" data-type="{{this.type}}" data-field-id="{{this.id}}">
         {{#if this.is_link}}
-            <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="custom-profile-field-value custom-profile-field-link tippy-zulip-tooltip" data-tippy-content="{{this.name}}" tabindex="0">
+            <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="custom-profile-field-value custom-profile-field-link" data-tippy-content="{{this.name}}" tabindex="0">
                 <span class="custom-profile-field-text">{{this.value}}</span>
             </a>
-            <a role="menuitem" tabindex="0" class="popover-menu-link copy-custom-profile-field-link tippy-zulip-tooltip" aria-label="{{t 'Copy URL' }}" data-tippy-content="{{t 'Copy URL' }}">
+            <a role="menuitem" tabindex="0" class="popover-menu-link copy-custom-profile-field-link" aria-label="{{t 'Copy URL' }}" data-tippy-content="{{t 'Copy URL' }}">
                 <i class="popover-menu-icon zulip-icon zulip-icon-copy" aria-hidden="true"></i>
             </a>
         {{else if this.is_external_account}}
-            <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="custom-profile-field-value custom-profile-field-link tippy-zulip-tooltip" data-tippy-content="{{this.name}}" tabindex="0">
+            <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="custom-profile-field-value custom-profile-field-link" data-tippy-content="{{this.name}}" tabindex="0">
                 {{#if (eq this.subtype "github") }}
                     <i class="popover-menu-icon fa fa-github" aria-hidden="true"></i>
                 {{else if (eq this.subtype "twitter") }}
@@ -17,11 +17,11 @@
                 <span class="custom-profile-field-text">{{this.value}}</span>
             </a>
         {{else if this.rendered_value}}
-            <div class="custom-profile-field-value rendered_markdown tippy-zulip-tooltip" data-tippy-content="{{this.name}}">
+            <div class="custom-profile-field-value rendered_markdown" data-tippy-content="{{this.name}}">
                 {{rendered_markdown this.rendered_value}}
             </div>
         {{else}}
-            <div class="custom-profile-field-value tippy-zulip-tooltip" data-tippy-content="{{this.name}}">
+            <div class="custom-profile-field-value" data-tippy-content="{{this.name}}">
                 <span class="custom-profile-field-text">{{this.value}}</span>
             </div>
         {{/if}}


### PR DESCRIPTION
When the user card is opened via the keyboard shortcut `U`, the initial focus should be on the first popover menu option, rather than the copy buttons or the custom profile field links which can be distracting due to the presence of tooltips on them.

This also adds the `LONG_HOVER_DELAY` delay to the user card tooltips to further reduce the distraction from the tooltips.

Fixes part of #31027.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![user_card_fix_focus_and_tooltip-before](https://github.com/user-attachments/assets/d7eac826-41c3-43c1-b3f7-8ef16c01d750) | ![user_card_fix_focus_and_tooltip-after](https://github.com/user-attachments/assets/e8b4060e-3e8b-4533-b839-627379dd2cb3) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
