### PR TITLE
thumbnail: Prefer 840x560 thumbnails for web app.

### DIFF
--- a/web/src/thumbnail.ts
+++ b/web/src/thumbnail.ts
@@ -16,7 +16,7 @@ export function initialize(): void {
     const format_preferences = ["webp", "jpg", "gif"];
     const sorted_formats = realm.server_thumbnail_formats.sort((a, b) => {
         if (a.max_width !== b.max_width) {
-            return Math.abs(a.max_width - 300) < Math.abs(b.max_width - 300) ? -1 : 1;
+            return Math.abs(a.max_width - 840) < Math.abs(b.max_width - 840) ? -1 : 1;
         } else if (a.format !== b.format) {
             let a_index = format_preferences.indexOf(a.format);
             if (a_index === -1) {


### PR DESCRIPTION
While this has no real effect in the message feed itself, it makes the transition in the lightbox a lot nicer.
