### PR TITLE
upload: Stop importing unused Uppy styles.

### DIFF
--- a/web/src/bundles/common.ts
+++ b/web/src/bundles/common.ts
@@ -15,5 +15,3 @@ import "../../styles/alerts.css";
 import "../../styles/modal.css";
 import "../../styles/progress_bar.css";
 import "../../styles/pygments.css";
-import "@uppy/core/dist/style.css";
-import "@uppy/progress-bar/dist/style.css";


### PR DESCRIPTION
I'm not aware of us using any of these; we don't generate the class names involved, and we're not using `uppy.use` on any of their UI components.

I confirmed that the only use of an Uppy UI component was the progress bar, which was stopped using in
b01ac3623fa2a6e98a917b0664568ff8b4e8aaba.
