### PR TITLE
support: Add ability to update max daily invitations for realm.

### DIFF
--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -73,7 +73,9 @@
             <button type="submit" class="support-submit-button">Update</button>
         </form>
         <form method="POST" class="support-form">
-            <b>Plan type</b>:<br />
+            <b>Plan type</b>: <i class="fa fa-question-circle-o" data-tippy-content="
+            Will also update maximum daily invitations to be the default value for the new plan type.
+            " data-tippy-maxWidth="auto"></i><br />
             {{ csrf_input }}
             <input type="hidden" name="realm_id" value="{{ realm.id }}" />
             <select name="plan_type">
@@ -85,6 +87,15 @@
                     {% endif %}
                 {% endfor %}
             </select>
+            <button type="submit" class="support-submit-button">Update</button>
+        </form>
+        <form method="POST" class="support-form">
+            <b>Maximum daily invitations</b>: <i class="fa fa-question-circle-o" data-tippy-content="
+            Setting to zero will attempt to reset this to the default maximum for the current plan type.
+            " data-tippy-maxWidth="auto"></i><br />
+            {{ csrf_input }}
+            <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+            <input type="number" name="max_invites" value="{{ realm.max_invites }}" min="0" required />
             <button type="submit" class="support-submit-button">Update</button>
         </form>
     </div>


### PR DESCRIPTION
Adds ability in Zulip Cloud support view to update the maximum number of email invitations that a realm can send per day.

**Notes**:
- Uses "0" as the value to reset the maximum number of invites to the default for the current plan type.
- Adds some validation for changing the realm's max invites via the support view so that it is not set below the default max for the realm's plan type, and so that if it's currently set to the default max it's not reset to that same value.
- The audit log event type used is `REALM_PROPERTY_CHANGED`.
- Adds some question mark icons with hover tooltips to note how to change back to the default for the current plan type, and that changing the plan type will reset the max invitations to be the default for the new plan type.

Generally, these realm management actions in the support view don't have the "Update" button disabled when there's no change to the setting input. So in theory, one could just set the plan type or organization type to the same thing either by accidentally clicking the wrong button or intentionally doing so. The current validation for max invites only stops resetting to the default accidentally. One could still "reset" the number of invites to the same value if it had been set to something other than the default. This seems like something that might be best addressed overall for this section of support actions though.

---

**Screenshots and screen captures:**

<details>
<summary>Updated realm management section in support view</summary>

![Screenshot from 2024-08-22 17-12-56](https://github.com/user-attachments/assets/2a7fd599-bfe3-4ffd-a0ad-2b372d4e03d0)
</details>
<details>
<summary>Showing tooltip for plan type field</summary>

![Screenshot from 2024-08-22 18-13-50](https://github.com/user-attachments/assets/02f418d4-a2ca-4729-8994-624c72a2b221)
</details>
<details>
<summary>Showing tooltip for max invitations field</summary>

![Screenshot from 2024-08-22 18-13-58](https://github.com/user-attachments/assets/6b1f8bda-ee06-4990-ac15-c52ffc7207b9)
</details>
<details>
<summary>Error when trying to set max lower than default for plan type</summary>

![Screenshot from 2024-08-22 17-13-10](https://github.com/user-attachments/assets/45dd3816-347c-4464-bdce-d82211d84ccb)
</details>
<details>
<summary>Error when trying to set max to default when it's already at the default</summary>

![Screenshot from 2024-08-22 17-13-20](https://github.com/user-attachments/assets/47ec40ec-32e9-488f-bebd-8a0ce98029c6)
</details>
<details>
<summary>Success when setting above default max</summary>

![Screenshot from 2024-08-22 17-13-32](https://github.com/user-attachments/assets/749ad090-4ccf-49bb-8f04-a562b0c7f3fa)
</details>
<details>
<summary>Changed plan type to Standard Free - note change to max invites, which was previously 250</summary>

![Screenshot from 2024-08-22 17-13-49](https://github.com/user-attachments/assets/53af1e77-0623-45be-9a5b-8361ff035849)
</details>
<details>
<summary>Success when setting back to default for current plan type</summary>

![Screenshot from 2024-08-22 17-15-07](https://github.com/user-attachments/assets/1af8a94c-8a6a-43e4-8e72-ab97d3f484f7)
</details>
<details>
<summary>Input field set to negative number</summary>

![Screenshot from 2024-08-22 18-42-44](https://github.com/user-attachments/assets/c19503a3-8eb1-4d4b-9ce1-0e2f64f29337)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
