### PR TITLE
tooltip: Add a tippy tooltip for unsubscribed channel

### DIFF
--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -43,6 +43,6 @@
     {{~/if}}
 </div>
 {{#if is_unsubscribed}}
-    <span class="fa fa-exclamation-triangle unsubscribed_icon"
-      title="{{t 'You are not currently subscribed to this channel.' }}"></span>
+    <span class="fa fa-exclamation-triangle unsubscribed_icon
+      toggle-subscription-tooltip" data-tippy-content="{{t 'You are not currently subscribed to this channel.' }}"></span>
 {{/if}}


### PR DESCRIPTION
**Description:**

This PR migrates the tooltip to a tippy tooltip for the message 'You are not currently subscribed to this channel'.

**Fixes:** #30668

---

**UI Changes:**

Before: <img width="1010" alt="Screenshot 2024-08-30 at 8 23 08 PM" src="https://github.com/user-attachments/assets/4a7235c5-f267-4fb0-91d5-845d9c0b6a06">

After:
<img width="1010" alt="Screenshot 2024-08-30 at 8 13 59 PM" src="https://github.com/user-attachments/assets/0825e001-2c8b-48f3-82e3-ef8b2f19e1d1">




---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
