### PR TITLE
message_previews: Simplify presentation of message previews.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -39,7 +39,6 @@ export function clear_private_stream_alert() {
 }
 
 export function clear_preview_area() {
-    $("textarea#compose-textarea").show();
     $("textarea#compose-textarea").trigger("focus");
     $("#compose .undo_markdown_preview").hide();
     $("#compose .preview_message_area").hide();
@@ -60,7 +59,6 @@ export function show_preview_area() {
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
     const content = $("textarea#compose-textarea").val();
-    $("textarea#compose-textarea").hide();
     $("#compose .markdown_preview").hide();
     $("#compose .undo_markdown_preview").show();
     $("#compose .undo_markdown_preview").trigger("focus");

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -58,11 +58,19 @@ export function show_preview_area() {
     $("#compose").addClass("preview_mode");
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
-    const content = $("textarea#compose-textarea").val();
+    const $compose_textarea = $("textarea#compose-textarea");
+    const content = $compose_textarea.val();
+    const edit_height = $compose_textarea.height();
+
     $("#compose .markdown_preview").hide();
     $("#compose .undo_markdown_preview").show();
     $("#compose .undo_markdown_preview").trigger("focus");
-    $("#compose .preview_message_area").show();
+
+    const $preview_message_area = $("#compose .preview_message_area");
+    // Set the preview area to the edit height to keep from
+    // having the preview jog the size of the compose box.
+    $preview_message_area.css({height: edit_height + "px"});
+    $preview_message_area.show();
 
     compose_ui.render_and_show_preview(
         $("#compose .markdown_preview_spinner"),

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1424,6 +1424,7 @@ export function is_message_oldest_or_newest(
 export function show_preview_area($element) {
     const $row = rows.get_closest_row($element);
     const $msg_edit_content = $row.find(".message_edit_content");
+    const edit_height = $msg_edit_content.height();
     const content = $msg_edit_content.val();
 
     // Disable unneeded compose_control_buttons as we don't
@@ -1434,7 +1435,11 @@ export function show_preview_area($element) {
     $msg_edit_content.hide();
     $row.find(".markdown_preview").hide();
     $row.find(".undo_markdown_preview").show();
-    $row.find(".preview_message_area").show();
+    const $preview_message_area = $row.find(".preview_message_area");
+    // Set the preview area to the edit height to keep from
+    // having the preview jog the size of the message-edit box.
+    $preview_message_area.css({height: edit_height + "px"});
+    $preview_message_area.show();
 
     compose_ui.render_and_show_preview(
         $row.find(".markdown_preview_spinner"),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -468,6 +468,9 @@
     */
     --max-unmaximized-compose-height: 40vh;
 
+    /* Maximum height of the message-edit and preview areas. */
+    --max-message-edit-height: 24em;
+
     /*
     Line height of the message buttons in compose box. Here it's necessary
     to control this value uniformly and precisely to avoid issues with

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -826,7 +826,7 @@
 
 textarea.new_message_textarea {
     display: table-cell;
-    padding: 5px;
+    padding: 5px 5px 0;
     height: 1.5em;
     max-height: 22em;
     margin: 0;
@@ -1359,7 +1359,7 @@ textarea.new_message_textarea {
 }
 
 .preview_message_area {
-    padding: 5px;
+    padding: 5px 5px 0;
     overflow: auto;
 
     border-radius: 3px 3px 0 0;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1360,10 +1360,6 @@ textarea.new_message_textarea {
 
 .preview_message_area {
     padding: 5px;
-    /* the maximum height the textarea gets to. */
-    max-height: 308px;
-    /* the minimum height the textarea collapses to. */
-    min-height: 42px;
     overflow: auto;
 
     border-radius: 3px 3px 0 0;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -681,7 +681,7 @@
 }
 
 .message_edit_content {
-    max-height: 24em;
+    max-height: var(--max-message-edit-height);
     width: 100%;
     min-width: 206px;
     min-height: 52px;
@@ -775,6 +775,10 @@ of the base style defined for a read-only textarea in dark mode. */
     .edit-controls {
         margin-left: 0;
         margin-top: 0;
+    }
+
+    .preview_message_area {
+        max-height: var(--max-message-edit-height);
     }
 }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -696,7 +696,7 @@
     border: none;
     /* Match textarea padding to compose box and
        message-edit preview area. */
-    padding: 5px;
+    padding: 5px 5px 0;
     margin: 0;
 
     box-shadow: none;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -349,13 +349,6 @@
         }
     }
 
-    & > .spoiler-block:last-child {
-        /* A spoiler block at the end of a message, or as
-           a message's only content, gets the same bottom
-           margin as other elements. */
-        margin-bottom: var(--markdown-interelement-space-px);
-    }
-
     /* embedded link previews */
     .message_inline_image_title {
         font-weight: bold;
@@ -894,18 +887,6 @@
             max-width: 100%;
             margin-top: 10px;
         }
-    }
-}
-
-.preview_content.rendered_markdown {
-    /*  Ensure that the first child and last child
-    don't have blank area at the top and bottom respectively. */
-    & > :first-child {
-        margin-top: 0;
-    }
-
-    & > :last-child:not(.message_inline_image) {
-        margin-bottom: 0;
     }
 }
 

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -653,6 +653,9 @@ test_ui("on_events", ({override, override_rewire}) => {
 
     (function test_markdown_preview_compose_clicked() {
         // Tests setup
+        $("textarea#compose-textarea").set_height(50);
+        $("#compose .preview_message_area").css = noop;
+
         function setup_visibilities() {
             $("#compose .markdown_preview").show();
             $("#compose .undo_markdown_preview").hide();

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -405,7 +405,6 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     compose_state.set_stream_id(social.stream_id);
 
     $("textarea#compose-textarea").val("message me");
-    $("textarea#compose-textarea").hide();
     $("#compose .undo_markdown_preview").show();
     $("#compose .preview_message_area").show();
     $("#compose .markdown_preview").hide();
@@ -416,7 +415,6 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
         send_message_called = true;
     });
     compose.enter_with_preview_open();
-    assert.ok($("textarea#compose-textarea").visible());
     assert.ok(!$("#compose .undo_markdown_preview").visible());
     assert.ok(!$("#compose .preview_message_area").visible());
     assert.ok($("#compose .markdown_preview").visible());
@@ -490,7 +488,6 @@ test_ui("finish", ({override, override_rewire}) => {
             send_message_called = true;
         });
         assert.ok(compose.finish());
-        assert.ok($("textarea#compose-textarea").visible());
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
         assert.ok($("#compose .markdown_preview").visible());
@@ -657,7 +654,6 @@ test_ui("on_events", ({override, override_rewire}) => {
     (function test_markdown_preview_compose_clicked() {
         // Tests setup
         function setup_visibilities() {
-            $("textarea#compose-textarea").show();
             $("#compose .markdown_preview").show();
             $("#compose .undo_markdown_preview").hide();
             $("#compose .preview_message_area").hide();
@@ -665,7 +661,6 @@ test_ui("on_events", ({override, override_rewire}) => {
         }
 
         function assert_visibilities() {
-            assert.ok(!$("textarea#compose-textarea").visible());
             assert.ok(!$("#compose .markdown_preview").visible());
             assert.ok($("#compose .undo_markdown_preview").visible());
             assert.ok($("#compose .preview_message_area").visible());
@@ -785,7 +780,6 @@ test_ui("on_events", ({override, override_rewire}) => {
     (function test_undo_markdown_preview_clicked() {
         const handler = $("#compose").get_on_handler("click", ".undo_markdown_preview");
 
-        $("textarea#compose-textarea").hide();
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
         $("#compose .markdown_preview").hide();
@@ -806,7 +800,6 @@ test_ui("on_events", ({override, override_rewire}) => {
 
         handler(event);
 
-        assert.ok($("textarea#compose-textarea").visible());
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
         assert.ok($("#compose .markdown_preview").visible());


### PR DESCRIPTION
This PR does three things:

1) It eliminates expensive, anonymous `:first-child` and `:last-child` selectors from the rendered Markdown CSS.

2) It reads the `height` value of both the compose and message-edit textareas to set a `height` value on the preview area, eliminating a small but annoying jog in the size of the compose box and preview areas. The jog became larger and more annoying with the fixes from 1) in place, which is why these two aspects appear inside the same PR.

3) It removes show/hide logic from the compose textarea, which is needless because the textarea will automatically be obscured by the preview area in preview mode. That keeps the textarea an active part of the DOM, ensuring that the compose box's resize buttons and logic work as expected even in preview mode.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/behavior.20of.20spoilers.20in.20message.20previews/near/1906862)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![message-edit-preview-before](https://github.com/user-attachments/assets/9adde6df-75f4-4854-8fb3-9a7bd99d17ed) | ![message-edit-preview-after](https://github.com/user-attachments/assets/725d7f69-ad03-4f3a-b6ac-3e0dfa290386) |
| ![compose-preview-before](https://github.com/user-attachments/assets/140083ad-0a7c-45dd-890d-23e4b637ad0f) | ![compose-preview-after](https://github.com/user-attachments/assets/4dd83927-89e7-4c6a-87a4-f2c3b0a2fb9d) |


There is an edge case not yet properly addressed here, which is the behavior of long spoiler blocks in message previews.

The current behavior is that the preview area effectively cinches up to the size of the collapsed spoiler block, and the entire preview area expands, up to `max-height`, along with the spoiler.

With the changes here, the preview area remains the size of the textarea, with the spoiler expanding to fill the area, again up to `max-height`. The difference is that the formatting controls and preview area remain undisturbed.

Of course, behavior aside, the preview behavior in `main` is arguably a better message preview than this new version; collapsed spoilers are not of course shown with a massive expanse of white space below them.

However, this is also arguably a better experience for editors of spoilers, who may well want to open the spoiler and inspect the preview of its contents. That spoiler state is not accurately previewed in either case, being always clipped to the `max-height` allotted the preview area.

| Spoilers, before | Spoilers, after |
| --- | --- |
| ![spoiler-preview-before](https://github.com/user-attachments/assets/6b04c2da-19d9-4fa0-9933-4ae25e3a6002) | ![spoiler-preview-after](https://github.com/user-attachments/assets/15f6499c-fa26-475c-9f30-2dfd9a54d20d) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>