### PR TITLE
web: Condense unnecessarily verbose function signatures

### DIFF
--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -70,7 +70,7 @@ export function generate_and_insert_audio_or_video_call_link(
             is_video_call: !is_audio_call,
         };
 
-        const make_zoom_call: () => void = () => {
+        const make_zoom_call = (): void => {
             const xhr = channel.post({
                 url: "/json/calls/zoom/create",
                 data: request,

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -24,13 +24,12 @@ import {user_settings} from "./user_settings";
 export let toggler: Toggle | undefined;
 
 function format_usage_html(...keys: string[]): string {
-    const get_formatted_keys: () => string = () => keys.map((key) => `<kbd>${key}</kbd>`).join("+");
     return $t_html(
         {
             defaultMessage: "(or <key-html></key-html>)",
         },
         {
-            "key-html": get_formatted_keys,
+            "key-html": () => keys.map((key) => `<kbd>${key}</kbd>`).join("+"),
         },
     );
 }

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -424,8 +424,7 @@ export function show_from_selected_message(): void {
     const $message_selected = $(".selected_message");
     let $message = $message_selected;
     // This is a function to satisfy eslint unicorn/no-array-callback-reference
-    const media_classes: () => string = () =>
-        ".message_inline_image img, .message_inline_image video";
+    const media_classes = (): string => ".message_inline_image img, .message_inline_image video";
     let $media = $message.find<HTMLMediaElement>(media_classes());
     let $prev_traverse = false;
 

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -25,10 +25,7 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
-const show_step: ($process: JQuery, step: number) => void = function (
-    $process: JQuery,
-    step: number,
-) {
+const show_step = function ($process: JQuery, step: number): void {
     $process
         .find("[data-step]")
         .hide()

--- a/web/src/portico/landing-page.ts
+++ b/web/src/portico/landing-page.ts
@@ -53,7 +53,7 @@ export function path_parts(): string[] {
     return window.location.pathname.split("/").filter((chunk) => chunk !== "");
 }
 
-const apps_events: () => void = function () {
+const apps_events = function (): void {
     const info: Record<UserOS, VersionInfo> = {
         windows: {
             alt: "Windows",
@@ -168,7 +168,7 @@ const apps_events: () => void = function () {
     update_page();
 };
 
-const events: () => void = function () {
+const events = function (): void {
     if (path_parts().includes("apps")) {
         apps_events();
     }
@@ -291,7 +291,7 @@ $(document).on("click", ".comparison-tab", function (this: HTMLElement) {
         // on subheaders of interest (those about to be sticky)
         let previous_entry_y = 0;
 
-        const isScrollingUp: () => boolean = () => {
+        const isScrollingUp = (): boolean => {
             let is_scrolling_up = true;
             if (window.scrollY > previous_y_position) {
                 is_scrolling_up = false;

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -556,7 +556,7 @@ function open_edit_form_modal(this: HTMLElement): void {
             }
 
             if (Object.keys(deleted_values).length !== 0) {
-                const edit_select_field_modal_callback: () => void = () => {
+                const edit_select_field_modal_callback = (): void => {
                     show_modal_for_deleting_options(field, deleted_values, update_profile_field);
                 };
                 dialog_widget.close(edit_select_field_modal_callback);


### PR DESCRIPTION
There is no need to add a separate function signature to a function variable; just add types directly to the function itself.

Cc @afeefuddin, who introduced all of these.