### PR TITLE
message_send: Convert to typed endpoint.

### DIFF
--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -572,10 +572,6 @@ def to_non_negative_int(var_name: str, s: str, max_int_size: int = 2**32 - 1) ->
     return x
 
 
-def to_float(var_name: str, s: str) -> float:
-    return float(s)
-
-
 def check_string_or_int_list(var_name: str, val: object) -> str | list[int]:
     if isinstance(val, str):
         return val


### PR DESCRIPTION
Convert `message_send.py` use `typed endpoint`.

Disable `message_send` endpoint `to` parameter in the `openapi`
`validate_json_schema` check, because it is a special case where the
content type of the parameter is application/json but the
parameter may or may not be JSON encoded since previously we also
accepted a raw string and some ad-hoc bot might still depend on sending
a raw string.
