### PR TITLE
settings: css selector performance .sidebar

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -697,8 +697,8 @@
     .member-list-box,
     .member-list-box .member_list_container .member-list td,
     #subscription_overlay .settings-radio-input-parent,
-    #settings_page .sidebar-wrapper,
-    #settings_page .sidebar-wrapper *,
+    #settings_page .sidebar,
+    #settings_page .sidebar .sidebar-item,
     #recent_view_table table td {
         border-color: hsl(0deg 0% 0% / 20%);
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1419,12 +1419,6 @@ $option_title_width: 180px;
             border-bottom: 1px solid hsl(0deg 0% 87%);
         }
 
-        & ul {
-            list-style: none;
-            margin: 0;
-            padding: 0;
-        }
-
         .sidebar-item {
             display: grid;
             /* 3.5714em is 50px at 14px/1em -- the legacy height of these rows. */
@@ -1484,6 +1478,9 @@ $option_title_width: 180px;
         .normal-settings-list,
         .org-settings-list {
             position: relative;
+            list-style: none;
+            margin: 0;
+            padding: 0;
         }
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1425,7 +1425,7 @@ $option_title_width: 180px;
             padding: 0;
         }
 
-        & li {
+        .sidebar-item {
             display: grid;
             /* 3.5714em is 50px at 14px/1em -- the legacy height of these rows. */
             grid-template:

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -12,106 +12,106 @@
         <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
             <div class="sidebar-list dark-grey small-text">
                 <ul class="normal-settings-list">
-                    <li tabindex="0" data-section="profile">
+                    <li class="sidebar-item" tabindex="0" data-section="profile">
                         <i class="icon fa fa-user" aria-hidden="true"></i>
                         <div class="text">{{t "Profile" }}</div>
                     </li>
-                    <li tabindex="0" data-section="account-and-privacy">
+                    <li class="sidebar-item" tabindex="0" data-section="account-and-privacy">
                         <i class="icon fa fa-lock" aria-hidden="true"></i>
                         <div class="text">{{t "Account & privacy" }}</div>
                     </li>
-                    <li tabindex="0" data-section="preferences">
+                    <li class="sidebar-item" tabindex="0" data-section="preferences">
                         <i class="icon fa fa-sliders" aria-hidden="true"></i>
                         <div class="text">{{t "Preferences" }}</div>
                     </li>
-                    <li tabindex="0" data-section="notifications">
+                    <li class="sidebar-item" tabindex="0" data-section="notifications">
                         <i class="icon fa fa-exclamation-triangle" aria-hidden="true"></i>
                         <div class="text">{{t "Notifications" }}</div>
                     </li>
                     {{#unless is_guest}}
-                    <li tabindex="0" data-section="your-bots">
+                    <li class="sidebar-item" tabindex="0" data-section="your-bots">
                         <i class="icon zulip-icon zulip-icon-smart-toy" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
                     </li>
                     {{/unless}}
-                    <li tabindex="0" data-section="alert-words">
+                    <li class="sidebar-item" tabindex="0" data-section="alert-words">
                         <i class="icon fa fa-book" aria-hidden="true"></i>
                         <div class="text">{{t "Alert words" }}</div>
                     </li>
                     {{#if show_uploaded_files_section}}
-                    <li tabindex="0" data-section="uploaded-files">
+                    <li class="sidebar-item" tabindex="0" data-section="uploaded-files">
                         <i class="icon fa fa-paperclip" aria-hidden="true"></i>
                         <div class="text">{{t "Uploaded files" }}</div>
                     </li>
                     {{/if}}
-                    <li tabindex="0" data-section="topics">
+                    <li class="sidebar-item" tabindex="0" data-section="topics">
                         <i class="icon zulip-icon zulip-icon-topic" aria-hidden="true"></i>
                         <div class="text">{{t "Topics" }}</div>
                     </li>
-                    <li tabindex="0" data-section="muted-users">
+                    <li class="sidebar-item" tabindex="0" data-section="muted-users">
                         <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
                         <div class="text">{{t "Muted users" }}</div>
                     </li>
                 </ul>
 
                 <ul class="org-settings-list">
-                    <li tabindex="0" data-section="organization-profile">
+                    <li class="sidebar-item" tabindex="0" data-section="organization-profile">
                         <i class="icon fa fa-id-card" aria-hidden="true"></i>
                         <div class="text">{{t "Organization profile" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-settings">
+                    <li class="sidebar-item" class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-settings">
                         <i class="icon fa fa-sliders" aria-hidden="true"></i>
                         <div class="text">{{t "Organization settings" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings' }}"></i>
                     </li>
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-permissions">
+                    <li class="sidebar-item" class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-permissions">
                         <i class="icon fa fa-lock" aria-hidden="true"></i>
                         <div class="text">{{t "Organization permissions" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
-                    <li tabindex="0" data-section="emoji-settings">
+                    <li class="sidebar-item" tabindex="0" data-section="emoji-settings">
                         <i class="icon fa fa-smile-o" aria-hidden="true"></i>
                         <div class="text">{{t "Custom emoji" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#unless show_emoji_settings_lock}}style="display: none;"{{/unless}} data-tippy-content="{{t 'You do not have permission to add custom emoji.'}}"></i>
                     </li>
-                    <li tabindex="0" data-section="linkifier-settings">
+                    <li class="sidebar-item" tabindex="0" data-section="linkifier-settings">
                         <i class="icon fa fa-font" aria-hidden="true"></i>
                         <div class="text">{{t "Linkifiers" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
-                    <li tabindex="0" data-section="playground-settings">
+                    <li class="sidebar-item" tabindex="0" data-section="playground-settings">
                         <i class="icon fa fa-external-link" aria-hidden="true"></i>
                         <div class="text">{{t "Code playgrounds" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{#unless is_guest}}
-                    <li tabindex="0" data-section="users">
+                    <li class="sidebar-item" tabindex="0" data-section="users">
                         <i class="icon fa fa-user" aria-hidden="true"></i>
                         <div class="text">{{t "Users" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_edit_user_panel }}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{/unless}}
                     {{#unless is_guest}}
-                    <li tabindex="0" data-section="bot-list-admin">
+                    <li class="sidebar-item" tabindex="0" data-section="bot-list-admin">
                         <i class="icon zulip-icon zulip-icon-smart-toy" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_create_new_bots}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{/unless}}
                     {{#if is_admin}}
-                    <li tabindex="0" data-section="profile-field-settings">
+                    <li class="sidebar-item" tabindex="0" data-section="profile-field-settings">
                         <i class="icon fa fa-id-card" aria-hidden="true"></i>
                         <div class="text">{{t "Custom profile fields" }}</div>
                     </li>
                     {{/if}}
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
+                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="organization-level-user-defaults">
                         <i class="icon fa fa-cog" aria-hidden="true"></i>
                         <div class="text">{{t "Default user settings" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_admin}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>
                     {{#unless is_guest}}
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
+                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="default-channels-list">
                         <i class="icon fa fa-exchange" aria-hidden="true"></i>
                         <div class="text">{{t "Default channels" }}</div>
                         {{#unless is_admin}}
@@ -119,19 +119,19 @@
                         {{/unless}}
                     </li>
                     {{/unless}}
-                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="auth-methods">
+                    <li class="sidebar-item collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="auth-methods">
                         <i class="icon fa fa-key" aria-hidden="true"></i>
                         <div class="text">{{t "Authentication methods" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if is_owner}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization owners can edit these settings.' }}"></i>
                     </li>
                     {{#if is_admin}}
-                    <li tabindex="0" data-section="data-exports-admin">
+                    <li class="sidebar-item" tabindex="0" data-section="data-exports-admin">
                         <i class="icon fa fa-database" aria-hidden="true"></i>
                         <div class="text">{{t "Data exports" }}</div>
                     </li>
                     {{/if}}
                     {{#unless is_admin}}
-                    <div class="collapse-settings-btn">
+                    <div class="sidebar-item collapse-settings-btn">
                         <i id='toggle_collapse_chevron' class='fa fa-angle-double-down'></i>
                         <p id='toggle_collapse'>{{t "Show more" }}</p>
                     </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: One point of https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20performance/near/1920156

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1038" alt="before_light_org" src="https://github.com/user-attachments/assets/b03b40e2-55e2-4b8f-b745-3991ecf38f35"> | <img width="1038" alt="after_light_org" src="https://github.com/user-attachments/assets/1d7c6db1-be32-439b-8e05-c0491acd3e80"> |
| <img width="1038" alt="before_light_personal" src="https://github.com/user-attachments/assets/08fcaf4f-5223-4e80-850f-ce256dd6e8ea"> |<img width="1038" alt="after_light_personal" src="https://github.com/user-attachments/assets/04cc370d-6578-40cc-9097-85bdded4da1c"> |
| <img width="1038" alt="before_dark_org" src="https://github.com/user-attachments/assets/09846c0e-cd20-40c1-850d-82b64ce4c49f"> | <img width="1038" alt="after_dark_org" src="https://github.com/user-attachments/assets/d4408833-1eb7-4704-b2a2-9bbeba057920"> |
| <img width="1038" alt="before_dark_personal" src="https://github.com/user-attachments/assets/bb4bc7f5-779b-496e-8753-bb3399def20c"> | <img width="1038" alt="after_dark_personal" src="https://github.com/user-attachments/assets/06ff6a98-88fc-4ecc-a8c0-333114af65ec"> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
