### PR TITLE
search operators: Add is-muted search operator.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 324**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added a new [search/narrow filter](/api/construct-narrow),
+  `is:muted`, matching messages in topics and channels that the user
+  has [muted](/help/mute-a-topic).
+
 **Feature level 323**
 
 * [`POST /register`](/api/register-queue), [`GET

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -53,6 +53,10 @@ messages](/api/update-message-flags-for-narrow)).
 
 ## Changes
 
+* In Zulip 9.0 (feature level 324), support was added for a
+  new `is:muted` matching messages in topics and channels that the user
+  has [muted](/help/mute-a-topic).
+
 * In Zulip 9.0 (feature level 271), support was added for a new filter
   operator, `with`, which uses a [message ID](#message-ids) for its
   operand, and is designed for creating permanent links to topics.

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -118,6 +118,8 @@ Zulip offers the following filters based on the location of the message.
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
 * `is:unread`: Search your unread messages.
 * `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
+* `is:muted`: Search messages in [muted topics](/help/mute-a-topic) or
+  [muted channels](/help/mute-a-channel).
 
 ### Search by message ID
 

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -252,6 +252,9 @@ export class MessageListData {
     }
 
     unmuted_messages(messages: Message[]): Message[] {
+        if (this.filter.can_show_muted_topics()) {
+            return messages;
+        }
         return this.messages_filtered_for_topic_mutes(
             this.messages_filtered_for_user_mutes(messages),
         );

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -710,6 +710,15 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
                 {operator: "dm-including"},
             ],
         },
+        {
+            search_string: "is:muted",
+            description_html: "muted messages",
+            is_people: false,
+            incompatible_patterns: [
+                {operator: "is", operand: "muted"},
+                {operator: "in", operand: "home"},
+            ],
+        },
     ];
     const special_filtered_suggestions = get_special_filter_suggestions(last, terms, suggestions);
     // Suggest "is:dm" to anyone with "is:private" in their muscle memory

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -46,6 +46,10 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}followed topics
             {{~!-- squash whitespace --~}}
+        {{else if (eq this.operand "muted")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}messages in muted streams/topics
+            {{~!-- squash whitespace --~}}
         {{else}}
             {{~!-- squash whitespace --~}}
             invalid {{this.operand}} operand for is operator

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -146,6 +146,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">is:muted</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages in muted topics or channels.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">near:<span class="operator_value">id</span></td>
                         <td class="definition">
                             {{#tr}}

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -377,6 +377,7 @@ test("empty_query_suggestions", () => {
         "is:alerted",
         "is:unread",
         "is:resolved",
+        "is:muted",
         "sender:myself@zulip.com",
         `channel:${devel_id}`,
         `channel:${office_id}`,
@@ -480,6 +481,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:alerted",
         "is:unread",
         "is:resolved",
+        "is:muted",
         "dm:alice@zulip.com",
         "sender:alice@zulip.com",
         "dm-including:alice@zulip.com",
@@ -498,6 +500,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
     assert.equal(describe("is:followed"), "Followed topics");
+    assert.equal(describe("is:muted"), "Muted messages");
 
     query = "-i";
     suggestions = get_suggestions(query);
@@ -510,6 +513,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "-is:alerted",
         "-is:unread",
         "-is:resolved",
+        "-is:muted",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -520,6 +524,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Exclude topics marked as resolved");
     assert.equal(describe("-is:followed"), "Exclude followed topics");
+    assert.equal(describe("-is:muted"), "Exclude muted messages");
 
     // operand suggestions follow.
 
@@ -533,6 +538,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:alerted",
         "is:unread",
         "is:resolved",
+        "is:muted",
     ];
     assert.deepEqual(suggestions.strings, expected);
 

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -425,6 +425,9 @@ class NarrowBuilder:
         elif operand == "followed":
             cond = get_followed_topic_condition_sa(self.user_profile.id)
             return query.where(maybe_negate(cond))
+        elif operand == "muted":
+            conditions = exclude_muting_conditions(self.user_profile, self.channel_data)
+            return query.where(maybe_negate(not_(and_(*conditions))))
         raise BadNarrowOperatorError("unknown 'is' operand " + operand)
 
     _alphanum = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")


### PR DESCRIPTION
Add the `is:muted` search operator.
`-is:muted` is an alias for the `in:home` operator.

Fix the existing logic for excluding muted messages.
Existing logic does not take into account followed topics and
unmuted topics in muted channels.

Existing logic did not work when including messages,
it only worked for excluding messages. For the `is:muted` operator,
we need to include messages that are muted.

Add tests for the different cases of the `is:muted` operator.


Fixes: #16943

<details>
<summary> <h2>Explain Analyze</h2></summary>

### The most complicated query is the regular `is:muted` operator (without channel narrow) query.

```
(SELECT message_id, flags
FROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id
WHERE user_profile_id = 72 AND NOT (((recipient_id NOT IN (165)) OR recipient_id = 165 AND upper(subject) = upper('bridge')) AND NOT (recipient_id = 157 AND upper(subject) = upper('little WEB APP was compiling quickly'))) ORDER BY message_id DESC);
````
#### Note: `recipient_id NOT IN (165)` will have all the muted channels ids, `recipient_id = 165 AND upper(subject) = upper('bridge')` will exist for all followed topics and similarly in the `NOT` part of the query it will exist for all muted topics.
These channel ids and topic data is fetched separately using Django's ORM (just as it was being fetched before). Not sure how that impacts the overall performance of the query.

### Explain Analyze
```
                                                                                                              QUERY PLAN

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=1095.31..1095.67 rows=144 width=12) (actual time=2.213..2.227 rows=324 loops=1)
   Sort Key: zerver_usermessage.message_id DESC
   Sort Method: quicksort  Memory: 40kB
   ->  Hash Join  (cost=616.83..1090.15 rows=144 width=12) (actual time=0.922..2.156 rows=324 loops=1)
         Hash Cond: (zerver_usermessage.message_id = zerver_message.id)
         ->  Bitmap Heap Scan on zerver_usermessage  (cost=42.99..508.60 rows=2929 width=12) (actual time=0.096..1.117 rows=2908 loops=1)
               Recheck Cond: (user_profile_id = 72)
               Heap Blocks: exact=203
               ->  Bitmap Index Scan on zerver_usermessage_user_profile_id_e901f3b7  (cost=0.00..42.26 rows=2929 width=0) (actual time=0.072..0.073 rows=2908 loops=1)
                     Index Cond: (user_profile_id = 72)
         ->  Hash  (cost=570.78..570.78 rows=245 width=4) (actual time=0.814..0.814 rows=324 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 20kB
               ->  Index Only Scan using zerver_message_realm_recipient_subject on zerver_message  (cost=0.28..570.78 rows=245 width=4) (actual time=0.213..0.773 rows=324 loops=1)
                     Filter: (((recipient_id = 165) AND ((recipient_id <> 165) OR (upper((subject)::text) <> 'BRIDGE'::text))) OR ((recipient_id = 157) AND (upper((subject)::text) = 'LITTLE WEB APP WAS COMPILING QUICKLY'::text)))
                     Rows Removed by Filter: 4676
                     Heap Fetches: 0
 Planning Time: 0.503 ms
 Execution Time: 2.407 ms
(18 rows)
```
### The less complicated query is the regular `is:muted channel:cname` operator query.

```
(SELECT message_id, flags
FROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id
WHERE user_profile_id = 72 AND NOT (recipient_id = 165 AND upper(subject) = upper('bridge')) AND recipient_id = 165 ORDER BY message_id DESC
)
```

### Explain Analyze

```
                                                                                     QUERY PLAN

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=974.42..974.78 rows=142 width=12) (actual time=1.536..1.548 rows=227 loops=1)
   Sort Key: zerver_usermessage.message_id DESC
   Sort Method: quicksort  Memory: 35kB
   ->  Hash Join  (cost=496.03..969.34 rows=142 width=12) (actual time=0.379..1.485 rows=227 loops=1)
         Hash Cond: (zerver_usermessage.message_id = zerver_message.id)
         ->  Bitmap Heap Scan on zerver_usermessage  (cost=42.99..508.60 rows=2929 width=12) (actual time=0.086..0.918 rows=2908 loops=1)
               Recheck Cond: (user_profile_id = 72)
               Heap Blocks: exact=203
               ->  Bitmap Index Scan on zerver_usermessage_user_profile_id_e901f3b7  (cost=0.00..42.26 rows=2929 width=0) (actual time=0.063..0.063 rows=2908 loops=1)
                     Index Cond: (user_profile_id = 72)
         ->  Hash  (cost=450.02..450.02 rows=242 width=4) (actual time=0.282..0.283 rows=227 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 16kB
               ->  Index Only Scan using zerver_message_realm_recipient_subject on zerver_message  (cost=0.28..450.02 rows=242 width=4) (actual time=0.081..0.255 rows=227 loops=1)
                     Index Cond: (recipient_id = 165)
                     Filter: ((recipient_id <> 165) OR (upper((subject)::text) <> 'BRIDGE'::text))
                     Rows Removed by Filter: 15
                     Heap Fetches: 0
 Planning Time: 0.515 ms
 Execution Time: 1.598 ms
(19 rows)
```

</details>
