### PR TITLE
release: Parse version.py using the language it was written in

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -76,10 +76,7 @@ expected_date="$(TZ=America/Los_Angeles date +%F)"
     || fail "Date in docs/overview/changelog.md does not match '$expected_date'"
 
 extract_version() {
-    setting="$1"
-    value=$(SETTING="$setting" perl -nle 'print $2 if /$ENV{SETTING} = (\"?)([^"]+)\1$/' version.py | head -n1)
-    [ -n "$value" ] || fail "Could not find $setting in version.py"
-    echo "$value"
+    python3 -c 'import sys, version; print(getattr(version, sys.argv[1]))' "$1"
 }
 
 # Check ZULIP_VERSION and LATEST_RELEASE_VERSION are set appropriately


### PR DESCRIPTION
[Discussion](https://chat.zulip.org/#narrow/stream/438-release-management/topic/release.20checklist/near/1902682).