### PR TITLE
css: Remove `*` selectors being used for CSS.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -719,7 +719,8 @@ div.overlay {
         transition: all 0.2s ease;
     }
 
-    * {
+    .zulip-icon,
+    .color-animated-button-text {
         padding: 6px 3px;
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -961,7 +961,8 @@
     .color_animated_button {
         background-color: hsl(211deg 29% 14%);
 
-        * {
+        .zulip-icon,
+        .color-animated-button-text {
             color: hsl(0deg 0% 100%);
         }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -44,7 +44,9 @@
         display: flex;
         align-items: center;
 
-        & > * {
+        .recent-view-table-link,
+        .recent-view-table-unread-count,
+        & > .zulip-icon {
             outline: 0;
         }
 

--- a/web/templates/login_to_view_image_button.hbs
+++ b/web/templates/login_to_view_image_button.hbs
@@ -1,6 +1,6 @@
 <div class="spectator_login_for_image_button">
     <a class="login_button color_animated_button" href="/login/">
         <i class='zulip-icon zulip-icon-log-in'></i>
-        <span>{{t "Log in to view image" }}</span>
+        <span class="color-animated-button-text">{{t "Log in to view image" }}</span>
     </a>
 </div>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -4,12 +4,12 @@
             <div class="left_part recent_view_focusable" data-col-index="{{ column_indexes.stream }}">
                 {{#if is_private}}
                 <span class="zulip-icon zulip-icon-user"></span>
-                <a href="{{pm_url}}">{{t "Direct messages" }}</a>
+                <a href="{{pm_url}}" class="recent-view-table-link">{{t "Direct messages" }}</a>
                 {{else}}
                 <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                     {{> stream_privacy }}
                 </span>
-                <a href="{{topic_url}}">{{stream_name}}</a>
+                <a href="{{topic_url}}" class="recent-view-table-link">{{stream_name}}</a>
                 {{/if}}
             </div>
             {{!-- For presence/group indicator --}}
@@ -32,16 +32,16 @@
         <div class="flex_container">
             <div class="left_part recent_view_focusable line_clamp" data-col-index="{{ column_indexes.topic }}">
                 {{#if is_private}}
-                <a href="{{pm_url}}">{{{rendered_pm_with}}}</a>
+                <a href="{{pm_url}}" class="recent-view-table-link">{{{rendered_pm_with}}}</a>
                 {{else}}
-                <a class="white-space-preserve-wrap" href="{{topic_url}}">{{topic}}</a>
+                <a class="white-space-preserve-wrap recent-view-table-link" href="{{topic_url}}">{{topic}}</a>
                 {{/if}}
             </div>
             <div class="right_part">
                 {{#if is_private}}
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable" data-col-index="{{ column_indexes.read }}">
-                        <span class="unread_count unread_count_pm {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                        <span class="unread_count unread_count_pm recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                     </div>
                 </div>
                 <div class="recent_topic_actions dummy_action_button">
@@ -55,7 +55,7 @@
                   data-tippy-content="{{t 'You have mentions'}}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable hidden-for-spectators" data-col-index="{{ column_indexes.read }}">
-                        <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                        <span class="unread_count recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                     </div>
                 </div>
                 <div class="recent_topic_actions">


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First two commits removes the use of `*` selector and uses class names instead of them.
- Last two commits removes the unnecessary CSS.

Fixes: <!-- Issue link, or clear description.--> Part of https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20performance

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
