### PR TITLE
ui: Add dynamic rendering in message_length_controller.

### DIFF
--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import {$t} from "./i18n";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
 import type {Message} from "./message_store";
@@ -222,7 +223,21 @@ export function condense_and_collapse(elems: JQuery): void {
     // More information here: https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/#avoid-layout-thrashing
     for (const {elem, $content, message, message_height} of rows_to_resize) {
         const long_message = message_height > height_cutoff;
+        const $message_length_controller = $(elem).find(".message_length_controller");
+
         if (long_message) {
+            const $expander = $("<button>")
+                .attr("type", "button")
+                .addClass("message_expander message_length_toggle tippy-zulip-delayed-tooltip")
+                .attr("data-tooltip-template-id", "message-expander-tooltip-template")
+                .text($t({defaultMessage: "Show more"}));
+            $message_length_controller.append($expander);
+            const $condenser = $("<button>")
+                .attr("type", "button")
+                .addClass("message_condenser message_length_toggle tippy-zulip-delayed-tooltip")
+                .attr("data-tooltip-template-id", "message-condenser-tooltip-template")
+                .text($t({defaultMessage: "Show less"}));
+            $message_length_controller.append($condenser);
             // All long messages are flagged as such.
             $content.addClass("could-be-condensed");
         } else {

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -64,8 +64,6 @@
 </div>
 
 <div class="message_length_controller">
-    <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
-    <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
 </div>
 
 {{#unless is_hidden}}


### PR DESCRIPTION
The message_length_controller had buttons that were present in all messages and were unused for most of them. This commit intends to fix this issue by adding a dynamic rendering of the buttons in the message_length_controller when the message is long enough to be condensed.

Fixes #31133

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/8608dfdc-b1ed-4d67-a949-a67cf202ace8

dark mode ss
<img width="1266" alt="Screenshot 2024-07-28 at 9 01 25 AM" src="https://github.com/user-attachments/assets/aaaf1959-94a3-45ff-beb9-9c5d78df9f16">
<img width="1266" alt="Screenshot 2024-07-28 at 9 01 35 AM" src="https://github.com/user-attachments/assets/4331f2c0-a0a3-412b-9983-0da3903d664a">
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

