### PR TITLE
Message UI: Remove extraneous spacing above collapsed message.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -853,11 +853,11 @@ export function end_message_row_edit($row: JQuery): void {
         message_lists.current.hide_edit_message($row);
         compose_call.abort_video_callbacks(message.id.toString());
     }
-    if ($row.find(".could-be-condensed").length !== 0) {
+    if ($row.find(".could-be-condensed").length !== 0 && message) {
         if ($row.find(".condensed").length !== 0) {
-            condense.show_message_expander($row);
+            condense.show_message_expander($row, message);
         } else {
-            condense.show_message_condenser($row);
+            condense.show_message_condenser($row, message);
         }
     }
     $row.find(".message_reactions").show();

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -237,7 +237,13 @@
            in the baseline group. */
         align-self: start;
 
-        .message_length_toggle {
+        .message_length_sender_include {
+            /* Ensure that a messgage in which sender is included
+            will collapse from bottom only */
+            margin: 0 0 4px;
+        }
+
+        .message_length_sender_exclude {
             /* Ensure that a collapsed message maintains the
                same space around the toggle button as any other
                message-row content. */

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -1,5 +1,5 @@
 {{#if (eq toggle_type "expander")}}
-    <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
+    <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip  {{#if include_sender}} message_length_sender_include {{else}} message_length_sender_exclude {{/if}}" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
 {{else if (eq toggle_type "condenser")}}
-    <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
+    <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip  {{#if include_sender}} message_length_sender_include {{else}} message_length_sender_exclude {{/if}}" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
 {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fixes: #31221

In This  PR Fixed the bug of extraneous spacing above the collapsed Message.
Changes Made: 
- Message which has sender - The top margin, which was previously set to 4px, has been removed, leaving only a 4px margin at the bottom.
- Message which does not have sender - Top margin remains as such
Impact Area:

- `message_body.hbs` - 2 buttons `Show More` and `Show Less`

- created a boolean method `check_sender_in_message` to check which CSS need to be applied.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Before 
<img width="692" alt="image" src="https://github.com/user-attachments/assets/1a0b8e9d-ee18-43f7-8508-4951e15a4a92">

### After

Message having sender
<img width="527" alt="Screenshot 2024-09-03 at 11 38 11 AM" src="https://github.com/user-attachments/assets/8177fb3b-367c-4924-a864-125725f3681d">

Message without sender
<img width="464" alt="Screenshot 2024-09-03 at 11 38 46 AM" src="https://github.com/user-attachments/assets/13a21516-18cd-4dc4-b814-e4d897895bbc">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
