### PR TITLE
search: Move group user remove logic out of input_pill.

### DIFF
--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -4,6 +4,8 @@ import assert from "minimalistic-assert";
 import render_input_pill from "../templates/input_pill.hbs";
 import render_search_user_pill from "../templates/search_user_pill.hbs";
 
+import * as compose_actions from "./compose_actions";
+import * as compose_state from "./compose_state";
 import {Filter} from "./filter";
 import * as input_pill from "./input_pill";
 import type {InputPill, InputPillContainer} from "./input_pill";
@@ -75,6 +77,13 @@ function on_pill_exit(
         remove_pill(clicked_pill);
         return;
     }
+    // We need to close the compose box if it's open, for two reasons. (1) its
+    // recipients are about to become out of date, and (2) if it's open, the
+    // global click handler will move
+    if (compose_state.composing()) {
+        compose_actions.cancel();
+    }
+
     // The user-pill-container container class is used exclusively for
     // group-DM search pills, where multiple user pills sit inside a larger
     // pill. The exit icons in those individual user pills should remove

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -485,9 +485,6 @@ run_test("exit button on pill", ({mock_template}) => {
                 assert.equal(sel, ".pill");
                 return $curr_pill_stub;
             },
-            parents() {
-                return [];
-            },
         }),
     };
 


### PR DESCRIPTION
First commit: a pure refactor, no functional changes expected. This is a followup to some code written for search pills -- at the time I couldn't figure out how to get it out of the generic `input_pill` code, but this seems like a reasonable solution.

🐞 Second commit: a bugfix for the moved code, rebased on top of the refactor. I'm happy to put this in a separate PR if that's desired.