### PR TITLE
External links to Twitter, Mastodon and Linkedln open on same page instead of new tab 

### DIFF
--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -91,25 +91,13 @@
                 </li>
                 <li><a href="/values/">{{ _("Values") }}</a></li>
                 <li><a href="/jobs/">{{ _("Jobs") }}</a></li>
-                <li><a href="https://blog.zulip.com/"  target="_blank">{{ _("Blog") }}</a></li>
+                <li><a href="https://blog.zulip.com/" target="_blank">{{ _("Blog") }}</a></li>
                 <li><a href="https://zulip.com/help/support-zulip-project">{{ _("Support Zulip") }}</a></li>
             </ul>
             <div class="footer-social-links">
-                <a class="footer-social-icon footer-social-icon-x" 
-                   title="{{ _('X (Twitter)') }}" 
-                   href="https://twitter.com/zulip" 
-                   target="_blank" 
-                   rel="noopener noreferrer"></a>
-                <a class="footer-social-icon footer-social-icon-mastodon" 
-                   title="{{ _('Mastodon') }}" 
-                   href="https://fosstodon.org/@zulip" 
-                   target="_blank" 
-                   rel="noopener noreferrer"></a>
-                <a class="footer-social-icon footer-social-icon-linkedin" 
-                   title="{{ _('LinkedIn') }}" 
-                   href="https://www.linkedin.com/company/zulip-by-kandra-labs/" 
-                   target="_blank" 
-                   rel="noopener noreferrer"></a>
+                <a class="footer-social-icon footer-social-icon-x"title="{{ _('X (Twitter)') }}"href="https://twitter.com/zulip"target="_blank"rel="noopener noreferrer"></a>
+                <a class="footer-social-icon footer-social-icon-mastodon"title="{{ _('Mastodon') }}"href="https://fosstodon.org/@zulip"target="_blank"rel="noopener noreferrer"></a>
+                <a class="footer-social-icon footer-social-icon-linkedin"title="{{ _('LinkedIn') }}"href="https://www.linkedin.com/company/zulip-by-kandra-labs/"target="_blank"rel="noopener noreferrer"></a>
             </div>            
         </div>
     </div>

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -95,10 +95,25 @@
                 <li><a href="https://zulip.com/help/support-zulip-project">{{ _("Support Zulip") }}</a></li>
             </ul>
             <div class="footer-social-links">
-                <a class="footer-social-icon footer-social-icon-x" title="{{ _('X (Twitter)') }}" href="https://twitter.com/zulip"></a>
-                <a class="footer-social-icon footer-social-icon-mastodon" title="{{ _('Mastodon') }}" href="https://fosstodon.org/@zulip"></a>
-                <a class="footer-social-icon footer-social-icon-linkedin" title="{{ _('LinkedIn') }}" href="https://www.linkedin.com/company/zulip-by-kandra-labs/"></a>
-            </div>
+                <a class="footer-social-icon footer-social-icon-x" 
+                   title="{{ _('X (Twitter)') }}" 
+                   href="https://twitter.com/zulip" 
+                   target="_blank" 
+                   rel="noopener noreferrer">
+                </a>
+                <a class="footer-social-icon footer-social-icon-mastodon" 
+                   title="{{ _('Mastodon') }}" 
+                   href="https://fosstodon.org/@zulip" 
+                   target="_blank" 
+                   rel="noopener noreferrer">
+                </a>
+                <a class="footer-social-icon footer-social-icon-linkedin" 
+                   title="{{ _('LinkedIn') }}" 
+                   href="https://www.linkedin.com/company/zulip-by-kandra-labs/" 
+                   target="_blank" 
+                   rel="noopener noreferrer">
+                </a>
+            </div>            
         </div>
     </div>
     {% endif %}

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -99,20 +99,17 @@
                    title="{{ _('X (Twitter)') }}" 
                    href="https://twitter.com/zulip" 
                    target="_blank" 
-                   rel="noopener noreferrer">
-                </a>
+                   rel="noopener noreferrer"></a>
                 <a class="footer-social-icon footer-social-icon-mastodon" 
                    title="{{ _('Mastodon') }}" 
                    href="https://fosstodon.org/@zulip" 
                    target="_blank" 
-                   rel="noopener noreferrer">
-                </a>
+                   rel="noopener noreferrer"></a>
                 <a class="footer-social-icon footer-social-icon-linkedin" 
                    title="{{ _('LinkedIn') }}" 
                    href="https://www.linkedin.com/company/zulip-by-kandra-labs/" 
                    target="_blank" 
-                   rel="noopener noreferrer">
-                </a>
+                   rel="noopener noreferrer"></a>
             </div>            
         </div>
     </div>


### PR DESCRIPTION
Updated the social media links in the footer section of the Zulip project to ensure they open in a new tab and include necessary security attributes. Specifically:

X (Twitter): Ensured the link to Zulip's Twitter account opens in a new tab with target="_blank" and includes the rel="noopener noreferrer" attribute for security and performance.
Mastodon: Added a link to Zulip's Mastodon account, ensuring it opens in a new tab with the appropriate attributes.
LinkedIn: Updated the link to Zulip's LinkedIn page with the same considerations for opening in a new tab and security.
