### PR TITLE
scheduled_messages: Migrate to typed_endpoint.

### DIFF
--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -133,7 +133,7 @@ def edit_scheduled_message(
     client: Client,
     scheduled_message_id: int,
     recipient_type_name: str | None,
-    message_to: str | None,
+    message_to: int | list[int] | None,
     topic_name: str | None,
     message_content: str | None,
     deliver_at: datetime | None,

--- a/zerver/lib/recipient_parsing.py
+++ b/zerver/lib/recipient_parsing.py
@@ -1,29 +1,17 @@
-import orjson
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 
 
-def extract_stream_id(req_to: str) -> int:
+def extract_stream_id(req_to: int | list[int]) -> int:
     # Recipient should only be a single stream ID.
-    try:
-        stream_id = int(req_to)
-    except ValueError:
+    if isinstance(req_to, list):
         raise JsonableError(_("Invalid data type for channel ID"))
-    return stream_id
+    return req_to
 
 
-def extract_direct_message_recipient_ids(req_to: str) -> list[int]:
-    try:
-        user_ids = orjson.loads(req_to)
-    except orjson.JSONDecodeError:
-        user_ids = req_to
-
-    if not isinstance(user_ids, list):
+def extract_direct_message_recipient_ids(req_to: int | list[int]) -> list[int]:
+    if not isinstance(req_to, list):
         raise JsonableError(_("Invalid data type for recipients"))
 
-    for user_id in user_ids:
-        if not isinstance(user_id, int):
-            raise JsonableError(_("Recipient list may only contain user IDs"))
-
-    return list(set(user_ids))
+    return list(set(req_to))

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -363,9 +363,12 @@ def has_request_variables(
                 #
                 # TODO: Either run validators for path_only parameters
                 # or don't declare them using REQ.
-                assert func_var_name in kwargs
+
+                # no coverage because has_request_variables will be removed once
+                # all the endpoints have been migrated to use typed_endpoint.
+                assert func_var_name in kwargs  # nocoverage
             if func_var_name in kwargs:
-                continue
+                continue  # nocoverage
             assert func_var_name is not None
 
             post_var_name: str | None

--- a/zerver/tests/test_recipient_parsing.py
+++ b/zerver/tests/test_recipient_parsing.py
@@ -1,5 +1,3 @@
-import orjson
-
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.recipient_parsing import extract_direct_message_recipient_ids, extract_stream_id
 from zerver.lib.test_classes import ZulipTestCase
@@ -8,39 +6,25 @@ from zerver.lib.test_classes import ZulipTestCase
 class TestRecipientParsing(ZulipTestCase):
     def test_extract_stream_id(self) -> None:
         # stream message recipient = single stream ID.
-        stream_id = extract_stream_id("1")
+        stream_id = extract_stream_id(1)
         self.assertEqual(stream_id, 1)
 
         with self.assertRaisesRegex(JsonableError, "Invalid data type for channel ID"):
-            extract_stream_id("1,2")
+            extract_stream_id([1, 2])
 
         with self.assertRaisesRegex(JsonableError, "Invalid data type for channel ID"):
-            extract_stream_id("[1]")
-
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for channel ID"):
-            extract_stream_id("general")
+            extract_stream_id([1])
 
     def test_extract_recipient_ids(self) -> None:
         # direct message recipients = user IDs.
-        user_ids = "[3,2,1]"
+        user_ids = [3, 2, 1]
         result = sorted(extract_direct_message_recipient_ids(user_ids))
         self.assertEqual(result, [1, 2, 3])
 
-        # JSON list w/duplicates
-        user_ids = orjson.dumps([3, 3, 12]).decode()
+        # list w/duplicates
+        user_ids = [3, 3, 12]
         result = sorted(extract_direct_message_recipient_ids(user_ids))
         self.assertEqual(result, [3, 12])
 
-        # Invalid data
-        user_ids = "1, 12"
         with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
-            extract_direct_message_recipient_ids(user_ids)
-
-        user_ids = orjson.dumps(dict(recipient=12)).decode()
-        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
-            extract_direct_message_recipient_ids(user_ids)
-
-        # Heterogeneous lists are not supported
-        user_ids = orjson.dumps([3, 4, "eeshan@example.com"]).decode()
-        with self.assertRaisesRegex(JsonableError, "Recipient list may only contain user IDs"):
-            extract_direct_message_recipient_ids(user_ids)
+            extract_direct_message_recipient_ids(1)

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -91,7 +91,7 @@ class ScheduledMessageTest(ZulipTestCase):
         result = self.do_schedule_message(
             "direct", [othello.email], content + " 4", scheduled_delivery_timestamp
         )
-        self.assert_json_error(result, "Recipient list may only contain user IDs")
+        self.assert_json_error(result, 'to["int"] is not an integer')
 
     def create_scheduled_message(self) -> None:
         content = "Test message"


### PR DESCRIPTION
Migrate `scheduled_message.py` to typed_endpoint.

Perform Json parsing in the endpoint itself instead of
in `recipient_parsing.py`.