### PR TITLE
apt-repos: Use PGroonga binaries on Ubuntu 24.04

### DIFF
--- a/scripts/setup/apt-repos/zulip/custom.sh
+++ b/scripts/setup/apt-repos/zulip/custom.sh
@@ -27,10 +27,6 @@ if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
             read -r release
         } <<<"$os_info"
 
-        if [ "$distribution" = ubuntu ] && [ "$release" = noble ]; then
-            # PGroonga binaries are not yet provided for Ubuntu 24.04.
-            exit
-        fi
         groonga_apt_source_deb="groonga-apt-source-latest-$release.deb"
         groonga_apt_source_deb_sign="$groonga_apt_source_deb.asc.$pgroonga_apt_sign_key_fingerprint"
         curl -fLO --retry 3 "https://packages.groonga.org/$distribution/$groonga_apt_source_deb"

--- a/scripts/setup/apt-repos/zulip/noble.list
+++ b/scripts/setup/apt-repos/zulip/noble.list
@@ -1,2 +1,5 @@
 deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main
 deb-src http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main
+
+deb http://ppa.launchpad.net/groonga/ppa/ubuntu noble main
+deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu noble main

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -149,7 +149,7 @@ COMMON_YUM_DEPENDENCIES = [
 
 BUILD_GROONGA_FROM_SOURCE = False
 BUILD_PGROONGA_FROM_SOURCE = False
-if (vendor == "debian" and os_version in []) or (vendor == "ubuntu" and os_version in ["24.04"]):
+if (vendor == "debian" and os_version in []) or (vendor == "ubuntu" and os_version in []):
     # For platforms without a PGroonga release, we need to build it
     # from source.
     BUILD_PGROONGA_FROM_SOURCE = True


### PR DESCRIPTION
These did not exist when we first added Ubuntu 24.04 support; now they do. Fixes #31261.

(Don’t auto-merge this, since that doesn’t check production tests.)