### PR TITLE
help: Fix minor bugs in keyboard shortcuts help.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -93,6 +93,8 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Go to next unread topic**: <kbd>N</kbd>
 
+* **Go to next unread followed topic**: <kbd>Shift</kbd> + <kbd>N</kbd>
+
 * **Go to next unread direct message**: <kbd>P</kbd>
 
 * **Go to topic or DM conversation**: <kbd>S</kbd>

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -71,15 +71,6 @@
         font-weight: normal;
     }
 
-    .small_hotkey {
-        font-size: 0.9em !important;
-        line-height: 12px;
-
-        & kbd {
-            font-size: 0.9em;
-        }
-    }
-
     .arrow-key {
         font-size: 1.36em;
         line-height: 1;

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -218,7 +218,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Send message' }}</td>
-                    <td><span class="hotkey"><span class="small_hotkey"><kbd>Tab</kbd> then <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd></span></span></td>
+                    <td><span class="hotkey"><kbd>Tab</kbd> then <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Insert new line' }}</td>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -160,6 +160,10 @@
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Go to next unread followed topic' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>N</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Go to next unread direct message' }}</td>
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>


### PR DESCRIPTION
## First commit

This info was already in the Basics section, but was missing from the Navigation section.

Current:  https://zulip.com/help/keyboard-shortcuts#navigation and help modal
<details>
<summary>
Updated
</summary>

![Screenshot 2024-09-03 at 12 39 55@2x](https://github.com/user-attachments/assets/e816e7de-7d07-41ea-99e8-e6ee30c5796f)
![Screenshot 2024-09-03 at 12 40 19@2x](https://github.com/user-attachments/assets/f2b39e98-c478-4d95-8042-f552995999b3)

</details>

## Second commit

The current sizing (12px) looks really bad at 16px font size:

It's also not necessary, as the modal is currently wide enough such that there's no line wrapping. It's not translated, so we can worry about line wrapping in other languages when we fix that (which may be after we redesign this modal).

<details>
<summary>
Before (16px)
</summary>

![Screenshot 2024-09-03 at 13 10 56](https://github.com/user-attachments/assets/79206939-7ff2-49d6-a7cb-dc47094d0542)


</details>

 
<details>
<summary>
After (16px, 14px)
</summary>

![Screenshot 2024-09-03 at 13 15 10](https://github.com/user-attachments/assets/59057f20-d69c-46dd-9829-12fb2f84f128)

![Screenshot 2024-09-03 at 13 17 07](https://github.com/user-attachments/assets/1137a1d1-edfd-4941-819e-f7aef4adff60)



</details>