### PR TITLE
user_card_popover: Focus on menu options first when key is pressed on a user card opened via mouse.

### DIFF
--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -89,7 +89,7 @@ class PopoverMenu {
             return;
         }
 
-        const $items = $("li:not(.divider):visible a:visible", $popover);
+        const $items = $("[tabindex='0']", $popover).filter(":visible");
 
         popover_items_handle_keyboard_with_overrides(key, $items);
     }
@@ -100,15 +100,21 @@ export const message_user_card = new PopoverMenu();
 export const user_card = new PopoverMenu();
 
 function popover_items_handle_keyboard_with_overrides(key, $items) {
-    /* Variant of popover_items_handle_keyboard */
+    /* Variant of popover_items_handle_keyboard for focusing on the
+       user card popover menu options first, instead of other tabbable
+       buttons and links which can be distracting. */
+
     if (!$items) {
         return;
     }
 
     const index = $items.index($items.filter(":focus"));
 
-    if (key === "enter" && index >= 0 && index < $items.length) {
-        $items[index].click();
+    if (index === -1) {
+        const first_menu_option_index = $items.index(
+            $items.filter(".link-item .popover-menu-link"),
+        );
+        $items.eq(first_menu_option_index).trigger("focus");
         return;
     }
 


### PR DESCRIPTION
As a follow-up to the previous commit f124ef931, which deals with the keyboard focus when opened via the keyboard shortcut `U`, this commit ensures that when the user card is opened via the mouse, and the first navigational key is pressed, the focus is on the first menu option instead of the other tabbable elements which can be distracting.

Fixes: https://github.com/zulip/zulip/pull/31047#issuecomment-2245742391 and [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.8E.AF.20keyboard.20focus.20when.20opening.20user.20card/near/1900196)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Other user's user card popover
![other-user-key-focus](https://github.com/user-attachments/assets/4bd0626d-cfed-424f-b1d2-5a226334543d)

### Self user card popover
![own-user-key-focus](https://github.com/user-attachments/assets/40b053de-5ad6-4a28-9c3e-cb479a323351)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
