### PR TITLE
search_box: Correct search box height.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -179,14 +179,20 @@
 
     /*
     Height of the search box, which appears in the header.
-    On very short screens, the search box's height becomes
-    the height of its parent (i.e. the header height).
     */
-    --search-box-height: 28px;
+    --search-box-height: 32px;
     --search-box-width: 150px;
 
     @media (width < $md_min) {
         --search-box-width: 40px;
+    }
+
+    /*
+        On very short screens, the search box's height becomes
+        is reduced to fit the available space.
+    */
+    @media (height < $short_navbar_cutoff_height) {
+        --search-box-height: 28px;
     }
 
     /*

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -40,8 +40,6 @@
         opacity: 0.5;
         line-height: 0;
         border-radius: 4px;
-        /* Leave room for the focus outline. */
-        margin-right: 1px;
 
         &:not(:focus-visible) {
             outline: none;

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -212,12 +212,8 @@
             background-color: var(--color-background-search);
             /* Maintain only a column gap. */
             gap: 0 5px;
-
-            @media (height < $short_navbar_cutoff_height) {
-                /* Lose the luxury of padding in short navbar settings. */
-                padding-top: 0;
-                padding-bottom: 0;
-            }
+            /* Override padding. */
+            padding: 0;
         }
 
         .pill {


### PR DESCRIPTION
This PR fixes some subtle but unmistakably annoying shifts in the height of the search bar. It does this by 1) correcting the variable referencing the height of the pill-container search box, and 2) overriding padding inherited from the pill container class, which becomes unnecessary when the search box has a correct height set. Adjustments are present for the height on short screens, too.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20inconsistent.20search.20box.20height/near/1900406)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![search-box-before](https://github.com/user-attachments/assets/a418304f-51ce-4d1c-aa1f-f61f2ad579f6) | ![search-box-after](https://github.com/user-attachments/assets/588a810d-5a48-4a69-bdbf-252e5f23e814) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>