### PR TITLE
search: Navigate results with up/down when input is focused.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -858,6 +858,18 @@ export function process_hotkey(e, hotkey) {
             return true;
         }
 
+        if (event_name === "down_arrow" && $(":focus").attr("id") === "search_query") {
+            $("#search_query").trigger("blur");
+            message_scroll_state.set_keyboard_triggered_current_scroll(true);
+            navigate.down(true);
+        }
+
+        if (event_name === "up_arrow" && $(":focus").attr("id") === "search_query") {
+            $("#search_query").trigger("blur");
+            message_scroll_state.set_keyboard_triggered_current_scroll(true);
+            navigate.up(true);
+        }
+
         if (
             ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
                 compose_state.focus_in_empty_compose()) ||


### PR DESCRIPTION
What was happening:

* Focus being in the search input text box made Up/Down be handled by the browser and move the cursor. This is default browser behavior, and not useful to us (you can use home/end for the same goal, but also one just doesn't put much text in that input given the pills system).
* We probably don't want to push keyboard focus out of the search box after completing a search, since that would make it annoying to type a new search term or whatnot.

The fix is to just make the existing Up/Down keyboard handler apply even if the search input is focused.

More context here:

https://chat.zulip.org/#narrow/stream/9-issues/topic/Can't.20navigate.20search.20results.20using.20the.20keyboard.20.2331291/near/1913535

