### PR TITLE
notification_settings: Fix the close notification for mark as read.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -99,7 +99,6 @@ EXEMPT_FILES = make_set(
         "web/src/drafts_overlay_ui.ts",
         "web/src/dropdown_widget.ts",
         "web/src/echo.ts",
-        "web/src/electron_bridge.ts",
         "web/src/email_pill.ts",
         "web/src/emoji_picker.ts",
         "web/src/emojisets.ts",

--- a/web/src/desktop_notifications.ts
+++ b/web/src/desktop_notifications.ts
@@ -2,7 +2,6 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 
 import {electron_bridge} from "./electron_bridge.ts";
-import type {Message} from "./message_store.ts";
 
 type NoticeMemory = Map<
     string,
@@ -92,9 +91,9 @@ export function permission_state(): string {
     return NotificationAPI.permission;
 }
 
-export function close_notification(message: Message): void {
+export function close_notification(message_id: number): void {
     for (const [key, notice_mem_entry] of notice_memory) {
-        if (notice_mem_entry.message_id === message.id) {
+        if (notice_mem_entry.message_id === message_id) {
             notice_mem_entry.obj.close();
             notice_memory.delete(key);
         }

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -1,6 +1,7 @@
 import type {z} from "zod";
 
 import * as blueslip from "./blueslip.ts";
+import * as desktop_notifications from "./desktop_notifications.ts";
 import {FoldDict} from "./fold_dict.ts";
 import * as message_store from "./message_store.ts";
 import type {Message} from "./message_store.ts";
@@ -853,6 +854,7 @@ export function mark_as_read(message_id: number): void {
     // was never set to unread.
     unread_direct_message_counter.delete(message_id);
 
+    desktop_notifications.close_notification(message_id);
     // Important: This function uses `unread_topic_counter` to look up
     // the stream/topic for this previously unread message, so much
     // happen before the message is removed from that data structure.

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -247,7 +247,7 @@ function process_newly_read_message(
     for (const msg_list of message_lists.all_rendered_message_lists()) {
         msg_list.view.show_message_as_read(message, options);
     }
-    desktop_notifications.close_notification(message);
+    desktop_notifications.close_notification(message.id);
     recent_view_ui.update_topic_unread_count(message);
 }
 

--- a/web/tests/notifications.test.cjs
+++ b/web/tests/notifications.test.cjs
@@ -413,7 +413,7 @@ test("basic_notifications", () => {
     assert.equal(last_shown_message_id, message_1.id.toString());
 
     // Remove notification.
-    desktop_notifications.close_notification(message_1);
+    desktop_notifications.close_notification(message_1.id);
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), false);
     assert.equal(n.size, 0);
@@ -444,8 +444,8 @@ test("basic_notifications", () => {
     assert.equal(last_shown_message_id, message_2.id.toString());
 
     // Remove notifications.
-    desktop_notifications.close_notification(message_1);
-    desktop_notifications.close_notification(message_2);
+    desktop_notifications.close_notification(message_1.id);
+    desktop_notifications.close_notification(message_2.id);
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), false);
     assert.equal(n.size, 0);

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -2,6 +2,8 @@
 
 const assert = require("node:assert/strict");
 
+const {JSDOM} = require("jsdom");
+
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 
@@ -252,6 +254,9 @@ test("server_history", () => {
 });
 
 test("test_unread_logic", () => {
+    const {window} = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+    global.document = window.document;
+    global.Element = window.Element;
     const stream_id = 77;
 
     stream_topic_history.add_message({

--- a/web/tests/unread.test.cjs
+++ b/web/tests/unread.test.cjs
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 
+const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
 const {set_global, with_overrides, zrequire} = require("./lib/namespace.cjs");
@@ -89,6 +90,9 @@ test("empty_counts_while_home", () => {
 });
 
 test("changing_topics", () => {
+    const {window} = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+    global.document = window.document;
+    global.Element = window.Element;
     // Summary: change the topic of a message from 'lunch'
     // to 'dinner' using update_unread_topics().
     let count = unread.num_unread_for_topic(social.stream_id, "lunch");
@@ -224,6 +228,8 @@ test("changing_topics", () => {
 
     // test coverage
     unread.update_unread_topics(sticky_message, {});
+    delete global.document;
+    delete global.Element;
 });
 
 test("muting", () => {


### PR DESCRIPTION
When a message is marked as read, we didn't  call Notification.close to officially clear any desktop notification that might have been generated from the message being sent. This PR is to fix this issue. 

Fixes: #31172

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
