### PR TITLE
user_card_popover: Use `oklch` color space in `color-mix`, use static color values for PostCSS compilation and improve text items contrast.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -699,16 +699,16 @@
     --color-tab-picker-icon: hsl(200deg 100% 40%);
     --color-user-circle-active: hsl(106deg 74% 44%);
     --color-user-circle-idle: hsl(29deg 84% 51%);
-    --color-copy-btn: color-mix(in srgb, var(--grey-600) 70%, transparent);
+    --color-copy-btn: color-mix(in oklch, var(--grey-600) 70%, transparent);
     --color-copy-btn-hover: var(--green-600);
     --color-copy-btn-bg-hover: color-mix(
-        in srgb,
+        in oklch,
         var(--green-600) 8%,
         transparent
     );
     --color-copy-btn-active: var(--green-500);
     --color-copy-btn-bg-active: color-mix(
-        in srgb,
+        in oklch,
         var(--green-500) 12%,
         transparent
     );
@@ -1096,16 +1096,16 @@
         --color-left-sidebar-navigation-icon
     );
     --color-tab-picker-icon: hsl(0deg 0% 80%);
-    --color-copy-btn: color-mix(in srgb, var(--grey-300) 70%, transparent);
+    --color-copy-btn: color-mix(in oklch, var(--grey-300) 70%, transparent);
     --color-copy-btn-hover: var(--green-300);
     --color-copy-btn-bg-hover: color-mix(
-        in srgb,
+        in oklch,
         var(--green-600) 8%,
         transparent
     );
     --color-copy-btn-active: var(--green-300);
     --color-copy-btn-bg-active: color-mix(
-        in srgb,
+        in oklch,
         var(--green-400) 17%,
         transparent
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -699,17 +699,26 @@
     --color-tab-picker-icon: hsl(200deg 100% 40%);
     --color-user-circle-active: hsl(106deg 74% 44%);
     --color-user-circle-idle: hsl(29deg 84% 51%);
-    --color-copy-btn: color-mix(in oklch, var(--grey-600) 70%, transparent);
+    /* hsl(229deg 9% 36%) corresponds to --grey-600.
+       We use the hsl() equivalent directly since postcss-color-mix-function
+       cannot dynamically resolve var() arguments. */
+    --color-copy-btn: color-mix(in oklch, hsl(229deg 9% 36%) 70%, transparent);
     --color-copy-btn-hover: var(--green-600);
+    /* hsl(144deg 84% 22%) corresponds to --green-600.
+       We use the hsl() equivalent directly since postcss-color-mix-function
+       cannot dynamically resolve var() arguments. */
     --color-copy-btn-bg-hover: color-mix(
         in oklch,
-        var(--green-600) 8%,
+        hsl(144deg 84% 22%) 8%,
         transparent
     );
     --color-copy-btn-active: var(--green-500);
+    /* hsl(146deg 90% 27%) corresponds to --green-500.
+       We use the hsl() equivalent directly since postcss-color-mix-function
+       cannot dynamically resolve var() arguments. */
     --color-copy-btn-bg-active: color-mix(
         in oklch,
-        var(--green-500) 12%,
+        hsl(146deg 90% 27%) 12%,
         transparent
     );
 
@@ -1096,17 +1105,26 @@
         --color-left-sidebar-navigation-icon
     );
     --color-tab-picker-icon: hsl(0deg 0% 80%);
-    --color-copy-btn: color-mix(in oklch, var(--grey-300) 70%, transparent);
+    /* hsl(229deg 9% 65%) corresponds to --grey-350.
+       We use the hsl() equivalent directly since postcss-color-mix-function
+       cannot dynamically resolve var() arguments. */
+    --color-copy-btn: color-mix(in oklch, hsl(229deg 9% 65%) 70%, transparent);
     --color-copy-btn-hover: var(--green-300);
+    /* hsl(144deg 84% 22%) corresponds to --green-600.
+       We use the hsl() equivalent directly since postcss-color-mix-function
+       cannot dynamically resolve var() arguments. */
     --color-copy-btn-bg-hover: color-mix(
         in oklch,
-        var(--green-600) 8%,
+        hsl(144deg 84% 22%) 8%,
         transparent
     );
     --color-copy-btn-active: var(--green-300);
+    /* hsl(139deg 54% 40%) corresponds to --green-400.
+       We use the hsl() equivalent directly since postcss-color-mix-function
+       cannot dynamically resolve var() arguments. */
     --color-copy-btn-bg-active: color-mix(
         in oklch,
-        var(--green-400) 17%,
+        hsl(139deg 54% 40%) 17%,
         transparent
     );
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -654,6 +654,7 @@
     --color-text-personal-menu-some-status: hsl(0deg 0% 40%);
     --color-text-sidebar-heading: hsl(0deg 0% 43%);
     --color-text-sidebar-popover-menu: hsl(0deg 0% 20%);
+    --color-text-user-card-secondary: var(--grey-550);
     --color-text-url: hsl(200deg 100% 40%);
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
@@ -1056,6 +1057,7 @@
     --color-text-personal-menu-no-status: hsl(0deg 0% 100% 35%);
     --color-text-personal-menu-some-status: hsl(0deg 0% 100% 50%);
     --color-text-sidebar-popover-menu: hsl(236deg 33% 90%);
+    --color-text-user-card-secondary: var(--grey-400);
     /* 75% opacity of --color-text-default against --color-background.
        We use color-mix here to avoid defining a separate, compounding
        `opacity` property, and also to preserve a record of the

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -130,6 +130,8 @@
 }
 
 .user-card-popover-actions {
+    --color-text-item: var(--color-text-user-card-secondary);
+
     .custom-profile-field-value {
         display: flex;
         align-items: center;


### PR DESCRIPTION
This PR updates the Zulip color palette by using the oklch color space in color-mix() functions and replacing var() color arguments with static hsl() values for better compatibility and browser support. Additionally, it improves the contrast of text items in the user card popover, enhancing readability and accessibility of user-related information.

Fixes: Part of #31027.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2024-07-24 at 3 03 53 AM](https://github.com/user-attachments/assets/4a814f7a-1371-48f3-be1e-23632d3b42e4) | ![Screenshot 2024-07-24 at 3 03 05 AM](https://github.com/user-attachments/assets/b67eb7c6-285d-4af4-bb9e-f1c1b4f1ae39) |
| ![Screenshot 2024-07-24 at 3 03 48 AM](https://github.com/user-attachments/assets/e074c525-e83a-48e6-9763-d2a655ac08ee) | ![Screenshot 2024-07-24 at 3 03 24 AM](https://github.com/user-attachments/assets/059e1496-100f-4b50-a723-972c2a7263f8) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
