### PR TITLE
biling: Avoid slow jQuery `:selected` selector extension

### DIFF
--- a/web/src/billing/sponsorship.ts
+++ b/web/src/billing/sponsorship.ts
@@ -2,6 +2,8 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
+import {the} from "../util";
+
 import * as helpers from "./helpers";
 
 const is_remotely_hosted = $("#sponsorship-form").attr("data-is-remotely-hosted") === "True";
@@ -93,9 +95,8 @@ export function initialize(): void {
 
     function update_discount_details(): void {
         const selected_org_type =
-            $<HTMLSelectElement>("select#organization-type")
-                .find(":selected")
-                .attr("data-string-value") ?? "";
+            the($<HTMLSelectElement>("select#organization-type")).selectedOptions[0]?.dataset
+                .stringValue ?? "";
         helpers.update_discount_details(selected_org_type, is_remotely_hosted);
     }
 

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -437,7 +437,10 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         });
 
         if (!user_has_email_set) {
-            $("#invite-user-form :input").prop("disabled", !user_has_email_set);
+            $(util.the($<HTMLFormElement>("form#invite-user-form")).elements).prop(
+                "disabled",
+                true,
+            );
         }
 
         const invite_tips_data = generate_invite_tips_data();

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -307,13 +307,12 @@ $(() => {
         $(e.target).hide();
     });
 
-    $("#how-realm-creator-found-zulip select").on("change", function () {
-        const elements: Record<string, string> = {
-            Other: "how-realm-creator-found-zulip-other",
-            Advertisement: "how-realm-creator-found-zulip-where-ad",
-            "At an organization that's using it":
-                "how-realm-creator-found-zulip-which-organization",
-        };
+    $<HTMLSelectElement>("#how-realm-creator-found-zulip select").on("change", function () {
+        const elements = new Map([
+            ["other", "how-realm-creator-found-zulip-other"],
+            ["ad", "how-realm-creator-found-zulip-where-ad"],
+            ["existing_user", "how-realm-creator-found-zulip-which-organization"],
+        ]);
 
         const hideElement = (element: string): void => {
             const $element = $(`#${element}`);
@@ -329,16 +328,15 @@ $(() => {
         };
 
         // Reset state
-        for (const element of Object.values(elements)) {
+        for (const element of elements.values()) {
             if (element) {
                 hideElement(element);
             }
         }
 
         // Show the additional input box if needed.
-        const selected_option = $("option:selected", this).text();
-        const selected_element = elements[selected_option];
-        if (selected_element) {
+        const selected_element = elements.get(this.value);
+        if (selected_element !== undefined) {
             showElement(selected_element);
         }
     });


### PR DESCRIPTION
[`:selected`](https://api.jquery.com/selected-selector/) is one of several [jQuery-specific selector extensions](https://github.com/wikimedia/eslint-plugin-no-jquery/blob/HEAD/docs/rules/no-sizzle.md) that force jQuery away from the native `document.querySelector` fast path onto the Sizzle slow path, and also present an extra obstacle to migrating away from jQuery. Replace `:selected` by simply using [`.val()`](https://api.jquery.com/val/)/[`.value`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/value) or [`.selectedOptions`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedOptions) on the `<select>` control.

Similarly, replace [`:input`](https://api.jquery.com/input-selector/) with [`HTMLFormElement.elements`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements).

Cc @amanagr (#27673, #28939)

- Followup to #25389.
