### PR TITLE
global_times: Correct malformed closing tags in overlay.

### DIFF
--- a/web/src/info_overlay.ts
+++ b/web/src/info_overlay.ts
@@ -160,7 +160,7 @@ def zulip():
     {
         markdown: "<time:2023-05-28T13:30:00+05:30>",
         output_html:
-            '<p><time datetime="2023-05-28T08:00:00Z"><span class="timestamp-content-wrapper"><i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Sun, May 28, 2023, 1:30 PM</time></span></p>',
+            '<p><time datetime="2023-05-28T08:00:00Z"><span class="timestamp-content-wrapper"><i class="zulip-icon zulip-icon-clock markdown-timestamp-icon"></i>Sun, May 28, 2023, 1:30 PM</span></time></p>',
     },
     {
         markdown: `/poll What did you drink this morning?


### PR DESCRIPTION
This corrects [malformed closing tags](https://github.com/zulip/zulip/pull/31416#discussion_r1725949135) in the information overlay, which were merged along with #31416. As such, I'm marking this PR also with the backport-candidate label.
