### PR TITLE
compose: Disable reply button if posting in stream not allowed.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -309,8 +309,15 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
         compose_state.set_compose_recipient_id(compose_state.DIRECT_MESSAGE_ID);
         compose_recipient.on_compose_select_recipient_update();
     } else if (opts.stream_id) {
-        compose_state.set_stream_id(opts.stream_id);
-        compose_recipient.on_compose_select_recipient_update();
+        const stream = stream_data.get_sub_by_id(opts.stream_id);
+        if (stream && stream_data.can_post_messages_in_stream(stream)) {
+            compose_state.set_stream_id(opts.stream_id);
+            compose_recipient.on_compose_select_recipient_update();
+        } else {
+            compose_state.set_stream_id("");
+            opts.topic = "";
+            compose_recipient.open_compose_recipient_dropdown();
+        }
     } else {
         // Open stream selection dropdown if no stream is selected.
         compose_state.set_stream_id("");

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -63,10 +63,17 @@ export function get_recipient_label(message?: ComposeClosedMessage): string {
 function update_reply_button_state(disable = false): void {
     $(".compose_reply_button").attr("disabled", disable ? "disabled" : null);
     if (disable) {
-        $("#compose_buttons .compose-reply-button-wrapper").attr(
-            "data-reply-button-type",
-            "direct_disabled",
-        );
+        if (maybe_get_selected_message_stream_id() !== undefined) {
+            $("#compose_buttons .compose-reply-button-wrapper").attr(
+                "data-reply-button-type",
+                "stream_disabled",
+            );
+        } else {
+            $("#compose_buttons .compose-reply-button-wrapper").attr(
+                "data-reply-button-type",
+                "direct_disabled",
+            );
+        }
         return;
     }
     if (narrow_state.is_message_feed_visible()) {
@@ -84,6 +91,28 @@ function update_reply_button_state(disable = false): void {
 
 function update_buttons(disable_reply?: boolean): void {
     update_reply_button_state(disable_reply);
+}
+
+function maybe_get_selected_message_stream_id(): number | undefined {
+    if (message_lists.current?.visibly_empty()) {
+        return undefined;
+    }
+    const selected_message = message_lists.current?.selected_message();
+    if (!selected_message?.is_stream) {
+        return undefined;
+    }
+    return selected_message.stream_id;
+}
+
+function should_disable_compose_reply_button_for_stream(): boolean {
+    const stream_id = maybe_get_selected_message_stream_id();
+    if (stream_id !== undefined) {
+        const stream = stream_data.get_sub_by_id(stream_id);
+        if (stream && !stream_data.can_post_messages_in_stream(stream)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export function update_buttons_for_private(): void {
@@ -105,12 +134,12 @@ export function update_buttons_for_private(): void {
 
 export function update_buttons_for_stream_views(): void {
     $("#new_conversation_button").attr("data-conversation-type", "stream");
-    update_buttons();
+    update_buttons(should_disable_compose_reply_button_for_stream());
 }
 
 export function update_buttons_for_non_specific_views(): void {
     $("#new_conversation_button").attr("data-conversation-type", "non-specific");
-    update_buttons();
+    update_buttons(should_disable_compose_reply_button_for_stream());
 }
 
 function set_reply_button_label(label: string): void {
@@ -140,6 +169,14 @@ export function initialize(): void {
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
             update_reply_recipient_label();
+
+            // Disable compose reply button if the selected message is a stream
+            // message and the user is not allowed to post in the stream the message
+            // belongs to.
+            if (maybe_get_selected_message_stream_id() !== undefined) {
+                update_buttons_for_stream_views();
+                update_buttons_for_non_specific_views();
+            }
         }
     });
 

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -51,6 +51,12 @@ export function initialize(): void {
                     instance.setContent(pick_empty_narrow_banner().title);
                     return;
                 }
+                case "stream_disabled": {
+                    instance.setContent(
+                        $("#compose_disable_stream_reply_button_tooltip_template").html(),
+                    );
+                    return;
+                }
                 case "selected_message": {
                     instance.setContent(
                         parse_html($("#compose_reply_message_button_tooltip_template").html()),
@@ -79,7 +85,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: "#new_conversation_button",
+        target: "#compose_buttons .new-conversation-button-wrapper",
         delay: EXTRA_LONG_HOVER_DELAY,
         // Only show on mouseenter since for spectators, clicking on these
         // buttons opens login modal, and Micromodal returns focus to the
@@ -87,12 +93,18 @@ export function initialize(): void {
         trigger: "mouseenter",
         appendTo: () => document.body,
         onShow(instance) {
-            const $elem = $(instance.reference);
-            const conversation_type = $elem.attr("data-conversation-type");
+            const $new_conversation_button = $("#new_conversation_button");
+            const conversation_type = $new_conversation_button.attr("data-conversation-type");
             if (conversation_type === "stream") {
-                instance.setContent(
-                    parse_html($("#new_topic_message_button_tooltip_template").html()),
-                );
+                if ($new_conversation_button.prop("disabled")) {
+                    instance.setContent(
+                        $("#compose_disable_stream_reply_button_tooltip_template").html(),
+                    );
+                } else {
+                    instance.setContent(
+                        parse_html($("#new_topic_message_button_tooltip_template").html()),
+                    );
+                }
                 return undefined;
             }
             // Use new_stream_message_button_tooltip_template when the

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -58,6 +58,10 @@
             );
         }
 
+        .new-conversation-button-wrapper {
+            display: flex;
+        }
+
         #left_bar_compose_reply_button_big,
         #new_conversation_button {
             /* Remove the border inherited from `.button` styles. */

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -19,11 +19,13 @@
                         {{t 'Compose message' }}
                     </button>
                 </div>
-                <button type="button" class="button compose_new_conversation_button"
-                  id="new_conversation_button"
-                  data-tooltip-template-id="new_stream_message_button_tooltip_template">
-                    {{t 'Start new conversation' }}
-                </button>
+                <div class="new-conversation-button-wrapper">
+                    <button type="button" class="button compose_new_conversation_button"
+                      id="new_conversation_button"
+                      data-tooltip-template-id="new_stream_message_button_tooltip_template">
+                        {{t 'Start new conversation' }}
+                    </button>
+                </div>
             </div>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button rounded compose_mobile_button"

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -10,6 +10,9 @@
     {{t 'Scroll to bottom' }}
     {{tooltip_hotkey_hints "End"}}
 </template>
+<template id="compose_disable_stream_reply_button_tooltip_template">
+    {{t 'You do not have permission to post in this channel.' }}
+</template>
 <template id="compose_reply_message_button_tooltip_template">
     {{t 'Reply to selected message' }}
     {{tooltip_hotkey_hints "R"}}

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -837,6 +837,26 @@ test_ui("create_message_object", ({override, override_rewire}) => {
     assert.deepEqual(message.to, [alice.email, bob.email]);
 });
 
+test_ui("Stream posting policy disabled", ({override_rewire}) => {
+    let reply_disabled = false;
+    override_rewire(compose_closed_ui, "update_reply_button_state", (disabled = false) => {
+        reply_disabled = disabled;
+    });
+    override_rewire(
+        compose_closed_ui,
+        "maybe_get_selected_message_stream_id",
+        () => social.stream_id,
+    );
+    // Test if "Message X" button is disabled when a user cannot post in a stream.
+    override_rewire(stream_data, "can_post_messages_in_stream", () => false);
+    compose_closed_ui.update_buttons_for_stream_views();
+    assert.ok(reply_disabled);
+    // User can post in the stream, so the "Message X" button is not disabled now.
+    override_rewire(stream_data, "can_post_messages_in_stream", () => true);
+    compose_closed_ui.update_buttons_for_stream_views();
+    assert.ok(!reply_disabled);
+});
+
 test_ui("DM policy disabled", ({override, override_rewire}) => {
     // Disable dms in the organisation
     override(realm, "realm_direct_message_permission_group", nobody.id);

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -139,6 +139,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "clear_textarea", noop);
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
     let compose_defaults;
@@ -275,6 +276,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "clear_textarea", noop);
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     override_private_message_recipient({override});
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
@@ -330,6 +332,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "clear_textarea", noop);
     override_private_message_recipient({override});
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
     const denmark = {


### PR DESCRIPTION
Disables "Message X" and "Start new conversation" button in compose closed UI when a user is not allowed to send messages in a stream.

Fixes #28410.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details><summary>Screenshots</summary>
<p>

![Screenshot 2024-07-23 170422](https://github.com/user-attachments/assets/0b3dd973-2879-4a4e-b712-6d6562c13ca2)

![Screenshot 2024-07-23 170436](https://github.com/user-attachments/assets/1a365474-5562-4068-af93-998910327fef)


</p>
</details> 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
