### PR TITLE
thumbnail: Do not Camo old thumbor URLs; serve images directly.

### DIFF
--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -5,15 +5,12 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TypeVar
-from urllib.parse import urljoin
 
 import pyvips
 from bs4 import BeautifulSoup
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from typing_extensions import override
 
-from zerver.lib.camo import get_camo_url
 from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.queue import queue_event_on_commit
 from zerver.models import AbstractAttachment, ImageAttachment
@@ -137,14 +134,6 @@ pyvips.voperation.cache_set_max(0)
 
 class BadImageError(JsonableError):
     code = ErrorCode.BAD_IMAGE
-
-
-def generate_thumbnail_url(path: str, size: str = "0x0") -> str:
-    path = urljoin("/", path)
-
-    if url_has_allowed_host_and_scheme(path, allowed_hosts=None):
-        return path
-    return get_camo_url(path)
 
 
 @contextmanager

--- a/zerver/views/development/camo.py
+++ b/zerver/views/development/camo.py
@@ -1,8 +1,10 @@
+from urllib.parse import urljoin
+
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from zerver.lib.camo import is_camo_url_valid
-from zerver.lib.thumbnail import generate_thumbnail_url
 
 
 def handle_camo_url(
@@ -10,6 +12,9 @@ def handle_camo_url(
 ) -> HttpResponse:  # nocoverage
     original_url = bytes.fromhex(received_url).decode()
     if is_camo_url_valid(digest, original_url):
-        return redirect(generate_thumbnail_url(original_url))
+        original_url = urljoin("/", original_url)
+        if url_has_allowed_host_and_scheme(original_url, allowed_hosts=None):
+            return redirect(original_url)
+        return HttpResponseForbidden("<p>Not a valid URL.</p>")
     else:
         return HttpResponseForbidden("<p>Not a valid URL.</p>")


### PR DESCRIPTION
Providing a signed Camo URL for arbitrary URLs opened the server up to being an open redirector.  Return a client redirect if the URL is not a user upload, and the backend image if it is.  Since we do not have ImageAttachment rows for uploads at a time we wrote `/thumbnail?` URLs, return the full-size content.
