### PR TITLE
narrow_banner: Fix message view banner for dm with deactivated user.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -346,12 +346,23 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
                         }),
                     };
                 }
+                // If the recipient is deactivated, we cannot start the conversation.
+                if (!people.is_person_active(recipient_user.user_id)) {
+                    return {
+                        title: $t(
+                            {
+                                defaultMessage: "You have no direct messages with {person}.",
+                            },
+                            {person: recipient_user.full_name},
+                        ),
+                    };
+                }
                 return {
                     title: $t(
                         {
                             defaultMessage: "You have no direct messages with {person} yet.",
                         },
-                        {person: people.get_by_user_id(user_ids[0]).full_name},
+                        {person: recipient_user.full_name},
                     ),
                     html: $t_html(
                         {
@@ -364,6 +375,11 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
                                 )}</a>`,
                         },
                     ),
+                };
+            }
+            if (people.get_non_active_user_ids_count(user_ids) !== 0) {
+                return {
+                    title: $t({defaultMessage: "You have no direct messages with these users."}),
                 };
             }
             return {

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -332,8 +332,9 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
                 };
             }
             if (!first_operand.includes(",")) {
+                const recipient_user = people.get_by_user_id(user_ids[0]);
                 // You have no direct messages with this person
-                if (people.is_current_user(first_operand)) {
+                if (people.is_current_user(recipient_user.email)) {
                     return {
                         title: $t({
                             defaultMessage:

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1017,6 +1017,16 @@ export function get_non_active_human_ids(): number[] {
     return human_ids;
 }
 
+export function get_non_active_user_ids_count(user_ids: number[]): number {
+    let count = 0;
+    for (const user_id of user_ids) {
+        if (non_active_user_dict.has(user_id)) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
 export function get_bot_ids(): number[] {
     const bot_ids = [];
 

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -418,6 +418,17 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    // sending direct messages to deactivated user
+    realm.realm_direct_message_permission_group = everyone.id;
+    people.deactivate(alice);
+    set_filter([["dm", alice.email]]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: You have no direct messages with Alice Smith."),
+    );
+    people.add_active_user(alice);
+
     people.add_active_user(me);
     people.initialize_current_user(me.user_id);
     set_filter([["dm", me.email]]);
@@ -439,6 +450,16 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
+
+    // group dm with a deactivated user
+    people.deactivate(alice);
+    set_filter([["dm", ray.email + "," + alice.email]]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: You have no direct messages with these users."),
+    );
+    people.add_active_user(alice);
 
     // organization has disabled sending direct messages
     realm.realm_direct_message_permission_group = nobody.id;

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -335,6 +335,7 @@ test_people("basics", ({override}) => {
     // Now deactivate isaac
     people.deactivate(isaac);
     assert.equal(people.get_non_active_human_ids().length, 1);
+    assert.equal(people.get_non_active_user_ids_count([isaac.user_id]), 1);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
     assert.equal(people.is_valid_email_for_compose(isaac.email), true);


### PR DESCRIPTION
Previously empty-view banner for DM / group DM with any recipients contained "Why not start the conversation".

For deactivated users/bots, we are now not displaying it as it is quite confusing (since it's not possible to dm them).

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/9d0aaf39-3d08-4a12-aee4-7b2adc546276) | ![After](https://github.com/user-attachments/assets/22c917c0-71bd-4160-8f9a-76e9e3fbad49) |
| ![image](https://github.com/user-attachments/assets/33ec13ff-d5d2-4321-b3fe-51d0b721d135) | ![image](https://github.com/user-attachments/assets/5f67aa1b-dc2a-4d2e-8102-9ece333560be) |

To reproduce: In search box type "Direct messages", with the deactivated user/users.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
