### PR TITLE
auth: Fix re-enabling of SAML/AzureAD in organization settings UI. 

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -7368,6 +7368,21 @@ class TestAdminSetBackends(ZulipTestCase):
                 result, "Authentication method AzureAD is not available on your current plan."
             )
 
+            # With BILLING_ENABLED=False, no such restrictions apply.
+            with self.settings(BILLING_ENABLED=False):
+                result = self.client_patch(
+                    "/json/realm",
+                    {
+                        "authentication_methods": orjson.dumps(
+                            {"Email": True, "Dev": True, "AzureAD": True}
+                        ).decode()
+                    },
+                )
+            self.assert_json_success(result)
+            self.assertEqual(
+                realm.authentication_methods_dict(), {"Dev": True, "Email": True, "AzureAD": True}
+            )
+
 
 class EmailValidatorTestCase(ZulipTestCase):
     def test_valid_email(self) -> None:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -7346,7 +7346,6 @@ class TestAdminSetBackends(ZulipTestCase):
                 "/json/realm",
                 {
                     "authentication_methods": orjson.dumps(
-                        # Github is not a supported authentication backend right now.
                         {"Email": True, "Dev": True, "AzureAD": False}
                     ).decode()
                 },
@@ -7361,7 +7360,6 @@ class TestAdminSetBackends(ZulipTestCase):
                 "/json/realm",
                 {
                     "authentication_methods": orjson.dumps(
-                        # Github is not a supported authentication backend right now.
                         {"Email": True, "Dev": True, "AzureAD": True}
                     ).decode()
                 },

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -25,7 +25,6 @@ from zerver.actions.realm_settings import (
     do_set_realm_zulip_update_announcements_stream,
     parse_and_set_setting_value_if_required,
     validate_authentication_methods_dict_from_api,
-    validate_plan_for_authentication_methods,
 )
 from zerver.decorator import require_realm_admin, require_realm_owner
 from zerver.forms import check_subdomain_available as check_subdomain
@@ -199,7 +198,6 @@ def update_realm(
         validate_authentication_methods_dict_from_api(realm, authentication_methods)
         if True not in authentication_methods.values():
             raise JsonableError(_("At least one authentication method must be enabled."))
-        validate_plan_for_authentication_methods(realm, authentication_methods)
 
     if video_chat_provider is not None and video_chat_provider not in {
         p["id"] for p in Realm.VIDEO_CHAT_PROVIDERS.values()


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/31-production-help/topic/can't.20enable.20SAML.20login/near/1912753

This bug was introduced in da9e4e6e54ddbd06e2c16db17eb7cb0678b5a786.
`validate_plan_for_authentication_methods` is already called inside
`validate_authentication_methods_dict_from_api`, conditionally on
`settings.BILLING_ENABLED`. This additional, redundant call runs
regardless of `BILLING_ENABLED`, and thus prevents a self-hosted server
from enabling certain backends in the organization settings UI.

The impact of this is limited - in order to encounter this bug, a
self-hosted server would have to first disable the backend in the UI, as
self-hosted realms are created with all backend flags enabled. A backend
doesn't show up in the org settings UI until it is first enabled in
`AUTHENTICATION_BACKENDS` in settings.py - that's why this is a rare
state. A sequence of steps like this has to be followed to reproduce:
1. Add the backend to `AUTHENTICATION_BACKENDS` in settings.py.
2. Disable the backend in the org settings UI.
3. Now try to re-enable it, which fails due to the bug.

