### PR TITLE
migrations: Fix Nagios bot cleanup crash.

### DIFF
--- a/zerver/migrations/0564_purge_nagios_messages.py
+++ b/zerver/migrations/0564_purge_nagios_messages.py
@@ -23,12 +23,16 @@ def purge_nagios_messages(apps: StateApps, schema_editor: BaseDatabaseSchemaEdit
             (settings.NAGIOS_STAGING_SEND_BOT, settings.NAGIOS_STAGING_RECEIVE_BOT),
         ]
         for sender_email, recipient_email in nagios_bot_tuples:
-            sender_id = UserProfile.objects.get(
-                delivery_email=sender_email, realm_id=bot_realm.id
-            ).id
-            recipient_id = UserProfile.objects.get(
-                delivery_email=recipient_email, realm_id=bot_realm.id
-            ).recipient_id
+            try:
+                sender_id = UserProfile.objects.get(
+                    delivery_email=sender_email, realm_id=bot_realm.id
+                ).id
+                recipient_id = UserProfile.objects.get(
+                    delivery_email=recipient_email, realm_id=bot_realm.id
+                ).recipient_id
+            except UserProfile.DoesNotExist:
+                # If these special users don't exist, there's nothing to do.
+                continue
 
             batch_size = 10000
             while True:


### PR DESCRIPTION
We didn't correctly check for the possibility that these users don't exist.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
