### PR TITLE
prep commits: use stream id instead of stream name

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -380,15 +380,15 @@ export class MessageList {
             return;
         }
 
-        const stream_name = narrow_state.stream_name();
-        if (stream_name === undefined) {
+        const stream_id = narrow_state.stream_id();
+        if (stream_id === undefined) {
             // Trailing bookends are only for channel views.
             return;
         }
 
         // If user narrows to a stream, don't update
         // trailing bookend if user is subscribed.
-        const sub = stream_data.get_sub(stream_name);
+        const sub = stream_data.get_sub_by_id(stream_id);
         if (
             sub &&
             sub.subscribed &&
@@ -401,7 +401,7 @@ export class MessageList {
 
         let deactivated = false;
         let just_unsubscribed = false;
-        const subscribed = stream_data.is_subscribed_by_name(stream_name);
+        const subscribed = stream_data.is_subscribed(stream_id);
         const invite_only = sub && sub.invite_only;
         const is_web_public = sub && sub.is_web_public;
         const can_toggle_subscription =
@@ -413,7 +413,7 @@ export class MessageList {
         }
 
         this.view.render_trailing_bookend(
-            stream_name,
+            sub.name,
             subscribed,
             deactivated,
             just_unsubscribed,

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -1071,45 +1071,47 @@ export function activate_stream_for_cycle_hotkey(stream_name) {
 }
 
 export function stream_cycle_backward() {
-    const curr_stream = narrow_state.stream_name();
+    const curr_stream_id = narrow_state.stream_id();
 
-    if (!curr_stream) {
+    if (!curr_stream_id) {
         return;
     }
 
-    const stream_name = topic_generator.get_prev_stream(curr_stream);
+    const stream_id = topic_generator.get_prev_stream(curr_stream_id);
 
-    if (!stream_name) {
+    if (!stream_id) {
         return;
     }
 
+    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     activate_stream_for_cycle_hotkey(stream_name);
 }
 
 export function stream_cycle_forward() {
-    const curr_stream = narrow_state.stream_name();
+    const curr_stream_id = narrow_state.stream_id();
 
-    if (!curr_stream) {
+    if (!curr_stream_id) {
         return;
     }
 
-    const stream_name = topic_generator.get_next_stream(curr_stream);
+    const stream_id = topic_generator.get_next_stream(curr_stream_id);
 
-    if (!stream_name) {
+    if (!stream_id) {
         return;
     }
 
+    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     activate_stream_for_cycle_hotkey(stream_name);
 }
 
 export function narrow_to_next_topic(opts = {}) {
     const curr_info = {
-        stream: narrow_state.stream_name(),
+        stream_id: narrow_state.stream_id(),
         topic: narrow_state.topic(),
     };
 
     const next_narrow = topic_generator.get_next_topic(
-        curr_info.stream,
+        curr_info.stream_id,
         curr_info.topic,
         opts.only_followed_topics,
     );
@@ -1136,8 +1138,9 @@ export function narrow_to_next_topic(opts = {}) {
         return;
     }
 
+    const stream_name = stream_data.get_stream_name_from_id(next_narrow.stream_id);
     const filter_expr = [
-        {operator: "channel", operand: next_narrow.stream},
+        {operator: "channel", operand: stream_name},
         {operator: "topic", operand: next_narrow.topic},
     ];
 

--- a/web/src/message_view.js
+++ b/web/src/message_view.js
@@ -1064,7 +1064,8 @@ export function render_message_list_with_selected_message(opts) {
     narrow_history.save_narrow_state_and_flush();
 }
 
-export function activate_stream_for_cycle_hotkey(stream_name) {
+export function activate_stream_for_cycle_hotkey(stream_id) {
+    const stream_name = stream_data.get_stream_name_from_id(stream_id);
     // This is the common code for A/D hotkeys.
     const filter_expr = [{operator: "channel", operand: stream_name}];
     show(filter_expr, {});
@@ -1083,8 +1084,7 @@ export function stream_cycle_backward() {
         return;
     }
 
-    const stream_name = stream_data.get_stream_name_from_id(stream_id);
-    activate_stream_for_cycle_hotkey(stream_name);
+    activate_stream_for_cycle_hotkey(stream_id);
 }
 
 export function stream_cycle_forward() {
@@ -1100,8 +1100,7 @@ export function stream_cycle_forward() {
         return;
     }
 
-    const stream_name = stream_data.get_stream_name_from_id(stream_id);
-    activate_stream_for_cycle_hotkey(stream_name);
+    activate_stream_for_cycle_hotkey(stream_id);
 }
 
 export function narrow_to_next_topic(opts = {}) {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -462,15 +462,6 @@ export function is_muted(stream_id: number): boolean {
     return sub.is_muted;
 }
 
-export function is_stream_muted_by_name(stream_name: string): boolean {
-    const sub = get_sub(stream_name);
-    // Return true for undefined streams
-    if (sub === undefined) {
-        return true;
-    }
-    return sub.is_muted;
-}
-
 export function is_new_stream_announcements_stream_muted(): boolean {
     return is_muted(realm.realm_new_stream_announcements_stream_id);
 }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -433,11 +433,6 @@ export function all_subscribed_streams_are_in_home_view(): boolean {
     return subscribed_subs().every((sub) => !sub.is_muted);
 }
 
-export function home_view_stream_names(): string[] {
-    const home_view_subs = subscribed_subs().filter((sub) => !sub.is_muted);
-    return home_view_subs.map((sub) => sub.name);
-}
-
 export function canonicalized_name(stream_name: string): string {
     return stream_name.toString().toLowerCase();
 }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -82,14 +82,14 @@ class BinaryDict<T> {
         yield* this.falses.values();
     }
 
-    get(k: number): T {
+    get(k: number): T | undefined {
         const res = this.trues.get(k);
 
         if (res !== undefined) {
             return res;
         }
 
-        return this.falses.get(k)!;
+        return this.falses.get(k);
     }
 
     set(k: number, v: T): void {

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -23,11 +23,8 @@ let all_streams: number[] = [];
 // to avoid making left sidebar rendering a quadratic operation.
 let filter_out_inactives = false;
 
-export function get_streams(): string[] {
-    return all_streams.flatMap((stream_id) => {
-        const stream_name = sub_store.maybe_get_stream_name(stream_id);
-        return stream_name === undefined ? [] : [stream_name];
-    });
+export function get_stream_ids(): number[] {
+    return [...all_streams];
 }
 
 function compare_function(a: number, b: number): number {

--- a/web/src/topic_generator.ts
+++ b/web/src/topic_generator.ts
@@ -10,48 +10,48 @@ import * as unread from "./unread";
 import * as user_topics from "./user_topics";
 
 export function next_topic(
-    streams: string[],
-    get_topics: (stream_name: string) => string[],
-    has_unread_messages: (stream_name: string, topic: string) => boolean,
-    curr_stream: string,
+    stream_ids: number[],
+    get_topics: (stream_id: number) => string[],
+    has_unread_messages: (stream_id: number, topic: string) => boolean,
+    curr_stream_id: number,
     curr_topic: string,
-): {stream: string; topic: string} | undefined {
-    const curr_stream_index = streams.indexOf(curr_stream); // -1 if not found
+): {stream_id: number; topic: string} | undefined {
+    const curr_stream_index = stream_ids.indexOf(curr_stream_id); // -1 if not found
 
     if (curr_stream_index >= 0) {
-        const stream = streams[curr_stream_index]!;
-        const topics = get_topics(stream);
+        const stream_id = stream_ids[curr_stream_index]!;
+        const topics = get_topics(stream_id);
         const curr_topic_index = topics.indexOf(curr_topic); // -1 if not found
 
         for (let i = curr_topic_index + 1; i < topics.length; i += 1) {
             const topic = topics[i]!;
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+            if (has_unread_messages(stream_id, topic)) {
+                return {stream_id, topic};
             }
         }
 
         for (let i = 0; i < curr_topic_index; i += 1) {
             const topic = topics[i]!;
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+            if (has_unread_messages(stream_id, topic)) {
+                return {stream_id, topic};
             }
         }
     }
 
-    for (let i = curr_stream_index + 1; i < streams.length; i += 1) {
-        const stream = streams[i]!;
-        for (const topic of get_topics(stream)) {
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+    for (let i = curr_stream_index + 1; i < stream_ids.length; i += 1) {
+        const stream_id = stream_ids[i]!;
+        for (const topic of get_topics(stream_id)) {
+            if (has_unread_messages(stream_id, topic)) {
+                return {stream_id, topic};
             }
         }
     }
 
     for (let i = 0; i < curr_stream_index; i += 1) {
-        const stream = streams[i]!;
-        for (const topic of get_topics(stream)) {
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+        const stream_id = stream_ids[i]!;
+        for (const topic of get_topics(stream_id)) {
+            if (has_unread_messages(stream_id, topic)) {
+                return {stream_id, topic};
             }
         }
     }
@@ -60,15 +60,13 @@ export function next_topic(
 }
 
 export function get_next_topic(
-    curr_stream: string,
+    curr_stream_id: number,
     curr_topic: string,
     only_followed_topics: boolean,
-): {stream: string; topic: string} | undefined {
-    let my_streams = stream_list_sort.get_streams();
+): {stream_id: number; topic: string} | undefined {
+    let my_streams = stream_list_sort.get_stream_ids();
 
-    my_streams = my_streams.filter((stream_name) => {
-        const stream_id = stream_data.get_stream_id(stream_name);
-        assert(stream_id !== undefined);
+    my_streams = my_streams.filter((stream_id) => {
         if (!stream_data.is_muted(stream_id)) {
             return true;
         }
@@ -77,7 +75,7 @@ export function get_next_topic(
             const topics = stream_topic_history.get_recent_topic_names(stream_id);
             return topics.some((topic) => user_topics.is_topic_followed(stream_id, topic));
         }
-        if (stream_name === curr_stream) {
+        if (stream_id === curr_stream_id) {
             // We can use n within a muted stream if we are
             // currently narrowed to it.
             return true;
@@ -87,8 +85,7 @@ export function get_next_topic(
         return topics.some((topic) => user_topics.is_topic_unmuted_or_followed(stream_id, topic));
     });
 
-    function get_unmuted_topics(stream_name: string): string[] {
-        const stream_id = stream_data.get_stream_id(stream_name);
+    function get_unmuted_topics(stream_id: number): string[] {
         const narrowed_steam_id = narrow_state.stream_id();
         assert(stream_id !== undefined);
         const topics = stream_topic_history.get_recent_topic_names(stream_id);
@@ -116,16 +113,13 @@ export function get_next_topic(
         return topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
     }
 
-    function get_followed_topics(stream_name: string): string[] {
-        const stream_id = stream_data.get_stream_id(stream_name);
-        assert(stream_id !== undefined);
+    function get_followed_topics(stream_id: number): string[] {
         let topics = stream_topic_history.get_recent_topic_names(stream_id);
         topics = topics.filter((topic) => user_topics.is_topic_followed(stream_id, topic));
         return topics;
     }
 
-    function has_unread_messages(stream_name: string, topic: string): boolean {
-        const stream_id = stream_data.get_stream_id(stream_name);
+    function has_unread_messages(stream_id: number, topic: string): boolean {
         assert(stream_id !== undefined);
         return unread.topic_has_any_unread(stream_id, topic);
     }
@@ -135,12 +129,18 @@ export function get_next_topic(
             my_streams,
             get_followed_topics,
             has_unread_messages,
-            curr_stream,
+            curr_stream_id,
             curr_topic,
         );
     }
 
-    return next_topic(my_streams, get_unmuted_topics, has_unread_messages, curr_stream, curr_topic);
+    return next_topic(
+        my_streams,
+        get_unmuted_topics,
+        has_unread_messages,
+        curr_stream_id,
+        curr_topic,
+    );
 }
 
 export function get_next_unread_pm_string(curr_pm: string): string | undefined {
@@ -162,9 +162,9 @@ export function get_next_unread_pm_string(curr_pm: string): string | undefined {
     return undefined;
 }
 
-export function get_next_stream(curr_stream: string): string | undefined {
-    const my_streams = stream_list_sort.get_streams();
-    const curr_stream_index = my_streams.indexOf(curr_stream);
+export function get_next_stream(curr_stream_id: number): number | undefined {
+    const my_streams = stream_list_sort.get_stream_ids();
+    const curr_stream_index = my_streams.indexOf(curr_stream_id);
     return my_streams[
         curr_stream_index < 0 || curr_stream_index === my_streams.length - 1
             ? 0
@@ -172,8 +172,8 @@ export function get_next_stream(curr_stream: string): string | undefined {
     ];
 }
 
-export function get_prev_stream(curr_stream: string): string | undefined {
-    const my_streams = stream_list_sort.get_streams();
-    const curr_stream_index = my_streams.indexOf(curr_stream);
+export function get_prev_stream(curr_stream_id: number): number | undefined {
+    const my_streams = stream_list_sort.get_stream_ids();
+    const curr_stream_index = my_streams.indexOf(curr_stream_id);
     return my_streams[curr_stream_index <= 0 ? my_streams.length - 1 : curr_stream_index - 1];
 }

--- a/web/src/topic_generator.ts
+++ b/web/src/topic_generator.ts
@@ -67,13 +67,13 @@ export function get_next_topic(
     let my_streams = stream_list_sort.get_streams();
 
     my_streams = my_streams.filter((stream_name) => {
-        if (!stream_data.is_stream_muted_by_name(stream_name)) {
+        const stream_id = stream_data.get_stream_id(stream_name);
+        assert(stream_id !== undefined);
+        if (!stream_data.is_muted(stream_id)) {
             return true;
         }
         if (only_followed_topics) {
             // We can use Shift + N to go to unread followed topic in muted stream.
-            const stream_id = stream_data.get_stream_id(stream_name);
-            assert(stream_id !== undefined);
             const topics = stream_topic_history.get_recent_topic_names(stream_id);
             return topics.some((topic) => user_topics.is_topic_followed(stream_id, topic));
         }
@@ -83,8 +83,6 @@ export function get_next_topic(
             return true;
         }
         // We can use N to go to next unread unmuted/followed topic in a muted stream .
-        const stream_id = stream_data.get_stream_id(stream_name);
-        assert(stream_id !== undefined);
         const topics = stream_topic_history.get_recent_topic_names(stream_id);
         return topics.some((topic) => user_topics.is_topic_unmuted_or_followed(stream_id, topic));
     });
@@ -110,7 +108,7 @@ export function get_next_topic(
 
             /* istanbul ignore next */
             return topics.filter((topic) => !user_topics.is_topic_muted(stream_id, topic));
-        } else if (stream_data.is_stream_muted_by_name(stream_name)) {
+        } else if (stream_data.is_muted(stream_id)) {
             return topics.filter((topic) =>
                 user_topics.is_topic_unmuted_or_followed(stream_id, topic),
             );

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -322,13 +322,13 @@ run_test("bookend", ({override}) => {
     list.view.clear_trailing_bookend = noop;
     list.is_combined_feed_view = false;
 
-    override(narrow_state, "stream_name", () => "IceCream");
+    override(narrow_state, "stream_id", () => 5);
 
     let is_subscribed = true;
     let invite_only = false;
 
-    override(stream_data, "is_subscribed_by_name", () => is_subscribed);
-    override(stream_data, "get_sub", () => ({invite_only}));
+    override(stream_data, "is_subscribed", () => is_subscribed);
+    override(stream_data, "get_sub_by_id", () => ({invite_only, name: "IceCream"}));
     override(stream_data, "can_toggle_subscription", () => true);
 
     {

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -123,7 +123,6 @@ test("basics", () => {
     assert.equal(stream_data.get_sub("web_public_stream"), web_public_stream);
     assert.ok(stream_data.is_web_public(web_public_stream.stream_id));
 
-    assert.deepEqual(stream_data.home_view_stream_names(), ["social"]);
     assert.deepEqual(stream_data.subscribed_streams(), ["social", "test"]);
     assert.deepEqual(stream_data.get_colors(), ["red", "yellow"]);
     assert.deepEqual(stream_data.subscribed_stream_ids(), [social.stream_id, test.stream_id]);

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -700,14 +700,6 @@ const jazy = {
     is_muted: true,
 };
 
-test("is_muted", () => {
-    stream_data.add_sub(tony);
-    stream_data.add_sub(jazy);
-    assert.ok(!stream_data.is_stream_muted_by_name("tony"));
-    assert.ok(stream_data.is_stream_muted_by_name("jazy"));
-    assert.ok(stream_data.is_stream_muted_by_name("EEXISTS"));
-});
-
 test("is_new_stream_announcements_stream_muted", () => {
     stream_data.add_sub(tony);
     stream_data.add_sub(jazy);

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -265,61 +265,63 @@ function add_row(sub) {
     stream_list.stream_sidebar.set_row(sub.stream_id, row);
 }
 
+const develSub = {
+    name: "devel",
+    stream_id: 1000,
+    color: "blue",
+    pin_to_top: true,
+    subscribed: true,
+};
+
+const RomeSub = {
+    name: "Rome",
+    stream_id: 2000,
+    color: "blue",
+    pin_to_top: true,
+    subscribed: true,
+};
+
+const testSub = {
+    name: "test",
+    stream_id: 3000,
+    color: "blue",
+    pin_to_top: true,
+    subscribed: true,
+};
+
+const announceSub = {
+    name: "announce",
+    stream_id: 4000,
+    color: "green",
+    pin_to_top: false,
+    subscribed: true,
+};
+
+const DenmarkSub = {
+    name: "Denmark",
+    stream_id: 5000,
+    color: "green",
+    pin_to_top: false,
+    subscribed: true,
+};
+
+const carSub = {
+    name: "cars",
+    stream_id: 6000,
+    color: "green",
+    pin_to_top: false,
+    subscribed: true,
+};
+
 function initialize_stream_data() {
     // pinned streams
-    const develSub = {
-        name: "devel",
-        stream_id: 1000,
-        color: "blue",
-        pin_to_top: true,
-        subscribed: true,
-    };
     add_row(develSub);
-
-    const RomeSub = {
-        name: "Rome",
-        stream_id: 2000,
-        color: "blue",
-        pin_to_top: true,
-        subscribed: true,
-    };
     add_row(RomeSub);
-
-    const testSub = {
-        name: "test",
-        stream_id: 3000,
-        color: "blue",
-        pin_to_top: true,
-        subscribed: true,
-    };
     add_row(testSub);
 
     // unpinned streams
-    const announceSub = {
-        name: "announce",
-        stream_id: 4000,
-        color: "green",
-        pin_to_top: false,
-        subscribed: true,
-    };
     add_row(announceSub);
-
-    const DenmarkSub = {
-        name: "Denmark",
-        stream_id: 5000,
-        color: "green",
-        pin_to_top: false,
-        subscribed: true,
-    };
     add_row(DenmarkSub);
-
-    const carSub = {
-        name: "cars",
-        stream_id: 6000,
-        color: "green",
-        pin_to_top: false,
-        subscribed: true,
-    };
     add_row(carSub);
 
     stream_list.build_stream_list();
@@ -520,18 +522,18 @@ test_ui("sort_streams", ({override_rewire, mock_template}) => {
     assert.ok(active_subheader_flag);
     assert.ok(inactive_subheader_flag);
 
-    const streams = stream_list_sort.get_streams();
+    const streams = stream_list_sort.get_stream_ids();
 
     assert.deepEqual(streams, [
         // three groups: pinned, normal, dormant
-        "devel",
-        "Rome",
-        "test",
+        develSub.stream_id,
+        RomeSub.stream_id,
+        testSub.stream_id,
         //
-        "announce",
-        "Denmark",
+        announceSub.stream_id,
+        DenmarkSub.stream_id,
         //
-        "cars",
+        carSub.stream_id,
     ]);
 
     const denmark_sub = stream_data.get_sub("Denmark");
@@ -681,6 +683,9 @@ test_ui("rename_stream", ({mock_template}) => {
 
     stream_list.rename_stream(sub);
     assert.equal($unread_count.text(), "99");
+
+    // Reset for the next initialize_stream_data()
+    develSub.name = "devel"; // Resets
 });
 
 test_ui("refresh_pin", ({override, override_rewire, mock_template}) => {

--- a/web/tests/topic_generator.test.js
+++ b/web/tests/topic_generator.test.js
@@ -85,6 +85,7 @@ run_test("topics", ({override}) => {
         muted: muted_stream_id,
         devel: devel_stream_id,
         announce: 402,
+        "test here": 200,
     };
 
     override(stream_topic_history, "get_recent_topic_names", (stream_id) => {
@@ -100,7 +101,7 @@ run_test("topics", ({override}) => {
 
     override(stream_data, "get_stream_id", (stream_name) => stream_id_dct[stream_name]);
 
-    override(stream_data, "is_stream_muted_by_name", (stream_name) => stream_name === "muted");
+    override(stream_data, "is_muted", (stream_id) => stream_id === muted_stream_id);
 
     let topic_has_unreads = new Set([
         "unmuted",

--- a/web/tests/topic_generator.test.js
+++ b/web/tests/topic_generator.test.js
@@ -17,36 +17,35 @@ const user_topics = mock_esm("../src/user_topics");
 const tg = zrequire("topic_generator");
 
 run_test("streams", ({override}) => {
-    function assert_next_stream(curr_stream, expected) {
-        const actual = tg.get_next_stream(curr_stream);
+    function assert_next_stream(curr_stream_id, expected) {
+        const actual = tg.get_next_stream(curr_stream_id);
         assert.equal(actual, expected);
     }
 
-    override(stream_list_sort, "get_streams", () => ["announce", "muted", "devel", "test here"]);
+    override(stream_list_sort, "get_stream_ids", () => [1, 2, 3, 4]);
 
-    assert_next_stream(undefined, "announce");
-    assert_next_stream("NOT THERE", "announce");
+    assert_next_stream(undefined, 1);
 
-    assert_next_stream("announce", "muted");
-    assert_next_stream("test here", "announce");
+    assert_next_stream(1, 2);
+    assert_next_stream(4, 1);
 
-    function assert_prev_stream(curr_stream, expected) {
-        const actual = tg.get_prev_stream(curr_stream);
+    function assert_prev_stream(curr_stream_id, expected) {
+        const actual = tg.get_prev_stream(curr_stream_id);
         assert.equal(actual, expected);
     }
 
-    assert_prev_stream(undefined, "test here");
-    assert_prev_stream("test here", "devel");
-    assert_prev_stream("announce", "test here");
+    assert_prev_stream(undefined, 4);
+    assert_prev_stream(4, 3);
+    assert_prev_stream(1, 4);
 });
 
 run_test("topics", ({override}) => {
-    const streams = ["stream1", "stream2", "stream3", "stream4"];
+    const streams = [1, 2, 3, 4];
     const topics = new Map([
-        ["stream1", ["read", "read", "1a", "1b", "read", "1c"]],
-        ["stream2", []],
-        ["stream3", ["3a", "read", "read", "3b", "read"]],
-        ["stream4", ["4a"]],
+        [1, ["read", "read", "1a", "1b", "read", "1c"]],
+        [2, []],
+        [3, ["3a", "read", "read", "3b", "read"]],
+        [4, ["4a"]],
     ]);
 
     function has_unread_messages(_stream, topic) {
@@ -61,32 +60,31 @@ run_test("topics", ({override}) => {
         return tg.next_topic(streams, get_topics, has_unread_messages, curr_stream, curr_topic);
     }
 
-    assert.deepEqual(next_topic("stream1", "1a"), {stream: "stream1", topic: "1b"});
-    assert.deepEqual(next_topic("stream1", undefined), {stream: "stream1", topic: "1a"});
-    assert.deepEqual(next_topic("stream2", "bogus"), {stream: "stream3", topic: "3a"});
-    assert.deepEqual(next_topic("stream3", "3b"), {stream: "stream3", topic: "3a"});
-    assert.deepEqual(next_topic("stream4", "4a"), {stream: "stream1", topic: "1a"});
-    assert.deepEqual(next_topic(undefined, undefined), {stream: "stream1", topic: "1a"});
+    assert.deepEqual(next_topic(1, "1a"), {stream_id: 1, topic: "1b"});
+    assert.deepEqual(next_topic(1, undefined), {stream_id: 1, topic: "1a"});
+    assert.deepEqual(next_topic(2, "bogus"), {stream_id: 3, topic: "3a"});
+    assert.deepEqual(next_topic(3, "3b"), {stream_id: 3, topic: "3a"});
+    assert.deepEqual(next_topic(4, "4a"), {stream_id: 1, topic: "1a"});
+    assert.deepEqual(next_topic(undefined, undefined), {stream_id: 1, topic: "1a"});
 
     assert.deepEqual(
-        tg.next_topic(streams, get_topics, () => false, "stream1", "1a"),
+        tg.next_topic(streams, get_topics, () => false, 1, "1a"),
         undefined,
     );
 
     // Now test the deeper function that is wired up to
     // real functions stream_data/stream_list_sort/unread.
 
-    override(stream_list_sort, "get_streams", () => ["announce", "muted", "devel", "test here"]);
-
     const muted_stream_id = 400;
     const devel_stream_id = 401;
-
-    const stream_id_dct = {
-        muted: muted_stream_id,
-        devel: devel_stream_id,
-        announce: 402,
-        "test here": 200,
-    };
+    const announce_stream_id = 402;
+    const test_here_stream_id = 403;
+    override(stream_list_sort, "get_stream_ids", () => [
+        announce_stream_id,
+        muted_stream_id,
+        devel_stream_id,
+        test_here_stream_id,
+    ]);
 
     override(stream_topic_history, "get_recent_topic_names", (stream_id) => {
         switch (stream_id) {
@@ -98,8 +96,6 @@ run_test("topics", ({override}) => {
 
         return [];
     });
-
-    override(stream_data, "get_stream_id", (stream_name) => stream_id_dct[stream_name]);
 
     override(stream_data, "is_muted", (stream_id) => stream_id === muted_stream_id);
 
@@ -130,30 +126,30 @@ run_test("topics", ({override}) => {
         (_stream_name, topic) => topic === "followed-muted" || topic === "followed-devel",
     );
 
-    let next_item = tg.get_next_topic("announce", "whatever");
+    let next_item = tg.get_next_topic(announce_stream_id, "whatever");
     assert.deepEqual(next_item, {
-        stream: "muted",
+        stream_id: muted_stream_id,
         topic: "unmuted",
     });
     mark_topic_as_read("unmuted");
 
-    next_item = tg.get_next_topic("muted", "unmuted");
+    next_item = tg.get_next_topic(muted_stream_id, "unmuted");
     assert.deepEqual(next_item, {
-        stream: "muted",
+        stream_id: muted_stream_id,
         topic: "followed-muted",
     });
     mark_topic_as_read("followed-muted");
 
-    next_item = tg.get_next_topic("muted", "followed-muted");
+    next_item = tg.get_next_topic(muted_stream_id, "followed-muted");
     assert.deepEqual(next_item, {
-        stream: "devel",
+        stream_id: devel_stream_id,
         topic: "python",
     });
     mark_topic_as_read("python");
 
-    next_item = tg.get_next_topic("devel", "python");
+    next_item = tg.get_next_topic(devel_stream_id, "python");
     assert.deepEqual(next_item, {
-        stream: "devel",
+        stream_id: devel_stream_id,
         topic: "followed-devel",
     });
     mark_topic_as_read("followed-devel");
@@ -162,21 +158,21 @@ run_test("topics", ({override}) => {
     topic_has_unreads = new Set(["unmuted", "followed-muted", "muted", "python", "followed-devel"]);
     // Shift + N takes the user to next unread followed topic,
     // even if the stream is muted.
-    next_item = tg.get_next_topic("announce", "whatever", true);
+    next_item = tg.get_next_topic(announce_stream_id, "whatever", true);
     assert.deepEqual(next_item, {
-        stream: "muted",
+        stream_id: muted_stream_id,
         topic: "followed-muted",
     });
 
-    next_item = tg.get_next_topic("muted", "whatever", true);
+    next_item = tg.get_next_topic(muted_stream_id, "whatever", true);
     assert.deepEqual(next_item, {
-        stream: "muted",
+        stream_id: muted_stream_id,
         topic: "followed-muted",
     });
 
-    next_item = tg.get_next_topic("muted", undefined);
+    next_item = tg.get_next_topic(muted_stream_id, undefined);
     assert.deepEqual(next_item, {
-        stream: "muted",
+        stream_id: muted_stream_id,
         topic: "unmuted",
     });
 });


### PR DESCRIPTION
This PR should have no user-facing changes. These are the simpler commits from #31299