### PR TITLE
search: Reset default iOS button styles.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -556,6 +556,7 @@
     --color-search-shadow-wide: hsl(0deg 0% 0% / 25%);
     --color-search-shadow-tight: hsl(0deg 0% 0% / 10%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 10%);
+    --color-search-icons: hsl(0deg 0% 0%);
     --color-background-image-loader: hsl(0deg 0% 0% / 10%);
     --color-icon-purple: hsl(240deg 35% 60%);
     --color-background-popover-menu: hsl(0deg 0% 100%);
@@ -958,6 +959,7 @@
     --color-background-search-option-hover: hsl(0deg 0% 30%);
     --color-search-box-hover-shadow: hsl(0deg 0% 0% / 30%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 35%);
+    --color-search-icons: hsl(0deg 0% 78%);
     --color-background-image-loader: hsl(0deg 0% 100% / 10%);
     --color-background-popover-menu: hsl(0deg 0% 17%);
     --color-border-popover-menu-separator: hsl(0deg 0% 0% / 40%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -458,12 +458,6 @@
             .search_icon {
             opacity: 0.75;
         }
-
-        /* Colors are inherited in light theme */
-        .navbar-search .search_icon,
-        .navbar-search .search_close_button {
-            color: hsl(0deg 0% 78%);
-        }
     }
 
     .new-style .button.no-style {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -17,7 +17,7 @@
         font-size: 17px;
         border: none;
         background-color: transparent;
-        color: hsl(0deg 0% 0%);
+        color: var(--color-search-icons);
         opacity: 0.5;
         cursor: default;
 
@@ -40,6 +40,9 @@
         opacity: 0.5;
         line-height: 0;
         border-radius: 4px;
+        /* Reset iOS button defaults. */
+        color: var(--color-search-icons);
+        padding: 0;
 
         &:not(:focus-visible) {
             outline: none;


### PR DESCRIPTION
This PR resets some default iOS button styles, and in doing so ensures better consistency in search-box icon colors. Dark mode styles are also removed in favor of CSS variables.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/blue.2C.20misaligned.20search.20close.20X.20on.20iPad/near/1922058)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| iPad, before | iPad, after |
| --- | --- |
| ![ipad-search-before](https://github.com/user-attachments/assets/240e104d-d826-47eb-9e77-200473e73acc) | ![ipad-search-after](https://github.com/user-attachments/assets/f7d39118-ef8a-464b-9371-f692e1ebb244) |

| Desktop (Firefox), before | Desktop (Firefox), after (no change) |
| --- | --- |
| ![search-icons-firefox-before](https://github.com/user-attachments/assets/7d307e45-ace1-438d-a0ca-b2bad1ce25c3) | ![search-icons-firefox-after-no-change](https://github.com/user-attachments/assets/d972208b-c198-4370-9a73-d5f01140052f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>