### PR TITLE
thumbnail: Resolve a race condition when rendering messages.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -118,6 +118,7 @@ class MessageRenderingResult:
     links_for_preview: set[str]
     user_ids_with_alert_words: set[int]
     potential_attachment_path_ids: list[str]
+    thumbnail_spinners: set[str]
 
 
 @dataclass
@@ -2625,6 +2626,7 @@ def do_convert(
         links_for_preview=set(),
         user_ids_with_alert_words=set(),
         potential_attachment_path_ids=[],
+        thumbnail_spinners=set(),
     )
 
     _md_engine.zulip_message = message
@@ -2683,9 +2685,10 @@ def do_convert(
 
         # Post-process the result with the rendered image previews:
         if user_upload_previews is not None:
-            content_with_thumbnails = rewrite_thumbnailed_images(
+            content_with_thumbnails, thumbnail_spinners = rewrite_thumbnailed_images(
                 rendering_result.rendered_content, user_upload_previews
             )
+            rendering_result.thumbnail_spinners = thumbnail_spinners
             if content_with_thumbnails is not None:
                 rendering_result.rendered_content = content_with_thumbnails
 

--- a/zerver/worker/thumbnail.py
+++ b/zerver/worker/thumbnail.py
@@ -170,7 +170,7 @@ def update_message_rendered_content(
                 message.rendered_content,
                 {} if image_data is None else {path_id: image_data},
                 {path_id} if image_data is None else set(),
-            )
+            )[0]
             if rendered_content is None:
                 # There were no updates -- for instance, if we re-run
                 # ensure_thumbnails on an ImageAttachment we already


### PR DESCRIPTION
Messages are rendered outside of a transaction, for performance reasons, and then sent inside of one.  This opens thumbnailing up to a race where the thumbnails have not yet been written when the message is rendered, but the message has not been sent when thumbnailing completes, causing `rewrite_thumbnailed_images` to be a no-op and the message being left with a spinner which never resolves.

Explicitly lock and use he ImageAttachment data inside the message-sending transaction, to rewrite the message content with the latest information about the existing thumbnails.

Despite the thumbnailing worker taking a lock on Message rows to update them, this does not lead to deadlocks -- the INSERT of the Message rows happens in a transaction, ensuring that either the message rending blocks the thumbnailing until the Message row is created, or that the `rewrite_thumbnailed_images` and Message INSERT waits until thumbnailing is complete (and updated no Message rows).

-----

This leads to two `rewrite_thumbnailed_images` calls per message send -- one in markdown, one inside the transaction.  We could possibly eliminate the former, if we can convince ourselves that the latter will always run when the former would have.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
