### PR TITLE
Sync 'Add option' button transition in polls with theme switch.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -209,18 +209,19 @@ button {
         padding: 4px;
         padding-left: 14px;
         padding-right: 14px;
-        transition: all 0.2s ease;
 
         &:hover,
         &:focus {
             outline: 0;
             border-color: hsl(156deg 30% 50%);
+            transition: all 0.2s ease;
         }
 
         &:active {
             border-color: hsl(156deg 30% 40%);
             color: hsl(156deg 44% 43%);
             background-color: hsl(154deg 33% 96%);
+            transition: all 0.2s ease;
         }
     }
 }


### PR DESCRIPTION
Removed the general transition from the  styles and added it to the pseudo selectors , , and  for the  and  buttons. This ensures the transition only applies during these states, resolving the issue with the theme switch transition.

Fixes #30628

### Changes
- Synchronized the transition of the "Add option" button and option field with the overall theme transition.
- Updated relevant CSS to ensure smooth and consistent theme changes across the entire UI.


### Testing
- Manually tested the theme switch to ensure the "Add option" button and option field transition smoothly with the rest of the UI.
- Updated relevant tests to cover this change and ensure no regressions.


### Additional Information
A video demonstrating the issue and the fix is attached to this pull request for better visualization of the changes. 

**Video:** 
Before:
https://github.com/user-attachments/assets/079abe2f-8dfd-4b46-98d4-c0d8927fd3ba

After:
https://github.com/user-attachments/assets/dfb00883-6ed8-46e9-887a-863d5e1f735c
<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

#### Communicate decisions, questions, and potential concerns.

- [x] Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Commit message(s) explain reasoning and motivation for changes.

#### Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>
