### PR TITLE
do_delete_old_unclaimed_attachments: Cap deletions at batch size.

### DIFF
--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -94,8 +94,8 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
         already_removed.add(attachment.path_id)
         attachment.delete()
         if len(storage_paths) >= DELETE_BATCH_SIZE:
-            delete_message_attachments(storage_paths)
-            storage_paths = []
+            delete_message_attachments(storage_paths[:DELETE_BATCH_SIZE])
+            storage_paths = storage_paths[DELETE_BATCH_SIZE:]
     for archived_attachment in old_unclaimed_archived_attachments:
         if archived_attachment.path_id not in already_removed:
             storage_paths.append(archived_attachment.path_id)
@@ -107,8 +107,9 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
                 image_row.delete()
         archived_attachment.delete()
         if len(storage_paths) >= DELETE_BATCH_SIZE:
-            delete_message_attachments(storage_paths)
-            storage_paths = []
+            delete_message_attachments(storage_paths[:DELETE_BATCH_SIZE])
+            storage_paths = storage_paths[DELETE_BATCH_SIZE:]
+
     if storage_paths:
         delete_message_attachments(storage_paths)
 


### PR DESCRIPTION
Since each loop may add more than one file to the `storage_paths` list, this may result in more than 1000 files being sent to delete_message_attachments.  Since the S3 backend only supports 1000 elements being deleted at once, we must partition the list into chunks which are no more than 1000 elements long.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
