### PR TITLE
input pill: Refactor to move custom attributes into relevant modules

### DIFF
--- a/docs/subsystems/input-pills.md
+++ b/docs/subsystems/input-pills.md
@@ -23,6 +23,7 @@ var pills = input_pill.create({
     $container: $pill_container,
     create_item_from_text: user_pill.create_item_from_email,
     get_text_from_item: user_pill.get_email_from_item,
+    get_display_value_from_item: user_pill.get_display_value_from_item,
 });
 ```
 
@@ -30,8 +31,7 @@ You can look at `web/src/user_pill.ts` to see how the above
 methods are implemented. Essentially you just need to convert
 from raw data (like an email) to structured data (like an object
 with display_value, email, and user_id for a user), and vice
-versa. The most important field to supply is `display_value`.
-For user pills `pill_item.display_value === user.full_name`.
+versa.
 
 ## Typeahead
 

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -4,20 +4,19 @@ import render_input_pill from "../templates/input_pill.hbs";
 
 import * as blueslip from "./blueslip";
 import * as input_pill from "./input_pill";
-import type {InputPillItem} from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import type {User} from "./people";
 import * as pill_typeahead from "./pill_typeahead";
 import * as stream_pill from "./stream_pill";
-import type {CombinedPill, CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
 import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
 
 function create_item_from_text(
     text: string,
-    current_items: CombinedPillItem[],
-): CombinedPillItem | undefined {
+    current_items: CombinedPill[],
+): CombinedPill | undefined {
     const funcs = [
         stream_pill.create_item_from_stream_name,
         user_group_pill.create_item_from_group_name,
@@ -32,7 +31,7 @@ function create_item_from_text(
     return undefined;
 }
 
-function get_text_from_item(item: CombinedPillItem): string {
+function get_text_from_item(item: CombinedPill): string {
     let text: string;
     switch (item.type) {
         case "stream":
@@ -66,7 +65,7 @@ function set_up_pill_typeahead({
     pill_typeahead.set_up_combined($pill_container.find(".input"), pill_widget, opts);
 }
 
-function get_display_value_from_item(item: InputPillItem<CombinedPill>): string {
+function get_display_value_from_item(item: CombinedPill): string {
     if (item.type === "user_group") {
         return user_group_pill.display_pill(user_groups.get_user_group_from_id(item.group_id));
     } else if (item.type === "stream") {
@@ -76,7 +75,7 @@ function get_display_value_from_item(item: InputPillItem<CombinedPill>): string 
     return user_pill.get_display_value_from_item(item);
 }
 
-function generate_pill_html(item: InputPillItem<CombinedPill>): string {
+function generate_pill_html(item: CombinedPill): string {
     if (item.type === "user_group") {
         return render_input_pill({
             display_value: get_display_value_from_item(item),

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -66,10 +66,20 @@ function set_up_pill_typeahead({
     pill_typeahead.set_up_combined($pill_container.find(".input"), pill_widget, opts);
 }
 
+function get_display_value_from_item(item: InputPillItem<CombinedPill>): string {
+    if (item.type === "user_group") {
+        return user_group_pill.display_pill(user_groups.get_user_group_from_id(item.group_id));
+    } else if (item.type === "stream") {
+        return stream_pill.get_display_value_from_item(item);
+    }
+    assert(item.type === "user");
+    return user_pill.get_display_value_from_item(item);
+}
+
 function generate_pill_html(item: InputPillItem<CombinedPill>): string {
     if (item.type === "user_group") {
         return render_input_pill({
-            display_value: item.display_value,
+            display_value: get_display_value_from_item(item),
             group_id: item.group_id,
         });
     } else if (item.type === "user") {
@@ -79,6 +89,7 @@ function generate_pill_html(item: InputPillItem<CombinedPill>): string {
     return render_input_pill({
         ...item,
         has_stream: true,
+        display_value: get_display_value_from_item(item),
     });
 }
 
@@ -93,6 +104,7 @@ export function create({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
+        get_display_value_from_item,
         generate_pill_html,
     });
     function get_users(): User[] {
@@ -138,6 +150,7 @@ export function create_without_add_button({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
+        get_display_value_from_item,
         generate_pill_html,
     });
     function get_users(): User[] {

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -1,5 +1,10 @@
+import assert from "minimalistic-assert";
+
+import render_input_pill from "../templates/input_pill.hbs";
+
 import * as blueslip from "./blueslip";
 import * as input_pill from "./input_pill";
+import type {InputPillItem} from "./input_pill";
 import * as keydown_util from "./keydown_util";
 import type {User} from "./people";
 import * as pill_typeahead from "./pill_typeahead";
@@ -61,6 +66,22 @@ function set_up_pill_typeahead({
     pill_typeahead.set_up_combined($pill_container.find(".input"), pill_widget, opts);
 }
 
+function generate_pill_html(item: InputPillItem<CombinedPill>): string {
+    if (item.type === "user_group") {
+        return render_input_pill({
+            display_value: item.display_value,
+            group_id: item.group_id,
+        });
+    } else if (item.type === "user") {
+        return user_pill.generate_pill_html(item);
+    }
+    assert(item.type === "stream");
+    return render_input_pill({
+        ...item,
+        has_stream: true,
+    });
+}
+
 export function create({
     $pill_container,
     get_potential_subscribers,
@@ -72,6 +93,7 @@ export function create({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
+        generate_pill_html,
     });
     function get_users(): User[] {
         const potential_subscribers = get_potential_subscribers();
@@ -116,6 +138,7 @@ export function create_without_add_button({
         $container: $pill_container,
         create_item_from_text,
         get_text_from_item,
+        generate_pill_html,
     });
     function get_users(): User[] {
         const potential_subscribers = get_potential_subscribers();

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -22,6 +22,7 @@ export function initialize_pill(): UserPillWidget {
         pill_config,
         create_item_from_text: user_pill.create_item_from_email,
         get_text_from_item: user_pill.get_email_from_item,
+        get_display_value_from_item: user_pill.get_display_value_from_item,
         generate_pill_html: (item: InputPillItem<UserPill>) =>
             user_pill.generate_pill_html(item, true),
     });

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-import type {InputPillConfig, InputPillItem} from "./input_pill";
+import type {InputPillConfig} from "./input_pill";
 import * as input_pill from "./input_pill";
 import type {User} from "./people";
 import * as people from "./people";
@@ -23,8 +23,7 @@ export function initialize_pill(): UserPillWidget {
         create_item_from_text: user_pill.create_item_from_email,
         get_text_from_item: user_pill.get_email_from_item,
         get_display_value_from_item: user_pill.get_display_value_from_item,
-        generate_pill_html: (item: InputPillItem<UserPill>) =>
-            user_pill.generate_pill_html(item, true),
+        generate_pill_html: (item: UserPill) => user_pill.generate_pill_html(item, true),
     });
 
     return pill;

--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -1,17 +1,16 @@
 import $ from "jquery";
 
-import type {InputPillConfig} from "./input_pill";
+import type {InputPillConfig, InputPillItem} from "./input_pill";
 import * as input_pill from "./input_pill";
 import type {User} from "./people";
 import * as people from "./people";
-import type {UserPillWidget} from "./user_pill";
+import type {UserPill, UserPillWidget} from "./user_pill";
 import * as user_pill from "./user_pill";
 import * as util from "./util";
 
 export let widget: UserPillWidget;
 
 const pill_config: InputPillConfig = {
-    show_user_status_emoji: true,
     exclude_inaccessible_users: true,
 };
 
@@ -23,6 +22,8 @@ export function initialize_pill(): UserPillWidget {
         pill_config,
         create_item_from_text: user_pill.create_item_from_email,
         get_text_from_item: user_pill.get_email_from_item,
+        generate_pill_html: (item: InputPillItem<UserPill>) =>
+            user_pill.generate_pill_html(item, true),
     });
 
     return pill;

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -1,7 +1,8 @@
-import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillConfig, InputPillContainer} from "./input_pill";
 import * as input_pill from "./input_pill";
 
 type EmailPill = {
+    type: "email";
     email: string;
 };
 
@@ -11,8 +12,8 @@ const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export function create_item_from_email(
     email: string,
-    current_items: InputPillItem<EmailPill>[],
-): InputPillItem<EmailPill> | undefined {
+    current_items: EmailPill[],
+): EmailPill | undefined {
     if (!email_regex.test(email)) {
         return undefined;
     }
@@ -28,7 +29,7 @@ export function create_item_from_email(
     };
 }
 
-export function get_email_from_item(item: InputPillItem<EmailPill>): string {
+export function get_email_from_item(item: EmailPill): string {
     return item.email;
 }
 

--- a/web/src/email_pill.ts
+++ b/web/src/email_pill.ts
@@ -24,7 +24,6 @@ export function create_item_from_email(
 
     return {
         type: "email",
-        display_value: email,
         email,
     };
 }
@@ -52,6 +51,7 @@ export function create_pills(
         pill_config,
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
+        get_display_value_from_item: get_email_from_item,
     });
     return pill_container;
 }

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -16,7 +16,7 @@ import * as util from "./util";
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html
 
-export type InputPillItem<T> = {
+export type InputPillItem<ItemType> = {
     display_value: string;
     type: string;
     img_src?: string;
@@ -28,41 +28,41 @@ export type InputPillItem<T> = {
     // Used for search pills
     operator?: string;
     stream?: StreamSubscription;
-} & T;
+} & ItemType;
 
 export type InputPillConfig = {
     show_user_status_emoji?: boolean;
     exclude_inaccessible_users?: boolean;
 };
 
-type InputPillCreateOptions<T> = {
+type InputPillCreateOptions<ItemType> = {
     $container: JQuery;
     pill_config?: InputPillConfig | undefined;
     split_text_on_comma?: boolean;
     convert_to_pill_on_enter?: boolean;
     create_item_from_text: (
         text: string,
-        existing_items: InputPillItem<T>[],
+        existing_items: InputPillItem<ItemType>[],
         pill_config?: InputPillConfig | undefined,
-    ) => InputPillItem<T> | undefined;
-    get_text_from_item: (item: InputPillItem<T>) => string;
+    ) => InputPillItem<ItemType> | undefined;
+    get_text_from_item: (item: InputPillItem<ItemType>) => string;
 };
 
-type InputPill<T> = {
-    item: InputPillItem<T>;
+type InputPill<ItemType> = {
+    item: InputPillItem<ItemType>;
     $element: JQuery;
 };
 
-type InputPillStore<T> = {
+type InputPillStore<ItemType> = {
     onTextInputHook?: () => void;
-    pills: InputPill<T>[];
-    pill_config: InputPillCreateOptions<T>["pill_config"];
+    pills: InputPill<ItemType>[];
+    pill_config: InputPillCreateOptions<ItemType>["pill_config"];
     $parent: JQuery;
     $input: JQuery;
-    create_item_from_text: InputPillCreateOptions<T>["create_item_from_text"];
-    get_text_from_item: InputPillCreateOptions<T>["get_text_from_item"];
+    create_item_from_text: InputPillCreateOptions<ItemType>["create_item_from_text"];
+    get_text_from_item: InputPillCreateOptions<ItemType>["get_text_from_item"];
     onPillCreate?: () => void;
-    onPillRemove?: (pill: InputPill<T>, trigger: RemovePillTrigger) => void;
+    onPillRemove?: (pill: InputPill<ItemType>, trigger: RemovePillTrigger) => void;
     createPillonPaste?: () => void;
     split_text_on_comma: boolean;
     convert_to_pill_on_enter: boolean;
@@ -83,28 +83,32 @@ type InputPillRenderingDetails = {
 };
 
 // These are the functions that are exposed to other modules.
-export type InputPillContainer<T> = {
+export type InputPillContainer<ItemType> = {
     appendValue: (text: string) => void;
-    appendValidatedData: (item: InputPillItem<T>) => void;
-    getByElement: (element: HTMLElement) => InputPill<T> | undefined;
-    items: () => InputPillItem<T>[];
+    appendValidatedData: (item: InputPillItem<ItemType>) => void;
+    getByElement: (element: HTMLElement) => InputPill<ItemType> | undefined;
+    items: () => InputPillItem<ItemType>[];
     onPillCreate: (callback: () => void) => void;
-    onPillRemove: (callback: (pill: InputPill<T>, trigger: RemovePillTrigger) => void) => void;
+    onPillRemove: (
+        callback: (pill: InputPill<ItemType>, trigger: RemovePillTrigger) => void,
+    ) => void;
     onTextInputHook: (callback: () => void) => void;
     createPillonPaste: (callback: () => void) => void;
     clear: (quiet?: boolean) => void;
     clear_text: () => void;
     getCurrentText: () => string | null;
     is_pending: () => boolean;
-    _get_pills_for_testing: () => InputPill<T>[];
+    _get_pills_for_testing: () => InputPill<ItemType>[];
 };
 
 export type RemovePillTrigger = "close" | "backspace" | "clear";
 
-export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T> {
+export function create<ItemType>(
+    opts: InputPillCreateOptions<ItemType>,
+): InputPillContainer<ItemType> {
     // a stateful object of this `pill_container` instance.
     // all unique instance information is stored in here.
-    const store: InputPillStore<T> = {
+    const store: InputPillStore<ItemType> = {
         pills: [],
         pill_config: opts.pill_config,
         $parent: opts.$container,
@@ -159,7 +163,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
         // This is generally called by typeahead logic, where we have all
         // the data we need (as opposed to, say, just a user-typed email).
-        appendValidatedData(item: InputPillItem<T>) {
+        appendValidatedData(item: InputPillItem<ItemType>) {
             if (!item.display_value) {
                 blueslip.error("no display_value returned");
                 return;
@@ -225,7 +229,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 }
                 pill_html = render_input_pill(opts);
             }
-            const payload: InputPill<T> = {
+            const payload: InputPill<ItemType> = {
                 item,
                 $element: $(pill_html),
             };
@@ -574,7 +578,7 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
     }
 
     // the external, user-accessible prototype.
-    const prototype: InputPillContainer<T> = {
+    const prototype: InputPillContainer<ItemType> = {
         appendValue: funcs.appendPill.bind(funcs),
         appendValidatedData: funcs.appendValidatedData.bind(funcs),
 

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -6,7 +6,6 @@ import assert from "minimalistic-assert";
 import render_input_pill from "../templates/input_pill.hbs";
 
 import * as blueslip from "./blueslip";
-import type {EmojiRenderingDetails} from "./emoji";
 import * as keydown_util from "./keydown_util";
 import type {SearchUserPill} from "./search_pill";
 import type {StreamSubscription} from "./sub_store";
@@ -17,11 +16,6 @@ import * as ui_util from "./ui_util";
 export type InputPillItem<ItemType> = {
     display_value: string;
     type: string;
-    img_src?: string;
-    deactivated?: boolean;
-    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined; // TODO: Move this in user_status.js
-    should_add_guest_user_indicator?: boolean;
-    user_id?: number;
     group_id?: number;
     // Used for search pills
     operator?: string;

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -8,7 +8,6 @@ import render_input_pill from "../templates/input_pill.hbs";
 import * as blueslip from "./blueslip";
 import * as keydown_util from "./keydown_util";
 import type {SearchUserPill} from "./search_pill";
-import type {StreamSubscription} from "./sub_store";
 import * as ui_util from "./ui_util";
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html
@@ -18,7 +17,6 @@ export type InputPillItem<ItemType> = {
     type: string;
     // Used for search pills
     operator?: string;
-    stream?: StreamSubscription;
 } & ItemType;
 
 export type InputPillConfig = {
@@ -62,8 +60,6 @@ type InputPillStore<ItemType> = {
 
 type InputPillRenderingDetails = {
     display_value: string;
-    has_stream?: boolean;
-    stream?: StreamSubscription;
 };
 
 // These are the functions that are exposed to other modules.
@@ -165,11 +161,6 @@ export function create<ItemType>(
                 const opts: InputPillRenderingDetails = {
                     display_value: item.display_value,
                 };
-
-                if (item.type === "stream" && item.stream) {
-                    opts.has_stream = true;
-                    opts.stream = item.stream;
-                }
                 pill_html = render_input_pill(opts);
             }
             const payload: InputPill<ItemType> = {

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -16,7 +16,6 @@ import * as ui_util from "./ui_util";
 export type InputPillItem<ItemType> = {
     display_value: string;
     type: string;
-    group_id?: number;
     // Used for search pills
     operator?: string;
     stream?: StreamSubscription;
@@ -63,7 +62,6 @@ type InputPillStore<ItemType> = {
 
 type InputPillRenderingDetails = {
     display_value: string;
-    group_id?: number | undefined;
     has_stream?: boolean;
     stream?: StreamSubscription;
 };
@@ -167,10 +165,6 @@ export function create<ItemType>(
                 const opts: InputPillRenderingDetails = {
                     display_value: item.display_value,
                 };
-
-                if (item.group_id) {
-                    opts.group_id = item.group_id;
-                }
 
                 if (item.type === "stream" && item.stream) {
                     opts.has_stream = true;

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -29,7 +29,6 @@ export type InputPillItem<ItemType> = {
 } & ItemType;
 
 export type InputPillConfig = {
-    show_user_status_emoji?: boolean;
     exclude_inaccessible_users?: boolean;
 };
 
@@ -70,13 +69,6 @@ type InputPillStore<ItemType> = {
 
 type InputPillRenderingDetails = {
     display_value: string;
-    has_image: boolean;
-    img_src?: string | undefined;
-    deactivated: boolean | undefined;
-    has_status?: boolean;
-    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined;
-    should_add_guest_user_indicator: boolean | undefined;
-    user_id?: number | undefined;
     group_id?: number | undefined;
     has_stream?: boolean;
     stream?: StreamSubscription;
@@ -178,37 +170,17 @@ export function create<ItemType>(
             if (store.generate_pill_html !== undefined) {
                 pill_html = store.generate_pill_html(item);
             } else {
-                const has_image = item.img_src !== undefined;
-
                 const opts: InputPillRenderingDetails = {
                     display_value: item.display_value,
-                    has_image,
-                    deactivated: item.deactivated,
-                    should_add_guest_user_indicator: item.should_add_guest_user_indicator,
                 };
 
-                if (item.user_id) {
-                    opts.user_id = item.user_id;
-                }
                 if (item.group_id) {
                     opts.group_id = item.group_id;
-                }
-
-                if (has_image) {
-                    opts.img_src = item.img_src;
                 }
 
                 if (item.type === "stream" && item.stream) {
                     opts.has_stream = true;
                     opts.stream = item.stream;
-                }
-
-                if (store.pill_config?.show_user_status_emoji === true) {
-                    const has_status = item.status_emoji_info !== undefined;
-                    if (has_status) {
-                        opts.status_emoji_info = item.status_emoji_info;
-                    }
-                    opts.has_status = has_status;
                 }
                 pill_html = render_input_pill(opts);
             }

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -346,6 +346,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             $container: $pill_container,
             create_item_from_text: email_pill.create_item_from_email,
             get_text_from_item: email_pill.get_email_from_item,
+            get_display_value_from_item: email_pill.get_email_from_item,
         });
 
         $("#invite-user-modal .dialog_submit_button").prop("disabled", true);

--- a/web/src/invite_stream_picker_pill.ts
+++ b/web/src/invite_stream_picker_pill.ts
@@ -4,7 +4,8 @@ import * as input_pill from "./input_pill";
 import {set_up_stream} from "./pill_typeahead";
 import * as stream_data from "./stream_data";
 import * as stream_pill from "./stream_pill";
-import type {CombinedPillItem} from "./typeahead_helper";
+import type {StreamPill} from "./stream_pill";
+import type {CombinedPill} from "./typeahead_helper";
 
 type SetUpPillTypeaheadConfig = {
     pill_widget: stream_pill.StreamPillWidget;
@@ -13,8 +14,8 @@ type SetUpPillTypeaheadConfig = {
 
 function create_item_from_stream_name(
     stream_name: string,
-    current_items: CombinedPillItem[],
-): input_pill.InputPillItem<stream_pill.StreamPill> | undefined {
+    current_items: CombinedPill[],
+): StreamPill | undefined {
     const stream_prefix_required = false;
     const get_allowed_streams = stream_data.get_invite_stream_data;
     const show_stream_sub_count = false;

--- a/web/src/invite_stream_picker_pill.ts
+++ b/web/src/invite_stream_picker_pill.ts
@@ -55,8 +55,9 @@ export function create($stream_pill_container: JQuery): stream_pill.StreamPillWi
             render_input_pill({
                 ...item,
                 has_stream: true,
-                display_value: stream_pill.get_display_string_from_item(item),
+                display_value: stream_pill.get_display_value_from_item(item),
             }),
+        get_display_value_from_item: stream_pill.get_display_value_from_item,
     });
     add_default_stream_pills(pill_widget);
     set_up_pill_typeahead({pill_widget, $pill_container: $stream_pill_container});

--- a/web/src/invite_stream_picker_pill.ts
+++ b/web/src/invite_stream_picker_pill.ts
@@ -1,3 +1,5 @@
+import render_input_pill from "../templates/input_pill.hbs";
+
 import * as input_pill from "./input_pill";
 import {set_up_stream} from "./pill_typeahead";
 import * as stream_data from "./stream_data";
@@ -49,6 +51,12 @@ export function create($stream_pill_container: JQuery): stream_pill.StreamPillWi
         $container: $stream_pill_container,
         create_item_from_text: create_item_from_stream_name,
         get_text_from_item: stream_pill.get_stream_name_from_item,
+        generate_pill_html: (item) =>
+            render_input_pill({
+                ...item,
+                has_stream: true,
+                display_value: stream_pill.get_display_string_from_item(item),
+            }),
     });
     add_default_stream_pills(pill_widget);
     set_up_pill_typeahead({pill_widget, $pill_container: $stream_pill_container});

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -18,7 +18,7 @@ export type SearchUserPill = {
     operator: string;
     negated: boolean;
     users: {
-        display_value: string;
+        full_name: string;
         user_id: number;
         email: string;
         img_src: string;
@@ -95,7 +95,7 @@ function append_user_pill(
         operator,
         negated,
         users: users.map((user) => ({
-            display_value: user.full_name,
+            full_name: user.full_name,
             user_id: user.user_id,
             email: user.email,
             img_src: people.small_avatar_url_for_person(user),

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -16,11 +16,6 @@ import type {UserStatusEmojiInfo} from "./user_status";
 export type SearchUserPill = {
     type: "search_user";
     operator: string;
-    // TODO: It would be nice if we just call this `search_string` instead of
-    // `display_value`, because we don't actually display this value for user
-    // pills, but `display_value` is needed to hook into the generic input pill
-    // logic and it would be a decent amount of work to change that.
-    display_value: string;
     negated: boolean;
     users: {
         display_value: string;
@@ -36,7 +31,6 @@ export type SearchUserPill = {
 type SearchPill =
     | {
           type: "search";
-          display_value: string;
           operator: string;
           operand: string;
           negated: boolean | undefined;
@@ -54,7 +48,6 @@ export function create_item_from_search_string(search_string: string): SearchPil
         return undefined;
     }
     return {
-        display_value: search_string,
         type: "search",
         operator: search_term.operator,
         operand: search_term.operand,
@@ -83,6 +76,7 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
                 display_value,
             });
         },
+        get_display_value_from_item: get_search_string_from_item,
     });
     // We don't automatically create pills on paste. When the user
     // presses enter, we validate the input then.
@@ -96,12 +90,9 @@ function append_user_pill(
     operator: string,
     negated: boolean,
 ): void {
-    const sign = negated ? "-" : "";
-    const search_string = sign + operator + ":" + users.map((user) => user.email).join(",");
     const pill_data: SearchUserPill = {
         type: "search_user",
         operator,
-        display_value: search_string,
         negated,
         users: users.map((user) => ({
             display_value: user.full_name,

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -1,6 +1,9 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import render_input_pill from "../templates/input_pill.hbs";
+import render_search_user_pill from "../templates/search_user_pill.hbs";
+
 import {Filter} from "./filter";
 import * as input_pill from "./input_pill";
 import type {InputPillContainer} from "./input_pill";
@@ -9,6 +12,7 @@ import type {User} from "./people";
 import type {NarrowTerm} from "./state_data";
 import * as user_status from "./user_status";
 import type {UserStatusEmojiInfo} from "./user_status";
+import * as util from "./util";
 
 export type SearchUserPill = {
     type: "search_user";
@@ -70,6 +74,25 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
         get_text_from_item: get_search_string_from_item,
         split_text_on_comma: false,
         convert_to_pill_on_enter: false,
+        generate_pill_html(item) {
+            if (item.type === "search_user") {
+                return render_search_user_pill(item);
+            }
+            // For search pills, we don't need to use + instead
+            // of spaces in the pill, since there is visual separation
+            // of pills. We also chose to add a space after the colon
+            // after the search operator.
+            // TODO: Ideally we wouldn't store a display value in a
+            // non-display format, but we currently use `display_value`
+            // not only for visual representation but also for parsing
+            // the value a pill represents.
+            // In the future we should change all input pills to have
+            // a `value` as well as a `display_value`.
+            let display_value = item.display_value.replaceAll("+", " ");
+            display_value = display_value.replace(":", ": ");
+            display_value = util.robust_url_decode(display_value).trim();
+            return render_input_pill({display_value});
+        },
     });
     // We don't automatically create pills on paste. When the user
     // presses enter, we validate the input then.

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -34,7 +34,6 @@ type SearchPill =
     | {
           type: "search";
           display_value: string;
-          description_html: string;
           operator: string;
           operand: string;
           negated: boolean | undefined;
@@ -51,11 +50,9 @@ export function create_item_from_search_string(search_string: string): SearchPil
         // This will cause pill validation to fail and trigger a shake animation.
         return undefined;
     }
-    const description_html = Filter.search_description_as_html(search_terms);
     return {
         display_value: search_string,
         type: "search",
-        description_html,
         operator: search_term.operator,
         operand: search_term.operand,
         negated: search_term.negated,

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -12,7 +12,6 @@ import type {User} from "./people";
 import type {NarrowTerm} from "./state_data";
 import * as user_status from "./user_status";
 import type {UserStatusEmojiInfo} from "./user_status";
-import * as util from "./util";
 
 export type SearchUserPill = {
     type: "search_user";
@@ -64,7 +63,8 @@ export function create_item_from_search_string(search_string: string): SearchPil
 }
 
 export function get_search_string_from_item(item: SearchPill): string {
-    return item.display_value;
+    const sign = item.negated ? "-" : "";
+    return `${sign}${item.operator}: ${get_search_operand(item)}`;
 }
 
 export function create_pills($pill_container: JQuery): SearchPillWidget {
@@ -78,20 +78,10 @@ export function create_pills($pill_container: JQuery): SearchPillWidget {
             if (item.type === "search_user") {
                 return render_search_user_pill(item);
             }
-            // For search pills, we don't need to use + instead
-            // of spaces in the pill, since there is visual separation
-            // of pills. We also chose to add a space after the colon
-            // after the search operator.
-            // TODO: Ideally we wouldn't store a display value in a
-            // non-display format, but we currently use `display_value`
-            // not only for visual representation but also for parsing
-            // the value a pill represents.
-            // In the future we should change all input pills to have
-            // a `value` as well as a `display_value`.
-            let display_value = item.display_value.replaceAll("+", " ");
-            display_value = display_value.replace(":", ": ");
-            display_value = util.robust_url_decode(display_value).trim();
-            return render_input_pill({display_value});
+            const display_value = get_search_string_from_item(item);
+            return render_input_pill({
+                display_value,
+            });
         },
     });
     // We don't automatically create pills on paste. When the user

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -971,8 +971,8 @@ class Attacher {
 }
 
 export function get_search_result(
-    query_from_pills: string,
-    query_from_text: string,
+    pill_search_terms: NarrowTerm[],
+    text_search_terms: NarrowTerm[],
     add_current_filter = false,
 ): Suggestion[] {
     let suggestion_line: SuggestionLine;
@@ -980,8 +980,6 @@ export function get_search_result(
     // search_terms correspond to the terms for the query in the input.
     // This includes the entire query entered in the searchbox.
     // terms correspond to the terms for the entire query entered in the searchbox.
-    const pill_search_terms = Filter.parse(query_from_pills);
-    const text_search_terms = Filter.parse(query_from_text);
     let all_search_terms = [...pill_search_terms, ...text_search_terms];
 
     // `last` will always be a text term, not a pill term. If there is no
@@ -1101,14 +1099,14 @@ export function get_search_result(
 }
 
 export function get_suggestions(
-    query_from_pills: string,
-    query_from_text: string,
+    pill_search_terms: NarrowTerm[],
+    text_search_terms: NarrowTerm[],
     add_current_filter = false,
 ): {
     strings: string[];
     lookup_table: Map<string, Suggestion>;
 } {
-    const result = get_search_result(query_from_pills, query_from_text, add_current_filter);
+    const result = get_search_result(pill_search_terms, text_search_terms, add_current_filter);
     return finalize_search_result(result);
 }
 

--- a/web/src/stream_pill.ts
+++ b/web/src/stream_pill.ts
@@ -1,3 +1,5 @@
+import assert from "minimalistic-assert";
+
 import {$t} from "./i18n";
 import type {InputPillContainer, InputPillItem} from "./input_pill";
 import * as peer_data from "./peer_data";
@@ -8,6 +10,7 @@ import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
 export type StreamPill = {
     type: "stream";
     stream: StreamSubscription;
+    show_subscriber_count: boolean;
 };
 
 export type StreamPillWidget = InputPillContainer<StreamPill>;
@@ -55,14 +58,9 @@ export function create_item_from_stream_name(
         return undefined;
     }
 
-    let display_value = sub.name;
-    if (show_subscriber_count) {
-        display_value = format_stream_name_and_subscriber_count(sub);
-    }
-
     return {
         type: "stream",
-        display_value,
+        show_subscriber_count,
         stream: sub,
     };
 }
@@ -82,18 +80,23 @@ export function get_user_ids(pill_widget: StreamPillWidget | CombinedPillContain
     return user_ids;
 }
 
+export function get_display_value_from_item(item: StreamPill): string {
+    const stream = stream_data.get_sub_by_id(item.stream.stream_id);
+    assert(stream !== undefined);
+    if (item.show_subscriber_count) {
+        return format_stream_name_and_subscriber_count(stream);
+    }
+    return stream.name;
+}
+
 export function append_stream(
     stream: StreamSubscription,
     pill_widget: StreamPillWidget | CombinedPillContainer,
     show_subscriber_count = true,
 ): void {
-    let display_value = stream.name;
-    if (show_subscriber_count) {
-        display_value = format_stream_name_and_subscriber_count(stream);
-    }
     pill_widget.appendValidatedData({
         type: "stream",
-        display_value,
+        show_subscriber_count,
         stream,
     });
     pill_widget.clear_text();

--- a/web/src/stream_pill.ts
+++ b/web/src/stream_pill.ts
@@ -1,11 +1,11 @@
 import assert from "minimalistic-assert";
 
 import {$t} from "./i18n";
-import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillContainer} from "./input_pill";
 import * as peer_data from "./peer_data";
 import * as stream_data from "./stream_data";
 import type {StreamSubscription} from "./sub_store";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 
 export type StreamPill = {
     type: "stream";
@@ -27,11 +27,11 @@ function format_stream_name_and_subscriber_count(sub: StreamSubscription): strin
 
 export function create_item_from_stream_name(
     stream_name: string,
-    current_items: CombinedPillItem[],
+    current_items: CombinedPill[],
     stream_prefix_required = true,
     get_allowed_streams: () => StreamSubscription[] = stream_data.get_unsorted_subs,
     show_subscriber_count = true,
-): InputPillItem<StreamPill> | undefined {
+): StreamPill | undefined {
     stream_name = stream_name.trim();
     if (stream_prefix_required) {
         if (!stream_name.startsWith("#")) {
@@ -65,7 +65,7 @@ export function create_item_from_stream_name(
     };
 }
 
-export function get_stream_name_from_item(item: InputPillItem<StreamPill>): string {
+export function get_stream_name_from_item(item: StreamPill): string {
     return item.stream.name;
 }
 

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -10,7 +10,7 @@ import {MAX_ITEMS} from "./bootstrap_typeahead";
 import * as buddy_data from "./buddy_data";
 import * as compose_state from "./compose_state";
 import type {LanguageSuggestion, SlashCommandSuggestion} from "./composebox_typeahead";
-import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillContainer} from "./input_pill";
 import * as people from "./people";
 import type {PseudoMentionUser, User} from "./people";
 import * as pm_conversations from "./pm_conversations";
@@ -36,7 +36,6 @@ export type UserOrMentionPillData = UserOrMention & {
 
 export type CombinedPill = StreamPill | UserGroupPill | UserPill;
 export type CombinedPillContainer = InputPillContainer<CombinedPill>;
-export type CombinedPillItem = InputPillItem<CombinedPill>;
 
 export function build_highlight_regex(query: string): RegExp {
     const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -18,7 +18,7 @@ export type UserGroupPillData = UserGroup & {
     is_silent?: boolean;
 };
 
-function display_pill(group: UserGroup): string {
+export function display_pill(group: UserGroup): string {
     const group_members = get_group_members(group);
     return $t_html(
         {defaultMessage: "{group_name}: {group_size, plural, one {# user} other {# users}}"},
@@ -42,7 +42,6 @@ export function create_item_from_group_name(
 
     return {
         type: "user_group",
-        display_value: display_pill(group),
         group_id: group.id,
         group_name: group.name,
     };
@@ -76,7 +75,6 @@ function get_group_members(user_group: UserGroup): number[] {
 export function append_user_group(group: UserGroup, pill_widget: CombinedPillContainer): void {
     pill_widget.appendValidatedData({
         type: "user_group",
-        display_value: display_pill(group),
         group_id: group.id,
         group_name: group.name,
     });

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,7 +1,7 @@
 import {$t_html} from "./i18n";
-import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillContainer} from "./input_pill";
 import * as people from "./people";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 import type {UserGroup} from "./user_groups";
 import * as user_groups from "./user_groups";
 
@@ -28,8 +28,8 @@ export function display_pill(group: UserGroup): string {
 
 export function create_item_from_group_name(
     group_name: string,
-    current_items: CombinedPillItem[],
-): InputPillItem<UserGroupPill> | undefined {
+    current_items: CombinedPill[],
+): UserGroupPill | undefined {
     group_name = group_name.trim();
     const group = user_groups.get_user_group_from_name(group_name);
     if (!group) {
@@ -47,7 +47,7 @@ export function create_item_from_group_name(
     };
 }
 
-export function get_group_name_from_item(item: InputPillItem<UserGroupPill>): string {
+export function get_group_name_from_item(item: UserGroupPill): string {
     return item.group_name;
 }
 

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -17,6 +17,7 @@ export type UserPill = {
     type: "user";
     user_id?: number;
     email: string;
+    full_name: string | undefined;
     img_src?: string;
     deactivated?: boolean;
     status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined; // TODO: Move this in user_status.js
@@ -46,7 +47,7 @@ export function create_item_from_email(
             // is the email itself.
             return {
                 type: "user",
-                display_value: email,
+                full_name: undefined,
                 email,
             };
         }
@@ -67,11 +68,9 @@ export function create_item_from_email(
 
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
 
-    // We must supply display_value for the widget to work.  Everything
-    // else is for our own use in callbacks.
     const item: InputPillItem<UserPill> = {
         type: "user",
-        display_value: user.full_name,
+        full_name: user.full_name,
         user_id: user.user_id,
         email: user.email,
         img_src: avatar_url,
@@ -108,7 +107,7 @@ export function append_person(opts: {
 
     const pill_data: InputPillItem<UserPill> = {
         type: "user",
-        display_value: person.full_name,
+        full_name: person.full_name,
         user_id: person.user_id,
         email: person.email,
         img_src: avatar_url,
@@ -166,6 +165,10 @@ export function append_user(user: User, pills: UserPillWidget | CombinedPillCont
     }
 }
 
+export function get_display_value_from_item(item: UserPill): string {
+    return item.full_name ?? item.email;
+}
+
 export function generate_pill_html(
     item: InputPillItem<UserPill>,
     show_user_status_emoji = false,
@@ -179,7 +182,7 @@ export function generate_pill_html(
         }
     }
     return render_input_pill({
-        display_value: item.display_value,
+        display_value: get_display_value_from_item(item),
         has_image: item.img_src !== undefined,
         deactivated: item.deactivated,
         should_add_guest_user_indicator: item.should_add_guest_user_indicator,
@@ -199,6 +202,7 @@ export function create_pills(
         pill_config,
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
+        get_display_value_from_item,
         generate_pill_html,
     });
     return pills;

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -2,12 +2,12 @@ import render_input_pill from "../templates/input_pill.hbs";
 
 import * as blueslip from "./blueslip";
 import type {EmojiRenderingDetails} from "./emoji";
-import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
+import type {InputPillConfig, InputPillContainer} from "./input_pill";
 import * as input_pill from "./input_pill";
 import type {User} from "./people";
 import * as people from "./people";
 import {realm} from "./state_data";
-import type {CombinedPillContainer, CombinedPillItem} from "./typeahead_helper";
+import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
 import * as user_status from "./user_status";
 
 // This will be used for pills for things like composing
@@ -30,9 +30,9 @@ export type UserPillData = {type: "user"; user: User};
 
 export function create_item_from_email(
     email: string,
-    current_items: CombinedPillItem[],
+    current_items: CombinedPill[],
     pill_config?: InputPillConfig | undefined,
-): InputPillItem<UserPill> | undefined {
+): UserPill | undefined {
     // For normal Zulip use, we need to validate the email for our realm.
     const user = people.get_by_email(email);
 
@@ -68,7 +68,7 @@ export function create_item_from_email(
 
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
 
-    const item: InputPillItem<UserPill> = {
+    const item: UserPill = {
         type: "user",
         full_name: user.full_name,
         user_id: user.user_id,
@@ -92,7 +92,7 @@ export function create_item_from_email(
     return item;
 }
 
-export function get_email_from_item(item: InputPillItem<UserPill>): string {
+export function get_email_from_item(item: UserPill): string {
     return item.email;
 }
 
@@ -105,7 +105,7 @@ export function append_person(opts: {
     const avatar_url = people.small_avatar_url_for_person(person);
     const status_emoji_info = user_status.get_status_emoji(opts.person.user_id);
 
-    const pill_data: InputPillItem<UserPill> = {
+    const pill_data: UserPill = {
         type: "user",
         full_name: person.full_name,
         user_id: person.user_id,
@@ -169,10 +169,7 @@ export function get_display_value_from_item(item: UserPill): string {
     return item.full_name ?? item.email;
 }
 
-export function generate_pill_html(
-    item: InputPillItem<UserPill>,
-    show_user_status_emoji = false,
-): string {
+export function generate_pill_html(item: UserPill, show_user_status_emoji = false): string {
     let status_emoji_info;
     let has_status;
     if (show_user_status_emoji) {

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -1,3 +1,5 @@
+import render_input_pill from "../templates/input_pill.hbs";
+
 import * as blueslip from "./blueslip";
 import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
 import * as input_pill from "./input_pill";
@@ -159,6 +161,30 @@ export function append_user(user: User, pills: UserPillWidget | CombinedPillCont
     }
 }
 
+export function generate_pill_html(
+    item: InputPillItem<UserPill>,
+    show_user_status_emoji = false,
+): string {
+    let status_emoji_info;
+    let has_status;
+    if (show_user_status_emoji) {
+        has_status = item.status_emoji_info !== undefined;
+        if (has_status) {
+            status_emoji_info = item.status_emoji_info;
+        }
+    }
+    return render_input_pill({
+        display_value: item.display_value,
+        has_image: item.img_src !== undefined,
+        deactivated: item.deactivated,
+        should_add_guest_user_indicator: item.should_add_guest_user_indicator,
+        user_id: item.user_id,
+        img_src: item.img_src,
+        has_status,
+        status_emoji_info,
+    });
+}
+
 export function create_pills(
     $pill_container: JQuery,
     pill_config?: InputPillConfig | undefined,
@@ -168,6 +194,7 @@ export function create_pills(
         pill_config,
         create_item_from_text: create_item_from_email,
         get_text_from_item: get_email_from_item,
+        generate_pill_html,
     });
     return pills;
 }

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -1,6 +1,7 @@
 import render_input_pill from "../templates/input_pill.hbs";
 
 import * as blueslip from "./blueslip";
+import type {EmojiRenderingDetails} from "./emoji";
 import type {InputPillConfig, InputPillContainer, InputPillItem} from "./input_pill";
 import * as input_pill from "./input_pill";
 import type {User} from "./people";
@@ -16,6 +17,10 @@ export type UserPill = {
     type: "user";
     user_id?: number;
     email: string;
+    img_src?: string;
+    deactivated?: boolean;
+    status_emoji_info?: (EmojiRenderingDetails & {emoji_alt_code?: boolean}) | undefined; // TODO: Move this in user_status.js
+    should_add_guest_user_indicator?: boolean;
 };
 
 export type UserPillWidget = InputPillContainer<UserPill>;

--- a/web/templates/search_user_pill.hbs
+++ b/web/templates/search_user_pill.hbs
@@ -7,7 +7,7 @@
         <div class="pill{{#if deactivated}} deactivated-pill{{/if}}" data-user-id="{{this.user_id}}">
             <img class="pill-image" src="{{this.img_src}}" />
             <span class="pill-label">
-                <span class="pill-value">{{ this.display_value }}</span>
+                <span class="pill-value">{{ this.full_name }}</span>
                 {{~#if this.should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
                 {{~#if deactivated}}&nbsp;({{t 'deactivated'}}){{~/if~}}
                 {{~#if this.status_emoji_info~}}

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -114,7 +114,7 @@ run_test("pills", ({override, override_rewire}) => {
             assert.ok(get_by_email_called);
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, iago.user_id);
-            assert.equal(res.display_value, iago.full_name);
+            assert.equal(res.full_name, iago.full_name);
         })();
 
         (function test_deactivated_pill() {
@@ -124,7 +124,7 @@ run_test("pills", ({override, override_rewire}) => {
             assert.ok(get_by_email_called);
             assert.equal(typeof res, "object");
             assert.equal(res.user_id, iago.user_id);
-            assert.equal(res.display_value, iago.full_name);
+            assert.equal(res.full_name, iago.full_name);
             assert.ok(res.deactivated);
             people.add_active_user(iago);
         })();

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -50,6 +50,7 @@ const typeahead_helper = zrequire("typeahead_helper");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
+const user_pill = zrequire("user_pill");
 const stream_data = zrequire("stream_data");
 const stream_list_sort = zrequire("stream_list_sort");
 const compose_pm_pill = zrequire("compose_pm_pill");
@@ -846,7 +847,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         onPillCreate() {},
         onPillRemove() {},
         appendValidatedData(item) {
-            appended_names.push(item.display_value);
+            appended_names.push(user_pill.get_display_value_from_item(item));
         },
     }));
     compose_pm_pill.initialize({

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -4,7 +4,6 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
-const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 
 set_global("document", {});
@@ -505,11 +504,9 @@ run_test("exit button on pill", ({mock_template}) => {
 run_test("misc things", () => {
     const info = set_up();
 
-    const config = info.config;
     const $container = info.$container;
     const $pill_input = info.$pill_input;
-
-    const widget = input_pill.create(config);
+    input_pill.create(info.config);
 
     // animation
     const animation_end_handler = $container.get_on_handler("animationend", ".input");
@@ -527,12 +524,6 @@ run_test("misc things", () => {
 
     animation_end_handler.call(input_stub);
     assert.ok(shake_class_removed);
-
-    // bad data
-    blueslip.expect("error", "no type defined for the item");
-    widget.appendValidatedData({
-        language: "js",
-    });
 
     // click on container
     const container_click_handler = $container.get_on_handler("click");

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -42,12 +42,13 @@ run_test("basics", ({mock_template}) => {
         $container,
         create_item_from_text: noop,
         get_text_from_item: noop,
+        get_display_value_from_item: (item) => item.language,
     });
 
     // type for a pill can be any string but it needs to be
     // defined while creating any pill.
     const item = {
-        display_value: "JavaScript",
+        language: "JavaScript",
         type: "language",
     };
 
@@ -68,19 +69,19 @@ run_test("basics", ({mock_template}) => {
 function set_up() {
     const items = {
         blue: {
-            display_value: "BLUE",
+            color_name: "BLUE",
             description: "color of the sky",
             type: "color",
         },
 
         red: {
-            display_value: "RED",
+            color_name: "RED",
             type: "color",
             description: "color of stop signs",
         },
 
         yellow: {
-            display_value: "YELLOW",
+            color_name: "YELLOW",
             type: "color",
             description: "color of bananas",
         },
@@ -99,7 +100,8 @@ function set_up() {
     const config = {
         $container,
         create_item_from_text,
-        get_text_from_item: (item) => item.display_value,
+        get_text_from_item: (item) => item.color_name,
+        get_display_value_from_item: (item) => item.color_name,
     };
 
     return {
@@ -403,7 +405,7 @@ run_test("insert_remove", ({mock_template}) => {
 
     const pills = widget._get_pills_for_testing();
     for (const pill of pills) {
-        pill.$element.remove = set_colored_removed_func(pill.item.display_value);
+        pill.$element.remove = set_colored_removed_func(pill.item.color_name);
     }
 
     let key_handler = $container.get_on_handler("keydown", ".input");
@@ -527,12 +529,8 @@ run_test("misc things", () => {
     assert.ok(shake_class_removed);
 
     // bad data
-    blueslip.expect("error", "no display_value returned");
-    widget.appendValidatedData("this-has-no-item-attribute");
-
     blueslip.expect("error", "no type defined for the item");
     widget.appendValidatedData({
-        display_value: "This item has no type.",
         language: "js",
     });
 
@@ -566,8 +564,9 @@ run_test("appendValue/clear", ({mock_template}) => {
 
     const config = {
         $container,
-        create_item_from_text: (s) => ({type: "color", display_value: s}),
-        get_text_from_item: /* istanbul ignore next */ (s) => s.display_value,
+        create_item_from_text: (s) => ({type: "color", color_name: s}),
+        get_text_from_item: /* istanbul ignore next */ (s) => s.color_name,
+        get_display_value_from_item: (s) => s.color_name,
     };
 
     $pill_input.before = noop;
@@ -587,7 +586,7 @@ run_test("appendValue/clear", ({mock_template}) => {
     const removed_colors = [];
     for (const pill of pills) {
         pill.$element.remove = () => {
-            removed_colors.push(pill.item.display_value);
+            removed_colors.push(pill.item.color_name);
         };
     }
 

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -11,8 +11,6 @@ set_global("document", {});
 class ClipboardEvent {}
 set_global("ClipboardEvent", ClipboardEvent);
 
-const example_img_link = "http://example.com/example.png";
-
 mock_esm("../src/ui_util", {
     place_caret_at_end: noop,
 });
@@ -23,24 +21,10 @@ set_global("getSelection", () => ({
 
 const input_pill = zrequire("input_pill");
 
-function pill_html(value, img_src, status_emoji_info) {
-    const has_image = img_src !== undefined;
-    const has_status = status_emoji_info !== undefined;
-
+function pill_html(value) {
     const opts = {
         display_value: value,
-        has_image,
-        has_status,
     };
-
-    if (has_image) {
-        opts.img_src = img_src;
-    }
-
-    if (has_status) {
-        opts.status_emoji_info = status_emoji_info;
-    }
-
     return require("../templates/input_pill.hbs")(opts);
 }
 
@@ -58,24 +42,17 @@ run_test("basics", ({mock_template}) => {
         $container,
         create_item_from_text: noop,
         get_text_from_item: noop,
-        pill_config: {
-            show_user_status_emoji: true,
-        },
     });
-    const status_emoji_info = {emoji_code: "5"};
 
     // type for a pill can be any string but it needs to be
     // defined while creating any pill.
     const item = {
         display_value: "JavaScript",
-        language: "js",
         type: "language",
-        img_src: example_img_link,
-        status_emoji_info,
     };
 
     let inserted_before;
-    const expected_html = pill_html("JavaScript", example_img_link, status_emoji_info);
+    const expected_html = pill_html("JavaScript");
 
     $pill_input.before = ($elem) => {
         inserted_before = true;
@@ -94,7 +71,6 @@ function set_up() {
             display_value: "BLUE",
             description: "color of the sky",
             type: "color",
-            img_src: example_img_link,
         },
 
         red: {
@@ -172,10 +148,7 @@ run_test("copy from pill", ({mock_template}) => {
 });
 
 run_test("paste to input", ({mock_template}) => {
-    mock_template("input_pill.hbs", true, (data, html) => {
-        assert.equal(typeof data.has_image, "boolean");
-        return html;
-    });
+    mock_template("input_pill.hbs", true, (_data, html) => html);
 
     const info = set_up();
     const config = info.config;
@@ -219,10 +192,7 @@ run_test("paste to input", ({mock_template}) => {
 });
 
 run_test("arrows on pills", ({mock_template}) => {
-    mock_template("input_pill.hbs", true, (data, html) => {
-        assert.equal(typeof data.has_image, "boolean");
-        return html;
-    });
+    mock_template("input_pill.hbs", true, (_data, html) => html);
 
     const info = set_up();
     const config = info.config;
@@ -413,11 +383,7 @@ run_test("insert_remove", ({mock_template}) => {
     assert.ok(created);
     assert.ok(!removed);
 
-    assert.deepEqual(inserted_html, [
-        pill_html("BLUE", example_img_link),
-        pill_html("RED"),
-        pill_html("YELLOW"),
-    ]);
+    assert.deepEqual(inserted_html, [pill_html("BLUE"), pill_html("RED"), pill_html("YELLOW")]);
 
     assert.deepEqual(widget.items(), [items.blue, items.red, items.yellow]);
 
@@ -568,7 +534,6 @@ run_test("misc things", () => {
     widget.appendValidatedData({
         display_value: "This item has no type.",
         language: "js",
-        img_src: example_img_link,
     });
 
     // click on container

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -137,10 +137,7 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
         sort_recipients_called = true;
         return users;
     });
-    mock_template("input_pill.hbs", true, (data, html) => {
-        assert.equal(typeof data.display_value, "string");
-        return html;
-    });
+    mock_template("input_pill.hbs", true, (_data, html) => html);
     let input_pill_typeahead_called = false;
     const $fake_input = $.create(".input");
     $fake_input.before = noop;
@@ -152,6 +149,7 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
         $container,
         create_item_from_text: noop,
         get_text_from_item: noop,
+        get_display_value_from_item: noop,
     });
 
     let update_func_called = false;
@@ -228,10 +226,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
         sort_streams_called = true;
         return streams;
     });
-    mock_template("input_pill.hbs", true, (data, html) => {
-        assert.equal(typeof data.display_value, "string");
-        return html;
-    });
+    mock_template("input_pill.hbs", true, (_data, html) => html);
     let input_pill_typeahead_called = false;
     const $fake_input = $.create(".input");
     $fake_input.before = noop;
@@ -243,6 +238,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
         $container,
         create_item_from_text: noop,
         get_text_from_item: noop,
+        get_display_value_from_item: noop,
     });
 
     let update_func_called = false;
@@ -315,10 +311,7 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
 
 run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
     override_typeahead_helper(override_rewire);
-    mock_template("input_pill.hbs", true, (data, html) => {
-        assert.equal(typeof data.display_value, "string");
-        return html;
-    });
+    mock_template("input_pill.hbs", true, (_data, html) => html);
     let input_pill_typeahead_called = false;
     const $fake_input = $.create(".input");
     $fake_input.before = noop;
@@ -330,6 +323,7 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         $container,
         create_item_from_text: noop,
         get_text_from_item: noop,
+        get_display_value_from_item: noop,
     });
 
     let update_func_called = false;

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -139,7 +139,6 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
     });
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
-        assert.equal(typeof data.has_image, "boolean");
         return html;
     });
     let input_pill_typeahead_called = false;
@@ -231,7 +230,6 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
     });
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
-        assert.equal(typeof data.has_image, "boolean");
         return html;
     });
     let input_pill_typeahead_called = false;
@@ -319,7 +317,6 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
     override_typeahead_helper(override_rewire);
     mock_template("input_pill.hbs", true, (data, html) => {
         assert.equal(typeof data.display_value, "string");
-        assert.equal(typeof data.has_image, "boolean");
         return html;
     });
     let input_pill_typeahead_called = false;

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -52,11 +52,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
         return html;
     });
 
-    let expected_suggestion_parts = [];
-    mock_template("search_description.hbs", false, (data, html) => {
-        assert.deepStrictEqual(data.parts, expected_suggestion_parts);
-        return html;
-    });
     let expected_pill_display_value = "";
     let input_pill_displayed = false;
     mock_template("input_pill.hbs", true, (data, html) => {
@@ -234,13 +229,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                     operand: "ver",
                 },
             ];
-            expected_suggestion_parts = [
-                {
-                    operand: "ver",
-                    prefix_for_operator: "search for",
-                    type: "prefix_for_operator",
-                },
-            ];
             expected_pill_display_value = null;
             _setup(terms);
             input_pill_displayed = false;
@@ -253,13 +241,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
                 {
                     negated: false,
                     operator: "channel",
-                    operand: "Verona",
-                },
-            ];
-            expected_suggestion_parts = [
-                {
-                    type: "prefix_for_operator",
-                    prefix_for_operator: "channel",
                     operand: "Verona",
                 },
             ];
@@ -370,13 +351,6 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             negated: false,
             operator: "search",
             operand: "ver",
-        },
-    ];
-    expected_suggestion_parts = [
-        {
-            operand: "ver",
-            prefix_for_operator: "search for",
-            type: "prefix_for_operator",
         },
     ];
     expected_pill_display_value = "ver";

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -11,6 +11,7 @@ const stream_topic_history_util = mock_esm("../src/stream_topic_history_util");
 
 const direct_message_group_data = zrequire("direct_message_group_data");
 
+const {Filter} = zrequire("filter");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
@@ -67,7 +68,7 @@ function init() {
 }
 
 function get_suggestions(query, pill_query = "") {
-    return search.get_suggestions(pill_query, query);
+    return search.get_suggestions(Filter.parse(pill_query), Filter.parse(query));
 }
 
 function test(label, f) {

--- a/web/tests/stream_pill.test.js
+++ b/web/tests/stream_pill.test.js
@@ -28,18 +28,18 @@ const germany = {
     invite_only: true,
 };
 
-peer_data.set_subscribers(denmark.stream_id, [1, 2, 3, 77]);
+peer_data.set_subscribers(denmark.stream_id, [1, 2, 77]);
 peer_data.set_subscribers(sweden.stream_id, [1, 2, 3, 4, 5]);
 
 const denmark_pill = {
     type: "stream",
-    display_value: "Denmark: 3 users",
     stream: denmark,
+    show_subscriber_count: true,
 };
 const sweden_pill = {
     type: "stream",
-    display_value: "translated: Sweden: 5 users",
     stream: sweden,
+    show_subscriber_count: true,
 };
 
 const subs = [denmark, sweden, germany];
@@ -80,6 +80,19 @@ run_test("create_item", () => {
     test_create_item("  #sweden", [], sweden_pill);
     test_create_item("#test", [], undefined);
     test_create_item("#germany", [], undefined, true, stream_data.get_invite_stream_data);
+});
+
+run_test("display_value", () => {
+    assert.deepEqual(
+        stream_pill.get_display_value_from_item(denmark_pill),
+        "translated: Denmark: 3 users",
+    );
+    assert.deepEqual(
+        stream_pill.get_display_value_from_item(sweden_pill),
+        "translated: Sweden: 5 users",
+    );
+    sweden_pill.show_subscriber_count = false;
+    assert.deepEqual(stream_pill.get_display_value_from_item(sweden_pill), "Sweden");
 });
 
 run_test("get_stream_id", () => {

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -68,13 +68,11 @@ const admins_pill = {
     group_id: admins.id,
     group_name: admins.name,
     type: "user_group",
-    display_value: "translated HTML: " + admins.name + ": " + admins.members.length + " users",
 };
 const testers_pill = {
     group_id: testers.id,
     group_name: testers.name,
     type: "user_group",
-    display_value: "translated HTML: " + testers.name + ": " + testers.members.length + " users",
 };
 const everyone_pill = {
     group_id: everyone.id,
@@ -83,7 +81,6 @@ const everyone_pill = {
     // While we can programmatically set the user count below,
     // calculating it would almost mimic the entire display function
     // here, reducing the usefulness of the test.
-    display_value: "translated HTML: translated: Everyone: 5 users",
 };
 
 const groups = [admins, testers, everyone];
@@ -102,6 +99,21 @@ run_test("create_item", () => {
     test_create_item("admins", [admins_pill], undefined);
     test_create_item("unknown", [], undefined);
     test_create_item("role:everyone", [], everyone_pill);
+});
+
+run_test("display_value", () => {
+    assert.deepEqual(
+        user_group_pill.display_pill(admins),
+        "translated HTML: " + admins.name + ": " + admins.members.length + " users",
+    );
+    assert.deepEqual(
+        user_group_pill.display_pill(testers),
+        "translated HTML: " + testers.name + ": " + testers.members.length + " users",
+    );
+    assert.deepEqual(
+        user_group_pill.display_pill(everyone),
+        "translated HTML: translated: Everyone: 5 users",
+    );
 });
 
 run_test("get_stream_id", () => {

--- a/web/tests/user_pill.test.js
+++ b/web/tests/user_pill.test.js
@@ -27,13 +27,13 @@ const isaac = {
 const bogus_item = {
     email: "bogus@example.com",
     type: "user",
-    display_value: "bogus@example.com",
+    full_name: undefined,
     // status_emoji_info: undefined,
 };
 
 const isaac_item = {
     email: "isaac@example.com",
-    display_value: "Isaac Newton",
+    full_name: "Isaac Newton",
     type: "user",
     user_id: isaac.user_id,
     deactivated: false,
@@ -46,7 +46,7 @@ const inaccessible_user_id = 103;
 
 const inaccessible_user_item = {
     email: "user103@example.com",
-    display_value: "translated: Unknown user",
+    full_name: "translated: Unknown user",
     type: "user",
     user_id: inaccessible_user_id,
     deactivated: false,
@@ -108,7 +108,7 @@ test("append", () => {
     function fake_append(opts) {
         appended = true;
         assert.equal(opts.email, isaac.email);
-        assert.equal(opts.display_value, isaac.full_name);
+        assert.equal(opts.full_name, isaac.full_name);
         assert.equal(opts.user_id, isaac.user_id);
         assert.equal(opts.img_src, isaac_item.img_src);
     }


### PR DESCRIPTION
This PR should have no visual changes to users, it's purely a refactor.

This change had two main motivators:

(1) We were putting a bunch of custom logic in `input_pill`, especially for display. This PR moves that to the relevant modules.

(2) `display_value` was being used for both the pill identifying "value" and for parsing the value a pill represented. This led to some hacks in the search pill code where we adjusted `display_value` just before displaying it. This PR removes `display_value` altogether and replaces it with relevant identifying information for each pill. Display values are calculated when we need them based on that identifying information. Maybe we want to tweak this to only generate `display_value` once, but I think the current state of the PR is fine since we don't display that pills in large quantities or in quick succession.

(3) (from a comment on the [search pills PR](https://github.com/zulip/zulip/pull/26803#issuecomment-2219032782)): The + format for strings with spaces in them should only be present in the code for generating a URL and parsing one; we should be storing the actual name in the pill object, not the URL-encoded name.

**Unit testing**

I removed some tests from `input_pill` that I haven't put elsewhere yet. If it seems like a good idea to add tests (especially `user_pill`) I can work on that.

**Manual testing**

search: DM (I also tested that the message view updates correctly)

<img width="227" alt="image" src="https://github.com/user-attachments/assets/8d4edf6f-8fce-450b-8411-08a244db21c9">

search: group DM (I also tested that the message view updates correctly)

<img width="461" alt="image" src="https://github.com/user-attachments/assets/b4c5eeb3-750d-4bb1-b67c-99703a9bebef">

search: DM with deactivated user (I also tested that the message view updates correctly)

<img width="323" alt="image" src="https://github.com/user-attachments/assets/bc1ee375-ce6c-42f4-8094-dfc697f26ddc">

search: DM with user with status_emoji_info (I also tested that the message view updates correctly)

<img width="276" alt="image" src="https://github.com/user-attachments/assets/959a5831-6807-499a-9a79-7c8f3bbc0634">

compose: deactivated user

<img width="360" alt="image" src="https://github.com/user-attachments/assets/5b5358ec-f12d-4af8-9377-7ed08c4765d4">

compose: user with guest indicator

<img width="381" alt="image" src="https://github.com/user-attachments/assets/067109a6-9573-4f14-9aa3-d048f2d13a84">

compose: user with status_emoji_info (I also tested that the message sends)

<img width="372" alt="image" src="https://github.com/user-attachments/assets/c6d74f74-d97b-4f46-8b28-638e34e22fb4">

stream add subscribers: user, usergroup, and channel (I also tested that adding works)

<img width="359" alt="image" src="https://github.com/user-attachments/assets/99d9b2e7-9ebc-4e50-b9cf-b91f480ce8a9">

stream add subscribers: user with status_emoji_info (it's expected that the emoji doesn't show)

<img width="209" alt="image" src="https://github.com/user-attachments/assets/247b0c87-9eaf-49aa-a3fc-e1bbc0539290">

invite: emails (I didn't test that the email was sent, only the visual state)

<img width="503" alt="image" src="https://github.com/user-attachments/assets/5ee1260f-82b8-4af2-ac68-6e286be4c7b1">

invite: stream picker  (I didn't test that the user was subscribed, only the visual state)

<img width="499" alt="image" src="https://github.com/user-attachments/assets/be27eff1-8bc0-4f03-9d47-f0ddfa6be546">