### PR TITLE
inbox_ui: Fix row_focus not synced with inbox rows.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1327,9 +1327,17 @@ export function update(): void {
     const has_visible_unreads = has_dms_post_filter || has_topics_post_filter;
     show_empty_inbox_text(has_visible_unreads);
 
+    // We want to avoid weird jumps when user is interacting with Inbox
+    // and we are updating the view. So, we only reset current focus if
+    // the update was triggered by user. This can mean `row_focus` can
+    // be out of bounds, so we need to fix that.
     if (update_triggered_by_user) {
         setTimeout(revive_current_focus, 0);
         update_triggered_by_user = false;
+    } else {
+        if (row_focus >= get_all_rows().length) {
+            revive_current_focus();
+        }
     }
 }
 


### PR DESCRIPTION
Have one inbox row and focus on it. Mark the message as read in another tab. Press `r` in the first tab will return an error as the row_focus didn't change but there is no present. So, we fix it by updating the row_focus if it can get out of bounds when updating inbox view.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/error.20in.20dev
