### PR TITLE
narrow: Adjust topic channel-narrows to always contain `with` operator.

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -162,6 +162,14 @@ function process_result(data: MessageFetchResponse, opts: MessageFetchOptions): 
             if (opts.validate_filter_topic_post_fetch) {
                 opts.msg_list.data.filter.try_adjusting_for_moved_with_target(messages[0]);
             }
+
+            // After fetching the messages, if we have a channel topic narrow, we try
+            // to add `with` term to it, with the last message of the list as operand.
+            const last_msg_id = messages.at(-1)!.id;
+            if (opts.msg_list.data.filter.has_exactly_channel_topic_operators()) {
+                opts.msg_list.data.filter.adjust_with_operand_to_message(last_msg_id);
+            }
+
             // Since this adds messages to the MessageList and renders MessageListView,
             // we don't need to call it if msg_list was not defined by the caller.
             opts.msg_list.add_messages(messages, {}, is_contiguous_history);

--- a/web/src/narrow_history.ts
+++ b/web/src/narrow_history.ts
@@ -50,7 +50,19 @@ function _save_narrow_state(): void {
         narrow_pointer,
         narrow_offset,
     };
-    browser_history.update_current_history_state_data(narrow_data);
+
+    let url = window.location.href;
+
+    // By this time, if the our narrow is still a channel topic
+    // narrow, then that means we have locally available message
+    // of this narrow.
+    // Hence, we update the url to contain a `with` term, so that
+    // we can convert it to a topic permalink.
+    if (current_filter.has_exactly_channel_topic_operators()) {
+        url += `with/${narrow_pointer}`;
+    }
+
+    browser_history.update_current_history_state_data(narrow_data, url);
 }
 
 // Safari limits you to 100 replaceState calls in 30 seconds.


### PR DESCRIPTION
This commit adjusts the narrows containing only "channel" and "topic" operators to also contain the "with" operator, so that the topic links are automatically converted to permalinks.

<!-- Describe your pull request here.-->

[CZO thread](https://chat.zulip.org/#narrow/stream/6-frontend/topic/presence.20of.20.60with.60.20operator.20after.20processing.20the.20permalink/near/1901764)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
