### PR TITLE
settings_users: Fix for filter search text issue in settings users.

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -111,7 +111,7 @@ function populate_invites(invites_data: {invites: Invite[]}): void {
         },
         filter: {
             $element: $invites_table
-                .closest(".settings-section")
+                .closest(".user-settings-section")
                 .find<HTMLInputElement>("input.search"),
             predicate(item, value) {
                 const referrer = people.get_by_user_id(item.invited_by_user_id);


### PR DESCRIPTION
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/filter.20text.20is.20applied.20in.20every.20tab.2E/near/1923769)



**Before:**
![botfiltertext_before](https://github.com/user-attachments/assets/c07ae58f-3295-47fe-9c73-fe260ce0d818)


**After:**
![botfiltertext](https://github.com/user-attachments/assets/9d455908-b3de-4024-8fa5-408d1724833a)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
