### PR TITLE
External links to Twitter, Mastodon and Linkedln open on same page instead of new tab

### DIFF
--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -95,9 +95,24 @@
                 <li><a href="https://zulip.com/help/support-zulip-project">{{ _("Support Zulip") }}</a></li>
             </ul>
             <div class="footer-social-links">
-                <a class="footer-social-icon footer-social-icon-x" title="{{ _('X (Twitter)') }}" href="https://twitter.com/zulip"></a>
-                <a class="footer-social-icon footer-social-icon-mastodon" title="{{ _('Mastodon') }}" href="https://fosstodon.org/@zulip"></a>
-                <a class="footer-social-icon footer-social-icon-linkedin" title="{{ _('LinkedIn') }}" href="https://www.linkedin.com/company/zulip-by-kandra-labs/"></a>
+    <a class="footer-social-icon footer-social-icon-x" 
+       title="{{ _('X (Twitter)') }}" 
+       href="https://twitter.com/zulip" 
+       target="_blank" 
+       rel="noopener noreferrer">
+    </a>
+    <a class="footer-social-icon footer-social-icon-mastodon" 
+       title="{{ _('Mastodon') }}" 
+       href="https://fosstodon.org/@zulip" 
+       target="_blank" 
+       rel="noopener noreferrer">
+    </a>
+    <a class="footer-social-icon footer-social-icon-linkedin" 
+       title="{{ _('LinkedIn') }}" 
+       href="https://www.linkedin.com/company/zulip-by-kandra-labs/" 
+       target="_blank" 
+       rel="noopener noreferrer">
+    </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Updated the social media links in the footer section of the Zulip project to ensure they open in a new tab and include necessary security attributes. Specifically:

X (Twitter): Ensured the link to Zulip's Twitter account opens in a new tab with target="_blank" and includes the rel="noopener noreferrer" attribute for security and performance.
Mastodon: Added a link to Zulip's Mastodon account, ensuring it opens in a new tab with the appropriate attributes.
LinkedIn: Updated the link to Zulip's LinkedIn page with the same considerations for opening in a new tab and security.
These changes enhance user experience by allowing users to explore Zulip's social media profiles without leaving the main website, while also adhering to best practices for security.

