### PR TITLE
Fix errors trying to local echo when offline.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -253,6 +253,10 @@ export function send_message(request = create_message_object()) {
         drafts.sync_count();
 
         const draft = drafts.draft_model.getDraft(request.draft_id);
+        if (!draft) {
+            return;
+        }
+
         draft.is_sending_saving = false;
         drafts.draft_model.editDraft(request.draft_id, draft);
     }
@@ -441,6 +445,10 @@ function schedule_message_to_custom_date() {
             $("textarea#compose-textarea"),
         );
         const draft = drafts.draft_model.getDraft(draft_id);
+        if (!draft) {
+            return;
+        }
+
         draft.is_sending_saving = false;
         drafts.draft_model.editDraft(draft_id, draft);
     };

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -396,7 +396,7 @@ export function process_from_server(messages) {
 
         reify_message_id(local_id, message.id);
 
-        if (message_store.get(message.id).failed_request) {
+        if (message_store.get(message.id)?.failed_request) {
             failed_message_success(message.id);
         }
 

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -442,7 +442,12 @@ export function show(raw_terms, opts) {
                     );
 
                     if (adjusted_terms === null) {
-                        blueslip.error("adjusted_terms impossibly null");
+                        // If the stream was deleted, there will be no change in
+                        // terms. We cannot narrow to the message in this case.
+                        // User likely starred the message and the message's
+                        // stream got deleted. When user clicks on the message
+                        // we reach here. Returning will keep user narrowed to
+                        // the starred messages which what we want here.
                         return;
                     }
 


### PR DESCRIPTION
First commit fixes an error when sending a message when user is offline.

Second commit is an attempt to ignore [this](https://zulip.sentry.io/issues/5088429359/events/oldest/?referrer=oldest-event) sentry traceback. Not sure why message store and echo are out of sync but likely cause is message being removed from `message_store` via a different event.