### PR TITLE
create-production-venv: Do not pull in "recommended" packages.

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -20,7 +20,7 @@ vendor = distro_info["ID"]
 os_version = distro_info["VERSION_ID"]
 VENV_DEPENDENCIES = get_venv_dependencies(vendor, os_version)
 if "debian" in os_families():
-    run(["apt-get", "-y", "install", *VENV_DEPENDENCIES])
+    run(["apt-get", "-y", "install", "--no-install-recommends", *VENV_DEPENDENCIES])
 elif "fedora" in os_families():
     run(["yum", "-y", "install", *VENV_DEPENDENCIES])
 else:

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -375,7 +375,7 @@ if [ "$package_system" = apt ]; then
     # Note that any additions to these lists must also be added to
     # `zulip::profile::base` such that the new dependency is seen by
     # upgrades, as well as new installs.
-    if ! apt-get install -y \
+    if ! apt-get install -y --no-install-recommends \
         python3 python3-yaml puppet git curl jq crudini \
         "${ADDITIONAL_PACKAGES[@]}"; then
         set +x


### PR DESCRIPTION
This prevents, among other things, `libvips` from pulling in the `firefox` package by way of the `nip2` package.

Fixes: #31411.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
