### PR TITLE
compose: Change cursor to default instead of not-allowed.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -844,7 +844,6 @@ textarea.new_message_textarea {
 
     &:read-only,
     &:disabled {
-        cursor: not-allowed;
         background-color: hsl(0deg 0% 93%);
     }
 }
@@ -1152,7 +1151,6 @@ textarea.new_message_textarea {
 
     .compose_control_button_container.disabled-on-hover:hover {
         opacity: 0.3;
-        cursor: not-allowed;
 
         .compose_control_button {
             pointer-events: none;
@@ -1340,8 +1338,6 @@ textarea.new_message_textarea {
     }
 
     &.disabled-message-send-controls {
-        cursor: not-allowed;
-
         & button {
             pointer-events: none;
             opacity: 0.5;
@@ -1363,7 +1359,6 @@ textarea.new_message_textarea {
     overflow: auto;
 
     border-radius: 3px 3px 0 0;
-    cursor: not-allowed;
 }
 
 .markdown_preview_spinner {
@@ -1617,7 +1612,6 @@ textarea.new_message_textarea {
     }
 
     .preview_mode_disabled {
-        cursor: not-allowed;
         opacity: 0.3;
 
         .compose_control_button {


### PR DESCRIPTION
Fixes #31214.


**Screenshots and screen captures:**

<img width="780" alt="compose_change_cusror_button_2" src="https://github.com/user-attachments/assets/d20ec46e-0cc4-40c2-a29a-7d375506d264">
<img width="996" alt="compose_change_cusror_button_1" src="https://github.com/user-attachments/assets/6c6924a4-78a1-420f-b006-90b031217a40">
<img width="762" alt="compose_change_cursor_preview" src="https://github.com/user-attachments/assets/f7ec90db-d110-4cd8-ac4a-91b76989d9a9">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
