### PR TITLE
recent_view_ui: Fix dm rows not updated for deleted messages.

### DIFF
--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -94,6 +94,12 @@ export function get_messages_in_topic(stream_id: number, topic: string): Message
         );
 }
 
+export function get_messages_in_dm_conversations(user_ids_strings: Set<string>): Message[] {
+    return all_messages_data
+        .all_messages()
+        .filter((x) => x.type === "private" && user_ids_strings.has(x.to_user_ids));
+}
+
 export function get_max_message_id_in_stream(stream_id: number): number {
     let max_message_id = 0;
     for (const msg of all_messages_data.all_messages()) {


### PR DESCRIPTION
Tested by deleting a DM and navigating to recent view. No error is thrown and dm row is correctly placed.

Fixes [this](https://chat.zulip.org/#narrow/stream/464-kandra-js-errors/topic/Error.3A.20Assertion.20failed/near/1898878) sentry exception.
