### PR TITLE
Display Placeholder for Groups with No Members in the Group Card

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -317,6 +317,13 @@ ul.popover-group-menu-member-list {
     }
 }
 
+ul.popover-group-menu-member-list:not(:has(li))::after {
+    content: "No members in the group" !important;
+    color: gray;
+    padding-left: 10px;
+    font-style: italic;
+}
+
 .popover-group-menu-member {
     display: flex;
     align-items: center;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -319,7 +319,7 @@ ul.popover-group-menu-member-list {
 
 ul.popover-group-menu-member-list:not(:has(li))::after {
     content: "No members in the group" !important;
-    color: gray;
+    color: var(--color-text-search-placeholder);
     padding-left: 10px;
     font-style: italic;
 }


### PR DESCRIPTION
# Description
- Added a placeholder message "No members in the group" for groups without members.
- Applied italicized formatting and left-aligned the text.

# Changes Made
- Placeholder message for empty groups.
- Italicized and left-aligned text.

# Screenshots
## Before
![image](https://github.com/user-attachments/assets/0698acac-cc68-46f7-bcf1-c68cc7ee87cc)

## After
![image](https://github.com/user-attachments/assets/39cdabdb-c728-42ad-a3af-e7be922059e3)

# Checks
- [x] Verified that the placeholder appears only when it is supposed to appear.
- [x] Verified that proper variables are used instead of hardcoded colors.

# Issue Reference
Addresses [Issue #30830](https://github.com/zulip/zulip/issues/30830)