### PR TITLE
remote-support: Add ability to configure temporary courtesy plan.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -579,6 +579,7 @@ class SupportType(Enum):
     update_required_plan_tier = 8
     configure_fixed_price_plan = 9
     delete_fixed_price_next_plan = 10
+    configure_temporary_courtesy_plan = 11
 
 
 class SupportViewRequest(TypedDict, total=False):
@@ -1410,6 +1411,28 @@ class BillingSession(ABC):
         if new_plan_tier is not None:
             plan_tier_name = CustomerPlan.name_from_tier(new_plan_tier)
         return f"Required plan tier for {self.billing_entity_display_name} set to {plan_tier_name}."
+
+    def configure_temporary_courtesy_plan(self, end_date_string: str) -> str:
+        plan_end_date = datetime.strptime(end_date_string, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        if plan_end_date.date() <= timezone_now().date():
+            raise SupportRequestError(
+                f"Cannot configure a courtesy plan for {self.billing_entity_display_name} to end on {end_date_string}."
+            )
+        customer = self.get_customer()
+        if customer is not None:
+            plan = get_current_plan_by_customer(customer)
+            if plan is not None:
+                raise SupportRequestError(
+                    f"Cannot configure a courtesy plan for {self.billing_entity_display_name} because of current plan."
+                )
+        plan_anchor_date = timezone_now()
+        if isinstance(self, RealmBillingSession):
+            raise SupportRequestError(
+                f"Cannot currently configure a courtesy plan for {self.billing_entity_display_name}."
+            )  # nocoverage
+
+        self.migrate_customer_to_legacy_plan(plan_anchor_date, plan_end_date)
+        return f"Temporary courtesy plan for {self.billing_entity_display_name} configured to end on {end_date_string}."
 
     def configure_fixed_price_plan(self, fixed_price: int, sent_invoice_id: str | None) -> str:
         customer = self.get_customer()
@@ -3384,6 +3407,10 @@ class BillingSession(ABC):
             new_fixed_price = support_request["fixed_price"]
             sent_invoice_id = support_request["sent_invoice_id"]
             success_message = self.configure_fixed_price_plan(new_fixed_price, sent_invoice_id)
+        elif support_type == SupportType.configure_temporary_courtesy_plan:
+            assert support_request["plan_end_date"] is not None
+            temporary_plan_end_date = support_request["plan_end_date"]
+            success_message = self.configure_temporary_courtesy_plan(temporary_plan_end_date)
         elif support_type == SupportType.update_billing_modality:
             assert support_request["billing_modality"] is not None
             assert support_request["billing_modality"] in VALID_BILLING_MODALITY_VALUES

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -7352,7 +7352,9 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         self.assertEqual(success_message, "Fixed price offer deleted")
         result = self.client_get("/activity/remote/support", {"q": "example.com"})
         self.assert_not_in_success_response(["Next plan information:"], result)
-        self.assert_in_success_response(["Fixed price", "Annual amount in dollars"], result)
+        self.assert_in_success_response(
+            ["Configure fixed price plan", "Annual amount in dollars"], result
+        )
 
     @responses.activate
     @mock_stripe()

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -651,6 +651,10 @@ def remote_servers_support(
     modify_plan: VALID_MODIFY_PLAN_METHODS | None = None,
     delete_fixed_price_next_plan: Json[bool] = False,
     remote_server_status: VALID_STATUS_VALUES | None = None,
+    temporary_courtesy_plan: Annotated[
+        str, AfterValidator(lambda x: check_date("temporary_courtesy_plan", x))
+    ]
+    | None = None,
 ) -> HttpResponse:
     context: dict[str, Any] = {}
 
@@ -705,6 +709,11 @@ def remote_servers_support(
                 support_type=SupportType.configure_fixed_price_plan,
                 fixed_price=fixed_price,
                 sent_invoice_id=sent_invoice_id,
+            )
+        elif temporary_courtesy_plan is not None:
+            support_view_request = SupportViewRequest(
+                support_type=SupportType.configure_temporary_courtesy_plan,
+                plan_end_date=temporary_courtesy_plan,
             )
         elif billing_modality is not None:
             support_view_request = SupportViewRequest(

--- a/templates/corporate/support/next_plan_forms_support.html
+++ b/templates/corporate/support/next_plan_forms_support.html
@@ -1,14 +1,24 @@
-<p class="support-section-header">⏱️ Schedule fixed price plan:</p>
+<p class="support-section-header">⏱️ Schedule plan:</p>
 <form method="POST" class="remote-form">
-    <b>Fixed price</b><br />
-    {% if not is_current_plan_billable %}
+    <b>Configure fixed price plan:</b><br />
+    {% if not plan_data.is_current_plan_billable %}
     <i>Enter Invoice ID only if the customer chose to pay by invoice.</i><br />
     {% endif %}
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     <input type="number" name="fixed_price" placeholder="Annual amount in dollars" required />
-    {% if not is_current_plan_billable %}
+    {% if not plan_data.is_current_plan_billable %}
     <input type="text" name="sent_invoice_id" placeholder="Sent invoice ID" />
     {% endif %}
     <button type="submit" class="support-submit-button">Schedule</button>
 </form>
+{% if not plan_data.current_plan %}
+<form method="POST" class="remote-form">
+    <b>Configure temporary courtesy plan:</b><br />
+    <i>Once created, the end date for the temporary courtesy plan can be extended.</i><br />
+    {{ csrf_input }}
+    <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
+    <input type="date" name="temporary_courtesy_plan" required />
+    <button type="submit" class="support-submit-button">Create</button>
+</form>
+{% endif %}

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -94,7 +94,7 @@
     {% elif not remote_server_deactivated %}
     <div class="next-plan-container">
         {% with %}
-            {% set is_current_plan_billable = support_data[remote_realm.id].plan_data.is_current_plan_billable %}
+            {% set plan_data = support_data[remote_realm.id].plan_data %}
             {% set remote_id = remote_realm.id %}
             {% set remote_type = "remote_realm_id" %}
             {% include 'corporate/support/next_plan_forms_support.html' %}

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -139,7 +139,7 @@
                 {% elif not remote_server.deactivated %}
                 <div class="next-plan-container">
                     {% with %}
-                        {% set is_current_plan_billable = remote_servers_support_data[remote_server.id].plan_data.is_current_plan_billable %}
+                        {% set plan_data = remote_servers_support_data[remote_server.id].plan_data %}
                         {% set remote_id = remote_server.id %}
                         {% set remote_type = "remote_server_id" %}
                         {% include 'corporate/support/next_plan_forms_support.html' %}


### PR DESCRIPTION
Expands section for scheduling plans in the remote support view to have a form to create a "temporary courtesy" plan (aka our legacy plan) for remote servers and realms.

**Notes**:
- Form is not shown if there is a current plan for the remote billing entity, and would raise a `SupportRequestError` in that case as well.
- There must be an end date submitted for the courtesy/legacy plan to be configured.
- The user-facing language for these plans is still "Free (legacy plan)". The terminology "temporary courtesy plan" is all internal to the support view/admin.
- Not implemented for non-remote support view because there is no legacy plan support in place for non-remote billing entities currently.

---

**Screenshots and screen captures:**

<details>
<summary>Schedule plan forms in remote support view</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-15 18-46-34](https://github.com/user-attachments/assets/8212e9ea-83f2-42b9-9aa9-361952ba705c) | ![Screenshot from 2024-08-15 18-36-27](https://github.com/user-attachments/assets/d4198b34-3485-47c3-b90c-62bb9f93a653)
</details>
<details>
<summary>Date field required for form submission</summary>

![Screenshot from 2024-08-15 18-49-17](https://github.com/user-attachments/assets/7a884504-93f1-41a6-9e3e-7e1d2f3c1ea7)
</details>
<details>
<summary>Error if date for courtesy plan set to be in the past</summary>

![Screenshot from 2024-08-15 18-37-53](https://github.com/user-attachments/assets/1f137ba3-deb8-4de2-84bf-1068dff5021e)
</details>
<details>
<summary>Example of remote support view with current plan - cannot schedule courtesy plan</summary>

![Screenshot from 2024-08-15 18-38-34](https://github.com/user-attachments/assets/4bc5e47c-dff1-4c12-90c7-d6238b795a5d)
</details>
<details>
<summary>Success message when courtesy plan is created</summary>

![Screenshot from 2024-08-15 18-38-58](https://github.com/user-attachments/assets/5e0a5dce-d0b3-46d6-820c-9b69b7a950d7)
</details>
<details>
<summary>Example of remote support view after configuring a courtesy plan</summary>

![Screenshot from 2024-08-15 18-39-11](https://github.com/user-attachments/assets/7731ec14-09e4-47b9-98bb-fdb7ffa39517)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
