### PR TITLE
message_reactions: Use the reactions tooltip template.

### DIFF
--- a/web/templates/message_reactions.hbs
+++ b/web/templates/message_reactions.hbs
@@ -1,7 +1,7 @@
 {{#each this/msg/message_reactions}}
     {{> message_reaction}}
 {{/each}}
-<div class="reaction_button" role="button" aria-haspopup="true" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
+<div class="reaction_button" role="button" aria-haspopup="true" data-tooltip-template-id="add-emoji-tooltip-template" aria-label="{{t 'Add emoji reaction' }} (:)">
     <div class="emoji-message-control-button-container">
         <i class="zulip-icon zulip-icon-smile" tabindex="0"></i>
         <div class="message_reaction_count">+</div>


### PR DESCRIPTION
Using the existing tooltip template for the other "add emoji reaction" element in message_controls results in the keyboard shortcut being shown and avoids doing work to translate the string for every single message containing emoji reactions.
