### PR TITLE
 tooltips: Change tooltip for subscribe/unsubscribe button 

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -152,6 +152,17 @@ export function initialize(): void {
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,
         placement: "bottom",
+        onShow(instance) {
+            let template = "show-unsubscribe-tooltip-template";
+            if (instance.reference.classList.contains("unsubscribed")) {
+                template = "show-subscribe-tooltip-template";
+            }
+            $(instance.reference).attr("data-tooltip-template-id", template);
+            instance.setContent(get_tooltip_content(instance.reference));
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
     });
 
     tippy.delegate("body", {

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -239,8 +239,12 @@
     {{t 'Create new channel' }}
     {{tooltip_hotkey_hints "N"}}
 </template>
-<template id="toggle-subscription-tooltip-template">
-    {{t 'Toggle subscription' }}
+<template id="show-subscribe-tooltip-template">
+    {{t 'Subscribe to this channel' }}
+    {{tooltip_hotkey_hints "Shift" "S"}}
+</template>
+<template id="show-unsubscribe-tooltip-template">
+    {{t 'Unsubscribe from this channel' }}
     {{tooltip_hotkey_hints "Shift" "S"}}
 </template>
 <template id="view-stream-tooltip-template">


### PR DESCRIPTION
Show  specific tooltips for button  `subscribe to/unsubscribe` in channel settings.

Fixes: [#31500](https://github.com/zulip/zulip/issues/31500)


- Added multiple HTML tooltip templates for different button states  subscribed, unsubscribed.
- Updated JavaScript to select and render the appropriate tooltip based on  the current  button's state.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.



Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![subscribe(before)](https://github.com/user-attachments/assets/84e73b5a-c72c-49a4-bb85-edae3f2a2223)| ![subscribe](https://github.com/user-attachments/assets/dabc0de6-bed4-41c2-a5e1-412f6d29e8c0)|
|![unsubscribe(before)](https://github.com/user-attachments/assets/54485914-65ec-4c47-86be-cb42a82bd9bc)| ![unsubscribe](https://github.com/user-attachments/assets/3018e320-a373-4578-b591-60ce06359ec2)

<details>






<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
