### PR TITLE
navbar: Remove signup button.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -443,33 +443,6 @@ body.has-overlay-scrollbar {
             }
         }
 
-        & .signup_button {
-            color: var(
-                --color-navbar-spectator-low-attention-brand-button-text
-            );
-            background-color: var(
-                --color-navbar-spectator-low-attention-brand-button-background
-            );
-
-            &:hover {
-                color: var(
-                    --color-navbar-spectator-low-attention-brand-button-text
-                );
-                background-color: var(
-                    --color-navbar-spectator-low-attention-brand-button-background-hover
-                );
-            }
-
-            &:active {
-                color: var(
-                    --color-navbar-spectator-low-attention-brand-button-text
-                );
-                background-color: var(
-                    --color-navbar-spectator-low-attention-brand-button-background-active
-                );
-            }
-        }
-
         & .login_button {
             color: var(
                 --color-navbar-spectator-medium-attention-brand-button-text

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -37,9 +37,6 @@
         </div>
         <div class="column-right">
             <div class="spectator_login_buttons only-visible-for-spectators">
-                <a href="/register/"  class="signup_button">
-                    {{t 'Sign up' }}
-                </a>
                 <a class="login_button">
                     {{t 'Log in' }}
                 </a>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.22sign.20up.22.20.2F.20.22login.22.20truncated

This allows log in button in navbar for spectators to have more space to be displayed in different languages without being truncated. Login page already has 2 buttons for user to sign up from.

<img width="392" alt="Screenshot 2024-08-21 at 3 14 44 PM" src="https://github.com/user-attachments/assets/8ab10781-9289-4af0-a9db-a7130db8c56e">

<img width="392" alt="Screenshot 2024-08-21 at 3 14 08 PM" src="https://github.com/user-attachments/assets/9d877b81-c5d8-45c6-9658-df7a238915a5">

<img width="392" alt="Screenshot 2024-08-21 at 3 22 43 PM" src="https://github.com/user-attachments/assets/e4514937-85c2-4659-a793-413dba6fd05e">


#### Couldn't find a languges where this would overflow but here is custom text overflow just in case it does:


<img width="392" alt="Screenshot 2024-08-21 at 3 17 01 PM" src="https://github.com/user-attachments/assets/936e8101-05f1-441d-9946-a8617b69fd06">