### PR TITLE
lightbox: Set payload.source on srcset.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -268,11 +268,15 @@ function display_image(payload: Payload): void {
         $img.attr("src", payload.preview);
         $img.attr("width", payload.original_width_px);
         $img.attr("height", payload.original_height_px);
-        $img.one("load", () => {
-            $img.attr("src", payload.source);
-        });
+        // srcset contains the reference to the original image,
+        // and will be preferred over the src image when available
+        $img.attr("srcset", `${payload.source} ${payload.original_width_px}w`);
+        $img.attr("sizes", "100vw");
     } else {
-        $img.attr("src", payload.source);
+        // this could be just assigned to src, but srcset is used here
+        // for consistency
+        $img.attr("srcset", `${payload.source} ${payload.original_width_px}w`);
+        $img.attr("sizes", "100vw");
     }
     $img_container.empty();
     $img_container.append($img).show();


### PR DESCRIPTION
This eliminates a flash of the smaller/blurrier preview image when navigating to images that have already been loaded in full. This is done by putting the preferred/original image on `srcset`, instead of swapping out the value on `src`--which will almost always cause a flash of the blurry version, especially on large source images (where it would be most noticeable anyway).

In manual testing, this is *almost* perfect. Navigating very quickly amongst a large (6+) set of large images in the lightbox can still sometimes cause the flash of the smaller blurred object, but under sensibly paced navigation, the higher-resolution image 

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/thumbnail.20flicker.20in.20lightbox/near/1900839)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>