### PR TITLE
unread_ops: Add confirm_dialog to bulk mark unread in interleaved views.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1747,6 +1747,13 @@ export class Filter {
         return false;
     }
 
+    may_contain_multiple_conversations(): boolean {
+        return !(
+            (this.has_operator("channel") && this.has_operator("topic")) ||
+            this.has_operator("dm")
+        );
+    }
+
     excludes_muted_topics(): boolean {
         return (
             // not narrowed to a topic

--- a/web/templates/confirm_dialog/confirm_mark_as_unread_from_here.hbs
+++ b/web/templates/confirm_dialog/confirm_mark_as_unread_from_here.hbs
@@ -1,0 +1,7 @@
+<p>
+    {{#if show_message_count}}
+        {{t "Are you sure you want to mark {count} messages as unread? Messages in multiple conversations may be affected."}}
+    {{else}}
+        {{t "Are you sure you want to mark messages as unread? Messages in multiple conversations may be affected."}}
+    {{/if}}
+</p>

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -154,6 +154,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.may_contain_multiple_conversations());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -194,6 +195,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -212,6 +214,7 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel"));
     assert.ok(filter.can_bucket_by("channel", "topic"));
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -231,6 +234,7 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel", "topic"));
     assert.ok(!filter.is_conversation_view());
     assert.ok(filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
     assert.ok(filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -245,6 +249,7 @@ test("basics", () => {
     assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     // Negated searches are just like positive searches for our purposes, since
     // the search logic happens on the backend and we need to have can_apply_locally()
@@ -258,6 +263,7 @@ test("basics", () => {
     assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -272,6 +278,7 @@ test("basics", () => {
     assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     terms = [{operator: "channels", operand: "public", negated: true}];
     filter = new Filter(terms);
@@ -283,6 +290,7 @@ test("basics", () => {
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     terms = [{operator: "channels", operand: "public"}];
     filter = new Filter(terms);
@@ -295,6 +303,7 @@ test("basics", () => {
     assert.ok(filter.includes_full_stream_history());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     // "streams" was renamed to "channels"
     terms = [{operator: "streams", operand: "public"}];
@@ -312,6 +321,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(filter.can_show_next_unread_dm_conversation_button());
 
@@ -332,6 +342,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -344,6 +355,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     terms = [{operator: "dm", operand: "joe@example.com"}];
     filter = new Filter(terms);
@@ -356,6 +368,7 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "dm", operand: "joe@example.com"},
@@ -371,6 +384,7 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
     assert.ok(filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [{operator: "dm", operand: "joe@example.com,jack@example.com"}];
     filter = new Filter(terms);
@@ -382,6 +396,7 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "dm", operand: "joe@example.com,jack@example.com"},
@@ -395,6 +410,7 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     // "pm-with" was renamed to "dm"
     terms = [{operator: "pm-with", operand: "joe@example.com"}];
@@ -412,6 +428,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     // "group-pm-with" was replaced with "dm-including"
     terms = [{operator: "group-pm-with", operand: "joe@example.com"}];
@@ -428,6 +445,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     // Highly complex query to exercise
     // filter.supports_collapsing_recipients loop.
@@ -451,6 +469,7 @@ test("basics", () => {
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -468,6 +487,7 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -487,6 +507,7 @@ test("basics", () => {
     assert.ok(filter.is_conversation_view());
     assert.ok(filter.can_bucket_by("channel", "topic", "with"));
     assert.ok(!filter.is_conversation_view_with_near());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     // "stream" was renamed to "channel"
     terms = [
@@ -505,6 +526,23 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
+
+    terms = [
+        {operator: "channel", operand: "channel_name"},
+        {operator: "channels", operand: "public"},
+        {operator: "topic", operand: "patience"},
+    ];
+    filter = new Filter(terms);
+    assert.ok(!filter.is_keyword_search());
+    assert.ok(!filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.allow_use_first_unread_when_narrowing());
+    assert.ok(filter.includes_full_stream_history());
+    assert.ok(!filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.may_contain_multiple_conversations());
 
     terms = [
         {operator: "channel", operand: "foo", negated: false},


### PR DESCRIPTION
Fixes #31292.

[CZO thread](https://chat.zulip.org/#narrow/stream/137-feedback/topic/unintentionally.20marking.20messages.20as.20unread/near/1638015)

Known number: (All Fetched)
- N < 50 - no confirmation dialog
- N >= 50 - confirmation dialog with the number of messages

Unknown number:
- N < 10 - no confirmation dialog
- N >= 10 - confirmation dialog with the minimum number of messages, rounded down to the nearest multiple of 25.

**Screenshots and screen captures:**
[Screen recording for the known number cases](https://github.com/user-attachments/assets/dcdf611d-0d6b-4538-b779-193df443ef4e)
[Screen recording for the unknown number confirmation dialog](https://github.com/user-attachments/assets/eaff8556-93d1-4c9a-a000-7eaf9eda3a60)

Screenshot for the unknown number case (and its threshold)
![image](https://github.com/user-attachments/assets/662f5984-1f1c-4b99-b44a-9f6be87cdb95)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
