### PR TITLE
lightbox: Remove unnecessary open_image call.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -694,8 +694,6 @@ export function initialize(): void {
 
     $("#lightbox_overlay").on("click", ".lightbox-zoom-reset", () => {
         if (!$("#lightbox_overlay .lightbox-zoom-reset").hasClass("disabled")) {
-            const $img = $("#lightbox_overlay").find<HTMLImageElement>(".image-preview img");
-            open_image($img);
             pan_zoom_control.reset();
         }
     });


### PR DESCRIPTION
Not sure why this `open_image` call was required. Likely we forgot to remove it in [this](https://github.com/zulip/zulip/pull/21227/files#diff-dc0c835aa47c6028f2a63c07f0f93129eb39d035c02089a636dacf07b50f15d7R511) migration 