### PR TITLE
scroll-to-bottom: Fix misclicks to scroll to bottom button.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -285,7 +285,11 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
 
-        navigate.to_end();
+        // Since it take a few milliseconds for this button complete disappear transition,
+        // it is possible for user to click it before it hides when switching narrows.
+        if (narrow_state.is_message_feed_visible()) {
+            navigate.to_end();
+        }
     });
 
     $("body").on("click", ".message_row", function () {


### PR DESCRIPTION
Scroll to bottom button is visible for a few ms when switching narrow to Inbox / Recent view while scrolling in message feed. While we can end the transition faster to completely avoid the issue for now but this seems like a more permanent and simpler fix than to fiddle with CSS.
