### PR TITLE
docs: Tweak server roadmap documentation.

### DIFF
--- a/docs/overview/release-lifecycle.md
+++ b/docs/overview/release-lifecycle.md
@@ -167,12 +167,13 @@ releases, and do not support them in production.
 The Zulip server project uses GitHub projects and labels to structure
 communication about priorities:
 
-- We use GitHub projects to track goals for major releases (e.g., [Zulip 9.0
-  priorities](https://github.com/orgs/zulip/projects/9/)). The project board
-  should be seen a list of priorities being _considered_ for the release, not a
-  guarantee that features will be included. As the release date approaches,
-  features that will not make it into the release are dropped from the project
-  board on an ongoing basis.
+- We use a [GitHub project
+  board](https://github.com/orgs/zulip/projects/9/views/13) to publicly track
+  goals for major releases. The items with the "Done" status will be included in
+  the next major release. Otherwise, the project board should be seen a list of
+  priorities being _considered_ for the release, not a guarantee that features
+  will be included. As the release date approaches, features that will not make
+  it into the release are dropped from the project board on an ongoing basis.
 
 - The [high priority][label-high] label tags issues that we consider important.
   It is reviewed in the planning stage of the release cycle to identify


### PR DESCRIPTION
I made a new view for us to link to from this documentation, designed for users, rather than for contributors: https://github.com/orgs/zulip/projects/9/views/13

Current doc: https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html#server-roadmap

Updated:
![Screenshot 2024-07-31 at 13 22 23@2x](https://github.com/user-attachments/assets/bc1d77ad-dede-436c-aec7-0a4f9963bb6f)

