### PR TITLE
Show System bots in the typeahead list.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -589,7 +589,7 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         topic: compose_state.topic(),
         filter_groups_for_guests: true,
     };
-    const suggestions = get_person_suggestions(query, opts);
+    const suggestions = get_person_suggestions(query, opts, true);
     // We know these aren't mentions because `want_broadcast` was `false`.
     // TODO: In the future we should separate user and mention so we don't have
     // to do this.
@@ -613,6 +613,7 @@ type PersonSuggestionOpts = {
 export function get_person_suggestions(
     query: string,
     opts: PersonSuggestionOpts,
+    exclude_non_welcome_bots = false,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
     query = typeahead.clean_query_lowercase(query);
 
@@ -702,7 +703,11 @@ export function get_person_suggestions(
     if (filtered_message_persons.length >= cutoff_length) {
         filtered_persons = filtered_message_persons;
     } else {
-        filtered_persons = filter_persons(people.get_realm_users());
+        if (exclude_non_welcome_bots) {
+            filtered_persons = filter_persons(people.get_realm_users_and_welcome_bot());
+        } else {
+            filtered_persons = filter_persons(people.get_realm_users_and_system_bots());
+        }
     }
 
     return typeahead_helper.sort_recipients({

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -980,6 +980,14 @@ export function get_realm_users(): User[] {
     return [...active_user_dict.values()];
 }
 
+export function get_realm_users_and_welcome_bot(): User[] {
+    return [...active_user_dict.values(), WELCOME_BOT];
+}
+
+export function get_realm_users_and_system_bots(): User[] {
+    return [...active_user_dict.values(), ...cross_realm_dict.values()];
+}
+
 export function get_realm_active_human_users(): User[] {
     // includes ONLY humans from your realm
     const humans = [];

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -421,6 +421,26 @@ const harry = {
 };
 const harry_item = user_item(harry);
 
+const welcome_bot = {
+    full_name: "Welcome Bot",
+    is_bot: true,
+    is_system_bot: true,
+    user_id: 110,
+    email: "welcome-bot@zulip.com",
+};
+
+const welcome_bot_item = user_item(welcome_bot);
+
+const notification_bot = {
+    full_name: "Notification Bot",
+    is_bot: true,
+    is_system_bot: true,
+    user_id: 111,
+    email: "notification-bot@zulip.com",
+};
+
+const notification_bot_item = user_item(notification_bot);
+
 const hamletcharacters = user_group_item({
     name: "hamletcharacters",
     id: 1,
@@ -472,6 +492,8 @@ const sorted_user_list = [
     twin1_item, // Mark Twin
     twin2_item,
     othello_item,
+    notification_bot_item,
+    welcome_bot_item,
 ];
 
 function test(label, f) {
@@ -491,6 +513,8 @@ function test(label, f) {
         people.add_active_user(hal);
         people.add_active_user(harry);
         people.add_active_user(deactivated_user);
+        people.add_cross_realm_user(welcome_bot);
+        people.add_cross_realm_user(notification_bot);
         people.deactivate(deactivated_user);
         people.initialize_current_user(hamlet.user_id);
 
@@ -965,6 +989,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                     twin1_item,
                     twin2_item,
                     othello_item,
+                    welcome_bot_item,
                     hamletcharacters,
                     backend,
                     call_center,
@@ -1527,15 +1552,36 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@_**", mentions_with_silent_marker(users_and_user_groups, true));
     assert_typeahead_equals(
         "test @**o",
-        mentions_with_silent_marker([othello_item, cordelia_item, mention_everyone], false),
+        mentions_with_silent_marker(
+            [
+                othello_item,
+                cordelia_item,
+                notification_bot_item,
+                welcome_bot_item,
+                mention_everyone,
+            ],
+            false,
+        ),
     );
     assert_typeahead_equals(
         "test @_**o",
-        mentions_with_silent_marker([othello_item, cordelia_item], true),
+        mentions_with_silent_marker(
+            [othello_item, cordelia_item, notification_bot_item, welcome_bot_item],
+            true,
+        ),
     );
     assert_typeahead_equals(
         "test @*o",
-        mentions_with_silent_marker([othello_item, cordelia_item, mention_everyone], false),
+        mentions_with_silent_marker(
+            [
+                othello_item,
+                cordelia_item,
+                notification_bot_item,
+                welcome_bot_item,
+                mention_everyone,
+            ],
+            false,
+        ),
     );
     assert_typeahead_equals(
         "test @_*k",
@@ -1581,6 +1627,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 twin1_item,
                 twin2_item,
                 othello_item,
+                notification_bot_item,
             ],
             false,
         ),
@@ -1598,6 +1645,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 twin1_item,
                 twin2_item,
                 othello_item,
+                notification_bot_item,
             ],
             true,
         ),
@@ -1614,6 +1662,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 gael_item,
                 hamlet_item,
                 othello_item,
+                welcome_bot_item,
                 mention_all,
             ],
             false,
@@ -1631,6 +1680,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 gael_item,
                 hamlet_item,
                 othello_item,
+                welcome_bot_item,
                 hamletcharacters,
                 call_center,
             ],
@@ -1645,11 +1695,23 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals(" @_zuli", []);
     assert_typeahead_equals(
         "test @o",
-        mentions_with_silent_marker([othello_item, cordelia_item, mention_everyone], false),
+        mentions_with_silent_marker(
+            [
+                othello_item,
+                cordelia_item,
+                notification_bot_item,
+                welcome_bot_item,
+                mention_everyone,
+            ],
+            false,
+        ),
     );
     assert_typeahead_equals(
         "test @_o",
-        mentions_with_silent_marker([othello_item, cordelia_item], true),
+        mentions_with_silent_marker(
+            [othello_item, cordelia_item, notification_bot_item, welcome_bot_item],
+            true,
+        ),
     );
     assert_typeahead_equals("test @z", []);
     assert_typeahead_equals("test @_z", []);
@@ -2124,6 +2186,7 @@ test("typeahead_results", () => {
         not_silent(hamlet_item),
         not_silent(lear_item),
         not_silent(othello_item),
+        not_silent(welcome_bot_item),
         not_silent(hamletcharacters),
         not_silent(call_center),
     ]);
@@ -2137,6 +2200,8 @@ test("typeahead_results", () => {
         not_silent(mention_everyone),
         not_silent(mention_topic),
         not_silent(cordelia_item),
+        not_silent(notification_bot_item),
+        not_silent(welcome_bot_item),
     ]);
 
     // Autocomplete by slash commands.


### PR DESCRIPTION
The PR make changes to show the system bots in the typeahead list when we use `@` or `@_` or send direct messages.

#### Consideration
Only the Welcome bot should be visible in the typeahead list when we try to send direct messages, whereas all the system bots should be present in the typeahead list for mentions in the compose box.

Fixes: #30817 


**Screenshots and screen captures:**
![Systembot present in composebox typeahead when do mentions](https://github.com/user-attachments/assets/cf1d5a18-1403-4f46-a7fc-fd6e4c4a8de5)
![Welcome bot visible in direct messages typeahead](https://github.com/user-attachments/assets/997c39f3-8289-4c25-bb92-1da24b390b14)
![Notification bot not visible in the Direct messages typeahead](https://github.com/user-attachments/assets/64838570-7103-4be5-97d4-0c78d60eed8e)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
