### PR TITLE
css: Use classname for ` i ` rules. 

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1161,7 +1161,7 @@ div.overlay {
 .setting-disabled-option {
     color: hsl(38deg 46% 54%);
 
-    & i {
+    .setting-disabled-option-icon {
         /* Values set to match text alignment in stream dropdown. */
         padding: 0 5px 0 1px;
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -343,7 +343,7 @@ li.show-more-topics {
     margin: 5px auto var(--left-sidebar-bottom-scrolling-buffer)
         var(--left-sidebar-toggle-width-offset);
 
-    & i {
+    .subscribe-more-icon {
         min-width: 19px;
         text-align: center;
 

--- a/web/styles/message_view_header.css
+++ b/web/styles/message_view_header.css
@@ -49,7 +49,7 @@
             padding: 0 3.5px; /* based on having ~41.66% decrease */
         }
 
-        & i {
+        .navbar-icon {
             margin: 0 6px 0 5px;
             /* Align all icons to center. */
             align-self: center;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -776,37 +776,19 @@ input[type="checkbox"] {
 
 .admin_profile_fields_table,
 .edit_profile_field_choices_container,
-.profile_field_choices_table {
-    .movable-row {
-        cursor: move;
-
-        .fa-ellipsis-v {
-            color: hsl(0deg 0% 75%);
-            position: relative;
-            top: 1px;
-
-            + i {
-                margin-right: 5px;
-            }
-        }
-    }
-}
-
+.profile_field_choices_table,
 .admin_linkifiers_table {
     .movable-row {
         .move-handle {
             cursor: move;
             user-select: none;
+            margin-right: 5px;
         }
 
         .fa-ellipsis-v {
             color: hsl(0deg 0% 75%);
             position: relative;
             top: 1px;
-
-            + i {
-                margin-right: 5px;
-            }
         }
     }
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -134,8 +134,10 @@ h3,
 .setting_notification_sound,
 .play_notification_sound {
     margin-right: 4px;
+}
 
-    & i {
+.play_notification_sound {
+    .notification-sound-icon {
         font-size: 22px;
         /* Visually center with chevron in select */
         line-height: 26px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1569,11 +1569,11 @@ $option_title_width: 180px;
         width: 100%;
         top: 20px;
         position: sticky;
-    }
 
-    #show_my_user_profile_modal i {
-        padding-left: 2px;
-        vertical-align: middle;
+        .show-user-profile-icon {
+            padding-left: 2px;
+            vertical-align: middle;
+        }
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1887,7 +1887,7 @@ body:not(.hide-left-sidebar) {
             background: hsl(240deg 96% 68% / 50%);
             border-radius: 50%;
 
-            & i {
+            & .scroll-to-bottom-icon {
                 color: hsl(0deg 0% 100%);
                 margin: 0 auto;
                 font-size: 21px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -137,7 +137,7 @@ p.n-margin {
     padding-left: 26px;
     text-indent: -10px;
 
-    & i {
+    .all-messages-search-caution-icon {
         margin: 0 3px 0 1px;
     }
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -6,7 +6,7 @@
     <div id="scroll-to-bottom-button-container" aria-hidden="true">
         <div id="scroll-to-bottom-button-clickable-area" data-tooltip-template-id="scroll-to-bottom-button-tooltip-template">
             <div id="scroll-to-bottom-button">
-                <i class="fa fa-chevron-down"></i>
+                <i class="scroll-to-bottom-icon fa fa-chevron-down"></i>
             </div>
         </div>
     </div>

--- a/web/templates/dropdown_list.hbs
+++ b/web/templates/dropdown_list.hbs
@@ -20,7 +20,7 @@
             {{else if is_direct_message}}
                 <i class="zulip-icon zulip-icon-users stream-privacy-type-icon"></i> {{name}}
             {{else if is_setting_disabled}}
-                <span class="setting-disabled-option"><i class="fa fa-ban" aria-hidden="true"></i>{{t "Disable" }}</span>
+                <span class="setting-disabled-option"><i class="setting-disabled-option-icon fa fa-ban" aria-hidden="true"></i>{{t "Disable" }}</span>
             {{else}}
                 {{#if bold_current_selection}}
                     <span class="dropdown-list-bold-selected">{{name}}</span>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -11,7 +11,7 @@
 </div>
 <div class="all-messages-search-caution hidden-for-spectators" hidden>
     <p>
-        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+        <i class="all-messages-search-caution-icon fa fa-exclamation-circle" aria-hidden="true"></i>
         {{#tr}}
         End of results from your
         <z-link>history</z-link>.

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -1,6 +1,6 @@
 {{#if zulip_icon}}
-<i class="zulip-icon zulip-icon-{{zulip_icon}}" aria-hidden="true"></i>
+<i class="navbar-icon zulip-icon zulip-icon-{{zulip_icon}}" aria-hidden="true"></i>
 {{else if icon}}
-<i class="fa fa-{{icon}}" aria-hidden="true"></i>
+<i class="navbar-icon fa fa-{{icon}}" aria-hidden="true"></i>
 {{/if}}
 <span class="message-header-navbar-title">{{title}}</span>

--- a/web/templates/settings/admin_profile_field_list.hbs
+++ b/web/templates/settings/admin_profile_field_list.hbs
@@ -2,8 +2,10 @@
 <tr class="profile-field-row movable-row" data-profile-field-id="{{id}}">
     <td class="profile_field_name">
         {{#if ../can_modify}}
-        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
-        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+        <span class="move-handle">
+            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+        </span>
         {{/if}}
         <span class="profile_field_name">{{name}}</span>
     </td>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -129,7 +129,7 @@
                 {{/each}}
             </select>
             <span class="play_notification_sound">
-                <i class="fa fa-play-circle" aria-label="{{t 'Play sound' }}"></i>
+                <i class="notification-sound-icon fa fa-play-circle" aria-label="{{t 'Play sound' }}"></i>
             </span>
         </div>
 

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -1,6 +1,8 @@
 <div class='choice-row movable-row' data-value="{{value}}">
-    <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
-    <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+    <span class="move-handle">
+        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+    </span>
     <input type='text' class="modal_text_input" placeholder='{{t "New option" }}' value="{{ text }}" />
 
     <button type='button' class="button rounded small delete-choice tippy-zulip-tooltip {{#if new_empty_choice_row}} hide {{/if}}" data-tippy-content="{{t 'Delete' }}">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -64,7 +64,7 @@
             </div>
             <button class="button rounded sea-green" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}
-                <i class="fa fa-external-link" aria-hidden="true"></i>
+                <i class="show-user-profile-icon fa fa-external-link" aria-hidden="true"></i>
             </button>
         </div>
     </div>

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,16 +1,16 @@
 {{#if exactly_one_unsubscribed_stream}}
     <a href="#channels/notsubscribed">
-        <i class="fa fa-plus-circle" aria-hidden="true"></i>
+        <i class="subscribe-more-icon fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Browse 1 more channel" ~}}
     </a>
 {{else if can_subscribe_stream_count}}
     <a href="#channels/notsubscribed">
-        <i class="fa fa-plus-circle" aria-hidden="true"></i>
+        <i class="subscribe-more-icon fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Browse {can_subscribe_stream_count} more channels" ~}}
     </a>
 {{else if can_create_streams}}
     <a href="#channels/new">
-        <i class="fa fa-plus-circle" aria-hidden="true"></i>
+        <i class="subscribe-more-icon fa fa-plus-circle" aria-hidden="true"></i>
         {{~t "Create a channel" ~}}
     </a>
 {{/if}}


### PR DESCRIPTION
` i ` occurences from portico haven't been touched. See https://github.com/zulip/zulip/pull/31204#discussion_r1716314707

In a lot of these commits, `i` has been replaced by `.zulip-icon` wherever applicable. These are cases where all <i> tags inside an element have `.zulip-icon` tag. 

The other common occuring class is `.fa`, but in those cases I've introduced a new class name, since I thought we're in the processing of transitioning from `fa` to `zulip-icon` and somehow it didn't feel right to introduce `.fa` rules now. 

1c8eaf722a5e0dbbe2784eab054827267e3b5cde is a bit different from other commits in the sense that it has some refactoring also going on. 

I haven't added screenshots, see https://github.com/zulip/zulip/pull/31204#issuecomment-2265944347

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
