### PR TITLE
lightbox: Improve Typescript types and handle undefined media.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -652,6 +652,17 @@ export function initialize(): void {
             );
         }
 
+        // If $original_media_element comes back empty, that means that
+        // something in the message list has changed (e.g., a moved or
+        // deleted message, or the deletion of a media element that was
+        // available when the lightbox opened). In that event, we continue
+        // to display whatever media is up in the lightbox, and remove
+        // the thumbnail from the media list.
+        if ($original_media_element.length === 0) {
+            $(this).remove();
+            return;
+        }
+
         open_image($original_media_element);
 
         if (!$(".image-list .image.selected").hasClass("lightbox_video") || !is_video) {

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -166,6 +166,9 @@
     }
 
     .center {
+        display: flex;
+        justify-items: center;
+
         .arrow {
             display: inline-block;
             vertical-align: top;


### PR DESCRIPTION
This PR makes two fixes to the Lightbox source:

1. It corrects the centering of the lightbox media list, which was lost from `.new-style` rewrites in #31497 (I have a planned follow-up to improve centering and layout in that area, and change the stretched out angle bracket characters to actual Zulip chevron icons.)
2. It addresses an edge case, reported in Sentry, where `media` may be undefined inside `canonical_url_of_media()`. This originates inside of click events (or keyboard-activated click events) on the media list, and protective logic here removes the problem thumbnail and exits the click event when it is clear that the original media is no longer available in the message list.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.E2.9C.94.20.F0.9F.8E.AF.20lightbox.20does.20not.20start.20selected.20on.20Firefox/near/1902479)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>