### PR TITLE
Support syncing user role during SAML login

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -15,7 +15,12 @@ _Unreleased_
 
 #### Upgrade notes for 10.0
 
-- None yet.
+- The `SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT` setting is deprecated in favor of the
+  more general `SOCIAL_AUTH_SYNC_ATTRS_DICT` setting structure, but still works in
+  this release for a smooth upgrade experience. The new setting supports
+  synchronizing role, and otherwise functions like the old one, except Zulip
+  custom profile fields are referred to with the prefix `custom__`. See the updated
+  comment documentation in `/etc/zulip/settings.py` for details.
 
 ## Zulip Server 9.x series
 

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -616,10 +616,10 @@ other IdPs (identity providers). You can configure it as follows:
 The above configuration is sufficient for Service Provider initialized
 SSO, i.e. you can visit the Zulip web app and click "Sign in with
 {IdP}" and it'll correctly start the authentication flow. If you are
-not hosting multiple organizations, with Zulip 3.0+, the above
-configuration is also sufficient for Identity Provider initiated SSO,
-i.e. clicking a "Sign in to Zulip" button on the IdP's website can
-correctly authenticate the user to Zulip.
+not hosting multiple organizations, the above configuration is also
+sufficient for Identity Provider initiated SSO, i.e. clicking a "Sign
+in to Zulip" button on the IdP's website can correctly authenticate
+the user to Zulip.
 
 If you're hosting multiple organizations and thus using the
 `SOCIAL_AUTH_SUBDOMAIN` setting, you'll need to configure a custom
@@ -1040,9 +1040,9 @@ self-hosted servers. To do so, you'll need to do the following:
 
 ## OpenID Connect
 
-Starting with Zulip 5.0, Zulip can be integrated with any OpenID
-Connect (OIDC) authentication provider. You can configure it by
-enabling `zproject.backends.GenericOpenIdConnectBackend` in
+Zulip can be integrated with any OpenID Connect (OIDC) authentication
+provider. You can configure it by enabling
+`zproject.backends.GenericOpenIdConnectBackend` in
 `AUTHENTICATION_BACKENDS` and following the steps outlined in the
 comment documentation in `/etc/zulip/settings.py`.
 

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -498,9 +498,8 @@ the bottom of the problem:
 
 ## SAML
 
-Zulip 2.1 and later supports SAML authentication, used by Okta,
-OneLogin, and many other IdPs (identity providers). You can configure
-it as follows:
+Zulip supports SAML authentication, used by Okta, OneLogin, and many
+other IdPs (identity providers). You can configure it as follows:
 
 1. These instructions assume you have an installed Zulip server; if
    you're using Zulip Cloud, see [this article][saml-help-center],
@@ -599,25 +598,6 @@ it as follows:
 1. Enable the `zproject.backends.SAMLAuthBackend` auth backend, in
    `AUTHENTICATION_BACKENDS` in `/etc/zulip/settings.py`.
 
-1. (Optional) New in Zulip 5.0: Zulip can synchronize [custom profile
-   fields][custom-profile-fields] from the SAML provider. Just
-   configure the `SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT`; the
-   [LDAP](#synchronizing-custom-profile-fields) documentation for
-   synchronizing custom profile fields will be helpful. Servers
-   installed before Zulip 5.0 may want to [update inline comment
-   documentation][update-inline-comments] so they can take advantage
-   of the latest inline SAML documentation in
-   `/etc/zulip/settings.py`.
-
-   Note that in contrast with LDAP, Zulip can only query the SAML
-   database for a user's settings when the user authenticates to Zulip
-   using SAML, so custom profile fields are only synchronized when the
-   user logs in.
-
-   Note also that the SAML feature currently only synchronizes custom
-   profile fields during login, not during account creation; we
-   consider this [a bug](https://github.com/zulip/zulip/issues/18746).
-
 1. [Restart the Zulip server](settings.md) to ensure
    your settings changes take effect. The Zulip login page should now
    have a button for SAML authentication that you can use to log in or
@@ -629,6 +609,7 @@ it as follows:
    IdP.
 
 [saml-help-center]: https://zulip.com/help/saml-authentication
+[user-role-help-center]: https://zulip.com/help/roles-and-permissions
 
 ### IdP-initiated SSO
 
@@ -674,6 +655,41 @@ to the root and `engineering` subdomains:
   </saml2:AttributeValue>
 </saml2:Attribute>
 ```
+
+### Synchronizing user role or custom profile fields during login
+
+In contrast with SCIM or LDAP, the SAML protocol only allows Zulip to
+access data about a user when that user authenticates to Zulip using
+SAML, so metadata can only be synchronized when the user logs in.
+
+As a result, most installations using SAML will want to use [SCIM
+provisioning](./scim.md) to synchronize metadata continuously. Zulip
+nonetheless includes support for copying certain fields from a SAML
+database, which can be a good option when a SAML provider does not
+offer SCIM or the fields one is interested in syncing change rarely
+enough that asking users to logout and then login again to resync
+their metadata might feel reasonable.
+
+Specifically, Zulip supports synchronizing the [user
+role][user-role-help-center] and [custom profile
+fields][custom-profile-fields] from the SAML provider.
+
+In order to use this functionality, configure
+`SOCIAL_AUTH_SYNC_ATTRS_DICT` in `/etc/zulip/settings.py` according to
+the instructions in the inline documentation in the file. Servers
+installed before Zulip 10.0 may want to [update inline comment
+documentation][update-inline-comments] first in order to access it.
+
+Custom profile fields are only synchronized during login, not during
+account creation; we consider this [a
+bug](https://github.com/zulip/zulip/issues/18746). User role is
+synchronized during both account creation and each consecutive login.
+
+:::{note}
+When user role is provided by the SAML IdP during signup of a
+user who's coming from an invitation link, the IdP-provided role will
+take precedence over the role set in the invitation.
+:::
 
 ### SCIM
 

--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -198,9 +198,9 @@ aren't receiving emails from Zulip:
   you can inspect the emails that reached the service, whether an
   email was flagged as spam, etc.
 
-- Starting with Zulip 1.7, Zulip logs an entry in
-  `/var/log/zulip/send_email.log` whenever it attempts to send an
-  email. The log entry includes whether the request succeeded or failed.
+- Zulip logs an entry in `/var/log/zulip/send_email.log` whenever it
+  attempts to send an email. The log entry includes whether the
+  request succeeded or failed.
 
 - If attempting to send an email throws an exception, a traceback
   should be in `/var/log/zulip/errors.log`, along with any other

--- a/docs/production/postgresql.md
+++ b/docs/production/postgresql.md
@@ -1,7 +1,6 @@
 # PostgreSQL database details
 
-Starting with Zulip 3.0, Zulip supports a range of PostgreSQL
-versions:
+Zulip supports a range of PostgreSQL versions:
 
 ```{include} postgresql-support-table.md
 

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -156,7 +156,11 @@ Zulip in production](install.md).
 
 This section details some basic guidelines for running a Zulip server
 for larger organizations (especially >1000 users or 500+ daily active
-users). Zulip's resource needs depend mainly on 3 parameters:
+users). These guidelines are conservative, since they are intended to
+be sufficient for a wide range of possible usage patterns that may not
+be applicable to your installation.
+
+Zulip's resource needs depend mainly on 3 parameters:
 
 - daily active users (e.g., number of employees if everyone's an
   employee)
@@ -177,7 +181,7 @@ installing Zulip with a dedicated database server.
   active users, we recommend using a [remote PostgreSQL
   database](postgresql.md), but it's not required.
 
-- **RAM:** We recommended more RAM for larger installations:
+- **RAM:** We recommend more RAM for larger installations:
 
   - With 25+ daily active users, 4 GB of RAM.
   - With 100+ daily active users, 8 GB of RAM.
@@ -225,23 +229,18 @@ installing Zulip with a dedicated database server.
   backend][s3-uploads].
 
 - **Sharding:** For servers with several thousand daily active users,
-  it is necessary to shard Zulip's Tornado service. Care must be taken
-  when dividing traffic for a single Zulip realm between multiple
-  Zulip application servers, which is why we recommend a hot spare
-  over load-balancing for most installations desiring extra
-  redundancy.
+  Zulip supports sharding its real-time-push Tornado service, both by
+  realm/organization (for hosting many organizations) and by user ID
+  (for hosting single very large organizations)
 
-  - Zulip 2.0 and later supports running multiple Tornado servers
-    sharded by realm/organization, which is how we scale Zulip Cloud.
-  - Zulip 6.0 and later supports running multiple Tornado servers
-    sharded by user ID, which is necessary for individual realms with
-    many thousands of daily active users.
+  Care must be taken when dividing traffic for a single Zulip realm
+  between multiple Zulip application servers, which is why we
+  recommend a hot spare over load-balancing for most installations
+  desiring extra redundancy.
 
-  [Contact us][contact-support] for help implementing the sharding policy.
-
-Scalability is an area of active development, so if you're unsure
-whether Zulip is a fit for your organization or need further advice
-[contact Zulip support][contact-support].
+If you have scalability questions or are unsure whether Zulip is a fit
+for your use case, contact [Zulip sales or support][contact-support]
+for assistance.
 
 For readers interested in technical details around what features
 impact Zulip's scalability, this [performance and scalability design

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -603,6 +603,17 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         ROLE_GUEST: gettext_lazy("Guest"),
     }
 
+    # Mapping of role ids to simple string identifiers for the roles,
+    # to be used in API contexts such as SCIM provisioning.
+    ROLE_ID_TO_API_NAME = {
+        ROLE_REALM_OWNER: "owner",
+        ROLE_REALM_ADMINISTRATOR: "administrator",
+        ROLE_MODERATOR: "moderator",
+        ROLE_MEMBER: "member",
+        ROLE_GUEST: "guest",
+    }
+    ROLE_API_NAME_TO_ID = {v: k for k, v in ROLE_ID_TO_API_NAME.items()}
+
     class Meta:
         indexes = [
             models.Index(Upper("email"), name="upper_userprofile_email_idx"),

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3193,7 +3193,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
             ],
         )
 
-    def test_social_auth_custom_profile_field_sync(self) -> None:
+    def test_social_auth_profile_field_sync(self) -> None:
         birthday_field = CustomProfileField.objects.get(
             realm=self.user_profile.realm, name="Birthday"
         )
@@ -3202,25 +3202,32 @@ class SAMLAuthBackendTest(SocialAuthBase):
         ).value
 
         idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_SAML_ENABLED_IDPS)
-        idps_dict["test_idp"]["extra_attrs"] = ["mobilePhone"]
+        idps_dict["test_idp"]["extra_attrs"] = ["mobilePhone", "zulip_role"]
 
         sync_custom_attrs_dict = {
             "zulip": {
                 "saml": {
-                    "phone_number": "mobilePhone",
+                    "custom__phone_number": "mobilePhone",
+                    "role": "zulip_role",
                 }
             }
         }
 
+        # Before we procee, verify the role, which is supposed to get synced, is like
+        # we expect.
+        self.assertEqual(self.user_profile.role, UserProfile.ROLE_MEMBER)
+
         with self.settings(
             SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_dict,
-            SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT=sync_custom_attrs_dict,
+            SOCIAL_AUTH_SYNC_ATTRS_DICT=sync_custom_attrs_dict,
         ):
             account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
             result = self.social_auth_test(
                 account_data_dict,
                 subdomain="zulip",
-                extra_attributes=dict(mobilePhone=["123412341234"], birthday=["2021-01-01"]),
+                extra_attributes=dict(
+                    mobilePhone=["123412341234"], birthday=["2021-01-01"], zulip_role=["owner"]
+                ),
             )
         data = load_subdomain_token(result)
         self.assertEqual(data["email"], self.email)
@@ -3242,12 +3249,131 @@ class SAMLAuthBackendTest(SocialAuthBase):
         ).value
         self.assertEqual(new_birthday_field_value, old_birthday_field_value)
 
-    def test_social_auth_custom_profile_field_sync_custom_field_not_existing(self) -> None:
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.role, UserProfile.ROLE_REALM_OWNER)
+
+        # Now test with an invalid role value.
+        idps_dict["test_idp"]["extra_attrs"] = ["zulip_role"]
         sync_custom_attrs_dict = {
             "zulip": {
                 "saml": {
-                    "title": "title",
-                    "phone_number": "mobilePhone",
+                    "role": "zulip_role",
+                }
+            }
+        }
+        with (
+            self.settings(
+                SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_dict,
+                SOCIAL_AUTH_SYNC_ATTRS_DICT=sync_custom_attrs_dict,
+            ),
+            self.assertLogs(self.logger_string, level="WARNING") as m,
+        ):
+            account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
+            result = self.social_auth_test(
+                account_data_dict,
+                subdomain="zulip",
+                extra_attributes=dict(zulip_role=["wrongrole"]),
+            )
+
+        data = load_subdomain_token(result)
+        self.assertEqual(data["email"], self.email)
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.role, UserProfile.ROLE_REALM_OWNER)
+        self.assertEqual(
+            m.output,
+            [
+                self.logger_output(
+                    f"Ignoring unsupported role value wrongrole for user {self.user_profile.id} in SOCIAL_AUTH_SYNC_ATTRS_DICT",
+                    type="warning",
+                )
+            ],
+        )
+
+        # Verify empty attribute is handled.
+        with self.settings(
+            SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_dict,
+            SOCIAL_AUTH_SYNC_ATTRS_DICT=sync_custom_attrs_dict,
+        ):
+            account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
+            result = self.social_auth_test(
+                account_data_dict,
+                subdomain="zulip",
+                extra_attributes=dict(zulip_role=[""]),
+            )
+        data = load_subdomain_token(result)
+        self.assertEqual(data["email"], self.email)
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.role, UserProfile.ROLE_REALM_OWNER)
+
+        # Disable syncing of role in SOCIAL_AUTH_SYNC_ATTRS_DICT, while keeping
+        # role in extra_attrs. This edge case means the attribute will be read from the
+        # data provided by the IdP, but won't be used for anything.
+        with self.settings(
+            SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_dict,
+            SOCIAL_AUTH_SYNC_ATTRS_DICT={},
+        ):
+            account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
+            result = self.social_auth_test(
+                account_data_dict,
+                subdomain="zulip",
+                extra_attributes=dict(zulip_role=["guest"]),
+            )
+        data = load_subdomain_token(result)
+        self.assertEqual(data["email"], self.email)
+        self.user_profile.refresh_from_db()
+        self.assertEqual(self.user_profile.role, UserProfile.ROLE_REALM_OWNER)
+
+    @override_settings(TERMS_OF_SERVICE_VERSION=None)
+    def test_social_auth_create_user_with_synced_role(self) -> None:
+        email = "newuser@zulip.com"
+        name = "Full Name"
+        subdomain = "zulip"
+        realm = get_realm("zulip")
+
+        account_data_dict = self.get_account_data_dict(email=email, name=name)
+        idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_SAML_ENABLED_IDPS)
+        idps_dict["test_idp"]["extra_attrs"] = ["zulip_role"]
+
+        sync_custom_attrs_dict = {
+            "zulip": {
+                "saml": {
+                    "role": "zulip_role",
+                }
+            }
+        }
+
+        with (
+            self.settings(
+                SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_dict,
+                SOCIAL_AUTH_SYNC_ATTRS_DICT=sync_custom_attrs_dict,
+            ),
+            self.assertLogs(self.logger_string, level="INFO") as m,
+        ):
+            result = self.social_auth_test(
+                account_data_dict,
+                subdomain="zulip",
+                is_signup=True,
+                extra_attributes=dict(
+                    mobilePhone=["123412341234"], birthday=["2021-01-01"], zulip_role=["owner"]
+                ),
+            )
+
+        self.stage_two_of_registration(
+            result, realm, subdomain, email, name, name, self.BACKEND_CLASS.full_name_validated
+        )
+        user_profile = get_user_by_delivery_email(email, realm)
+        self.assertEqual(user_profile.role, UserProfile.ROLE_REALM_OWNER)
+        self.assertEqual(
+            m.output[0], self.logger_output("Returning role owner for user creation", type="info")
+        )
+
+    def test_social_auth_sync_field_not_existing(self) -> None:
+        sync_custom_attrs_dict = {
+            "zulip": {
+                "saml": {
+                    "custom__title": "title",
+                    "custom__phone_number": "mobilePhone",
+                    "wrongfield": "wrongfield",
                 }
             }
         }
@@ -3262,7 +3388,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
 
         with self.settings(
             SOCIAL_AUTH_SAML_ENABLED_IDPS=idps_dict,
-            SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT=sync_custom_attrs_dict,
+            SOCIAL_AUTH_SYNC_ATTRS_DICT=sync_custom_attrs_dict,
         ):
             account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
             with self.assertLogs(self.logger_string, level="WARNING") as m:
@@ -3281,12 +3407,16 @@ class SAMLAuthBackendTest(SocialAuthBase):
             m.output,
             [
                 self.logger_output(
+                    "Ignoring unsupported UserProfile field wrongfield in SOCIAL_AUTH_SYNC_ATTRS_DICT",
+                    "warning",
+                ),
+                self.logger_output(
                     (
                         "Exception while syncing custom profile fields for user"
                         f" {self.user_profile.id}: Custom profile field with name title not found."
                     ),
                     "warning",
-                )
+                ),
             ],
         )
 

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from typing_extensions import override
 
 from zerver.actions.user_settings import do_change_full_name
-from zerver.lib.scim import ZulipSCIMUser
 from zerver.lib.stream_subscription import get_subscribed_stream_ids_for_user
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import UserProfile
@@ -39,7 +38,7 @@ class SCIMTestCase(ZulipTestCase):
             "userName": user_profile.delivery_email,
             "name": {"formatted": user_profile.full_name},
             "displayName": user_profile.full_name,
-            "role": ZulipSCIMUser.ROLE_TYPE_TO_NAME[user_profile.role],
+            "role": UserProfile.ROLE_ID_TO_API_NAME[user_profile.role],
             "active": True,
             "meta": {
                 "resourceType": "User",

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -156,6 +156,7 @@ def create_preregistration_realm(
 def maybe_send_to_registration(
     request: HttpRequest,
     email: str,
+    *,
     full_name: str = "",
     mobile_flow_otp: str | None = None,
     desktop_flow_otp: str | None = None,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -74,7 +74,7 @@ from zerver.actions.user_groups import (
     bulk_remove_members_from_user_groups,
 )
 from zerver.actions.user_settings import do_regenerate_api_key
-from zerver.actions.users import do_deactivate_user
+from zerver.actions.users import do_change_user_role, do_deactivate_user
 from zerver.lib.avatar import avatar_url, is_avatar_new
 from zerver.lib.avatar_hash import user_avatar_content_hash
 from zerver.lib.dev_ldap_directory import init_fakeldap
@@ -1413,6 +1413,7 @@ class ExternalAuthDataDict(TypedDict, total=False):
     subdomain: str
     full_name: str
     email: str
+    role: int | None
     is_signup: bool
     is_realm_creation: bool
     redirect_to: str
@@ -1628,6 +1629,89 @@ def redirect_deactivated_user_to_login(realm: Realm, email: str) -> HttpResponse
         realm.url + login_url, urlencode({"is_deactivated": email})
     )
     return HttpResponseRedirect(redirect_url)
+
+
+def social_auth_sync_user_attributes(
+    realm: Realm, user_profile: UserProfile | None, extra_attrs: dict[str, Any], backend: Any
+) -> int | None:
+    """
+    Syncs user attributes based on the SOCIAL_AUTH_SYNC_ATTRS_DICT setting.
+    Only supports:
+    1. Syncing the role. This is plumbed through to user creation, so can be
+       used to immediately create new users with their role set based on an attribute
+       provided by the IdP.
+    2. Syncing custom attributes. This isn't supported for user creation,
+       so they'll only be synced during the user's next login, not during
+       signup.
+    """
+    # This is only supported for SAML right now, though the design
+    # is meant to be easy to extend this to other backends if desired.
+    # Unlike LDAP or SCIM, this hook can only do syncing during the authentication
+    # flow, as that's when the data is provided and we don't have a way to query
+    # for it otherwise.
+    assert backend.name == "saml"
+
+    attrs_by_backend = settings.SOCIAL_AUTH_SYNC_ATTRS_DICT.get(realm.subdomain, {})
+    profile_field_name_to_attr_name = attrs_by_backend.get(backend.name, {})
+    if not extra_attrs or not profile_field_name_to_attr_name:
+        return None
+
+    user_id = None
+    if user_profile is not None:
+        user_id = user_profile.id
+
+    custom_profile_field_name_to_value = {}
+    new_role = None
+    for field_name, attr_name in profile_field_name_to_attr_name.items():
+        if field_name == "role":
+            attr_value = extra_attrs.get(attr_name)
+            if not attr_value:
+                continue
+            if attr_value not in UserProfile.ROLE_API_NAME_TO_ID:
+                backend.logger.warning(
+                    "Ignoring unsupported role value %s for user %s in SOCIAL_AUTH_SYNC_ATTRS_DICT",
+                    attr_value,
+                    user_id,
+                )
+                continue
+            new_role = UserProfile.ROLE_API_NAME_TO_ID[attr_value]
+        elif field_name.startswith("custom__"):
+            custom_profile_field_name_to_value[field_name.removeprefix("custom__")] = (
+                extra_attrs.get(attr_name)
+            )
+        else:
+            backend.logger.warning(
+                "Ignoring unsupported UserProfile field %s in SOCIAL_AUTH_SYNC_ATTRS_DICT",
+                field_name,
+            )
+
+    if user_profile is None:
+        # We don't support user creation with custom profile fields, so just
+        # return role so that it can be plumbed through to the signup flow.
+        if new_role is not None:
+            backend.logger.info(
+                "Returning role %s for user creation", UserProfile.ROLE_ID_TO_API_NAME[new_role]
+            )
+        return new_role
+
+    # Based on the information collected above, sync what's needed for the user_profile.
+    old_role = user_profile.role
+    if new_role is not None and old_role != new_role:
+        do_change_user_role(user_profile, new_role, acting_user=None)
+        backend.logger.info(
+            "Set role %s for user %s", UserProfile.ROLE_ID_TO_API_NAME[new_role], user_profile.id
+        )
+
+    try:
+        sync_user_profile_custom_fields(user_profile, custom_profile_field_name_to_value)
+    except SyncUserError as e:
+        backend.logger.warning(
+            "Exception while syncing custom profile fields for user %s: %s",
+            user_profile.id,
+            str(e),
+        )
+
+    return None
 
 
 def social_associate_user_helper(
@@ -1886,26 +1970,11 @@ def social_auth_finish(
         is_signup = False
 
     extra_attrs = return_data.get("extra_attrs", {})
-    attrs_by_backend = settings.SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT.get(realm.subdomain, {})
-    if user_profile is not None and extra_attrs and attrs_by_backend:
-        # This is only supported for SAML right now, though the design
-        # is meant to be easy to extend this to other backends if desired.
-        # Unlike with LDAP, here we can only do syncing during the authentication
-        # flow, as that's when the data is provided and we don't have a way to query
-        # for it otherwise.
-        assert backend.name == "saml"
-        custom_profile_field_name_to_attr_name = attrs_by_backend.get(backend.name, {})
-        custom_profile_field_name_to_value = {}
-        for field_name, attr_name in custom_profile_field_name_to_attr_name.items():
-            custom_profile_field_name_to_value[field_name] = extra_attrs.get(attr_name)
-        try:
-            sync_user_profile_custom_fields(user_profile, custom_profile_field_name_to_value)
-        except SyncUserError as e:
-            backend.logger.warning(
-                "Exception while syncing custom profile fields for user %s: %s",
-                user_profile.id,
-                str(e),
-            )
+    role_for_new_user = None
+    if extra_attrs:
+        role_for_new_user = social_auth_sync_user_attributes(
+            realm, user_profile, extra_attrs, backend
+        )
 
     if user_profile:
         # This call to authenticate() is just to get to invoke the custom_auth_decorator logic.
@@ -1965,7 +2034,7 @@ def social_auth_finish(
         params_to_store_in_authenticated_session=backend.get_params_to_store_in_authenticated_session(),
     )
     if user_profile is None:
-        data_dict.update(dict(full_name=full_name, email=email_address))
+        data_dict.update(dict(full_name=full_name, email=email_address, role=role_for_new_user))
 
     result = ExternalAuthResult(user_profile=user_profile, data_dict=data_dict)
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -113,6 +113,7 @@ SOCIAL_AUTH_OIDC_ENABLED_IDPS: dict[str, OIDCIdPConfigDict] = {}
 SOCIAL_AUTH_OIDC_FULL_NAME_VALIDATED = False
 
 SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT: dict[str, dict[str, dict[str, str]]] = {}
+SOCIAL_AUTH_SYNC_ATTRS_DICT: dict[str, dict[str, dict[str, str]]] = {}
 
 # Other auth
 SSO_APPEND_DOMAIN: str | None = None

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -508,6 +508,9 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
     "emailAddress": ZULIP_ADMINISTRATOR,
 }
 
+## Note: Any additional SAML attributes that'll be used here must be
+## listed in the "extra_attrs" field in the SOCIAL_AUTH_SAML_ENABLED_IDPS
+## configuration for your IdP.
 # SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT = {
 #    "example_org": {
 #        "saml": {

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -443,7 +443,7 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS: dict[str, Any] = {
         ## List of additional attributes to fetch from the SAMLResponse.
         ## These attributes will be available for synchronizing custom profile fields.
         ## in SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT.
-        # "extra_attrs": ["title", "mobilePhone"],
+        # "extra_attrs": ["title", "mobilePhone", "zulip_role"],
         ##
         ## The "x509cert" attribute is automatically read from
         ## /etc/zulip/saml/idps/{idp_name}.crt; don't specify it here.
@@ -511,14 +511,16 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 ## Note: Any additional SAML attributes that'll be used here must be
 ## listed in the "extra_attrs" field in the SOCIAL_AUTH_SAML_ENABLED_IDPS
 ## configuration for your IdP.
-# SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT = {
-#    "example_org": {
-#        "saml": {
-#            # Format: "<custom profile field name>": "<attribute name from extra_attrs above>"
-#            "title": "title",
-#            "phone_number": "mobilePhone",
-#        }
-#    }
+# SOCIAL_AUTH_SYNC_ATTRS_DICT = {
+#     "example_org": {
+#         "saml": {
+#             # role is currently the only supported major attribute.
+#             "role": "zulip_role",
+#             # Specify custom profile fields with a custom__ prefix for the
+#             # Zulip field name.
+#             "custom__title": "title",
+#         }
+#     }
 # }
 
 ########


### PR DESCRIPTION
    Replace the SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT with
    SOCIAL_AUTH_SYNC_ATTRS_DICT, designed to support also regular user attrs
    like role or full name (in the future).

    Custom attributes can stay configured as they were and will get merged
    into SOCIAL_AUTH_SYNC_ATTRS_DICT in computed_settings, or can be
    specified in SOCIAL_AUTH_SYNC_ATTRS_DICT directly with "custom__"
    prefix.

    The role sync is plumbed through to user creation, so users can
    immediately be created with their intended role as provided by the IdP
    when they're creating their account, even when doing this flow without
    an invitiation

Notes:
- The interface for configuring this may need some dicussion/revision of course. With my proposal here, the idea is to replace the `SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT` dict in settings with more general `SOCIAL_AUTH_SYNC_ATTRS_DICT`, which is the same in structure but can support more attributes. Custom attributes are configured in it like before, just with a `custom__` prefix for the attr name on the left (Zulip) side.

- Not sure if we want the backward compat code for `SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT`. This is probably not used much, so we may want to just get rid of supporting it, and existing configurations can update it to `SOCIAL_AUTH_SYNC_ATTRS_DICT`, adding the `custom__` prefix to their custom attr config rows.

TODO:
- [x] Documenting this role sync overall
- [x] We may want to use this time to document this feature better in ReadTheDocs and extract its instructions to a separate section. Right now this is a kind of passing note about "syncing custom profile fields" in the many points of SAML setup instructions. (https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#saml point 7)
- [x] I found the custom attr sync has a minor bug, where if a configured attribute isn't provided by the IdP in the SAMLResponse, we read it as `None` and then log a warning `Exception while syncing custom profile fields for user ` about the value being invalid. Should fix this here or as a follow-up.