### PR TITLE
filter: Canonicalize operator before creating parsed term.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -507,7 +507,11 @@ export class Filter {
                 // terms list. This is done so that the last active filter is correctly
                 // detected by the `get_search_result` function (in search_suggestions.ts).
                 maybe_add_search_terms();
-                term = {negated, operator, operand};
+                term = {
+                    negated,
+                    operator: Filter.canonicalize_operator(operator),
+                    operand,
+                };
                 terms.push(term);
             }
         }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1242,7 +1242,7 @@ test("parse", () => {
     // "stream" was renamed to "channel"
     string = "stream:Foo topic:Bar yo";
     terms = [
-        {operator: "stream", operand: "Foo"},
+        {operator: "channel", operand: "Foo"},
         {operator: "topic", operand: "Bar"},
         {operator: "search", operand: "yo"},
     ];
@@ -1313,7 +1313,7 @@ test("parse", () => {
 
     // "streams" was renamed to "channels"
     string = "streams:public";
-    terms = [{operator: "streams", operand: "public"}];
+    terms = [{operator: "channels", operand: "public"}];
     _test();
 
     string = "channel:foo :emoji: are cool";


### PR DESCRIPTION
We decide what operators are valid when parsing a term by calling `operator_to_prefix`, but `operator_to_prefix` calls `canonicalize_operator`, so we need to call `canonicalize_operator` on the operand we return from `parse`, or else we might end up with an invalid operator in a parsed term.

Fixes this bug:
https://chat.zulip.org/#narrow/stream/9-issues/topic/valid.20search.20terms.20in.20uppercase.20followed.20by.20.3A.20throwing.20error
