### PR TITLE
9.x: Backfill ImageAttachments

### DIFF
--- a/tools/semgrep-py.yml
+++ b/tools/semgrep-py.yml
@@ -54,6 +54,7 @@ rules:
 
   - id: dont-import-models-in-migrations
     patterns:
+      - pattern-not: from zerver.lib.partial import partial
       - pattern-not: from zerver.lib.mime_types import $X
       - pattern-not: from zerver.lib.redis_utils import get_redis_client
       - pattern-not: from zerver.lib.utils import generate_api_key

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -880,6 +880,7 @@ def do_send_messages(
                     send_request.message.realm_id,
                     send_request.message.content,
                     lock=True,
+                    enqueue=False,
                     path_ids=list(send_request.rendering_result.thumbnail_spinners),
                 )
                 new_rendered_content = rewrite_thumbnailed_images(

--- a/zerver/migrations/0576_backfill_imageattachment.py
+++ b/zerver/migrations/0576_backfill_imageattachment.py
@@ -1,0 +1,126 @@
+import os
+from functools import reduce
+from operator import or_
+
+import boto3
+import pyvips
+from botocore.client import Config
+from botocore.exceptions import ClientError
+from botocore.response import StreamingBody
+from django.conf import settings
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import Exists, OuterRef, Q
+
+from zerver.lib.partial import partial
+
+
+def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    ImageAttachment = apps.get_model("zerver", "ImageAttachment")
+    Attachment = apps.get_model("zerver", "Attachment")
+
+    if settings.LOCAL_UPLOADS_DIR is None:
+        upload_bucket = boto3.resource(
+            "s3",
+            aws_access_key_id=settings.S3_KEY,
+            aws_secret_access_key=settings.S3_SECRET_KEY,
+            region_name=settings.S3_REGION,
+            endpoint_url=settings.S3_ENDPOINT_URL,
+            config=Config(
+                signature_version=None,
+                s3={"addressing_style": settings.S3_ADDRESSING_STYLE},
+            ),
+        ).Bucket(settings.S3_AUTH_UPLOADS_BUCKET)
+
+    # Historical attachments do not have a mime_type value, so we used
+    # to rely on the file extension.  We replicate that when
+    # backfilling.  This is the value from zerver.lib.markdown:
+    IMAGE_EXTENSIONS = [".bmp", ".gif", ".jpe", ".jpeg", ".jpg", ".png", ".webp"]
+
+    extension_limits = Q()
+    extension_limits = reduce(
+        or_,
+        [Q(file_name__endswith=extension) for extension in IMAGE_EXTENSIONS],
+        extension_limits,
+    )
+
+    min_id: int | None = 0
+    while True:
+        attachments = (
+            Attachment.objects.alias(
+                has_imageattachment=Exists(
+                    ImageAttachment.objects.filter(path_id=OuterRef("path_id"))
+                )
+            )
+            .filter(extension_limits, has_imageattachment=False, id__gt=min_id)
+            .order_by("id")
+        )[:1000]
+
+        min_id = None
+        for attachment in attachments:
+            min_id = attachment.id
+
+            if settings.LOCAL_UPLOADS_DIR is None:
+                try:
+                    metadata = upload_bucket.Object(attachment.path_id).get()
+                except ClientError:
+                    print(f"{attachment.path_id}: Missing!")
+                    continue
+
+                def s3_read(streamingbody: StreamingBody, size: int) -> bytes:
+                    return streamingbody.read(amt=size)
+
+                # We use the streaming body to only pull down as much
+                # of the image as we need to examine the headers --
+                # generally about 40k
+                source: pyvips.Source = pyvips.SourceCustom()
+                source.on_read(partial(s3_read, metadata["Body"]))
+            else:
+                attachment_path = os.path.join(settings.LOCAL_UPLOADS_DIR, attachment.path_id)
+                if not os.path.exists(attachment_path):
+                    print(f"{attachment.path_id}: Missing!")
+                    continue
+                source = pyvips.Source.new_from_file(attachment_path)
+            try:
+                image = pyvips.Image.new_from_source(source, "", access="sequential")
+
+                # "original_width_px" and "original_height_px" here are
+                # _as rendered_, after applying the orientation
+                # information which the image may contain.
+                if (
+                    "orientation" in image.get_fields()
+                    and image.get("orientation") >= 5
+                    and image.get("orientation") <= 8
+                ):
+                    (width, height) = (image.height, image.width)
+                else:
+                    (width, height) = (image.width, image.height)
+
+                ImageAttachment.objects.create(
+                    realm_id=attachment.realm_id,
+                    path_id=attachment.path_id,
+                    original_width_px=width,
+                    original_height_px=height,
+                    frames=image.get_n_pages(),
+                    thumbnail_metadata=[],
+                )
+            except pyvips.Error:
+                pass
+
+        if min_id is None:
+            break
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        # Because this will be backported to 9.x, we only depend on the last migration in 9.x
+        ("zerver", "0558_realmuserdefault_web_animate_image_previews_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_imageattachment, reverse_code=migrations.RunPython.noop, elidable=True
+        )
+    ]

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1038,7 +1038,9 @@ class NormalActionsTest(BaseAction):
             "img.png", "image/png", read_test_image_file("img.png"), self.example_user("iago")
         )
         path_id = url[len("/user_upload/") + 1 :]
-        self.send_stream_message(iago, "Verona", f"[img.png]({url})")
+        self.send_stream_message(
+            iago, "Verona", f"[img.png]({url})", skip_capture_on_commit_callbacks=True
+        )
 
         # Generating a thumbnail for an image sends a message update event
         with self.verify_action(state_change_expected=False) as events:


### PR DESCRIPTION
Backport of #31468.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
