### PR TITLE
invite_modal: Simplify Administrator, Owner role labels.

### DIFF
--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -61,10 +61,10 @@
             <option name="invite_as" selected="selected" value="{{ invite_as_options.member.code }}">{{t "Members" }}</option>
             {{#if is_admin}}
             <option name="invite_as" value="{{ invite_as_options.moderator.code }}">{{t "Moderators" }}</option>
-            <option name="invite_as" value="{{ invite_as_options.admin.code }}">{{t "Organization administrators" }}</option>
+            <option name="invite_as" value="{{ invite_as_options.admin.code }}">{{t "Administrators" }}</option>
             {{/if}}
             {{#if is_owner}}
-            <option name="invite_as" value="{{ invite_as_options.owner.code }}">{{t "Organization owners" }}</option>
+            <option name="invite_as" value="{{ invite_as_options.owner.code }}">{{t "Owners" }}</option>
             {{/if}}
         </select>
     </div>


### PR DESCRIPTION
This PR removes the "organization" qualifier in front of administrator and owner roles in the invite modal.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/role.20names.20in.20invite.20modal/near/1900317)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>