### PR TITLE
typeahead: Fix compose topic typeahead partially hidden.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -439,27 +439,27 @@ export class Typeahead<ItemType extends string | object> {
                     }
                     return [0, gap];
                 },
-                onShow(instance) {
-                    if (input_element.type === "textarea") {
-                        // Since we use an offset which can partially hide typeahead
-                        // at certain caret positions, we need to push it back into
-                        // view once we have rendered the typeahead. The movement
-                        // feels like an animation to the user.
-                        setTimeout(() => {
-                            // This detects any overflows by default and adjusts
-                            // the placement of typeahead.
-                            void instance.popperInstance?.update();
-                        }, 0);
-                    }
-                },
                 // We have event handlers to hide the typeahead, so we
                 // don't want tippy to hide it for us.
                 hideOnClick: false,
-                onMount: () => {
+                onMount: (instance) => {
                     // The container has `display: none` as a default style.
                     // We make sure to display it. For tippy elements, this
                     // must happen after we insert the typeahead into the DOM.
                     this.$container.show();
+                    // Reasons to update the position of the typeahead here:
+                    // * Simplebar causes the height of the typeahead to
+                    //   change, which can cause the typeahead to go off
+                    //   screen like in compose topic typeahead.
+                    // * Since we use an offset which can partially hide
+                    //   typeahead at certain caret positions in textarea
+                    //   input, we need to push it back into view once we
+                    //   have rendered the typeahead.
+                    requestAnimationFrame(() => {
+                        // This detects any overflows by default and adjusts
+                        // the placement of typeahead.
+                        void instance.popperInstance?.update();
+                    });
                 },
             });
         }


### PR DESCRIPTION
The `flip` popper function is not working properly here since we migrated to use Simplebar (Can be verified by removing `data-simplebar`).

To fix it, we need to force trigger the function as soon as tippy is attached to DOM.

![Screenshot 2024-09-02 at 1 45 44 PM](https://github.com/user-attachments/assets/e3aeec02-a888-42e8-816d-448366917b37)
![Screenshot 2024-09-02 at 1 45 56 PM](https://github.com/user-attachments/assets/ec5a5644-7c4a-4540-927b-2fa275ec48e9)

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20typeahead.20opening.20downwards