### PR TITLE
settings: Fix broken label interactions in settings.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -45,6 +45,7 @@ async function close_settings_and_date_picker(page: Page): Promise<void> {
 }
 
 async function test_change_full_name(page: Page): Promise<void> {
+    await page.waitForSelector("#full_name", {visible: true});
     await page.click("#full_name");
 
     const full_name_input_selector = 'input[name="full_name"]';

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -154,6 +154,16 @@ export function initialize_custom_user_type_fields(
         }
     }
 
+    // Enable the label associated to this field to focus on the input when clicked.
+    $(element_id)
+        .find(".custom_user_field label.settings-field-label")
+        .on("click", function () {
+            const $input_element = $(this)
+                .closest(".custom_user_field")
+                .find(".person_picker.pill-container .input");
+            $input_element.trigger("focus");
+        });
+
     return user_pills;
 }
 

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -170,6 +170,13 @@ export function initialize_custom_date_type_fields(element_id: string): void {
         static: true,
     });
 
+    // Enable the label associated to this field to open the datepicker when clicked.
+    $(element_id)
+        .find(".custom_user_field label.settings-field-label")
+        .on("click", function () {
+            $(this).closest(".custom_user_field").find("input.datepicker").trigger("click");
+        });
+
     $(element_id)
         .find<HTMLInputElement>(".custom_user_field input.datepicker")
         .on("mouseenter", function () {

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -591,6 +591,7 @@ export function set_up_handlers(): void {
     });
 
     set_up_group_setting_widgets();
+    settings_components.enable_opening_typeahead_on_clicking_label($container);
 }
 
 export function initialize(): void {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -391,6 +391,8 @@
 
 .modal-field-label {
     margin-bottom: var(--margin-bottom-field-description);
+    /* Avoid having the clickable area extend to the full width of the containing element */
+    width: fit-content;
 }
 
 .dropdown-widget-button {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1645,6 +1645,8 @@ $option_title_width: 180px;
 
 .settings-field-label {
     margin-bottom: var(--margin-bottom-field-description);
+    /* Avoid having the clickable area extend to the full width of the containing element */
+    width: fit-content;
 }
 
 .settings-profile-user-field-hint {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1192,6 +1192,11 @@ div.settings-radio-input-parent {
     height: inherit;
 }
 
+.group-setting-label {
+    /* Avoid having the clickable area extend to the full width of the containing element */
+    width: fit-content;
+}
+
 @media (width < $lg_min) {
     .user-groups-container,
     .subscriptions-container {

--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,4 @@
 <form id="change_email_form">
-    <label for="email" class="modal-field-label">{{t "New email" }}</label>
-    <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+    <label for="change-email-form-input-email" class="modal-field-label">{{t "New email" }}</label>
+    <input id="change-email-form-input-email" type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -7,7 +7,7 @@
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
-                    <label class="settings-field-label">{{t "Email" }}</label>
+                    <label class="settings-field-label" for="change_email_button">{{t "Email" }}</label>
                     <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                         <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
                             {{current_user.delivery_email}}
@@ -42,7 +42,7 @@
             <form class="password-change-form grid">
                 {{#if user_can_change_password}}
                 <div>
-                    <label class="settings-field-label">{{t "Password" }}</label>
+                    <label class="settings-field-label" for="change_password">{{t "Password" }}</label>
                     <div class="input-group">
                         <button id="change_password" type="button" class="button rounded" data-dismiss="modal">{{t "Change your password" }}</button>
                     </div>
@@ -102,7 +102,7 @@
                   }}
             </div>
             <div class="input-group">
-                <label for="email_address_visibility" class="settings-field-label">{{t "Who can access your email address" }}
+                <label for="user_email_address_visibility" class="settings-field-label">{{t "Who can access your email address" }}
                     {{> ../help_link_widget link="/help/configure-email-visibility" }}
                 </label>
                 <div id="user_email_address_dropdown_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -1,7 +1,7 @@
 <form id="create_bot_form">
     <div class="new-bot-form">
         <div class="input-group">
-            <label for="bot_type" class="modal-field-label">
+            <label for="create_bot_type" class="modal-field-label">
                 {{t "Bot type" }}
                 {{> ../help_link_widget link="/help/bots-overview#bot-type" }}
             </label>
@@ -28,7 +28,7 @@
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
         <div class="input-group">
-            <label for="bot_short_name" class="modal-field-label">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
+            <label for="create_bot_short_name" class="modal-field-label">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"
               placeholder="{{t 'cookie' }}" value="" />
             -bot@{{ realm_bot_domain }}

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -13,7 +13,7 @@
                     <div id="api_key_form">
                         <p>{{t "Please re-enter your password to confirm your identity." }}</p>
                         <div class="settings-password-div">
-                            <label for="password" class="modal-field-label">{{t "Your password" }}</label>
+                            <label for="get_api_key_password" class="modal-field-label">{{t "Your password" }}</label>
                             <div class="password-input-row">
                                 <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
                                 <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -1,15 +1,15 @@
 <div class="custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
     <span class="custom-user-field-label-wrapper {{#if field.required}}required-field-wrapper{{/if}}">
-        <label class="settings-field-label inline-block title" for="{{ field.name }}">{{ field.name }}</label>
+        <label class="settings-field-label inline-block title" for="id_custom_profile_field_input_{{ field.id }}">{{ field.name }}</label>
         <span class="required-symbol {{#unless is_empty_required_field}}hidden{{/unless}}"> *</span>
     </span>
     <div class="alert-notification custom-field-status"></div>
     <div class="settings-profile-user-field-hint">{{ field.hint }}</div>
     <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}} {{#unless editable_by_user}}not-editable-by-user-input-wrapper{{/unless}}">
         {{#if is_long_text_field}}
-        <textarea maxlength="500" class="custom_user_field_value settings_textarea" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
+        <textarea id="id_custom_profile_field_input_{{ field.id }}" maxlength="500" class="custom_user_field_value settings_textarea" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
         {{else if is_select_field}}
-        <select class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>
+        <select id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>
             <option value=""></option>
             {{#each field_choices}}
                 <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
@@ -24,11 +24,11 @@
           value="{{ field_value.value }}" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{#if editable_by_user}}<span class="remove_date"><i class="fa fa-close"></i></span>{{/if}}
         {{else if is_url_field }}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" {{#unless editable_by_user}}disabled{{/unless}}/>
+        <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else if is_pronouns_field}}
-        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
+        <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else}}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
+        <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{/if}}
     </div>
 </div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -1,6 +1,6 @@
 <div class="custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
     <span class="custom-user-field-label-wrapper {{#if field.required}}required-field-wrapper{{/if}}">
-        <label class="settings-field-label inline-block" for="{{ field.name }}" class="title">{{ field.name }}</label>
+        <label class="settings-field-label inline-block title" for="{{ field.name }}">{{ field.name }}</label>
         <span class="required-symbol {{#unless is_empty_required_field}}hidden{{/unless}}"> *</span>
     </span>
     <div class="alert-notification custom-field-status"></div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -1,6 +1,6 @@
 <div class="custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
     <span class="custom-user-field-label-wrapper {{#if field.required}}required-field-wrapper{{/if}}">
-        <label class="settings-field-label inline-block title" for="id_custom_profile_field_input_{{ field.id }}">{{ field.name }}</label>
+        <label class="settings-field-label inline-block" for="id_custom_profile_field_input_{{ field.id }}">{{ field.name }}</label>
         <span class="required-symbol {{#unless is_empty_required_field}}hidden{{/unless}}"> *</span>
     </span>
     <div class="alert-notification custom-field-status"></div>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -1,11 +1,11 @@
 {{#with profile_field_info}}
 <form class="name-setting profile-field-form" id="edit-custom-profile-field-form-{{id}}" data-profile-field-id="{{id}}">
     <div class="input-group">
-        <label for="name" class="modal-field-label">{{t "Label" }}</label>
+        <label for="id-custom-profile-field-name" class="modal-field-label">{{t "Label" }}</label>
         <input type="text" name="name" id="id-custom-profile-field-name" class="modal_text_input prop-element" value="{{ name }}" maxlength="40" data-setting-widget-type="string" />
     </div>
     <div class="input-group hint_change_container">
-        <label for="hint" class="modal-field-label">{{t "Hint" }}</label>
+        <label for="id-custom-profile-field-hint" class="modal-field-label">{{t "Hint" }}</label>
         <input type="text" name="hint" id="id-custom-profile-field-hint" class="modal_text_input prop-element" value="{{ hint }}" maxlength="80" data-setting-widget-type="string" />
     </div>
     {{#if is_select_field }}

--- a/web/templates/settings/language_selection_widget.hbs
+++ b/web/templates/settings/language_selection_widget.hbs
@@ -1,11 +1,11 @@
 <div class="language_selection_widget input-group prop-element" id="id_{{section_name}}" data-setting-widget-type="language-setting">
-    <label class="settings-field-label">
+    <label class="settings-field-label" for="id_language_selection_button">
         {{section_title}}
         {{#if help_link_widget_link}}
         {{> ../help_link_widget link=help_link_widget_link }}
         {{/if}}
     </label>
-    <button type="button" class="language_selection_button button rounded tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
+    <button type="button" id="id_language_selection_button" class="language_selection_button button rounded tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
         <span class="{{section_name}}" data-language-code="{{language_code}}">{{setting_value}}</span>
     </button>
 </div>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -70,7 +70,7 @@
         </div>
 
         <div class="input-group">
-            <label for="automatically_follow_topics_policy" class="settings-field-label">
+            <label for="{{prefix}}automatically_follow_topics_policy" class="settings-field-label">
                 {{ settings_label.automatically_follow_topics_policy }}
                 {{> ../help_link_widget link="/help/follow-a-topic" }}
             </label>
@@ -81,7 +81,7 @@
         </div>
 
         <div class="input-group">
-            <label for="automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">
+            <label for="{{prefix}}automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">
                 {{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}
                 {{> ../help_link_widget link="/help/mute-a-topic" }}
             </label>
@@ -139,7 +139,7 @@
         </div>
 
         <div class="input-group">
-            <label for="desktop_icon_count_display" class="settings-field-label">{{ settings_label.desktop_icon_count_display }}</label>
+            <label for="{{prefix}}desktop_icon_count_display" class="settings-field-label">{{ settings_label.desktop_icon_count_display }}</label>
             <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element settings_select bootstrap-focus-style" id="{{prefix}}desktop_icon_count_display" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=desktop_icon_count_display_values}}
             </select>
@@ -184,7 +184,7 @@
 
         <div class="input-group time-limit-setting">
 
-            <label for="email_notifications_batching_period" class="settings-field-label">
+            <label for="{{prefix}}email_notifications_batching_period_seconds" class="settings-field-label">
                 {{t "Delay before sending message notification emails" }}
             </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element settings_select bootstrap-focus-style" id="{{prefix}}email_notifications_batching_period_seconds" data-setting-widget-type="time-limit">
@@ -193,7 +193,7 @@
                 {{/each}}
             </select>
             <div class="dependent-settings-block">
-                <label for="email_notification_batching_period_edit_minutes" class="inline-block">
+                <label for="{{prefix}}email_notification_batching_period_edit_minutes" class="inline-block">
                     {{t 'Delay period (minutes)' }}:
                 </label>
                 <input type="text"
@@ -206,7 +206,7 @@
         </div>
 
         <div class="input-group">
-            <label for="realm_name_in_email_notifications_policy" class="settings-field-label">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
+            <label for="{{prefix}}realm_name_in_email_notifications_policy" class="settings-field-label">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
             <select name="realm_name_in_email_notifications_policy" class="setting_realm_name_in_email_notifications_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}realm_name_in_email_notifications_policy" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=realm_name_in_email_notifications_policy_values}}
             </select>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -16,7 +16,7 @@
                       prefix="id_"
                       is_checked=realm_invite_required
                       label=admin_settings_label.realm_invite_required}}
-                    <label for="realm_invite_to_realm_policy" class="settings-field-label">{{t "Who can send email invitations to new users" }}
+                    <label for="id_realm_invite_to_realm_policy" class="settings-field-label">{{t "Who can send email invitations to new users" }}
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
@@ -28,7 +28,7 @@
                   label=(t 'Who can create reusable invitation links')}}
 
                 <div class="input-group">
-                    <label for="realm_org_join_restrictions" class="settings-field-label">{{t "Restrict email domains of new users" }}</label>
+                    <label for="id_realm_org_join_restrictions" class="settings-field-label">{{t "Restrict email domains of new users" }}</label>
                     <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
                         <option value="no_restriction">{{t "No restrictions" }}</option>
                         <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
@@ -42,7 +42,7 @@
                     </div>
                 </div>
                 <div class="input-group time-limit-setting">
-                    <label for="realm_waiting_period_threshold" class="settings-field-label">
+                    <label for="id_realm_waiting_period_threshold" class="settings-field-label">
                         {{t "Waiting period before new members turn into full members" }}
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
@@ -90,13 +90,13 @@
                   label=(t 'Who can create private channels')}}
 
                 <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="settings-field-label">{{t "Who can add users to channels" }}</label>
+                    <label for="id_realm_invite_to_stream_policy" class="settings-field-label">{{t "Who can add users to channels" }}</label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_wildcard_mention_policy" class="settings-field-label">{{t "Who can notify a large number of users with a wildcard mention" }}
+                    <label for="id_realm_wildcard_mention_policy" class="settings-field-label">{{t "Who can notify a large number of users with a wildcard mention" }}
                         {{> ../help_link_widget link="/help/restrict-wildcard-mentions" }}
                     </label>
                     <select name="realm_wildcard_mention_policy" id="id_realm_wildcard_mention_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
@@ -162,7 +162,7 @@
                   label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_edit_limit_seconds" class="settings-field-label">{{t "Time limit for editing messages" }}</label>
+                    <label for="id_realm_message_content_edit_limit_seconds" class="settings-field-label">{{t "Time limit for editing messages" }}</label>
                     <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
                         {{#each msg_edit_limit_dropdown_values}}
                             <option value="{{value}}">{{text}}</option>
@@ -196,7 +196,7 @@
               label=(t 'Who can move messages to another topic')}}
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_within_stream_limit_seconds" class="settings-field-label">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="id_realm_move_messages_within_stream_limit_seconds" class="settings-field-label">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
                 <select name="realm_move_messages_within_stream_limit_seconds" id="id_realm_move_messages_within_stream_limit_seconds" class="prop-element settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
@@ -218,7 +218,7 @@
               label=(t 'Who can move messages to another channel')}}
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_between_streams_limit_seconds" class="settings-field-label">{{t "Time limit for moving messages between channels" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="id_realm_move_messages_between_streams_limit_seconds" class="settings-field-label">{{t "Time limit for moving messages between channels" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
                 <select name="realm_move_messages_between_streams_limit_seconds" id="id_realm_move_messages_between_streams_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
@@ -253,7 +253,7 @@
                   label=(t 'Who can delete their own messages')}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_delete_limit_seconds" class="settings-field-label">
+                    <label for="id_realm_message_content_delete_limit_seconds" class="settings-field-label">
                         {{t "Time limit for deleting messages" }} <i>({{t "does not apply to users who can delete any message" }})</i>
                     </label>
                     <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
@@ -338,7 +338,7 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_bot_creation_policy" class="settings-field-label">{{t "Who can add bots" }}</label>
+                    <label for="id_realm_bot_creation_policy" class="settings-field-label">{{t "Who can add bots" }}</label>
                     <select name="realm_bot_creation_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_bot_creation_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=bot_creation_policy_values}}
                     </select>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -18,7 +18,7 @@
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
-                    <label for="realm_org_type" class="settings-field-label">{{t "Organization type" }}
+                    <label for="id_realm_org_type" class="settings-field-label">{{t "Organization type" }}
                         {{> ../help_link_widget link="/help/organization-type" }}
                     </label>
                     <select name="realm_org_type" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_org_type" data-setting-widget-type="number">
@@ -33,7 +33,7 @@
                   label=admin_settings_label.realm_want_advertise_in_communities_directory
                   help_link="/help/communities-directory"}}
                 <div class="input-group admin-realm">
-                    <label for="realm_description" class="settings-field-label">{{t "Organization description" }}</label>
+                    <label for="id_realm_description" class="settings-field-label">{{t "Organization description" }}</label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element settings_textarea"
                       maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>
                 </div>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -50,7 +50,7 @@
                   label=admin_settings_label.realm_digest_emails_enabled}}
                 {{/if}}
                 <div class="input-group">
-                    <label for="realm_digest_weekday" class="settings-field-label">{{t "Day of the week to send digests" }}</label>
+                    <label for="id_realm_digest_weekday" class="settings-field-label">{{t "Day of the week to send digests" }}</label>
                     <select name="realm_digest_weekday"
                       id="id_realm_digest_weekday"
                       class="setting-widget prop-element settings_select bootstrap-focus-style"
@@ -110,7 +110,7 @@
             </div>
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
-                    <label for="realm_video_chat_provider" class="settings-field-label">
+                    <label for="id_realm_video_chat_provider" class="settings-field-label">
                         {{t 'Call provider' }}
                         {{> ../help_link_widget link="/help/start-a-call" }}
                     </label>
@@ -148,7 +148,7 @@
                     </div>
                 </div>
                 <div class="input-group">
-                    <label for="realm_giphy_rating" class="settings-field-label">
+                    <label for="id_realm_giphy_rating" class="settings-field-label">
                         {{t 'GIPHY integration' }}
                         {{> ../help_link_widget link=giphy_help_link }}
                     </label>

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -40,7 +40,7 @@
           help_link="/help/read-receipts"}}
 
         <div class="input-group">
-            <label for="email_address_visibility" class="settings-field-label">{{t "Who can access user's email address" }}
+            <label for="realm_email_address_visibility" class="settings-field-label">{{t "Who can access user's email address" }}
                 {{> ../help_link_widget link="/help/configure-email-visibility" }}
             </label>
             <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -14,7 +14,7 @@
     {{/unless}}
 
     <div class="input-group">
-        <label for="twenty_four_hour_time" class="settings-field-label">{{ settings_label.twenty_four_hour_time }}</label>
+        <label for="{{prefix}}twenty_four_hour_time" class="settings-field-label">{{ settings_label.twenty_four_hour_time }}</label>
         <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style" id="{{prefix}}twenty_four_hour_time" data-setting-widget-type="string">
             {{#each twenty_four_hour_time_values}}
                 <option value='{{ this.value }}'>{{ this.description }}</option>
@@ -22,7 +22,7 @@
         </select>
     </div>
     <div class="input-group">
-        <label for="color_scheme" class="settings-field-label">{{t "Theme" }}</label>
+        <label for="{{prefix}}color_scheme" class="settings-field-label">{{t "Theme" }}</label>
         <select name="color_scheme" class="setting_color_scheme prop-element settings_select bootstrap-focus-style" id="{{prefix}}color_scheme" data-setting-widget-type="number">
             {{> dropdown_options_widget option_values=color_scheme_values}}
         </select>

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -50,14 +50,14 @@
     </div>
 
     <div class="input-group thinner setting-next-is-related">
-        <label for="web_animate_image_previews" class="settings-field-label">{{t "Play animated images" }}</label>
+        <label for="{{prefix}}web_animate_image_previews" class="settings-field-label">{{t "Play animated images" }}</label>
         <select name="web_animate_image_previews" class="setting_web_animate_image_previews prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_animate_image_previews" data-setting-widget-type="string">
             {{> dropdown_options_widget option_values=web_animate_image_previews_values}}
         </select>
     </div>
 
     <div class="input-group">
-        <label for="web_stream_unreads_count_display_policy" class="settings-field-label">{{t "Show unread counts for" }}</label>
+        <label for="{{prefix}}web_stream_unreads_count_display_policy" class="settings-field-label">{{t "Show unread counts for" }}</label>
         <select name="web_stream_unreads_count_display_policy" class="setting_web_stream_unreads_count_display_policy prop-element bootstrap-focus-style settings_select" id="{{prefix}}web_stream_unreads_count_display_policy"  data-setting-widget-type="number">
             {{> dropdown_options_widget option_values=web_stream_unreads_count_display_policy_values}}
         </select>
@@ -73,7 +73,7 @@
     {{/each}}
 
     <div class="input-group">
-        <label for="demote_inactive_streams" class="settings-field-label">{{t "Demote inactive channels" }}
+        <label for="{{prefix}}demote_inactive_streams" class="settings-field-label">{{t "Demote inactive channels" }}
             {{> ../help_link_widget link="/help/manage-inactive-channels" }}
         </label>
         <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element settings_select bootstrap-focus-style" id="{{prefix}}demote_inactive_streams"  data-setting-widget-type="number">

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -5,7 +5,7 @@
     </div>
 
     <div class="input-group thinner setting-next-is-related">
-        <label for="web_home_view" class="settings-field-label">{{t "Home view" }}
+        <label for="{{prefix}}web_home_view" class="settings-field-label">{{t "Home view" }}
             {{> ../help_link_widget link="/help/configure-home-view" }}
         </label>
         <select name="web_home_view" class="setting_web_home_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_home_view" data-setting-widget-type="string">
@@ -26,7 +26,7 @@
       prefix=prefix}}
 
     <div class="input-group">
-        <label for="web_mark_read_on_scroll_policy" class="settings-field-label">{{t "Automatically mark messages as read" }}
+        <label for="{{prefix}}web_mark_read_on_scroll_policy" class="settings-field-label">{{t "Automatically mark messages as read" }}
             {{> ../help_link_widget link="/help/marking-messages-as-read" }}
         </label>
         <select name="web_mark_read_on_scroll_policy" class="setting_web_mark_read_on_scroll_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_mark_read_on_scroll_policy"  data-setting-widget-type="number">
@@ -35,7 +35,7 @@
     </div>
 
     <div class="input-group">
-        <label for="web_channel_default_view" class="settings-field-label">{{t "Channel links in the left sidebar go to" }}</label>
+        <label for="{{prefix}}web_channel_default_view" class="settings-field-label">{{t "Channel links in the left sidebar go to" }}</label>
         <select name="web_channel_default_view" class="setting_web_channel_default_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_channel_default_view"  data-setting-widget-type="number">
             {{> dropdown_options_widget option_values=web_channel_default_view_values}}
         </select>

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -18,7 +18,7 @@
 
                 <form class="timezone-setting-form">
                     <div class="input-group grid">
-                        <label for="timezone" class="settings-field-label inline-block">{{t "Time zone" }}</label>
+                        <label for="user_timezone" class="settings-field-label inline-block">{{t "Time zone" }}</label>
                         <div class="alert-notification timezone-setting-status"></div>
                         <div class="timezone-input">
                             <select name="timezone" id="user_timezone" class="bootstrap-focus-style settings_select">

--- a/web/templates/stream_settings/announce_stream_checkbox.hbs
+++ b/web/templates/stream_settings/announce_stream_checkbox.hbs
@@ -1,5 +1,5 @@
-<label class="checkbox">
-    <input type="checkbox" name="announce" value="announce" checked />
+<label class="checkbox" for="id_should_announce_new_stream">
+    <input type="checkbox" name="announce" value="announce" checked id="id_should_announce_new_stream"/>
     <span class="rendered-checkbox"></span>
     {{t "Announce new channel in"}}
     {{#if new_stream_announcements_stream_sub}}

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -34,7 +34,7 @@
                 </div>
                 <div class="subscribers_container stream_creation_container">
                     <section class="stream_create_add_subscriber_container">
-                        <label class="choose-subscribers-label" for="people_to_add">
+                        <label class="choose-subscribers-label">
                             <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
                         </label>
                         <span class="add_all_users_to_stream_button_container">

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -54,7 +54,7 @@
     <div class="advanced-configurations-collapase-view hide">
 
         <div class="input-group">
-            <label class="dropdown-title" for="{{prefix}}stream_post_policy">{{t 'Who can post to this channel'}}
+            <label class="dropdown-title settings-field-label" for="{{prefix}}stream_post_policy">{{t 'Who can post to this channel'}}
                 {{> ../help_link_widget link="/help/stream-sending-policy" }}
             </label>
             <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="{{prefix}}stream_post_policy" data-setting-widget-type="number">
@@ -74,7 +74,7 @@
         {{#if (or is_owner is_stream_edit)}}
             <div>
                 <div class="input-group inline-block message-retention-setting-group time-limit-setting">
-                    <label class="dropdown-title" for="{{prefix}}message_retention_days">{{t "Message retention period" }}
+                    <label class="dropdown-title settings-field-label" for="{{prefix}}message_retention_days">{{t "Message retention period" }}
                         {{> ../help_link_widget link="/help/message-retention-policy" }}
                     </label>
 

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -54,7 +54,7 @@
     <div class="advanced-configurations-collapase-view hide">
 
         <div class="input-group">
-            <label class="dropdown-title">{{t 'Who can post to this channel'}}
+            <label class="dropdown-title" for="{{prefix}}stream_post_policy">{{t 'Who can post to this channel'}}
                 {{> ../help_link_widget link="/help/stream-sending-policy" }}
             </label>
             <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="{{prefix}}stream_post_policy" data-setting-widget-type="number">
@@ -74,7 +74,7 @@
         {{#if (or is_owner is_stream_edit)}}
             <div>
                 <div class="input-group inline-block message-retention-setting-group time-limit-setting">
-                    <label class="dropdown-title">{{t "Message retention period" }}
+                    <label class="dropdown-title" for="{{prefix}}message_retention_days">{{t "Message retention period" }}
                         {{> ../help_link_widget link="/help/message-retention-policy" }}
                     </label>
 
@@ -90,7 +90,7 @@
                     </select>
 
                     <div class="dependent-settings-block stream-message-retention-days-input">
-                        <label class="inline-block">
+                        <label class="inline-block" for="{{prefix}}stream_message_retention_custom_input">
                             {{t 'Retention period (days)' }}:
                         </label>
                         <input type="text" autocomplete="off"


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Currently, there are a lot of clickable labels in our settings menu, however upon clicking on the labels actually performs no actions. These cursors should at least perform an action when being clicked upon, otherwise they should remain to be default cursor.

Changes are of the following:

- Text that point to a button will automatically perform the button's action (e.g. opening menu). Uses pointer cursor.
- Text that point to a select/dropdown will focus on those select/dropdodwn. Uses pointer cursor.
- Text that point to a textfield will focus on those textfield. Uses pointer cursor.
- Text that clearly doesn't serve as a heading or label for a setting selector, will do nothing and receive a regular cursor rather than a pointer cursor.

- Labels uses the width of its text rather than the container. 

- Add event listeners to labels with non-native elements so they can open their corresponding element when clicked. 

Changes here are apply to: Personal settings, Organization settings, Channel settings

Fixes: https://github.com/zulip/zulip/issues/21769.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Ensure interactivity in labels</summary>
<br>

| Before | After |
| --- | --- |
| ![2370896ae9ec2940ca87c2b636bb9e85](https://github.com/user-attachments/assets/daac8c63-9908-4be0-814b-20ccc56bdb75) | ![4ff31e4d493aeff04741284e7b1e6b6b](https://github.com/user-attachments/assets/d115a78d-6156-4962-9eed-3b33d7334bc7)
| ![5a67a35b3e2979c1341f5489edf21a9f](https://github.com/user-attachments/assets/e543fc24-12f2-4468-a6e5-1f04c8c25f8d) | ![6297886392cc476d9921e4e055fc4d6c](https://github.com/user-attachments/assets/259b3d88-035e-49a9-8cca-f9ea123655b5)
</details>

<details>
<summary>Ensure labels only take up its content's width</summary>

| Before | After |
| --- | --- |
| ![280c42ad13873bcf3e5c27e10ada52a1](https://github.com/user-attachments/assets/b792ae28-ea2a-4d12-b52f-4d92677c49cd) | ![0ce56ec17414066f96a1aee6a11016c9](https://github.com/user-attachments/assets/aa2af737-8127-47ef-8968-96bac7dddaec)|
</details>

<details>
<summary>Add event listeners to non-native elements</summary>

| Before | After |
| --- | --- |
|![860175875f9b81657df1a4d158ba08be](https://github.com/user-attachments/assets/a608e8c9-59af-4937-ace8-9c9ab9afc2e6)|![b12e738f9bdc70fbc9733cf812ae2cc0](https://github.com/user-attachments/assets/992d9756-d2bb-4d85-9f5e-e7f7f2f33d45)|
|![a5c4bd2005586229eb28d2c379789560](https://github.com/user-attachments/assets/4088e68c-8dd1-4967-815b-113c7451c97d)|![d53cf6c041132fcb5d534610e6f2a831](https://github.com/user-attachments/assets/f4be6a9c-3954-4c19-b2e6-f6ca8ecd3b68)|
|![4987474646e4b0879152d9c7dba36d75](https://github.com/user-attachments/assets/f6296ebb-95ae-47a2-843c-242e8e540430)| ![17f80de523e187818965b034aadd679a](https://github.com/user-attachments/assets/6ddedf15-6030-4bfb-afa8-751ccd929aee)|
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
