### PR TITLE
message_list: Conditionally render message edit form container element.

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -447,21 +447,22 @@ export class MessageList {
         if ($row.find(".message_edit_form form").length !== 0) {
             return;
         }
-        $row.find(".message_edit_form").append($form);
+        $row.find(".messagebox-content").append($form);
         $row.find(".message_content, .status-message, .message_controls").hide();
         $row.find(".messagebox-content").addClass("content_edit_mode");
-        $row.find(".message_edit").css("display", "block");
         // autosize will not change the height of the textarea if the `$row` is not
         // rendered in DOM yet. So, we call `autosize.update` post render.
         autosize($row.find(".message_edit_content"));
     }
 
     hide_edit_message($row) {
+        if ($row.find(".message_edit_form form").length === 0) {
+            return;
+        }
         compose_tooltips.hide_compose_control_button_tooltips($row);
         $row.find(".message_content, .status-message, .message_controls").show();
-        $row.find(".message_edit_form").empty();
         $row.find(".messagebox-content").removeClass("content_edit_mode");
-        $row.find(".message_edit").hide();
+        $row.find(".message_edit").remove();
         $row.trigger("mouseleave");
     }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -763,10 +763,6 @@ of the base style defined for a read-only textarea in dark mode. */
     }
 }
 
-.message_edit {
-    display: none;
-}
-
 /* Reduce some of the heavy padding from Bootstrap. */
 .message_edit_form {
     margin-bottom: 10px;

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -59,10 +59,6 @@
 {{> edited_notice}}
 {{/if}}
 
-<div class="message_edit">
-    <div class="message_edit_form"></div>
-</div>
-
 <div class="message_length_controller">
     <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
     <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -1,40 +1,43 @@
 {{! Client-side Handlebars template for rendering the message edit form. }}
-
-<form id="edit_form_{{message_id}}" class="new-style">
-    <div class="edit_form_banners"></div>
-    <div class="edit-controls edit-content-container {{#if is_editable}}surround-formatting-buttons-row{{/if}}">
-        {{> copy_message_button message_id=this.message_id}}
-        <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
-        <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
-            <div class="markdown_preview_spinner"></div>
-            <div class="preview_content rendered_markdown"></div>
-        </div>
-    </div>
-    <div class="action-buttons">
-        <div class="controls edit-controls">
-            {{#if is_editable}}
-            <div class="message-edit-feature-group">
-                {{> compose_control_buttons }}
+<div class="message_edit">
+    <div class="message_edit_form">
+        <form id="edit_form_{{message_id}}" class="new-style">
+            <div class="edit_form_banners"></div>
+            <div class="edit-controls edit-content-container {{#if is_editable}}surround-formatting-buttons-row{{/if}}">
+                {{> copy_message_button message_id=this.message_id}}
+                <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
+                <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
+                    <div class="markdown_preview_spinner"></div>
+                    <div class="preview_content rendered_markdown"></div>
+                </div>
             </div>
-            {{/if}}
-            <div class="message-edit-buttons-and-timer">
-                {{#if is_editable}}
-                    <div class="message_edit_save_container"
-                      data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
-                        <button type="button" class="message-actions-button message_edit_save">
-                            <img class="loader" alt="" src="" />
-                            <span>{{t "Save" }}</span>
-                        </button>
+            <div class="action-buttons">
+                <div class="controls edit-controls">
+                    {{#if is_editable}}
+                    <div class="message-edit-feature-group">
+                        {{> compose_control_buttons }}
                     </div>
-                    <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
-                    <div class="message-edit-timer">
-                        <span class="message_edit_countdown_timer
-                          tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
+                    {{/if}}
+                    <div class="message-edit-buttons-and-timer">
+                        {{#if is_editable}}
+                            <div class="message_edit_save_container"
+                              data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
+                                <button type="button" class="message-actions-button message_edit_save">
+                                    <img class="loader" alt="" src="" />
+                                    <span>{{t "Save" }}</span>
+                                </button>
+                            </div>
+                            <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
+                            <div class="message-edit-timer">
+                                <span class="message_edit_countdown_timer
+                                  tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>
+                            </div>
+                        {{else}}
+                            <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
+                        {{/if}}
                     </div>
-                {{else}}
-                    <button type="button" class="message-actions-button message_edit_close"><span>{{t "Close" }}</span></button>
-                {{/if}}
+                </div>
             </div>
-        </div>
+        </form>
     </div>
-</form>
+</div>

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -11,6 +11,7 @@
     <div class="messagebox">
         <div class="messagebox-content {{#if status_message}}is-me-message{{/if}}">
             {{> message_body}}
+            {{!-- message_edit_form.hbs is inserted here when editing a message. --}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
This moves the placeholder elements for the message edit form, to `message_edit_form.hbs`, so they are conditionally rendered only when a message is being edited, rather than being present for every message in the list.

Fixes #31134.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures: (Testing screencast)**
![Testing](https://github.com/user-attachments/assets/dc07a9f7-55db-4a79-b8d2-f626254cfef5)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
