### PR TITLE
corporate: Update license ledger string method.

### DIFF
--- a/corporate/models.py
+++ b/corporate/models.py
@@ -538,6 +538,12 @@ class LicenseLedger(models.Model):
     # equal to the number of activated users in the organization.
     licenses_at_next_renewal = models.IntegerField(null=True)
 
+    @override
+    def __str__(self) -> str:
+        ledger_type = "renewal" if self.is_renewal else "update"
+        ledger_time = self.event_time.strftime("%Y-%m-%d %H:%M")
+        return f"License {ledger_type}, {self.licenses} purchased, {self.licenses_at_next_renewal} next cycle, {ledger_time} (id={self.id})"
+
 
 class SponsoredPlanTypes(Enum):
     # unspecified used for cloud sponsorship requests

--- a/corporate/views/plan_activity.py
+++ b/corporate/views/plan_activity.py
@@ -47,9 +47,17 @@ def get_plan_ledger(request: HttpRequest, plan_id: int) -> HttpResponse:
     )
     header_entries.append(
         ActivityHeaderEntry(
-            name="Next invoice (UTC)", value=format_optional_datetime(plan.next_invoice_date, True)
+            name="Start of next billing cycle (UTC)",
+            value=format_optional_datetime(plan.next_invoice_date, True),
         )
     )
+    if plan.invoiced_through is not None:
+        header_entries.append(
+            ActivityHeaderEntry(
+                name="Entry for last invoice",
+                value=str(plan.invoiced_through),
+            )
+        )
 
     content = make_table(title, cols, rows, header=header_entries)
 


### PR DESCRIPTION
Updates the string method for `LicenseLedger` objects to include the license counts, date and type of entry.

**Notes**:
- Main known use case is printing the ledger entry for a customer plan via the `invoiced_through` field.
- Translated the `is_renewal` bool as a string to be "renewal" or "update".
- Updated the header area of the plan activity view in second commit:
  - Adds the `invoiced_through` entry.
  - Revises the `next_invoice` date to have the same name as the support view: "Start of next billing cycle".

<details>
<summary>python shell example</summary>

```
In [1]: plan = CustomerPlan.objects.get(id=8)

In [2]: ledger_entries = LicenseLedger.objects.filter(plan=plan).order_by("-event_time")

In [3]: for entry in ledger_entries:
   ...:     print(entry)
   ...: 
License update, 3 purchased, 2 next cycle, 2024-08-29 10:47 (id=12)
License update, 3 purchased, 3 next cycle, 2024-08-28 15:41 (id=11)
License update, 2 purchased, 2 next cycle, 2024-08-28 15:40 (id=10)
License renewal, 1 purchased, 1 next cycle, 2024-08-28 15:40 (id=9)

In [4]: print(plan.invoiced_through)
License renewal, 1 purchased, 1 next cycle, 2024-08-28 15:40 (id=9)

```
</details>

--

**Screenshots and screen captures:**

<details>
<summary>Updated plan activity view</summary>

![Screenshot from 2024-08-29 16-32-25](https://github.com/user-attachments/assets/1fd6cb4d-0ef1-4dcc-9223-7796037de635)
</details>
<details>
<summary>Same plan on support view</summary>

![Screenshot from 2024-08-29 16-35-34](https://github.com/user-attachments/assets/8dafcede-ceb0-44f2-b256-d3f26781857d)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
