### PR TITLE
CSS selector performance: Use classnames instead of div.

### DIFF
--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -68,12 +68,12 @@
                 </div>
             </div>
             <div class="client-logos">
-                <div class='client-logos__logo_akamai'></div>
-                <div class='client-logos__logo_tum'></div>
-                <div class='client-logos__logo_wikimedia'></div>
-                <div class='client-logos__logo_rust'></div>
-                <div class='client-logos__logo_dr_on_demand'></div>
-                <div class='client-logos__logo_maria'></div>
+                <div class='client-logos-div client-logos__logo_akamai'></div>
+                <div class='client-logos-div client-logos__logo_tum'></div>
+                <div class='client-logos-div client-logos__logo_wikimedia'></div>
+                <div class='client-logos-div client-logos__logo_rust'></div>
+                <div class='client-logos-div client-logos__logo_dr_on_demand'></div>
+                <div class='client-logos-div client-logos__logo_maria'></div>
             </div>
         </div>
         <div class="screen-2">

--- a/web/src/portico/hello.ts
+++ b/web/src/portico/hello.ts
@@ -12,30 +12,32 @@ function get_random_item_from_array<T>(array: T[]): T {
 }
 
 const current_client_logo_class_names = new Set([
-    "client-logos__logo_akamai",
-    "client-logos__logo_tum",
-    "client-logos__logo_wikimedia",
-    "client-logos__logo_rust",
-    "client-logos__logo_dr_on_demand",
-    "client-logos__logo_maria",
+    "client-logos-div client-logos__logo_akamai",
+    "client-logos-div client-logos__logo_tum",
+    "client-logos-div client-logos__logo_wikimedia",
+    "client-logos-div client-logos__logo_rust",
+    "client-logos-div client-logos__logo_dr_on_demand",
+    "client-logos-div client-logos__logo_maria",
 ]);
 const future_client_logo_class_names = new Set([
-    "client-logos__logo_pilot",
-    "client-logos__logo_recurse",
-    "client-logos__logo_level_up",
+    "client-logos-div client-logos__logo_pilot",
+    "client-logos-div client-logos__logo_recurse",
+    "client-logos-div client-logos__logo_level_up",
 
-    "client-logos__logo_layershift",
-    "client-logos__logo_julia",
-    "client-logos__logo_ucsd",
-    "client-logos__logo_lean",
-    "client-logos__logo_asciidoc",
+    "client-logos-div client-logos__logo_layershift",
+    "client-logos-div client-logos__logo_julia",
+    "client-logos-div client-logos__logo_ucsd",
+    "client-logos-div client-logos__logo_lean",
+    "client-logos-div client-logos__logo_asciidoc",
 ]);
 let current_client_logo_class_names_index = 0;
 function update_client_logo(): void {
     if (document.hidden) {
         return;
     }
-    const client_logos = [...document.querySelectorAll("[class^='client-logos__']")];
+    const client_logos = [
+        ...document.querySelectorAll("[class^='client-logos-div client-logos__']"),
+    ];
     current_client_logo_class_names_index = get_new_rand(
         current_client_logo_class_names_index,
         client_logos.length,

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1044,11 +1044,6 @@ div.overlay {
 .overlay-messages-container .overlay-message-row {
     padding: 5px 0;
 
-    > div {
-        display: inline-block;
-        vertical-align: top;
-    }
-
     .overlay-message-info-box {
         width: 100%;
         margin-bottom: 10px;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -532,7 +532,7 @@
         background-color: hsl(212deg 28% 8% / 75%);
     }
 
-    & div.overlay .flex.overlay-content > div,
+    & div.overlay .flex.overlay-content > .overlay-container,
     #settings_page,
     .informational-overlays .overlay-content {
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
@@ -541,7 +541,7 @@
     #draft_overlay,
     #scheduled_messages_overlay_container,
     #message-edit-history-overlay-container {
-        .flex.overlay-content > div {
+        .flex.overlay-content > .overlay-container {
             box-shadow: 0 0 30px hsl(213deg 31% 0%);
             background-color: var(--color-background);
         }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -697,7 +697,6 @@
     .subscriber-list-box .subscriber_list_container .subscriber-list td,
     .member-list-box,
     .member-list-box .member_list_container .member-list td,
-    #subscription_overlay .subsection-parent div,
     #subscription_overlay .settings-radio-input-parent,
     #settings_page .sidebar-wrapper,
     #settings_page .sidebar-wrapper *,

--- a/web/styles/portico/hello.css
+++ b/web/styles/portico/hello.css
@@ -197,7 +197,7 @@ ul {
         place-items: center;
     }
 
-    .client-logos div {
+    .client-logos-div {
         transition: all 0.7s ease-out;
         background-position: center;
     }
@@ -679,7 +679,7 @@ ul {
             background: hsl(238deg 28% 21%);
         }
 
-        .client-logos div {
+        .client-logos-div {
             opacity: 0.7;
         }
     }

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -454,7 +454,7 @@
             margin-bottom: 10px;
             border: 1px solid hsl(0deg 0% 87%);
 
-            & > div {
+            .tab-content {
                 display: none;
             }
         }
@@ -467,7 +467,7 @@
             border-radius: 6px;
         }
 
-        &.no-tabs .blocks > div,
+        &.no-tabs .blocks > .tab-content,
         &.has-tabs .blocks > .active {
             display: block;
         }

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -304,8 +304,10 @@ html {
     font-weight: 400;
 }
 
-.thanks-page div {
-    text-align: center;
+.thanks-page {
+    .white-box {
+        text-align: center;
+    }
 }
 
 .lead {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -651,11 +651,6 @@
             overflow: hidden;
         }
 
-        .data-container div {
-            display: block;
-            border: none;
-        }
-
         .data-container::after {
             content: " ";
             position: absolute;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -551,8 +551,8 @@ input[type="checkbox"] {
     }
 }
 
-.organization-settings-parent > div:first-of-type {
-    margin-top: 10px;
+.organization-settings-parent {
+    padding-top: 10px;
 }
 
 #id_org_profile_preview {
@@ -563,8 +563,8 @@ input[type="checkbox"] {
     margin-bottom: 20px;
 }
 
-.inline-block.organization-permissions-parent div:first-of-type {
-    margin-top: 10px;
+.inline-block.organization-permissions-parent {
+    padding-top: 10px;
 }
 
 .language_selection_widget .language_selection_button {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -633,11 +633,6 @@ h4.user_group_setting_subsection_title {
             margin-right: 5px;
         }
 
-        .top-bar > div {
-            display: inline-block;
-            vertical-align: top;
-        }
-
         .top-bar .stream-name,
         .top-bar .group-name-wrapper {
             font-weight: 600;
@@ -646,11 +641,6 @@ h4.user_group_setting_subsection_title {
         .bottom-bar {
             margin-top: 2px;
             line-height: 1.5;
-        }
-
-        .bottom-bar > div {
-            display: inline-block;
-            vertical-align: bottom;
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -533,12 +533,13 @@ h4.user_group_setting_subsection_title {
     padding: 15px 10px 11px;
     border-bottom: 1px solid hsl(0deg 0% 93%);
     cursor: pointer;
+    display: flex;
 
     .check {
         width: 25px;
         height: 25px;
         position: relative;
-        margin-right: 8px;
+        margin-right: 12px;
         margin-top: 9px;
         background-size: 60% auto;
         background-repeat: no-repeat;
@@ -584,7 +585,7 @@ h4.user_group_setting_subsection_title {
     .icon {
         width: 35px;
         height: 35px;
-        margin-right: 8px;
+        margin-right: 12px;
         margin-top: 4px;
         background-color: hsl(300deg 100% 25%);
         border-radius: 4px;
@@ -604,6 +605,7 @@ h4.user_group_setting_subsection_title {
     .sub-info-box,
     .group-info-box {
         width: calc(100% - 90px);
+        margin-right: 4px;
 
         .top-bar,
         .bottom-bar {
@@ -646,11 +648,6 @@ h4.user_group_setting_subsection_title {
 
     &.active {
         background-color: hsl(0deg 0% 93%);
-    }
-
-    > div {
-        display: inline-block;
-        vertical-align: top;
     }
 
     .check:not(.checked, .disabled):hover svg,

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -33,7 +33,7 @@ NAV_LIST_ITEM_TEMPLATE = """
 """.strip()
 
 DIV_TAB_CONTENT_TEMPLATE = """
-<div data-tab-key="{data_tab_key}" markdown="1">
+<div class="tab-content" data-tab-key="{data_tab_key}" markdown="1">
 {content}
 </div>
 """.strip()

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -42,10 +42,10 @@ header
       <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
     </ul>
     <div class="blocks">
-      <div data-tab-key="ios" markdown="1"></p>
+      <div class="tab-content" data-tab-key="ios" markdown="1"></p>
         <p>iOS instructions</p>
       <p></div>
-      <div data-tab-key="desktop-web" markdown="1"></p>
+      <div class="tab-content" data-tab-key="desktop-web" markdown="1"></p>
         <p>Desktop/browser instructions</p>
       <p></div>
     </div>
@@ -60,10 +60,10 @@ header
       <li data-tab-key="android" tabindex="0">Android</li>
     </ul>
     <div class="blocks">
-      <div data-tab-key="desktop-web" markdown="1"></p>
+      <div class="tab-content" data-tab-key="desktop-web" markdown="1"></p>
         <p>Desktop/browser instructions</p>
       <p></div>
-      <div data-tab-key="android" markdown="1"></p>
+      <div class="tab-content" data-tab-key="android" markdown="1"></p>
         <p>Android instructions</p>
       <p></div>
     </div>
@@ -77,7 +77,7 @@ header
       <li data-tab-key="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
     </ul>
     <div class="blocks">
-      <div data-tab-key="instructions-for-all-platforms" markdown="1"></p>
+      <div class="tab-content" data-tab-key="instructions-for-all-platforms" markdown="1"></p>
         <p>Instructions for all platforms</p>
       <p></div>
     </div>


### PR DESCRIPTION
Two instances of the div selector haven't been removed, which is at https://github.com/zulip/zulip/blob/69194489177bc3b43ff7002bd4de92ceda628f77/web/styles/portico/portico.css#L277 and https://github.com/zulip/zulip/blob/69194489177bc3b43ff7002bd4de92ceda628f77/templates/zerver/emails/email.css#L322. At both of these places, using the div selector feels like the right thing to do since it is applying generic rules to divs. For the second case of email, it's more clear cut, since it applies to all divs, for `.help .markdown`, it might be up for debate. 

There is one commit which changes a bit of behaviour, which has been approved in https://chat.zulip.org/#narrow/stream/6-frontend/topic/Subscription.20list.20slight.20look.20change/near/1906254

Fixes part of : https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20performance/near/1845719

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

I've used before and after screenshots for most of the commits to check for any regressions myself. I think it would take some time to put all those together in a presentable and I'm not too sure if same images in before/after will help in review or not. Let me know if you need screenshots and I will include it.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
