### PR TITLE
settings: Rename user_display_settings to user_preferences.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -706,7 +706,7 @@ export function dispatch_normal_event(event) {
                 break;
             }
 
-            const user_display_settings = [
+            const user_preferences = [
                 "color_scheme",
                 "web_font_size_px",
                 "web_line_height_percent",
@@ -736,7 +736,7 @@ export function dispatch_normal_event(event) {
             ];
 
             const original_home_view = user_settings.web_home_view;
-            if (user_display_settings.includes(event.property)) {
+            if (user_preferences.includes(event.property)) {
                 user_settings[event.property] = event.value;
             }
             if (event.property === "default_language") {

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -157,7 +157,7 @@ export const twenty_four_hour_time_values = {
 
 export type DisplaySettings = {
     settings: {
-        user_display_settings: string[];
+        user_preferences: string[];
     };
     render_group?: boolean;
 };
@@ -165,7 +165,7 @@ export type DisplaySettings = {
 /* istanbul ignore next */
 export const information_section_checkbox_group: DisplaySettings = {
     settings: {
-        user_display_settings: [
+        user_preferences: [
             "starred_message_counts",
             "receives_typing_notifications",
             "fluid_layout_width",
@@ -177,7 +177,7 @@ export const information_section_checkbox_group: DisplaySettings = {
 export const get_information_density_preferences = (): DisplaySettings => ({
     render_group: page_params.development_environment,
     settings: {
-        user_display_settings: ["web_font_size_px", "web_line_height_percent"],
+        user_preferences: ["web_font_size_px", "web_line_height_percent"],
     },
 });
 

--- a/web/templates/settings/display_settings_general.hbs
+++ b/web/templates/settings/display_settings_general.hbs
@@ -36,7 +36,7 @@
 
     <div class="information-density-settings">
         <div class="title">{{t "Information density settings"}}</div>
-        {{#each information_density_settings.settings.user_display_settings}}
+        {{#each information_density_settings.settings.user_preferences}}
             {{> settings_numeric_input
               setting_name=this
               setting_value=(lookup ../settings_object this)

--- a/web/templates/settings/display_settings_information.hbs
+++ b/web/templates/settings/display_settings_information.hbs
@@ -49,7 +49,7 @@
         </select>
     </div>
 
-    {{#each information_section_checkbox_group.settings.user_display_settings}}
+    {{#each information_section_checkbox_group.settings.user_preferences}}
         {{> settings_checkbox
           setting_name=this
           is_checked=(lookup ../settings_object this)


### PR DESCRIPTION
Finished renaming `user_display_settings` to `user_preferences`.

Fixes part of zulip#26874.

this pull request:

Renames user_display_settings to user_preferences.

Changed Files:
`web/src/server_events_dispatch.js`
`web/src/settings_config.ts`
`web/templates/settings/display_settings_general.hbs`
`web/templates/settings/display_settings_information.hbs`

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
