### PR TITLE
settings: Clear all .new-style references.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -71,21 +71,6 @@ h3,
         width: 200px;
     }
 
-    .grid {
-        & label {
-            min-width: 200px;
-        }
-    }
-
-    #account-settings,
-    #profile-field-settings {
-        .grid {
-            & label {
-                min-width: 120px;
-            }
-        }
-    }
-
     .button {
         & ul {
             text-align: left;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -67,10 +67,6 @@ h3,
         text-align: center;
     }
 
-    .w-200 {
-        width: 200px;
-    }
-
     .button {
         & ul {
             text-align: left;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -54,14 +54,6 @@ h3,
     }
 }
 
-.new-style {
-    .button {
-        & ul {
-            text-align: left;
-        }
-    }
-}
-
 .profile-settings-form {
     display: flex;
     justify-content: space-between;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -75,14 +75,6 @@ h3,
         & label {
             min-width: 200px;
         }
-
-        .warning {
-            display: inline-block;
-            vertical-align: top;
-            width: 150px;
-            padding: 5px 10px;
-            text-align: left;
-        }
     }
 
     #account-settings,
@@ -91,20 +83,6 @@ h3,
             & label {
                 min-width: 120px;
             }
-
-            .warning {
-                display: block;
-                width: calc(100% - 20px - 5px);
-                text-align: right;
-            }
-        }
-    }
-
-    .warning {
-        #pw_strength {
-            width: 140px;
-            height: 8px;
-            margin: 6px 0 0;
         }
     }
 
@@ -1821,10 +1799,6 @@ $option_title_width: 180px;
     .user-avatar-section,
     .realm-icon-section {
         display: block;
-    }
-
-    #settings_content .warning {
-        display: none;
     }
 
     .subsection-failed-status p {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -55,14 +55,6 @@ h3,
 }
 
 .new-style {
-    .center-block {
-        margin: 0 auto;
-    }
-
-    .center {
-        text-align: center;
-    }
-
     .button {
         & ul {
             text-align: left;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -55,10 +55,6 @@ h3,
 }
 
 .new-style {
-    .block {
-        display: block;
-    }
-
     .center-block {
         margin: 0 auto;
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -519,7 +519,7 @@ h4.user_group_setting_subsection_title {
 
 .user-group-creation-body,
 .stream-creation-body {
-    & section.block {
+    & section {
         margin-bottom: 20px;
     }
 

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -2,7 +2,7 @@
     <div class="settings-password-div">
         <label for="old_password" class="modal-field-label">{{t "Old password" }}</label>
         <div class="password-input-row">
-            <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block modal_password_input" value="" />
+            <input type="password" autocomplete="off" name="old_password" id="old_password" class="inline-block modal_password_input" value="" />
             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
             <a href="/accounts/password/reset/" class="settings-forgot-password sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
         </div>
@@ -10,7 +10,7 @@
     <div class="settings-password-div">
         <label for="new_password" class="modal-field-label">{{t "New password" }}</label>
         <div class="password-input-row">
-            <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="w-200 inline-block modal_password_input" value=""
+            <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="inline-block modal_password_input" value=""
               data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />
             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
         </div>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -1,69 +1,67 @@
 <div id="account-settings" class="settings-section" data-name="account-and-privacy">
     <div class="alert" id="dev-account-settings-status"></div>
     <div class="account-settings-form">
-        <div class="inline-block">
-            <div id="user_details_section">
-                <h3 class="inline-block account-settings-heading">{{t "Account" }}</h3>
-                <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
-                <form class="grid">
-                    {{#if user_has_email_set}}
-                    <div class="input-group">
-                        <label class="settings-field-label">{{t "Email" }}</label>
-                        <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
-                            <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
-                                {{current_user.delivery_email}}
-                            </button>
-                        </div>
-                    </div>
-                    {{else}}
-                    {{! Demo organizations before the owner has configured an email address. }}
-                    <div class="input-group">
-                        <p>
-                            {{#tr}}
-                                Add your email to <z-link-invite-users-help>invite other users</z-link-invite-users-help>
-                                or <z-link-convert-demo-organization-help>convert to a permanent Zulip organization</z-link-convert-demo-organization-help>.
-                                {{#*inline "z-link-invite-users-help"}}<a href="/help/invite-new-users" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-                                {{#*inline "z-link-convert-demo-organization-help"}}<a href="/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-                            {{/tr}}
-                        </p>
-                        <button id="demo_organization_add_email_button" type="button" class="button rounded sea-green">
-                            {{t "Add email"}}
-                        </button>
-                    </div>
-                    {{/if}}
-                </form>
-
-                {{#if page_params.two_fa_enabled }}
-                <p for="two_factor_auth" class="inline-block title">
-                    {{t "Two factor authentication" }}: {{#if page_params.two_fa_enabled_user }}{{t "Enabled" }}{{else}}{{t "Disabled" }}{{/if}}
-                    <a target="_blank" rel="noopener noreferrer" id="two_factor_auth" href="/account/two_factor/" title="{{t 'Set up two factor authentication' }}">[{{t "Setup" }}]</a>
-                </p>
-                {{/if}}
-
-                <form class="password-change-form grid">
-                    {{#if user_can_change_password}}
-                    <div>
-                        <label class="settings-field-label">{{t "Password" }}</label>
-                        <div class="input-group">
-                            <button id="change_password" type="button" class="button rounded" data-dismiss="modal">{{t "Change your password" }}</button>
-                        </div>
-                    </div>
-                    {{/if}}
-                </form>
-
+        <div id="user_details_section">
+            <h3 class="inline-block account-settings-heading">{{t "Account" }}</h3>
+            <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
+            <form class="grid">
+                {{#if user_has_email_set}}
                 <div class="input-group">
-                    <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
-                        <button type="submit" class="button rounded btn-danger" id="user_deactivate_account_button"
-                          {{#if user_is_only_organization_owner}}disabled="disabled"{{/if}}>
-                            {{t 'Deactivate account' }}
+                    <label class="settings-field-label">{{t "Email" }}</label>
+                    <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
+                        <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
+                            {{current_user.delivery_email}}
                         </button>
                     </div>
-                    {{#if owner_is_only_user_in_organization}}
-                        <button type="submit" class="button rounded btn-danger deactivate_realm_button">
-                            {{t 'Deactivate organization' }}
-                        </button>
-                    {{/if}}
                 </div>
+                {{else}}
+                {{! Demo organizations before the owner has configured an email address. }}
+                <div class="input-group">
+                    <p>
+                        {{#tr}}
+                            Add your email to <z-link-invite-users-help>invite other users</z-link-invite-users-help>
+                            or <z-link-convert-demo-organization-help>convert to a permanent Zulip organization</z-link-convert-demo-organization-help>.
+                            {{#*inline "z-link-invite-users-help"}}<a href="/help/invite-new-users" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                            {{#*inline "z-link-convert-demo-organization-help"}}<a href="/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                        {{/tr}}
+                    </p>
+                    <button id="demo_organization_add_email_button" type="button" class="button rounded sea-green">
+                        {{t "Add email"}}
+                    </button>
+                </div>
+                {{/if}}
+            </form>
+
+            {{#if page_params.two_fa_enabled }}
+            <p for="two_factor_auth" class="inline-block title">
+                {{t "Two factor authentication" }}: {{#if page_params.two_fa_enabled_user }}{{t "Enabled" }}{{else}}{{t "Disabled" }}{{/if}}
+                <a target="_blank" rel="noopener noreferrer" id="two_factor_auth" href="/account/two_factor/" title="{{t 'Set up two factor authentication' }}">[{{t "Setup" }}]</a>
+            </p>
+            {{/if}}
+
+            <form class="password-change-form grid">
+                {{#if user_can_change_password}}
+                <div>
+                    <label class="settings-field-label">{{t "Password" }}</label>
+                    <div class="input-group">
+                        <button id="change_password" type="button" class="button rounded" data-dismiss="modal">{{t "Change your password" }}</button>
+                    </div>
+                </div>
+                {{/if}}
+            </form>
+
+            <div class="input-group">
+                <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
+                    <button type="submit" class="button rounded btn-danger" id="user_deactivate_account_button"
+                      {{#if user_is_only_organization_owner}}disabled="disabled"{{/if}}>
+                        {{t 'Deactivate account' }}
+                    </button>
+                </div>
+                {{#if owner_is_only_user_in_organization}}
+                    <button type="submit" class="button rounded btn-danger deactivate_realm_button">
+                        {{t 'Deactivate organization' }}
+                    </button>
+                {{/if}}
             </div>
         </div>
 

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -49,7 +49,7 @@
               is_editable_by_current_user = is_admin
               image = realm_icon_url }}
         </div>
-        <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded sea-green w-200 block" id="id_org_profile_preview">
+        <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded sea-green block" id="id_org_profile_preview">
             {{t 'Preview organization profile' }}
             <i class="fa fa-external-link" aria-hidden="true"></i>
         </a>

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -62,7 +62,7 @@
                     <span class="user-details-desc">{{date_joined_text}}</span>
                 </div>
             </div>
-            <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
+            <button class="button rounded sea-green block" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}
                 <i class="fa fa-external-link" aria-hidden="true"></i>
             </button>

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -62,7 +62,7 @@
                     <span class="user-details-desc">{{date_joined_text}}</span>
                 </div>
             </div>
-            <button class="button rounded sea-green block" id="show_my_user_profile_modal">
+            <button class="button rounded sea-green" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}
                 <i class="fa fa-external-link" aria-hidden="true"></i>
             </button>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -8,7 +8,7 @@
         <div class="clear-float"></div>
     </div>
     <div class="sidebar-wrapper">
-        <div class="center tab-container"></div>
+        <div class="tab-container"></div>
         <div class="sidebar left" data-simplebar data-simplebar-tab-index="-1">
             <div class="sidebar-list dark-grey small-text">
                 <ul class="normal-settings-list">

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -6,7 +6,7 @@
             <div id="stream_creating_indicator"></div>
             <div class="stream-creation-body">
                 <div class="configure_channel_settings stream_creation_container">
-                    <section id="create_stream_title_container" class="block">
+                    <section id="create_stream_title_container">
                         <label for="create_stream_name">
                             {{t "Channel name" }}
                         </label>
@@ -14,7 +14,7 @@
                           placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
                         <div id="stream_name_error" class="stream_creation_error"></div>
                     </section>
-                    <section id="create_stream_description_container" class="block">
+                    <section id="create_stream_description_container">
                         <label for="create_stream_description" class="settings-field-label">
                             {{t "Channel description" }}
                             {{> ../help_link_widget link="/help/change-the-channel-description" }}
@@ -22,7 +22,7 @@
                         <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
                           placeholder="{{t 'Channel description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
                     </section>
-                    <section class="block" id="make-invite-only">
+                    <section id="make-invite-only">
                         <div class="stream-types">
                             {{> stream_types
                               stream_post_policy=stream_post_policy_values.everyone.code
@@ -32,7 +32,7 @@
                     </section>
                 </div>
                 <div class="subscribers_container stream_creation_container">
-                    <section class="block stream_create_add_subscriber_container">
+                    <section class="stream_create_add_subscriber_container">
                         <label class="choose-subscribers-label" for="people_to_add">
                             <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
                         </label>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -6,7 +6,7 @@
             <div id="user_group_creating_indicator"></div>
             <div class="user-group-creation-body">
                 <div class="configure_user_group_settings user_group_creation">
-                    <section id="user-group-name-container" class="block">
+                    <section id="user-group-name-container">
                         <label for="create_user_group_name" class="settings-field-label">
                             {{t "User group name" }}
                         </label>
@@ -14,14 +14,14 @@
                           placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="{{ max_user_group_name_length }}"/>
                         <div id="user_group_name_error" class="user_group_creation_error"></div>
                     </section>
-                    <section id="user-group-description-container" class="block">
+                    <section id="user-group-description-container">
                         <label for="create_user_group_description" class="settings-field-label">
                             {{t "User group description" }}
                         </label>
                         <input type="text" name="user_group_description" id="create_user_group_description" class="settings_text_input"
                           placeholder="{{t 'User group description' }}" value="" autocomplete="off" />
                     </section>
-                    <section id="user-group-permission-container" class="block">
+                    <section id="user-group-permission-container">
                         <div class="group-permissions settings-subsection-parent" id="new_group_permission_settings">
                             <div class="subsection-header">
                                 <h3 class="user_group_setting_subsection_title">{{t "Group permissions" }}
@@ -35,7 +35,7 @@
                     </section>
                 </div>
                 <div class="user_group_members_container user_group_creation">
-                    <section id="choose_member_section" class="block">
+                    <section id="choose_member_section">
                         <label for="people_to_add_in_group">
                             <h4 class="user_group_setting_subsection_title">{{t "Choose members" }}</h4>
                         </label>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -34,7 +34,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </div>
-            <div id="tab-toggle" class="center"></div>
+            <div id="tab-toggle"></div>
             <main class="modal__body" id="body" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                 <div class="tab-data">
                     <div class="tabcontent active" id="profile-tab">


### PR DESCRIPTION
This PR removes all `.new-style` references from `settings.css`. It does not yet clear the `new-style` class from the HTML, which must wait until the remaining `.new-style` values are cleaned up elsewhere in the codebase, including especially `components.css` and `app_components.css`.

An extensive set of matching before-and-after screenshots appear below; but it would be good to have testing and visual scans by multiple sets of eyeballs that none of the removals here negatively impact especially the settings modals or channel and groups modals.

**Screenshots and screen captures:**

_Before and After are identical throughout._

| Before | After |
| --- | --- |
| ![group-settings-before](https://github.com/user-attachments/assets/8da7a3d3-7a3a-4476-9101-92b2ca487159) | ![group-settings-after](https://github.com/user-attachments/assets/b4a3cbf5-458d-4271-acda-574ef57f172c) |
| ![channel-settings-before](https://github.com/user-attachments/assets/f468a915-3fc8-4b81-8798-0e738acdb97a) | ![channel-settings-after](https://github.com/user-attachments/assets/e05e8d9c-25c1-48df-ba21-65fa6a45eebe) |
| ![new-channel-modal-before](https://github.com/user-attachments/assets/d4ce7840-9788-40db-9d6b-511b28f4672f) | ![new-channel-modal-after](https://github.com/user-attachments/assets/c2348c62-3fda-4b6e-93c0-38cd51cb7d9d) |
| ![password-modal-before](https://github.com/user-attachments/assets/96332ca9-5d57-4388-94b0-07b1a7bef762) | ![password-modal-after](https://github.com/user-attachments/assets/95b4132c-3c62-4902-8af6-c289032cdf35) |
| ![organization-profile-before](https://github.com/user-attachments/assets/c7d92336-285d-4952-a2ea-cffa8960b412) | ![organization-profile-after](https://github.com/user-attachments/assets/3da393f8-ac08-4d02-adae-8267193b2acd) |
| ![settings-profile-before](https://github.com/user-attachments/assets/4a721d5c-f850-43ec-8b3e-b89e00de3282) | ![settings-profile-after](https://github.com/user-attachments/assets/30268ea4-b501-4db8-a9db-1e3eb6299877) |
| ![settings-password-before](https://github.com/user-attachments/assets/fb43f40d-3a40-489f-9bd0-61aa89753607) | ![settings-password-after](https://github.com/user-attachments/assets/c036e7f6-48e6-42c5-ad48-6677396b35f0) |
| ![profile-modal-before](https://github.com/user-attachments/assets/fde486fc-5f31-4c26-9437-f23492e09e96) | ![profile-modal-after](https://github.com/user-attachments/assets/058f82c4-4aae-4e32-b781-b3b291459816) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>



