### PR TITLE
Include tooltips count in left sidebar

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -7,11 +7,15 @@ import render_change_visibility_policy_button_tooltip from "../templates/change_
 import render_org_logo_tooltip from "../templates/org_logo_tooltip.hbs";
 import render_tooltip_templates from "../templates/tooltip_templates.hbs";
 
+import * as drafts from "./drafts.ts";
 import {$t} from "./i18n.ts";
 import * as people from "./people.ts";
+import * as scheduled_messages from "./scheduled_messages.ts";
 import * as settings_config from "./settings_config.ts";
+import * as starred_messages from "./starred_messages.ts";
 import * as stream_data from "./stream_data.ts";
 import * as ui_util from "./ui_util.ts";
+import * as unread from "./unread.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
@@ -190,8 +194,71 @@ export function initialize(): void {
         appendTo: () => document.body,
         onShow(instance) {
             const $container = $(instance.popper).find(".views-tooltip-container");
-            if ($container.attr("data-view-code") === user_settings.web_home_view) {
-                $container.find(".views-tooltip-home-view-note").removeClass("hide");
+            let display_count = 0;
+            const sidebar_option = $container.attr("data-view-code");
+
+            switch (sidebar_option) {
+                case user_settings.web_home_view:
+                    $container.find(".views-tooltip-home-view-note").removeClass("hide");
+                    display_count = unread.get_unread_message_count();
+                    $container.find(".views-message-count").text(
+                        $t(
+                            {
+                                defaultMessage:
+                                    "You have {display_count, plural, =0 {no unread messages} one {# unread message} other {# unread messages}}.",
+                            },
+                            {display_count},
+                        ),
+                    );
+                    break;
+                case "mentions":
+                    display_count = unread.unread_mentions_counter.size;
+                    $container.find(".views-message-count").text(
+                        $t(
+                            {
+                                defaultMessage:
+                                    "You have {display_count, plural, =0 {no unread mentions} one {# unread mention} other {# unread mentions}}.",
+                            },
+                            {display_count},
+                        ),
+                    );
+                    break;
+                case "starred_message":
+                    display_count = starred_messages.get_count();
+                    $container.find(".views-message-count").text(
+                        $t(
+                            {
+                                defaultMessage:
+                                    "You have {display_count, plural, =0 {no starred messages} one {# starred message} other {# starred messages}}.",
+                            },
+                            {display_count},
+                        ),
+                    );
+                    break;
+                case "drafts":
+                    display_count = drafts.draft_model.getDraftCount();
+                    $container.find(".views-message-count").text(
+                        $t(
+                            {
+                                defaultMessage:
+                                    "You have {display_count, plural, =0 {no drafts} one {# draft} other {# drafts}}.",
+                            },
+                            {display_count},
+                        ),
+                    );
+                    break;
+                case "scheduled_message":
+                    display_count = scheduled_messages.get_count();
+                    $container.find(".views-message-count").text(
+                        $t(
+                            {
+                                defaultMessage:
+                                    "You have {display_count, plural, =0 {no scheduled messages} one {# scheduled message} other {# scheduled messages}}.",
+                            },
+                            {display_count},
+                        ),
+                    );
+                    break;
             }
 
             // Since the tooltip is attached to the anchor tag which doesn't

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -188,6 +188,25 @@ export function initialize(): void {
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
+        onShow(instance) {
+            const $container = $(instance.popper).find(".views-tooltip-container");
+            if ($container.attr("data-view-code") === user_settings.web_home_view) {
+                $container.find(".views-tooltip-home-view-note").removeClass("hide");
+            }
+
+            // Since the tooltip is attached to the anchor tag which doesn't
+            // include width of the ellipsis icon, we need to offset the
+            // tooltip so that the tooltip is displayed to right of the
+            // ellipsis icon.
+            if (instance.reference.classList.contains("left-sidebar-navigation-label-container")) {
+                instance.setProps({
+                    offset: [0, 40],
+                });
+            }
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
         popperOptions: {
             modifiers: [
                 {
@@ -209,44 +228,6 @@ export function initialize(): void {
         placement: "right",
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
-        popperOptions: {
-            modifiers: [
-                {
-                    name: "flip",
-                    options: {
-                        fallbackPlacements: "bottom",
-                    },
-                },
-            ],
-        },
-    });
-
-    // Variant of .tippy-left-sidebar-tooltip configuration. Here
-    // we need to dynamically check which view is the home view.
-    tippy.delegate("body", {
-        target: ".tippy-views-tooltip",
-        placement: "right",
-        delay: EXTRA_LONG_HOVER_DELAY,
-        appendTo: () => document.body,
-        onShow(instance) {
-            const $container = $(instance.popper).find(".views-tooltip-container");
-            if ($container.attr("data-view-code") === user_settings.web_home_view) {
-                $container.find(".views-tooltip-home-view-note").removeClass("hide");
-            }
-
-            // Since the tooltip is attached the anchor tag which doesn't
-            // include with of the ellipsis icon, we need to offset the
-            // tooltip so that the tooltip is displayed to right of the
-            // ellipsis icon.
-            if (instance.reference.classList.contains("left-sidebar-navigation-label-container")) {
-                instance.setProps({
-                    offset: [0, 40],
-                });
-            }
-        },
-        onHidden(instance) {
-            instance.destroy();
-        },
         popperOptions: {
             modifiers: [
                 {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -6,7 +6,7 @@
             <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
                 <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
-                    <a href="#inbox" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
+                    <a href="#inbox" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                         </span>
@@ -14,7 +14,7 @@
                     </a>
                 </li>
                 <li class="top_left_recent_view left-sidebar-navigation-condensed-item {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
-                    <a href="#recent" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+                    <a href="#recent" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
                         </span>
@@ -22,7 +22,7 @@
                     </a>
                 </li>
                 <li class="top_left_all_messages left-sidebar-navigation-condensed-item {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                    <a href="#feed" class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
+                    <a href="#feed" class="home-link tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                         </span>
@@ -38,7 +38,7 @@
                     </a>
                 </li>
                 <li class="top_left_starred_messages left-sidebar-navigation-condensed-item">
-                    <a href="#narrow/is/starred" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="starred-tooltip-template">
+                    <a href="#narrow/is/starred" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="starred-message-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
                         </span>
@@ -52,7 +52,7 @@
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
             <li class="top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}">
-                <a href="#inbox" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="inbox-tooltip-template">
+                <a href="#inbox" class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" data-tooltip-template-id="inbox-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
@@ -63,7 +63,7 @@
                 <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
-                <a href="#recent" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <a href="#recent" class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
                     </span>
@@ -76,7 +76,7 @@
                 </span>
             </li>
             <li class="top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                <a href="#feed" class="home-link left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="all-message-tooltip-template">
+                <a href="#feed" class="home-link left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
@@ -99,7 +99,7 @@
                 </a>
             </li>
             <li class="top_left_my_reactions top_left_row hidden-for-spectators">
-                <a class="left-sidebar-navigation-label-container tippy-views-tooltip" href="#narrow/has/reaction/sender/me" data-tooltip-template-id="my-reactions-tooltip-template">
+                <a class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" href="#narrow/has/reaction/sender/me" data-tooltip-template-id="my-reactions-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-smile" aria-hidden="true"></i>
                     </span>
@@ -109,7 +109,7 @@
                 </a>
             </li>
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
-                <a class="left-sidebar-navigation-label-container tippy-views-tooltip" href="#narrow/is/starred" data-tooltip-template-id="starred-message-tooltip-template">
+                <a class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" href="#narrow/is/starred" data-tooltip-template-id="starred-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
                     </span>
@@ -123,7 +123,7 @@
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_drafts top_left_row hidden-for-spectators">
-                <a href="#drafts" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="drafts-tooltip-template">
+                <a href="#drafts" class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
                     </span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -89,7 +89,7 @@
                 </span>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators">
-                <a class="left-sidebar-navigation-label-container" href="#narrow/is/mentioned">
+                <a class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" href="#narrow/is/mentioned" data-tooltip-template-id="mentions-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                     </span>
@@ -134,7 +134,7 @@
                 <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
-                <a class="left-sidebar-navigation-label-container" href="#scheduled">
+                <a class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" href="#scheduled" data-tooltip-template-id="scheduled-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-calendar-days" aria-hidden="true"></i>
                     </span>

--- a/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
@@ -17,7 +17,7 @@
         </li>
         {{#if has_scheduled_messages }}
         <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-scheduled-messages">
-            <a href="#scheduled" role="menuitem" class="popover-menu-link" tabindex="0">
+            <a href="#scheduled" role="menuitem" class="popover-menu-link tippy-left-sidebar-tooltip" tabindex="0" data-tooltip-template-id="scheduled-tooltip-template">
                 <i class="popover-menu-icon zulip-icon zulip-icon-calendar-days" aria-hidden="true"></i>
                 <span class="label-and-unread-wrapper">
                     <span class="popover-menu-label">{{t 'Scheduled messages' }}</span>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -112,6 +112,7 @@
 <template id="all-message-tooltip-template">
     <div class="views-tooltip-container" data-view-code="all_messages">
         <div>{{t 'Combined feed' }}</div>
+        <div class="tootlip-inner-content views-message-count italic hidden-for-spectators"></div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>
     {{tooltip_hotkey_hints "A"}}
@@ -119,13 +120,15 @@
 <template id="recent-conversations-tooltip-template">
     <div class="views-tooltip-container" data-view-code="recent_topics">
         <div>{{t 'Recent conversations' }}</div>
-        <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
+        <div class="tootlip-inner-content views-message-count italic hidden-for-spectators"></div>
+        <div class="tooltip-inner-content views-tooltip-home-view-note italic hide hidden-for-spectators">{{t 'This is your home view.' }}</div>
     </div>
     {{tooltip_hotkey_hints "T"}}
 </template>
 <template id="starred-message-tooltip-template">
     <div class="views-tooltip-container" data-view-code="starred_message">
         <div>{{t 'Starred messages' }}</div>
+        <div class="tootlip-inner-content views-message-count italic"></div>
     </div>
     {{tooltip_hotkey_hints "*"}}
 </template>
@@ -137,6 +140,7 @@
 <template id="inbox-tooltip-template">
     <div class="views-tooltip-container" data-view-code="inbox">
         <div>{{t 'Inbox' }}</div>
+        <div class="tootlip-inner-content views-message-count italic"></div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>
     {{tooltip_hotkey_hints "Shift" "I"}}
@@ -144,8 +148,15 @@
 <template id="drafts-tooltip-template">
     <div class="views-tooltip-container" data-view-code="drafts">
         <div>{{t 'Drafts' }}</div>
+        <div class="tootlip-inner-content views-message-count italic"></div>
     </div>
     {{tooltip_hotkey_hints "D"}}
+</template>
+<template id="scheduled-tooltip-template">
+    <div class="views-tooltip-container" data-view-code="scheduled_message">
+        <div>{{t 'Scheduled messages'}}</div>
+        <div class="tootlip-inner-content views-message-count italic"></div>
+    </div>
 </template>
 <template id="show-all-direct-messages-template">
     {{t 'Direct message feed' }}
@@ -154,6 +165,7 @@
 <template id="mentions-tooltip-template">
     <div class="views-tooltip-container" data-view-code="mentions">
         <div>{{t 'Mentions' }}</div>
+        <div class="tootlip-inner-content views-message-count italic"></div>
     </div>
 </template>
 <template id="filter-streams-tooltip-template">

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -124,7 +124,7 @@
     {{tooltip_hotkey_hints "T"}}
 </template>
 <template id="starred-message-tooltip-template">
-    <div class="views-tooltip-container">
+    <div class="views-tooltip-container" data-view-code="starred_message">
         <div>{{t 'Starred messages' }}</div>
     </div>
     {{tooltip_hotkey_hints "*"}}
@@ -142,7 +142,9 @@
     {{tooltip_hotkey_hints "Shift" "I"}}
 </template>
 <template id="drafts-tooltip-template">
-    {{t 'Drafts' }}
+    <div class="views-tooltip-container" data-view-code="drafts">
+        <div>{{t 'Drafts' }}</div>
+    </div>
     {{tooltip_hotkey_hints "D"}}
 </template>
 <template id="show-all-direct-messages-template">
@@ -150,10 +152,9 @@
     {{tooltip_hotkey_hints "Shift" "P"}}
 </template>
 <template id="mentions-tooltip-template">
-    {{t 'Mentions' }}
-</template>
-<template id="starred-tooltip-template">
-    {{t 'Starred messages' }}
+    <div class="views-tooltip-container" data-view-code="mentions">
+        <div>{{t 'Mentions' }}</div>
+    </div>
 </template>
 <template id="filter-streams-tooltip-template">
     {{t 'Filter channels' }}


### PR DESCRIPTION
This PR includes counts in tooltips for different navigation list in left sidebar.

Fixes: zulip#25901

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-08-22 22-45-05](https://github.com/user-attachments/assets/cbc7781b-672c-4d93-acca-acbcb4ac614e)
![Screenshot from 2024-08-22 22-45-14](https://github.com/user-attachments/assets/0f5257aa-0bf3-4baa-87b8-438767d477b2)
![Screenshot from 2024-08-22 22-45-23](https://github.com/user-attachments/assets/fee213df-16dc-4925-9b0b-15f86a87b8af)
![Screenshot from 2024-08-22 22-45-32](https://github.com/user-attachments/assets/4b797f40-25d9-4a28-aed8-7ad745238c25)
![Screenshot from 2024-08-22 22-45-37](https://github.com/user-attachments/assets/f0675538-0e37-405e-95d4-0cac7c4f5e1a)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
