### PR TITLE
slack_import: Support converting Slack's integration bot messages.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -46,6 +46,7 @@ from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack_message_conversion import (
     convert_to_zulip_markdown,
     get_user_full_name,
+    process_slack_block_and_attachment,
 )
 from zerver.lib.emoji import codepoint_to_name, get_emoji_file_name
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE, do_common_export_processes
@@ -932,6 +933,15 @@ def channel_message_to_zerver_message(
         ]:
             continue
 
+        formatted_block = process_slack_block_and_attachment(message)
+
+        # Leave it as is if formatted_block is an empty string, it's likely
+        # one of the unhandled_types.
+        if formatted_block != "":
+            # For most cases, the value of message["text"] will be just an
+            # empty string.
+            message["text"] = formatted_block
+
         try:
             content, mentioned_user_ids, has_link = convert_to_zulip_markdown(
                 message["text"], users, added_channels, slack_user_id_to_zulip_user_id
@@ -1272,6 +1282,8 @@ def get_message_sending_user(message: ZerverFieldsT) -> str | None:
         return message["user"]
     if message.get("file"):
         return message["file"].get("user")
+    if message.get("bot_id"):
+        return message.get("bot_id")
     return None
 
 

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1446,6 +1446,188 @@ class SlackImporter(ZulipTestCase):
             zerver_message[1]["recipient"], slack_recipient_name_to_zulip_recipient_id["random"]
         )
 
+    @mock.patch("zerver.data_import.slack.build_usermessages", return_value=(2, 4))
+    def test_channel_message_to_zerver_message_with_integration_bots(
+        self, mock_build_usermessage: mock.Mock
+    ) -> None:
+        """
+        Most of the core logic for converting Slack blocks is in slack_incoming/test.py,
+        so the purpose for this test is to verify the import tool portion of this system.
+        """
+        user_data = [
+            {"id": "U066MTL5U", "name": "john doe", "deleted": False, "real_name": "John"},
+            {"id": "U061A5N1G", "name": "jane doe", "deleted": False, "real_name": "Jane"},
+            {
+                "id": "B06NWMNUQ3W",  # Bot user
+                "name": "ClickUp",
+                "deleted": False,
+                "real_name": "ClickUp",
+            },
+        ]
+
+        slack_user_id_to_zulip_user_id = {"U066MTL5U": 5, "U061A5N1G": 24, "B06NWMNUQ3W": 43}
+
+        all_messages: list[dict[str, Any]] = [
+            {
+                "subtype": "bot_message",
+                "text": "",
+                "username": "ClickUp",
+                "attachments": [
+                    {
+                        "id": 1,
+                        "color": "008844",
+                        "fallback": "dsdaddsa",
+                        "text": "Added assignee Pieter\n\nby Pieter\n_<https://app.clickup.com/25567147/v/s/43687023|Task one> &gt; <https://app.clickup.com/25567147/v/li/901601846060|dsad>_",
+                        "title": "dsdaddsa",
+                        "title_link": "https://app.clickup.com/t/86cv0v5my",
+                        "mrkdwn_in": ["text"],
+                    }
+                ],
+                "type": "message",
+                "ts": "1712027355.830689",
+                "bot_id": "B06NWMNUQ3W",
+                "app_id": "A3G4A68V9",
+                "channel_name": "general",
+            },
+            {
+                "subtype": "bot_message",
+                "text": "",
+                "username": "ClickUp",
+                "attachments": [
+                    {
+                        "id": 1,
+                        "blocks": [
+                            {
+                                "type": "section",
+                                "block_id": "qvtCh",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "<https://app.clickup.com/t/86cv0v5my| dsda>",
+                                    "verbatim": False,
+                                },
+                            },
+                            {
+                                "type": "section",
+                                "block_id": "7LtRa",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "Task Created\nBy Pieter\n",
+                                    "verbatim": False,
+                                },
+                            },
+                            {
+                                "type": "section",
+                                "block_id": "XgOBF",
+                                "fields": [
+                                    {
+                                        "type": "mrkdwn",
+                                        "text": "_<https://app.clickup.com/25567147/v/s/43687023|Task one> &gt; <https://app.clickup.com/25567147/v/li/901601846060|dsad>_",
+                                        "verbatim": False,
+                                    }
+                                ],
+                            },
+                        ],
+                        "color": "#656f7d",
+                        "fallback": "[no preview available]",
+                    }
+                ],
+                "type": "message",
+                "ts": "1712026462.647119",
+                "bot_id": "B06NWMNUQ3W",
+                "app_id": "A3G4A68V9",
+                "channel_name": "general",
+            },
+            {
+                "subtype": "bot_message",
+                "text": "",
+                "username": "ClickUp",
+                "attachments": [
+                    {
+                        "id": 1,
+                        "color": "656f7d",
+                        "fallback": "Buy Ingredients!",
+                        "text": "New comment:  where can I buy it?\n\nby Pieter\n_<https://app.clickup.com/25567147/v/s/43687023|Task one> &gt; <https://app.clickup.com/25567147/v/li/901601846060|dsad>_",
+                        "title": "Buy Ingredients!",
+                        "title_link": "https://app.clickup.com/t/86cuy8e4y?comment=90160026391938",
+                        "mrkdwn_in": ["text"],
+                    }
+                ],
+                "type": "message",
+                "ts": "1711032565.114789",
+                "bot_id": "B06NWMNUQ3W",
+                "app_id": "A3G4A68V9",
+                "channel_name": "general",
+            },
+        ]
+
+        slack_recipient_name_to_zulip_recipient_id = {
+            "random": 2,
+            "general": 1,
+        }
+        dm_members: DMMembersT = {}
+
+        zerver_usermessage: list[dict[str, Any]] = []
+        subscriber_map: dict[int, set[int]] = {}
+        added_channels: dict[str, tuple[str, int]] = {"random": ("c5", 1), "general": ("c6", 2)}
+
+        (
+            zerver_message,
+            zerver_usermessage,
+            attachment,
+            uploads,
+            reaction,
+        ) = channel_message_to_zerver_message(
+            1,
+            user_data,
+            slack_user_id_to_zulip_user_id,
+            slack_recipient_name_to_zulip_recipient_id,
+            all_messages,
+            [],
+            subscriber_map,
+            added_channels,
+            dm_members,
+            "domain",
+            set(),
+            convert_slack_threads=True,
+        )
+        # functioning already tested in helper function
+        self.assertEqual(zerver_usermessage, [])
+        # subtype: channel_join is filtered
+        self.assert_length(zerver_message, 3)
+
+        self.assertEqual(uploads, [])
+        self.assertEqual(attachment, [])
+
+        expected_message_attachment = """## [dsdaddsa](https://app.clickup.com/t/86cv0v5my)
+
+Added assignee Pieter
+
+by Pieter
+*[Task one](https://app.clickup.com/25567147/v/s/43687023) &gt; [dsad](https://app.clickup.com/25567147/v/li/901601846060)*
+""".strip()
+        self.assertEqual(zerver_message[0]["content"], expected_message_attachment)
+        self.assertEqual(zerver_message[0]["sender"], slack_user_id_to_zulip_user_id["B06NWMNUQ3W"])
+
+        expected_message_block = """[ dsda](https://app.clickup.com/t/86cv0v5my)
+
+Task Created
+By Pieter
+
+*[Task one](https://app.clickup.com/25567147/v/s/43687023) &gt; [dsad](https://app.clickup.com/25567147/v/li/901601846060)*
+""".strip()
+        self.assertEqual(zerver_message[1]["content"], expected_message_block)
+        self.assertEqual(zerver_message[1]["sender"], slack_user_id_to_zulip_user_id["B06NWMNUQ3W"])
+
+        expected_message_block_2 = """## [Buy Ingredients!](https://app.clickup.com/t/86cuy8e4y?comment=90160026391938)
+
+New comment:  where can I buy it?
+
+by Pieter
+*[Task one](https://app.clickup.com/25567147/v/s/43687023) &gt; [dsad](https://app.clickup.com/25567147/v/li/901601846060)*
+""".strip()
+        self.assertEqual(zerver_message[2]["content"], expected_message_block_2)
+        self.assertEqual(zerver_message[2]["sender"], slack_user_id_to_zulip_user_id["B06NWMNUQ3W"])
+
     @mock.patch("zerver.data_import.slack.channel_message_to_zerver_message")
     @mock.patch("zerver.data_import.slack.get_messages_iterator")
     def test_convert_slack_workspace_messages(


### PR DESCRIPTION
### Overview
This PR adds support for handling Slack integration bot messages. Previously, this type of message wasn't supported because Slack's integration bots aren't Slack users, so we couldn't create a dummy Zulip user to send those messages during conversion.

Prep PRs:
- #32162
- #32164
- #32163

Fixes: #31162

<details>
<summary>


## Follow up:
- #31930 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Slack | Zulip |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cf5ae327-fb18-47ea-a292-4e89643333fc) | ![image](https://github.com/user-attachments/assets/985e839c-e23c-4ba8-bec0-eafb311bb199) |
| ![image](https://github.com/user-attachments/assets/7553a2b6-af10-4d1b-9263-039d0ea53509) | ![image](https://github.com/user-attachments/assets/fbbdbedc-b0d7-4920-9ca9-2cc9bbfba521) |
| ![image](https://github.com/user-attachments/assets/98b7c19d-0ceb-47ea-beb5-c22e8878435f) | ![image](https://github.com/user-attachments/assets/880456d5-8d62-437f-9596-90fe810532ca) | 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
