### PR TITLE
help: Fix up message deletion permissions documentation.

### DIFF
--- a/help/delete-a-message.md
+++ b/help/delete-a-message.md
@@ -5,9 +5,9 @@ if these actions are allowed in your organization. Only server administrators
 can restore deleted messages.
 
 Organization administrators can
-[configure](/help/restrict-message-editing-and-deletion) who can edit
-and delete their who messages, set a time limits for such deletions,
-and configure who can delete any message.
+[configure](/help/restrict-message-editing-and-deletion) who can edit and delete
+their own messages, and who can delete any message. They can also set time
+limits on message editing and deletion.
 
 ## Delete message content
 

--- a/help/restrict-message-editing-and-deletion.md
+++ b/help/restrict-message-editing-and-deletion.md
@@ -43,8 +43,8 @@ irretrievably) removes the message from Zulip.
 1. Under **Message deletion**:
     - Configure **Who can delete any message**.
     - Configure **Who can delete their own messages**.
-    - Configure **Time limit for deleting messages**, which restricts
-      your own messages.
+    - Configure **Time limit for deleting messages**. This time limit does not
+      apply to users who can delete any message.
 
 {!save-changes.md!}
 


### PR DESCRIPTION
Current: https://zulip.com/help/delete-a-message
Updated:
![Screenshot 2024-08-21 at 19 06 47@2x](https://github.com/user-attachments/assets/5136a2da-cfea-425e-b54b-c22dc6c3051b)

Current: https://zulip.com/help/restrict-message-editing-and-deletion
Updated:
![Screenshot 2024-08-21 at 19 07 47@2x](https://github.com/user-attachments/assets/6653b0eb-1de6-49d4-bdd2-090059173bbc)
