### PR TITLE
search-operators: Add before and after operators.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 281**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added two new [search/narrow filters](/api/construct-narrow#changes),
+  `before:yyyy-mm-dd` and `after:yyyy-mm-dd`, matching messages before
+  and after the specified date (inclusively).
+
 **Feature level 280**
 
 * `PATCH /realm`, [`POST /register`](/api/register-queue),

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -53,6 +53,10 @@ messages](/api/update-message-flags-for-narrow)).
 
 ## Changes
 
+* In Zulip 10.0 (feature level 281), support was added for two new filters,
+  `before:yyyy-mm-dd` and `after:yyyy-mm-dd`, matching messages before
+  and after the specified date (inclusively).
+
 * In Zulip 9.0 (feature level 271), support was added for a new filter
   operator, `with`, which uses a [message ID](#message-ids) for its
   operand, and is designed for creating permanent links to topics.

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -164,6 +164,25 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">before:<span class="operator_value">date</span></td>
+                        <td class="definition">
+                            {{#tr}}
+                                Narrow to messages sent before <z-value></z-value>.
+                                {{#*inline "z-value"}}<span class="operator_value">date</span>{{/inline}}
+                            {{/tr}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">after:<span class="operator_value">date</span></td>
+                        <td class="definition">
+                            {{#tr}}
+                                Narrow to messages sent after <z-value></z-value>.
+                                {{#*inline "z-value"}}<span class="operator_value">date</span>{{/inline}}
+                            {{/tr}}
+                        </td>
+                    </tr>
+
+                    <tr>
                         <td class="operator">-topic:<span class="operator_value">topic</span></td>
                         <td class="definition">
                             {{#tr}}

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -1011,3 +1011,63 @@ test("queries_with_spaces", () => {
     expected = ["channel:office"];
     assert.deepEqual(suggestions.strings, expected);
 });
+
+test("after_before_suggestions", () => {
+    // Blank query should give the default suggestions, which consists of today's date
+    // and the last 4 days.
+    let query = "after:";
+    let suggestions = get_suggestions(query);
+
+    const curr_date = new Date();
+
+    const expected_default_after = [];
+    for (let i = 0; i < 5; i += 1) {
+        expected_default_after.push("after:" + curr_date.toISOString().slice(0, 10));
+        curr_date.setDate(curr_date.getDate() - 1);
+    }
+    assert.deepEqual(suggestions.strings, expected_default_after);
+
+    query = "before:";
+    suggestions = get_suggestions(query);
+
+    curr_date.setTime(Date.now());
+    const expected_default_before = [];
+    for (let i = 0; i < 5; i += 1) {
+        expected_default_before.push("before:" + curr_date.toISOString().slice(0, 10));
+        curr_date.setDate(curr_date.getDate() - 1);
+    }
+    assert.deepEqual(suggestions.strings, expected_default_before);
+
+    query = "after:20";
+    suggestions = get_suggestions(query);
+
+    curr_date.setTime(Date.now());
+    const expected_after = [];
+    for (let i = 0; i < 5; i += 1) {
+        expected_after.push("after:20" + curr_date.toISOString().slice(2, 10));
+        curr_date.setDate(curr_date.getDate() - 1);
+    }
+    assert.deepEqual(suggestions.strings, expected_after);
+
+    query = "before:20";
+    suggestions = get_suggestions(query);
+
+    curr_date.setTime(Date.now());
+    const expected_before = [];
+    for (let i = 0; i < 5; i += 1) {
+        expected_before.push("before:20" + curr_date.toISOString().slice(2, 10));
+        curr_date.setDate(curr_date.getDate() - 1);
+    }
+    assert.deepEqual(suggestions.strings, expected_before);
+
+    // Invalid date should give the default suggestions
+    query = "after:2022-01-42";
+    suggestions = get_suggestions(query);
+
+    assert.deepEqual(suggestions.strings, expected_default_after);
+
+    query = "before:2022-01-42";
+    suggestions = get_suggestions(query);
+
+    assert.deepEqual(suggestions.strings, expected_default_before);
+});


### PR DESCRIPTION
The `before` operator is used to search for messages sent before the
specified date, while the `after` operator is used to search for
messages sent after the specified date. Both are inclusive.
The date should be in the yyyy-mm-dd format.

Partially fixes #25436.