### PR TITLE
left_sidebar: Render brackets only on non-empty channels.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -166,7 +166,13 @@ export class TopicListWidget {
             list_info.items.length === num_possible_topics &&
             stream_topic_history.is_complete_for_stream_id(this.my_stream_id);
 
-        const attrs: [string, string][] = [["class", "topic-list"]];
+        const topic_list_classes: [string] = ["topic-list"];
+
+        if (list_info.items.length > 0) {
+            topic_list_classes.push("topic-list-has-topics");
+        }
+
+        const attrs: [string, string][] = [["class", topic_list_classes.join(" ")]];
 
         const nodes = list_info.items.map((conversation) => keyed_topic_li(conversation));
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1160,7 +1160,7 @@ ul.topic-list {
     font-weight: normal;
 }
 
-ul.topic-list::before {
+ul.topic-list.topic-list-has-topics::before {
     content: " ";
     display: block;
     position: absolute;
@@ -1175,7 +1175,7 @@ ul.topic-list::before {
     pointer-events: none;
 }
 
-ul.topic-list::after {
+ul.topic-list.topic-list-has-topics::after {
     content: " ";
     display: block;
     position: absolute;


### PR DESCRIPTION
Grouping should not be rendered in the event a channel is empty. This PR explicitly adds a class declaring that case, so that there is no need of fancy `:has()` portions to the CSS selectors.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20with.20no.20topics.20topic.20wrapper.20line/near/1934129)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change for channels with topics |
| --- | --- |
| ![empty-channel-before](https://github.com/user-attachments/assets/f9215b1b-e167-47ee-8bcd-f7a96a852bda) | ![empty-channel-after](https://github.com/user-attachments/assets/7344b513-c230-46df-8b2c-531b8f1379b5) |
| ![channel-with-topics-before](https://github.com/user-attachments/assets/051a4757-df3e-4230-b05b-c4faaca442bf) | ![channel-with-topics-after](https://github.com/user-attachments/assets/f5a8d7aa-ca37-43f0-9fef-0e448d139790) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>