### PR TITLE
use stream id instead of stream name for Filter (and some other related places)

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -186,16 +186,16 @@ export function initialize() {
 
                     // Renarrow to the unresolved topic if currently viewing the resolved topic.
                     const current_filter = narrow_state.filter();
-                    const channel_name = sub_store.maybe_get_stream_name(stream_id);
+                    const stream_id_string = stream_id.toString();
                     if (
                         current_filter &&
                         (current_filter.is_conversation_view() ||
                             current_filter.is_conversation_view_with_near()) &&
-                        current_filter.has_topic(channel_name, topic_name)
+                        current_filter.has_topic(stream_id_string, topic_name)
                     ) {
                         message_view.show(
                             [
-                                {operator: "channel", operand: channel_name},
+                                {operator: "channel", operand: stream_id_string},
                                 {operator: "topic", operand: new_topic},
                             ],
                             {},

--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -9,6 +9,7 @@ import * as compose_ui from "./compose_ui";
 import * as hash_util from "./hash_util";
 import * as message_lists from "./message_lists";
 import * as rows from "./rows";
+import * as stream_data from "./stream_data";
 import * as topic_link_util from "./topic_link_util";
 import * as util from "./util";
 
@@ -662,7 +663,10 @@ export function try_stream_topic_syntax_text(text: string): string | null {
         return null;
     }
 
-    if (topic_link_util.will_produce_broken_stream_topic_link(stream_topic.stream_name)) {
+    const stream = stream_data.get_sub_by_id(stream_topic.stream_id);
+    assert(stream !== undefined);
+    const stream_name = stream.name;
+    if (topic_link_util.will_produce_broken_stream_topic_link(stream_name)) {
         return null;
     }
 
@@ -673,7 +677,7 @@ export function try_stream_topic_syntax_text(text: string): string | null {
         return null;
     }
 
-    let syntax_text = "#**" + stream_topic.stream_name;
+    let syntax_text = "#**" + stream_name;
     if (stream_topic.topic_name) {
         syntax_text += ">" + stream_topic.topic_name;
     }

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -12,7 +12,6 @@ import * as messages_overlay_ui from "./messages_overlay_ui";
 import * as overlays from "./overlays";
 import * as people from "./people";
 import * as rendered_markdown from "./rendered_markdown";
-import * as stream_data from "./stream_data";
 import * as user_card_popover from "./user_card_popover";
 import * as user_group_popover from "./user_group_popover";
 
@@ -30,7 +29,7 @@ function restore_draft(draft_id) {
                 [
                     {
                         operator: "channel",
-                        operand: stream_data.get_stream_name_from_id(compose_args.stream_id),
+                        operand: compose_args.stream_id.toString(),
                     },
                     {operator: "topic", operand: compose_args.topic},
                 ],

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -54,7 +54,6 @@ import * as sidebar_ui from "./sidebar_ui";
 import * as spectators from "./spectators";
 import * as starred_messages_ui from "./starred_messages_ui";
 import {realm} from "./state_data";
-import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as stream_settings_ui from "./stream_settings_ui";
@@ -1234,7 +1233,7 @@ export function process_hotkey(e, hotkey) {
                         [
                             {
                                 operator: "channel",
-                                operand: stream_data.get_stream_name_from_id(msg.stream_id),
+                                operand: msg.stream_id.toString(),
                             },
                             {operator: "topic", operand: msg.topic},
                             {operator: "near", operand: msg.id},

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -472,7 +472,6 @@ export function update_messages(events) {
                 });
             }
 
-            const old_stream_name = stream_archived ? undefined : old_stream.name;
             if (
                 going_forward_change &&
                 // This logic is a bit awkward.  What we're trying to
@@ -490,7 +489,8 @@ export function update_messages(events) {
                 // messages within a narrow.
                 selection_changed_topic &&
                 current_filter &&
-                current_filter.has_topic(old_stream_name, orig_topic)
+                old_stream_id &&
+                current_filter.has_topic(old_stream_id, orig_topic)
             ) {
                 let new_filter = current_filter;
                 if (new_filter && stream_changed) {
@@ -501,10 +501,9 @@ export function update_messages(events) {
                     // stream_data lookup here to fail.
                     //
                     // The fix is likely somewhat involved, so punting for now.
-                    const new_stream_name = sub_store.get(new_stream_id).name;
                     new_filter = new_filter.filter_with_new_params({
                         operator: "channel",
-                        operand: new_stream_name,
+                        operand: new_stream_id.toString(),
                     });
                     changed_narrow = true;
                 }
@@ -533,10 +532,10 @@ export function update_messages(events) {
             // If a message was moved to the current narrow and we don't have
             // the message cached, we need to refresh the narrow to display the message.
             if (!changed_narrow && local_cache_missing_messages && current_filter) {
-                let moved_message_stream = old_stream_name;
+                let moved_message_stream_id = old_stream_id;
                 let moved_message_topic = orig_topic;
                 if (stream_changed) {
-                    moved_message_stream = sub_store.get(new_stream_id).name;
+                    moved_message_stream_id = sub_store.get(new_stream_id).stream_id.toString();
                 }
 
                 if (topic_edited) {
@@ -545,7 +544,7 @@ export function update_messages(events) {
 
                 if (
                     current_filter.can_newly_match_moved_messages(
-                        moved_message_stream,
+                        moved_message_stream_id,
                         moved_message_topic,
                     )
                 ) {

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -340,7 +340,25 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
         if (page_params.narrow !== undefined) {
             terms = [...terms, ...page_params.narrow];
         }
-        data.narrow = JSON.stringify(terms);
+        // TODO(stream_id): The server would ideally work with stream ids instead
+        // of stream names.
+        const server_terms = [];
+        for (const term of terms) {
+            if (term.operator === "channel") {
+                const sub = stream_data.get_sub_by_id_string(term.operand);
+                server_terms.push({
+                    ...term,
+                    // If the sub is undefined, we'll get an error which is handled
+                    // later by showing a "this channel does not exist or is private"
+                    // notice.
+                    operand: sub?.name,
+                });
+            } else {
+                server_terms.push({...term});
+            }
+        }
+
+        data.narrow = JSON.stringify(server_terms);
     }
 
     let update_loading_indicator =

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -450,10 +450,11 @@ export function show(raw_terms, opts) {
                 // location, then we should retarget this narrow operation
                 // to where the message is located now.
                 const narrow_topic = filter.operands("topic")[0];
-                const narrow_stream_name = filter.operands("channel")[0];
-                const narrow_stream_data = stream_data.get_sub(narrow_stream_name);
+                const narrow_stream_data = stream_data.get_sub_by_id_string(
+                    filter.operands("channel")[0],
+                );
                 if (!narrow_stream_data) {
-                    // The stream name is invalid or incorrect in the URL.
+                    // The stream id is invalid or incorrect in the URL.
                     // We reconstruct the narrow with the data from the
                     // target message ID that we have.
                     const adjusted_terms = Filter.adjusted_terms_if_moved(
@@ -1085,10 +1086,9 @@ export function render_message_list_with_selected_message(opts) {
     narrow_history.save_narrow_state_and_flush();
 }
 
-export function activate_stream_for_cycle_hotkey(stream_id) {
-    const stream_name = stream_data.get_stream_name_from_id(stream_id);
+function activate_stream_for_cycle_hotkey(stream_id) {
     // This is the common code for A/D hotkeys.
-    const filter_expr = [{operator: "channel", operand: stream_name}];
+    const filter_expr = [{operator: "channel", operand: stream_id.toString()}];
     show(filter_expr, {});
 }
 
@@ -1158,9 +1158,8 @@ export function narrow_to_next_topic(opts = {}) {
         return;
     }
 
-    const stream_name = stream_data.get_stream_name_from_id(next_narrow.stream_id);
     const filter_expr = [
-        {operator: "channel", operand: stream_name},
+        {operator: "channel", operand: next_narrow.stream_id.toString()},
         {operator: "topic", operand: next_narrow.topic},
     ];
 
@@ -1218,9 +1217,8 @@ export function narrow_by_topic(target_id, opts) {
         unread_ops.notify_server_message_read(original);
     }
 
-    const stream_name = stream_data.get_stream_name_from_id(original.stream_id);
     const search_terms = [
-        {operator: "channel", operand: stream_name},
+        {operator: "channel", operand: original.stream_id.toString()},
         {operator: "topic", operand: original.topic},
     ];
     opts = {then_select_id: target_id, ...opts};
@@ -1264,7 +1262,7 @@ export function narrow_by_recipient(target_id, opts) {
                 [
                     {
                         operator: "stream",
-                        operand: stream_data.get_stream_name_from_id(message.stream_id),
+                        operand: message.stream_id.toString(),
                     },
                 ],
                 opts,
@@ -1289,10 +1287,9 @@ export function to_compose_target() {
         if (!stream_id) {
             return;
         }
-        const stream_name = stream_data.get_sub_by_id(stream_id).name;
         // If we are composing to a new topic, we narrow to the stream but
         // grey-out the message view instead of narrowing to an empty view.
-        const terms = [{operator: "channel", operand: stream_name}];
+        const terms = [{operator: "channel", operand: stream_id.toString()}];
         const topic = compose_state.topic();
         if (topic !== "") {
             terms.push({operator: "topic", operand: topic});

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -76,10 +76,11 @@ function retrieve_search_query_data(): SearchData {
 
     // Add in stream:foo and topic:bar if present
     if (current_filter.has_operator("channel") || current_filter.has_operator("topic")) {
-        const stream = current_filter.operands("channel")[0];
+        const stream_id = current_filter.operands("channel")[0];
         const topic = current_filter.operands("topic")[0];
-        if (stream) {
-            search_string_result.stream_query = stream;
+        if (stream_id) {
+            const stream_name = stream_data.get_valid_sub_by_id_string(stream_id).name;
+            search_string_result.stream_query = stream_name;
         }
         if (topic) {
             search_string_result.topic_query = topic;
@@ -184,7 +185,7 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
         if (
             page_params.is_spectator &&
             first_operator === "channel" &&
-            !stream_data.is_web_public_by_stream_name(first_operand)
+            !stream_data.is_web_public_by_stream_id(Number.parseInt(first_operand, 10))
         ) {
             // For non web-public streams, show `login_to_access` modal.
             spectators.login_to_access(true);
@@ -264,7 +265,7 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
             // fallthrough to default case if no match is found
             break;
         case "channel":
-            if (!stream_data.is_subscribed_by_name(first_operand)) {
+            if (!stream_data.is_subscribed(Number.parseInt(first_operand, 10))) {
                 // You are narrowed to a stream which does not exist or is a private stream
                 // in which you were never subscribed.
 
@@ -280,7 +281,7 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
                         return false;
                     }
 
-                    const stream_sub = stream_data.get_sub(first_operand);
+                    const stream_sub = stream_data.get_sub_by_id_string(first_operand);
                     return stream_sub && stream_data.can_toggle_subscription(stream_sub);
                 }
 

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -114,19 +114,24 @@ export function set_compose_defaults(): {
     return opts;
 }
 
-export function stream_name(current_filter: Filter | undefined = filter()): string | undefined {
+export function stream_id(current_filter: Filter | undefined = filter()): number | undefined {
     if (current_filter === undefined) {
         return undefined;
     }
     const stream_operands = current_filter.operands("channel");
     if (stream_operands.length === 1 && stream_operands[0] !== undefined) {
-        const name = stream_operands[0];
-
-        // Use get_name() to get the most current stream
-        // name (considering renames and capitalization).
-        return stream_data.get_name(name);
+        return Number.parseInt(stream_operands[0], 10);
     }
     return undefined;
+}
+
+export function stream_name(current_filter: Filter | undefined = filter()): string | undefined {
+    const id = stream_id(current_filter);
+    if (id === undefined) {
+        return undefined;
+    }
+    const sub = stream_data.get_sub_by_id(id);
+    return sub?.name;
 }
 
 export function stream_sub(
@@ -140,19 +145,7 @@ export function stream_sub(
     if (stream_operands.length !== 1 || stream_operands[0] === undefined) {
         return undefined;
     }
-
-    const name = stream_operands[0];
-    const sub = stream_data.get_sub_by_name(name);
-
-    return sub;
-}
-
-export function stream_id(filter?: Filter): number | undefined {
-    const sub = stream_sub(filter);
-    if (sub === undefined) {
-        return undefined;
-    }
-    return sub.stream_id;
+    return stream_data.get_sub_by_id_string(stream_operands[0]);
 }
 
 export function topic(current_filter: Filter | undefined = filter()): string | undefined {

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -8,6 +8,7 @@ import * as inbox_util from "./inbox_util";
 import * as people from "./people";
 import * as recent_view_util from "./recent_view_util";
 import {realm} from "./state_data";
+import * as stream_data from "./stream_data";
 import * as unread from "./unread";
 import type {FullUnreadCountsData} from "./unread";
 
@@ -34,10 +35,11 @@ export function compute_narrow_title(filter?: Filter): string {
     }
 
     if (filter.has_operator("channel")) {
-        if (!filter._sub) {
+        const sub = stream_data.get_sub_by_id_string(filter.operands("channel")[0]!);
+        if (!sub) {
             // The stream is not set because it does not currently
-            // exist (possibly due to a stream name change), or it
-            // is a private stream and the user is not subscribed.
+            // exist, or it is a private stream and the user is not
+            // subscribed.
             return filter_title;
         }
         if (filter.has_operator("topic")) {

--- a/web/src/scheduled_messages_ui.js
+++ b/web/src/scheduled_messages_ui.js
@@ -8,7 +8,6 @@ import {$t} from "./i18n";
 import * as message_view from "./message_view";
 import * as people from "./people";
 import * as scheduled_messages from "./scheduled_messages";
-import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 
 export function hide_scheduled_message_success_compose_banner(scheduled_message_id) {
@@ -23,7 +22,7 @@ function narrow_via_edit_scheduled_message(compose_args) {
             [
                 {
                     operator: "channel",
-                    operand: stream_data.get_stream_name_from_id(compose_args.stream_id),
+                    operand: compose_args.stream_id,
                 },
                 {operator: "topic", operand: compose_args.topic},
             ],

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -10,6 +10,7 @@ import type {InputPill, InputPillContainer} from "./input_pill";
 import * as people from "./people";
 import type {User} from "./people";
 import type {NarrowTerm} from "./state_data";
+import * as stream_data from "./stream_data";
 import * as user_status from "./user_status";
 import type {UserStatusEmojiInfo} from "./user_status";
 import * as util from "./util";
@@ -56,7 +57,7 @@ export function create_item_from_search_string(search_string: string): SearchPil
 
 export function get_search_string_from_item(item: SearchPill): string {
     const sign = item.negated ? "-" : "";
-    return `${sign}${item.operator}: ${get_search_operand(item)}`;
+    return `${sign}${item.operator}: ${get_search_operand(item, true)}`;
 }
 
 // This is called when the a pill is closed. We have custom logic here
@@ -215,9 +216,12 @@ export function set_search_bar_contents(
     }
 }
 
-function get_search_operand(item: SearchPill): string {
+function get_search_operand(item: SearchPill, for_display: boolean): string {
     if (item.type === "search_user") {
         return item.users.map((user) => user.email).join(",");
+    }
+    if (for_display && item.operator === "channel") {
+        return stream_data.get_valid_sub_by_id_string(item.operand).name;
     }
     return item.operand;
 }
@@ -225,6 +229,6 @@ function get_search_operand(item: SearchPill): string {
 export function get_current_search_pill_terms(pill_widget: SearchPillWidget): NarrowTerm[] {
     return pill_widget.items().map((item) => ({
         ...item,
-        operand: get_search_operand(item),
+        operand: get_search_operand(item, false),
     }));
 }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -273,7 +273,7 @@ export function slug_to_stream_id(slug: string): number | undefined {
     // "New" (2018) format: ${stream_id}-${stream_name} .
     const match = /^(\d+)(?:-.*)?$/.exec(slug);
     const newFormatStreamId = match ? Number.parseInt(match[1]!, 10) : null;
-    if (newFormatStreamId && stream_info.get(newFormatStreamId)) {
+    if (newFormatStreamId !== null && stream_info.get(newFormatStreamId)) {
         return newFormatStreamId;
     }
 

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -1,3 +1,5 @@
+import assert from "minimalistic-assert";
+
 import * as blueslip from "./blueslip";
 import * as color_data from "./color_data";
 import {FoldDict} from "./fold_dict";
@@ -177,6 +179,18 @@ export function get_sub(stream_name: string): StreamSubscription | undefined {
     return undefined;
 }
 
+export function get_sub_by_id_string(stream_id_string: string): StreamSubscription | undefined {
+    const stream_id = Number.parseInt(stream_id_string, 10);
+    const stream = stream_info.get(stream_id);
+    return stream;
+}
+
+export function get_valid_sub_by_id_string(stream_id_string: string): StreamSubscription {
+    const stream = get_sub_by_id_string(stream_id_string);
+    assert(stream !== undefined);
+    return stream;
+}
+
 export function get_sub_by_id(stream_id: number): StreamSubscription | undefined {
     return stream_info.get(stream_id);
 }
@@ -222,13 +236,8 @@ export function get_sub_by_name(name: string): StreamSubscription | undefined {
     return sub_store.get(stream_id);
 }
 
-export function name_to_slug(name: string): string {
-    const stream_id = get_stream_id(name);
-
-    if (!stream_id) {
-        return name;
-    }
-
+export function id_to_slug(stream_id: number): string {
+    let name = get_stream_name_from_id(stream_id);
     // The name part of the URL doesn't really matter, so we try to
     // make it pretty.
     name = name.replaceAll(" ", "-");
@@ -601,11 +610,6 @@ export function can_post_messages_in_stream(stream: StreamSubscription): boolean
     return true;
 }
 
-export function is_subscribed_by_name(stream_name: string): boolean {
-    const sub = get_sub(stream_name);
-    return sub ? sub.subscribed : false;
-}
-
 export function is_subscribed(stream_id: number): boolean {
     const sub = sub_store.get(stream_id);
     return sub ? sub.subscribed : false;
@@ -639,8 +643,8 @@ export function is_invite_only_by_stream_id(stream_id: number): boolean {
     return sub.invite_only;
 }
 
-export function is_web_public_by_stream_name(stream_name: string): boolean {
-    const sub = get_sub(stream_name);
+export function is_web_public_by_stream_id(stream_id: number): boolean {
+    const sub = get_sub_by_id(stream_id);
     if (sub === undefined) {
         return false;
     }
@@ -661,22 +665,6 @@ export function get_default_stream_ids(): number[] {
 
 export function is_default_stream_id(stream_id: number): boolean {
     return default_stream_ids.has(stream_id);
-}
-
-export function get_name(stream_name: string): string {
-    // This returns the actual name of a stream if we are subscribed to
-    // it (e.g. "Denmark" vs. "denmark"), while falling thru to
-    // stream_name if we don't have a subscription.  (Stream names
-    // are case-insensitive, but we try to display the actual name
-    // when we know it.)
-    //
-    // This function will also do the right thing if we have
-    // an old stream name in memory for a recently renamed stream.
-    const sub = get_sub_by_name(stream_name);
-    if (sub === undefined) {
-        return stream_name;
-    }
-    return sub.name;
 }
 
 export function is_user_subscribed(stream_id: number, user_id: number): boolean {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -271,7 +271,7 @@ export function slug_to_stream_id(slug: string): number | undefined {
     */
 
     // "New" (2018) format: ${stream_id}-${stream_name} .
-    const match = /^(\d+)(-.*)?$/.exec(slug);
+    const match = /^(\d+)(?:-.*)?$/.exec(slug);
     const newFormatStreamId = match ? Number.parseInt(match[1]!, 10) : null;
     if (newFormatStreamId && stream_info.get(newFormatStreamId)) {
         return newFormatStreamId;

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -682,8 +682,7 @@ export function get_sidebar_stream_topic_info(filter: Filter): {
         return result;
     }
 
-    const stream_name = op_stream[0];
-    const stream_id = stream_data.get_stream_id(stream_name);
+    const stream_id = Number.parseInt(op_stream[0], 10);
 
     if (!stream_id) {
         return result;

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -139,7 +139,7 @@ function build_stream_popover(opts) {
                     [
                         {
                             operator: "stream",
-                            operand: sub.name,
+                            operand: sub.stream_id.toString(),
                         },
                     ],
                     {trigger: "stream-popover"},

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -903,7 +903,7 @@ export function view_stream() {
     const row_data = get_row_data(active_data.$row);
     if (row_data) {
         const stream_narrow_hash =
-            "#narrow/stream/" + hash_util.encode_stream_name(row_data.object.name);
+            "#narrow/stream/" + hash_util.encode_stream_id(row_data.object.stream_id);
         browser_history.go_to_location(stream_narrow_hash);
     }
 }

--- a/web/src/topic_generator.ts
+++ b/web/src/topic_generator.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import assert from "minimalistic-assert";
 
 import * as narrow_state from "./narrow_state";
 import * as pm_conversations from "./pm_conversations";
@@ -87,7 +86,6 @@ export function get_next_topic(
 
     function get_unmuted_topics(stream_id: number): string[] {
         const narrowed_steam_id = narrow_state.stream_id();
-        assert(stream_id !== undefined);
         const topics = stream_topic_history.get_recent_topic_names(stream_id);
         const narrowed_topic = narrow_state.topic();
         if (
@@ -119,16 +117,11 @@ export function get_next_topic(
         return topics;
     }
 
-    function has_unread_messages(stream_id: number, topic: string): boolean {
-        assert(stream_id !== undefined);
-        return unread.topic_has_any_unread(stream_id, topic);
-    }
-
     if (only_followed_topics) {
         return next_topic(
             my_streams,
             get_followed_topics,
-            has_unread_messages,
+            unread.topic_has_any_unread,
             curr_stream_id,
             curr_topic,
         );
@@ -137,7 +130,7 @@ export function get_next_topic(
     return next_topic(
         my_streams,
         get_unmuted_topics,
-        has_unread_messages,
+        unread.topic_has_any_unread,
         curr_stream_id,
         curr_topic,
     );

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -549,7 +549,7 @@ export function initialize_everything(state_data) {
                 [
                     {
                         operator: "stream",
-                        operand: sub.name,
+                        operand: sub.stream_id.toString(),
                     },
                 ],
                 {trigger},
@@ -658,7 +658,7 @@ export function initialize_everything(state_data) {
             const sub = sub_store.get(stream_id);
             message_view.show(
                 [
-                    {operator: "channel", operand: sub.name},
+                    {operator: "channel", operand: sub.stream_id.toString()},
                     {operator: "topic", operand: topic},
                 ],
                 {trigger: "sidebar"},

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -22,7 +22,6 @@ import * as overlays from "./overlays";
 import * as people from "./people";
 import * as recent_view_ui from "./recent_view_ui";
 import type {NarrowTerm} from "./state_data";
-import * as stream_data from "./stream_data";
 import * as ui_report from "./ui_report";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
@@ -610,22 +609,20 @@ export function process_visible(): void {
 }
 
 export function mark_stream_as_read(stream_id: number): void {
-    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
         [
             {operator: "is", operand: "unread", negated: false},
-            {operator: "channel", operand: stream_name},
+            {operator: "channel", operand: stream_id.toString()},
         ],
         "add",
     );
 }
 
 export function mark_topic_as_read(stream_id: number, topic: string): void {
-    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
         [
             {operator: "is", operand: "unread", negated: false},
-            {operator: "channel", operand: stream_name},
+            {operator: "channel", operand: stream_id.toString()},
             {operator: "topic", operand: topic},
         ],
         "add",
@@ -633,10 +630,9 @@ export function mark_topic_as_read(stream_id: number, topic: string): void {
 }
 
 export function mark_topic_as_unread(stream_id: number, topic: string): void {
-    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
         [
-            {operator: "channel", operand: stream_name},
+            {operator: "channel", operand: stream_id.toString()},
             {operator: "topic", operand: topic},
         ],
         "remove",

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -105,7 +105,7 @@ const $fred_stub = $.create("fred stub");
 const rome_sub = {name: "Rome", subscribed: true, stream_id: 1001};
 function add_sub_and_set_as_current_narrow(sub) {
     stream_data.add_sub(sub);
-    const filter = new Filter([{operator: "stream", operand: sub.name}]);
+    const filter = new Filter([{operator: "stream", operand: sub.stream_id}]);
     message_lists.set_current({
         data: {
             filter,

--- a/web/tests/example3.test.js
+++ b/web/tests/example3.test.js
@@ -34,7 +34,7 @@ run_test("filter", () => {
     stream_data.add_sub(denmark_stream);
 
     const filter_terms = [
-        {operator: "stream", operand: "Denmark"},
+        {operator: "stream", operand: denmark_stream.stream_id.toString()},
         {operator: "topic", operand: "copenhagen"},
     ];
 
@@ -85,7 +85,7 @@ run_test("narrow_state", () => {
 
     // Now set up a Filter object.
     const filter_terms = [
-        {operator: "stream", operand: "Denmark"},
+        {operator: "stream", operand: denmark_stream.stream_id.toString()},
         {operator: "topic", operand: "copenhagen"},
     ];
 

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -21,8 +21,9 @@ const hamlet = {
 
 people.add_active_user(hamlet);
 
+const frontend_id = 99;
 const frontend = {
-    stream_id: 99,
+    stream_id: frontend_id,
     name: "frontend",
 };
 
@@ -44,7 +45,7 @@ run_test("hash_util", () => {
     encode_decode_operand(operator, operand, "15-Hamlet");
 
     operator = "stream";
-    operand = "frontend";
+    operand = frontend_id.toString();
 
     encode_decode_operand(operator, operand, "99-frontend");
 
@@ -175,19 +176,19 @@ run_test("test_is_in_specified_hash_category", () => {
 
 run_test("test_parse_narrow", () => {
     assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "99-frontend"]), [
-        {negated: false, operator: "stream", operand: "frontend"},
+        {negated: false, operator: "stream", operand: frontend_id.toString()},
     ]);
 
     assert.deepEqual(hash_util.parse_narrow(["narrow", "-stream", "99-frontend"]), [
-        {negated: true, operator: "stream", operand: "frontend"},
+        {negated: true, operator: "stream", operand: frontend_id.toString()},
     ]);
 
     assert.equal(hash_util.parse_narrow(["narrow", "BOGUS"]), undefined);
 
-    // For nonexistent streams, we get the full slug.
-    // We possibly should remove the prefix and fix this test.
+    // For nonexistent streams, we get an empty string. We don't use this
+    // anywhere, and just show "Invalid stream" in the navbar.
     assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "42-bogus"]), [
-        {negated: false, operator: "stream", operand: "42-bogus"},
+        {negated: false, operator: "stream", operand: ""},
     ]);
 });
 

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -242,7 +242,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // for non-existent or private stream
-    set_filter([["stream", "Foo"]]);
+    set_filter([["stream", "999"]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
@@ -250,8 +250,9 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // for non-subbed public stream
-    stream_data.add_sub({name: "ROME", stream_id: 99});
-    set_filter([["stream", "Rome"]]);
+    const rome_id = 99;
+    stream_data.add_sub({name: "ROME", stream_id: rome_id});
+    set_filter([["stream", rome_id.toString()]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
@@ -263,7 +264,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
 
     // for non-web-public stream for spectator
     page_params.is_spectator = true;
-    set_filter([["stream", "Rome"]]);
+    set_filter([["stream", rome_id.toString()]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
@@ -274,7 +275,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     set_filter([
-        ["stream", "Rome"],
+        ["stream", rome_id.toString()],
         ["topic", "foo"],
     ]);
     narrow_banner.show_empty_narrow_message();
@@ -287,9 +288,10 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // for web-public stream for spectator
-    stream_data.add_sub({name: "web-public-stream", stream_id: 1231, is_web_public: true});
+    const web_public_id = 1231;
+    stream_data.add_sub({name: "web-public-stream", stream_id: web_public_id, is_web_public: true});
     set_filter([
-        ["stream", "web-public-stream"],
+        ["stream", web_public_id.toString()],
         ["topic", "foo"],
     ]);
     narrow_banner.show_empty_narrow_message();
@@ -524,7 +526,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
 
     set_filter([
         ["sender", "alice@example.com"],
-        ["stream", "Rome"],
+        ["stream", rome_id.toString()],
     ]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
@@ -542,14 +544,15 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    const my_stream_id = 103;
     const my_stream = {
         name: "my stream",
-        stream_id: 103,
+        stream_id: my_stream_id,
     };
     stream_data.add_sub(my_stream);
     stream_data.subscribe_myself(my_stream);
 
-    set_filter([["stream", "my stream"]]);
+    set_filter([["stream", my_stream_id.toString()]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
@@ -617,6 +620,8 @@ run_test("show_search_stopwords", ({mock_template}) => {
         empty_narrow_html("translated: No search results.", undefined, expected_search_data),
     );
 
+    const streamA_id = 88;
+    stream_data.add_sub({name: "streamA", stream_id: streamA_id});
     const expected_stream_search_data = {
         has_stop_word: true,
         stream_query: "streamA",
@@ -627,7 +632,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
         ],
     };
     set_filter([
-        ["stream", "streamA"],
+        ["stream", streamA_id.toString()],
         ["search", "what about grail"],
     ]);
     narrow_banner.show_empty_narrow_message();
@@ -647,7 +652,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
         ],
     };
     set_filter([
-        ["stream", "streamA"],
+        ["stream", streamA_id.toString()],
         ["topic", "topicA"],
         ["search", "what about grail"],
     ]);
@@ -666,12 +671,14 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     message_lists.set_current(undefined);
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
-    stream_data.add_sub({name: "streamA", stream_id: 88});
-    stream_data.add_sub({name: "streamB", stream_id: 77});
+    const streamA_id = 88;
+    const streamB_id = 77;
+    stream_data.add_sub({name: "streamA", stream_id: streamA_id});
+    stream_data.add_sub({name: "streamB", stream_id: streamB_id});
 
     set_filter([
-        ["stream", "streamA"],
-        ["stream", "streamB"],
+        ["stream", streamA_id.toString()],
+        ["stream", streamB_id.toString()],
     ]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
@@ -734,7 +741,8 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     });
 
     compose_state.set_message_type("stream");
-    stream_data.add_sub({name: "ROME", stream_id: 99});
+    const rome_id = 99;
+    stream_data.add_sub({name: "ROME", stream_id: rome_id});
     compose_state.set_stream_id(99);
 
     // Test with existing topic
@@ -744,7 +752,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     assert.equal(args.called, true);
     assert.equal(args.opts.trigger, "narrow_to_compose_target");
     assert.deepEqual(args.terms, [
-        {operator: "channel", operand: "ROME"},
+        {operator: "channel", operand: rome_id.toString()},
         {operator: "topic", operand: "one"},
     ]);
 
@@ -754,7 +762,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     message_view.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [
-        {operator: "channel", operand: "ROME"},
+        {operator: "channel", operand: rome_id.toString()},
         {operator: "topic", operand: "four"},
     ]);
 
@@ -763,14 +771,14 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     args.called = false;
     message_view.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.terms, [{operator: "channel", operand: "ROME"}]);
+    assert.deepEqual(args.terms, [{operator: "channel", operand: rome_id.toString()}]);
 
     // Test with no topic
     compose_state.topic(undefined);
     args.called = false;
     message_view.to_compose_target();
     assert.equal(args.called, true);
-    assert.deepEqual(args.terms, [{operator: "channel", operand: "ROME"}]);
+    assert.deepEqual(args.terms, [{operator: "channel", operand: rome_id.toString()}]);
 });
 
 run_test("narrow_to_compose_target direct messages", ({override, override_rewire}) => {
@@ -851,26 +859,24 @@ run_test("narrow_compute_title", () => {
     assert.equal(narrow_title.compute_narrow_title(filter), "translated: Messages sent by you");
 
     // Stream narrows
+    const foo_stream_id = 43;
     const sub = {
         name: "Foo",
-        stream_id: 43,
+        stream_id: foo_stream_id,
     };
     stream_data.add_sub(sub);
 
     filter = new Filter([
-        {operator: "stream", operand: "foo"},
+        {operator: "stream", operand: foo_stream_id.toString()},
         {operator: "topic", operand: "bar"},
     ]);
     assert.equal(narrow_title.compute_narrow_title(filter), "#Foo > bar");
 
-    filter = new Filter([{operator: "stream", operand: "foo"}]);
+    filter = new Filter([{operator: "stream", operand: foo_stream_id.toString()}]);
     assert.equal(narrow_title.compute_narrow_title(filter), "#Foo");
 
     filter = new Filter([{operator: "stream", operand: "Elephant"}]);
-    assert.equal(
-        narrow_title.compute_narrow_title(filter),
-        "translated: Unknown channel #Elephant",
-    );
+    assert.equal(narrow_title.compute_narrow_title(filter), "translated: Unknown channel");
 
     // Direct messages with narrows
     const joe = {

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -171,7 +171,7 @@ run_test("basics", ({override, override_rewire}) => {
     override_rewire(message_view, "try_rendering_locally_for_same_narrow", noop);
 
     const helper = test_helper({override});
-    const terms = [{operator: "stream", operand: "Denmark"}];
+    const terms = [{operator: "stream", operand: denmark.stream_id.toString()}];
 
     const selected_id = 1000;
 

--- a/web/tests/narrow_unread.test.js
+++ b/web/tests/narrow_unread.test.js
@@ -25,6 +25,8 @@ const alice = {
     full_name: "Alice",
 };
 
+const bogus_stream_id = "999999";
+
 people.init();
 people.add_active_user(alice);
 
@@ -111,12 +113,12 @@ run_test("get_unread_ids", () => {
     assert.deepEqual(unread_ids, []);
     assert_unread_info({flavor: "not_found"});
 
-    terms = [{operator: "stream", operand: "bogus"}];
+    terms = [{operator: "stream", operand: bogus_stream_id}];
     set_filter(terms);
     unread_ids = candidate_ids();
     assert.deepEqual(unread_ids, []);
 
-    terms = [{operator: "stream", operand: sub.name}];
+    terms = [{operator: "stream", operand: sub.stream_id.toString()}];
     set_filter(terms);
     unread_ids = candidate_ids();
     assert.deepEqual(unread_ids, []);
@@ -131,7 +133,7 @@ run_test("get_unread_ids", () => {
     });
 
     terms = [
-        {operator: "stream", operand: "bogus"},
+        {operator: "stream", operand: bogus_stream_id},
         {operator: "topic", operand: "my topic"},
     ];
     set_filter(terms);
@@ -139,7 +141,7 @@ run_test("get_unread_ids", () => {
     assert.deepEqual(unread_ids, []);
 
     terms = [
-        {operator: "stream", operand: sub.name},
+        {operator: "stream", operand: sub.stream_id.toString()},
         {operator: "topic", operand: "my topic"},
     ];
     set_filter(terms);
@@ -226,7 +228,7 @@ run_test("get_unread_ids", () => {
     // destination topic.
     unread.process_loaded_messages([other_topic_message]);
     terms = [
-        {operator: "channel", operand: sub.name},
+        {operator: "channel", operand: sub.stream_id.toString()},
         {operator: "topic", operand: "another topic"},
     ];
     set_filter(terms);
@@ -234,7 +236,7 @@ run_test("get_unread_ids", () => {
     assert.deepEqual(unread_ids, [other_topic_message.id]);
 
     terms = [
-        {operator: "channel", operand: sub.name},
+        {operator: "channel", operand: sub.stream_id.toString()},
         {operator: "topic", operand: "another topic"},
         {operator: "with", operand: stream_msg.id},
     ];
@@ -243,7 +245,7 @@ run_test("get_unread_ids", () => {
     assert.deepEqual(unread_ids, [stream_msg.id]);
 
     terms = [
-        {operator: "channel", operand: sub.name},
+        {operator: "channel", operand: sub.stream_id.toString()},
         {operator: "topic", operand: "another topic"},
         {operator: "with", operand: private_msg.id},
     ];

--- a/web/tests/peer_data.test.js
+++ b/web/tests/peer_data.test.js
@@ -66,19 +66,19 @@ test("unsubscribe", () => {
     stream_data.add_sub(devel);
 
     // verify clean slate
-    assert.ok(!stream_data.is_subscribed_by_name("devel"));
+    assert.ok(!stream_data.is_subscribed(devel.stream_id));
 
     // set up our subscription
     devel.subscribed = true;
     peer_data.set_subscribers(devel.stream_id, [me.user_id]);
 
     // ensure our setup is accurate
-    assert.ok(stream_data.is_subscribed_by_name("devel"));
+    assert.ok(stream_data.is_subscribed(devel.stream_id));
 
     // DO THE UNSUBSCRIBE HERE
     stream_data.unsubscribe_myself(devel);
     assert.ok(!devel.subscribed);
-    assert.ok(!stream_data.is_subscribed_by_name("devel"));
+    assert.ok(!stream_data.is_subscribed(devel.stream_id));
     assert.ok(!contains_sub(stream_data.subscribed_subs(), devel));
     assert.ok(contains_sub(stream_data.unsubscribed_subs(), devel));
 
@@ -96,7 +96,7 @@ test("subscribers", () => {
     people.add_active_user(george);
 
     // verify setup
-    assert.ok(stream_data.is_subscribed_by_name(sub.name));
+    assert.ok(stream_data.is_subscribed(sub.stream_id));
 
     const stream_id = sub.stream_id;
 

--- a/web/tests/search.test.js
+++ b/web/tests/search.test.js
@@ -237,25 +237,26 @@ run_test("initialize", ({override, override_rewire, mock_template}) => {
             assert.equal(opts.updater("ver"), "ver");
             assert.ok(!input_pill_displayed);
 
+            const verona_stream_id = verona.stream_id.toString();
             terms = [
                 {
                     negated: false,
                     operator: "channel",
-                    operand: "Verona",
+                    operand: verona_stream_id,
                 },
             ];
             expected_pill_display_value = "channel: Verona";
             _setup(terms);
             input_pill_displayed = false;
             mock_pill_removes(search.search_pill_widget);
-            assert.equal(opts.updater("channel:Verona"), "");
+            assert.equal(opts.updater(`channel:${verona_stream_id}`), "");
             assert.ok(input_pill_displayed);
 
             search.__Rewire__("is_using_input_method", true);
             _setup(terms);
             input_pill_displayed = false;
             mock_pill_removes(search.search_pill_widget);
-            assert.equal(opts.updater("channel:Verona"), "");
+            assert.equal(opts.updater(`channel:${verona_stream_id}`), "");
             assert.ok(input_pill_displayed);
         }
         return {

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -83,7 +83,7 @@ const frontend = {
 };
 
 function narrow_to_frontend() {
-    const filter = new Filter([{operator: "stream", operand: "frontend"}]);
+    const filter = new Filter([{operator: "stream", operand: frontend.stream_id.toString()}]);
     message_lists.current = {
         data: {
             filter,
@@ -382,12 +382,12 @@ test("marked_subscribed (emails)", ({override}) => {
 
     $("#channels_overlay_container .stream-row:not(.notdisplayed)").length = 0;
 
-    assert.ok(!stream_data.is_subscribed_by_name(sub.name));
+    assert.ok(!stream_data.is_subscribed(sub.stream_id));
 
     const user_ids = [15, 20, 25, me.user_id];
     stream_events.mark_subscribed(sub, user_ids, "");
     assert.deepEqual(new Set(peer_data.get_subscribers(sub.stream_id)), new Set(user_ids));
-    assert.ok(stream_data.is_subscribed_by_name(sub.name));
+    assert.ok(stream_data.is_subscribed(sub.stream_id));
 
     const args = subs_stub.get_args("sub");
     assert.deepEqual(sub, args.sub);

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -429,19 +429,19 @@ test_ui("narrowing", ({mock_template}) => {
 
     let filter;
 
-    filter = new Filter([{operator: "stream", operand: "devel"}]);
+    filter = new Filter([{operator: "stream", operand: develSub.stream_id.toString()}]);
     stream_list.handle_narrow_activated(filter);
     assert.ok($("<devel-sidebar-row-stub>").hasClass("active-filter"));
 
     filter = new Filter([
-        {operator: "stream", operand: "cars"},
+        {operator: "stream", operand: carSub.stream_id.toString()},
         {operator: "topic", operand: "sedans"},
     ]);
     stream_list.handle_narrow_activated(filter);
     assert.ok(!$("ul.filters li").hasClass("active-filter"));
     assert.ok(!$("<cars-sidebar-row-stub>").hasClass("active-filter")); // false because of topic
 
-    filter = new Filter([{operator: "stream", operand: "cars"}]);
+    filter = new Filter([{operator: "stream", operand: carSub.stream_id.toString()}]);
     stream_list.handle_narrow_activated(filter);
     assert.ok(!$("ul.filters li").hasClass("active-filter"));
     assert.ok($("<cars-sidebar-row-stub>").hasClass("active-filter"));


### PR DESCRIPTION
This PR should have no user-facing changes except for being able to enter`stream: $stream_id` in search input (you would enter `stream: $stream_name` before and also after this change).

This is a very challenging refactor to find bugs for. I found several bugs through unit tests and futzing around in the dev environment, but I don't feel like there's any particularly good way to guarantee that all possible things that could break have been tested since the filter code is used for so many things. Seeking advice on what to do about that.


---

Two things I'm considering:

* ~~Looking for help with what we do in `slug_to_id_string` when neither id nor name is present. Maybe what's already written there is fine? It similar to what we did before~~
* Maybe make a prep commit removing the use of `_sub`?
