### PR TITLE
corporate:  Add activity view for plan ledger entries.

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -42,11 +42,18 @@ class RemoteActivityPlanData:
     rate: str
 
 
+@dataclass
+class ActivityHeaderEntry:
+    name: str
+    value: str | Markup
+
+
 def make_table(
     title: str,
     cols: Sequence[str],
     rows: Sequence[Any],
     *,
+    header: list[ActivityHeaderEntry] | None = None,
     totals: Any | None = None,
     stats_link: Markup | None = None,
     has_row_class: bool = False,
@@ -58,7 +65,9 @@ def make_table(
 
         rows = list(map(fix_row, rows))
 
-    data = dict(title=title, cols=cols, rows=rows, totals=totals, stats_link=stats_link)
+    data = dict(
+        title=title, cols=cols, rows=rows, header=header, totals=totals, stats_link=stats_link
+    )
 
     content = loader.render_to_string(
         "corporate/activity/activity_table.html",

--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -55,7 +55,7 @@ def make_table(
     *,
     header: list[ActivityHeaderEntry] | None = None,
     totals: Any | None = None,
-    stats_link: Markup | None = None,
+    title_link: Markup | None = None,
     has_row_class: bool = False,
 ) -> str:
     if not has_row_class:
@@ -66,7 +66,7 @@ def make_table(
         rows = list(map(fix_row, rows))
 
     data = dict(
-        title=title, cols=cols, rows=rows, header=header, totals=totals, stats_link=stats_link
+        title=title, cols=cols, rows=rows, header=header, totals=totals, title_link=title_link
     )
 
     content = loader.render_to_string(
@@ -140,6 +140,13 @@ def realm_stats_link(realm_str: str) -> Markup:
 
     url = reverse(stats_for_realm, kwargs=dict(realm_str=realm_str))
     return Markup('<a href="{url}"><i class="fa fa-pie-chart"></i></a>').format(url=url)
+
+
+def user_support_link(email: str) -> Markup:
+    support_url = reverse("support")
+    query = urlencode({"q": email})
+    url = append_url_query_string(support_url, query)
+    return Markup('<a href="{url}"><i class="fa fa-gear"></i></a>').format(url=url)
 
 
 def realm_support_link(realm_str: str) -> Markup:

--- a/corporate/tests/test_activity_views.py
+++ b/corporate/tests/test_activity_views.py
@@ -208,6 +208,10 @@ class ActivityTest(ZulipTestCase):
             result = self.client_get(f"/user_activity/{iago.id}/")
             self.assertEqual(result.status_code, 200)
 
+        with self.assert_database_query_count(8):
+            result = self.client_get(f"/activity/plan_ledger/{plan.id}/")
+            self.assertEqual(result.status_code, 200)
+
     def test_get_remote_server_guest_and_non_guest_count(self) -> None:
         RemoteRealmAuditLog.objects.bulk_create([RemoteRealmAuditLog(**data) for data in data_list])
         server_id = 1

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -25,6 +25,7 @@ from corporate.views.installation_activity import (
     get_installation_activity,
     get_integrations_activity,
 )
+from corporate.views.plan_activity import get_plan_ledger
 from corporate.views.portico import (
     app_download_link_redirect,
     apps_view,
@@ -105,6 +106,7 @@ i18n_urlpatterns: Any = [
     path("user_activity/<user_profile_id>/", get_user_activity),
     path("activity/remote", get_remote_server_activity),
     path("activity/remote/support", remote_servers_support, name="remote_servers_support"),
+    path("activity/plan_ledger/<plan_id>/", get_plan_ledger),
 ]
 
 v1_api_and_json_patterns = [

--- a/corporate/views/plan_activity.py
+++ b/corporate/views/plan_activity.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+
+from corporate.lib.activity import ActivityHeaderEntry, format_optional_datetime, make_table
+from corporate.models import Customer, CustomerPlan, LicenseLedger
+from zerver.decorator import require_server_admin
+
+
+def get_plan_billing_entity_name(customer: Customer) -> str:
+    if customer.realm:
+        return customer.realm.name
+    elif customer.remote_realm:
+        return customer.remote_realm.name
+    assert customer.remote_server is not None
+    return customer.remote_server.hostname
+
+
+@require_server_admin
+def get_plan_ledger(request: HttpRequest, plan_id: int) -> HttpResponse:
+    plan = CustomerPlan.objects.get(id=plan_id)
+    ledger_entries = LicenseLedger.objects.filter(plan=plan).order_by("-event_time")
+
+    name = get_plan_billing_entity_name(plan.customer)
+    title = f"{name}"
+    cols = [
+        "Event time (UTC)",
+        "Renewal",
+        "License count",
+        "Renewal count",
+    ]
+
+    def row(record: LicenseLedger) -> list[Any]:
+        return [
+            format_optional_datetime(record.event_time),
+            record.is_renewal,
+            record.licenses,
+            record.licenses_at_next_renewal,
+        ]
+
+    rows = list(map(row, ledger_entries))
+
+    header_entries = []
+    header_entries.append(
+        ActivityHeaderEntry(name="Plan name", value=CustomerPlan.name_from_tier(plan.tier))
+    )
+    header_entries.append(
+        ActivityHeaderEntry(
+            name="Next invoice (UTC)", value=format_optional_datetime(plan.next_invoice_date, True)
+        )
+    )
+
+    content = make_table(title, cols, rows, header=header_entries)
+
+    return render(
+        request,
+        "corporate/activity/activity.html",
+        context=dict(
+            data=content,
+            title=title,
+            is_home=False,
+        ),
+    )

--- a/corporate/views/realm_activity.py
+++ b/corporate/views/realm_activity.py
@@ -146,7 +146,7 @@ def realm_user_summary_table(
         return row["cells"][4]
 
     rows = sorted(rows, key=by_last_heard_from, reverse=True)
-    content = make_table(title, cols, rows, stats_link=stats_link, has_row_class=True)
+    content = make_table(title, cols, rows, title_link=stats_link, has_row_class=True)
     return content
 
 

--- a/templates/corporate/activity/activity_table.html
+++ b/templates/corporate/activity/activity_table.html
@@ -4,6 +4,14 @@
 {% include "corporate/activity/remote_activity_key.html" %}
 {% endif %}
 
+{% if data.header %}
+<div class="activity-header-information">
+    {% for entry in data.header %}
+    <p class="activity-header-entry"><b>{{ entry.name }}</b>: {{ entry.value }}</p>
+    {% endfor %}
+</div>
+{% endif %}
+
 {{ data.rows|length}} rows
 <table class="table sortable table-striped table-bordered analytics-table">
 

--- a/templates/corporate/activity/activity_table.html
+++ b/templates/corporate/activity/activity_table.html
@@ -1,4 +1,4 @@
-<h3>{{ data.title }} {% if data.stats_link %}{{ data.stats_link }}{% endif %}</h3>
+<h3>{{ data.title }} {% if data.title_link %}{{ data.title_link }}{% endif %}</h3>
 
 {% if data.title == "Remote servers" %}
 {% include "corporate/activity/remote_activity_key.html" %}

--- a/templates/corporate/support/current_plan_details.html
+++ b/templates/corporate/support/current_plan_details.html
@@ -33,5 +33,6 @@
         <b>Annual recurring revenue</b>: ${{ dollar_amount(plan_data.annual_recurring_revenue) }}<br />
         <b>Start of next billing cycle</b>: {{ plan_data.next_billing_cycle_start.strftime('%d %B %Y') }}<br />
     {% endif %}
+    <a target="_blank" rel="noopener noreferrer" href="/activity/plan_ledger/{{ plan_data.current_plan.id }}/">License ledger entries</a><br />
     {% endif %}
 </div>

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -54,6 +54,7 @@ not_yet_fully_covered = [
     # TODO: This is a work in progress and therefore without
     # tests yet.
     "corporate/views/installation_activity.py",
+    "corporate/views/plan_activity.py",
     "corporate/views/realm_activity.py",
     "corporate/views/remote_billing_page.py",
     "corporate/views/support.py",

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -463,6 +463,7 @@ tr.admin td:first-child {
     padding-bottom: 25px;
 }
 
+.activity-header-information,
 .push-notification-status,
 .realm-management-actions,
 .next-plan-container,
@@ -471,6 +472,17 @@ tr.admin td:first-child {
     border-radius: 4px;
     padding: 10px;
     margin: 10px 0;
+}
+
+.activity-header-information {
+    border: 2px solid hsl(330deg 3% 40%);
+    background-color: hsl(60deg 12% 90%);
+    width: fit-content;
+}
+
+.activity-header-entry {
+    margin: 0;
+    padding: 2px 0;
 }
 
 .push-notification-status,


### PR DESCRIPTION
Adds an activity view that shows the `LicenseLedger` entries for a `CustomerPlan`.

**Notes**:
- The url pattern for the new view is currently: `/activity/plan_ledger/<plan_id>/`. We could alternatively use something more similar to the realm and user activity views, e.g., `/user_activity/<user_profile_id>/`.
- Expands the shared activity table HTML to have a section between the title and the chart for some useful header information.
  - Adds the plan name and next invoice date to the new plan ledger view.
  - Revises the title for the user activity view to use this header area for the user's email and realm name, and shows the user full name as the title.
  - Though currently all of implemented header entries use strings, added the ability to use `Markup` so that we can add links in the header area, for example adding a link to a realm's audit logs via the realm activity page when we have that implemented.
  - It should be pretty straightforward to add and/or remove information from the header area of these views moving forward.
- In both the remote and Cloud support views, there's a link to the new license ledger view in the current plan details section.
  - Currently, implemented as "License ledger entries" text as a link, but we could consider using an icon link like we did for linking to Stripe. Maybe next to the plan name?

---

**Screenshots and screen captures:**

<details>
<summary>Plan ledger view - Zulip Standard</summary>

![Screenshot from 2024-08-28 17-41-22](https://github.com/user-attachments/assets/07952b1b-b6f4-44dc-a208-860e9c4268ed)
</details>
<details>
<summary>Plan ledger view - Legacy plan</summary>

![Screenshot from 2024-08-28 17-42-01](https://github.com/user-attachments/assets/98c7b6e8-2080-4be3-982d-3de4675686a6)
</details>
<details>
<summary>Support view - remote realm</summary>

![Screenshot from 2024-08-28 17-42-26](https://github.com/user-attachments/assets/5aa1834b-77ed-4d36-9cb7-63dadc4736e4)
</details>
<details>
<summary>Support view - Cloud realm</summary>

![Screenshot from 2024-08-28 17-42-39](https://github.com/user-attachments/assets/94853f3d-a279-4601-9cf3-86f23d36116f)
</details>
<details>
<summary>User activity view - Iago</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-28 17-54-13](https://github.com/user-attachments/assets/967622d0-975e-477e-937b-c7de9e677605) | ![Screenshot from 2024-08-28 17-43-50](https://github.com/user-attachments/assets/9131cee1-5cb5-4bbc-b712-ab5cc2f0814e)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
