### PR TITLE
topic: Add first-time explanation for "Resolve topic".

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -8,6 +8,7 @@ import render_wildcard_mention_not_allowed_error from "../templates/compose_bann
 import render_delete_message_modal from "../templates/confirm_dialog/confirm_delete_message.hbs";
 import render_confirm_merge_topics_with_rename from "../templates/confirm_dialog/confirm_merge_topics_with_rename.hbs";
 import render_confirm_moving_messages_modal from "../templates/confirm_dialog/confirm_moving_messages.hbs";
+import render_intro_resolve_topic_modal from "../templates/confirm_dialog/intro_resolve_topic.hbs";
 import render_message_edit_form from "../templates/message_edit_form.hbs";
 import render_message_moved_widget_body from "../templates/message_moved_widget_body.hbs";
 import render_resolve_topic_time_limit_error_modal from "../templates/resolve_topic_time_limit_error_modal.hbs";
@@ -42,6 +43,7 @@ import * as message_live_update from "./message_live_update";
 import * as message_store from "./message_store";
 import type {Message} from "./message_store";
 import * as message_viewport from "./message_viewport";
+import * as onboarding_steps from "./onboarding_steps";
 import * as people from "./people";
 import * as resize from "./resize";
 import * as rows from "./rows";
@@ -755,6 +757,17 @@ function handle_resolve_topic_failure_due_to_time_limit(topic_is_resolved: boole
     });
 }
 
+function show_intro_resolve_topic_modal(topic_name: string, cb: () => void): void {
+    confirm_dialog.launch({
+        html_heading: $t_html({defaultMessage: "Mark topic as resolved"}),
+        html_body: render_intro_resolve_topic_modal({topic_name}),
+        id: "intro_resolve_topic_modal",
+        on_click: cb,
+        html_submit_button: $t({defaultMessage: "Got it, Confirm"}),
+        html_exit_button: $t({defaultMessage: "Got it, Cancel"}),
+    });
+}
+
 export function toggle_resolve_topic(
     message_id: number,
     old_topic_name: string,
@@ -769,6 +782,39 @@ export function toggle_resolve_topic(
         new_topic_name = resolved_topic.resolve_name(old_topic_name);
     }
 
+    if (
+        !topic_is_resolved &&
+        onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has("intro_resolve_topic")
+    ) {
+        show_intro_resolve_topic_modal(old_topic_name, () => {
+            do_toggle_resolve_topic(
+                message_id,
+                new_topic_name,
+                topic_is_resolved,
+                report_errors_in_global_banner,
+                $row,
+            );
+        });
+        onboarding_steps.post_onboarding_step_as_read("intro_resolve_topic");
+        return;
+    }
+
+    do_toggle_resolve_topic(
+        message_id,
+        new_topic_name,
+        topic_is_resolved,
+        report_errors_in_global_banner,
+        $row,
+    );
+}
+
+function do_toggle_resolve_topic(
+    message_id: number,
+    new_topic_name: string,
+    topic_is_resolved: boolean,
+    report_errors_in_global_banner: boolean,
+    $row: JQuery,
+): void {
     if ($row) {
         show_toggle_resolve_topic_spinner($row);
     }

--- a/web/templates/confirm_dialog/intro_resolve_topic.hbs
+++ b/web/templates/confirm_dialog/intro_resolve_topic.hbs
@@ -1,0 +1,5 @@
+{{#tr}}
+You're marking the topic <b>{topic_name}</b> as resolved. This adds a ✔ at the beginning of the topic name to let everyone know that this conversation is done. <z-link>Learn more</z-link>
+{{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/resolve-a-topic">{{>
+    @partial-block}}</a>{{/inline}}
+{{/tr}}

--- a/zerver/lib/onboarding_steps.py
+++ b/zerver/lib/onboarding_steps.py
@@ -52,6 +52,9 @@ ONE_TIME_NOTICES: list[OneTimeNotice] = [
     OneTimeNotice(
         name="interleaved_view_messages_fading",
     ),
+    OneTimeNotice(
+        name="intro_resolve_topic",
+    ),
 ]
 
 ONE_TIME_ACTIONS = [OneTimeAction(name="narrow_to_dm_with_welcome_bot_new_user")]

--- a/zerver/tests/test_onboarding_steps.py
+++ b/zerver/tests/test_onboarding_steps.py
@@ -25,13 +25,14 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
 
         do_mark_onboarding_step_as_read(self.user, "intro_inbox_view_modal")
         onboarding_steps = get_next_onboarding_steps(self.user)
-        self.assert_length(onboarding_steps, 6)
+        self.assert_length(onboarding_steps, 7)
         self.assertEqual(onboarding_steps[0]["name"], "intro_recent_view_modal")
         self.assertEqual(onboarding_steps[1]["name"], "first_stream_created_banner")
         self.assertEqual(onboarding_steps[2]["name"], "jump_to_conversation_banner")
         self.assertEqual(onboarding_steps[3]["name"], "non_interleaved_view_messages_fading")
         self.assertEqual(onboarding_steps[4]["name"], "interleaved_view_messages_fading")
-        self.assertEqual(onboarding_steps[5]["name"], "narrow_to_dm_with_welcome_bot_new_user")
+        self.assertEqual(onboarding_steps[5]["name"], "intro_resolve_topic")
+        self.assertEqual(onboarding_steps[6]["name"], "narrow_to_dm_with_welcome_bot_new_user")
 
         with self.settings(TUTORIAL_ENABLED=False):
             onboarding_steps = get_next_onboarding_steps(self.user)


### PR DESCRIPTION
We show a modal explaining the "resolve topics" feature when the user marks a topic resolved for the first time.

We don't show anything the first time a topic is marked unresolved.

Fixes #31242

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


![image](https://github.com/user-attachments/assets/eb7efcad-1a3e-4a58-80aa-3de06d07fb81)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
