### PR TITLE
channel: Add option to notify users newly added to a channel.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,20 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
+**Feature level 397**
+
+* [`POST /users/me/subscriptions`](/api/subscribe): Added parameter
+  `send_new_subscription_messages` which determines whether the user
+  would like Notification Bot to notify other users who the request
+  adds to a channel.
+
+* [`POST /users/me/subscriptions`](/api/subscribe): Added
+  `new_subscription_messages_sent` to the response, which is only
+  present if `send_new_subscription_messages` was `true` in the request.
+
+* [`POST /register`](/api/register-queue): Added `max_bulk_new_subscription_messages`
+  to the response.
+
 **Feature level 396**
 
 * [`GET /users/me/subscriptions`](/api/get-subscriptions),

--- a/help/subscribe-users-to-a-channel.md
+++ b/help/subscribe-users-to-a-channel.md
@@ -24,6 +24,8 @@ You will only see the options below if you have the required permissions.
 1. Under **Add subscribers**, enter a name or email address. The typeahead
    will only include users who aren't already subscribed to the channel.
 
+1. Configure **Send notification message to newly subscribed users** as desired.
+
 1. Click **Add**.
 
 !!! tip ""
@@ -51,6 +53,8 @@ You will only see the options below if you have the required permissions.
 
 1. Under **Add subscribers**, enter a name or email address. The typeahead
    will only include users who aren't already subscribed to the channel.
+
+1. Configure **Send notification message to newly subscribed users** as desired.
 
 1. Click **Add**.
 

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 396
+API_FEATURE_LEVEL = 397
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -214,7 +214,7 @@ export function append_user_group_from_name(
     user_group_pill.append_user_group(user_group, pill_widget);
 }
 
-async function get_pill_user_ids(pill_widget: CombinedPillContainer): Promise<number[]> {
+export async function get_pill_user_ids(pill_widget: CombinedPillContainer): Promise<number[]> {
     const user_ids = user_pill.get_user_ids(pill_widget);
     const stream_user_ids = await stream_pill.get_user_ids(pill_widget);
     const group_user_ids = user_group_pill.get_user_ids(pill_widget);

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -105,6 +105,7 @@ export function generate_pill_html(item: CombinedPill): string {
 export function set_up_handlers_for_add_button_state(
     pill_widget: CombinedPillContainer | user_group_pill.UserGroupPillWidget,
     $pill_container: JQuery,
+    pill_update_callback?: () => void,
 ): void {
     const $pill_widget_input = $pill_container.find(".input");
     const $pill_widget_button = $pill_container.closest(".add-button-container").find("button");
@@ -112,11 +113,19 @@ export function set_up_handlers_for_add_button_state(
     $pill_widget_button.prop("disabled", true);
 
     // If all the pills are removed, disable the add button.
-    pill_widget.onPillRemove(() =>
-        $pill_widget_button.prop("disabled", pill_widget.items().length === 0),
-    );
+    pill_widget.onPillRemove(() => {
+        $pill_widget_button.prop("disabled", pill_widget.items().length === 0);
+        if (pill_update_callback) {
+            pill_update_callback();
+        }
+    });
     // If a pill is added, enable the add button.
-    pill_widget.onPillCreate(() => $pill_widget_button.prop("disabled", false));
+    pill_widget.onPillCreate(() => {
+        $pill_widget_button.prop("disabled", false);
+        if (pill_update_callback) {
+            pill_update_callback();
+        }
+    });
     // Disable the add button when there is no pending text that can be converted
     // into a pill and the number of existing pills is zero.
     $pill_widget_input.on("input", () =>
@@ -134,6 +143,7 @@ export function create({
     with_add_button,
     onPillCreateAction,
     onPillRemoveAction,
+    add_button_pill_update_callback,
 }: {
     $pill_container: JQuery;
     get_potential_subscribers: () => User[];
@@ -141,6 +151,7 @@ export function create({
     with_add_button: boolean;
     onPillCreateAction?: (pill_user_ids: number[]) => void;
     onPillRemoveAction?: (pill_user_ids: number[]) => void;
+    add_button_pill_update_callback?: () => void;
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
@@ -193,7 +204,11 @@ export function create({
     });
 
     if (with_add_button) {
-        set_up_handlers_for_add_button_state(pill_widget, $pill_container);
+        set_up_handlers_for_add_button_state(
+            pill_widget,
+            $pill_container,
+            add_button_pill_update_callback,
+        );
     }
 
     return pill_widget;

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -295,7 +295,7 @@ export function initialize() {
 
             const sub = sub_store.get(stream_id);
 
-            subscriber_api.add_user_ids_to_stream([user_id], sub, success, xhr_failure);
+            subscriber_api.add_user_ids_to_stream([user_id], sub, true, success, xhr_failure);
         },
     );
 

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -283,6 +283,7 @@ export const realm_schema = z.object({
     max_stream_description_length: z.number(),
     max_stream_name_length: z.number(),
     max_topic_length: z.number(),
+    max_bulk_new_subscription_messages: z.number(),
     password_min_guesses: z.number(),
     password_min_length: z.number(),
     password_max_length: z.number(),

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -649,6 +649,7 @@ export async function build_move_topic_to_stream_popover(
             subscriber_api.add_user_ids_to_stream(
                 unsubscribed_participant_ids,
                 destination_stream,
+                true,
                 success,
                 xhr_failure,
             );

--- a/web/src/subscriber_api.ts
+++ b/web/src/subscriber_api.ts
@@ -12,6 +12,7 @@ import type {StreamSubscription} from "./sub_store.ts";
 export function add_user_ids_to_stream(
     user_ids: number[],
     sub: StreamSubscription,
+    send_new_subscription_messages: boolean,
     success: (data: unknown) => void,
     failure: (xhr: JQuery.jqXHR<unknown>) => void,
 ): void {
@@ -22,7 +23,10 @@ export function add_user_ids_to_stream(
         const color = sub.color;
         void channel.post({
             url: "/json/users/me/subscriptions",
-            data: {subscriptions: JSON.stringify([{name: stream_name, color}])},
+            data: {
+                subscriptions: JSON.stringify([{name: stream_name, color}]),
+                send_new_subscription_messages,
+            },
             success,
             error: failure,
         });
@@ -33,6 +37,7 @@ export function add_user_ids_to_stream(
         data: {
             subscriptions: JSON.stringify([{name: stream_name}]),
             principals: JSON.stringify(user_ids),
+            send_new_subscription_messages,
         },
         success,
         error: failure,

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -13,6 +13,7 @@ import {$t} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as people from "./people.ts";
 import * as settings_config from "./settings_config.ts";
+import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
@@ -830,6 +831,28 @@ export function initialize(): void {
             return false;
         },
         appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
+        target: ".send_notification_to_new_subscribers_container.control-label-disabled",
+        trigger: "mouseenter",
+        placement: "top",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const content = $t(
+                {
+                    defaultMessage:
+                        "Notification message cannot be sent when subscribing more than {max_users} users.",
+                },
+                {
+                    max_users: realm.max_bulk_new_subscription_messages,
+                },
+            );
+            instance.setContent(content);
+        },
         onHidden(instance) {
             instance.destroy();
         },

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1285,6 +1285,7 @@ export function initialize(): void {
         subscriber_api.add_user_ids_to_stream(
             [target_user_id],
             sub,
+            true,
             addition_success,
             addition_failure,
         );

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -3,6 +3,15 @@
     <h4 class="stream_setting_subsection_title">
         {{t "Add subscribers" }}
     </h4>
+    <div>
+        <div class="subsection-parent send_notification_to_new_subscribers_container inline-block">
+            {{> ./../settings/settings_checkbox
+              setting_name="send_notification_to_new_subscribers"
+              is_checked=true
+              label=(t "Send notification message to newly subscribed users")
+              }}
+        </div>
+    </div>
     <div class="subscriber_list_settings">
         <div class="subscriber_list_add float-left">
             {{> add_subscribers_form .}}

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -550,6 +550,7 @@ def fetch_initial_state_data(
 
         state["max_stream_name_length"] = Stream.MAX_NAME_LENGTH
         state["max_stream_description_length"] = Stream.MAX_DESCRIPTION_LENGTH
+        state["max_bulk_new_subscription_messages"] = settings.MAX_BULK_NEW_SUBSCRIPTION_MESSAGES
         state["max_topic_length"] = MAX_TOPIC_NAME_LENGTH
         state["max_message_length"] = settings.MAX_MESSAGE_LENGTH
         if realm.demo_organization_scheduled_deletion_date is not None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11596,6 +11596,23 @@ paths:
                     **Changes**: New in Zulip 11.0 (feature level 389).
                   type: integer
                   example: 1
+                send_new_subscription_messages:
+                  description: |
+                    Whether any other users newly subscribed via this request should be
+                    sent a Notification Bot DM notifying them about their new
+                    subscription.
+
+                    The server will never send Notification Bot DMs if more than
+                    `max_bulk_new_subscription_messages` (available in the [`POST
+                    /register`](/api/register-queue) response) users were subscribed in
+                    this request.
+
+                    **Changes**: Before Zulip 11.0 (feature level 397), new subscribers
+                    were always sent a Notification Bot DM, which was unduly expensive
+                    when bulk-subscribing thousands of users to a channel.
+                  type: boolean
+                  default: true
+                  example: true
               required:
                 - subscriptions
             encoding:
@@ -11686,6 +11703,18 @@ paths:
                         description: |
                           A list of names of channels that the requesting user/bot was not
                           authorized to subscribe to. Only present if `"authorization_errors_fatal": false`.
+                      new_subscription_messages_sent:
+                        type: boolean
+                        description: |
+                          Only present if the parameter `send_new_subscription_messages`
+                          in the request was `true`.
+
+                          Whether Notification Bot DMs in fact sent to the added
+                          subscribers as requested by the `send_new_subscription_messages`
+                          parameter. Clients may find this value useful to communicate
+                          with users about the effect of this request.
+
+                          **Changes**: New in Zulip 11.0 (feature level 397).
                     example:
                       {
                         "already_subscribed": {"1": ["testing-help"]},
@@ -11822,6 +11851,18 @@ paths:
                         description: |
                           A list of the names of channels which were unsubscribed
                           from as a result of the query.
+                      new_subscription_messages_sent:
+                        type: boolean
+                        description: |
+                          Only present if the parameter `send_new_subscription_messages`
+                          in the request was `true`.
+
+                          Whether Notification Bot DMs in fact sent to the added
+                          subscribers as requested by the `send_new_subscription_messages`
+                          parameter. Clients may find this value useful to communicate
+                          with users about the effect of this request.
+
+                          **Changes**: New in Zulip 11.0 (feature level 397).
                     example:
                       {
                         "msg": "",
@@ -20083,6 +20124,15 @@ paths:
                               Configuration for group level group permission settings.
                             additionalProperties:
                               $ref: "#/components/schemas/GroupPermissionSetting"
+                      max_bulk_new_subscription_messages:
+                        description: |
+                          Maximum number of new subscribers for which the server will
+                          respect the `send_new_subscription_messages` parameter when
+                          [adding subscribers to a channel](/api/subscribe#parameter-send_new_subscription_messages).
+
+                          **Changes**: New in Zulip 11.0 (feature level 397).
+                        type: number
+                        example: 100
                     example:
                       {
                         "last_event_id": -1,

--- a/zerver/tests/test_channel_creation.py
+++ b/zerver/tests/test_channel_creation.py
@@ -328,6 +328,7 @@ class TestCreateStreams(ZulipTestCase):
                 "8": ["brand new stream"],
             },
             "already_subscribed": {},
+            "new_subscription_messages_sent": True,
         }
         self.assertEqual(response.status_code, 200)
         self.assertEqual(orjson.loads(response.content), expected_response)

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -104,6 +104,7 @@ class HomeTest(ZulipTestCase):
         "max_message_length",
         "max_stream_description_length",
         "max_stream_name_length",
+        "max_bulk_new_subscription_messages",
         "max_topic_length",
         "muted_topics",
         "muted_users",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4926,6 +4926,32 @@ class SubscriptionAPITest(ZulipTestCase):
             expected_difference=0,
         )
 
+    def test_notification_bot_dm_on_subscription(self) -> None:
+        desdemona = self.example_user("desdemona")
+        self.login_user(desdemona)
+
+        user_ids = [
+            desdemona.id,
+            self.example_user("cordelia").id,
+            self.example_user("hamlet").id,
+            self.example_user("othello").id,
+            self.example_user("iago").id,
+            self.example_user("prospero").id,
+        ]
+
+        response = self.subscribe_via_post(
+            desdemona, ["Test stream 1"], dict(principals=orjson.dumps(user_ids).decode())
+        )
+        data = self.assert_json_success(response)
+        self.assertEqual(data["new_subscription_messages_sent"], True)
+
+        with self.settings(MAX_BULK_NEW_SUBSCRIPTION_MESSAGES=5):
+            response = self.subscribe_via_post(
+                desdemona, ["Test stream 2"], dict(principals=orjson.dumps(user_ids).decode())
+            )
+        data = self.assert_json_success(response)
+        self.assertEqual(data["new_subscription_messages_sent"], False)
+
 
 class InviteOnlyStreamTest(ZulipTestCase):
     def test_must_be_subbed_to_send(self) -> None:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -894,10 +894,10 @@ def send_messages_for_new_subscribers(
     if new_subscriptions:
         for id, subscribed_stream_names in new_subscriptions.items():
             if id == str(user_profile.id):
-                # Don't send a Zulip if you invited yourself.
+                # Don't send a notification DM if you subscribed yourself.
                 continue
             if bots[id]:
-                # Don't send invitation Zulips to bots
+                # Don't send notification DMs to bots.
                 continue
 
             # For each user, we notify them about newly subscribed streams, except for

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -681,6 +681,10 @@ MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS = 100
 # be soft-reactivated in the case of user group mention.
 MAX_GROUP_SIZE_FOR_MENTION_REACTIVATION = 11
 
+# The maximum number of newly subscribed users for which the server
+# will consider sending DMs to each new subscriber.
+MAX_BULK_NEW_SUBSCRIPTION_MESSAGES = 100
+
 # Limiting guest access to other users via the
 # can_access_all_users_group setting makes presence queries much more
 # expensive. This can be a significant performance problem for


### PR DESCRIPTION
When someone adds another user to a channel, we send the user that was added a Notification Bot message to let them know.

This PR adds an option for whether or not this message is sent. If the number of newly added users is more than 100, 
we don't send notifications.

- The checkbox unchecks and becomes disabled if the number of users to be added to the channel crosses the limit (100).
- If the number of users then reduces, the checkbox becomes enabled again, but is left unchecked.


Fixes #31189

[#api design > options for notifying new channel subscribers @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/options.20for.20notifying.20new.20channel.20subscribers/near/2199784)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Screenshots and screen captures</summary>

*I have set the max limit to 2 users for testing*

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/f0044934-13ce-4e7a-aff2-a58ff2201f16" />

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/fc713773-6bf7-4031-91a2-fb77c7fcc674" />


**Narrow width**
<img width="842" alt="image" src="https://github.com/user-attachments/assets/49b37fa2-f8c1-400b-86d3-232df69a1369" />

The cursor changes to <not-allowed> when hovering over the checkbox while it is disabled. 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
