### PR TITLE
right_sidebar: Adjust padding, gridded row values.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -273,6 +273,10 @@
 
     /* Right sidebar */
     --right-sidebar-padding-right: 8px;
+    /* Vlad's design adds 2px of extra padding beyond the
+       space created by the padding-left on .right-sidebar,
+       which separates the right sidebar from the message area. */
+    --right-sidebar-padding-left: 2px;
 
     /* Tippy popover related values */
     --navbar-popover-menu-min-width: 230px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -432,6 +432,14 @@
     */
     --browser-overlay-scrollbar-width: 10px;
 
+    /*
+    Sometimes it's necessary to keep elements, especially those with hover
+    controls or other interactivity, from appearing beneath Simplebar scroll
+    bars.
+    */
+    --width-simplebar-scroll: 11px;
+    --width-simplebar-scroll-hover: 15px;
+
     /* This is a rough estimate for height occupied by Recent Conversations filters.
        We expect `resize.ts` to update this once UI is initialized. */
     --recent-topics-filters-height: 50px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -271,6 +271,9 @@
     --line-height-sidebar-row-prominent: 1.7142em; /* 24px / 14px em */
     --line-height-sidebar-row: 1.5714em; /* 22px / 14px em */
 
+    /* Right sidebar */
+    --right-sidebar-padding-right: 8px;
+
     /* Tippy popover related values */
     --navbar-popover-menu-min-width: 230px;
     --message-actions-popover-min-width: 230px;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -60,8 +60,6 @@ $user_status_emoji_width: 24px;
 
 #buddy-list-users-matching-view,
 #buddy-list-other-users {
-    width: 90%;
-    margin-left: 10px;
     margin-bottom: 0;
     overflow-x: hidden;
     list-style-position: inside; /* Draw the bullets inside our box */

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -9,6 +9,7 @@ $user_status_emoji_width: 24px;
 
 .right-sidebar-items {
     padding-right: var(--right-sidebar-padding-right);
+    padding-left: var(--right-sidebar-padding-left);
 }
 
 .right-sidebar-title {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -182,7 +182,7 @@ $user_status_emoji_width: 24px;
     user-select: none;
     font-weight: 600;
     margin: 0;
-    padding: 5px;
+    padding: 5px 5px 5px 0;
 }
 
 .buddy-list-subsection-header.no-display {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -263,6 +263,7 @@ $user_status_emoji_width: 24px;
         "row-content ending-anchor-element" var(--line-height-sidebar-row)
         "row-content ." auto / minmax(0, 1fr) 26px;
     align-content: baseline;
+    margin-right: var(--width-simplebar-scroll-hover);
 
     .user-name-and-status-emoji {
         display: flex;
@@ -326,6 +327,7 @@ $user_status_emoji_width: 24px;
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     grid-template-columns: minmax(0, 1fr) 20px;
     align-items: center;
+    margin-right: var(--width-simplebar-scroll-hover);
 
     #userlist-title {
         margin: 0;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -362,17 +362,27 @@ $user_status_emoji_width: 24px;
 }
 
 #user_search_section {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 28px;
+    grid-template-rows: var(--line-height-sidebar-row-prominent);
     white-space: nowrap;
     margin-bottom: 10px;
 
     & .user-list-filter {
+        grid-area: 1 / 1 / 2 / 3;
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
-        width: var(100% - var(--right-sidebar-padding-right));
+        /* Prevent text from colliding with .clear_search_button */
+        padding-right: 28px;
+        /* Push back against inherited styles; let CSS Grid be in
+           charge of the height. */
+        height: auto;
     }
 
     .clear_search_button {
-        margin-left: -1px;
+        grid-area: 1 / 2 / 2 / 3;
+        position: static;
+        padding: 0;
     }
 }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -7,6 +7,10 @@ $user_status_emoji_width: 24px;
     }
 }
 
+.right-sidebar-items {
+    padding-right: var(--right-sidebar-padding-right);
+}
+
 .right-sidebar-title {
     color: var(--color-text-sidebar-heading);
     font-size: inherit;
@@ -319,11 +323,10 @@ $user_status_emoji_width: 24px;
 
 #userlist-header {
     cursor: pointer;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    display: grid;
+    grid-template-rows: var(--line-height-sidebar-row-prominent);
+    grid-template-columns: minmax(0, 1fr) 20px;
     align-items: center;
-    margin-right: 10px;
 
     #userlist-title {
         margin: 0;
@@ -331,7 +334,7 @@ $user_status_emoji_width: 24px;
 
     #user_filter_icon {
         opacity: 0.5;
-        margin-right: 5px;
+        justify-self: center;
 
         &:hover {
             opacity: 1;
@@ -361,12 +364,11 @@ $user_status_emoji_width: 24px;
     white-space: nowrap;
     margin-bottom: 10px;
 
-    & input {
+    & .user-list-filter {
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
-        padding-right: 20px;
-        width: calc(100% - 40px - 3px);
+        width: var(100% - var(--right-sidebar-padding-right));
     }
 
     .clear_search_button {

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -7,7 +7,7 @@
                 </h4>
                 <i id="user_filter_icon" class="fa fa-search"></i>
             </div>
-            <div class="input-append notdisplayed" id="user_search_section">
+            <div class="notdisplayed" id="user_search_section">
                 <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
                     <i class="fa fa-remove" aria-hidden="true"></i>


### PR DESCRIPTION
**This PR builds on commits that should be merged first in #31277**

Parallel to #31277, this refactors the right sidebar to make better use of CSS Grid to match @terpimost's right sidebar redesign, https://terpimost.github.io/zulip-sidebar/

Fixes #27574.

| Before (showing #31277) | After |
| --- | --- |
| ![right-sidebar-before](https://github.com/user-attachments/assets/59e2bf90-186b-41e9-be5a-331df3543cc2) | ![right-sidebar-after](https://github.com/user-attachments/assets/f1fb61c4-331a-43a2-a98d-6b987af0ab0e) |

In bringing the right sidebar into better concord with the left sidebar, this PR includes the following improvements:

* The USERS heading is now perfectly vertically aligned with the VIEWS heading in the left sidebar
* The user filter box matches the style and font-size of the filter boxes in the left sidebar (a follow up pass there, however, should apply the same clear-search-button layout technique as in this PR)
* All right sidebar elements now share the same lefthand alignment, as called for in Vlad's design
* All right sidebar rows now occupy more of the right sidebar space, allowing for more of a username to be revealed

The changes here also will make it relatively easy to place the new presence icons and establish subheader typography (i.e., "In this channel") to match that of the left sidebar (i.e., there, "Inactive," "Pinned," etc.).




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
