### PR TITLE
streams_settings: Removed unused FontAwesome references.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -525,11 +525,6 @@ h4.user_group_setting_subsection_title {
 
     #announce-new-stream {
         margin: 20px auto;
-
-        & div[class^="fa"] {
-            margin-left: 3px;
-            margin-right: 8px;
-        }
     }
 }
 


### PR DESCRIPTION
These selectors drill all the way down to `inline_decorated_stream_name.hbs`, which no longer contains any Font Awesome references.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20performance/near/1904125)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
