### PR TITLE
Migrate action functions to send event on commit.

### DIFF
--- a/zerver/actions/alert_words.py
+++ b/zerver/actions/alert_words.py
@@ -1,15 +1,18 @@
 from collections.abc import Iterable, Sequence
 
+from django.db import transaction
+
 from zerver.lib.alert_words import add_user_alert_words, remove_user_alert_words
 from zerver.models import UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_alert_words(user_profile: UserProfile, words: Sequence[str]) -> None:
     event = dict(type="alert_words", alert_words=words)
-    send_event(user_profile.realm, event, [user_profile.id])
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
+@transaction.atomic(savepoint=False)
 def do_add_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) -> None:
     words = add_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, words)

--- a/zerver/actions/alert_words.py
+++ b/zerver/actions/alert_words.py
@@ -18,6 +18,7 @@ def do_add_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) ->
     notify_alert_words(user_profile, words)
 
 
+@transaction.atomic(savepoint=False)
 def do_remove_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) -> None:
     words = remove_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, words)

--- a/zerver/actions/user_status.py
+++ b/zerver/actions/user_status.py
@@ -1,10 +1,13 @@
+from django.db import transaction
+
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.lib.user_status import update_user_status
 from zerver.lib.users import get_user_ids_who_can_access_user
 from zerver.models import UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
+@transaction.atomic(savepoint=False)
 def do_update_user_status(
     user_profile: UserProfile,
     away: bool | None,
@@ -49,4 +52,4 @@ def do_update_user_status(
         event["emoji_name"] = emoji_name
         event["emoji_code"] = emoji_code
         event["reaction_type"] = reaction_type
-    send_event(realm, event, get_user_ids_who_can_access_user(user_profile))
+    send_event_on_commit(realm, event, get_user_ids_who_can_access_user(user_profile))

--- a/zerver/lib/alert_words.py
+++ b/zerver/lib/alert_words.py
@@ -50,7 +50,7 @@ def user_alert_words(user_profile: UserProfile) -> list[str]:
     return list(AlertWord.objects.filter(user_profile=user_profile).values_list("word", flat=True))
 
 
-@transaction.atomic
+@transaction.atomic(savepoint=False)
 def add_user_alert_words(user_profile: UserProfile, new_words: Iterable[str]) -> list[str]:
     existing_words_lower = {word.lower() for word in user_alert_words(user_profile)}
 

--- a/zerver/lib/alert_words.py
+++ b/zerver/lib/alert_words.py
@@ -72,7 +72,7 @@ def add_user_alert_words(user_profile: UserProfile, new_words: Iterable[str]) ->
     return user_alert_words(user_profile)
 
 
-@transaction.atomic
+@transaction.atomic(savepoint=False)
 def remove_user_alert_words(user_profile: UserProfile, delete_words: Iterable[str]) -> list[str]:
     # TODO: Ideally, this would be a bulk query, but Django doesn't have a `__iexact`.
     # We can clean this up if/when PostgreSQL has more native support for case-insensitive fields.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1676,13 +1676,13 @@ class NormalActionsTest(BaseAction):
                 client_id=client.id,
             )
 
+        check_user_settings_update("events[0]", events[0])
+        check_update_global_notifications("events[1]", events[1], not away_val)
         check_user_status(
-            "events[0]",
-            events[0],
+            "events[2]",
+            events[2],
             {"away", "status_text", "emoji_name", "emoji_code", "reaction_type"},
         )
-        check_user_settings_update("events[1]", events[1])
-        check_update_global_notifications("events[2]", events[2], not away_val)
         check_presence(
             "events[3]",
             events[3],
@@ -1704,13 +1704,13 @@ class NormalActionsTest(BaseAction):
                 client_id=client.id,
             )
 
+        check_user_settings_update("events[0]", events[0])
+        check_update_global_notifications("events[1]", events[1], not away_val)
         check_user_status(
-            "events[0]",
-            events[0],
+            "events[2]",
+            events[2],
             {"away", "status_text", "emoji_name", "emoji_code", "reaction_type"},
         )
-        check_user_settings_update("events[1]", events[1])
-        check_update_global_notifications("events[2]", events[2], not away_val)
         check_presence(
             "events[3]",
             events[3],
@@ -1732,9 +1732,9 @@ class NormalActionsTest(BaseAction):
                 client_id=client.id,
             )
 
-        check_user_status("events[0]", events[0], {"away"})
-        check_user_settings_update("events[1]", events[1])
-        check_update_global_notifications("events[2]", events[2], not away_val)
+        check_user_settings_update("events[0]", events[0])
+        check_update_global_notifications("events[1]", events[1], not away_val)
+        check_user_status("events[2]", events[2], {"away"})
         check_presence(
             "events[3]",
             events[3],

--- a/zerver/tests/test_user_status.py
+++ b/zerver/tests/test_user_status.py
@@ -183,7 +183,10 @@ class UserStatusTest(ZulipTestCase):
         with self.capture_send_event_calls(expected_num_events=num_events) as events:
             result = self.client_post("/json/users/me/status", payload)
         self.assert_json_success(result)
-        self.assertEqual(events[0]["event"], expected_event)
+        if num_events == 1:
+            self.assertEqual(events[0]["event"], expected_event)
+        else:
+            self.assertEqual(events[2]["event"], expected_event)
 
     def test_endpoints(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
Migrates 4 action functions to use `send_event_on_commit`.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
