### PR TITLE
uploads: Ask users to delete uploaded files when removed from edited message.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 285**
+
+* [`PATCH /messages/{message_id}`](/api/update-message): Added
+  `detached_uploads` to the response, indicating which uploaded files
+  are now only accessible via message edit history.
+
 **Feature level 284**
 
 * [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -53,6 +53,7 @@ EXEMPT_FILES = make_set(
         "web/src/alert_words_ui.ts",
         "web/src/archive.js",
         "web/src/assets.d.ts",
+        "web/src/attachments.ts",
         "web/src/attachments_ui.ts",
         "web/src/audible_notifications.ts",
         "web/src/avatar.ts",

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
 
-API_FEATURE_LEVEL = 284  # Last bumped for removing 'prev_rendered_content_version'
+API_FEATURE_LEVEL = 285  # Last bumped for detached_uploads
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/attachments.ts
+++ b/web/src/attachments.ts
@@ -1,0 +1,22 @@
+import {z} from "zod";
+
+const attachments_schema = z.array(
+    z.object({
+        id: z.number(),
+        name: z.string(),
+        path_id: z.string(),
+        size: z.number(),
+        create_time: z.number(),
+        messages: z.array(
+            z.object({
+                id: z.number(),
+                date_sent: z.number(),
+            }),
+        ),
+    }),
+);
+
+export const attachment_api_response_schema = z.object({
+    attachments: attachments_schema,
+    upload_space_used: z.number(),
+});

--- a/web/src/attachments.ts
+++ b/web/src/attachments.ts
@@ -20,3 +20,7 @@ export const attachment_api_response_schema = z.object({
     attachments: attachments_schema,
     upload_space_used: z.number(),
 });
+
+export const detached_uploads_api_response_schema = z.object({
+    detached_uploads: attachments_schema,
+});

--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -1,10 +1,11 @@
 import $ from "jquery";
-import {z} from "zod";
+import type {z} from "zod";
 
 import render_confirm_delete_attachment from "../templates/confirm_dialog/confirm_delete_attachment.hbs";
 import render_settings_upload_space_stats from "../templates/settings/upload_space_stats.hbs";
 import render_uploaded_files_list from "../templates/settings/uploaded_files_list.hbs";
 
+import {attachment_api_response_schema} from "./attachments";
 import * as channel from "./channel";
 import * as dialog_widget from "./dialog_widget";
 import {$t, $t_html} from "./i18n";
@@ -33,25 +34,6 @@ type AttachmentEvent =
           attachment: {id: number};
           upload_space_used: number;
       };
-
-const attachment_api_response_schema = z.object({
-    attachments: z.array(
-        z.object({
-            id: z.number(),
-            name: z.string(),
-            path_id: z.string(),
-            size: z.number(),
-            create_time: z.number(),
-            messages: z.array(
-                z.object({
-                    id: z.number(),
-                    date_sent: z.number(),
-                }),
-            ),
-        }),
-    ),
-    upload_space_used: z.number(),
-});
 
 let attachments: Attachment[];
 let upload_space_used: z.infer<typeof attachment_api_response_schema>["upload_space_used"];

--- a/web/templates/confirm_dialog/confirm_delete_detached_attachments.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_detached_attachments.hbs
@@ -1,0 +1,22 @@
+<div>
+    {{#if realm_allow_edit_history}}
+        {{#tr}}
+            The following <z-link>uploaded files</z-link> are no longer attached to any messages. They can still be accessed from this message's edit history. Would you like to delete them entirely?
+            {{#*inline "z-link"}}<a class="uploaded_files_settings_link" href="/#settings/uploaded-files">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{else}}
+        {{#tr}}
+            The following <z-link>uploaded files</z-link> are no longer attached to any messages. Would you like to delete them entirely?
+            {{#*inline "z-link"}}<a class="uploaded_files_settings_link" href="/#settings/uploaded-files">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    {{/if}}
+</div>
+<p>
+    <ul>
+        {{#each attachments_list}}
+            <li>
+                <a href="/user_uploads/{{this.path_id}}" rel="noopener noreferrer" target="_blank">{{this.name}}</a>
+            </li>
+        {{/each}}
+    </ul>
+</p>

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -223,9 +223,10 @@ def edit_scheduled_message(
         )
         scheduled_message_object.content = send_request.message.content
         scheduled_message_object.rendered_content = rendering_result.rendered_content
-        scheduled_message_object.has_attachment = check_attachment_reference_change(
+        attachment_reference_change = check_attachment_reference_change(
             scheduled_message_object, rendering_result
         )
+        scheduled_message_object.has_attachment = attachment_reference_change.did_attachment_change
 
     if deliver_at is not None:
         # User has updated the scheduled message's send timestamp.

--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from zerver.lib.attachments import get_old_unclaimed_attachments, validate_attachment_request
@@ -14,6 +15,12 @@ from zerver.models import (
     UserProfile,
 )
 from zerver.tornado.django_api import send_event_on_commit
+
+
+@dataclass
+class AttachmentChangeResult:
+    did_attachment_change: bool
+    detached_attachments: list[dict[str, Any]]
 
 
 def notify_attachment_update(
@@ -116,7 +123,7 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
 
 def check_attachment_reference_change(
     message: Message | ScheduledMessage, rendering_result: MessageRenderingResult
-) -> bool:
+) -> AttachmentChangeResult:
     # For a unsaved message edit (message.* has been updated, but not
     # saved to the database), adjusts Attachment data to correspond to
     # the new content.
@@ -124,15 +131,21 @@ def check_attachment_reference_change(
     new_attachments = set(rendering_result.potential_attachment_path_ids)
 
     if new_attachments == prev_attachments:
-        return bool(prev_attachments)
+        return AttachmentChangeResult(bool(prev_attachments), [])
 
     to_remove = list(prev_attachments - new_attachments)
     if len(to_remove) > 0:
         attachments_to_update = Attachment.objects.filter(path_id__in=to_remove).select_for_update()
         message.attachment_set.remove(*attachments_to_update)
 
+    sender = message.sender
+    detached_attachments_query = Attachment.objects.filter(
+        path_id__in=to_remove, messages__isnull=True, owner=sender
+    )
+    detached_attachments = [attachment.to_dict() for attachment in detached_attachments_query]
+
     to_add = list(new_attachments - prev_attachments)
     if len(to_add) > 0:
         do_claim_attachments(message, to_add)
 
-    return message.attachment_set.exists()
+    return AttachmentChangeResult(message.attachment_set.exists(), detached_attachments)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -16,6 +16,7 @@ import orjson
 import responses
 from django.apps import apps
 from django.conf import settings
+from django.core.files.uploadedfile import UploadedFile
 from django.core.mail import EmailMessage
 from django.core.signals import got_request_exception
 from django.db import connection, transaction
@@ -76,6 +77,7 @@ from zerver.lib.test_helpers import (
 )
 from zerver.lib.thumbnail import ThumbnailFormat
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, filter_by_topic_name_via_message
+from zerver.lib.upload import upload_message_attachment_from_request
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.users import get_api_key
 from zerver.lib.webhooks.common import (
@@ -2026,6 +2028,14 @@ Output:
             mock.patch("zerver.views.upload.THUMBNAIL_OUTPUT_FORMATS", thumbnail_formats),
         ):
             yield
+
+    def create_attachment_helper(self, user: UserProfile) -> str:
+        with tempfile.NamedTemporaryFile() as attach_file:
+            attach_file.write(b"Hello, World!")
+            attach_file.flush()
+            with open(attach_file.name, "rb") as fp:
+                file_path = upload_message_attachment_from_request(UploadedFile(fp), user)
+                return file_path
 
 
 class ZulipTestCase(ZulipTestCaseMixin, TestCase):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6009,7 +6009,18 @@ paths:
                 contentType: application/json
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                    example: {"result": "success", "msg": ""}
         "400":
           description: Bad request.
           content:
@@ -7976,7 +7987,48 @@ paths:
                 contentType: application/json
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      detached_uploads:
+                        type: array
+                        description: |
+                          Details on all files uploaded by the acting user whose only references
+                          were removed when editing this message. Clients should ask the acting user
+                          if they wish to delete the uploaded files returned in this response,
+                          which might otherwise remain visible only in message edit history.
+
+                          Note that [access to message edit
+                          history](/help/disable-message-edit-history) is configurable; this detail
+                          may be important in presenting the question clearly to users.
+
+                          New in Zulip 10.0 (feature level 285).
+                        items:
+                          $ref: "#/components/schemas/Attachments"
+                    example:
+                      {
+                        "result": "success",
+                        "msg": "",
+                        "detached_uploads":
+                          [
+                            {
+                              "id": 3,
+                              "name": "1253601-1.jpg",
+                              "path_id": "2/5d/BD5NRptFxPDKY3RUKwhhup8r/1253601-1.jpg",
+                              "size": 1339060,
+                              "create_time": 1687984706000,
+                              "messages": [],
+                            },
+                          ],
+                      }
         "400":
           description: Bad request.
           content:

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -128,7 +128,7 @@ def update_message_backend(
     send_notification_to_new_thread: Json[bool] = True,
     content: str | None = None,
 ) -> HttpResponse:
-    number_changed = check_update_message(
+    updated_message_result = check_update_message(
         user_profile,
         message_id,
         stream_id,
@@ -142,9 +142,9 @@ def update_message_backend(
     # Include the number of messages changed in the logs
     log_data = RequestNotes.get_notes(request).log_data
     assert log_data is not None
-    log_data["extra"] = f"[{number_changed}]"
+    log_data["extra"] = f"[{updated_message_result.changed_message_count}]"
 
-    return json_success(request)
+    return json_success(request, data={"detached_uploads": updated_message_result.detached_uploads})
 
 
 def validate_can_delete_message(user_profile: UserProfile, message: Message) -> None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->
When a user edits a message, attachments can be removed or changed. When the user hits 'save', if any attachments are removed, a modal will pop up asking the user to delete them.

**Notes:**
Currently when you try to upload multiple files, the app will throw random errors and is independent of these changes as discussed in [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/blueslip.20error.20due.20to.20originalevent.2Eerror.20being.20null)

Fixes: #25525.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/3de17512-ff23-49f9-bfec-15ccfa74a67c)
![image](https://github.com/user-attachments/assets/6cd770bc-70f2-47f6-b687-ab014ff89d56)
![image](https://github.com/user-attachments/assets/9d910511-bbc8-44e2-8582-a9cba96cff50)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
