### PR TITLE
left_sidebar: Adjust lefthand padding, gridded row values.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -546,6 +546,7 @@
     --color-background-modal: hsl(0deg 0% 98%);
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 100%);
     --color-unmuted-or-followed-topic-list-item: hsl(0deg 0% 20%);
+    --color-topic-indent-border: hsl(0deg 0% 0% / 19%);
     --color-outline-focus: hsl(215deg 47% 50%);
     --color-background-search: hsl(0deg 0% 100%);
     --color-background-search-option-hover: hsl(0deg 0% 94%);
@@ -952,6 +953,7 @@
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 0% / 20%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);
+    --color-topic-indent-border: hsl(0deg 0% 100% / 19%);
     --color-background-search: hsl(0deg 0% 20%);
     --color-background-search-option-hover: hsl(0deg 0% 30%);
     --color-search-box-hover-shadow: hsl(0deg 0% 0% / 30%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -218,28 +218,23 @@
     Our sidebars (and anything that top-align
     with them) go beneath the header.
     */
-    --left-sidebar-padding-left: 8px;
     /* The width of the empty space in the sidebar to separate
        content from the edge of the window */
-    --left-sidebar-far-left-gutter-size: 10px;
+    --left-sidebar-padding-left: 8px;
+    /* The empty space between left-sidebar row icons and
+       the row content.
+       7px at 16px/1em */
+    --left-sidebar-icon-content-gap: 0.4375em;
+    /* The space allotted in gridded rows for the toggle icon. */
+    --left-sidebar-header-icon-toggle-width: 20px;
+    /* Other rows need an offset to preserve a column the
+       entire height of the left sidebar for where toggles sit. */
+    --left-sidebar-toggle-width-offset: var(
+        --left-sidebar-header-icon-toggle-width
+    );
     /* This represents the space in the sidebar reserved for symbols like
        the #; labels like the stream name go to the right of this. */
-    --left-sidebar-privacy-icon-column-size: 19px;
-    /* 13px at 14px/1em */
-    --left-sidebar-topic-resolve-width: 0.9286em;
-    /* At legacy sizes, the full indentation to the
-       left of the topic name was 25px of gutter,
-       plus 13px for the topic-resolution checkmark.
-       That works out to 38px (25px + 13px), which
-       we here express as pixels, as that is always
-       the amount of space to the left of the topic
-       name. However, CSS subtracts the em-unit width
-       of the topic-resolution checkmark to prevent
-       the the topic name from being shifted to the
-       right. */
-    --left-sidebar-topic-indent: calc(
-        38px - var(--left-sidebar-topic-resolve-width)
-    );
+    --left-sidebar-icon-column-width: 16px;
     /* space direct message / stream / topic names from unread counters
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -539,6 +539,14 @@
     --color-background-navbar: hsl(0deg 0% 97%);
     --color-background-active-narrow-filter: hsl(202deg 56% 91%);
     --color-background-hover-narrow-filter: hsl(120deg 12.3% 71.4% / 38%);
+    /* We mix an opaque version with the background for
+       replicating the color on .sidebar-topic-check, which
+       will mask a portion of the topic-grouping bracket. */
+    --color-background-opaque-hover-narrow-filter: color-mix(
+        in srgb,
+        hsl(120deg 12.3% 71.4%) 38%,
+        hsl(0deg 0% 94%)
+    );
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
@@ -946,6 +954,14 @@
     --color-background-navbar: hsl(0deg 0% 13%);
     --color-background-active-narrow-filter: hsl(200deg 17% 18%);
     --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
+    /* We mix an opaque version with the background for
+       replicating the color on .sidebar-topic-check, which
+       will mask a portion of the topic-grouping bracket. */
+    --color-background-opaque-hover-narrow-filter: color-mix(
+        in srgb,
+        hsl(136deg 25% 73%) 20%,
+        hsl(0deg 0% 11%)
+    );
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -218,7 +218,7 @@
     Our sidebars (and anything that top-align
     with them) go beneath the header.
     */
-    --left-sidebar-collapse-widget-gutter: 10px;
+    --left-sidebar-padding-left: 8px;
     /* The width of the empty space in the sidebar to separate
        content from the edge of the window */
     --left-sidebar-far-left-gutter-size: 10px;
@@ -244,8 +244,10 @@
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;
     --left-sidebar-right-margin: 12px;
-    /* 287px at 14px/1em */
-    --left-sidebar-max-width: calc(20.5em - var(--left-sidebar-right-margin));
+    /* 289px at 14px/1em */
+    --left-sidebar-max-width: calc(
+        20.6429em - var(--left-sidebar-right-margin)
+    );
     /* Sidebar width is 1/3 of the screen at smaller
        sizes, but gets held to the left sidebar's max width.
        This is very useful for areas in the CSS codebase

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -891,13 +891,17 @@ li.top_left_scheduled_messages {
 
 .topic-box,
 .searching-for-more-topics {
-    margin-left: var(--left-sidebar-toggle-width-offset);
     grid-template-columns:
         0 var(--left-sidebar-icon-column-width) var(
             --left-sidebar-icon-content-gap
         )
         minmax(0, 1fr) minmax(0, max-content)
         30px 0;
+}
+
+.searching-for-more-topics {
+    margin-left: var(--left-sidebar-toggle-width-offset);
+    height: var(--line-height-sidebar-row-prominent);
 }
 
 .topic_search_section {
@@ -1083,9 +1087,46 @@ ul.topic-list {
     font-weight: normal;
 }
 
+ul.topic-list::before {
+    content: " ";
+    display: block;
+    position: absolute;
+    /* 12px at 16px/1em */
+    top: 0.75em;
+    bottom: 0.75em;
+    left: 9px;
+    border: 1px solid var(--color-topic-indent-border);
+    border-right: 0;
+    border-radius: 9px 0 0 9px;
+    width: 6px;
+    pointer-events: none;
+}
+
+ul.topic-list::after {
+    content: " ";
+    display: block;
+    position: absolute;
+    /* -14px at 16px/1em */
+    top: -0.875em;
+    /* 12px at 16px/1em */
+    bottom: 0.75em;
+    left: 16px;
+    width: 8px;
+    border-bottom: 1px solid var(--color-topic-indent-border);
+    pointer-events: none;
+}
+
+/* The grouping border should not be shown
+   on zoomed-in views. */
+.zoom-in .topic-list::before,
+.zoom-in .topic-list::after {
+    border: 0;
+}
+
 li.topic-list-item {
     position: relative;
     padding-right: 5px;
+    margin-left: var(--left-sidebar-toggle-width-offset);
 }
 
 .dm-box {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1111,9 +1111,19 @@ ul.topic-list::after {
     /* 12px at 16px/1em */
     bottom: 0.75em;
     left: 16px;
+    /* The bottom bracket should avoid colliding
+       with the checkmark on resolved topics, as
+       would otherwise happen when the last topic
+       in a list is resolved. */
     width: 8px;
     border-bottom: 1px solid var(--color-topic-indent-border);
     pointer-events: none;
+}
+
+ul.topic-list:has(.show-more-topics)::after {
+    /* When the show all topics control is displayed,
+       extend the bottom bracket. */
+    width: 18px;
 }
 
 /* The grouping border should not be shown

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -307,6 +307,12 @@ li.show-more-topics {
     &.top_left_row:hover,
     &.bottom_left_row:hover {
         background-color: var(--color-background-hover-narrow-filter);
+
+        .sidebar-topic-check {
+            background-color: var(
+                --color-background-opaque-hover-narrow-filter
+            );
+        }
     }
 }
 
@@ -478,6 +484,10 @@ li.active-sub-filter {
     position: relative;
     border-radius: 4px;
     background-color: var(--color-background-active-narrow-filter);
+
+    .sidebar-topic-check {
+        background-color: var(--color-background-active-narrow-filter);
+    }
 }
 
 #stream_filters .narrow-filter.active-filter {
@@ -954,6 +964,18 @@ li.top_left_scheduled_messages {
     justify-self: end;
     /* 15px at 14px/1em */
     font-size: 1.0714em;
+    /* Use background to mask part of grouping bracket. */
+    padding-left: 3px;
+    /* Keep background from affecting rounded corners on
+       .active-sub-filter by reducing the checkbox
+       line-height to match its font size. */
+    line-height: 1;
+    /* As a grid item, adjust the checkmark's z-index here so
+       that the background color appears above the grouping
+       bracket's bottom line. Its value must less than
+       the z-index set on the #streams_header selector. */
+    z-index: 1;
+    background-color: var(--color-background);
 }
 
 .stream-markers-and-controls,
@@ -1111,11 +1133,7 @@ ul.topic-list::after {
     /* 12px at 16px/1em */
     bottom: 0.75em;
     left: 16px;
-    /* The bottom bracket should avoid colliding
-       with the checkmark on resolved topics, as
-       would otherwise happen when the last topic
-       in a list is resolved. */
-    width: 8px;
+    width: 12px;
     border-bottom: 1px solid var(--color-topic-indent-border);
     pointer-events: none;
 }
@@ -1251,10 +1269,8 @@ li.topic-list-item {
     position: sticky;
     /* Keep sticky within SimpleBar context. */
     top: 0;
+    z-index: 2;
     background-color: var(--color-background);
-    /* Ideally, 0px should work here, but maybe simplebar is doing something
-       that is creating `0.5px` extra gap in zoomed-in windows. */
-    z-index: 1;
 
     &.showing-stream-search-section {
         /* Open up the stream-search rows. The 10px

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -180,17 +180,17 @@ li.show-more-topics {
 }
 
 #direct-messages-section-header {
-    grid-template-columns: 0 15px minmax(0, 1fr) max-content 30px 0;
+    grid-template-columns:
+        0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 1fr)
+        max-content 30px 0;
     grid-template-rows: var(--line-height-sidebar-row-prominent);
-    /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
-       value and the styles dependent on it so that this kind of
-       1990s layout shenanigans is made unnecessary. */
-    margin-left: -3px;
     cursor: pointer;
     white-space: nowrap;
 
     #toggle-direct-messages-section-icon {
         grid-area: starting-anchor-element;
+        /* Horizontally center the icon in its allotted grid area. */
+        justify-self: center;
     }
 
     .left-sidebar-title {
@@ -334,8 +334,8 @@ li.show-more-topics {
 #login-link-container,
 #subscribe-to-more-streams {
     text-decoration: none;
-    margin: 5px auto 5.5px 10px;
-    margin-bottom: var(--left-sidebar-bottom-scrolling-buffer);
+    margin: 5px auto var(--left-sidebar-bottom-scrolling-buffer)
+        var(--left-sidebar-toggle-width-offset);
 
     & i {
         min-width: 19px;
@@ -646,7 +646,11 @@ li.top_left_scheduled_messages {
        for laying out the items that are its
        children. Same template areas, different
        column widths. */
-    grid-template-columns: 0 22px minmax(0, 1fr) max-content 0 0;
+    grid-template-columns:
+        var(--left-sidebar-toggle-width-offset) var(
+            --left-sidebar-icon-column-width
+        )
+        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) max-content 0 0;
 
     .filter-icon {
         grid-area: starting-anchor-element;
@@ -714,7 +718,7 @@ li.top_left_scheduled_messages {
        modified or reassigned as needed, without running up against `padding`
        (which alters the box size) or `margin` (which notoriously bleeds outside
        of the element it's defined on). */
-    grid-template-areas: "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset";
+    grid-template-areas: "starting-offset starting-anchor-element icon-content-gap row-content markers-and-controls ending-anchor-element ending-offset";
 }
 
 .top_left_row {
@@ -725,7 +729,7 @@ li.top_left_scheduled_messages {
     /* The row grid for the outer .top_left_row
        is chiefly for lefthand spacing and placing
        the inner row content and vdots. */
-    grid-template-columns: 7px 0 minmax(0, 1fr) 0 30px 0;
+    grid-template-columns: 0 0 0 minmax(0, 1fr) 0 30px 0;
 
     .sidebar-menu-icon {
         grid-area: ending-anchor-element;
@@ -746,19 +750,18 @@ li.top_left_scheduled_messages {
        that now by having it share this grid template. Its row and column
        definitions have the final say about dimensions and placement. */
     grid-template-areas:
-        "starting-offset starting-anchor-element row-content markers-and-controls ending-anchor-element ending-offset"
-        ".               .                       filter-box  filter-box           filter-box            .            ";
+        "starting-offset starting-anchor-element icon-content-gap row-content markers-and-controls ending-anchor-element ending-offset"
+        ".               .                       filter-box       filter-box  filter-box           filter-box            .            ";
 }
 
 #views-label-container {
     grid-template-columns:
-        0 15px minmax(0, 0.5fr) minmax(0, 1fr)
+        0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 0.5fr) minmax(
+            0,
+            1fr
+        )
         30px var(--left-sidebar-right-margin);
     grid-template-rows: var(--line-height-sidebar-row-prominent);
-    /* TODO: Rewrite the `--left-sidebar-collapse-widget-gutter`
-       value and the styles dependent on it so that this kind of
-       1990s layout shenanigans is made unnecessary. */
-    margin-left: -3px;
     cursor: pointer;
 
     &.showing-expanded-navigation {
@@ -806,6 +809,8 @@ li.top_left_scheduled_messages {
 
     #toggle-top-left-navigation-area-icon {
         grid-area: starting-anchor-element;
+        /* Horizontally center the icon in its allotted grid area. */
+        justify-self: center;
     }
 
     .left-sidebar-title {
@@ -848,7 +853,13 @@ li.top_left_scheduled_messages {
 
 .subscription_block {
     grid-template-columns:
-        7px 22px minmax(0, 1fr) minmax(0, max-content)
+        var(--left-sidebar-toggle-width-offset) var(
+            --left-sidebar-icon-column-width
+        )
+        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) minmax(
+            0,
+            max-content
+        )
         30px 0;
     white-space: nowrap;
 
@@ -880,15 +891,21 @@ li.top_left_scheduled_messages {
 
 .topic-box,
 .searching-for-more-topics {
+    margin-left: var(--left-sidebar-toggle-width-offset);
     grid-template-columns:
-        var(--left-sidebar-topic-indent) var(--left-sidebar-topic-resolve-width)
+        0 var(--left-sidebar-icon-column-width) var(
+            --left-sidebar-icon-content-gap
+        )
         minmax(0, 1fr) minmax(0, max-content)
         30px 0;
 }
 
 .topic_search_section {
     grid-template-columns:
-        var(--left-sidebar-topic-indent) 0 minmax(0, 1fr) minmax(0, max-content)
+        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr) minmax(
+            0,
+            max-content
+        )
         30px 0;
 }
 
@@ -930,6 +947,7 @@ li.top_left_scheduled_messages {
 
 .sidebar-topic-check {
     grid-area: starting-anchor-element;
+    justify-self: end;
     /* 15px at 14px/1em */
     font-size: 1.0714em;
 }
@@ -1071,7 +1089,15 @@ li.topic-list-item {
 }
 
 .dm-box {
-    grid-template-columns: 7px 22px minmax(0, 1fr) minmax(0, max-content) 30px 0;
+    grid-template-columns:
+        var(--left-sidebar-toggle-width-offset) var(
+            --left-sidebar-icon-column-width
+        )
+        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) minmax(
+            0,
+            max-content
+        )
+        30px 0;
 
     .conversation-partners-icon {
         grid-area: starting-anchor-element;
@@ -1143,7 +1169,9 @@ li.topic-list-item {
     position: sticky;
     top: 0;
     z-index: 2;
-    grid-template-columns: 0 0 minmax(0, 1fr) max-content 0 42px;
+    grid-template-columns:
+        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
+        max-content 0 42px;
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     padding-top: var(--left-sidebar-sections-vertical-gutter);
     color: hsl(0deg 0% 43%);
@@ -1154,13 +1182,6 @@ li.topic-list-item {
         color: inherit;
         text-decoration: none;
         text-transform: uppercase;
-        margin-left: calc(var(--left-sidebar-far-left-gutter-size) + 2px);
-
-        & i {
-            margin: 0 6px 0 13px;
-            position: relative;
-            top: 1px;
-        }
     }
 
     .unread_count {
@@ -1169,14 +1190,13 @@ li.topic-list-item {
 }
 
 #streams_header {
-    grid-template-columns: 0 0 minmax(0, 1fr) minmax(17px, max-content) 30px var(
-            --left-sidebar-right-margin
-        );
+    grid-template-columns:
+        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
+        minmax(17px, max-content) 30px var(--left-sidebar-right-margin);
     /* Keep the stream-search area rows collapsed. */
     grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
     cursor: pointer;
-    padding: var(--left-sidebar-sections-vertical-gutter) 0 3px
-        calc(var(--left-sidebar-far-left-gutter-size) + 2px);
+    padding: var(--left-sidebar-sections-vertical-gutter) 0 3px 0;
     position: sticky;
     /* Keep sticky within SimpleBar context. */
     top: 0;
@@ -1316,9 +1336,9 @@ li.topic-list-item {
    one that reassigns the vdots space to markers and
    controls. */
 .spectator-view #streams_header {
-    grid-template-columns: 0 0 minmax(0, 1fr) minmax(30px, max-content) 0 var(
-            --left-sidebar-right-margin
-        );
+    grid-template-columns:
+        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
+        minmax(30px, max-content) 0 var(--left-sidebar-right-margin);
 
     /* With markers and controls now sized the same
        as the ordinary vdots area (but allowed to grow,
@@ -1336,7 +1356,7 @@ li.topic-list-item {
     font-weight: normal;
     /* 16px line-height at 0.8em (11.2px at 14px legacy em) */
     line-height: 1.4286em;
-    padding-left: var(--left-sidebar-far-left-gutter-size);
+    padding-left: var(--left-sidebar-toggle-width-offset);
     cursor: pointer;
     text-align: center;
     margin-right: var(--left-sidebar-right-margin);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -535,7 +535,7 @@ body.has-overlay-scrollbar {
 
     .column-left .left-sidebar {
         width: var(--left-sidebar-width);
-        padding-left: var(--left-sidebar-collapse-widget-gutter);
+        padding-left: var(--left-sidebar-padding-left);
     }
 
     .column-right .right-sidebar {
@@ -553,7 +553,7 @@ body.has-overlay-scrollbar {
 #compose-content {
     margin-right: var(--right-sidebar-width);
     margin-left: calc(
-        var(--left-sidebar-width) + var(--left-sidebar-collapse-widget-gutter)
+        var(--left-sidebar-width) + var(--left-sidebar-padding-left)
     );
     position: relative;
 }


### PR DESCRIPTION
This PR opens the next phase of the redesigned left sidebar as articulated in @terpimost's design at https://terpimost.github.io/zulip-sidebar/

Fixes #27565

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/proposed.20left-sidebar.20spacing.20and.20alignment/near/1918358)

It removes the awkwardly named `--left-sidebar-collapse-widget-gutter` value and replaces it with `--left-sidebar-padding-left`. Negative-margin values that pulled expand/collapse toggles and otherwise worked around the larger-than-necessary "widget gutter" have also been adjusted.

Note that the width of the left sidebar has been preserved here (2px from the old value have been added to the width of the sidebar itself). Eagle-eyed reviewers may notice a very slight shift in some of the screenshots below, but that is owing to a rounding error on the `--left-sidebar-max-width` value's em conversion.

Additionally, gridded left sidebar rows and their relationship to the left edge of the viewport have been reworked to match Vlad's design. The PR at this stage will appear to show excess whitespace to the left of the left sidebar rows, but those will eventually be occupied by more generous row highlights as well as a proposed curvature for grouping topics under their respective active channels.

Finally, more of the spacing concerns in the left sidebar have been offloaded to the gridded rows. That paves the way for changing up the elements on which colors and borders are declared for highlighting purposes, and should maintain or even enhance control over clickable/hoverable areas to uniformly match content.

(Note that Vlad's design calls for narrower highlights on topic rows compared to other rows in the left sidebar; those have been left as-is for now, as they won't make visual sense until the grouping curvature is in place.)

**This PR now also includes styles for the curvature to group channels and topics.** Brackets are tuned based on the terminating topic row: an ordinary topic, a resolved topic, or the "show all topics" control:

| Ordinary topic | Resolved topic | Show all topics
| --- | --- | --- |
| ![bracket-with-topic](https://github.com/user-attachments/assets/a8dd67bf-3ba7-49d0-8099-7b1c4a120b4c) | ![bracket-with-resolved-topic](https://github.com/user-attachments/assets/af53fe24-aa3e-4a72-b9ef-a8ae72408c97) | ![bracket-with-show-all-topics](https://github.com/user-attachments/assets/a782dbf6-7b94-4f44-a0cd-2e136b765afe) |

The curvature is not shown on zoomed-in channels, in concord with Vlad's design. Highlights on topic rows now also conform to the space marked by the curvature, making them narrower than the highlights on their stream-row counterparts.

| Left sidebar curvature | Zoomed-in view |
| --- | --- |
| ![grouped-topics](https://github.com/user-attachments/assets/c6182e3d-3c33-44d7-8aa7-3844c7cff74c) |  ![zoomed-in-topics](https://github.com/user-attachments/assets/58191c52-d180-4309-b8fb-f7e2ac53a82c) |

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![left-sidebar-grids-before](https://github.com/user-attachments/assets/01512afa-f35b-4012-a6b3-04ff3b5d3cfc) | ![left-sidebar-grids-after](https://github.com/user-attachments/assets/ad9b7c4d-3861-42ca-b5de-c0f2b94ba080) |
| ![left-sidebar-filter-topics-collapsed-views-before](https://github.com/user-attachments/assets/e2e9754c-cec4-4acf-90e7-94dd6d1afaa5) | ![left-sidebar-filter-topics-collapsed-views-after](https://github.com/user-attachments/assets/1f22bf50-2690-406b-8938-3d454de02df3) |
| ![left-sidebar-subheaders-before](https://github.com/user-attachments/assets/7167b135-a7ae-4742-adb0-e6512e68a1f0) | ![left-sidebar-subheaders-after](https://github.com/user-attachments/assets/727f6c04-95b0-4303-9f0c-110d6388839e) |
| ![left-sidebar-collapsed-before](https://github.com/user-attachments/assets/7ce1e1fd-a955-49de-a470-0fa2d9d2ff65) | ![left-sidebar-collapsed-after](https://github.com/user-attachments/assets/77d24d99-abc6-4c11-bc9d-779e36798c0b) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>