### PR TITLE
support: Add shared general realm data section to views.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -154,22 +154,26 @@ def get_cached_seat_count(realm: Realm) -> int:
     return get_latest_seat_count(realm)
 
 
-def get_seat_count(
-    realm: Realm, extra_non_guests_count: int = 0, extra_guests_count: int = 0
-) -> int:
-    non_guests = (
+def get_non_guest_user_count(realm: Realm) -> int:
+    return (
         UserProfile.objects.filter(realm=realm, is_active=True, is_bot=False)
         .exclude(role=UserProfile.ROLE_GUEST)
         .count()
-    ) + extra_non_guests_count
-
-    # This guest count calculation should match the similar query in render_stats().
-    guests = (
-        UserProfile.objects.filter(
-            realm=realm, is_active=True, is_bot=False, role=UserProfile.ROLE_GUEST
-        ).count()
-        + extra_guests_count
     )
+
+
+def get_guest_user_count(realm: Realm) -> int:
+    # Same query to get guest user count as in render_stats in analytics/views/stats.py.
+    return UserProfile.objects.filter(
+        realm=realm, is_active=True, is_bot=False, role=UserProfile.ROLE_GUEST
+    ).count()
+
+
+def get_seat_count(
+    realm: Realm, extra_non_guests_count: int = 0, extra_guests_count: int = 0
+) -> int:
+    non_guests = get_non_guest_user_count(realm) + extra_non_guests_count
+    guests = get_guest_user_count(realm) + extra_guests_count
 
     # This formula achieves the pricing of the first 5*N guests
     # being free of charge (where N is the number of non-guests in the organization)

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -747,7 +747,7 @@ class TestSupportEndpoint(ZulipTestCase):
     def test_realm_support_view_queries(self) -> None:
         iago = self.example_user("iago")
         self.login_user(iago)
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(18):
             result = self.client_get("/activity/support", {"q": "zulip"}, subdomain="zulip")
             self.assertEqual(result.status_code, 200)
 

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -170,6 +170,13 @@ class TestRemoteServerSupportEndpoint(ZulipTestCase):
             remote_server=remote_realm.server, email="server-admin@example.com"
         )
 
+    def test_remote_support_view_queries(self) -> None:
+        iago = self.example_user("iago")
+        self.login_user(iago)
+        with self.assert_database_query_count(28):
+            result = self.client_get("/activity/remote/support", {"q": "zulip-3.example.com"})
+            self.assertEqual(result.status_code, 200)
+
     def test_search(self) -> None:
         def assert_server_details_in_response(
             html_response: "TestHttpResponse", hostname: str
@@ -736,6 +743,13 @@ class TestSupportEndpoint(ZulipTestCase):
             plan=plan,
         )
         return customer
+
+    def test_realm_support_view_queries(self) -> None:
+        iago = self.example_user("iago")
+        self.login_user(iago)
+        with self.assert_database_query_count(16):
+            result = self.client_get("/activity/support", {"q": "zulip"}, subdomain="zulip")
+            self.assertEqual(result.status_code, 200)
 
     def test_search(self) -> None:
         reset_email_visibility_to_everyone_in_zulip_realm()

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -343,6 +343,12 @@ VALID_BILLING_MODALITY_VALUES = Literal[
     "charge_automatically",
 ]
 
+SHARED_SUPPORT_CONTEXT = {
+    "get_org_type_display_name": get_org_type_display_name,
+    "get_plan_type_name": get_plan_type_string,
+    "dollar_amount": cents_to_dollar_string,
+}
+
 
 @require_server_admin
 @typed_endpoint
@@ -367,7 +373,7 @@ def support(
     org_type: Json[NonNegativeInt] | None = None,
     max_invites: Json[NonNegativeInt] | None = None,
 ) -> HttpResponse:
-    context: dict[str, Any] = {}
+    context: dict[str, Any] = {**SHARED_SUPPORT_CONTEXT}
 
     if "success_message" in request.session:
         context["success_message"] = request.session["success_message"]
@@ -601,7 +607,6 @@ def support(
 
     context["get_realm_owner_emails_as_string"] = get_realm_owner_emails_as_string
     context["get_realm_admin_emails_as_string"] = get_realm_admin_emails_as_string
-    context["dollar_amount"] = cents_to_dollar_string
     context["realm_icon_url"] = realm_icon_url
     context["Confirmation"] = Confirmation
     context["REALM_PLAN_TYPES"] = get_realm_plan_type_options()
@@ -690,7 +695,7 @@ def remote_servers_support(
     ]
     | None = None,
 ) -> HttpResponse:
-    context: dict[str, Any] = {}
+    context: dict[str, Any] = {**SHARED_SUPPORT_CONTEXT}
 
     if "success_message" in request.session:
         context["success_message"] = request.session["success_message"]
@@ -875,10 +880,7 @@ def remote_servers_support(
     context["remote_server_to_max_monthly_messages"] = remote_server_to_max_monthly_messages
     context["remote_realms"] = remote_realms
     context["remote_realms_support_data"] = realm_support_data
-    context["get_plan_type_name"] = get_plan_type_string
-    context["get_org_type_display_name"] = get_org_type_display_name
     context["format_optional_datetime"] = format_optional_datetime
-    context["dollar_amount"] = cents_to_dollar_string
     context["server_analytics_link"] = remote_installation_stats_link
     context["REMOTE_PLAN_TIERS"] = get_remote_plan_tier_options()
     context["get_remote_server_billing_user_emails"] = (

--- a/templates/corporate/support/basic_realm_data.html
+++ b/templates/corporate/support/basic_realm_data.html
@@ -1,0 +1,4 @@
+<b>Organization type</b>: {{ get_org_type_display_name(realm.org_type) }}<br />
+<b>Plan type</b>: {{ get_plan_type_name(realm.plan_type) }}<br />
+<b>Non-guest user count</b>: {{ user_data.non_guest_user_count }}<br />
+<b>Guest user count</b>: {{ user_data.guest_user_count }}<br />

--- a/templates/corporate/support/realm_details.html
+++ b/templates/corporate/support/realm_details.html
@@ -33,9 +33,17 @@
     <a title="Copy emails" class="copy-button" data-clipboard-text="{{ first_human_user.delivery_email }}">
         <i class="fa fa-copy"></i>
     </a>
+    <br />
     {% else %}
     <b>First human user</b>:
+    <br />
     {% endif %}
+    <br />
+    {% with %}
+        {% set realm = realm %}
+        {% set user_data = realm_support_data[realm.id].user_data %}
+        {% include 'corporate/support/basic_realm_data.html' %}
+    {% endwith %}
 </div>
 <div>
     <div class="realm-management-actions">

--- a/templates/corporate/support/remote_realm_details.html
+++ b/templates/corporate/support/remote_realm_details.html
@@ -29,10 +29,11 @@
         <b>Date created</b>: {{ support_data[remote_realm.id].date_created.strftime('%d %B %Y') }}<br />
         <b>UUID</b>: {{ remote_realm.uuid }}<br />
         <br />
-        <b>Organization type</b>: {{ get_org_type_display_name(remote_realm.org_type) }}<br />
-        <b>Plan type</b>: {{ get_plan_type_name(remote_realm.plan_type) }}<br />
-        <b>Non-guest user count</b>: {{ support_data[remote_realm.id].user_data.non_guest_user_count }}<br />
-        <b>Guest user count</b>: {{ support_data[remote_realm.id].user_data.guest_user_count }}<br />
+        {% with %}
+            {% set realm = remote_realm %}
+            {% set user_data = support_data[remote_realm.id].user_data %}
+            {% include 'corporate/support/basic_realm_data.html' %}
+        {% endwith %}
         <br />
         <b>Mobile user count</b>: {{ support_data[remote_realm.id].mobile_push_data.total_mobile_users }}<br />
         <b>7-day mobile pushes count</b>: {{ support_data[remote_realm.id].mobile_push_data.mobile_pushes_forwarded }}<br />


### PR DESCRIPTION
Adds a shared realm data section to both remote and Zulip Cloud support views with this information:
- Organization type
- Plan type
- Non-guest user count
- Guest user count

**Notes**:
- The remote realm section of the support view already had this information, so we're mostly adding it to the Zulip Cloud realm support view.
- Adds two simple database query tests to the support views for a single realm or single remote realm, so that we have a baseline for these views and can assess performance as we expand/change the features on these views.
  - Confirms that these updates add two more queries to the Zulip Cloud support view for a realm.
- The user counts for the Zulip Cloud view uses the same queries as is used for getting the realm's seat count.
- Adds a shared context dict to the support view code for variables that are used in both remote and Zulip Cloud support views.

---

**Screenshots and screen captures:**

<details>
<summary>Updated Zulip Cloud support view for realm</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-26 18-16-59](https://github.com/user-attachments/assets/d9cfda46-cbb6-4685-af1a-d0410760f2d7) | ![Screenshot from 2024-08-26 18-15-10](https://github.com/user-attachments/assets/803d89b1-baab-4e07-a693-0e1147d99fa1)

</details>
<details>
<summary>No change in remote support view for realm</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-26 18-18-14](https://github.com/user-attachments/assets/b7a8cd17-313d-4b12-8fc5-92fbb8c667bb) | ![Screenshot from 2024-08-26 18-18-33](https://github.com/user-attachments/assets/9514325e-93c1-4917-ae0d-bc15aa99ebb8)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
