### PR TITLE
message_controls: Add missing class to edit buttons.

### DIFF
--- a/web/templates/edit_content_button.hbs
+++ b/web/templates/edit_content_button.hbs
@@ -1,5 +1,5 @@
 {{#if is_content_editable}}
-<i class="zulip-icon zulip-icon-edit edit_content_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)"></i>
+<i class="message-controls-icon zulip-icon zulip-icon-edit edit_content_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)"></i>
 {{else if can_move_message}}
-<i class="zulip-icon zulip-icon-move-alt move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (m)"></i>
+<i class="message-controls-icon zulip-icon zulip-icon-move-alt move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (m)"></i>
 {{/if}}


### PR DESCRIPTION
This adds a missing `message-controls-icon` class to the edit buttons, which caused the misalignment of edit and related icons. This was overlooked in #31157.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![Screen Shot 2024-07-30 at 14 57 39](https://github.com/user-attachments/assets/e6a19b73-5ee1-4803-b08f-fdea8d16e888) | ![Screen Shot 2024-07-30 at 14 57 15](https://github.com/user-attachments/assets/858d3f97-7ce8-4144-b198-c63c230255dc) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>