### PR TITLE
util: Use blueslip error for util.the instead of an assert.

### DIFF
--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import assert from "minimalistic-assert";
 
 import * as blueslip from "./blueslip";
 import type {MatchedMessage, Message, RawMessage} from "./message_store";
@@ -458,6 +457,12 @@ export function get_remaining_time(start_time: number, duration: number): number
 // Helper for shorthand for Typescript to get an item from a list with
 // exactly one item.
 export function the<T>(items: T[] | JQuery<T>): T {
-    assert.equal(items.length, 1, "the: expected exactly one item");
+    if (items.length === 0) {
+        blueslip.error("the: expected only 1 item, got none");
+    } else if (items.length > 1) {
+        blueslip.error("the: expected only 1 item, got more", {
+            num_items: items.length,
+        });
+    }
     return items[0]!;
 }

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -388,4 +388,16 @@ run_test("get_remaining_time", () => {
 run_test("the", () => {
     const list_with_one_item = ["foo"];
     assert.equal(util.the(list_with_one_item), "foo");
+
+    blueslip.expect("error", "the: expected only 1 item, got more");
+    const list_with_more_items = ["foo", "bar"];
+    // Error is thrown, but we still return the first item to avoid
+    // unnecessarily breaking the app.
+    assert.equal(util.the(list_with_more_items), "foo");
+
+    blueslip.expect("error", "the: expected only 1 item, got none");
+    // Error is thrown, but we still return the "first" item to avoid
+    // unnecessarily breaking the app for places we refactored this that
+    // were previously typed wrong but not breaking the app.
+    assert.equal(util.the([]), undefined);
 });


### PR DESCRIPTION
discussed here: https://chat.zulip.org/#narrow/stream/9-issues/topic/Search.3A.20Cannot.20find.20active.20element/near/1928574

I decided to change this to fail quieter, because when introducing uses of `util.the` across the codebase it was hard to know for sure if I made any mistakes, and this will let us catch mistakes without unnecessarily breaking the website. 