### PR TITLE
condense: Dynamically render content for message length toggle.

### DIFF
--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -1,6 +1,8 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import render_message_length_toggle from "../templates/message_length_toggle.hbs";
+
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
 import type {Message} from "./message_store";
@@ -20,26 +22,32 @@ This library implements two related, similar concepts:
 
 */
 
-function show_more_link($row: JQuery): void {
-    $row.find(".message_condenser").hide();
-    $row.find(".message_expander").show();
+export function show_message_expander($row: JQuery): void {
+    $row.find(".message_length_controller").html(
+        render_message_length_toggle({toggle_type: "expander"}),
+    );
 }
 
-function show_condense_link($row: JQuery): void {
-    $row.find(".message_expander").hide();
-    $row.find(".message_condenser").show();
+export function show_message_condenser($row: JQuery): void {
+    $row.find(".message_length_controller").html(
+        render_message_length_toggle({toggle_type: "condenser"}),
+    );
+}
+
+export function hide_message_length_toggle($row: JQuery): void {
+    $row.find(".message_length_controller").empty();
 }
 
 function condense_row($row: JQuery): void {
     const $content = $row.find(".message_content");
     $content.addClass("condensed");
-    show_more_link($row);
+    show_message_expander($row);
 }
 
 function uncondense_row($row: JQuery): void {
     const $content = $row.find(".message_content");
     $content.removeClass("condensed");
-    show_condense_link($row);
+    show_message_condenser($row);
 }
 
 export function uncollapse(message: Message): void {
@@ -65,7 +73,7 @@ export function uncollapse(message: Message): void {
             condense_row($row);
         } else {
             // This was a short message, no more need for a [More] link.
-            $row.find(".message_expander").hide();
+            hide_message_length_toggle($row);
         }
     };
 
@@ -92,7 +100,7 @@ export function collapse(message: Message): void {
 
     const process_row = function process_row($row: JQuery): void {
         $row.find(".message_content").addClass("collapsed");
-        show_more_link($row);
+        show_message_expander($row);
     };
 
     for (const list of message_lists.all_rendered_message_lists()) {
@@ -133,15 +141,13 @@ export function toggle_collapse(message: Message): void {
             message.condensed = true;
             $content.addClass("condensed");
             show_message_expander($row);
-            $row.find(".message_condenser").hide();
         }
         uncollapse(message);
     } else {
         if (is_condensed) {
             message.condensed = false;
             $content.removeClass("condensed");
-            hide_message_expander($row);
-            $row.find(".message_condenser").show();
+            show_message_condenser($row);
         } else {
             collapse(message);
         }
@@ -153,30 +159,6 @@ function get_message_height(elem: HTMLElement): number {
     // when displaying a message feed view that has hundreds of message
     // history, which ideally should render in <100ms.
     return util.the($(elem).find(".message_content")).scrollHeight;
-}
-
-export function hide_message_expander($row: JQuery): void {
-    if ($row.find(".could-be-condensed").length !== 0) {
-        $row.find(".message_expander").hide();
-    }
-}
-
-export function hide_message_condenser($row: JQuery): void {
-    if ($row.find(".could-be-condensed").length !== 0) {
-        $row.find(".message_condenser").hide();
-    }
-}
-
-export function show_message_expander($row: JQuery): void {
-    if ($row.find(".could-be-condensed").length !== 0) {
-        $row.find(".message_expander").show();
-    }
-}
-
-export function show_message_condenser($row: JQuery): void {
-    if ($row.find(".could-be-condensed").length !== 0) {
-        $row.find(".message_condenser").show();
-    }
 }
 
 export function condense_and_collapse(elems: JQuery): void {
@@ -247,14 +229,14 @@ export function condense_and_collapse(elems: JQuery): void {
             condense_row($(elem));
         } else {
             $content.removeClass("condensed");
-            $(elem).find(".message_expander").hide();
+            hide_message_length_toggle($(elem));
         }
 
         // Completely hide the message and replace it with a "Show more"
         // button if the user has collapsed it.
         if (message.collapsed) {
             $content.addClass("collapsed");
-            $(elem).find(".message_expander").show();
+            show_message_expander($(elem));
         }
     }
 }
@@ -277,9 +259,7 @@ export function initialize(): void {
         } else if ($content.hasClass("condensed")) {
             // Uncondense (show the full long message).
             message.condensed = false;
-            $content.removeClass("condensed");
-            $(this).hide();
-            $row.find(".message_condenser").show();
+            uncondense_row($row);
         }
         e.stopPropagation();
         e.preventDefault();

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -469,8 +469,7 @@ function edit_message($row: JQuery, raw_content: string): void {
     const message = message_lists.current.get(rows.id($row));
     assert(message !== undefined);
     $row.find(".message_reactions").hide();
-    condense.hide_message_expander($row);
-    condense.hide_message_condenser($row);
+    condense.hide_message_length_toggle($row);
 
     // We potentially got to this function by clicking a button that implied the
     // user would be able to edit their message.  Give a little bit of buffer in
@@ -854,10 +853,12 @@ export function end_message_row_edit($row: JQuery): void {
         message_lists.current.hide_edit_message($row);
         compose_call.abort_video_callbacks(message.id.toString());
     }
-    if ($row.find(".condensed").length !== 0) {
-        condense.show_message_expander($row);
-    } else {
-        condense.show_message_condenser($row);
+    if ($row.find(".could-be-condensed").length !== 0) {
+        if ($row.find(".condensed").length !== 0) {
+            condense.show_message_expander($row);
+        } else {
+            condense.show_message_condenser($row);
+        }
     }
     $row.find(".message_reactions").show();
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -987,7 +987,6 @@ div.focused-message-list {
 
 .message_length_controller {
     .message_length_toggle {
-        display: none;
         width: 100%;
         height: 24px;
         margin-bottom: var(--message-box-markdown-aligned-vertical-space);

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -59,10 +59,7 @@
 {{> edited_notice}}
 {{/if}}
 
-<div class="message_length_controller">
-    <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
-    <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
-</div>
+<div class="message_length_controller"></div>
 
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -1,0 +1,5 @@
+{{#if (eq toggle_type "expander")}}
+    <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
+{{else if (eq toggle_type "condenser")}}
+    <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
+{{/if}}


### PR DESCRIPTION
This moves the content inside `message_length_controller` to a new handlerbars template `message_length_toggle.hbs`, and dynamically renders the content based on the message length.

Since the majority of the messages aren't collapsed/condensed, this change should improve the initial rendering of the message list.

Fixes #31133.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## **Performance testing:**

**Setup**: Created two channels with 50 messages each, one of the channel contained only short messages, while the other contained only long messages that would render the `SHOW MORE`/`SHOW LESS` toggle buttons.

**Method used**: Used `performance.now()` to measure the time taken by `condense.condense_and_collapse()` in the initial message rendering.

**Note:** There may be better options to measure the performance of this, like using profiling with filters, but I'm not well versed in that atm. I did simply try measuring the time elapsed in Performance profile, but that gave me more or less the same values for both the cases (~2% difference), but at least that suggests that there should not be any negative impact backfiring the performance from these changes.

### Performance — Short messages (in ms) [%change = -7.82%]
| Test No. | Before | After |
|----------|--------|-------|
| 1        | 10.8   | 8.9   |
| 2        | 9.2    | 8.8   |
| 3        | 10.3   | 10.8  |
| 4        | 9.8    | 8.7   |
| 5        | 9      | 8.8   |
| 6        | 9.7    | 8.6   |
| 7        | 9.2    | 8.7   |
| 8        | 10.7   | 9.4   |
| 9        | 9.4    | 8.6   |
| 10       | 9.1    | 8.3   |
| Avg     | 9.72   | 8.96  |

### Performance — Long messages (in ms) [%change = -7.59%]
| Test No. | Before | After |
|----------|--------|-------|
| 1        | 34.8   | 34    |
| 2        | 35.9   | 33    |
| 3        | 38.8   | 35    |
| 4        | 34.5   | 33    |
| 5        | 33.8   | 33    |
| 6        | 40.4   | 34    |
| 7        | 33.7   | 34    |
| 8        | 37.9   | 33    |
| 9        | 38.6   | 34    |
| 10       | 34.1   | 32    |
| Avg     | 36.25  | 33.5  |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
