### PR TITLE
channel_subscribe: Use IDs instead of emails when processing results.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 289**
+
+* [`POST /users/{user_id}/subscription`](/api/subscribe): In the response,
+  users are identified by their numeric user ID rather than by their
+  Zulip API email address.
+
 **Feature level 288**
 
 * [`POST /register`](/api/register-queue):

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 288  # Last bumped for presence_history_limit_days
+API_FEATURE_LEVEL = 289  # return ID as key while subscribing to a stream.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -226,11 +226,11 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
     function invite_success(raw_data: unknown): void {
         const data = add_user_ids_api_response_schema.parse(raw_data);
         pill_widget.clear();
-        const subscribed_users = Object.keys(data.subscribed).map(
-            (email) => people.get_by_email(email)!,
+        const subscribed_users = Object.keys(data.subscribed).map((user_id) =>
+            people.get_by_user_id(Number(user_id)),
         );
-        const already_subscribed_users = Object.keys(data.already_subscribed).map(
-            (email) => people.get_by_email(email)!,
+        const already_subscribed_users = Object.keys(data.already_subscribed).map((user_id) =>
+            people.get_by_user_id(Number(user_id)),
         );
 
         show_stream_subscription_request_result({

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -129,7 +129,7 @@ def add_subscriptions(client: Client) -> None:
     # {code_example|end}
     assert_success_response(result)
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "200")
-    assert "newbie@zulip.com" in result["subscribed"]
+    assert str(user_id) in result["subscribed"]
 
 
 def test_add_subscriptions_already_subscribed(client: Client) -> None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9916,12 +9916,15 @@ paths:
                       subscribed:
                         type: object
                         description: |
-                          A dictionary where the key is the Zulip API email address of the user/bot
-                          and the value is a list of the names of the channels that were subscribed
-                          to as a result of the query.
+                          A dictionary where the key is the ID of the user and the value
+                          is a list of the names of the channels that user was subscribed
+                          to as a result of the request.
+
+                          **Changes**: Before Zulip 10.0 (feature level 289), the user
+                          keys were Zulip API email addresses, not user ID.
                         additionalProperties:
                           description: |
-                            `{email_address}`: List of the names of the channels that were subscribed
+                            `{id}`: List of the names of the channels that were subscribed
                             to as a result of the query.
                           type: array
                           items:
@@ -9929,12 +9932,16 @@ paths:
                       already_subscribed:
                         type: object
                         description: |
-                          A dictionary where the key is the Zulip API email address of the user/bot
-                          and the value is a list of the names of the channels that the user/bot is
-                          already subscribed to.
+                          A dictionary where the key is the ID of the user and the value
+                          is a list of the names of the channels that where the user was
+                          not added as a subscriber in this request, because they were
+                          already a subscriber.
+
+                          **Changes**: Before Zulip 10.0 (feature level 289), the user
+                          keys were Zulip API email addresses, not user IDs.
                         additionalProperties:
                           description: |
-                            `{email_address}`: List of the names of the channels that the user is
+                            `{id}`: List of the names of the channels that the user is
                             already subscribed to.
                           type: array
                           items:
@@ -9948,11 +9955,10 @@ paths:
                           authorized to subscribe to. Only present if `"authorization_errors_fatal": false`.
                     example:
                       {
-                        "already_subscribed":
-                          {"iago@zulip.com": ["testing-help"]},
+                        "already_subscribed": {"1": ["testing-help"]},
                         "msg": "",
                         "result": "success",
-                        "subscribed": {"newbie@zulip.com": ["testing-help"]},
+                        "subscribed": {"2": ["testing-help"]},
                       }
         "400":
           description: Bad request.


### PR DESCRIPTION
As part of our todo in the code, we want to use the unique user IDs instead of emails when processing the results of subscribing users to a channel. These changes apply those changes and streamlines the use of IDs.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details><summary>Help Center</summary>
<p>

Before:
![image](https://github.com/user-attachments/assets/e1486f03-b926-4f75-ac65-17c0ffb2ea81)
After:
![image](https://github.com/user-attachments/assets/219f9844-8953-4415-9f2c-dfdbc47d9db9)

</p>
</details> 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
