### PR TITLE
data_import_rocketchat: Fix import rocketchat bugs.

### DIFF
--- a/help/import-from-rocketchat.md
+++ b/help/import-from-rocketchat.md
@@ -35,7 +35,8 @@ Rocket.Chat does not provide an official data export feature, so the Zulip
 import tool works by importing data from a Rocket.Chat database dump.
 
 If you're self-hosting your Rocket.Chat instance, you can create a
-database dump using the `mongodump` utility.
+database dump using the `mongodump` utility. Make sure your Rocket.Chat
+server is **NOT** shut down while creating database dump using `mongodump`.
 
 If your organization is hosted on Rocket.Chat Cloud or another hosting
 provider that doesn't provide you with database access, you will need

--- a/help/import-from-rocketchat.md
+++ b/help/import-from-rocketchat.md
@@ -128,6 +128,8 @@ keep in mind about the import process:
 - Messages longer than Zulip's limit of 10,000 characters are not
   imported.
 
+- Livechat channels/messages are not imported.
+
 - Messages from Rocket.Chat Discussions are imported as topics
   inside the Zulip channel corresponding to the parent channel of the
   Rocket.Chat Discussion.

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -402,7 +402,7 @@ def process_message_attachment(
         logging.info("Replacing invalid attachment name with random uuid: %s", file_name)
         sanitized_name = uuid.uuid4().hex
 
-    if len(sanitized_name) >= 255:  # nocoverage
+    if len(sanitized_name.encode("utf-8")) >= 255:  # nocoverage
         logging.info("Replacing too long attachment name with random uuid: %s", file_name)
         sanitized_name = uuid.uuid4().hex
 


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Migration.20from.20Rocket.2EChat.20issues.3A.20messages.20and.20uploads/near/1906256)

List of bugs discussed in #20108 


* Bug: https://github.com/zulip/zulip/issues/20108#issuecomment-960665584
   Resolved: https://github.com/zulip/zulip/commit/1cc2764d4560a7678ecc8f089c9aaab7d2a9c16c

* Bug: https://github.com/zulip/zulip/issues/20108#issuecomment-961455420
   Resolved: https://github.com/zulip/zulip/commit/51421f378b92ef6e3378ca982f00be3ce20cd7a2

* Bug: https://github.com/zulip/zulip/issues/20108#issuecomment-962091717
   Resolved: https://github.com/zulip/zulip/commit/c308799133229e3e00dde46f4e014a84bd2da617

* Bug: https://github.com/zulip/zulip/issues/20108#issuecomment-962235336
   Resolved: Second Commit

* Bug: https://github.com/zulip/zulip/issues/20108#issuecomment-962078907
   Resolved: Second Commit

---
* First Commit:
  <details><summary>Fifth point</summary>
  <img src="https://github.com/user-attachments/assets/385e0bf3-5bd0-4a64-aa36-131dab861e85">
  </img>
  </details> 
* Second Commit:
  <details><summary>Help Docs</summary>
  <img src="https://github.com/user-attachments/assets/919a5ae0-5e32-4716-aed2-4f7fb3baf2d2">
  </img>
  </details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
