### PR TITLE
UI redesign: new topic indicator in typeaheads

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -562,8 +562,8 @@ export class Typeahead<ItemType extends string | object> {
 
             if (option_label_html) {
                 $item_html
-                    .append($(option_label_html))
-                    .addClass("typeahead-option-label-container");
+                    .addClass("typeahead-option-label-container")
+                    .append($(option_label_html).addClass("typeahead-option-label"));
             }
             return $i;
         });

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -561,7 +561,9 @@ export class Typeahead<ItemType extends string | object> {
             const option_label_html = this.option_label(matching_items, item);
 
             if (option_label_html) {
-                $item_html.append($(option_label_html)).addClass("typeahead-option-label");
+                $item_html
+                    .append($(option_label_html))
+                    .addClass("typeahead-option-label-container");
             }
             return $i;
         });

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -905,6 +905,7 @@
     --color-active-dropdown-item: hsl(0deg 0% 0%);
     --background-color-active-dropdown-item: hsl(220deg 12% 4.9% / 5%);
     --background-color-active-typeahead-item: hsl(221.14deg 89.74% 92.35%);
+    --color-typeahead-option-label: var(--grey-500);
 }
 
 %dark-theme {
@@ -1296,6 +1297,7 @@
     --background-color-active-typeahead-item: hsl(
         226.35deg 82.53% 55.1% / 38.82%
     );
+    --color-typeahead-option-label: var(--grey-400);
 }
 
 @media screen {

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -149,7 +149,7 @@
     }
 }
 
-.typeahead-option-label {
+.typeahead-option-label-container {
     display: flex !important;
     justify-content: space-between;
 

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -156,6 +156,10 @@
     > strong {
         margin-right: 14px;
     }
+
+    .typeahead-option-label {
+        color: var(--color-typeahead-option-label);
+    }
 }
 
 .typeahead-image {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20new.20topic.20indicator.20in.20typeaheads/near/1908770

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
The first commit is a refactor.

Second commit fixes the issue at hand, these are the screenshots after the second commit (does not include changes from the third commit):
<img width="421" alt="light_new_final" src="https://github.com/user-attachments/assets/9b2dbb8c-6df1-4a44-a534-0c9ebf24cdc3">
<img width="421" alt="dark_new_final" src="https://github.com/user-attachments/assets/c71782fe-1766-44c3-a791-1c764ff99631">

For the third commit, there was a css rule to apply a right margin of 14px to a direct descendant of `.typeahead-option-label-container` that was a `<strong>` element. I suspect at one point, another layer of element was added b/w the container and the `<strong>` element and the style ended up getting ignored. I've not spent time digging through when this change might have happened since this is a small visual change and it would be more efficient to just confirm which visual behaviour we want.

I have some confidence that we want the margin there and we can just as easily remove the rule if we don't want that margin, that's why I didn't discuss on CZO.

| Before | After |
| -- | -- |
| <img width="421" alt="no_margin" src="https://github.com/user-attachments/assets/c652bd51-4a93-4f85-bf54-c1a1a4996cc8"> | <img width="421" alt="yes_margin" src="https://github.com/user-attachments/assets/7975a3de-7660-45b6-98d4-602adc430ed6"> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
