### PR TITLE
puppeteer: Use a robust method to verify if we switched narrow.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -36,6 +36,11 @@ async function test_send_messages(page: Page): Promise<void> {
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
     assert.equal((await page.$$(".message-list .message_row")).length, initial_msgs_count + 2);
 }
 
@@ -137,10 +142,11 @@ async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): 
 
     // Go back to the combined feed view and make sure all messages are loaded.
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-
-    await page.waitForSelector(".message-list .message_row", {visible: true});
-    // Assert that there is only one message list.
-    assert.equal((await page.$$(".message-list")).length, 1);
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
     const pm = await page.waitForSelector(
         `xpath/(//*[${common.has_class_x(
             "messagebox",
@@ -219,7 +225,11 @@ async function test_markdown_preview(page: Page): Promise<void> {
 async function compose_tests(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
     await test_send_messages(page);
     await test_keyboard_shortcuts(page);
     await test_reply_by_click_prepopulates_stream_topic_names(page);

--- a/web/e2e-tests/copy-and-paste.test.ts
+++ b/web/e2e-tests/copy-and-paste.test.ts
@@ -130,9 +130,11 @@ async function test_copying_messages_from_several_topics(page: Page): Promise<vo
 async function copy_paste_test(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
-    // Assert that there is only one message list.
-    assert.equal((await page.$$(".message-list")).length, 1);
+    let message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
 
     await common.send_multiple_messages(page, [
         {stream_name: "Verona", topic: "copy-paste-topic #1", content: "copy paste test A"},
@@ -151,7 +153,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    const message_list_id = await common.get_current_msg_list_id(page, true);
+    message_list_id = await common.get_current_msg_list_id(page, true);
     await common.check_messages_sent(page, message_list_id, [
         ["Verona > copy-paste-topic #1", ["copy paste test A", "copy paste test B"]],
         [

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -290,9 +290,11 @@ async function test_delete_draft_on_clearing_text(page: Page): Promise<void> {
 async function drafts_test(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
-    // Assert that there is only one message list.
-    assert.equal((await page.$$(".message-list")).length, 1);
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
 
     await test_empty_drafts(page);
 

--- a/web/e2e-tests/edit.test.ts
+++ b/web/e2e-tests/edit.test.ts
@@ -97,7 +97,11 @@ async function test_edit_private_message(page: Page): Promise<void> {
 async function edit_tests(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
 
     await test_stream_message_edit(page);
     await test_edit_message_with_slash_me(page);

--- a/web/e2e-tests/mention.test.ts
+++ b/web/e2e-tests/mention.test.ts
@@ -7,7 +7,11 @@ import * as common from "./lib/common";
 async function test_mention(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
+    let message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
     await page.keyboard.press("KeyC");
     await page.waitForSelector("#compose", {visible: true});
 
@@ -33,7 +37,7 @@ async function test_mention(page: Page): Promise<void> {
     await page.click("#compose_banners .wildcard_warning .main-view-banner-action-button");
     await page.waitForSelector(".wildcard_warning", {hidden: true});
 
-    const message_list_id = await common.get_current_msg_list_id(page, true);
+    message_list_id = await common.get_current_msg_list_id(page, true);
     await common.check_messages_sent(page, message_list_id, [
         ["Verona > Test mention all", ["@all"]],
     ]);

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -503,9 +503,11 @@ async function test_narrow_public_streams(page: Page): Promise<void> {
 async function message_basic_tests(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    await page.waitForSelector(".message-list .message_row", {visible: true});
-    // Assert that there is only one message list.
-    assert.equal((await page.$$(".message-list")).length, 1);
+    const message_list_id = await common.get_current_msg_list_id(page, true);
+    await page.waitForSelector(
+        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
+        {visible: true},
+    );
 
     console.log("Sending messages");
     await common.send_multiple_messages(page, [


### PR DESCRIPTION
Just verifying that a `message-list` is rendered is not enough to ensure that we are in the correct narrow. We need to check if we are narrowed to the correct message list id.

This prevents CI from failing unexpectedly.
