### PR TITLE
left_sidebar: Fix user unable to type in DM search input.

### DIFF
--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -156,7 +156,7 @@
             <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
         </a>
         <div class="zoom-out-hide direct-messages-search-section">
-            <input class="direct-messages-list-filter filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
+            <input class="direct-messages-list-filter filter_text_input home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
             <button type="button" class="btn clear_search_button" id="clear-direct-messages-search-button">
                 <i class="fa fa-remove" aria-hidden="true"></i>
             </button>


### PR DESCRIPTION
This was due to non message list views didn't know that they shouldn't try to process hotkey when DM search input is in focus.

https://chat.zulip.org/#narrow/stream/9-issues/topic/filter-DMs.20box.20overridden.20by.20keyboard.20shortcuts