### PR TITLE
user_groups: Refactor code to compute user group objects.

### DIFF
--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1176,7 +1176,7 @@ class FetchQueriesTest(ZulipTestCase):
         realm = get_realm_with_settings(realm_id=user.realm_id)
 
         with (
-            self.assert_database_query_count(41),
+            self.assert_database_query_count(39),
             mock.patch("zerver.lib.events.always_want") as want_mock,
         ):
             fetch_initial_state_data(user, realm=realm)
@@ -1202,7 +1202,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_linkifiers=0,
             realm_playgrounds=1,
             realm_user=4,
-            realm_user_groups=5,
+            realm_user_groups=3,
             realm_user_settings_defaults=1,
             recent_private_conversations=1,
             scheduled_messages=1,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -268,7 +268,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(52),
+            self.assert_database_query_count(50),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -572,7 +572,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(52),
+            self.assert_database_query_count(50),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -604,7 +604,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(47):
+        with self.assert_database_query_count(45):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -106,8 +106,9 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[9]["can_mention_group"], everyone_group.id)
 
         othello = self.example_user("othello")
+        hamletcharacters_group = NamedUserGroup.objects.get(name="hamletcharacters", realm=realm)
         setting_group = self.create_or_update_anonymous_group_for_setting(
-            [othello], [admins_system_group]
+            [othello], [admins_system_group, hamletcharacters_group]
         )
         new_user_group = check_add_user_group(
             realm,
@@ -121,12 +122,11 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[10]["name"], "newgroup2")
         self.assertEqual(user_groups[10]["description"], "")
         self.assertEqual(user_groups[10]["members"], [othello.id])
-        self.assertEqual(
-            user_groups[10]["can_mention_group"],
-            AnonymousSettingGroupDict(
-                direct_members=[othello.id],
-                direct_subgroups=[admins_system_group.id],
-            ),
+        assert isinstance(user_groups[10]["can_mention_group"], AnonymousSettingGroupDict)
+        self.assertEqual(user_groups[10]["can_mention_group"].direct_members, [othello.id])
+        self.assertCountEqual(
+            user_groups[10]["can_mention_group"].direct_subgroups,
+            [admins_system_group.id, hamletcharacters_group.id],
         )
 
     def test_get_direct_user_groups(self) -> None:


### PR DESCRIPTION
This PR refactors code in `user_groups_in_realm_serialized` such that we do not prefetch `can_mention_group__direct_members` and `can_mention_group__direct_subgroups` using `prefetch_related` and instead fetch members and subgroups for all groups in separate queries and then use that data to find the members and subgroups of the group used for that setting.

This change helps us in avoiding two prefetch queries for each setting when we add more group settings.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
