### PR TITLE
Use new pills UI for `can_manage_group` setting.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -114,6 +114,7 @@ EXEMPT_FILES = make_set(
         "web/src/giphy.js",
         "web/src/giphy_state.ts",
         "web/src/global.ts",
+        "web/src/group_setting_pill.ts",
         "web/src/hash_util.ts",
         "web/src/hashchange.js",
         "web/src/hbs.d.ts",

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -179,14 +179,12 @@ export function get_language_matcher(query: string): (language: string) => boole
     };
 }
 
-export function get_stream_or_user_group_matcher(
-    query: string,
-): (user_group_or_stream: UserGroupPillData | StreamPillData) => boolean {
+export function get_stream_matcher(query: string): (stream: StreamPillData) => boolean {
     // Case-insensitive.
     query = typeahead.clean_query_lowercase(query);
 
-    return function (user_group_or_stream: UserGroupPillData | StreamPillData) {
-        return typeahead_helper.query_matches_name(query, user_group_or_stream);
+    return function (stream: StreamPillData) {
+        return typeahead_helper.query_matches_stream_name(query, stream);
     };
 }
 
@@ -669,7 +667,7 @@ export function get_person_suggestions(
     }));
 
     const filtered_groups = group_pill_data.filter((item) =>
-        typeahead_helper.query_matches_name(query, item),
+        typeahead_helper.query_matches_group_name(query, item),
     );
 
     /*
@@ -897,7 +895,7 @@ export function get_candidates(
             ...sub,
             type: "stream",
         }));
-        const matcher = get_stream_or_user_group_matcher(token);
+        const matcher = get_stream_matcher(token);
         const matches = candidate_list.filter((item) => matcher(item));
         return typeahead_helper.sort_streams(matches, token);
     }

--- a/web/src/group_setting_pill.ts
+++ b/web/src/group_setting_pill.ts
@@ -1,0 +1,104 @@
+import assert from "minimalistic-assert";
+
+import render_input_pill from "../templates/input_pill.hbs";
+
+import * as group_permission_settings from "./group_permission_settings";
+import * as input_pill from "./input_pill";
+import type {InputPillConfig} from "./input_pill";
+import type {GroupSettingPill, GroupSettingPillContainer} from "./typeahead_helper";
+import * as user_group_pill from "./user_group_pill";
+import type {UserGroupPill} from "./user_group_pill";
+import * as user_groups from "./user_groups";
+import * as user_pill from "./user_pill";
+
+function check_group_allowed_for_setting(group_item: UserGroupPill, setting_name: string): boolean {
+    const group_setting_config = group_permission_settings.get_group_permission_setting_config(
+        setting_name,
+        "group",
+    );
+
+    assert(group_setting_config !== undefined);
+
+    const group = user_groups.get_user_group_from_id(group_item.group_id);
+    if (!group.is_system_group) {
+        if (group_setting_config.require_system_group) {
+            return false;
+        }
+
+        return true;
+    }
+
+    return user_groups.check_system_user_group_allowed_for_setting(
+        group.name,
+        group_setting_config,
+        true,
+    );
+}
+
+export function create_item_from_text(
+    text: string,
+    current_items: GroupSettingPill[],
+    pill_config?: InputPillConfig,
+): GroupSettingPill | undefined {
+    const group_item = user_group_pill.create_item_from_group_name(text, current_items);
+    if (group_item) {
+        const setting_name = pill_config?.setting_name;
+        assert(setting_name !== undefined);
+        if (check_group_allowed_for_setting(group_item, setting_name)) {
+            return group_item;
+        }
+
+        return undefined;
+    }
+
+    return user_pill.create_item_from_email(text, current_items);
+}
+
+export function get_text_from_item(item: GroupSettingPill): string {
+    let text: string;
+    switch (item.type) {
+        case "user_group":
+            text = user_group_pill.get_group_name_from_item(item);
+            break;
+        case "user":
+            text = user_pill.get_email_from_item(item);
+            break;
+    }
+    return text;
+}
+
+export function get_display_value_from_item(item: GroupSettingPill): string {
+    if (item.type === "user_group") {
+        return user_group_pill.display_pill(user_groups.get_user_group_from_id(item.group_id));
+    }
+    assert(item.type === "user");
+    return user_pill.get_display_value_from_item(item);
+}
+
+export function generate_pill_html(item: GroupSettingPill): string {
+    if (item.type === "user_group") {
+        return render_input_pill({
+            display_value: get_display_value_from_item(item),
+            group_id: item.group_id,
+        });
+    }
+    assert(item.type === "user");
+    return user_pill.generate_pill_html(item);
+}
+
+export function create_pills(
+    $pill_container: JQuery,
+    setting_name: string,
+): GroupSettingPillContainer {
+    const pill_widget = input_pill.create<GroupSettingPill>({
+        $container: $pill_container,
+        create_item_from_text,
+        get_text_from_item,
+        get_display_value_from_item,
+        generate_pill_html,
+        pill_config: {
+            setting_name,
+        },
+    });
+    return pill_widget;
+}

--- a/web/src/group_setting_pill.ts
+++ b/web/src/group_setting_pill.ts
@@ -5,10 +5,12 @@ import render_input_pill from "../templates/input_pill.hbs";
 import * as group_permission_settings from "./group_permission_settings";
 import * as input_pill from "./input_pill";
 import type {InputPillConfig} from "./input_pill";
+import * as pill_typeahead from "./pill_typeahead";
 import type {GroupSettingPill, GroupSettingPillContainer} from "./typeahead_helper";
 import * as user_group_pill from "./user_group_pill";
 import type {UserGroupPill} from "./user_group_pill";
 import * as user_groups from "./user_groups";
+import type {UserGroup} from "./user_groups";
 import * as user_pill from "./user_pill";
 
 function check_group_allowed_for_setting(group_item: UserGroupPill, setting_name: string): boolean {
@@ -101,4 +103,23 @@ export function create_pills(
         },
     });
     return pill_widget;
+}
+
+export function set_up_pill_typeahead({
+    pill_widget,
+    $pill_container,
+    opts,
+}: {
+    pill_widget: GroupSettingPillContainer;
+    $pill_container: JQuery;
+    opts: {
+        setting_name: string;
+        group: UserGroup | undefined;
+    };
+}): void {
+    pill_typeahead.set_up_group_setting_typeahead(
+        $pill_container.find(".input"),
+        pill_widget,
+        opts,
+    );
 }

--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -13,6 +13,7 @@ import * as util from "./util";
 
 export type InputPillConfig = {
     exclude_inaccessible_users?: boolean;
+    setting_name?: string;
 };
 
 type InputPillCreateOptions<ItemType> = {

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -22,7 +22,7 @@ function person_matcher(query: string, item: UserPillData): boolean {
 }
 
 function group_matcher(query: string, item: UserGroupPillData): boolean {
-    return typeahead_helper.query_matches_name(query, item);
+    return typeahead_helper.query_matches_group_name(query, item);
 }
 
 type TypeaheadItem = UserGroupPillData | StreamPillData | UserPillData;

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -921,34 +921,42 @@ export const desktop_icon_count_display_values = {
 export const system_user_groups_list = [
     {
         name: "role:internet",
+        dropdown_option_name: $t({defaultMessage: "Everyone on the internet"}),
         display_name: $t({defaultMessage: "Everyone on the internet"}),
     },
     {
         name: "role:everyone",
-        display_name: $t({defaultMessage: "Admins, moderators, members and guests"}),
+        dropdown_option_name: $t({defaultMessage: "Admins, moderators, members and guests"}),
+        display_name: $t({defaultMessage: "Everyone"}),
     },
     {
         name: "role:members",
-        display_name: $t({defaultMessage: "Admins, moderators and members"}),
+        dropdown_option_name: $t({defaultMessage: "Admins, moderators and members"}),
+        display_name: $t({defaultMessage: "Members"}),
     },
     {
         name: "role:fullmembers",
-        display_name: $t({defaultMessage: "Admins, moderators and full members"}),
+        dropdown_option_name: $t({defaultMessage: "Admins, moderators and full members"}),
+        display_name: $t({defaultMessage: "Full members"}),
     },
     {
         name: "role:moderators",
-        display_name: $t({defaultMessage: "Admins and moderators"}),
+        dropdown_option_name: $t({defaultMessage: "Admins and moderators"}),
+        display_name: $t({defaultMessage: "Moderators"}),
     },
     {
         name: "role:administrators",
-        display_name: $t({defaultMessage: "Admins"}),
+        dropdown_option_name: $t({defaultMessage: "Admins"}),
+        display_name: $t({defaultMessage: "Administrators"}),
     },
     {
         name: "role:owners",
+        dropdown_option_name: $t({defaultMessage: "Owners"}),
         display_name: $t({defaultMessage: "Owners"}),
     },
     {
         name: "role:nobody",
+        dropdown_option_name: $t({defaultMessage: "Nobody"}),
         display_name: $t({defaultMessage: "Nobody"}),
     },
 ];

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -4,6 +4,7 @@ import * as group_permission_settings from "./group_permission_settings";
 import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import {current_user, realm} from "./state_data";
+import type {GroupSettingType} from "./state_data";
 import * as user_groups from "./user_groups";
 import {user_settings} from "./user_settings";
 
@@ -109,7 +110,7 @@ function user_has_permission(policy_value: number): boolean {
 }
 
 export function user_has_permission_for_group_setting(
-    setting_group_id: number,
+    setting_group_id: GroupSettingType,
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
 ): boolean {
@@ -123,7 +124,7 @@ export function user_has_permission_for_group_setting(
         return false;
     }
 
-    return user_groups.is_user_in_group(setting_group_id, current_user.user_id);
+    return user_groups.is_user_in_setting_group(setting_group_id, current_user.user_id);
 }
 
 export function user_can_invite_users_by_email(): boolean {

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -613,8 +613,10 @@ export function discard_group_property_element_changes(elem, group) {
     const property_name = settings_components.extract_property_name($elem);
     const property_value = settings_components.get_group_property_value(property_name, group);
 
-    if (property_name === "can_manage_group" || property_name === "can_mention_group") {
+    if (property_name === "can_mention_group") {
         settings_components.set_dropdown_list_widget_setting_value(property_name, property_value);
+    } else if (property_name === "can_manage_group") {
+        settings_components.set_group_setting_widget_value(property_name, property_value);
     } else if (property_value !== undefined) {
         settings_components.set_input_element_value($elem, property_value);
     } else {

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -256,6 +256,7 @@ export function set_up(settings_panel: SettingsPanel): void {
             assert(setting !== undefined);
             const data: Record<string, string | boolean | number> = {};
             const setting_value = settings_components.get_input_element_value(this)!;
+            assert(typeof setting_value !== "object");
             data[setting] = setting_value;
 
             if (setting === "dense_mode") {

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -144,7 +144,7 @@ export const user_group_schema = z.object({
     members: z.array(z.number()),
     is_system_group: z.boolean(),
     direct_subgroup_ids: z.array(z.number()),
-    can_manage_group: z.number(),
+    can_manage_group: group_setting_type_schema,
     can_mention_group: z.number(),
     deactivated: z.boolean(),
 });

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -37,6 +37,9 @@ export type UserOrMentionPillData = UserOrMention & {
 export type CombinedPill = StreamPill | UserGroupPill | UserPill;
 export type CombinedPillContainer = InputPillContainer<CombinedPill>;
 
+export type GroupSettingPill = UserGroupPill | UserPill;
+export type GroupSettingPillContainer = InputPillContainer<GroupSettingPill>;
+
 export function build_highlight_regex(query: string): RegExp {
     const regex = new RegExp("(" + _.escapeRegExp(query) + ")", "ig");
     return regex;

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -665,11 +665,8 @@ export function query_matches_person(
     return false;
 }
 
-export function query_matches_name(
-    query: string,
-    user_group_or_stream: UserGroupPillData | StreamPillData,
-): boolean {
-    return typeahead.query_matches_string_in_order(query, user_group_or_stream.name, " ");
+export function query_matches_stream_name(query: string, stream: StreamPillData): boolean {
+    return typeahead.query_matches_string_in_order(query, stream.name, " ");
 }
 
 export function query_matches_group_name(query: string, user_group: UserGroupPillData): boolean {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -22,6 +22,7 @@ import * as stream_list_sort from "./stream_list_sort";
 import type {StreamPill, StreamPillData} from "./stream_pill";
 import type {StreamSubscription} from "./sub_store";
 import type {UserGroupPill, UserGroupPillData} from "./user_group_pill";
+import * as user_groups from "./user_groups";
 import type {UserPill, UserPillData} from "./user_pill";
 import * as user_status from "./user_status";
 import type {UserStatusEmojiInfo} from "./user_status";
@@ -155,7 +156,7 @@ export function render_person(person: UserPillData | UserOrMentionPillData): str
 
 export function render_user_group(user_group: {name: string; description: string}): string {
     return render_typeahead_item({
-        primary: user_group.name,
+        primary: user_groups.get_display_group_name(user_group.name),
         secondary: user_group.description,
         is_user_group: true,
     });
@@ -669,4 +670,12 @@ export function query_matches_name(
     user_group_or_stream: UserGroupPillData | StreamPillData,
 ): boolean {
     return typeahead.query_matches_string_in_order(query, user_group_or_stream.name, " ");
+}
+
+export function query_matches_group_name(query: string, user_group: UserGroupPillData): boolean {
+    return typeahead.query_matches_string_in_order(
+        query,
+        user_groups.get_display_group_name(user_group.name),
+        "",
+    );
 }

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -10,7 +10,7 @@ import type {UserGroup} from "./user_groups";
 
 export let active_group_id: number | undefined;
 
-type group_setting = "can_manage_group" | "can_mention_group";
+type group_setting = "can_mention_group";
 export function setup_permissions_dropdown(
     setting_name: group_setting,
     group: UserGroup | undefined,
@@ -58,11 +58,7 @@ export function setup_permissions_dropdown(
         },
     });
     if (for_group_creation) {
-        if (setting_name === "can_mention_group") {
-            settings_components.set_new_group_can_mention_group_widget(group_setting_widget);
-        } else {
-            settings_components.set_new_group_can_manage_group_widget(group_setting_widget);
-        }
+        settings_components.set_new_group_can_mention_group_widget(group_setting_widget);
     } else {
         settings_components.set_dropdown_setting_widget(setting_name, group_setting_widget);
     }

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -150,13 +150,9 @@ function create_user_group(): void {
     }
     const user_ids = user_group_create_members.get_principals();
 
-    assert(settings_components.new_group_can_manage_group_widget !== null);
-    const can_manage_group_value = settings_components.new_group_can_manage_group_widget.value();
-    assert(can_manage_group_value !== undefined);
-    const can_manage_group =
-        typeof can_manage_group_value === "number"
-            ? can_manage_group_value
-            : Number.parseInt(can_manage_group_value, 10);
+    const can_manage_group = settings_components.get_group_setting_widget_value(
+        $("#id_new_group_can_manage_group"),
+    );
 
     assert(settings_components.new_group_can_mention_group_widget !== null);
     const can_mention_group_value = settings_components.new_group_can_mention_group_widget.value();
@@ -170,8 +166,8 @@ function create_user_group(): void {
         name: group_name,
         description,
         members: JSON.stringify(user_ids),
-        can_manage_group,
         can_mention_group,
+        can_manage_group: JSON.stringify(can_manage_group),
     };
     loading.make_indicator($("#user_group_creating_indicator"), {
         text: $t({defaultMessage: "Creating group..."}),
@@ -243,6 +239,11 @@ export function set_up_handlers(): void {
         }
     });
 
-    user_group_components.setup_permissions_dropdown("can_manage_group", undefined, true);
+    const $pill_container = $container.find(".can-manage-group-container .pill-container");
+    settings_components.create_group_setting_widget({
+        $pill_container,
+        setting_name: "can_manage_group",
+    });
+
     user_group_components.setup_permissions_dropdown("can_mention_group", undefined, true);
 }

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -117,20 +117,37 @@ function update_group_permission_settings_elements(group) {
     const $permission_dropdown_elements =
         $group_permission_settings.find(".dropdown-widget-button");
 
+    const $permission_pill_container_elements = $group_permission_settings.find(".pill-container");
+
     if (settings_data.can_edit_user_group(group.id)) {
         $permission_dropdown_elements.prop("disabled", false);
+        $permission_pill_container_elements.find(".input").prop("contenteditable", true);
+        $permission_pill_container_elements.removeClass("group_setting_disabled");
 
         $permission_dropdown_elements.each(function () {
             const $dropdown_wrapper = $(this).closest(".dropdown_widget_with_label_wrapper");
             $dropdown_wrapper[0]._tippy?.destroy();
         });
+
+        $permission_pill_container_elements.each(function () {
+            $(this)[0]._tippy?.destroy();
+        });
     } else {
         $permission_dropdown_elements.prop("disabled", true);
+        $permission_pill_container_elements.find(".input").prop("contenteditable", false);
+        $permission_pill_container_elements.addClass("group_setting_disabled");
 
         $permission_dropdown_elements.each(function () {
             const $dropdown_wrapper = $(this).closest(".dropdown_widget_with_label_wrapper");
             settings_components.initialize_disable_btn_hint_popover(
                 $dropdown_wrapper,
+                $t({defaultMessage: "You do not have permission to edit this setting."}),
+            );
+        });
+
+        $permission_pill_container_elements.each(function () {
+            settings_components.initialize_disable_btn_hint_popover(
+                $(this),
                 $t({defaultMessage: "You do not have permission to edit this setting."}),
             );
         });
@@ -150,12 +167,18 @@ function show_membership_settings(group) {
 }
 
 function show_general_settings(group) {
-    user_group_components.setup_permissions_dropdown("can_manage_group", group, false);
     user_group_components.setup_permissions_dropdown("can_mention_group", group, false);
+    const $edit_container = get_edit_container(group);
+    const $pill_container = $edit_container.find(".can-manage-group-container .pill-container");
+    settings_components.create_group_setting_widget({
+        $pill_container,
+        setting_name: "can_manage_group",
+        group,
+    });
     update_general_panel_ui(group);
 
     if (!page_params.development_environment) {
-        $("#can_manage_group_widget_container").hide();
+        $(".can-manage-group-container").hide();
     }
 }
 

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -22,7 +22,10 @@ export function display_pill(group: UserGroup): string {
     const group_members = get_group_members(group);
     return $t_html(
         {defaultMessage: "{group_name}: {group_size, plural, one {# user} other {# users}}"},
-        {group_name: user_groups.get_display_group_name(group), group_size: group_members.length},
+        {
+            group_name: user_groups.get_display_group_name(group.name),
+            group_size: group_members.length,
+        },
     );
 }
 

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,7 +1,11 @@
 import {$t_html} from "./i18n";
 import type {InputPillContainer} from "./input_pill";
 import * as people from "./people";
-import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
+import type {
+    CombinedPill,
+    CombinedPillContainer,
+    GroupSettingPillContainer,
+} from "./typeahead_helper";
 import type {UserGroup} from "./user_groups";
 import * as user_groups from "./user_groups";
 
@@ -75,7 +79,10 @@ function get_group_members(user_group: UserGroup): number[] {
     return user_ids.filter((user_id) => people.is_person_active(user_id));
 }
 
-export function append_user_group(group: UserGroup, pill_widget: CombinedPillContainer): void {
+export function append_user_group(
+    group: UserGroup,
+    pill_widget: CombinedPillContainer | GroupSettingPillContainer,
+): void {
     pill_widget.appendValidatedData({
         type: "user_group",
         group_id: group.id,
@@ -84,22 +91,32 @@ export function append_user_group(group: UserGroup, pill_widget: CombinedPillCon
     pill_widget.clear_text();
 }
 
-export function get_group_ids(pill_widget: CombinedPillContainer): number[] {
+export function get_group_ids(
+    pill_widget: CombinedPillContainer | GroupSettingPillContainer,
+): number[] {
     const items = pill_widget.items();
     return items.flatMap((item) => (item.type === "user_group" ? item.group_id : []));
 }
 
 export function filter_taken_groups(
     items: UserGroup[],
-    pill_widget: CombinedPillContainer,
+    pill_widget: CombinedPillContainer | GroupSettingPillContainer,
 ): UserGroup[] {
     const taken_group_ids = get_group_ids(pill_widget);
     items = items.filter((item) => !taken_group_ids.includes(item.id));
     return items;
 }
 
-export function typeahead_source(pill_widget: CombinedPillContainer): UserGroupPillData[] {
-    const groups = user_groups.get_realm_user_groups();
+export function typeahead_source(
+    pill_widget: CombinedPillContainer | GroupSettingPillContainer,
+    setting_name?: string,
+): UserGroupPillData[] {
+    let groups;
+    if (setting_name !== undefined) {
+        groups = user_groups.get_realm_user_groups_for_setting(setting_name, "group", true);
+    } else {
+        groups = user_groups.get_realm_user_groups();
+    }
     return filter_taken_groups(groups, pill_widget).map((user_group) => ({
         ...user_group,
         type: "user_group",

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -93,7 +93,7 @@ export function toggle_user_group_info_popover(
                 }
                 user_group_popover_instance = instance;
                 const args = {
-                    group_name: user_groups.get_display_group_name(group),
+                    group_name: user_groups.get_display_group_name(group.name),
                     group_description: group.description,
                     members: sort_group_members(
                         fetch_group_members([...user_groups.get_recursive_group_members(group)]),

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -440,7 +440,7 @@ export function get_realm_user_groups_for_dropdown_list_widget(
 
         const display_name = settings_config.system_user_groups_list.find(
             (system_group) => system_group.name === group.name,
-        )!.display_name;
+        )!.dropdown_option_name;
 
         return {
             name: get_display_name_for_system_group_option(setting_name, display_name),
@@ -449,14 +449,14 @@ export function get_realm_user_groups_for_dropdown_list_widget(
     });
 }
 
-// Group name for user-facing display. For settings, we already use
-// description strings for system groups. But those description strings
-// might not be suitable for every case, e.g. we want the name for
-// `role:everyone` to be `Everyone` instead of
-// `Admins, moderators, members and guests` from `settings_config`.
-// Right now, we only change the name for `role:everyone`, that's why
-// we don't store the values in a structured way like
-// `settings_config` yet.
-export function get_display_group_name(user_group: UserGroup): string {
-    return user_group.name === "role:everyone" ? $t({defaultMessage: "Everyone"}) : user_group.name;
+export function get_display_group_name(group_name: string): string {
+    const group = settings_config.system_user_groups_list.find(
+        (system_group) => system_group.name === group_name,
+    );
+
+    if (group === undefined) {
+        return group_name;
+    }
+
+    return group.display_name;
 }

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -13,7 +13,7 @@ import type {
     StateData,
     user_group_schema,
 } from "./state_data";
-import {current_user} from "./state_data";
+import {current_user, realm} from "./state_data";
 import type {UserOrMention} from "./typeahead_helper";
 import type {UserGroupUpdateEvent} from "./types";
 
@@ -342,6 +342,7 @@ function get_display_name_for_system_group_option(setting_name: string, name: st
 export function check_system_user_group_allowed_for_setting(
     group_name: string,
     group_setting_config: GroupPermissionSetting,
+    for_new_settings_ui = false,
 ): boolean {
     const {
         allow_internet_group,
@@ -359,7 +360,7 @@ export function check_system_user_group_allowed_for_setting(
         return false;
     }
 
-    if (!allow_nobody_group && group_name === "role:nobody") {
+    if ((!allow_nobody_group || for_new_settings_ui) && group_name === "role:nobody") {
         return false;
     }
 
@@ -368,6 +369,18 @@ export function check_system_user_group_allowed_for_setting(
     }
 
     if (allowed_system_groups.length && !allowed_system_groups.includes(group_name)) {
+        return false;
+    }
+
+    if (
+        group_name === "role:fullmembers" &&
+        for_new_settings_ui &&
+        realm.realm_waiting_period_threshold === 0
+    ) {
+        // We hide the full members group in the typeahead when
+        // there is no separation between member and full member
+        // users due to organization not having set a waiting
+        // period for member users to become full members.
         return false;
     }
 

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -133,6 +133,14 @@ export function get_realm_user_groups(include_deactivated = false): UserGroup[] 
     });
 }
 
+// This is only used for testing currently, but would be used in
+// future when we use system groups more and probably show them
+// in the UI as well.
+export function get_all_realm_user_groups(): UserGroup[] {
+    const user_groups = [...user_group_by_id_dict.values()].sort((a, b) => a.id - b.id);
+    return user_groups;
+}
+
 export function get_user_groups_allowed_to_mention(): UserGroup[] {
     const user_groups = get_realm_user_groups();
     return user_groups.filter((group) => {
@@ -342,7 +350,7 @@ function get_display_name_for_system_group_option(setting_name: string, name: st
 export function check_system_user_group_allowed_for_setting(
     group_name: string,
     group_setting_config: GroupPermissionSetting,
-    for_new_settings_ui = false,
+    for_new_settings_ui: boolean,
 ): boolean {
     const {
         allow_internet_group,
@@ -390,6 +398,7 @@ export function check_system_user_group_allowed_for_setting(
 export function get_realm_user_groups_for_setting(
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
+    for_new_settings_ui = false,
 ): UserGroup[] {
     const group_setting_config = group_permission_settings.get_group_permission_setting_config(
         setting_name,
@@ -402,7 +411,11 @@ export function get_realm_user_groups_for_setting(
 
     const system_user_groups = settings_config.system_user_groups_list
         .filter((group) =>
-            check_system_user_group_allowed_for_setting(group.name, group_setting_config),
+            check_system_user_group_allowed_for_setting(
+                group.name,
+                group_setting_config,
+                for_new_settings_ui,
+            ),
         )
         .map((group) => {
             const user_group = get_user_group_from_name(group.name);

--- a/web/src/user_pill.ts
+++ b/web/src/user_pill.ts
@@ -7,7 +7,11 @@ import * as input_pill from "./input_pill";
 import type {User} from "./people";
 import * as people from "./people";
 import {realm} from "./state_data";
-import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper";
+import type {
+    CombinedPill,
+    CombinedPillContainer,
+    GroupSettingPillContainer,
+} from "./typeahead_helper";
 import * as user_status from "./user_status";
 
 // This will be used for pills for things like composing
@@ -98,7 +102,7 @@ export function get_email_from_item(item: UserPill): string {
 
 export function append_person(opts: {
     person: User;
-    pill_widget: UserPillWidget | CombinedPillContainer;
+    pill_widget: UserPillWidget | CombinedPillContainer | GroupSettingPillContainer;
 }): void {
     const person = opts.person;
     const pill_widget = opts.pill_widget;
@@ -119,7 +123,9 @@ export function append_person(opts: {
     pill_widget.clear_text();
 }
 
-export function get_user_ids(pill_widget: UserPillWidget | CombinedPillContainer): number[] {
+export function get_user_ids(
+    pill_widget: UserPillWidget | CombinedPillContainer | GroupSettingPillContainer,
+): number[] {
     const items = pill_widget.items();
     return items.flatMap((item) => (item.type === "user" ? (item.user_id ?? []) : [])); // be defensive about undefined users
 }
@@ -138,7 +144,7 @@ export function has_unconverted_data(pill_widget: UserPillWidget): boolean {
 }
 
 export function typeahead_source(
-    pill_widget: UserPillWidget | CombinedPillContainer,
+    pill_widget: UserPillWidget | CombinedPillContainer | GroupSettingPillContainer,
     exclude_bots?: boolean,
 ): UserPillData[] {
     const users = exclude_bots ? people.get_realm_active_human_users() : people.get_realm_users();
@@ -147,14 +153,17 @@ export function typeahead_source(
 
 export function filter_taken_users(
     items: User[],
-    pill_widget: UserPillWidget | CombinedPillContainer,
+    pill_widget: UserPillWidget | CombinedPillContainer | GroupSettingPillContainer,
 ): User[] {
     const taken_user_ids = get_user_ids(pill_widget);
     items = items.filter((item) => !taken_user_ids.includes(item.user_id));
     return items;
 }
 
-export function append_user(user: User, pills: UserPillWidget | CombinedPillContainer): void {
+export function append_user(
+    user: User,
+    pills: UserPillWidget | CombinedPillContainer | GroupSettingPillContainer,
+): void {
     if (user) {
         append_person({
             pill_widget: pills,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -688,6 +688,16 @@ h4.user_group_setting_subsection_title {
     }
 }
 
+.group_setting_disabled.pill-container {
+    cursor: not-allowed;
+
+    .pill {
+        .exit {
+            display: none;
+        }
+    }
+}
+
 #groups_overlay,
 #subscription_overlay {
     .tab-switcher {
@@ -1071,6 +1081,22 @@ div.settings-radio-input-parent {
 
         .inline {
             display: inline;
+        }
+    }
+
+    .pill-container {
+        /* 319px + 2 * (2px padding) + 2 * (1px border) = 325px, which is the total
+        width of dropdown widget buttons */
+        min-width: 319px;
+        background-color: hsl(0deg 0% 100%);
+
+        .input {
+            flex-grow: 1;
+
+            &:first-child:empty::before {
+                opacity: 0.5;
+                content: attr(data-placeholder);
+            }
         }
     }
 }

--- a/web/templates/user_group_settings/group_permissions.hbs
+++ b/web/templates/user_group_settings/group_permissions.hbs
@@ -3,7 +3,12 @@
   label=(t 'Who can mention this group?')
   value_type="number"}}
 
-{{> ../dropdown_widget_with_label
-  widget_name=can_manage_group_widget_name
-  label=(t 'Who can manage this group?')
-  value_type="number"}}
+<div class="input-group can-manage-group-container">
+    <label>{{t "Who can manage this group" }}</label>
+    <div class="pill-container person_picker prop-element" id="id_{{can_manage_group_widget_name}}" data-setting-widget-type="group-setting-type">
+        <div class="input" contenteditable="true"
+          data-placeholder="{{t 'Add roles, groups or users' }}">
+            {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
+        </div>
+    </div>
+</div>

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1166,7 +1166,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 assert.equal(matcher(make_emoji(emoji_tada)), true);
                 assert.equal(matcher(make_emoji(emoji_moneybag)), false);
 
-                matcher = ct.get_stream_or_user_group_matcher("swed");
+                matcher = ct.get_stream_matcher("swed");
                 assert.equal(matcher(sweden_stream), true);
                 assert.equal(matcher(denmark_stream), false);
 
@@ -2022,7 +2022,7 @@ test("typeahead_results", () => {
         assert.deepEqual(returned, expected);
     }
     function assert_stream_matches(input, expected) {
-        const matcher = ct.get_stream_or_user_group_matcher(input);
+        const matcher = ct.get_stream_matcher(input);
         const returned = stream_list.filter((item) => matcher(item));
         assert.deepEqual(returned, expected);
     }

--- a/web/tests/user_groups.test.js
+++ b/web/tests/user_groups.test.js
@@ -528,7 +528,7 @@ run_test("get_realm_user_groups_for_dropdown_list_widget", () => {
 
 run_test("get_display_group_name", () => {
     const admins = {
-        name: "Admins",
+        name: "role:administrators",
         description: "foo",
         id: 1,
         members: new Set([1]),
@@ -542,7 +542,19 @@ run_test("get_display_group_name", () => {
         is_system_group: false,
         direct_subgroup_ids: new Set([1]),
     };
+    const students = {
+        name: "Students",
+        id: 3,
+        members: new Set([1, 3]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([]),
+    };
 
-    assert.equal(user_groups.get_display_group_name(admins), "Admins");
-    assert.equal(user_groups.get_display_group_name(all), "translated: Everyone");
+    user_groups.initialize({
+        realm_user_groups: [admins, all, students],
+    });
+
+    assert.equal(user_groups.get_display_group_name(admins.name), "translated: Administrators");
+    assert.equal(user_groups.get_display_group_name(all.name), "translated: Everyone");
+    assert.equal(user_groups.get_display_group_name(students.name), "Students");
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First three commits are prep commits with one of them adding a new function to check permission when a setting is set to anonymous group and the other two being code refactors.
- Fourth commit is to add a new module to handle pills for group setting.
- Fifth commit is to not show `role:` for system groups.
- Sixth commit is to add code for typeahead shown for group settings.
- Last commit is to use the pills UI for `can_manage_group` setting.

Part of #28808.
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![groups-ui-create](https://github.com/user-attachments/assets/c5f06895-6209-4743-9745-6f74127f97ca)
![groups-ui-update](https://github.com/user-attachments/assets/a32800ab-24a2-4d4d-a0ec-bd76843bbd82)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
