### PR TITLE
typeahead: typeahead-strong-section should have a font weight of 500.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -132,6 +132,7 @@
            typeahead lines, e.g., between the channel
            name and its description. */
         gap: 0.25ch;
+        font-weight: 500;
     }
 
     .active {


### PR DESCRIPTION
Fixes https://chat.zulip.org/#narrow/stream/101-design/topic/font.20weight.20in.20typeaheads/near/1911442.

I've included a few screenshots to demonstrate the change, let me know if you need more screenshots.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before - compose box | After - compose box |
| -- | -- |
| <img width="471" alt="typeahead_font_weight_compose_before" src="https://github.com/user-attachments/assets/04dc7d67-fe3e-4542-8382-17b39501f2eb">   | <img width="471" alt="typeahead_font_weight_compose_after" src="https://github.com/user-attachments/assets/8a08876f-fd2e-4938-90c5-20ef20f17e1e"> |
| Before - user group | After - user group |
| <img width="592" alt="typeahead_font_weight_user_group_before" src="https://github.com/user-attachments/assets/7eaf8741-b900-47d5-9cff-8b8cb2fb456d">| <img width="592" alt="typeahead_font_weight_user_group_after" src="https://github.com/user-attachments/assets/5c009e39-41ac-4004-975f-1b1c15a1d6df"> |
| Before - code playground | After - code playground |
| <img width="480" alt="typeahead_font_weight_code_playground_before" src="https://github.com/user-attachments/assets/17ca809f-7037-4582-b28e-2955ce15c418"> |  <img width="480" alt="typeahead_font_weight_code_playground_after" src="https://github.com/user-attachments/assets/ebb03b84-ac15-4e30-84a3-ff07addf6c27"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
