### PR TITLE
lightbox: Disable controls on video previews in lightbox.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -251,7 +251,6 @@ export function render_lightbox_media_list(displayed_source: string): void {
 
                 const $video = $("<video>");
                 $video.attr("src", payload.source);
-                $video.attr("controls", "false");
 
                 $node.append($video);
             } else {


### PR DESCRIPTION
Setting any value for a boolean attribute (like "controls") enables it.
