### PR TITLE
docs: Fix help center links that are being redirected.

### DIFF
--- a/docs/contributing/asking-great-questions.md
+++ b/docs/contributing/asking-great-questions.md
@@ -18,7 +18,7 @@ guide](https://zulip.com/development-community/#where-do-i-send-my-message)
 offers guidelines on how the major public channels in the community are used.
 Don’t stress too much about picking the right place if you’re not sure, as
 moderators can [move your question thread to a different
-channel](https://zulip.com/help/move-content-to-another-stream) if needed.
+channel](https://zulip.com/help/move-content-to-another-channel) if needed.
 
 ## How to ask a great question
 

--- a/docs/contributing/reporting-bugs.md
+++ b/docs/contributing/reporting-bugs.md
@@ -104,8 +104,9 @@ Steps and best practices for starting a conversation:
      help](https://chat.zulip.org/#narrow/channel/31-production-help) for issues
      related to self-hosting Zulip. See the [troubleshooting
      guide](../production/troubleshooting.md) for additional details.
-3. **[Start a new topic](https://zulip.com/help/starting-a-new-topic)** for
-   discussing your issue, using a brief summary of the issue as the name of the topic.
+3. **[Start a new topic](https://zulip.com/help/introduction-to-topics#how-to-start-a-new-topic)**
+   for discussing your issue, using a brief summary of the issue as the name of
+   the topic.
 
 If you aren't sure where to post or how to name your topic, don't worry!
 Moderators can always rename the topic, or move the thread to another channel.

--- a/docs/contributing/suggesting-features.md
+++ b/docs/contributing/suggesting-features.md
@@ -46,8 +46,8 @@ Steps and best practices for starting a conversation:
    - [#production
      help](https://chat.zulip.org/#narrow/channel/31-production-help) for suggestions
      related to self-hosting Zulip.
-3. **[Start a new topic](https://zulip.com/help/starting-a-new-topic)** for
-   discussing your suggestions, using a brief summary of your idea as the
+3. **[Start a new topic](https://zulip.com/help/introduction-to-topics#how-to-start-a-new-topic)**
+   for discussing your suggestions, using a brief summary of your idea as the
    name of the topic.
 
 If you aren't sure where to post or how to name your topic, don't worry!

--- a/docs/documentation/helpcenter.md
+++ b/docs/documentation/helpcenter.md
@@ -103,7 +103,7 @@ existing help center articles:
   would be appropriate in the description of the feature. For example,
   your new feature might relate to general Zulip features like
   [keyboard shortcuts](https://zulip.com/help/keyboard-shortcuts)
-  or [channels and topics](https://zulip.com/help/streams-and-topics).
+  or [topics](https://zulip.com/help/introduction-to-topics).
 
 - Make sure there is a **Related articles** section at the end
   of the article that again links to any help center documentation

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -685,7 +685,7 @@ _Released 2023-11-16_
   Zulip does not yet support PostgreSQL 16.
 - Renamed the `reactivate_stream` management command to `unarchive_stream`, to
   match terminology in the app, and [documented
-  it](https://zulip.com/help/archive-a-stream#unarchiving-archived-streams).
+  it](https://zulip.com/help/archive-a-channel#unarchiving-archived-channels).
 - Fixed a regression, introduced in 6.0, where users created via the API or LDAP
   would have English set as their language, ignoring the configured realm
   default.
@@ -736,7 +736,7 @@ _Released 2023-08-25_
   [resolving](https://zulip.com/help/resolve-a-topic) or
   [moving](https://zulip.com/help/move-content-to-another-topic) long topics.
 - Fixed bad rendering of stream links in
-  [stream descriptions](https://zulip.com/help/change-the-stream-description).
+  [stream descriptions](https://zulip.com/help/change-the-channel-description).
 - Fixed broken and misaligned images in Zulip welcome emails.
 - Fixed YouTube video previews to be ordered in the order they are linked, not
   reverse order.
@@ -1019,13 +1019,13 @@ _Released 2023-05-19_
   control that was not in the organization's LDAP directory.
 - CVE-2023-32677: Fixed a vulnerability which allowed users to invite new users
   to streams when inviting them to the server, even if they did not have
-  [permission to invite existing users to streams](https://zulip.com/help/configure-who-can-invite-to-streams).
+  [permission to invite existing users to streams](https://zulip.com/help/configure-who-can-invite-to-channels).
   This did not allow users to invite others to streams that they themselves were
   not a member of, and only affected deployments with the rare configuration of
   a permissive
   [realm invitation policy](https://zulip.com/help/restrict-account-creation#change-who-can-send-invitations)
   and a strict
-  [stream invitation policy](https://zulip.com/help/configure-who-can-invite-to-streams).
+  [stream invitation policy](https://zulip.com/help/configure-who-can-invite-to-channels).
 - Fixed a bug that could cause duplicate push notifications when using the
   mobile push notifications service.
 - Fixed several bugs in the Zulip server and PostgreSQL version upgrade
@@ -1082,7 +1082,7 @@ _Released 2023-01-23_
   “[delay before sending message notification emails](https://zulip.com/help/email-notifications#delay-before-sending-emails)”
   setting.
 - Fixed an error which prevented users from changing
-  [stream-specific notification settings](https://zulip.com/help/stream-notifications#configure-notifications-for-a-single-stream).
+  [stream-specific notification settings](https://zulip.com/help/channel-notifications#configure-notifications-for-a-single-channel).
 - Fixed the redirect from `/apps` to https://zulip.com/apps/.
 - Started preserving timezone information in
   [Rocket.Chat imports](https://zulip.com/help/import-from-rocketchat).
@@ -1395,7 +1395,7 @@ _Released 2022-06-21_
 - CVE-2022-31017: Fixed message edit event exposure in
   protected-history streams.
   Zulip allows a stream to be configured as [private with protected
-  history](https://zulip.com/help/stream-permissions#stream-privacy-settings),
+  history](https://zulip.com/help/channel-permissions#channel-privacy-settings),
   which means that new subscribers should only see messages sent after
   they join. However, due to a logic bug in Zulip Server 2.1.0 through
   5.2, when a message was edited, the server would incorrectly send an
@@ -3098,7 +3098,7 @@ _Released 2018-11-07_
 - Users can now configure email and mobile push notifications for
   all messages in a stream (useful for low-traffic
   streams/organizations), not just for messages mentioning them.
-- New [stream settings](https://zulip.com/help/stream-permissions)
+- New [stream settings](https://zulip.com/help/channel-permissions)
   control whether private stream subscribers can access history
   from before they joined, and allow configuring streams to only
   allow administrators to post.

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -2667,7 +2667,7 @@ _Released 2019-12-12_
   setting is disabled. As a result, organization administrators can
   configure this feature entirely in the UI. However, servers that had
   previously [enabled previews of linked
-  websites](https://zulip.com/help/allow-image-link-previews) will
+  websites](https://zulip.com/help/image-video-and-website-previews) will
   lose the setting and need to re-enable it.
 - We rewrote the Google authentication backend to use the
   `python-social-auth` system we use for other third-party

--- a/docs/production/management-commands.md
+++ b/docs/production/management-commands.md
@@ -129,7 +129,7 @@ There are dozens of useful management commands under
   export tools](export-and-import.md) containing just
   the messages accessible by a single user.
 - `./manage.py unarchive_channel`:
-  [Reactivates](https://zulip.com/help/archive-a-stream#unarchiving-archived-streams)
+  [Reactivates](https://zulip.com/help/archive-a-channel#unarchiving-archived-channels)
   an archived channel.
 - `./manage.py reactivate_realm`: Reactivates a realm.
 - `./manage.py deactivate_user`: Deactivates a user. This can be done

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -96,7 +96,7 @@ on hardware requirements for larger organizations.
   that Zulip can properly manage image and website previews and mobile
   push notifications. Outgoing Internet access is not required if you
   [disable those
-  features](https://zulip.com/help/allow-image-link-previews).
+  features](https://zulip.com/help/image-video-and-website-previews).
 - Outgoing SMTP access (usually port 587) to your [SMTP
   server](email.md) so that Zulip can send emails.
 - A domain name (e.g., `zulip.example.com`) that your users will use to

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -118,7 +118,7 @@ strength allowed is controlled by two settings in
     figure out whether a channel with that name exists, but cannot see any
     other details about the channel.
 
-  - See [Channel permissions](https://zulip.com/help/stream-permissions) for more details.
+  - See [Channel permissions](https://zulip.com/help/channel-permissions) for more details.
 
 - Zulip supports editing the content and topics of messages that have
   already been sent. As a general philosophy, our policies provide

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -61,8 +61,8 @@ HELP_DOCUMENTATION_REDIRECTS: list[URLRedirect] = [
     URLRedirect("/help/disable-new-login-emails", "/help/email-notifications#new-login-emails"),
     # The `help/about-streams-and-topics` and `help/streams-and-topics` redirects are particularly
     # important, because the old URLs appear in links from Welcome Bot messages.
-    URLRedirect("/help/about-streams-and-topics", "/help/channels-and-topics"),
-    URLRedirect("/help/streams-and-topics", "/help/channels-and-topics"),
+    URLRedirect("/help/about-streams-and-topics", "/help/introduction-to-topics"),
+    URLRedirect("/help/streams-and-topics", "/help/introduction-to-topics"),
     URLRedirect("/help/community-topic-edits", "/help/restrict-moving-messages"),
     URLRedirect(
         "/help/only-allow-admins-to-add-emoji", "/help/custom-emoji#change-who-can-add-custom-emoji"


### PR DESCRIPTION
Did a quick sweep of recent help center URL redirects that haven't been updated in the RtD contributor documentation.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
