### PR TITLE
Show action buttons only on hover for non sticky header.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1086,6 +1086,13 @@ export class MessageListView {
             }
         }
 
+        const is_conversation_view = message_lists.current.is_combined_feed_view;
+        if (is_conversation_view) {
+            $(".focused-message-list").addClass("combined-feed-view");
+        } else {
+            $(".focused-message-list").removeClass("combined-feed-view");
+        }
+
         return undefined;
     }
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1723,8 +1723,8 @@ export class MessageListView {
             // This value is dependent upon space between two `recipient_row` message groups.
             const margin_between_recipient_rows = 10;
             const sticky_or_about_to_be_sticky_header_position =
-                navbar_bottom + header_props.height + margin_between_recipient_rows;
-            if (header_props.top < partially_hidden_header_position) {
+                navbar_bottom + header_props.height / 5 + margin_between_recipient_rows;
+            if (header_props.top < partially_hidden_header_position - header_props.height / 2) {
                 return -1;
             } else if (header_props.top > sticky_or_about_to_be_sticky_header_position) {
                 return 1;

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -147,6 +147,12 @@
                 padding-top: 5px;
             }
         }
+
+        &:hover {
+            .recipient_bar_control_button {
+                visibility: visible !important;
+            }
+        }
     }
 
     .message_header {
@@ -162,6 +168,10 @@
 
         &.sticky_header {
             box-shadow: var(--unread-marker-left) 0 0 0 var(--color-background);
+
+            .recipient_bar_control_button {
+                visibility: visible !important;
+            }
 
             .recipient_row_date {
                 display: block;
@@ -208,6 +218,20 @@
             &::after {
                 font-size: 16px;
             }
+        }
+    }
+}
+
+.visibility-policy-popover-visible {
+    visibility: visible !important;
+    pointer-events: all !important;
+    opacity: 1 !important;
+}
+
+.combined-feed-view .recipient_bar_controls {
+    @media (width > $md_min) {
+        .recipient_bar_control_button {
+            visibility: hidden;
         }
     }
 }

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -44,22 +44,22 @@
 
             {{! edit topic pencil icon }}
             {{#if always_visible_topic_edit}}
-                <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
+                <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon recipient_bar_control_button hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
             {{else if on_hover_topic_edit}}
-                <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
+                <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon recipient_bar_control_button hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
             {{/if}}
 
             {{#if user_can_resolve_topic}}
                 {{#if topic_is_resolved}}
-                    <i class="fa fa-check on_hover_topic_unresolve recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as unresolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as unresolved' }}"></i>
+                    <i class="fa fa-check on_hover_topic_unresolve recipient_bar_icon recipient_bar_control_button hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as unresolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as unresolved' }}"></i>
                 {{else}}
-                    <i class="fa fa-check on_hover_topic_resolve recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as resolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as resolved' }}"></i>
+                    <i class="fa fa-check on_hover_topic_resolve recipient_bar_icon recipient_bar_control_button hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as resolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as resolved' }}"></i>
                 {{/if}}
                 <div class="toggle_resolve_topic_spinner" style="display: none"></div>
             {{/if}}
 
             {{#if is_subscribed}}
-                <span class="change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
+                <span class="change_visibility_policy hidden-for-spectators recipient_bar_control_button" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
                     {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
                         <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic.'}}"
                           role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic.' }}"></i>


### PR DESCRIPTION
Earlier, action buttons on recipient_bar_controls was always displayed for all message_row containers.

This PR changes the recipient_bar_controls to display only on hover for non sticker message_header while sticky header has always on display.

Fixes: zulip#26852.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Before:

[Screencast from 03-08-24 02:54:12 AM IST.webm](https://github.com/user-attachments/assets/25cc5408-2bfe-47f1-a4dd-bf08450f82ac)

### After:

[Screencast from 03-08-24 02:54:34 AM IST.webm](https://github.com/user-attachments/assets/777e48d0-2725-48cf-8fb1-c3d8a3494659)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
