### PR TITLE
actions: Use 'durable=True' in outermost transaction.atomic block.

### DIFF
--- a/zerver/actions/alert_words.py
+++ b/zerver/actions/alert_words.py
@@ -12,13 +12,13 @@ def notify_alert_words(user_profile: UserProfile, words: Sequence[str]) -> None:
     send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
-@transaction.atomic(savepoint=False)
+@transaction.atomic(durable=True)
 def do_add_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) -> None:
     words = add_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, words)
 
 
-@transaction.atomic(savepoint=False)
+@transaction.atomic(durable=True)
 def do_remove_alert_words(user_profile: UserProfile, alert_words: Iterable[str]) -> None:
     words = remove_user_alert_words(user_profile, alert_words)
     notify_alert_words(user_profile, words)

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -93,7 +93,7 @@ def do_schedule_messages(
 
         scheduled_messages.append((scheduled_message, send_request))
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         ScheduledMessage.objects.bulk_create(
             [scheduled_message for scheduled_message, ignored in scheduled_messages]
         )

--- a/zerver/actions/user_status.py
+++ b/zerver/actions/user_status.py
@@ -7,7 +7,7 @@ from zerver.models import UserProfile
 from zerver.tornado.django_api import send_event_on_commit
 
 
-@transaction.atomic(savepoint=False)
+@transaction.atomic(durable=True)
 def do_update_user_status(
     user_profile: UserProfile,
     away: bool | None,


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/31169#issuecomment-2262076392

> Though as discussed on chat.zulip.org today, I wonder if some of these should be using durable=True instead, we can handle that in a follow-up sweep.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
