### PR TITLE
Optimize DOM cost of message reactions by conditional rendering

### DIFF
--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -3,6 +3,7 @@ import assert from "minimalistic-assert";
 import {z} from "zod";
 
 import render_message_reaction from "../templates/message_reaction.hbs";
+import render_message_reactions from "../templates/message_reactions.hbs";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
@@ -369,11 +370,23 @@ export function insert_new_reaction(
         class: reaction_class,
     };
 
-    const $new_reaction = $(render_message_reaction(context));
-
-    // Now insert it before the add button.
     const $reaction_button_element = get_add_reaction_button(message.id);
-    $new_reaction.insertBefore($reaction_button_element);
+    if ($reaction_button_element.length === 0) {
+        // create a new reactions section and append the new reaction
+        const $reactions = $(
+            render_message_reactions({
+                msg: {
+                    message_reactions: [context],
+                },
+            }),
+        );
+        const $reactions_section = get_reaction_sections(message.id);
+        $reactions_section.append($reactions);
+    } else {
+        // insert the new reaction before it
+        const $new_reaction = $(render_message_reaction(context));
+        $new_reaction.insertBefore($reaction_button_element);
+    }
 
     update_vote_text_on_message(message);
 }

--- a/web/templates/message_reactions.hbs
+++ b/web/templates/message_reactions.hbs
@@ -1,9 +1,11 @@
-{{#each this/msg/message_reactions}}
-    {{> message_reaction}}
-{{/each}}
-<div class="reaction_button" role="button" aria-haspopup="true" data-tooltip-template-id="add-emoji-tooltip-template" aria-label="{{t 'Add emoji reaction' }} (:)">
-    <div class="emoji-message-control-button-container">
-        <i class="zulip-icon zulip-icon-smile" tabindex="0"></i>
-        <div class="message_reaction_count">+</div>
+{{#if this/msg/message_reactions.length}}
+    {{#each this/msg/message_reactions}}
+        {{> message_reaction}}
+    {{/each}}
+    <div class="reaction_button" role="button" aria-haspopup="true" data-tooltip-template-id="add-emoji-tooltip-template" aria-label="{{t 'Add emoji reaction' }} (:)">
+        <div class="emoji-message-control-button-container">
+            <i class="zulip-icon zulip-icon-smile" tabindex="0"></i>
+            <div class="message_reaction_count">+</div>
+        </div>
     </div>
-</div>
+{{/if}}


### PR DESCRIPTION
### Description

This pull request optimizes the DOM cost of the `message_reactions` elements to improve performance. Previously, the `message_reactions` area was included in every message's DOM, regardless of whether that message had any emoji reactions. This resulted in unnecessary DOM elements and increased rendering costs.

### Fixes

Fixes #31137. This optimization ensures that the `message_reactions` element is only rendered if there are actual reactions to display. It also improves the efficiency of the DOM updates related to emoji reactions.



<details>
<summary>Self-review checklist</summary>

- [x] **Self-reviewed** the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips. (Only if you modified or added new strings/tooltips)
- [x] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>