### PR TITLE
support: Show sponsorship and discount headers.

### DIFF
--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -58,6 +58,7 @@ class SponsorshipRequestDict(TypedDict):
 @dataclass
 class SponsorshipData:
     sponsorship_pending: bool = False
+    has_discount: bool = False
     monthly_discounted_price: int | None = None
     annual_discounted_price: int | None = None
     original_monthly_plan_price: int | None = None
@@ -132,14 +133,17 @@ def get_customer_sponsorship_data(customer: Customer) -> SponsorshipData:
     pending = customer.sponsorship_pending
     licenses = customer.minimum_licenses
     plan_tier = customer.required_plan_tier
+    has_discount = False
     sponsorship_request = None
     monthly_discounted_price = None
     annual_discounted_price = None
     original_monthly_plan_price = None
     original_annual_plan_price = None
     if customer.monthly_discounted_price:
+        has_discount = True
         monthly_discounted_price = customer.monthly_discounted_price
     if customer.annual_discounted_price:
+        has_discount = True
         annual_discounted_price = customer.annual_discounted_price
     if plan_tier is not None:
         original_monthly_plan_price = get_price_per_license(
@@ -173,6 +177,7 @@ def get_customer_sponsorship_data(customer: Customer) -> SponsorshipData:
 
     return SponsorshipData(
         sponsorship_pending=pending,
+        has_discount=has_discount,
         monthly_discounted_price=monthly_discounted_price,
         annual_discounted_price=annual_discounted_price,
         original_monthly_plan_price=original_monthly_plan_price,

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -549,6 +549,7 @@ def support(
             realm_data = get_data_for_cloud_support_view(billing_session)
             realm_support_data[realm.id] = realm_data
         context["realm_support_data"] = realm_support_data
+        context["SPONSORED_PLAN_TYPE"] = Realm.PLAN_TYPE_STANDARD_FREE
 
     def get_realm_owner_emails_as_string(realm: Realm) -> str:
         return ", ".join(

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -1,6 +1,12 @@
 <div class="realm-support-information">
     <span class="cloud-label">Cloud realm</span>
     <h3><img src="{{ realm_icon_url(realm) }}" class="support-realm-icon" /> {{ realm.name }}</h3>
+    {% if realm.plan_type == SPONSORED_PLAN_TYPE %}
+        <p class="support-section-header">On 100% sponsored Zulip Standard Free 🎉</p>
+    {% endif %}
+    {% if realm_support_data[realm.id].sponsorship_data.has_discount %}
+        <p class="support-section-header">Has a discount 💸</p>
+    {% endif %}
     <b>URL</b>: <a target="_blank" rel="noopener noreferrer" href="{{ realm.url }}">{{ realm.url }}</a> |
     <a target="_blank" rel="noopener noreferrer" href="/stats/realm/{{ realm.string_id }}/">stats</a> |
     <a target="_blank" rel="noopener noreferrer" href="/realm_activity/{{ realm.string_id }}/">activity</a><br />

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -14,7 +14,7 @@
         {% if remote_realm.plan_type == SPONSORED_PLAN_TYPE %}
             <p class="support-section-header">On 100% sponsored Zulip Community plan 🎉</p>
         {% endif %}
-        {% if support_data[remote_realm.id].sponsorship_data.default_discount %}
+        {% if support_data[remote_realm.id].sponsorship_data.has_discount %}
             <p class="support-section-header">Has a discount 💸</p>
         {% endif %}
         <b>Remote realm host:</b> {{ remote_realm.host }}<br />
@@ -48,6 +48,7 @@
     <div class="remote-support-sponsorship-container">
         {% with %}
             {% set sponsorship_data = support_data[remote_realm.id].sponsorship_data %}
+            {% set dollar_amount = dollar_amount %}
             {% include 'corporate/support/sponsorship_details.html' %}
         {% endwith %}
     </div>

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -46,7 +46,7 @@
                     {% if remote_server.plan_type == SPONSORED_PLAN_TYPE %}
                         <p class="support-section-header">On 100% sponsored Zulip Community plan 🎉</p>
                     {% endif %}
-                    {% if remote_servers_support_data[remote_server.id].sponsorship_data.default_discount %}
+                    {% if remote_servers_support_data[remote_server.id].sponsorship_data.has_discount %}
                         <p class="support-section-header">Has a discount 💸</p>
                     {% endif %}
                     <b>Contact email</b>: {{ remote_server.contact_email }}

--- a/templates/corporate/support/sponsorship_details.html
+++ b/templates/corporate/support/sponsorship_details.html
@@ -1,10 +1,15 @@
 <div class="remote-sponsorship-details">
     <p class="support-section-header">💸 Discount and sponsorship information:</p>
     <b>Sponsorship pending</b>: {{ sponsorship_data.sponsorship_pending }}<br />
-    {% if sponsorship_data.default_discount %}
-        <b>Discount</b>: {{ sponsorship_data.default_discount }}%<br />
+    {% if sponsorship_data.has_discount %}
+        {% if sponsorship_data.monthly_discounted_price %}
+            <b>Discounted price (monthly)</b>: {{ dollar_amount(sponsorship_data.monthly_discounted_price) }}%<br />
+        {% endif %}
+        {% if sponsorship_data.annual_discounted_price %}
+            <b>Discounted price (annual)</b>: {{ dollar_amount(sponsorship_data.monthly_discounted_price) }}%<br />
+        {% endif %}
     {% else %}
-        <b>Discount</b>: None<br />
+        <b>Discounted price</b>: None<br />
     {% endif %}
     <b>Minimum licenses</b>: {{ sponsorship_data.minimum_licenses }}<br />
     {% if sponsorship_data.required_plan_tier %}


### PR DESCRIPTION
**Updates**:
- Fixes the remote support view to show discount header after the removal of `default_discount` on the `Customer` model.
- Updates the Zulip Cloud support view to show discount and 100% sponsored headers.

---

**Screenshots and screen captures:**

<details>
<summary>Remote support view for realm with discount</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-14 18-59-58](https://github.com/user-attachments/assets/9066d707-38cf-4a35-93ca-67df9c589214) | ![Screenshot from 2024-08-14 18-58-36](https://github.com/user-attachments/assets/ba5eb92a-a16c-47d7-8747-2f3ee7f460b9)
</details>
<details>
<summary>Zulip Cloud support view for realm with discount</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-14 19-05-54](https://github.com/user-attachments/assets/42e43fb2-fe33-4819-896d-1b0abb562433) | ![Screenshot from 2024-08-14 19-06-47](https://github.com/user-attachments/assets/2d314489-3995-495b-86f0-4dbc3596bd3c)
</details>
<details>
<summary>Zulip Cloud support view for fully sponsored realm</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-14 19-08-01](https://github.com/user-attachments/assets/9ffc3c03-f824-4367-87d6-795ad3176354) | ![Screenshot from 2024-08-14 19-07-38](https://github.com/user-attachments/assets/4981e285-7b6c-432a-ac4f-cb545b6a58e4) 
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
