### PR TITLE
sidebars: Place new heading typography, icons, and partial colors.

### DIFF
--- a/help/include/left-sidebar-conversations.md
+++ b/help/include/left-sidebar-conversations.md
@@ -12,7 +12,7 @@ and the channels you are subscribed to.
 
 !!! tip ""
 
-    To see all conversations, click on **more conversations** (in direct messages) or **show all topics**
+    To see all conversations, click on **MORE CONVERSATIONS** (in direct messages) or **SHOW ALL TOPICS**
     (in a channel).
 
 {end_tabs}

--- a/help/left-sidebar.md
+++ b/help/left-sidebar.md
@@ -48,11 +48,11 @@ information you need in the moment.
 1. If the **DIRECT MESSAGES** section in the left sidebar is collapsed, click the triangle to the
    left of **DIRECT MESSAGES** to expand it.
 
-1. Click **more conversations** at the bottom of the list of recent DM conversations.
+1. Click **MORE CONVERSATIONS** at the bottom of the list of recent DM conversations.
 
 !!! tip ""
 
-    To return to the channel list in the left sidebar, click **back to channels**.
+    To return to the channel list in the left sidebar, click **BACK TO CHANNELS**.
 
 {end_tabs}
 
@@ -63,7 +63,7 @@ information you need in the moment.
 
 1. Click on a channel in the left sidebar.
 
-1. Click **show all topics** at the bottom of the list of recent topics in the
+1. Click **SHOW ALL TOPICS** at the bottom of the list of recent topics in the
    selected channel.
 
 !!! tip ""

--- a/web/shared/icons/heading-triangle-right.svg
+++ b/web/shared/icons/heading-triangle-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'><path fill='black' d='M5 4.24 12.53 8 5 11.76V4.24Z'/></svg>

--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -146,15 +146,15 @@ function toggle_condensed_navigation_area(): void {
         // Toggle into the condensed state
         $views_label_container.addClass("showing-condensed-navigation");
         $views_label_container.removeClass("showing-expanded-navigation");
-        $views_label_icon.addClass("fa-caret-right");
-        $views_label_icon.removeClass("fa-caret-down");
+        $views_label_icon.addClass("rotate-icon-right");
+        $views_label_icon.removeClass("rotate-icon-down");
         save_state(STATES.CONDENSED);
     } else {
         // Toggle into the expanded state
         $views_label_container.addClass("showing-expanded-navigation");
         $views_label_container.removeClass("showing-condensed-navigation");
-        $views_label_icon.addClass("fa-caret-down");
-        $views_label_icon.removeClass("fa-caret-right");
+        $views_label_icon.addClass("rotate-icon-down");
+        $views_label_icon.removeClass("rotate-icon-right");
         save_state(STATES.EXPANDED);
     }
     resize.resize_stream_filters_container();

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -36,8 +36,8 @@ export function set_count(count: number): void {
 
 export function close(): void {
     private_messages_collapsed = true;
-    $("#toggle-direct-messages-section-icon").removeClass("fa-caret-down");
-    $("#toggle-direct-messages-section-icon").addClass("fa-caret-right");
+    $("#toggle-direct-messages-section-icon").removeClass("rotate-icon-down");
+    $("#toggle-direct-messages-section-icon").addClass("rotate-icon-right");
 
     update_private_messages();
 }
@@ -109,8 +109,8 @@ export function update_private_messages(): void {
 export function expand(): void {
     private_messages_collapsed = false;
 
-    $("#toggle-direct-messages-section-icon").addClass("fa-caret-down");
-    $("#toggle-direct-messages-section-icon").removeClass("fa-caret-right");
+    $("#toggle-direct-messages-section-icon").addClass("rotate-icon-down");
+    $("#toggle-direct-messages-section-icon").removeClass("rotate-icon-right");
     update_private_messages();
 }
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -912,11 +912,11 @@ export function set_event_handlers({
         assert(scroll_position !== undefined);
         assert(pm_list_height !== undefined);
         if (scroll_position > pm_list_height) {
-            $("#toggle-direct-messages-section-icon").addClass("fa-caret-right");
-            $("#toggle-direct-messages-section-icon").removeClass("fa-caret-down");
+            $("#toggle-direct-messages-section-icon").addClass("rotate-icon-right");
+            $("#toggle-direct-messages-section-icon").removeClass("rotate-icon-down");
         } else {
-            $("#toggle-direct-messages-section-icon").addClass("fa-caret-down");
-            $("#toggle-direct-messages-section-icon").removeClass("fa-caret-right");
+            $("#toggle-direct-messages-section-icon").addClass("rotate-icon-down");
+            $("#toggle-direct-messages-section-icon").removeClass("rotate-icon-right");
         }
     }
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -534,7 +534,7 @@ export function initialize(): void {
     tippy.delegate("body", {
         target: ".views-tooltip-target",
         onShow(instance) {
-            if ($("#toggle-top-left-navigation-area-icon").hasClass("fa-caret-down")) {
+            if ($("#toggle-top-left-navigation-area-icon").hasClass("rotate-icon-down")) {
                 instance.setContent(
                     $t({
                         defaultMessage: "Collapse views",
@@ -555,7 +555,7 @@ export function initialize(): void {
                 return false;
             }
 
-            if ($("#toggle-direct-messages-section-icon").hasClass("fa-caret-down")) {
+            if ($("#toggle-direct-messages-section-icon").hasClass("rotate-icon-down")) {
                 instance.setContent(
                     $t({
                         defaultMessage: "Collapse direct messages",

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -328,6 +328,10 @@
         --message-box-markdown-aligned-vertical-space: 5px;
     }
 
+    /* Shared sidebar typography and effects values. */
+    --font-weight-sidebar-heading: 600;
+    --letter-spacing-sidebar-heading: 0.0469em;
+
     /*
     Message box elements and values.
     */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -330,7 +330,16 @@
 
     /* Shared sidebar typography and effects values. */
     --font-weight-sidebar-heading: 600;
+    --font-weight-sidebar-action-heading: 370;
+    --font-variant-sidebar-action-heading: all-small-caps;
+    --font-feature-settings-sidebar-action-heading: "c2sc", "smcp";
+    /* 17px at 16px/1em = 1.0625em */
+    --font-size-sidebar-action-heading: 1.0625em;
+    --text-transform-sidebar-action-heading: uppercase;
     --letter-spacing-sidebar-heading: 0.0469em;
+    --opacity-sidebar-heading: 0.7;
+    --opacity-right-sidebar-subheading: 0.65;
+    --opacity-right-sidebar-subheading-hover: 0.9;
 
     /*
     Message box elements and values.

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -701,7 +701,8 @@
     --color-text-item: hsl(0deg 0% 40%);
     --color-text-personal-menu-no-status: hsl(0deg 0% 50%);
     --color-text-personal-menu-some-status: hsl(0deg 0% 40%);
-    --color-text-sidebar-heading: hsl(0deg 0% 43%);
+    --color-text-sidebar-heading: hsl(216deg 65% 20%);
+    --color-text-sidebar-action-heading: hsl(240deg 30% 40%);
     --color-text-sidebar-popover-menu: hsl(0deg 0% 20%);
     --color-text-user-card-secondary: var(--grey-550);
     --color-text-url: hsl(200deg 100% 40%);
@@ -1163,15 +1164,8 @@
     --color-text-personal-menu-some-status: hsl(0deg 0% 100% 50%);
     --color-text-sidebar-popover-menu: hsl(236deg 33% 90%);
     --color-text-user-card-secondary: var(--grey-400);
-    /* 75% opacity of --color-text-default against --color-background.
-       We use color-mix here to avoid defining a separate, compounding
-       `opacity` property, and also to preserve a record of the
-       relationship of the color of sidebar headings to other colors. */
-    --color-text-sidebar-heading: color-mix(
-        in srgb,
-        hsl(0deg 0% 75%) 75%,
-        hsl(0deg 0% 11%)
-    );
+    --color-text-sidebar-heading: hsl(216deg 50% 75%);
+    --color-text-sidebar-action-heading: hsl(240deg 35% 68%);
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -611,6 +611,8 @@
     --color-background-alert-word: hsl(18deg 100% 84%);
     --color-buddy-list-highlighted-user: hsl(120deg 12.3% 71.4% / 38%);
     --color-border-sidebar: hsl(0deg 0% 87%);
+    --color-text-sidebar-base: hsl(0deg 0% 0%);
+    --color-border-sidebar-subheader: hsl(0deg 0% 0% / 15%);
 
     /* Recent view */
     --color-border-recent-view-row: hsl(0deg 0% 87%);
@@ -1067,6 +1069,8 @@
     --color-background-alert-word: hsl(22deg 70% 35%);
     --color-buddy-list-highlighted-user: hsl(136deg 25% 73% / 20%);
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
+    --color-text-sidebar-base: hsl(0deg 0% 100%);
+    --color-border-sidebar-subheader: hsl(0deg 0% 100% / 15%);
 
     /* Recent view */
     --color-border-recent-view-row: hsl(0deg 0% 0% / 20%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -38,10 +38,6 @@
     & ul.filters {
         color: hsl(0deg 0% 100% / 80%);
 
-        & a:hover {
-            color: inherit;
-        }
-
         .has-unmuted-mentions .unread_mention_info {
             color: hsl(236deg 33% 90%);
         }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -831,15 +831,6 @@
         background-color: hsl(51deg 100% 23%);
     }
 
-    .streams_subheader {
-        color: hsl(240deg 11% 85%);
-
-        & .streams_subheader_name::before,
-        .streams_subheader_name::after {
-            border-color: hsl(240deg 11% 85%);
-        }
-    }
-
     .sub-unsub-message span::before,
     .sub-unsub-message span::after,
     .date_row span::before,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1510,41 +1510,45 @@ li.topic-list-item {
 }
 
 .streams_subheader {
-    font-size: 0.8em;
+    /* 14px at 16px/1em */
+    font-size: 0.875em;
     font-weight: normal;
     /* 16px line-height at 0.8em (11.2px at 14px legacy em) */
     line-height: 1.4286em;
+    letter-spacing: 0.04em;
     padding-left: var(--left-sidebar-toggle-width-offset);
     cursor: pointer;
     text-align: center;
     margin-right: var(--left-sidebar-right-margin);
-    color: hsl(240deg 10% 50%);
 
-    & .streams_subheader_name {
+    & .streams-subheader-wrapper {
         display: flex;
         flex-direction: row;
         width: 100%;
         left: 0.5em;
         right: 0.5em;
-        opacity: 0.5;
+        color: var(--color-text-sidebar-base);
     }
 
-    & .streams_subheader_name::before,
-    .streams_subheader_name::after {
+    & .streams-subheader-wrapper::before,
+    .streams-subheader-wrapper::after {
         content: " ";
         flex: 1 1;
         vertical-align: middle;
         margin: auto;
-        border: 0.5px solid hsl(240deg 10% 50%);
-        opacity: 0.2;
+        border-top: 1px solid var(--color-border-sidebar-subheader);
     }
 
-    & .streams_subheader_name::before {
-        margin-right: 0.5em;
+    & .streams-subheader-wrapper::before {
+        margin-right: 0.2em;
     }
 
-    & .streams_subheader_name::after {
-        margin-left: 0.5em;
+    & .streams-subheader-wrapper::after {
+        margin-left: 0.2em;
+    }
+
+    .streams-subheader-name {
+        opacity: 0.4;
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -12,8 +12,8 @@
 .left-sidebar-title {
     color: var(--color-text-sidebar-heading);
     font-size: inherit;
-    font-weight: normal;
-    display: inline;
+    font-weight: var(--font-weight-sidebar-heading);
+    letter-spacing: var(--letter-spacing-sidebar-heading);
     /* Override heading margin from Bootstrap. */
     margin: 0;
     /* Show an ellipsis on a heading when

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -256,15 +256,24 @@
     }
 }
 
+.zulip-icon-heading-triangle-right {
+    transition:
+        opacity 140ms linear,
+        rotate 140ms linear;
+}
+
+.zulip-icon-heading-triangle-right.rotate-icon-down {
+    rotate: 90deg;
+}
+
+.zulip-icon-heading-triangle-right.rotate-icon-right {
+    rotate: 0deg;
+}
+
 #toggle-direct-messages-section-icon,
 #toggle-top-left-navigation-area-icon {
     color: var(--color-text-sidebar-heading);
     opacity: var(--opacity-sidebar-heading);
-
-    &.fa-caret-right {
-        position: relative;
-        left: 3px;
-    }
 
     &:hover {
         opacity: 1;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -37,13 +37,6 @@
     margin-right: var(--left-sidebar-right-margin);
 }
 
-li.show-more-topics {
-    & a {
-        /* 12px at 14px/1em */
-        font-size: 0.8571em;
-    }
-}
-
 #streams_inline_icon,
 .streams_filter_icon {
     opacity: 0.5;
@@ -243,16 +236,16 @@ li.show-more-topics {
         }
 
         & li#show-more-direct-messages {
+            font-size: var(--font-size-sidebar-action-heading);
+            font-weight: var(--font-weight-sidebar-action-heading);
+            letter-spacing: var(--letter-spacing-sidebar-action-heading);
+            font-variant: var(--font-variant-sidebar-action-heading);
+            text-transform: var(--text-transform-sidebar-action-heading);
             cursor: pointer;
             /* The 'more conversations' line has no icons,
                so vertically align the text with the unread
                count, when one appears there. */
             align-items: baseline;
-
-            & a {
-                /* 12px at 14px/1em */
-                font-size: 0.8571em;
-            }
 
             .unread_count {
                 margin-top: 2px;
@@ -996,6 +989,14 @@ li.top_left_scheduled_messages {
     }
 }
 
+.sidebar-topic-action-heading {
+    font-size: var(--font-size-sidebar-action-heading);
+    font-weight: var(--font-weight-sidebar-action-heading);
+    font-variant: var(--font-variant-sidebar-action-heading);
+    font-feature-settings: var(--font-feature-settings-sidebar-action-heading);
+    text-transform: var(--text-transform-sidebar-action-heading);
+}
+
 .topic-list-filter {
     grid-area: row-content;
 }
@@ -1209,14 +1210,15 @@ li.topic-list-item {
 
 .dm-box {
     grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) var(
+        var(--left-sidebar-toggle-width-offset) [action-heading-start] var(
             --left-sidebar-icon-column-width
         )
-        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) minmax(
+        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) [action-heading-end] minmax(
             0,
             max-content
         )
         30px 0;
+    grid-template-rows: [action-heading-start] auto [action-heading-end];
 
     .conversation-partners-icon {
         grid-area: starting-anchor-element;
@@ -1224,7 +1226,7 @@ li.topic-list-item {
     }
 
     .dm-name {
-        grid-area: row-content;
+        grid-area: action-heading;
     }
 
     .user_circle {
@@ -1294,9 +1296,12 @@ li.topic-list-item {
 
     .show-all-streams {
         grid-area: row-content;
+        font-size: var(--font-size-sidebar-action-heading);
+        font-weight: var(--font-weight-sidebar-action-heading);
+        font-variant: var(--font-variant-sidebar-action-heading);
+        text-transform: var(--text-transform-sidebar-action-heading);
         color: inherit;
         text-decoration: none;
-        text-transform: uppercase;
     }
 
     .unread_count {
@@ -1550,10 +1555,12 @@ li.topic-list-item {
         line-height: var(--line-height-sidebar-row);
         text-decoration: none;
         color: inherit;
-        /* 12px at 14px/1em */
 
         .hide-more-direct-messages-text {
-            font-size: 0.8571em;
+            font-size: var(--font-size-sidebar-action-heading);
+            font-weight: var(--font-weight-sidebar-action-heading);
+            font-variant: var(--font-variant-sidebar-action-heading);
+            text-transform: var(--text-transform-sidebar-action-heading);
             grid-area: row-content;
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -11,6 +11,7 @@
 
 .left-sidebar-title {
     color: var(--color-text-sidebar-heading);
+    opacity: var(--opacity-sidebar-heading);
     font-size: inherit;
     font-weight: var(--font-weight-sidebar-heading);
     letter-spacing: var(--letter-spacing-sidebar-heading);
@@ -74,7 +75,7 @@
     }
 
     & li {
-        & a:hover {
+        & .sidebar-topic-name:hover {
             text-decoration: none;
         }
 
@@ -236,6 +237,7 @@
         }
 
         & li#show-more-direct-messages {
+            color: var(--color-text-sidebar-action-heading);
             font-size: var(--font-size-sidebar-action-heading);
             font-weight: var(--font-weight-sidebar-action-heading);
             letter-spacing: var(--letter-spacing-sidebar-action-heading);
@@ -256,7 +258,8 @@
 
 #toggle-direct-messages-section-icon,
 #toggle-top-left-navigation-area-icon {
-    opacity: 0.7;
+    color: var(--color-text-sidebar-heading);
+    opacity: var(--opacity-sidebar-heading);
 
     &.fa-caret-right {
         position: relative;
@@ -364,8 +367,14 @@ ul.filters {
     /* Streams take a standard row height. */
     line-height: var(--line-height-sidebar-row);
 
-    & a {
+    .sidebar-topic-name,
+    .left-sidebar-navigation-label-container {
         color: inherit;
+
+        &:hover {
+            /* Push back against a:hover color in dark_theme.css */
+            color: inherit !important;
+        }
 
         &:focus {
             text-decoration: none;
@@ -966,7 +975,8 @@ li.top_left_scheduled_messages {
     display: none;
 }
 
-.sidebar-topic-name {
+.sidebar-topic-name,
+.sidebar-topic-action-heading {
     cursor: pointer;
     grid-area: row-content;
     padding: 0 var(--left-sidebar-before-unread-count-padding) 0 0;
@@ -987,14 +997,30 @@ li.top_left_scheduled_messages {
     span.sidebar-topic-name-inner {
         white-space: pre;
     }
+
+    &:hover {
+        color: inherit;
+    }
+
+    &:focus {
+        text-decoration: none;
+    }
 }
 
 .sidebar-topic-action-heading {
+    color: var(--color-text-sidebar-action-heading);
     font-size: var(--font-size-sidebar-action-heading);
     font-weight: var(--font-weight-sidebar-action-heading);
     font-variant: var(--font-variant-sidebar-action-heading);
     font-feature-settings: var(--font-feature-settings-sidebar-action-heading);
     text-transform: var(--text-transform-sidebar-action-heading);
+
+    &:hover {
+        text-decoration: none;
+        /* Push back against a:hover color in dark_theme.css
+           Eventually this will take redesigned hover colors. */
+        color: var(--color-text-sidebar-action-heading) !important;
+    }
 }
 
 .topic-list-filter {
@@ -1300,7 +1326,7 @@ li.topic-list-item {
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);
         text-transform: var(--text-transform-sidebar-action-heading);
-        color: inherit;
+        color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
     }
 
@@ -1557,6 +1583,7 @@ li.topic-list-item {
         color: inherit;
 
         .hide-more-direct-messages-text {
+            color: var(--color-text-sidebar-action-heading);
             font-size: var(--font-size-sidebar-action-heading);
             font-weight: var(--font-weight-sidebar-action-heading);
             font-variant: var(--font-variant-sidebar-action-heading);

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -14,6 +14,7 @@ $user_status_emoji_width: 24px;
 
 .right-sidebar-title {
     color: var(--color-text-sidebar-heading);
+    opacity: var(--opacity-sidebar-heading);
     font-size: inherit;
     font-weight: var(--font-weight-sidebar-heading);
     letter-spacing: var(--letter-spacing-sidebar-heading);

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -15,8 +15,8 @@ $user_status_emoji_width: 24px;
 .right-sidebar-title {
     color: var(--color-text-sidebar-heading);
     font-size: inherit;
-    font-weight: normal;
-    display: inline;
+    font-weight: var(--font-weight-sidebar-heading);
+    letter-spacing: var(--letter-spacing-sidebar-heading);
 }
 
 #buddy_list_wrapper {

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,7 +1,7 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
         <div id="views-label-container" class="showing-expanded-navigation {{#if is_spectator}}remove-pointer-for-spectator{{/if}}">
-            <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
+            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
             {{~!-- squash whitespace --~}}
             <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
@@ -145,7 +145,7 @@
     </div>
 
     <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
-        <i id="toggle-direct-messages-section-icon" class="fa fa-sm fa-caret-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+        <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
         <div class="heading-markers-and-controls">
             <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -2,7 +2,7 @@
   {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <div class="topic-box">
-        <a class="sidebar-topic-name" tabindex="0">{{t "show all topics" }}</a>
+        <a class="sidebar-topic-action-heading sidebar-topic-name" tabindex="0">{{t "Show all topics" }}</a>
         <div class="topic-markers-and-controls">
             {{#if more_topics_have_unread_mention_messages}}
                 <span class="unread_mention_info">

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -2,7 +2,7 @@
   {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <div class="topic-box">
-        <a class="sidebar-topic-action-heading sidebar-topic-name" tabindex="0">{{t "Show all topics" }}</a>
+        <a class="sidebar-topic-action-heading" tabindex="0">{{t "Show all topics" }}</a>
         <div class="topic-markers-and-controls">
             {{#if more_topics_have_unread_mention_messages}}
                 <span class="unread_mention_info">

--- a/web/templates/streams_subheader.hbs
+++ b/web/templates/streams_subheader.hbs
@@ -1,3 +1,7 @@
 <div class="streams_subheader">
-    <span class="streams_subheader_name">{{ subheader_name }}</span>
+    <span class="streams-subheader-wrapper">
+        <span class="streams-subheader-name">
+            {{ subheader_name }}
+        </span>
+    </span>
 </div>


### PR DESCRIPTION
This PR implements new heading typography and expand/collapse icons from @terpimost's [sidebar redesign](https://terpimost.github.io/zulip-sidebar/), as well as new colors on the headings and subheadings.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/proposed.20left-sidebar.20spacing.20and.20alignment/near/1922052)

There are a few things not yet implemented from Vlad's design, all of which are effects-based:

* Hover styles and triangle-rotation effects are not yet implemented on the buddy list subheaders; those will require reworking how buddy lists are added and removed from the DOM, even on clicking expand/collapse
* Drop shadows on the buddy list subheader are not yet implemented; that represents a bit too much churn in an already quite large PR

**Screenshots and screen captures** (updated 2024-09-09):

| Before | After |
| --- | --- |
| ![headings-20240909-light-before](https://github.com/user-attachments/assets/f4b7bb51-e9f4-453b-8f5f-65ea4c768d0e) | ![headings-20240909-light-after](https://github.com/user-attachments/assets/c8e68709-fc63-4e1f-96eb-391be8c8f043) |
| ![headings-20240909-dark-before](https://github.com/user-attachments/assets/15ab8bd6-80d2-4c51-9677-555a6eb8ba89) | ![headings-20240909-dark-after](https://github.com/user-attachments/assets/1a4030c1-f6d8-4d9c-a736-753e334043d9) |

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


