### PR TITLE
edit_history: Remove 'prev_rendered_content_version' field.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 284**
+
+* [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),
+  [`GET /messages/{message_id}`](/api/get-message),
+  [`POST /zulip-outgoing-webhook`](/api/zulip-outgoing-webhooks): Removed
+  the `prev_rendered_content_version` field from the `edit_history` object
+  within message objects and the `update_message` event type as it is an
+  internal server implementation detail not used by any client.
+
 **Feature level 283**
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -35,7 +35,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
 
-API_FEATURE_LEVEL = 283  # Last bumped for can_manage_group
+API_FEATURE_LEVEL = 284  # Last bumped for removing 'prev_rendered_content_version'
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -155,7 +155,6 @@ export function update_messages(events) {
                         user_id: event.user_id,
                         prev_content: event.orig_content,
                         prev_rendered_content: event.orig_rendered_content,
-                        prev_rendered_content_version: event.prev_rendered_content_version,
                         timestamp: event.edit_timestamp,
                     };
                     // Add message's edit_history in message dict

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -37,7 +37,6 @@ const message_edit_history_entry_schema = z.object({
     timestamp: z.number(),
     prev_content: z.optional(z.string()),
     prev_rendered_content: z.optional(z.string()),
-    prev_rendered_content_version: z.optional(z.number()),
     prev_stream: z.optional(z.number()),
     prev_topic: z.optional(z.string()),
     stream: z.optional(z.number()),

--- a/web/src/server_message.ts
+++ b/web/src/server_message.ts
@@ -10,7 +10,6 @@ export const message_edit_history_schema = z.array(
     z.object({
         prev_content: z.optional(z.string()),
         prev_rendered_content: z.optional(z.string()),
-        prev_rendered_content_version: z.optional(z.number()),
         prev_stream: z.optional(z.number()),
         prev_topic: z.optional(z.string()),
         stream: z.optional(z.number()),

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -40,7 +40,6 @@ export type UpdateMessageEvent = {
     topic_links?: TopicLink[];
     orig_content?: string;
     orig_rendered_content?: string;
-    prev_rendered_content_version?: number;
     content?: string;
     rendered_content?: string;
     is_me_message?: boolean;

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -508,7 +508,6 @@ def do_update_message(
         target_message.rendered_content_version = markdown_version
         event["content"] = content
         event["rendered_content"] = rendering_result.rendered_content
-        event["prev_rendered_content_version"] = target_message.rendered_content_version
         event["is_me_message"] = Message.is_status_message(
             content, rendering_result.rendered_content
         )

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1674,7 +1674,6 @@ update_message_content_fields: list[tuple[str, object]] = [
     ("is_me_message", bool),
     ("orig_content", str),
     ("orig_rendered_content", str),
-    ("prev_rendered_content_version", int),
 ]
 
 update_message_content_or_embedded_data_fields: list[tuple[str, object]] = [

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -246,6 +246,10 @@ class MessageDict:
         else:
             obj["content_type"] = "text/x-markdown"
 
+        for item in obj.get("edit_history", []):
+            if "prev_rendered_content_version" in item:
+                del item["prev_rendered_content_version"]
+
         if not keep_rendered_content:
             del obj["rendered_content"]
         del obj["sender_realm_id"]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2369,6 +2369,10 @@ paths:
                                 message.
 
                                 [inline-url-previews]: https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#inline-url-previews
+
+                                **Changes**: In Zulip 10.0 (feature level 284), removed the
+                                `prev_rendered_content_version` field as it is an internal
+                                server implementation detail not used by any client.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2589,14 +2593,6 @@ paths:
 
                                     The original content of the message with ID `message_id`
                                     immediately prior to this edit, rendered as HTML.
-                                prev_rendered_content_version:
-                                  type: integer
-                                  description: |
-                                    Only present if this event changed the message content.
-
-                                    The Markdown processor version number for the pre-edit message.
-
-                                    Clients should ignore this field.
                                 content:
                                   type: string
                                   description: |
@@ -2644,7 +2640,6 @@ paths:
                                   "orig_rendered_content": "<p>hello</p>",
                                   "content": "new content",
                                   "rendered_content": "<p>new content</p>",
-                                  "prev_rendered_content_version": 1,
                                   "is_me_message": false,
                                   "propagate_mode": "change_all",
                                   "stream_id": 5,
@@ -21825,13 +21820,6 @@ components:
                   Only present if message's content was edited.
 
                   The rendered HTML representation of `prev_content`.
-              prev_rendered_content_version:
-                type: integer
-                description: |
-                  Only present if message's content was edited.
-
-                  The Markdown processor version number for the message
-                  immediately prior to this edit event.
               prev_stream:
                 type: integer
                 description: |
@@ -21908,6 +21896,10 @@ components:
             will be present in addition to `user_id` and `timestamp`.
 
             [disable-edit-history]: /help/disable-message-edit-history
+
+            **Changes**: In Zulip 10.0 (feature level 284), removed the
+            `prev_rendered_content_version` field as it is an internal
+            server implementation detail not used by any client.
         id:
           type: integer
           description: |

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -67,9 +67,14 @@ class EditMessageTest(ZulipTestCase):
         )
 
         if msg.edit_history:
+            message_edit_history = orjson.loads(msg.edit_history)
+            for item in message_edit_history:
+                if "prev_rendered_content_version" in item:
+                    del item["prev_rendered_content_version"]
+
             self.assertEqual(
                 fetch_message_dict["edit_history"],
-                orjson.loads(msg.edit_history),
+                message_edit_history,
             )
 
     def test_edit_message_no_changes(self) -> None:


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/edit.20history/near/1928233)

PR to remove the `prev_rendered_content_version` field from:

* the 'edit_history' object within message objects in the API response of `GET /messages`, `GET /messages/{message_id}` and `POST /zulip-outgoing-webhook`.
* the 'update_message' event type

as it is not used by any client.

Note: The field is still stored in the 'edit_history' column of the 'Message' table as it will be helpful when making major changes to the markup rendering process.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
