### PR TITLE
user_card_popover: Improvements for bot and bot owner user cards.

### DIFF
--- a/web/src/emoji_picker.ts
+++ b/web/src/emoji_picker.ts
@@ -726,6 +726,7 @@ export function toggle_emoji_popover(
         },
         {
             show_as_overlay_on_mobile: true,
+            show_as_overlay_always: false,
         },
     );
 }

--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -209,6 +209,7 @@ function toggle_giphy_popover(target) {
         },
         {
             show_as_overlay_on_mobile: true,
+            show_as_overlay_always: false,
         },
     );
 }

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -379,7 +379,7 @@ function get_props_for_popover_centering(
 export function toggle_popover_menu(
     target: tippy.ReferenceElement,
     popover_props: Partial<tippy.Props>,
-    options?: {show_as_overlay_on_mobile: boolean},
+    options?: {show_as_overlay_on_mobile: boolean; show_as_overlay_always: boolean},
 ): tippy.Instance {
     const instance = target._tippy;
     if (instance) {
@@ -391,7 +391,11 @@ export function toggle_popover_menu(
 
     // If the window is mobile-sized, we will render the
     // popover centered on the screen as an overlay.
-    if (options?.show_as_overlay_on_mobile && window.innerWidth <= media_breakpoints_num.md) {
+    if (
+        (options?.show_as_overlay_on_mobile === true &&
+            window.innerWidth <= media_breakpoints_num.md) ||
+        options?.show_as_overlay_always === true
+    ) {
         mobile_popover_props = {
             ...get_props_for_popover_centering(popover_props),
         };

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -190,6 +190,19 @@ export function toggle_user_card_popover(element, user) {
     );
 }
 
+function toggle_user_card_popover_for_bot_owner(element, user) {
+    show_user_card_popover(
+        user,
+        $(element),
+        false,
+        false,
+        "compose_private_message",
+        "user_card",
+        "right",
+        true,
+    );
+}
+
 function get_user_card_popover_data(
     user,
     has_message_context,
@@ -292,6 +305,7 @@ function show_user_card_popover(
     private_msg_class,
     template_class,
     popover_placement,
+    show_as_overlay,
     on_mount,
 ) {
     let popover_html;
@@ -350,6 +364,7 @@ function show_user_card_popover(
         },
         {
             show_as_overlay_on_mobile: true,
+            show_as_overlay_always: show_as_overlay,
         },
     );
 }
@@ -433,6 +448,7 @@ function toggle_user_card_popover_for_message(
         "respond_personal_button",
         "message_user_card",
         "right",
+        false,
         on_mount,
     );
 }
@@ -530,6 +546,7 @@ function toggle_sidebar_user_card_popover($target) {
         "compose_private_message",
         "user_sidebar",
         "left",
+        false,
         (instance) => {
             /* See comment in get_props_for_popover_centering for explanation of this. */
             $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
@@ -711,7 +728,12 @@ function register_click_handlers() {
     $("body").on("click", ".view_user_profile, .person_picker .pill[data-user-id]", (e) => {
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         const user = people.get_by_user_id(user_id);
-        toggle_user_card_popover(e.currentTarget, user);
+        if ($(e.target).closest(".user-card-popover-bot-owner-field").length > 0) {
+            hide_all_user_card_popovers();
+            toggle_user_card_popover_for_bot_owner(e.target, user);
+        } else {
+            toggle_user_card_popover(e.target, user);
+        }
         e.stopPropagation();
         e.preventDefault();
     });

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -708,15 +708,6 @@ function register_click_handlers() {
         e.preventDefault();
     });
 
-    $("body").on("click", ".view_bot_owner_user_profile", (e) => {
-        const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
-        const user = people.get_by_user_id(user_id);
-        const $target = $(e.currentTarget).closest(".popover-menu-user-type");
-        toggle_user_card_popover($target, user);
-        e.stopPropagation();
-        e.preventDefault();
-    });
-
     $("body").on("click", ".view_user_profile, .person_picker .pill[data-user-id]", (e) => {
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         const user = people.get_by_user_id(user_id);

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -110,6 +110,7 @@ export function toggle_user_group_info_popover(
         },
         {
             show_as_overlay_on_mobile: true,
+            show_as_overlay_always: false,
         },
     );
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -85,6 +85,10 @@ kbd {
     order: 3;
 }
 
+.lowercase {
+    text-transform: lowercase;
+}
+
 /*
 Consistent placeholder styling, introduced to allow us to style the
 Reply box like a placeholder.  Chrome uses color to set placeholder,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -788,6 +788,7 @@
 
     /* Input pills */
     --color-background-input-pill: hsl(237deg 68% 94%);
+    --color-background-input-pill-hover: hsl(240deg 70% 70% / 30%);
     --color-focus-outline-input-pill: hsl(240deg 50% 50%);
     --color-input-pill-close: hsl(240deg 60% 65%);
     --color-background-input-pill-exit-hover: hsla(240deg 70% 70% / 15%);
@@ -1204,6 +1205,7 @@
 
     /* Input pills */
     --color-background-input-pill: hsl(240deg 65% 60% / 22%);
+    --color-background-input-pill-hover: hsl(240deg 52% 60% / 45%);
     --color-focus-outline-input-pill: hsl(0deg 0% 100% / 60%);
     --color-input-pill-close: hsl(240deg 50% 74%);
     --color-background-input-pill-exit-hover: hsl(0deg 0% 100% / 7%);

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -122,8 +122,7 @@
     --box-shadow-popover-menu: var(--box-shadow-gear-menu);
 }
 
-.user_full_name,
-.bot_owner {
+.user_full_name {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -131,6 +130,36 @@
 
 .user-card-popover-actions {
     --color-text-item: var(--color-text-user-card-secondary);
+
+    .user-card-popover-bot-owner-field {
+        &.text-item {
+            align-items: center;
+            white-space: nowrap;
+        }
+
+        .pill-container {
+            border: none !important;
+        }
+
+        .pill {
+            border: none;
+            text-decoration: none;
+            color: var(--color-text-popover-menu);
+            background-color: var(--color-background-text-direct-mention);
+
+            &:hover {
+                color: var(--color-text-popover-menu);
+                background-color: var(
+                    --color-background-text-hover-direct-mention
+                );
+                text-decoration: none;
+            }
+        }
+    }
+
+    .pill-container {
+        padding: 0;
+    }
 
     .custom-profile-field-value {
         display: flex;

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -19,7 +19,9 @@
                         <div>{{t "System bot" }}</div>
                     {{else}}
                         <div>{{t "Bot" }}
-                            <span class="lowercase">({{user_type}})</span>
+                            {{~#unless (eq user_type "Member")}}
+                                <span class="lowercase">({{user_type}})</span>
+                            {{/unless~}}
                         </div>
                     {{/if}}
                 {{else}}

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -18,7 +18,7 @@
                     {{#if is_system_bot}}
                         <div>{{t "System bot" }}</div>
                     {{else}}
-                        <div>{{t "Bot" }}</div>
+                        <div>{{t "Bot ({user_type})" }}</div>
                     {{/if}}
                 {{else}}
                     <div>{{ user_type }}</div>

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -15,13 +15,7 @@
             </div>
             <div class="popover-menu-user-type">
                 {{#if is_bot}}
-                    {{#if bot_owner}}
-                        <div class="bot_owner" data-tippy-content="{{ bot_owner.full_name }}">{{t "Owner" }}:
-                            <span class="bot-owner-name view_bot_owner_user_profile" data-user-id='{{ bot_owner.user_id }}'>
-                                {{bot_owner.full_name}}
-                            </span>
-                        </div>
-                    {{else if is_system_bot}}
+                    {{#if is_system_bot}}
                         <div>{{t "System bot" }}</div>
                     {{else}}
                         <div>{{t "Bot" }}</div>
@@ -123,6 +117,14 @@
             </li>
         {{/if}}
         <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
+        {{#if is_bot}}
+            {{#if bot_owner}}
+                <li role="none" class="popover-menu-list-item user-card-popover-bot-owner-field text-item hidden-for-spectators">
+                    <span class="bot_owner" data-tippy-content="{{ bot_owner.full_name }}">{{t "Bot owner" }}:</span>
+                    {{> ../../user_display_only_pill display_value=bot_owner.full_name user_id=bot_owner.user_id img_src=bot_owner.avatar_url is_active=true}}
+                </li>
+            {{/if}}
+        {{/if}}
         {{#if is_active }}
             {{#if user_email}}
                 <li role="none" class="popover-menu-list-item text-item user-card-popover-email-field hidden-for-spectators">

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -18,7 +18,9 @@
                     {{#if is_system_bot}}
                         <div>{{t "System bot" }}</div>
                     {{else}}
-                        <div>{{t "Bot ({user_type})" }}</div>
+                        <div>{{t "Bot" }}
+                            <span class="lowercase">({{user_type}})</span>
+                        </div>
                     {{/if}}
                 {{else}}
                     <div>{{ user_type }}</div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -57,7 +57,9 @@
                                             {{#if is_system_bot}}
                                             <div class="value">{{t "System bot" }}</div>
                                             {{else}}
-                                            <div class="value">{{t "Bot ({user_type})" }}</div>
+                                            <div class="value">{{t "Bot" }}
+                                                <span class="lowercase">({{user_type}})</span>
+                                            </div>
                                             {{/if}}
                                         {{else}}
                                             <div class="value">{{user_type}}</div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -57,7 +57,7 @@
                                             {{#if is_system_bot}}
                                             <div class="value">{{t "System bot" }}</div>
                                             {{else}}
-                                            <div class="value">{{t "Bot" }}</div>
+                                            <div class="value">{{t "Bot ({user_type})" }}</div>
                                             {{/if}}
                                         {{else}}
                                             <div class="value">{{user_type}}</div>


### PR DESCRIPTION
This PR enhances the user_card_popover experience for bot users:
1. The bot owner card now appears as an overlay, centered on the screen, similar to mobile display behavior. This also hides the bot user card when the bot owner card is active.
2. The bot user role is now displayed in the bot user card, below the bot full name.
3. The bot owner field has been repositioned alongside user fields, making room for the new user pill display.

This also adds the detailed bot role in the bot's user profile modal in the format: `Bot ({role})`.

Fixes: Part of #31027.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-07-25 at 6 02 14 PM](https://github.com/user-attachments/assets/e5243b21-1ce0-4a12-b5e3-dee07299d935) | ![Screenshot 2024-07-30 at 3 44 35 AM](https://github.com/user-attachments/assets/d8d3740c-886d-418a-a906-55b6a5afefd9) |
| ![bot_owner_card_before](https://github.com/user-attachments/assets/f73e2cd4-ceef-4d9b-bbbf-2472931d3ad0) | ![bot_owner_card_after](https://github.com/user-attachments/assets/0960bcb5-2c9c-430f-82cf-b6d5d650bee6) | 
| ![Screenshot 2024-07-30 at 3 46 43 AM](https://github.com/user-attachments/assets/f812e03d-a0af-45be-963f-a04099456266) | ![Screenshot 2024-07-30 at 3 46 10 AM](https://github.com/user-attachments/assets/99bc5bb4-f4f9-4a1c-b3fc-1f96571c5ced) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
