### PR TITLE
Add warning banner if moving topic or multiple messages to a pre-existing conversation. #31151

### DIFF
--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -86,6 +86,17 @@ export function stream_has_topics(stream_id: number): boolean {
     return history.has_topics();
 }
 
+export function stream_has_topic(stream_id: number, topic_name: string): boolean {
+    if (!stream_dict.has(stream_id)) {
+        return false;
+    }
+
+    const history = stream_dict.get(stream_id);
+    assert(history !== undefined);
+
+    return history.has_topic(topic_name);
+}
+
 export type TopicHistoryEntry = {
     count: number;
     message_id: number;
@@ -124,6 +135,10 @@ export class PerStreamHistory {
 
     has_topics(): boolean {
         return this.topics.size !== 0;
+    }
+
+    has_topic(topic_name: string): boolean {
+        return this.topics.has(topic_name);
     }
 
     update_stream_with_message_id(message_id: number): void {

--- a/web/templates/modal_banner/message_moving_warning_banner.hbs
+++ b/web/templates/modal_banner/message_moving_warning_banner.hbs
@@ -1,0 +1,7 @@
+{{#> modal_banner }}
+    <p class="banner_message">
+        {{#tr}}
+            You are moving messages to a topic that already exists. Messages from these topics will be combined.
+        {{/tr}}
+    </p>
+{{/modal_banner}}

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -2,6 +2,7 @@
 <p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
 {{/unless}}
 <form id="move_topic_form">
+    <div class="move_topic_form_warning_container"></div>
     {{#if only_topic_edit }}
     <p>{{t "Rename topic to:" }}</p>
     {{else if from_message_actions_popover}}

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -307,6 +307,25 @@ test("test_stream_has_topics", () => {
     assert.equal(stream_topic_history.stream_has_topics(stream_id), true);
 });
 
+test("test_stream_has_topic", () => {
+    const stream_id = 88;
+    const topic_name = "fake topic name";
+
+    assert.equal(stream_topic_history.stream_has_topic(stream_id, topic_name), false);
+
+    stream_topic_history.find_or_create(stream_id);
+
+    assert.equal(stream_topic_history.stream_has_topic(stream_id, topic_name), false);
+
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 888,
+        topic_name,
+    });
+
+    assert.equal(stream_topic_history.stream_has_topic(stream_id, topic_name), true);
+});
+
 test("server_history_end_to_end", () => {
     stream_topic_history.reset();
 


### PR DESCRIPTION
Only show the warning banner if submit button is enabled and the number of messages being moved are more than one.

Fixes: #31151

[CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.93.81.20.22Merge.20with.20another.20topic.3F.22.20dialog.20.2F.20banner/near/1883678)

**Screenshots and screen captures:**
![move_messages](https://github.com/user-attachments/assets/667f6672-56b9-40c0-a97d-c42e3e55cb89)
![move_topic](https://github.com/user-attachments/assets/39f638ae-abc8-42ae-8c75-5ddef497901d)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

NOTE: just want to get some quick feedback so no unit test yet.

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
