### PR TITLE
message_row: Add ellipsis to edited notices below avatar.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -362,6 +362,8 @@
             vertical-align: baseline;
             /* A bit of margin here helps these not look associated with the name. */
             margin-left: 4px;
+            /* Unset the padding used on edited notices under the avatar. */
+            padding-right: 0;
         }
 
         .message_sender {
@@ -656,6 +658,8 @@ of the base style defined for a read-only textarea in dark mode. */
     white-space: nowrap;
     overflow-x: hidden;
     overflow-x: clip;
+    text-overflow: ellipsis;
+    padding-right: 5.5px;
 }
 
 .fade-in-message {


### PR DESCRIPTION
This PR modestly improves i18n on edited/moved notices (both in Compact mode and at 16/140) while alternative solutions, including icons, are discussed on CZO.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20.22Edited.22.20marker.20internationalization/near/1899489)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![edited-before](https://github.com/user-attachments/assets/632dff81-5538-49e8-bd00-17954e898e07) | ![edited-after](https://github.com/user-attachments/assets/bd6e4bb0-60f7-400f-af13-b07ce5060094) |
| ![edited-compact-before](https://github.com/user-attachments/assets/d64d1317-3980-4c57-94e6-c635f17549f2) | ![edited-compact-after](https://github.com/user-attachments/assets/613d1d04-4e7b-4dbd-b942-2fbc363597da) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>