### PR TITLE
nginx: Adjust default gzip level.

### DIFF
--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -34,6 +34,7 @@ http {
 
     gzip on;
     gzip_proxied any;
+    gzip_comp_level 3;
     gzip_types
       application/javascript
       application/json


### PR DESCRIPTION
The default compression level is 1; increasing this to 3 takes a small amount more CPU time (single-digit ms on multi-MB transfers), but results in a small but noticeable (4-7%) percentage better compression in JSON content.

Assuming a 25 megabit connection (the current average data rate for cell phones in the U.S.), a 2MB file which is shrunk an additional 4% saves approximately 25 milliseconds of transfer time; thus the additional few milliseconds of CPU-time is well worth the cost.  For faster connections (e.g. 100 megabit), the tradeoff is more or less a wash.
