### PR TITLE
buddy_list: Remove deactivated users from right sidebar.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -326,6 +326,11 @@ function filter_user_ids(user_filter_text: string, user_ids: number[]): number[]
             return false;
         }
 
+        if (!people.is_person_active(user_id)) {
+            // Deactivated users are hidden from the right sidebar entirely.
+            return false;
+        }
+
         if (muted_users.is_user_muted(user_id)) {
             // Muted users are hidden from the right sidebar entirely.
             return false;

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -52,7 +52,7 @@ function get_total_human_subscriber_count(
 
         let human_user_count = 0;
         for (const pm_id of all_recipient_user_ids_set) {
-            if (!people.is_valid_bot_user(pm_id)) {
+            if (!people.is_valid_bot_user(pm_id) && people.is_person_active(pm_id)) {
                 human_user_count += 1;
             }
         }

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -76,7 +76,7 @@ export function get_subscriber_count(stream_id: number, include_bots = true): nu
 
     let count = 0;
     for (const user_id of get_user_set(stream_id).keys()) {
-        if (!people.is_valid_bot_user(user_id)) {
+        if (!people.is_valid_bot_user(user_id) && people.is_person_active(user_id)) {
             count += 1;
         }
     }

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -218,15 +218,26 @@ test("title_data", () => {
     assert.deepEqual(buddy_data.get_title_data(old_user.user_id, is_group), expected_data);
 });
 
-test("simple search", () => {
+test("filters deactivated users", () => {
     add_canned_users();
 
     set_presence(selma.user_id, "active");
     set_presence(me.user_id, "active");
 
-    const user_ids = buddy_data.get_filtered_and_sorted_user_ids("selm");
+    let user_ids = buddy_data.get_filtered_and_sorted_user_ids("selm");
 
     assert.deepEqual(user_ids, [selma.user_id]);
+    assert.ok(buddy_data.matches_filter("selm", selma.user_id));
+
+    // Deactivated users are excluded.
+    people.deactivate(selma);
+
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids("selm");
+    assert.deepEqual(user_ids, []);
+
+    user_ids = buddy_data.get_filtered_and_sorted_user_ids();
+    assert.equal(user_ids.includes(selma.user_id), false);
+    assert.ok(!buddy_data.matches_filter("selm", selma.user_id));
 });
 
 test("muted users excluded from search", () => {


### PR DESCRIPTION
Filter out active people from the buddy list in the right sidebar.

Screenshots:

| Before | After |
|--------|-------|
| ![Screenshot from 2024-08-09 23-59-23](https://github.com/user-attachments/assets/adc91d35-55ab-409f-adc0-9692140242c7) | ![Screenshot from 2024-08-10 00-06-08](https://github.com/user-attachments/assets/ad4f20bd-3cf8-4846-a24e-be2f0b58b748) |

CZO: [link](https://chat.zulip.org/#narrow/stream/9-issues/topic/Showing.20deactivated.20users.20in.20buddy.20list)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
