### PR TITLE
Style supplementary info in typeaheads consistently.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -487,7 +487,8 @@ export function broadcast_mentions(): PseudoMentionUser[] {
     }
 
     return wildcard_mention_array.map((mention, idx) => ({
-        special_item_text: `${mention} (${get_wildcard_string(mention)})`,
+        special_item_text: mention,
+        secondary_text: get_wildcard_string(mention),
         email: mention,
 
         // Always sort above, under the assumption that names will

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -68,6 +68,7 @@ import * as util from "./util";
 type SlashCommand = {
     text: string;
     name: string;
+    info: string;
     aliases: NamedCurve;
     placeholder?: string;
 };
@@ -529,35 +530,40 @@ function should_show_custom_query(query: string, items: string[]): boolean {
 
 export const dev_only_slash_commands = [
     {
-        text: $t({defaultMessage: "/dark (Switch to the dark theme)"}),
+        text: $t({defaultMessage: "/dark"}),
         name: "dark",
         aliases: "night",
+        info: $t({defaultMessage: "Switch to the dark theme"}),
     },
     {
-        text: $t({defaultMessage: "/light (Switch to light theme)"}),
+        text: $t({defaultMessage: "/light"}),
         name: "light",
         aliases: "day",
+        info: $t({defaultMessage: "Switch to light theme"}),
     },
 ];
 
 export const slash_commands = [
     {
-        text: $t({defaultMessage: "/me (Action message)"}),
+        text: $t({defaultMessage: "/me"}),
         name: "me",
         aliases: "",
         placeholder: $t({defaultMessage: "is …"}),
+        info: $t({defaultMessage: "Action message"}),
     },
     {
-        text: $t({defaultMessage: "/poll (Create a poll)"}),
+        text: $t({defaultMessage: "/poll"}),
         name: "poll",
         aliases: "",
         placeholder: $t({defaultMessage: "Question"}),
+        info: $t({defaultMessage: "Create a poll"}),
     },
     {
-        text: $t({defaultMessage: "/todo (Create a collaborative to-do list)"}),
+        text: $t({defaultMessage: "/todo"}),
         name: "todo",
         aliases: "",
         placeholder: $t({defaultMessage: "Task list"}),
+        info: $t({defaultMessage: "Create a collaborative to-do list"}),
     },
 ];
 
@@ -976,6 +982,7 @@ export function content_highlighter_html(item: TypeaheadSuggestion): string | un
         case "slash":
             return typeahead_helper.render_typeahead_item({
                 primary: item.text,
+                secondary: item.info,
             });
         case "stream":
             return typeahead_helper.render_stream(item);

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -33,6 +33,7 @@ export type SenderInfo = User & {
 export type PseudoMentionUser = {
     special_item_text: string;
     email: string;
+    secondary_text: string;
     pm_recipient_count: number;
     full_name: string;
     idx: number;

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -121,6 +121,7 @@ export function render_person(person: UserPillData | UserOrMentionPillData): str
     if (person.type === "broadcast") {
         return render_typeahead_item({
             primary: person.user.special_item_text,
+            secondary: person.user.secondary_text,
             is_person: true,
         });
     }

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -84,17 +84,22 @@
         }
     }
 
+    .pronouns,
     .autocomplete_secondary {
         align-self: end;
         opacity: 0.8;
         font-size: 85%;
-        flex: 1 1 0;
         overflow: hidden;
         text-overflow: ellipsis;
         position: relative;
         top: -1px;
     }
 
+    .autocomplete_secondary {
+        flex: 1 1 0;
+    }
+
+    .active .pronouns,
     .active .autocomplete_secondary {
         opacity: 1;
     }

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -26,7 +26,7 @@
         {{~/if~}}
     </strong>
     {{~#if has_pronouns}}
-        <span class="pronouns">({{pronouns}})</span>
+        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
     {{~/if}}
     {{~#if should_add_guest_user_indicator}}
         <i>({{t 'guest'}})</i>

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -225,8 +225,9 @@ const emojis_by_name = new Map(
 const me_command = {
     name: "me",
     aliases: "",
-    text: "translated: /me (Action message)",
+    text: "translated: /me",
     placeholder: "translated: is …",
+    info: "translated: Action message",
 };
 const me_command_item = slash_item(me_command);
 
@@ -239,14 +240,16 @@ const my_command_item = slash_item({
 const dark_command = {
     name: "dark",
     aliases: "night",
-    text: "translated: /dark (Switch to the dark theme)",
+    text: "translated: /dark",
+    info: "translated: Switch to the dark theme",
 };
 const dark_command_item = slash_item(dark_command);
 
 const light_command = {
     name: "light",
     aliases: "day",
-    text: "translated: /light (Switch to light theme)",
+    text: "translated: /light",
+    info: "translated: Switch to light theme",
 };
 const light_command_item = slash_item(light_command);
 
@@ -1701,15 +1704,17 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("test no#o", []);
 
     const poll_command = {
-        text: "translated: /poll (Create a poll)",
+        text: "translated: /poll",
         name: "poll",
+        info: "translated: Create a poll",
         aliases: "",
         placeholder: "translated: Question",
         type: "slash",
     };
     const todo_command = {
-        text: "translated: /todo (Create a collaborative to-do list)",
+        text: "translated: /todo",
         name: "todo",
+        info: "translated: Create a collaborative to-do list",
         aliases: "",
         placeholder: "translated: Task list",
         type: "slash",
@@ -1896,12 +1901,14 @@ test("content_highlighter_html", ({override_rewire}) => {
     ct.get_or_set_completing_for_tests("slash");
     let th_render_slash_command_called = false;
     const me_slash = {
-        text: "/me (Action message)",
+        text: "/me",
         type: "slash",
+        info: "translated: Action message",
     };
     override_rewire(typeahead_helper, "render_typeahead_item", (item) => {
         assert.deepEqual(item, {
-            primary: "/me (Action message)",
+            primary: "/me",
+            secondary: "translated: Action message",
         });
         th_render_slash_command_called = true;
     });

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -114,11 +114,16 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
     assert.equal(mention_topic.email, "topic");
     assert.equal(mention_topic.full_name, "topic");
 
-    assert.equal(mention_all.special_item_text, "all (translated: Notify channel)");
-    assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify channel)");
-    assert.equal(mention_stream.special_item_text, "stream (translated: Notify channel)");
-    assert.equal(mention_channel.special_item_text, "channel (translated: Notify channel)");
-    assert.equal(mention_topic.special_item_text, "topic (translated: Notify topic)");
+    assert.equal(mention_all.special_item_text, "all");
+    assert.equal(mention_all.secondary_text, "translated: Notify channel");
+    assert.equal(mention_everyone.special_item_text, "everyone");
+    assert.equal(mention_everyone.secondary_text, "translated: Notify channel");
+    assert.equal(mention_stream.special_item_text, "stream");
+    assert.equal(mention_stream.secondary_text, "translated: Notify channel");
+    assert.equal(mention_channel.special_item_text, "channel");
+    assert.equal(mention_channel.secondary_text, "translated: Notify channel");
+    assert.equal(mention_topic.special_item_text, "topic");
+    assert.equal(mention_topic.secondary_text, "translated: Notify topic");
 
     compose_validate.stream_wildcard_mention_allowed = () => false;
     compose_validate.topic_wildcard_mention_allowed = () => true;
@@ -142,8 +147,10 @@ run_test("verify wildcard mentions typeahead for direct message", () => {
     assert.equal(mention_everyone.email, "everyone");
     assert.equal(mention_everyone.full_name, "everyone");
 
-    assert.equal(mention_all.special_item_text, "all (translated: Notify recipients)");
-    assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify recipients)");
+    assert.equal(mention_all.special_item_text, "all");
+    assert.equal(mention_all.secondary_text, "translated: Notify recipients");
+    assert.equal(mention_everyone.special_item_text, "everyone");
+    assert.equal(mention_all.secondary_text, "translated: Notify recipients");
 });
 
 const emoji_stadium = {


### PR DESCRIPTION
This PR styles info in typeaheads in a consistent way.

- Pronouns in @-mention typeaheads now don't have parentheses around them and uses css same as that of user emails.
- Slash commands now have extra field info to render supplementary text as secondary without parens.
- Wildcard mention have separate secondary_text field to render wildcard string without parens.

Fixes: zulip#31245.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-08-26 02-52-46](https://github.com/user-attachments/assets/6a5692a1-aa4d-4f89-b3f5-d0d09e7b7fad)
![Screenshot from 2024-08-26 02-52-56](https://github.com/user-attachments/assets/02b70980-5b2f-4a21-8f26-aecc942e50cf)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
