### PR TITLE
stream_list: Fix handling of unsubscribing from last channel.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -241,21 +241,17 @@ export function build_stream_list(force_rerender: boolean): void {
     //
     // Within the first two sections, muted streams are sorted to the
     // bottom; we skip that for dormant streams to simplify discovery.
-    const streams = stream_data.subscribed_stream_ids();
-    const $parent = $("#stream_filters");
-    if (streams.length === 0) {
-        $parent.empty();
-        return;
-    }
-
+    //
     // The main logic to build the list is in stream_list_sort.ts, and
     // we get five lists of streams (pinned/normal/muted_pinned/muted_normal/dormant).
+    const streams = stream_data.subscribed_stream_ids();
     const stream_groups = stream_list_sort.sort_groups(streams, get_search_term());
 
     if (stream_groups.same_as_before && !force_rerender) {
         return;
     }
 
+    const $parent = $("#stream_filters");
     const elems = [];
 
     function add_sidebar_li(stream_id: number): void {


### PR DESCRIPTION
This check been present since
466beef6fedbd800933fecb59f1b492865035b84, but it seems unnecessary in that the main logic handles there being 0 channels just fine, that's a rare case (so not a useful optimization), and importantly, not calling stream_list_sort.sort_groups for that transition resulted in `stream_list_sort` having stale data structures, resulting in exceptions if one tried to open the CHANNELS filter widget in the newly-no-channels state.
