### PR TITLE
narrow: Make `with` operator behaviour consistent with API behaviour.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -402,7 +402,8 @@ export class Filter {
             return orig_terms;
         }
 
-        const updated_terms = [...orig_terms];
+        const updated_terms = orig_terms.filter((term: NarrowTerm) => term.operator !== "dm");
+
         let channel_term = updated_terms.find(
             (term: NarrowTerm) => Filter.canonicalize_operator(term.operator) === "channel",
         );
@@ -616,9 +617,9 @@ export class Filter {
             "channels-public",
             "channel",
             "topic",
-            "with",
             "dm",
             "dm-including",
+            "with",
             "sender",
             "near",
             "id",
@@ -879,6 +880,8 @@ export class Filter {
         this.cached_sorted_terms_for_comparison = undefined;
         if (this.has_operator("channel")) {
             this._sub = stream_data.get_sub_by_name(this.operands("channel")[0]!);
+        } else {
+            this._sub = undefined;
         }
     }
 
@@ -1063,6 +1066,10 @@ export class Filter {
         }
 
         if (_.isEqual(term_types, ["channel", "topic"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["dm", "with"])) {
             return true;
         }
 
@@ -1291,6 +1298,7 @@ export class Filter {
         }
         if (
             (term_types.length === 2 && _.isEqual(term_types, ["dm", "near"])) ||
+            (term_types.length === 2 && _.isEqual(term_types, ["dm", "with"])) ||
             (term_types.length === 1 && _.isEqual(term_types, ["dm"]))
         ) {
             const emails = this.operands("dm")[0]!.split(",");
@@ -1463,7 +1471,6 @@ export class Filter {
     fix_terms(terms: NarrowTerm[]): NarrowTerm[] {
         terms = this._canonicalize_terms(terms);
         terms = this._fix_redundant_is_private(terms);
-        terms = this._fix_redundant_with_dm(terms);
         return terms;
     }
 
@@ -1474,16 +1481,6 @@ export class Filter {
         }
 
         return terms.filter((term) => Filter.term_type(term) !== "is-dm");
-    }
-
-    _fix_redundant_with_dm(terms: NarrowTerm[]): NarrowTerm[] {
-        // Because DMs can't move, the `with` operator is a noop on a
-        // DM conversation.
-        if (terms.some((term) => Filter.term_type(term) === "dm")) {
-            return terms.filter((term) => Filter.term_type(term) !== "with");
-        }
-
-        return terms;
     }
 
     _canonicalize_terms(terms_mixed_case: NarrowTerm[]): NarrowTerm[] {
@@ -1601,6 +1598,7 @@ export class Filter {
         if (
             _.isEqual(term_type, ["channel", "topic", "with"]) ||
             _.isEqual(term_type, ["channel", "topic"]) ||
+            _.isEqual(term_type, ["dm", "with"]) ||
             _.isEqual(term_type, ["dm"])
         ) {
             return true;

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -304,7 +304,7 @@ export function _possible_unread_message_ids(
         return unread.get_msg_ids_for_stream(sub.stream_id);
     }
 
-    if (current_filter.can_bucket_by("dm")) {
+    if (current_filter.can_bucket_by("dm", "with") || current_filter.can_bucket_by("dm")) {
         current_filter_pm_string = pm_ids_string(current_filter);
         if (current_filter_pm_string === undefined) {
             return [];
@@ -349,7 +349,7 @@ export function narrowed_by_pm_reply(current_filter: Filter | undefined = filter
     if (current_filter === undefined) {
         return false;
     }
-    const terms = current_filter.terms();
+    const terms = current_filter.terms().filter((term) => term.operator !== "with");
     return terms.length === 1 && current_filter.has_operator("dm");
 }
 


### PR DESCRIPTION
Previously, in presence of `dm` operators, the `with` operator behaviour in the web client was not consistent with that of the API. For instance, when `with` points to a stream message, while the narrow containing `dm`, rather than correcting narrow to point to the anchor message, it used to remove the `with`.

Similarly, when `with` pointed to a direct message, then it used to narrow to the correct narrow, but `with` used to be removed from the filter.

This commit removes these inconsistencies of `with` in case of `dm` operators, and makes it consistent to those mentioned in the api documentation.

<!-- Describe your pull request here.-->
[CZO thread](https://chat.zulip.org/#narrow/stream/378-api-design/topic/topic.20permalinks/near/1907306)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
