### PR TITLE
portico: Add Zulip Server 9.0 relese to /history.

### DIFF
--- a/templates/corporate/history.md
+++ b/templates/corporate/history.md
@@ -197,6 +197,11 @@ badge](https://www.capterra.com/p/197945/Zulip/).
 
 ## Major server releases and product announcements
 
+- July 2024: [Zulip Server 9.0
+  released](https://blog.zulip.com/2024/07/25/zulip-9-0-released/), with over
+  5300 new commits. 124 people contributed commits to Zulip since the 8.0
+  release.
+
 - December 2023: [Zulip Server 8.0
   released](https://blog.zulip.com/2023/12/15/zulip-8-0-released/), with over
   4700 new commits. 116 people contributed commits to Zulip since the 7.0


### PR DESCRIPTION
Current: https:/zulip.com/history/#major-server-releases-and-product-announcements

Updated:
![Screenshot 2024-07-25 at 14 16 00](https://github.com/user-attachments/assets/a79e5bf9-2ada-4018-9e77-f07762881671)
