### PR TITLE
message_view: Update narrow title after change in narrow filter.

### DIFF
--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -282,6 +282,7 @@ export function try_rendering_locally_for_same_narrow(filter, opts) {
 
     message_lists.current.data.filter = filter;
     update_hash_to_match_filter(filter, "retarget message location");
+    message_view_header.render_title_area();
     return true;
 }
 


### PR DESCRIPTION
This needs to be done to update narrow title for different `near` message targets or no `near` topic narrows.

Tested full behaviour described here - https://chat.zulip.org/#narrow/stream/9-issues/topic/Navigation.20within.20a.20topic.20fails.20to.20update.20near.3A.20search.20pills/near/1902599