### PR TITLE
move_topic: Remove extraneous classname on hidden input, fixes bug.

### DIFF
--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -13,7 +13,7 @@
         <i class="fa fa-angle-right" aria-hidden="true"></i>
         {{/unless}}
         <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
-        <input name="old_topic_name" type="hidden" class="move_messages_edit_topic" value="{{topic_name}}" />
+        <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}
         <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">


### PR DESCRIPTION
We initialize the topic typeahead in the modal with the element `$("#move_topic_form .move_messages_edit_topic")`, which previously was capturing two elements, the second one being a hidden input element.

This wasn't causing issues, but once we added `util.the` in the typeahead code we were getting errors for having multiple elements where we expected one.

The fix is removing `move_messages_edit_topic` from the hidden element's classnames, since that class is only used for input and styling things.
