### PR TITLE
User card and user group card popover should work in all rendered messages

### DIFF
--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -13,6 +13,7 @@ import * as overlays from "./overlays";
 import * as people from "./people";
 import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
+import * as user_card_popover from "./user_card_popover";
 
 function restore_draft(draft_id) {
     const draft = drafts.draft_model.getDraft(draft_id);
@@ -190,6 +191,10 @@ export function launch() {
             const $draft_row = $(this).closest(".overlay-message-row");
             const draft_id = $draft_row.attr("data-draft-id");
             restore_draft(draft_id);
+        });
+
+        $("#drafts_table .restore-overlay-message").on("click", ".user-mention", (e) => {
+            user_card_popover.unsaved_message_user_mention_event_handler(e);
         });
 
         $("#drafts_table .overlay_message_controls .delete-overlay-message").on(

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -14,6 +14,7 @@ import * as people from "./people";
 import * as rendered_markdown from "./rendered_markdown";
 import * as stream_data from "./stream_data";
 import * as user_card_popover from "./user_card_popover";
+import * as user_group_popover from "./user_group_popover";
 
 function restore_draft(draft_id) {
     const draft = drafts.draft_model.getDraft(draft_id);
@@ -195,6 +196,11 @@ export function launch() {
 
         $("#drafts_table .restore-overlay-message").on("click", ".user-mention", (e) => {
             user_card_popover.unsaved_message_user_mention_event_handler(e);
+        });
+
+        $("#drafts_table .restore-overlay-message").on("click", ".user-group-mention", (e) => {
+            user_group_popover.toggle_user_group_info_popover(e.currentTarget, undefined);
+            e.stopPropagation();
         });
 
         $("#drafts_table .overlay_message_controls .delete-overlay-message").on(

--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -200,13 +200,13 @@ function parse_with_options(
                 let classes;
                 let display_text;
                 if (silently) {
-                    classes = "user-mention silent";
+                    classes = "user-mention channel-wildcard-mention silent";
                     display_text = mention;
                 } else {
                     // Stream Wildcard mention
                     mentioned_stream_wildcard = true;
                     display_text = "@" + mention;
-                    classes = "user-mention";
+                    classes = "user-mention channel-wildcard-mention";
                 }
 
                 return `<span class="${classes}" data-user-id="*">${_.escape(display_text)}</span>`;
@@ -334,8 +334,8 @@ function parse_with_options(
         silencedMentionHandler(quote: string): string {
             // Silence quoted personal and stream wildcard mentions.
             quote = quote.replaceAll(
-                /(<span class="user-mention)(" data-user-id="(\d+|\*)">)@/g,
-                "$1 silent$2",
+                /(<span class="user-mention( channel-wildcard-mention)?)(" data-user-id="(\d+|\*)">)@/g,
+                "$1 silent$3",
             );
 
             // Silence quoted topic wildcard mentions.

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -411,23 +411,14 @@ function load_medium_avatar(user, $elt) {
 
 // Functions related to message user card popover.
 
-// element is the target element to pop off of
-// user is the user whose profile to show
-// message is the message containing it, which should be selected
-function toggle_user_card_popover_for_message(element, user, message, on_mount) {
+// element is the target element to pop off of.
+// user is the user whose profile to show.
+// sender_id is the user id of the sender for the message we are
+// showing the popover from.
+function toggle_user_card_popover_for_message(element, user, sender_id, on_mount) {
     const $elt = $(element);
 
-    if (user === undefined) {
-        // This is never supposed to happen, not even for deactivated
-        // users, so we'll need to debug this error if it occurs.
-        blueslip.error("Bad sender in message", {
-            message_id: message.id,
-            sender_id: message.sender_id,
-        });
-        return;
-    }
-
-    const is_sender_popover = message.sender_id === user.user_id;
+    const is_sender_popover = sender_id === user.user_id;
     show_user_card_popover(
         user,
         $elt,
@@ -462,7 +453,7 @@ export function toggle_sender_info() {
     assert(message_lists.current !== undefined);
     const message = message_lists.current.get(rows.id($message));
     const user = people.get_by_user_id(message.sender_id);
-    toggle_user_card_popover_for_message($sender[0], user, message, () => {
+    toggle_user_card_popover_for_message($sender[0], user, message.sender_id, () => {
         if (!page_params.is_spectator) {
             focus_user_card_popover_item();
         }
@@ -534,7 +525,7 @@ function register_click_handlers() {
         assert(message_lists.current !== undefined);
         const message = message_lists.current.get(rows.id($row));
         const user = people.get_by_user_id(message.sender_id);
-        toggle_user_card_popover_for_message(this, user, message);
+        toggle_user_card_popover_for_message(this, user, message.sender_id);
     });
 
     $("#main_div").on("click", ".user-mention", function (e) {
@@ -565,7 +556,7 @@ function register_click_handlers() {
                 return;
             }
         }
-        toggle_user_card_popover_for_message(this, user, message);
+        toggle_user_card_popover_for_message(this, user, message.sender_id);
     });
 
     $("body").on("click", ".user-card-popover-actions .narrow_to_private_messages", (e) => {

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -580,6 +580,10 @@ function register_click_handlers() {
         toggle_user_card_popover_for_message(this, user, message.sender_id, true);
     });
 
+    // Note: Message feeds and drafts have their own direct event listeners
+    // that run before this one and call stopPropagation.
+    $("body").on("click", ".messagebox .user-mention", unsaved_message_user_mention_event_handler);
+
     $("body").on("click", ".user-card-popover-actions .narrow_to_private_messages", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const email = people.get_by_user_id(user_id).email;

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -416,29 +416,28 @@ function load_medium_avatar(user, $elt) {
 // message is the message containing it, which should be selected
 function toggle_user_card_popover_for_message(element, user, message, on_mount) {
     const $elt = $(element);
-    if (!message_user_card.is_open()) {
-        if (user === undefined) {
-            // This is never supposed to happen, not even for deactivated
-            // users, so we'll need to debug this error if it occurs.
-            blueslip.error("Bad sender in message", {
-                message_id: message.id,
-                sender_id: message.sender_id,
-            });
-            return;
-        }
 
-        const is_sender_popover = message.sender_id === user.user_id;
-        show_user_card_popover(
-            user,
-            $elt,
-            is_sender_popover,
-            true,
-            "respond_personal_button",
-            "message_user_card",
-            "right",
-            on_mount,
-        );
+    if (user === undefined) {
+        // This is never supposed to happen, not even for deactivated
+        // users, so we'll need to debug this error if it occurs.
+        blueslip.error("Bad sender in message", {
+            message_id: message.id,
+            sender_id: message.sender_id,
+        });
+        return;
     }
+
+    const is_sender_popover = message.sender_id === user.user_id;
+    show_user_card_popover(
+        user,
+        $elt,
+        is_sender_popover,
+        true,
+        "respond_personal_button",
+        "message_user_card",
+        "right",
+        on_mount,
+    );
 }
 
 // This function serves as the entry point for toggling

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -143,6 +143,13 @@ export function register_click_handlers(): void {
             toggle_user_group_info_popover(this, undefined);
         },
     );
+
+    // Note: Message feeds and drafts have their own direct event listeners
+    // that run before this one and call stopPropagation.
+    $("body").on("click", ".messagebox .user-group-mention", function (this: HTMLElement, e) {
+        e.stopPropagation();
+        toggle_user_group_info_popover(this, undefined);
+    });
 }
 
 function fetch_group_members(member_ids: number[]): PopoverGroupMember[] {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -173,9 +173,6 @@
     }
 
     .user-mention {
-        /* We have to explicitly mention this for compose box preview
-           where cursor is set to not-allowed */
-        cursor: pointer;
         color: var(--color-text-other-mention);
         background-color: var(--color-background-text-direct-mention);
 
@@ -187,6 +184,13 @@
         &:hover {
             background-color: var(--color-background-text-hover-direct-mention);
         }
+    }
+
+    .user-mention,
+    .user-group-mention {
+        /* We have to explicitly mention this for compose box preview
+           where cursor is set to not-allowed */
+        cursor: pointer;
     }
 
     /* We show the same cursor as the parent element for `@all`

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -173,6 +173,9 @@
     }
 
     .user-mention {
+        /* We have to explicitly mention this for compose box preview
+           where cursor is set to not-allowed */
+        cursor: pointer;
         color: var(--color-text-other-mention);
         background-color: var(--color-background-text-direct-mention);
 
@@ -184,6 +187,12 @@
         &:hover {
             background-color: var(--color-background-text-hover-direct-mention);
         }
+    }
+
+    /* We show the same cursor as the parent element for `@all`
+       mention */
+    .user-mention-all {
+        cursor: inherit;
     }
 
     .user-mention[data-user-id="*"],

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -441,17 +441,17 @@ test("marked", () => {
         {
             input: "Stream Wildcard mention: @**all**\nStream Wildcard silent mention: @_**all**",
             expected:
-                '<p>Stream Wildcard mention: <span class="user-mention" data-user-id="*">@all</span><br>\nStream Wildcard silent mention: <span class="user-mention silent" data-user-id="*">all</span></p>',
+                '<p>Stream Wildcard mention: <span class="user-mention channel-wildcard-mention" data-user-id="*">@all</span><br>\nStream Wildcard silent mention: <span class="user-mention channel-wildcard-mention silent" data-user-id="*">all</span></p>',
         },
         {
             input: "> Stream Wildcard mention in quote: @**all**\n\n> Another stream wildcard mention in quote: @_**all**",
             expected:
-                '<blockquote>\n<p>Stream Wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another stream wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
+                '<blockquote>\n<p>Stream Wildcard mention in quote: <span class="user-mention channel-wildcard-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another stream wildcard mention in quote: <span class="user-mention channel-wildcard-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
         },
         {
             input: "```quote\nStream Wildcard mention in quote: @**all**\n```\n\n```quote\nAnother stream wildcard mention in quote: @_**all**\n```",
             expected:
-                '<blockquote>\n<p>Stream Wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another stream wildcard mention in quote: <span class="user-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
+                '<blockquote>\n<p>Stream Wildcard mention in quote: <span class="user-mention channel-wildcard-mention silent" data-user-id="*">all</span></p>\n</blockquote>\n<blockquote>\n<p>Another stream wildcard mention in quote: <span class="user-mention channel-wildcard-mention silent" data-user-id="*">all</span></p>\n</blockquote>',
         },
         {
             input: "Topic Wildcard mention: @**topic**\nTopic Wildcard silent mention: @_**topic**",

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1928,6 +1928,8 @@ class UserMentionPattern(CompiledInlineProcessor):
             text = f"@{name}"
             if topic_wildcard:
                 el.set("class", "topic-mention")
+            elif stream_wildcard:
+                el.set("class", "user-mention channel-wildcard-mention")
             else:
                 el.set("class", "user-mention")
             if silent:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -2140,7 +2140,7 @@ class MarkdownMentionTest(ZulipTestCase):
             rendering_result = render_message_markdown(msg, content)
             self.assertEqual(
                 rendering_result.rendered_content,
-                f'<p><span class="user-mention" data-user-id="*">@{stream_wildcard}</span> test</p>',
+                f'<p><span class="user-mention channel-wildcard-mention" data-user-id="*">@{stream_wildcard}</span> test</p>',
             )
             self.assertFalse(rendering_result.mentions_topic_wildcard)
             self.assertTrue(rendering_result.mentions_stream_wildcard)
@@ -2363,7 +2363,7 @@ class MarkdownMentionTest(ZulipTestCase):
             rendering_result = render_message_markdown(msg, content)
             self.assertEqual(
                 rendering_result.rendered_content,
-                f'<p><span class="user-mention silent" data-user-id="*">{wildcard}</span></p>',
+                f'<p><span class="user-mention channel-wildcard-mention silent" data-user-id="*">{wildcard}</span></p>',
             )
             self.assertFalse(rendering_result.mentions_stream_wildcard)
 
@@ -2566,7 +2566,7 @@ class MarkdownMentionTest(ZulipTestCase):
         def assert_silent_mention(content: str, wildcard: str) -> None:
             expected = (
                 "<blockquote>\n<p>"
-                f'<span class="user-mention silent" data-user-id="*">{wildcard}</span>'
+                f'<span class="user-mention channel-wildcard-mention silent" data-user-id="*">{wildcard}</span>'
                 "</p>\n</blockquote>"
             )
             rendering_result = render_message_markdown(message, content)


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes #31102.

TO CHECK: The default placement for the user group popover is right and it opens in the right everywhere except compose box preview. It's somehow running out of space and opening on top as its fallback placement. Not sure if we wanna look into this more or not.

For compose box preview, a `pointer` cursor will show up for `@all` and `@topic` when the default cursor for that area is `not-allowed` (cursor with a ban icon on it). This was to ensure consistency with all types of mention. LMK if this needs to change.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| User card - compose preview - self | User card - compose preview - other user | User Group - compose preview | 
| -- | -- | -- |
| <img width="399" alt="user_mention_self_compose_box" src="https://github.com/user-attachments/assets/8e32cb2b-a7a3-4d7d-baac-5ecbf3dbd18c"> | <img width="399" alt="user_mention_other_compose_box" src="https://github.com/user-attachments/assets/50ed6f6e-44c9-445b-96e6-5b75858d147f"> | <img width="399" alt="user_group_compose_box" src="https://github.com/user-attachments/assets/550e56a3-8481-4c6e-86fc-c4afa6a873fb"> |


| User card - edit preview - self | User card - edit preview - other user | User group - edit preview |
| -- | -- | -- |
| <img width="399" alt="user_mention_self_message_edit" src="https://github.com/user-attachments/assets/f1a55c8a-53fa-4a54-8637-0c91ce3a7af9"> | <img width="399" alt="user_mention_other_message_edit" src="https://github.com/user-attachments/assets/04bb8f60-95af-4c6c-8551-9d1b57f742af"> | <img width="399" alt="user_group_message_edit" src="https://github.com/user-attachments/assets/88dbedc1-e0fa-48cc-a982-75887d34c73b"> |

| User card - edit history - self | User card - edit history - other user | User group - edit history |
| -- | -- | -- |
| <img width="399" alt="user_mention_self_edit_history" src="https://github.com/user-attachments/assets/f5c3d84a-516a-47a7-824f-529989813b92"> | <img width="399" alt="user_mention_other_edit_history" src="https://github.com/user-attachments/assets/c6607b96-f09d-4121-b2a0-e701d6888db5"> | <img width="399" alt="user_group_edit_history" src="https://github.com/user-attachments/assets/4ac1560a-e917-44c5-8f1a-dcae0762d738"> |

| User card - scheduled messages - self | User card -  scheduled messages - other user | User group -  scheduled messages  |
| -- | -- | -- |
| <img width="399" alt="user_mention_self_scheduled_messages" src="https://github.com/user-attachments/assets/7d320b62-fafb-4b71-ad8e-36ddd5008c85"> | <img width="399" alt="user_mention_other_scheduled_messages" src="https://github.com/user-attachments/assets/ec5fc4cb-ad74-468f-bfb2-6aada62aa6fe"> | <img width="399" alt="user_group_scheduled messages" src="https://github.com/user-attachments/assets/fd4faec3-1d87-4fc0-b996-51465e7e60ce"> |

| User card - drafts - self | User card -  drafts - other user | User group -  drafts  |
| -- | -- | -- |
| <img width="399" alt="user_mention_self_drafts" src="https://github.com/user-attachments/assets/bcd46da0-fc9f-4fd5-9b06-99b9c6380038"> | <img width="399" alt="user_group_drafts" src="https://github.com/user-attachments/assets/4a1b44cb-f962-49dc-aafa-9b233149d2c0"> | <img width="399" alt="user_mention_other_drafts" src="https://github.com/user-attachments/assets/f5d6a6ae-95b2-44b8-b19e-64cc1700f6c4"> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
