### PR TITLE
emoji: Fix canonical name for folded_hands emoji.

### DIFF
--- a/tools/setup/emoji/custom_emoji_names.py
+++ b/tools/setup/emoji/custom_emoji_names.py
@@ -179,7 +179,10 @@ CUSTOM_EMOJI_NAME_MAPS: dict[str, dict[str, Any]] = {
     # welcome and thank_you from
     # https://emojipedia.org/person-with-folded-hands/, namaste from Indian
     # culture
-    "1f64f": {"canonical_name": "pray", "aliases": ["welcome", "thank_you", "namaste"]},
+    "1f64f": {
+        "canonical_name": "folded_hands",
+        "aliases": ["welcome", "thank_you", "namaste", "pray"],
+    },
     # done_deal seems like a natural addition
     "1f91d": {"canonical_name": "handshake", "aliases": ["done_deal"]},
     "1f44d": {"canonical_name": "+1", "aliases": ["thumbs_up", "like"]},

--- a/tools/setup/emoji/emoji_names.py
+++ b/tools/setup/emoji/emoji_names.py
@@ -1245,7 +1245,10 @@ EMOJI_NAME_MAPS: dict[str, dict[str, Any]] = {
     "1f64e-200d-2640": {"canonical_name": "woman_pouting", "aliases": []},
     "1f64e-200d-2642": {"canonical_name": "man_pouting", "aliases": []},
     "1f64e": {"canonical_name": "person_pouting", "aliases": []},
-    "1f64f": {"canonical_name": "pray", "aliases": ["welcome", "thank_you", "namaste"]},
+    "1f64f": {
+        "canonical_name": "folded_hands",
+        "aliases": ["welcome", "thank_you", "namaste", "pray"],
+    },
     "1f680": {"canonical_name": "rocket", "aliases": []},
     "1f681": {"canonical_name": "helicopter", "aliases": []},
     "1f682": {"canonical_name": "train", "aliases": ["steam_locomotive"]},


### PR DESCRIPTION
The more neutral folded_hands is the official name and should make folks more confortable with using this for thank_you, which is certainly a more common use in work contexts than pray.

