### PR TITLE
support: Consolidate sponsorship discount forms.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3999,7 +3999,7 @@ class RealmBillingSession(BillingSession):
                     end_link="](/help/linking-to-zulip-website)",
                 )
                 internal_send_private_message(notification_bot, user, message)
-        return f"Sponsorship approved for {self.billing_entity_display_name}"
+        return f"Sponsorship approved for {self.billing_entity_display_name}; Emailed organization owners and billing admins."
 
     @override
     def is_sponsored(self) -> bool:

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -221,7 +221,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     "<b>UUID</b>:",
                     "<b>Zulip version</b>:",
                     "📶 Push notification status:",
-                    "💸 Discount and sponsorship information:",
+                    "💸 Discounts and sponsorship information:",
                 ],
                 result,
             )

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -199,7 +199,7 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
                     f"<h3>{name}</h3>",
                     f"<b>Remote realm host:</b> {host}<br />",
                     "<b>Date created</b>: 01 December 2023",
-                    "<b>Org type</b>: Unspecified<br />",
+                    "<b>Organization type</b>: Unspecified<br />",
                     "<b>Has remote realms</b>: True<br />",
                     "📶 Push notification status:",
                 ],
@@ -1155,7 +1155,7 @@ class TestSupportEndpoint(ZulipTestCase):
             )
             m.assert_called_once_with(get_realm("zulip"), 70, acting_user=iago)
             self.assert_in_success_response(
-                ["Org type of zulip changed from Business to Government"], result
+                ["Organization type of zulip changed from Business to Government"], result
             )
 
     def test_attach_discount(self) -> None:

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -417,7 +417,7 @@ def support(
         elif org_type is not None:
             current_realm_type = realm.org_type
             do_change_realm_org_type(realm, org_type, acting_user=acting_user)
-            msg = f"Org type of {realm.string_id} changed from {get_org_type_display_name(current_realm_type)} to {get_org_type_display_name(org_type)} "
+            msg = f"Organization type of {realm.string_id} changed from {get_org_type_display_name(current_realm_type)} to {get_org_type_display_name(org_type)} "
             context["success_message"] = msg
         elif new_subdomain is not None:
             old_subdomain = realm.string_id

--- a/templates/corporate/activity/installation_activity_table.html
+++ b/templates/corporate/activity/installation_activity_table.html
@@ -41,7 +41,7 @@
             <th>ARR</th>
             <th>Rate (%)</th>
             {% endif %}
-            <th>Org type</th>
+            <th>Organization type</th>
             <th>Referrer</th>
             <th>DAU</th>
             <th>WAU</th>

--- a/templates/corporate/support/current_plan_forms_support.html
+++ b/templates/corporate/support/current_plan_forms_support.html
@@ -1,4 +1,4 @@
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Billing collection method</b><br />
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
@@ -10,7 +10,7 @@
 </form>
 
 {% if current_plan.status == current_plan.ACTIVE %}
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Plan end date</b><br />
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
@@ -20,7 +20,7 @@
 </form>
 {% endif %}
 
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Modify current plan</b><br />
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />

--- a/templates/corporate/support/next_plan_forms_support.html
+++ b/templates/corporate/support/next_plan_forms_support.html
@@ -1,5 +1,5 @@
 <p class="support-section-header">⏱️ Schedule plan:</p>
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Configure fixed price plan:</b><br />
     {% if not plan_data.is_current_plan_billable %}
     <i>Enter Invoice ID only if the customer chose to pay by invoice.</i><br />
@@ -13,7 +13,7 @@
     <button type="submit" class="support-submit-button">Schedule</button>
 </form>
 {% if not plan_data.current_plan %}
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Configure temporary courtesy plan:</b><br />
     <i>Once created, the end date for the temporary courtesy plan can be extended.</i><br />
     {{ csrf_input }}

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -37,8 +37,9 @@
     <b>First human user</b>:
     {% endif %}
 </div>
-<div class="realm-support-forms">
-    <div class="realm-form-container">
+<div>
+    <div class="realm-management-actions">
+        <p class="support-section-header">🛠️ Realm management:</p>
         <form method="POST" class="support-form">
             <b>Status</b>:<br />
             {{ csrf_input }}
@@ -86,44 +87,18 @@
             </select>
             <button type="submit" class="support-submit-button">Update</button>
         </form>
-        <form method="POST" class="support-form">
-            <b>Sponsorship pending</b>:<br />
-            {{ csrf_input }}
-            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-            <select name="sponsorship_pending">
-                <option value="true" {% if realm_support_data[realm.id].sponsorship_data.sponsorship_pending %}selected{% endif %}>Yes</option>
-                <option value="false" {% if not realm_support_data[realm.id].sponsorship_data.sponsorship_pending %}selected{% endif %}>No</option>
-            </select>
-            <button type="submit" class="support-submit-button">Update</button>
-        </form>
-
-        {% if realm_support_data[realm.id].sponsorship_data.sponsorship_pending %}
-        <form method="POST" class="support-form">
-            {{ csrf_input }}
-            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-            <input type="hidden" name="approve_sponsorship" value="true" />
-            <button class="approve-sponsorship-button">
-                Approve full sponsorship
-            </button>
-            (will email organization owners)
-        </form>
-        {% endif %}
-
+    </div>
+    {% if realm.plan_type != SPONSORED_PLAN_TYPE %}
+    <div class="support-sponsorship-container">
         {% with %}
             {% set sponsorship_data = realm_support_data[realm.id].sponsorship_data %}
             {% set PLAN_TYPES = REALM_PLAN_TYPES_FOR_DISCOUNT %}
             {% set remote_id = realm.id %}
             {% set remote_type = "realm_id" %}
-            {% include 'corporate/support/sponsorship_discount_forms.html' %}
+            {% include 'corporate/support/sponsorship_forms_support.html' %}
         {% endwith %}
-
-        {% if realm_support_data[realm.id].sponsorship_data.sponsorship_pending %}
-            {% with %}
-                {% set latest_sponsorship_request = realm_support_data[realm.id].sponsorship_data.latest_sponsorship_request %}
-                {% include 'corporate/support/sponsorship_request_details.html' %}
-            {% endwith %}
-        {% endif %}
     </div>
+    {% endif %}
     {% if realm_support_data[realm.id].plan_data.current_plan %}
     <div class="current-plan-container">
         {% with %}

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -58,7 +58,7 @@
             <button type="submit" class="support-submit-button">Update</button>
         </form>
         <form method="POST" class="support-form">
-            <b>Org type</b>:<br />
+            <b>Organization type</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
             <select name="org_type" id="org_type">

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -39,7 +39,7 @@
 </div>
 <div class="realm-support-forms">
     <div class="realm-form-container">
-        <form method="POST" class="support-realm-status-form support-form">
+        <form method="POST" class="support-form">
             <b>Status</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -49,14 +49,14 @@
             </select>
             <button type="submit" class="support-submit-button">Update</button>
         </form>
-        <form method="POST" class="realm-subdomain-form support-form">
+        <form method="POST" class="support-form">
             <b>New subdomain</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
             <input type="text" name="new_subdomain" required />
             <button type="submit" class="support-submit-button">Update</button>
         </form>
-        <form method="POST" class="realm-organization-type-form support-form">
+        <form method="POST" class="support-form">
             <b>Org type</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -71,7 +71,7 @@
             </select>
             <button type="submit" class="support-submit-button">Update</button>
         </form>
-        <form method="POST" class="support-plan-type-form support-form">
+        <form method="POST" class="support-form">
             <b>Plan type</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -86,7 +86,7 @@
             </select>
             <button type="submit" class="support-submit-button">Update</button>
         </form>
-        <form method="POST" class="sponsorship-pending-form support-form">
+        <form method="POST" class="support-form">
             <b>Sponsorship pending</b>:<br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -98,7 +98,7 @@
         </form>
 
         {% if realm_support_data[realm.id].sponsorship_data.sponsorship_pending %}
-        <form method="POST" class="approve-sponsorship-form support-form">
+        <form method="POST" class="support-form">
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
             <input type="hidden" name="approve_sponsorship" value="true" />
@@ -132,7 +132,7 @@
             {% include 'corporate/support/current_plan_details.html' %}
         {% endwith %}
 
-        <form method="POST" class="billing-modality-form support-form">
+        <form method="POST" class="support-form">
             <b>Billing collection method</b><br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -143,7 +143,7 @@
             <button type="submit" class="support-submit-button">Update</button>
         </form>
 
-        <form method="POST" class="downgrade-plan-form support-form">
+        <form method="POST" class="support-form">
             <b>Modify plan</b><br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -45,7 +45,7 @@
     {% endwith %}
 
     {% if remote_server_deactivated %}
-    <div class="remote-support-sponsorship-container">
+    <div class="support-sponsorship-container">
         {% with %}
             {% set sponsorship_data = support_data[remote_realm.id].sponsorship_data %}
             {% set dollar_amount = dollar_amount %}
@@ -53,9 +53,10 @@
         {% endwith %}
     </div>
     {% elif remote_realm.plan_type != SPONSORED_PLAN_TYPE %}
-    <div class="remote-support-sponsorship-container">
+    <div class="support-sponsorship-container">
         {% with %}
             {% set sponsorship_data = support_data[remote_realm.id].sponsorship_data %}
+            {% set PLAN_TYPES = REMOTE_PLAN_TIERS %}
             {% set remote_id = remote_realm.id %}
             {% set remote_type = "remote_realm_id" %}
             {% set has_fixed_price = support_data[remote_realm.id].plan_data.has_fixed_price %}

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -29,7 +29,7 @@
         <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />
         <b>UUID</b>: {{ remote_realm.uuid }}<br />
         <br />
-        <b>Org type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
+        <b>Organization type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
         <b>Plan type</b>: {{ get_plan_type_name(remote_realm.plan_type) }}<br />
         <b>Non-guest user count</b>: {{ support_data[remote_realm.id].user_data.non_guest_user_count }}<br />
         <b>Guest user count</b>: {{ support_data[remote_realm.id].user_data.guest_user_count }}<br />

--- a/templates/corporate/support/remote_server_support.html
+++ b/templates/corporate/support/remote_server_support.html
@@ -91,16 +91,17 @@
                 {% endwith %}
 
                 {% if remote_server.deactivated %}
-                <div class="remote-support-sponsorship-container">
+                <div class="support-sponsorship-container">
                     {% with %}
                         {% set sponsorship_data = remote_servers_support_data[remote_server.id].sponsorship_data %}
                         {% include 'corporate/support/sponsorship_details.html' %}
                     {% endwith %}
                 </div>
                 {% elif remote_server.plan_type != SPONSORED_PLAN_TYPE %}
-                <div class="remote-support-sponsorship-container">
+                <div class="support-sponsorship-container">
                     {% with %}
                         {% set sponsorship_data = remote_servers_support_data[remote_server.id].sponsorship_data %}
+                        {% set PLAN_TYPES = REMOTE_PLAN_TIERS %}
                         {% set remote_id = remote_server.id %}
                         {% set remote_type = "remote_server_id" %}
                         {% set has_fixed_price = remote_servers_support_data[remote_server.id].plan_data.has_fixed_price %}

--- a/templates/corporate/support/sponsorship_details.html
+++ b/templates/corporate/support/sponsorship_details.html
@@ -1,5 +1,5 @@
 <div class="remote-sponsorship-details">
-    <p class="support-section-header">💸 Discount and sponsorship information:</p>
+    <p class="support-section-header">💸 Discounts and sponsorship information:</p>
     <b>Sponsorship pending</b>: {{ sponsorship_data.sponsorship_pending }}<br />
     {% if sponsorship_data.has_discount %}
         {% if sponsorship_data.monthly_discounted_price %}

--- a/templates/corporate/support/sponsorship_discount_forms.html
+++ b/templates/corporate/support/sponsorship_discount_forms.html
@@ -1,4 +1,4 @@
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Required plan tier for discounts and fixed prices</b>:<br />
     <i>Updates will not change any pre-existing plans or scheduled upgrades.</i><br />
     {{ csrf_input }}
@@ -15,7 +15,7 @@
     <button type="submit" class="support-submit-button">Update</button>
 </form>
 
-<form method="POST" class="remote-form discounted-price-form">
+<form method="POST" class="discounted-price-form support-form">
     <b>Discounted price <i class="fa fa-question-circle-o" data-tippy-content="
         Needs required plan tier to be set.<br />
         Default price for tier will be used if discounted price for the schedule is not specified or is 0.<br />
@@ -51,7 +51,7 @@
 </form>
 
 {% if not has_fixed_price and (sponsorship_data.monthly_discounted_price or sponsorship_data.annual_discounted_price or sponsorship_data.minimum_licenses) %}
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Minimum licenses</b>:<br />
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -1,4 +1,4 @@
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     <b>Sponsorship pending</b>:<br />
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
@@ -10,7 +10,7 @@
 </form>
 
 {% if sponsorship_data.sponsorship_pending %}
-<form method="POST" class="remote-form">
+<form method="POST" class="support-form">
     {{ csrf_input }}
     <input type="hidden" name="{{ remote_type }}" value="{{ remote_id }}" />
     <input type="hidden" name="approve_sponsorship" value="true" />

--- a/templates/corporate/support/sponsorship_forms_support.html
+++ b/templates/corporate/support/sponsorship_forms_support.html
@@ -1,3 +1,4 @@
+<p class="support-section-header">💸 Discounts and sponsorship:</p>
 <form method="POST" class="support-form">
     <b>Sponsorship pending</b>:<br />
     {{ csrf_input }}
@@ -21,7 +22,7 @@
 {% endif %}
 
 {% with %}
-    {% set PLAN_TYPES = REMOTE_PLAN_TIERS %}
+    {% set PLAN_TYPES = PLAN_TYPES %}
     {% include 'corporate/support/sponsorship_discount_forms.html' %}
 {% endwith %}
 

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -334,14 +334,6 @@ tr.admin td:first-child {
     text-align: center;
 }
 
-.reactivate-remote-server-form,
-.deactivate-remote-server-form,
-.realm-support-information,
-.remote-server-information,
-.remote-realm-information {
-    margin-bottom: 10px;
-}
-
 .support-section-header {
     font-size: 1.2em;
     font-weight: bold;
@@ -356,9 +348,13 @@ tr.admin td:first-child {
     top: -2px;
 }
 
+.reactivate-remote-server-form,
+.deactivate-remote-server-form,
+.realm-support-information,
+.remote-server-information,
+.remote-realm-information,
 .remote-sponsorship-details,
 .support-form,
-.remote-form,
 .next-plan-information,
 .current-plan-information {
     margin-bottom: 10px;

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -464,29 +464,28 @@ tr.admin td:first-child {
 }
 
 .push-notification-status,
-.realm-form-container,
+.realm-management-actions,
 .next-plan-container,
 .current-plan-container,
-.remote-support-sponsorship-container {
+.support-sponsorship-container {
     border-radius: 4px;
     padding: 10px;
     margin: 10px 0;
 }
 
-.push-notification-status {
+.push-notification-status,
+.realm-management-actions {
     border: 2px solid hsl(186deg 76% 36%);
     background-color: hsl(188deg 35% 87%);
 }
 
-.realm-form-container,
 .next-plan-container,
 .current-plan-container,
-.remote-support-sponsorship-container {
+.support-sponsorship-container {
     border: 2px solid hsl(33deg 99% 60%);
 }
 
-.realm-form-container,
-.remote-support-sponsorship-container {
+.support-sponsorship-container {
     background-color: hsl(30deg 100% 96%);
 }
 


### PR DESCRIPTION
Use the same sponsorship form template for both remote and Zulip Cloud support views.

**Notes**:
- Removes "Org type" abbreviation from support/activity views, and instead uses "Organization type".
- Adds a "🛠️ Realm management" header/section to Zulip Cloud view for support actions that are specific to non-remote realms (e.g., changing an organization's type).
- Moves notification about notifying organization owners when sponsorship is approved on Zulip Cloud to success message in view, which mirrors how this information is shown in the remote support view for billing users.
- If a Zulip Cloud realm is 100% sponsored for the Standard plan, then the discount and sponsorship forms are no longer shown in the support view, which mirrors the behavior of the remote support views for the Community plan.
  - Note the ways to remove Cloud and remote 100% sponsorship have not changed. For Cloud, the support admin can change the plan type to "Limited". And for remote, the support admin, can downgrade the Community plan or set an end date.
  - Once the sponsorship is removed, then the discount and sponsorship forms are shown in the support view.
- Removes the following class names (after changes `git-grep` shows no results):
  - remote-form
  - support-realm-status-form
  - realm-subdomain-form
  - realm-organization-type-form
  - support-plan-type-form
  - sponsorship-pending-form
  - approve-sponsorship-form
  - billing-modality-form
  - downgrade-plan-form


---

**Screenshots and screen captures:**

<details>
<summary>Header change in activity chart for Zulip Cloud - Organization type</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-19 13-05-03](https://github.com/user-attachments/assets/2beca081-f0eb-47b3-b15d-f6c75d420c76) |  ![Screenshot from 2024-08-19 13-05-20](https://github.com/user-attachments/assets/43bbbb06-6ff2-4235-b91f-58e5ecb45301)
</details>
<details>
<summary>Zulip Cloud support - no sponsorship</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-19 13-06-33](https://github.com/user-attachments/assets/9bfe61d5-df7a-4e6a-b6a7-2887262e462d) | ![Screenshot from 2024-08-19 13-06-49](https://github.com/user-attachments/assets/c917a51b-5ff4-4643-be30-b1fc8c56f9c2)
</details>
<details>
<summary>Zulip Cloud support - full sponsorship</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-19 13-09-53](https://github.com/user-attachments/assets/2d4dd248-4abe-4def-9556-ab4bebfdc38d) | ![Screenshot from 2024-08-19 13-10-13](https://github.com/user-attachments/assets/95e639be-df71-4e9f-91b1-b5716182edb1)
</details>
<details>
<summary>Remote support view</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-19 13-08-06](https://github.com/user-attachments/assets/59b1f905-bcd4-4c1c-9a1f-5ad7ed73f268) | ![Screenshot from 2024-08-19 13-08-26](https://github.com/user-attachments/assets/767a468f-31a9-4cde-9f3c-8d25283fc1ad)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
