### PR TITLE
Defer computing last_edit_timestr until tooltip renders.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -364,15 +364,16 @@ export function initialize(): void {
         },
         onShow(instance) {
             const $elem = $(instance.reference);
-            assert(message_lists.current !== undefined);
             const message_id = Number($elem.closest(".message_row").attr("data-message-id"));
+
+            assert(message_lists.current !== undefined);
             const message_container = message_lists.current.view.message_containers.get(message_id);
             assert(message_container !== undefined);
             const last_edit_timestr = get_last_edit_timestr(message_container.msg);
             instance.setContent(
                 parse_html(
                     render_message_edit_notice_tooltip({
-                        message_container,
+                        moved: message_container.moved,
                         last_edit_timestr,
                         realm_allow_edit_history: realm.realm_allow_edit_history,
                     }),

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,14 +1,14 @@
 {{#if modified}}
     {{#if msg/local_edit_timestamp}}
-        <div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
+        <div class="message_edit_notice">
             {{t "SAVING"}}
         </div>
     {{else if moved}}
-        <div class="message_edit_notice" data-tippy-content="{{t 'Last moved {last_edit_timestr}.'}}">
+        <div class="message_edit_notice">
             {{t "MOVED"}}
         </div>
     {{else}}
-        <div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}.'}}">
+        <div class="message_edit_notice">
             {{t "EDITED"}}
         </div>
     {{/if}}

--- a/web/templates/message_edit_notice_tooltip.hbs
+++ b/web/templates/message_edit_notice_tooltip.hbs
@@ -1,7 +1,11 @@
 <div>
     <div>{{t "View edit history"}}</div>
     {{#if realm_allow_edit_history}}
-        <div class="tooltip-inner-content italic">{{edited_notice_str}}</div>
+        {{#if message_container/moved}}
+            <div class="tooltip-inner-content italic">{{t 'Last moved {last_edit_timestr}.'}}</div>
+        {{else}}
+            <div class="tooltip-inner-content italic">{{t 'Last edited {last_edit_timestr}.'}}</div>
+        {{/if}}
     {{/if}}
 </div>
 {{tooltip_hotkey_hints "Shift" "H"}}

--- a/web/templates/message_edit_notice_tooltip.hbs
+++ b/web/templates/message_edit_notice_tooltip.hbs
@@ -1,11 +1,15 @@
 <div>
-    <div>{{t "View edit history"}}</div>
     {{#if realm_allow_edit_history}}
-        {{#if message_container/moved}}
-            <div class="tooltip-inner-content italic">{{t 'Last moved {last_edit_timestr}.'}}</div>
-        {{else}}
-            <div class="tooltip-inner-content italic">{{t 'Last edited {last_edit_timestr}.'}}</div>
-        {{/if}}
+    <div>{{t "View edit history"}}</div>
     {{/if}}
+    <div class="tooltip-inner-content italic">
+        {{#if moved}}
+        {{t 'Last moved {last_edit_timestr}.'}}
+        {{else}}
+        {{t 'Last edited {last_edit_timestr}.'}}
+        {{/if}}
+    </div>
 </div>
+{{#if realm_allow_edit_history}}
 {{tooltip_hotkey_hints "Shift" "H"}}
+{{/if}}


### PR DESCRIPTION
Earlier, we used to compute last_edit_timestr as data-tippy-content when rendering the whole message feed.

This commit changes the behaviour by computing the `last_edit_timestr` when a user hovers over the message_edit_notice.

Fixes: zulip#27240.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
