### PR TITLE
analytics: Migrate to @typed_endpoint.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -955,7 +955,7 @@ def internal_api_view(
     return _wrapped_view_func
 
 
-def to_utc_datetime(var_name: str, timestamp: str) -> datetime:
+def to_utc_datetime(timestamp: str) -> datetime:
     return timestamp_to_datetime(float(timestamp))
 
 


### PR DESCRIPTION
Migrate analytics to `typed_endpoint`.

Split `get_chart_data` into two functions `get_chart_data` (the endpoint) and `do_get_chart_data` (the function that is called by other endpoints) because `typed_endpoint` was attempting to validate ` server: Optional["RemoteZulipServer"] = None,` but when `"RemoteZulipServer"` is not imported an error was occurring as observed in #30652 .
