### PR TITLE
help: Fix details in "Change your call provider" section.

### DIFF
--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -69,6 +69,8 @@
 
 ## Change your call provider
 
+{!admin-only.md!}
+
 By default, Zulip integrates with
 [Jitsi Meet](https://jitsi.org/jitsi-meet/), a fully-encrypted, 100% open
 source video conferencing solution. Organization administrators can also
@@ -80,8 +82,8 @@ supported by Zulip are:
 * [BigBlueButton integration](/integrations/doc/big-blue-button)
 
 If you choose BigBlueButton as the call provider, there will be a single button
-(<i class="fa fa-video-camera"></i>) for starting a call. The call is initiated
-with cameras turned off.
+(<i class="zulip-icon zulip-icon-video-call"></i>) for starting a call in the
+compose box. The call is initiated with cameras turned off.
 
 !!! tip ""
 


### PR DESCRIPTION
**Updates**:
- Adds note about feature being available only to organization owners and administrators.
- Fixes the icon in the note about BigBlueButton to be the zulip icon that's currently used in the compose box.

**Screenshots and screen captures:**
 [Current documentation](https://zulip.com/help/start-a-call#change-your-call-provider)
![Screenshot from 2024-08-14 20-22-29](https://github.com/user-attachments/assets/8a1ad1bb-50f9-413a-abfc-3cde301b0601)


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
