### PR TITLE
markdown: Render mentions, global times as inline elements.

### DIFF
--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -65,12 +65,14 @@ const markdown_help_rows = [
     },
     {
         markdown: "@**Joe Smith**",
-        output_html: '<p><span class="user-mention">@Joe Smith</span></p>',
+        output_html:
+            '<p><span class="user-mention"><span class="mention-content-wrapper">@Joe Smith</span></span></p>',
         effect_html: "(notifies Joe Smith)",
     },
     {
         markdown: "@_**Joe Smith**",
-        output_html: '<p><span class="user-mention">Joe Smith</span></p>',
+        output_html:
+            '<p><span class="user-mention"><span class="mention-content-wrapper">Joe Smith</span></span></p>',
         effect_html: "(links to profile but doesn't notify Joe Smith)",
     },
     {
@@ -85,7 +87,7 @@ const markdown_help_rows = [
         // code for that case works ... but it might be better to just
         // user your own name/user ID anyway.
         output_html:
-            '<p><span class="user-group-mention" data-user-group-id="0">@support team</span></p>',
+            '<p><span class="user-group-mention" data-user-group-id="0"><span class="mention-content-wrapper">@support team</span></span></p>',
         effect_html: "(notifies <b>support team</b> group)",
     },
     {

--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -160,7 +160,7 @@ def zulip():
     {
         markdown: "<time:2023-05-28T13:30:00+05:30>",
         output_html:
-            '<p><time datetime="2023-05-28T08:00:00Z"><i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Sun, May 28, 2023, 1:30 PM</time></p>',
+            '<p><time datetime="2023-05-28T08:00:00Z"><span class="timestamp-content-wrapper"><i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Sun, May 28, 2023, 1:30 PM</time></span></p>',
     },
     {
         markdown: `/poll What did you drink this morning?

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -169,7 +169,15 @@
         padding: 0 3px;
         border-radius: 3px;
         white-space: nowrap;
-        display: inline-block;
+        /* Reduce the font-size to reduce the
+           footprint of the background highlight. */
+        font-size: 0.95em;
+    }
+
+    .mention-content-wrapper {
+        /* Restore the font-size to match the rest
+           of the message area. */
+        font-size: 1.0526em;
     }
 
     .user-mention {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -236,15 +236,25 @@
 
     /* Timestamps */
     & time {
-        display: inline-flex;
-        align-items: baseline;
-        gap: 3px;
         background: hsl(0deg 0% 93%);
         border-radius: 3px;
-        padding: 0 0.2em;
         box-shadow: 0 0 0 1px hsl(0deg 0% 80%);
         white-space: nowrap;
-        margin: 0 2px 1px;
+        margin: 0 2px;
+        /* Reduce the font-size to reduce the
+           footprint of the timestamp block. */
+        font-size: 0.95em;
+
+        .timestamp-content-wrapper {
+            /* Restore the font-size to match the rest
+               of the message area, and apply the layout
+               for the icon. */
+            font-size: 1.0526em;
+            padding: 0 0.2em;
+            display: inline-flex;
+            align-items: baseline;
+            gap: 3px;
+        }
 
         .markdown-timestamp-icon {
             align-self: center;

--- a/web/templates/markdown_timestamp.hbs
+++ b/web/templates/markdown_timestamp.hbs
@@ -1,2 +1,6 @@
-<i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>
-{{ text ~}}
+{{~!-- --~}}
+<span class="timestamp-content-wrapper">
+    <i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>
+    {{~ text ~}}
+</span>
+{{~!-- --~}}

--- a/web/templates/mention_content_wrapper.hbs
+++ b/web/templates/mention_content_wrapper.hbs
@@ -1,0 +1,3 @@
+{{~!-- --~}}
+<span class="mention-content-wrapper">{{ mention_text }}</span>
+{{~!-- --~}}

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -426,7 +426,7 @@ run_test("timestamp", ({mock_template}) => {
     // Final asserts
     assert.equal(
         $timestamp.html(),
-        '<i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>\nThu, Jan 1, 1970, 12:00 AM',
+        '<span class="timestamp-content-wrapper">\n    <i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Thu, Jan 1, 1970, 12:00 AM</span>',
     );
     assert.equal($timestamp_invalid.text(), "never-been-set");
 });
@@ -448,14 +448,14 @@ run_test("timestamp-twenty-four-hour-time", ({mock_template, override}) => {
     rm.update_elements($content);
     assert.equal(
         $timestamp.html(),
-        '<i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>\nWed, Jul 15, 2020, 20:40',
+        '<span class="timestamp-content-wrapper">\n    <i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Wed, Jul 15, 2020, 20:40</span>',
     );
 
     override(user_settings, "twenty_four_hour_time", false);
     rm.update_elements($content);
     assert.equal(
         $timestamp.html(),
-        '<i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>\nWed, Jul 15, 2020, 8:40 PM',
+        '<span class="timestamp-content-wrapper">\n    <i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Wed, Jul 15, 2020, 8:40 PM</span>',
     );
 });
 


### PR DESCRIPTION
This PR fixes long-standing problems with `inline-block` and `inline-flex` causing trailing punctuation especially to drop to the line below mentions and global times. 

Not only are the design and near-pixel-perfect approximate dimensions of mentions and global times preserved here, but in the case of global times, they now do not disturb the line-height otherwise set in the message area. Global times retain their `inline-flex` layout, which is now specified on the inner element, while the outer global time element displays properly inline.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/wrangling.20inline.20elements/near/1922053), [CZO issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/global.20time.20wrapping/near/1907899)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures**

**Mentions:**

| Mentions, before | Mentions, after |
| --- | --- |
| ![mention-pills-before](https://github.com/user-attachments/assets/59d0b98c-de9a-4445-a57d-4c8209b49b93) | ![mention-pills-after](https://github.com/user-attachments/assets/a0b8af6c-efa9-473b-98e2-40aa2bf1e874) |

| Mentions w/ punctuation, before | Mentions w/ punctuation, after |
| --- | --- |
| ![mention-pills-trailing-punctuation-before](https://github.com/user-attachments/assets/92afb52d-6974-4383-8b4d-c53facd178fa) | ![mention-pills-trailing-punctuation-after](https://github.com/user-attachments/assets/8ed958db-99db-47c2-997f-5553d3b375e3) |

| Mentions in info overlay, before | Mentions in info overlay, after |
| --- | --- |
| ![mentions-overlay-before](https://github.com/user-attachments/assets/9b02eb22-d7a5-41e3-9f7e-e269b17985fe) | ![mentions-overlay-after](https://github.com/user-attachments/assets/28ca7a95-f66c-4d0d-b9ba-180bac186b0c) |

**Global times:**

| Global times, before | Global times, after (no disturbed surrounding line-height) |
| --- | --- |
| ![timestamps-before](https://github.com/user-attachments/assets/f33c06d2-69d3-4689-a836-79c4981a1498) | ![timestamps-after-better-line-height](https://github.com/user-attachments/assets/eee32420-1bb7-499b-bfd8-6cc001ddbced) |

| Global times w/ punctuation, before | Global times w/ punctuation, after |
| --- | --- |
| ![timestamps-trailing-punctuation-before](https://github.com/user-attachments/assets/e2395f5a-81a1-4e3b-99a9-8332f5c972a1) | ![timestamps-trailing-punctuation-after](https://github.com/user-attachments/assets/cff54127-3e3d-4695-9b3a-91df2a1bbf91) | 

| Global time in info overlay, before | Global time in info overlay, after |
| --- | --- |
| ![timestamps-overlay-before](https://github.com/user-attachments/assets/5332f3ef-af62-4ce8-b082-680617d9b0c3) | ![timestamps-overlay-after](https://github.com/user-attachments/assets/bd8a4420-aedc-4aa2-ad0e-42fcf435871e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>