### PR TITLE
left sidebar: Improve how starred message count is hidden.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -37,9 +37,15 @@ function save_state(state: string): void {
     ls.set(ls_key, state);
 }
 
-export function update_starred_count(count: number): void {
+export function update_starred_count(count: number, hidden: boolean): void {
     const $starred_li = $(".top_left_starred_messages");
     ui_util.update_unread_count_in_dom($starred_li, count);
+
+    if (hidden) {
+        $starred_li.addClass("hide_starred_message_count");
+        return;
+    }
+    $starred_li.removeClass("hide_starred_message_count");
 }
 
 export function update_scheduled_messages_row(): void {

--- a/web/src/starred_messages_ui.ts
+++ b/web/src/starred_messages_ui.ts
@@ -57,16 +57,17 @@ export function update_starred_flag(message_id: number, updated_starred_flag: bo
 }
 
 export function rerender_ui(): void {
-    let count = starred_messages.get_count();
+    const count = starred_messages.get_count();
+    let hidden = false;
 
     if (!user_settings.starred_message_counts) {
         // This essentially hides the count
-        count = 0;
+        hidden = true;
     }
 
     popover_menus.get_topic_menu_popover()?.hide();
     popover_menus.get_starred_messages_popover()?.hide();
-    left_sidebar_navigation_area.update_starred_count(count);
+    left_sidebar_navigation_area.update_starred_count(count, hidden);
 }
 
 export function confirm_unstar_all_messages(): void {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -370,6 +370,7 @@
     it doesn't leak through message header.
     */
     --unread-marker-left: -1px;
+    --masked-unread-count-margin-right: 3px;
 
     /*
     Compose-recipient box minimum height. Used in a flexbox context to

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -103,7 +103,7 @@ li.show-more-topics {
                We have to do this with margin,
                because width or padding will
                distort the CSS-created dot. */
-            margin-right: 3px;
+            margin-right: var(--masked-unread-count-margin-right);
         }
 
         .unread_count {
@@ -663,6 +663,57 @@ li.top_left_scheduled_messages {
 
     .unread_count {
         grid-area: markers-and-controls;
+    }
+}
+
+.top_left_starred_messages {
+    &.hide_starred_message_count {
+        .masked_unread_count {
+            display: block;
+            grid-area: markers-and-controls;
+            /* Adding margin-right aligns the .masked_unread_count with the rest of the masked unread counts in the channel list. */
+            margin-right: var(--masked-unread-count-margin-right);
+        }
+
+        .unread_count {
+            display: none;
+        }
+        /* When starred message count is 0, we dont want to show unread_count or masked_unread_count. */
+        .unread_count.hide + .masked_unread_count {
+            display: none;
+        }
+    }
+}
+
+.top_left_starred_messages:hover {
+    &.hide_starred_message_count {
+        .masked_unread_count {
+            display: none;
+        }
+
+        .unread_count {
+            display: inline;
+        }
+
+        .unread_count.hide {
+            display: none;
+        }
+    }
+}
+
+.top_left_starred_messages.active-filter {
+    &.hide_starred_message_count {
+        .masked_unread_count {
+            display: none;
+        }
+
+        .unread_count {
+            display: inline;
+        }
+
+        .unread_count.hide {
+            display: none;
+        }
     }
 }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -116,6 +116,7 @@
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
+                    <span class="masked_unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -99,7 +99,7 @@ run_test("update_count_in_dom", () => {
     make_elem($("#topics_header"), "<topics-count>");
 
     left_sidebar_navigation_area.update_dom_with_unread_counts(counts, false);
-    left_sidebar_navigation_area.update_starred_count(444);
+    left_sidebar_navigation_area.update_starred_count(444, false);
     // Calls left_sidebar_navigation_area.update_scheduled_messages_row
     left_sidebar_navigation_area.initialize();
 
@@ -114,11 +114,11 @@ run_test("update_count_in_dom", () => {
     scheduled_messages.get_count = () => 0;
 
     left_sidebar_navigation_area.update_dom_with_unread_counts(counts, false);
-    left_sidebar_navigation_area.update_starred_count(0);
+    left_sidebar_navigation_area.update_starred_count(444, true);
     left_sidebar_navigation_area.update_scheduled_messages_row();
 
     assert.ok(!$("<mentioned-count>").visible());
     assert.equal($("<mentioned-count>").text(), "");
-    assert.equal($("<starred-count>").text(), "");
+    assert.equal($("<starred-count>").text(), "444");
     assert.ok(!$(".top_left_scheduled_messages").visible());
 });

--- a/web/tests/starred_messages.test.js
+++ b/web/tests/starred_messages.test.js
@@ -102,8 +102,9 @@ run_test("rerender_ui", () => {
         override(left_sidebar_navigation_area, "update_starred_count", stub.f);
         starred_messages_ui.rerender_ui();
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("count");
+        const args = stub.get_args("count", "hidden");
         assert.equal(args.count, 3);
+        assert.equal(args.hidden, false);
     });
 
     user_settings.starred_message_counts = false;
@@ -112,7 +113,8 @@ run_test("rerender_ui", () => {
         override(left_sidebar_navigation_area, "update_starred_count", stub.f);
         starred_messages_ui.rerender_ui();
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("count");
-        assert.equal(args.count, 0);
+        const args = stub.get_args("count", "hidden");
+        assert.equal(args.count, 3);
+        assert.equal(args.hidden, true);
     });
 });


### PR DESCRIPTION
Fixes #30898.

This PR improves how the starred message count is hidden and follows the following pattern:

- Shows a dot where the counter would be.
- The message counter is revealed by hovering over the starred message row.
- The message counter is revealed when the user is in the starred message view.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details><summary>GIF</summary>
<p>

![starred_count](https://github.com/user-attachments/assets/aa051278-b944-457f-a49e-c726c44e0e8c)


</p>
</details> 

<details><summary>Pic</summary>
<p>

![image](https://github.com/user-attachments/assets/b8794109-61e3-406c-8eba-e51858d33da4)


</p>
</details> 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
