### PR TITLE
Migrate action functions to send event on commit.

### DIFF
--- a/zerver/actions/onboarding_steps.py
+++ b/zerver/actions/onboarding_steps.py
@@ -1,9 +1,12 @@
+from django.db import transaction
+
 from zerver.lib.onboarding_steps import get_next_onboarding_steps
 from zerver.models import OnboardingStep, UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
+@transaction.atomic(durable=True)
 def do_mark_onboarding_step_as_read(user: UserProfile, onboarding_step: str) -> None:
     OnboardingStep.objects.get_or_create(user=user, onboarding_step=onboarding_step)
     event = dict(type="onboarding_steps", onboarding_steps=get_next_onboarding_steps(user))
-    send_event(user.realm, event, [user.id])
+    send_event_on_commit(user.realm, event, [user.id])

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -255,6 +255,7 @@ def notify_remove_scheduled_message(user_profile: UserProfile, scheduled_message
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
+@transaction.atomic(durable=True)
 def delete_scheduled_message(user_profile: UserProfile, scheduled_message_id: int) -> None:
     scheduled_message_object = access_scheduled_message(user_profile, scheduled_message_id)
     scheduled_message_id = scheduled_message_object.id

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -26,7 +26,7 @@ from zerver.models import (
 )
 from zerver.models.groups import SystemGroups
 from zerver.models.users import active_user_ids
-from zerver.tornado.django_api import send_event, send_event_on_commit
+from zerver.tornado.django_api import send_event_on_commit
 
 
 class MemberGroupUserDict(TypedDict):
@@ -35,7 +35,7 @@ class MemberGroupUserDict(TypedDict):
     date_joined: datetime
 
 
-@transaction.atomic
+@transaction.atomic(savepoint=False)
 def create_user_group_in_database(
     name: str,
     members: list[UserProfile],
@@ -182,7 +182,7 @@ def do_send_create_user_group_event(
             can_mention_group=get_group_setting_value_for_api(user_group.can_mention_group),
         ),
     )
-    send_event(user_group.realm, event, active_user_ids(user_group.realm_id))
+    send_event_on_commit(user_group.realm, event, active_user_ids(user_group.realm_id))
 
 
 def check_add_user_group(

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -425,7 +425,7 @@ def remove_subgroups_from_user_group(
 
 def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: int) -> None:
     event = dict(type="user_group", op="remove", group_id=user_group_id)
-    send_event(realm, event, active_user_ids(realm_id))
+    send_event_on_commit(realm, event, active_user_ids(realm_id))
 
 
 def check_delete_user_group(user_group: NamedUserGroup, *, acting_user: UserProfile) -> None:

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -213,7 +213,7 @@ def do_send_user_group_update_event(
     user_group: NamedUserGroup, data: dict[str, str | int | AnonymousSettingGroupDict]
 ) -> None:
     event = dict(type="user_group", op="update", group_id=user_group.id, data=data)
-    send_event(user_group.realm, event, active_user_ids(user_group.realm_id))
+    send_event_on_commit(user_group.realm, event, active_user_ids(user_group.realm_id))
 
 
 @transaction.atomic(savepoint=False)

--- a/zerver/actions/video_calls.py
+++ b/zerver/actions/video_calls.py
@@ -1,11 +1,14 @@
+from django.db import transaction
+
 from zerver.models import UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
+@transaction.atomic(durable=True)
 def do_set_zoom_token(user: UserProfile, token: dict[str, object] | None) -> None:
     user.zoom_token = token
     user.save(update_fields=["zoom_token"])
-    send_event(
+    send_event_on_commit(
         user.realm,
         dict(type="has_zoom_token", value=token is not None),
         [user.id],

--- a/zerver/lib/drafts.py
+++ b/zerver/lib/drafts.py
@@ -18,7 +18,7 @@ from zerver.lib.streams import access_stream_by_id
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.typed_endpoint import RequiredStringConstraint
 from zerver.models import Draft, UserProfile
-from zerver.tornado.django_api import send_event, send_event_on_commit
+from zerver.tornado.django_api import send_event_on_commit
 
 ParamT = ParamSpec("ParamT")
 
@@ -150,6 +150,7 @@ def do_edit_draft(draft_id: int, draft: DraftData, user_profile: UserProfile) ->
         send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
+@transaction.atomic(durable=True)
 def do_delete_draft(draft_id: int, user_profile: UserProfile) -> None:
     """Delete a draft belonging to a particular user."""
     try:
@@ -161,4 +162,4 @@ def do_delete_draft(draft_id: int, user_profile: UserProfile) -> None:
     draft_object.delete()
 
     event = {"type": "drafts", "op": "remove", "draft_id": draft_id}
-    send_event(user_profile.realm, event, [user_profile.id])
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -580,9 +580,11 @@ class GetEventsTest(ZulipTestCase):
 
             client = allocate_client_descriptor(queue_data)
 
-            try_update_realm_custom_profile_field(
-                realm=user_profile.realm, field=profile_field, name=new_name
-            )
+            with self.captureOnCommitCallbacks(execute=True):
+                try_update_realm_custom_profile_field(
+                    realm=user_profile.realm, field=profile_field, name=new_name
+                )
+
             result = self.tornado_call(
                 get_events,
                 user_profile,

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -95,7 +95,7 @@ def get_user_group(request: HttpRequest, user_profile: UserProfile) -> HttpRespo
     return json_success(request, data={"user_groups": user_groups})
 
 
-@transaction.atomic
+@transaction.atomic(durable=True)
 @require_user_group_edit_permission
 @typed_endpoint
 def edit_user_group(

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -45,6 +45,7 @@ from zerver.models.users import get_system_bot
 from zerver.views.streams import compose_views
 
 
+@transaction.atomic(durable=True)
 @require_user_group_edit_permission
 @typed_endpoint
 def add_user_group(


### PR DESCRIPTION
PR to continue the sweep work of `send_event` -> `send_event_on_commit` after the [recent discussion in CZO](https://chat.zulip.org/#narrow/stream/3-backend/topic/make.20add_subscription_backend.20atomic/near/1910620)

After this PR:
* 25 more occurrences of `send_event` is remaining to sweep.
* Changes to use `durable=True` instead of `savepoint=False` in the outermost transactions, in the existing code.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
