### PR TITLE
rendered_markdown: Remove incorrect selector with unused color.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -163,10 +163,6 @@
     }
 
     /* Mentions and alert words */
-    .user-mention-me :not(.silent) {
-        background-color: hsl(112deg 88% 87%);
-    }
-
     .user-group-mention,
     .user-mention,
     .topic-mention {


### PR DESCRIPTION
This removes a malformed selector that referenced an incorrect color, even when correctly formed:

![not-silent-greenish-color](https://github.com/user-attachments/assets/0f67bc15-5795-4986-b5ed-c19006993932)

The color in question is already better declared as `--color-text-self-direct-mention` further down in the rendered markdown CSS file.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20performance/near/1904125)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->