### PR TITLE
realm-settings: Get max invites for realm plan type helper.

### DIFF
--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -75,7 +75,11 @@ from zerver.models import (
     RealmReactivationStatus,
     UserProfile,
 )
-from zerver.models.realms import get_org_type_display_name, get_realm
+from zerver.models.realms import (
+    get_default_max_invites_for_realm_plan_type,
+    get_org_type_display_name,
+    get_realm,
+)
 from zerver.models.users import get_user_profile_by_id
 from zerver.views.invite import get_invitee_emails_set
 from zilencer.lib.remote_counts import MissingDataError, compute_max_monthly_messages
@@ -314,13 +318,10 @@ def get_realm_plan_type_options_for_discount() -> list[SupportSelectOption]:
 
 
 def get_default_max_invites_for_plan_type(realm: Realm) -> int:
-    if realm.plan_type in [
-        Realm.PLAN_TYPE_PLUS,
-        Realm.PLAN_TYPE_STANDARD,
-        Realm.PLAN_TYPE_STANDARD_FREE,
-    ]:
-        return Realm.INVITES_STANDARD_REALM_DAILY_MAX
-    return settings.INVITES_DEFAULT_REALM_DAILY_MAX
+    default_max = get_default_max_invites_for_realm_plan_type(realm.plan_type)
+    if default_max is None:
+        return settings.INVITES_DEFAULT_REALM_DAILY_MAX
+    return default_max
 
 
 def check_update_max_invites(realm: Realm, new_max: int, default_max: int) -> bool:

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -555,7 +555,7 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
     PLAN_TYPE_STANDARD_FREE = 4
     PLAN_TYPE_PLUS = 10
 
-    # Used for creating realms with different plan types.
+    # Used to check valid plan_type values and when populating test billing realms.
     ALL_PLAN_TYPES = {
         PLAN_TYPE_SELF_HOSTED: "self-hosted-plan",
         PLAN_TYPE_LIMITED: "limited-plan",
@@ -1208,6 +1208,19 @@ def get_corresponding_policy_value_for_group_setting(
 
     assert valid_policy_enums == Realm.COMMON_POLICY_TYPES
     return Realm.POLICY_MEMBERS_ONLY
+
+
+def get_default_max_invites_for_realm_plan_type(plan_type: int) -> int | None:
+    assert plan_type in Realm.ALL_PLAN_TYPES
+    if plan_type in [
+        Realm.PLAN_TYPE_PLUS,
+        Realm.PLAN_TYPE_STANDARD,
+        Realm.PLAN_TYPE_STANDARD_FREE,
+    ]:
+        return Realm.INVITES_STANDARD_REALM_DAILY_MAX
+    if plan_type == Realm.PLAN_TYPE_SELF_HOSTED:
+        return None
+    return settings.INVITES_DEFAULT_REALM_DAILY_MAX
 
 
 class RealmDomain(models.Model):


### PR DESCRIPTION
There are a few places where we want to set the `max_invites` for a realm to the default for a realm's `plan_type`, so this creates a helper function that can be used consistently to get that default value.

**Notes**:
- Follow-up from [review comment](https://github.com/zulip/zulip/pull/31430#discussion_r1729591686).
- Uses `Realm.ALL_PLAN_TYPES` dict for check/assertions that a `plan_type` value is one of the valid plan types. This dict was added for populating realms with different plan types for billing testing (see commit 9ebb3f06b3ad87e91e1f66bb5a94fe377c4196b9).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
