### PR TITLE
compose: Specify non-alpha message-area colors.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -585,6 +585,8 @@
     --color-recent-view-link-hover: hsl(214deg 40% 58%);
 
     /* Compose box colors */
+    --color-compose-box-background: hsl(232deg 30% 92%);
+    --color-compose-message-content-background: hsl(0deg 0% 100%);
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
     --color-compose-send-button-background: hsl(240deg 96% 68%);
     --color-compose-send-button-background-interactive: hsl(240deg 41% 50%);
@@ -988,6 +990,12 @@
     --color-recent-view-link-hover: hsl(208deg 64% 52%);
 
     /* Compose box colors */
+    --color-compose-box-background: hsl(228deg 11% 17%);
+    --color-compose-message-content-background: color-mix(
+        in srgb,
+        var(--color-compose-box-background),
+        hsl(0deg 0% 0%) 20%
+    );
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);
     --color-compose-send-control-button: hsl(240deg 30% 70%);
     --color-compose-send-control-button-background: transparent;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -119,7 +119,7 @@
 
 /* Main geometry for this element is in zulip.css */
 #compose-content {
-    background-color: hsl(232deg 30% 92%);
+    background-color: var(--color-compose-box-background);
     padding: 7px 7px 8px;
     border: 1px solid hsl(0deg 0% 0% / 10%);
     border-radius: 9px 9px 0 0;
@@ -352,6 +352,7 @@
 #preview_message_area {
     margin-right: calc(var(--composebox-buttons-width) * -1);
     padding-right: var(--composebox-buttons-width);
+    background-color: var(--color-compose-message-content-background);
     color: var(--color-text-default);
 }
 
@@ -833,7 +834,6 @@ textarea.new_message_textarea {
     resize: none !important;
     border-radius: 3px 3px 0 0;
     border: none;
-    background-color: hsl(0deg 0% 100%);
     scrollbar-width: thin;
     scrollbar-color: hsl(0deg 0% 50%) transparent;
     box-shadow: none;
@@ -1363,7 +1363,6 @@ textarea.new_message_textarea {
     overflow: auto;
 
     border-radius: 3px 3px 0 0;
-    background-color: hsl(0deg 0% 100%);
     cursor: not-allowed;
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -500,7 +500,6 @@
     }
 
     #compose-content {
-        background-color: hsl(228deg 11% 17%);
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
@@ -515,10 +514,6 @@
     .overlay-message-row .overlay-message-info-box,
     .preview_message_area {
         border-color: hsl(0deg 0% 0% / 40%);
-    }
-
-    .preview_message_area {
-        background-color: hsl(0deg 0% 0% / 20%);
     }
 
     .top-navbar-border {


### PR DESCRIPTION
This keeps colors uniform between edit and preview modes, and also ensures no bleedthrough of the editor when in preview mode. In using `color-mix`, it maintains the colors as-is, but removes an alpha channel in preview mode that is at the heart of a serious dark-mode regression introduced in #31177.

ID selectors have been used for those colors to both keep the text color declaration in the same place, and to avoid a dark-theme specificity problem where the generic textarea took precedence over the colors specified on the compose box's own textarea.

<!-- Describe your pull request here.-->

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/message.20preview.20overlapping.20with.20original.20message/near/1908596)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Preview mode, before | Preview mode, after (no change in light mode) |
| --- | --- |
| ![dark-mode-preview-before](https://github.com/user-attachments/assets/a39a3fe7-565a-4606-95b1-db336256b9f1) | ![dark-mode-preview-after](https://github.com/user-attachments/assets/60b14ad3-8b27-47a2-b726-fc0265fac0fc) |
| ![light-mode-preview-before](https://github.com/user-attachments/assets/43475f86-4511-4b74-8e2e-b9b639636e4b) | ![light-mode-preview-after](https://github.com/user-attachments/assets/e611e422-6f75-4c07-a798-8b7448ad22e0) |

| Edit mode, before | Edit mode, after (no change) |
| --- | --- |
| ![dark-mode-edit-before](https://github.com/user-attachments/assets/f2ea00ab-acdb-406f-800b-bd052df73675) | ![dark-mode-edit-after](https://github.com/user-attachments/assets/87deb9f6-88a1-4fb2-82e2-6eb52e730f24) |
| ![light-mode-edit-before](https://github.com/user-attachments/assets/8329a9f4-ea5a-468d-9181-8f0588bc516c) | ![light-mode-edit-after](https://github.com/user-attachments/assets/44d9e6f1-46b4-4a04-baa4-661f3feebe08) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
