### PR TITLE
[WIP] message_send: Convert to typed endpoint.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1237,17 +1237,10 @@ def already_sent_mirrored_message_id(message: Message) -> int | None:
     return None
 
 
-def extract_stream_indicator(s: str) -> str | int:
+def extract_stream_indicator(data: str | int | list[int] | list[str]) -> str | int:
     # Users can pass stream name as either an id or a name,
     # and if they choose to pass a name, they may JSON encode
     # it for legacy reasons.
-
-    try:
-        data = orjson.loads(s)
-    except orjson.JSONDecodeError:
-        # If there was no JSON encoding, then we just
-        # have a raw stream name.
-        return s
 
     # We should stop supporting this odd use case
     # once we improve our documentation.
@@ -1267,14 +1260,9 @@ def extract_stream_indicator(s: str) -> str | int:
     raise JsonableError(_("Invalid data type for channel"))
 
 
-def extract_private_recipients(s: str) -> list[str] | list[int]:
+def extract_private_recipients(data: str | int | list[int] | list[str]) -> list[str] | list[int]:
     # We try to accept multiple incoming formats for recipients.
     # See test_extract_recipients() for examples of what we allow.
-
-    try:
-        data = orjson.loads(s)
-    except orjson.JSONDecodeError:
-        data = s
 
     if isinstance(data, str):
         data = data.split(",")
@@ -1295,7 +1283,7 @@ def extract_private_recipients(s: str) -> list[str] | list[int]:
     return get_validated_user_ids(data)
 
 
-def get_validated_user_ids(user_ids: Collection[int]) -> list[int]:
+def get_validated_user_ids(user_ids: Collection[Any]) -> list[int]:
     for user_id in user_ids:
         if not isinstance(user_id, int):
             raise JsonableError(_("Recipient lists may contain emails or user IDs, but not both."))
@@ -1303,7 +1291,7 @@ def get_validated_user_ids(user_ids: Collection[int]) -> list[int]:
     return list(set(user_ids))
 
 
-def get_validated_emails(emails: Collection[str]) -> list[str]:
+def get_validated_emails(emails: Collection[Any]) -> list[str]:
     for email in emails:
         if not isinstance(email, str):
             raise JsonableError(_("Recipient lists may contain emails or user IDs, but not both."))

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -45,6 +45,7 @@ VARMAP = {
     "boolean": bool,
     "object": dict,
     "NoneType": type(None),
+    "number": float,
 }
 
 

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -1,11 +1,12 @@
 from collections.abc import Iterable, Sequence
 from email.headerregistry import Address
-from typing import cast
+from typing import Annotated, Literal, cast
 
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
+from pydantic import Json
 
 from zerver.actions.message_send import (
     check_send_message,
@@ -17,10 +18,14 @@ from zerver.actions.message_send import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.markdown import render_message_markdown
-from zerver.lib.request import REQ, RequestNotes, has_request_variables
+from zerver.lib.request import RequestNotes
 from zerver.lib.response import json_success
-from zerver.lib.topic import REQ_topic
-from zerver.lib.validator import check_bool, check_string_in, to_float
+from zerver.lib.typed_endpoint import (
+    DOCUMENTATION_PENDING,
+    ApiParamConfig,
+    OptionalTopic,
+    typed_endpoint,
+)
 from zerver.lib.zcommand import process_zcommands
 from zerver.lib.zephyr import compute_mit_user_fullname
 from zerver.models import Client, Message, RealmDomain, UserProfile
@@ -123,21 +128,30 @@ def same_realm_jabber_user(user_profile: UserProfile, email: str) -> bool:
     return RealmDomain.objects.filter(realm=user_profile.realm, domain=domain).exists()
 
 
-@has_request_variables
+@typed_endpoint
 def send_message_backend(
     request: HttpRequest,
     user_profile: UserProfile,
-    req_type: str = REQ("type", str_validator=check_string_in(Message.API_RECIPIENT_TYPES)),
-    req_to: str | None = REQ("to", default=None),
-    req_sender: str | None = REQ("sender", default=None, documentation_pending=True),
-    forged_str: str | None = REQ("forged", default=None, documentation_pending=True),
-    topic_name: str | None = REQ_topic(),
-    message_content: str = REQ("content"),
-    widget_content: str | None = REQ(default=None, documentation_pending=True),
-    local_id: str | None = REQ(default=None),
-    queue_id: str | None = REQ(default=None),
-    time: float | None = REQ(default=None, converter=to_float, documentation_pending=True),
-    read_by_sender: bool | None = REQ(json_validator=check_bool, default=None),
+    *,
+    req_type: Annotated[Literal["direct", "private", "stream", "channel"], ApiParamConfig("type")],
+    to: Json[str | int | list[int] | list[str]] | None = None,
+    req_sender: Annotated[
+        str | None, ApiParamConfig("sender", documentation_status=DOCUMENTATION_PENDING)
+    ] = None,
+    forged_str: Annotated[
+        str | None, ApiParamConfig("forged", documentation_status=DOCUMENTATION_PENDING)
+    ] = None,
+    topic_name: OptionalTopic = None,
+    message_content: Annotated[str, ApiParamConfig("content")],
+    widget_content: Annotated[
+        str | None, ApiParamConfig("widget_content", documentation_status=DOCUMENTATION_PENDING)
+    ] = None,
+    local_id: str | None = None,
+    queue_id: str | None = None,
+    time: Annotated[
+        Json[float] | None, ApiParamConfig("time", documentation_status=DOCUMENTATION_PENDING)
+    ] = None,
+    read_by_sender: Json[bool] | None = None,
 ) -> HttpResponse:
     recipient_type_name = req_type
     if recipient_type_name == "direct":
@@ -151,13 +165,13 @@ def send_message_backend(
         # message (created, schdeduled, drafts) objects/dicts.
         recipient_type_name = "stream"
 
-    # If req_to is None, then we default to an
+    # If to is None, then we default to an
     # empty list of recipients.
     message_to: Sequence[int] | Sequence[str] = []
 
-    if req_to is not None:
+    if to is not None:
         if recipient_type_name == "stream":
-            stream_indicator = extract_stream_indicator(req_to)
+            stream_indicator = extract_stream_indicator(to)
 
             # For legacy reasons check_send_message expects
             # a list of streams, instead of a single stream.
@@ -170,7 +184,7 @@ def send_message_backend(
             else:
                 message_to = [stream_indicator]
         else:
-            message_to = extract_private_recipients(req_to)
+            message_to = extract_private_recipients(to)
 
     # Temporary hack: We're transitioning `forged` from accepting
     # `yes` to accepting `true` like all of our normal booleans.
@@ -258,16 +272,19 @@ def send_message_backend(
     return json_success(request, data=data)
 
 
-@has_request_variables
+@typed_endpoint
 def zcommand_backend(
-    request: HttpRequest, user_profile: UserProfile, command: str = REQ("command")
+    request: HttpRequest, user_profile: UserProfile, *, command: str
 ) -> HttpResponse:
     return json_success(request, data=process_zcommands(command, user_profile))
 
 
-@has_request_variables
+@typed_endpoint
 def render_message_backend(
-    request: HttpRequest, user_profile: UserProfile, content: str = REQ()
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    content: str,
 ) -> HttpResponse:
     message = Message()
     message.sender = user_profile


### PR DESCRIPTION
This pull request is to demonstrate the issues with the `to` parameter when converting to typed_endpoint.

The OpenApi schema requires `to` to be a Json encoded `str | int | list[int] list[str]`. But, the existing implementation also accepts a raw string. We also use a raw string in many of the test cases(that are failing right now due to the conversion). 

Allowing the endpoint to accept a raw string fixes these errors but raises an error with OpenApi tests which requires `to` to accept only `Json`.