### PR TITLE
user_topics_ui: Fix `toggle_topic_visibility_policy` behavior.

### DIFF
--- a/web/src/user_topics_ui.ts
+++ b/web/src/user_topics_ui.ts
@@ -8,6 +8,7 @@ import * as overlays from "./overlays";
 import * as popover_menus from "./popover_menus";
 import * as recent_view_ui from "./recent_view_ui";
 import * as settings_user_topics from "./settings_user_topics";
+import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as sub_store from "./sub_store";
 import * as unread_ui from "./unread_ui";
@@ -88,6 +89,10 @@ export function toggle_topic_visibility_policy(message: Message): void {
 
     const stream_id = message.stream_id;
     const topic = message.topic;
+
+    if (!stream_data.is_subscribed(stream_id)) {
+        return;
+    }
 
     if (
         user_topics.is_topic_muted(stream_id, topic) ||

--- a/web/src/user_topics_ui.ts
+++ b/web/src/user_topics_ui.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import * as inbox_util from "./inbox_util";
 import * as message_lists from "./message_lists";
@@ -94,21 +95,31 @@ export function toggle_topic_visibility_policy(message: Message): void {
         return;
     }
 
-    if (
-        user_topics.is_topic_muted(stream_id, topic) ||
-        user_topics.is_topic_unmuted(stream_id, topic)
-    ) {
-        user_topics.set_user_topic_visibility_policy(
-            stream_id,
-            topic,
-            user_topics.all_visibility_policies.INHERIT,
-        );
-    } else {
-        if (sub_store.get(stream_id)?.is_muted) {
+    const sub = sub_store.get(stream_id);
+    assert(sub !== undefined);
+
+    if (sub.is_muted) {
+        if (user_topics.is_topic_unmuted_or_followed(stream_id, topic)) {
+            user_topics.set_user_topic_visibility_policy(
+                stream_id,
+                topic,
+                user_topics.all_visibility_policies.INHERIT,
+                true,
+            );
+        } else {
             user_topics.set_user_topic_visibility_policy(
                 stream_id,
                 topic,
                 user_topics.all_visibility_policies.UNMUTED,
+                true,
+            );
+        }
+    } else {
+        if (user_topics.is_topic_muted(stream_id, topic)) {
+            user_topics.set_user_topic_visibility_policy(
+                stream_id,
+                topic,
+                user_topics.all_visibility_policies.INHERIT,
                 true,
             );
         } else {

--- a/web/tests/user_topics_ui.test.js
+++ b/web/tests/user_topics_ui.test.js
@@ -8,6 +8,7 @@ const {run_test} = require("./lib/test");
 const user_topics = zrequire("user_topics");
 const user_topics_ui = zrequire("user_topics_ui");
 const stream_data = zrequire("stream_data");
+const sub_store = zrequire("sub_store");
 
 const design = {
     stream_id: 101,
@@ -29,7 +30,7 @@ function update_visibility_policy(visibility_policy) {
     user_topics.update_user_topics(design.stream_id, design.name, "java", visibility_policy);
 }
 
-test("toggle_topic_visibility_policy", () => {
+test("toggle_topic_visibility_policy", ({override_rewire}) => {
     // Mute a topic
     assert.ok(!user_topics.is_topic_muted(design.stream_id, "java"));
     update_visibility_policy(user_topics.all_visibility_policies.MUTED);
@@ -47,4 +48,57 @@ test("toggle_topic_visibility_policy", () => {
     // Verify that we can't toggle visibility policy in unsubscribed channel.
     user_topics_ui.toggle_topic_visibility_policy(message);
     assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+
+    override_rewire(
+        user_topics,
+        "set_user_topic_visibility_policy",
+        (stream_id, topic_name, visibility_policy) => {
+            const stream_name = sub_store.maybe_get_stream_name(stream_id);
+            user_topics.update_user_topics(stream_id, stream_name, topic_name, visibility_policy);
+        },
+    );
+
+    design.subscribed = true;
+
+    // For NOT muted channel
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(
+        user_topics.get_topic_visibility_policy(design.stream_id, "java") ===
+            user_topics.all_visibility_policies.INHERIT,
+    );
+
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+
+    update_visibility_policy(user_topics.all_visibility_policies.UNMUTED);
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+
+    update_visibility_policy(user_topics.all_visibility_policies.FOLLOWED);
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+
+    // For muted channel
+    design.is_muted = true;
+
+    update_visibility_policy(user_topics.all_visibility_policies.INHERIT);
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(user_topics.is_topic_unmuted(design.stream_id, "java"));
+
+    update_visibility_policy(user_topics.all_visibility_policies.MUTED);
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(user_topics.is_topic_unmuted(design.stream_id, "java"));
+
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(
+        user_topics.get_topic_visibility_policy(design.stream_id, "java") ===
+            user_topics.all_visibility_policies.INHERIT,
+    );
+
+    update_visibility_policy(user_topics.all_visibility_policies.FOLLOWED);
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(
+        user_topics.get_topic_visibility_policy(design.stream_id, "java") ===
+            user_topics.all_visibility_policies.INHERIT,
+    );
 });

--- a/web/tests/user_topics_ui.test.js
+++ b/web/tests/user_topics_ui.test.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
+
+const user_topics = zrequire("user_topics");
+const user_topics_ui = zrequire("user_topics_ui");
+const stream_data = zrequire("stream_data");
+
+const design = {
+    stream_id: 101,
+    name: "design",
+    subscribed: false,
+    is_muted: false,
+};
+
+stream_data.add_sub(design);
+
+function test(label, f) {
+    run_test(label, (helpers) => {
+        user_topics.set_user_topics([]);
+        return f(helpers);
+    });
+}
+
+function update_visibility_policy(visibility_policy) {
+    user_topics.update_user_topics(design.stream_id, design.name, "java", visibility_policy);
+}
+
+test("toggle_topic_visibility_policy", () => {
+    // Mute a topic
+    assert.ok(!user_topics.is_topic_muted(design.stream_id, "java"));
+    update_visibility_policy(user_topics.all_visibility_policies.MUTED);
+    assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+
+    // Unsubscribe the channel
+    design.subscribed = false;
+
+    const message = {
+        type: "stream",
+        stream_id: design.stream_id,
+        topic: "java",
+    };
+
+    // Verify that we can't toggle visibility policy in unsubscribed channel.
+    user_topics_ui.toggle_topic_visibility_policy(message);
+    assert.ok(user_topics.is_topic_muted(design.stream_id, "java"));
+});


### PR DESCRIPTION
[CZO Discussion
](https://chat.zulip.org/#narrow/stream/9-issues/topic/Mute.20keyboard.20shortcut.20most.20unresponsive.20in.209.2Ex.20.2331275/near/1917971)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

Fixes the buggy behavior of `Shift + M` hotkey.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
