### PR TITLE
zulip_updates: Update the content of a zulip update announcement.

### DIFF
--- a/zerver/management/commands/update_zulip_update_announcement_content.py
+++ b/zerver/management/commands/update_zulip_update_announcement_content.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from typing_extensions import override
+from argparse import ArgumentParser
+
+from zerver.lib.management import ZulipBaseCommand
+from zerver.lib.zulip_update_announcements import update_zulip_update_announcement_content
+
+
+class Command(ZulipBaseCommand):
+    help = """Script to update the content of a zulip update announcement."""
+
+    @override
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--level",
+            type=int,
+            required=True,
+            help="The level whose content needs to be updated.",
+        )
+
+        parser.add_argument(
+            "--old-content",
+            type=str,
+            required=True,
+            help="The old announcement content which needs to be updated."
+        )
+
+    @override
+    def handle(self, *args: Any, **options: Any) -> None:
+        update_zulip_update_announcement_content(options["level"], options["old_content"])


### PR DESCRIPTION
Adds a management command to update the content of a zulip update announcement.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
