### PR TITLE
hotkey: Add keyboard shortcut to navigate to starred messages view.

### DIFF
--- a/help/include/view-starred-messages.md
+++ b/help/include/view-starred-messages.md
@@ -11,6 +11,11 @@
     You can also [search your starred messages](/help/search-for-messages)
     using the `is:starred` filter.
 
+!!! keyboard_tip ""
+
+    Use <kbd>*</kbd> to view your starred messages.
+
+
 {tab|mobile}
 
 1. Tap the **Starred messages**

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -108,6 +108,8 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Go to combined feed**: <kbd>A</kbd> — Shows all unmuted messages.
 
+* **Go to starred messages**: <kbd>*</kbd>
+
 * **Go to the conversation you are composing to**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 
 ## Composing messages

--- a/web/src/deprecated_feature_notice.ts
+++ b/web/src/deprecated_feature_notice.ts
@@ -1,7 +1,6 @@
 import {z} from "zod";
 
 import * as blueslip from "./blueslip";
-import * as common from "./common";
 import * as dialog_widget from "./dialog_widget";
 import {$t_html} from "./i18n";
 import {localstorage} from "./localstorage";
@@ -23,13 +22,9 @@ let shown_deprecation_notices: string[] = [];
 
 export function maybe_show_deprecation_notice(key: string): void {
     let message;
-    const isCmdOrCtrl = common.has_mac_keyboard() ? "Cmd" : "Ctrl";
     switch (key) {
         case "Shift + C":
             message = get_hotkey_deprecation_notice("Shift + C", "X");
-            break;
-        case "*":
-            message = get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + S");
             break;
         case "Shift + S":
             message = get_hotkey_deprecation_notice("Shift + S", "S");

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -150,7 +150,7 @@ const keydown_either_mappings = {
 };
 
 const keypress_mappings = {
-    42: {name: "star_deprecated", message_view_only: true}, // '*'
+    42: {name: "open_starred_message_view", message_view_only: true}, // '*'
     43: {name: "thumbs_up_emoji", message_view_only: true}, // '+'
     61: {name: "upvote_first_emoji", message_view_only: true}, // '='
     45: {name: "toggle_message_collapse", message_view_only: true}, // '-'
@@ -996,6 +996,9 @@ export function process_hotkey(e, hotkey) {
         case "open_inbox":
             browser_history.go_to_location("#inbox");
             return true;
+        case "open_starred_message_view":
+            browser_history.go_to_location("#narrow/is/starred");
+            return true;
         case "open_combined_feed":
             browser_history.go_to_location("#feed");
             return true;
@@ -1043,9 +1046,6 @@ export function process_hotkey(e, hotkey) {
             return true;
         case "C_deprecated":
             deprecated_feature_notice.maybe_show_deprecation_notice("Shift + C");
-            return true;
-        case "star_deprecated":
-            deprecated_feature_notice.maybe_show_deprecation_notice("*");
             return true;
     }
 

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -172,6 +172,10 @@
                     <td><span class="hotkey"><kbd>A</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Go to starred messages' }}</td>
+                    <td><span class="hotkey"><kbd>*</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Go to the conversation you are composing to' }}</td>
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
                 </tr>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -109,7 +109,7 @@
                 </a>
             </li>
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
-                <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
+                <a class="left-sidebar-navigation-label-container tippy-views-tooltip" href="#narrow/is/starred" data-tooltip-template-id="starred-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-star-filled" aria-hidden="true"></i>
                     </span>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -117,6 +117,12 @@
     </div>
     {{tooltip_hotkey_hints "T"}}
 </template>
+<template id="starred-message-tooltip-template">
+    <div class="views-tooltip-container">
+        <div>{{t 'Starred messages' }}</div>
+    </div>
+    {{tooltip_hotkey_hints "*"}}
+</template>
 <template id="my-reactions-tooltip-template">
     <div class="views-tooltip-container" data-view-code="recent_topics">
         <div>{{t 'Reactions to your messages' }}</div>

--- a/web/tests/deprecated_feature_notice.test.js
+++ b/web/tests/deprecated_feature_notice.test.js
@@ -13,18 +13,7 @@ const deprecated_feature_notice = zrequire("deprecated_feature_notice");
 
 run_test("get_hotkey_deprecation_notice", () => {
     const expected =
-        'translated HTML: We\'ve replaced the "*" hotkey with "Ctrl + s" to make this common shortcut easier to trigger.';
-    const actual = deprecated_feature_notice.get_hotkey_deprecation_notice("*", "Ctrl + s");
+        'translated HTML: We\'ve replaced the "Shift + C" hotkey with "X" to make this common shortcut easier to trigger.';
+    const actual = deprecated_feature_notice.get_hotkey_deprecation_notice("Shift + C", "X");
     assert.equal(actual, expected);
-});
-
-run_test("get_hotkey_deprecation_notice_mac", () => {
-    navigator.userAgent =
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36";
-    const expected =
-        'translated HTML: We\'ve replaced the "*" hotkey with "Cmd + s" to make this common shortcut easier to trigger.';
-    const actual = deprecated_feature_notice.get_hotkey_deprecation_notice("*", "Cmd + s");
-    assert.equal(actual, expected);
-    // Reset userAgent
-    navigator.userAgent = "";
 });


### PR DESCRIPTION
This PR adds '*' as a keyboard shortcut to navigate to the starred messages view and the shortcut is documented in various required locations accordingly. 

Fixes: [#31397](https://github.com/zulip/zulip/issues/31397).

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Screencast |
|--------|
|![keyboard shortcut](https://github.com/user-attachments/assets/e644d8a8-3958-4a1a-a89b-dd2c684bee0a)| 

| Desc | After PR |
|--------|--------|
| Tooltip in the left sidebar | ![image](https://github.com/user-attachments/assets/334afbf2-6935-4c58-946a-8e8f35f1f6a3) |
| `?` menu | ![image](https://github.com/user-attachments/assets/a2ee4ad6-5c18-41c6-b069-d827bc8ac1aa) | 
| Help center->Keyboard shortcuts | ![image](https://github.com/user-attachments/assets/58508616-e052-470e-bd62-2722a976d280) | 
| Help center-> View Starred messages | ![image](https://github.com/user-attachments/assets/0f34c52d-4373-4aec-9269-d3402b350ddf) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
