### PR TITLE
users: Soften assumptions that all bots have owners.

### DIFF
--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -1128,12 +1128,14 @@ def bot_owner_user_ids(user_profile: UserProfile) -> set[int]:
         user_profile.default_events_register_stream
         and user_profile.default_events_register_stream.invite_only
     )
-    assert user_profile.bot_owner_id is not None
     if is_private_bot:
-        return {user_profile.bot_owner_id}
+        if user_profile.bot_owner_id is not None:
+            return {user_profile.bot_owner_id}
+        return set()
     else:
         users = {user.id for user in user_profile.realm.get_human_admin_users()}
-        users.add(user_profile.bot_owner_id)
+        if user_profile.bot_owner_id is not None:
+            users.add(user_profile.bot_owner_id)
         return users
 
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -580,14 +580,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.deactivate_bot()
         self.assert_num_bots_equal(0)
 
-    def test_deactivate_bogus_bot(self) -> None:
-        """Deleting a bogus bot will succeed silently."""
+    def test_deactivate_bot_invalid_id(self) -> None:
         self.login("hamlet")
         self.assert_num_bots_equal(0)
         self.create_bot()
         self.assert_num_bots_equal(1)
-        invalid_user_id = 1000
-        result = self.client_delete(f"/json/bots/{invalid_user_id}")
+        invalid_bot_id = 1000
+        result = self.client_delete(f"/json/bots/{invalid_bot_id}")
         self.assert_json_error(result, "No such bot")
         self.assert_num_bots_equal(1)
 


### PR DESCRIPTION
Imported Slack bots currently do not have owners (#23145).  Soften the deactivation codepath to allow them to be successfully deactivated despite this.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
