### PR TITLE
prep commits (part 2) for converting message_list_view to typescript

### DIFF
--- a/web/src/compose_fade.ts
+++ b/web/src/compose_fade.ts
@@ -14,7 +14,7 @@ import type {AllVisibilityPolicies} from "./user_topics";
 import * as util from "./util";
 
 // TODO/TypeScript: Move this to message_list_view.js when it's migrated to TypeScript.
-type MessageContainer = {
+export type MessageContainer = {
     background_color: string;
     date_divider_html?: string;
     edited_alongside_sender: boolean;

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -427,7 +427,7 @@ export class MessageListView {
         return undefined;
     }
 
-    _add_msg_edited_vars(message_container) {
+    _get_message_edited_vars(message) {
         // This function computes data on whether the message was edited
         // and in what ways, as well as where the "EDITED" or "MOVED"
         // label should be located, and adds it to the message_container
@@ -438,8 +438,8 @@ export class MessageListView {
         //   * `edited_in_left_col`      -- when label appears in left column.
         //   * `edited_alongside_sender` -- when label appears alongside sender info.
         //   * `edited_status_msg`       -- when label appears for a "/me" message.
-        const last_edit_timestr = this._get_msg_timestring(message_container.msg);
-        const edit_history_details = analyze_edit_history(message_container.msg, last_edit_timestr);
+        const last_edit_timestr = this._get_msg_timestring(message);
+        const edit_history_details = analyze_edit_history(message, last_edit_timestr);
 
         if (
             last_edit_timestr === undefined ||
@@ -450,16 +450,19 @@ export class MessageListView {
             // notice at all. (The message actions popover will still
             // display an edit history option, so you can see when it
             // was marked as resolved if you need to).
-            delete message_container.last_edit_timestr;
-            message_container.edited_in_left_col = false;
-            message_container.edited_alongside_sender = false;
-            message_container.edited_status_msg = false;
-            return;
+            return {
+                last_edit_timestr: undefined,
+                edited_in_left_col: false,
+                edited_alongside_sender: false,
+                edited_status_msg: false,
+            };
         }
 
-        message_container.last_edit_timestr = last_edit_timestr;
-        message_container.moved = edit_history_details.moved && !edit_history_details.edited;
-        message_container.modified = true;
+        return {
+            last_edit_timestr,
+            moved: edit_history_details.moved && !edit_history_details.edited,
+            modified: true,
+        };
     }
 
     is_current_message_list() {
@@ -548,9 +551,8 @@ export class MessageListView {
         Object.assign(
             message_container,
             this._maybe_get_me_message(message_container.is_hidden, message_container.msg),
+            this._get_message_edited_vars(message_container.msg),
         );
-        // Once all other variables are updated
-        this._add_msg_edited_vars(message_container);
     }
 
     maybe_add_subscription_marker(group, last_msg_container, first_msg_container) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -174,26 +174,31 @@ function get_timestr(message) {
     return timerender.stringify_time(time);
 }
 
-function set_topic_edit_properties(group, message) {
-    group.always_visible_topic_edit = false;
-    group.on_hover_topic_edit = false;
+function get_topic_edit_properties(message) {
+    let always_visible_topic_edit = false;
+    let on_hover_topic_edit = false;
 
     const is_topic_editable = message_edit.is_topic_editable(message);
 
     // if a user who can edit a topic, can resolve it as well
-    group.user_can_resolve_topic = is_topic_editable;
+    const user_can_resolve_topic = is_topic_editable;
 
-    if (!is_topic_editable) {
-        return;
+    if (is_topic_editable) {
+        // Messages with no topics should always have an edit icon visible
+        // to encourage updating them. Admins can also edit any topic.
+        if (message.topic === compose_state.empty_topic_placeholder()) {
+            always_visible_topic_edit = true;
+        } else {
+            on_hover_topic_edit = true;
+        }
     }
 
-    // Messages with no topics should always have an edit icon visible
-    // to encourage updating them. Admins can also edit any topic.
-    if (message.topic === compose_state.empty_topic_placeholder()) {
-        group.always_visible_topic_edit = true;
-    } else {
-        group.on_hover_topic_edit = true;
-    }
+    return {
+        always_visible_topic_edit,
+        on_hover_topic_edit,
+        is_topic_editable,
+        user_can_resolve_topic,
+    };
 }
 
 function get_users_for_recipient_row(message) {
@@ -325,7 +330,7 @@ function populate_group_from_message_container(group, message_container) {
     group.display_recipient = message_container.msg.display_recipient;
     group.topic_links = message_container.msg.topic_links;
 
-    set_topic_edit_properties(group, message_container.msg);
+    Object.assign(group, get_topic_edit_properties(message_container.msg));
     group.date = get_group_display_date(message_container.msg);
 }
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -124,10 +124,10 @@ function get_group_display_date(message) {
     return date_element.outerHTML;
 }
 
-function update_group_date(group, message_container, prev) {
+function update_group_date(group, message, prev) {
     // Mark whether we should display a date marker because this
     // message has a different date than the previous one.
-    group.date_unchanged = same_day(message_container?.msg, prev?.msg);
+    group.date_unchanged = same_day(message, prev);
 }
 
 function clear_group_date(group) {
@@ -630,7 +630,7 @@ export class MessageListView {
                 current_group = start_group();
                 add_message_container_to_group(message_container);
 
-                update_group_date(current_group, message_container, prev);
+                update_group_date(current_group, message_container.msg, prev?.msg);
                 message_container.want_date_divider = false;
                 message_container.date_divider_html = undefined;
 
@@ -783,7 +783,7 @@ export class MessageListView {
                 )
             ) {
                 // The groups did not merge, so we need up update the date row for the old group
-                update_group_date(second_group, curr_msg_container, prev_msg_container);
+                update_group_date(second_group, curr_msg_container.msg, prev_msg_container?.msg);
                 // We could add an action to update the date row, but for now rerender the group.
                 message_actions.rerender_groups.push(second_group);
             }
@@ -800,7 +800,11 @@ export class MessageListView {
                 } else {
                     // If we just sent the first message on a new day
                     // in a narrow, make sure we render a date.
-                    update_group_date(second_group, curr_msg_container, prev_msg_container);
+                    update_group_date(
+                        second_group,
+                        curr_msg_container.msg,
+                        prev_msg_container?.msg,
+                    );
                 }
             }
             message_actions.append_groups = new_message_groups;

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -930,10 +930,20 @@ export class MessageListView {
         const include_sender = message_container.include_sender;
         const is_hidden = message_container.is_hidden;
         const status_message = Boolean(message_container.status_message);
-        message_container.message_edit_notices_in_left_col = !include_sender && !is_hidden;
-        message_container.message_edit_notices_alongside_sender = include_sender && !status_message;
-        message_container.message_edit_notices_for_status_message =
-            include_sender && status_message;
+        Object.assign(
+            message_container,
+            this.get_edited_notice_locations(include_sender, is_hidden, status_message),
+        );
+    }
+
+    get_edited_notice_locations(include_sender, is_hidden, status_message) {
+        // Based on the variables that define the overall message's HTML layout, set
+        // variables defining where the message-edited notices should be placed.
+        return {
+            message_edit_notices_in_left_col: !include_sender && !is_hidden,
+            message_edit_notices_alongside_sender: include_sender && !status_message,
+            message_edit_notices_for_status_message: include_sender && status_message,
+        };
     }
 
     render(messages, where, messages_are_new) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -55,7 +55,7 @@ function same_sender(a, b) {
     if (a === undefined || b === undefined) {
         return false;
     }
-    return util.same_sender(a.msg, b.msg);
+    return a.msg.sender_id === b.msg.sender_id;
 }
 
 function same_recipient(a, b) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -119,7 +119,7 @@ function analyze_edit_history(message, last_edit_timestr) {
 
 function get_group_display_date(message) {
     const time = new Date(message.timestamp * 1000);
-    const date_element = util.the(timerender.render_date(time));
+    const date_element = timerender.render_date(time);
 
     return date_element.outerHTML;
 }
@@ -165,7 +165,7 @@ function get_message_date_divider_data(opts) {
 
     return {
         want_date_divider: true,
-        date_divider_html: util.the(timerender.render_date(curr_time)).outerHTML,
+        date_divider_html: timerender.render_date(curr_time).outerHTML,
     };
 }
 
@@ -404,7 +404,7 @@ export class MessageListView {
         }
         if (last_edit_timestamp !== undefined) {
             const last_edit_time = new Date(last_edit_timestamp * 1000);
-            let date = util.the(timerender.render_date(last_edit_time)).textContent;
+            let date = timerender.render_date(last_edit_time).textContent;
             // If the date is today or yesterday, we don't want to show the date as capitalized.
             // Thus, we need to check if the date string contains a digit or not using regex,
             // since any other date except today/yesterday will contain a digit.
@@ -1832,7 +1832,7 @@ export class MessageListView {
         }
         this.sticky_recipient_message_id = message.id;
         const time = new Date(message.timestamp * 1000);
-        const rendered_date = util.the(timerender.render_date(time));
+        const rendered_date = timerender.render_date(time);
         dom_updates.html_updates.push({
             $element: $sticky_header.find(".recipient_row_date"),
             rendered_date,

--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -1,17 +1,10 @@
 import $ from "jquery";
 
+import type {MessageContainer} from "./compose_fade";
 import * as inbox_util from "./inbox_util";
 import type {MessageListData} from "./message_list_data";
 import type {Message} from "./message_store";
 import * as ui_util from "./ui_util";
-
-// TODO(typescript): Move this to message_list_view when it's
-// converted to TypeScript.
-export type MessageContainer = {
-    msg: Message;
-    is_hidden: boolean;
-    url: string;
-};
 
 // TODO(typescript): Move this to message_list_view when it's
 // converted to typescript.

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -14,6 +14,7 @@ import {$t} from "./i18n";
 import {difference_in_calendar_days, get_offset, start_of_day} from "./time_zone_util";
 import {parse_html} from "./ui_util";
 import {user_settings} from "./user_settings";
+import * as util from "./util";
 
 let next_timerender_id = 0;
 
@@ -353,7 +354,7 @@ function render_date_span($elem: JQuery, rendered_time: TimeRender): JQuery {
 // (What's actually spliced into the message template is the contents
 // of this DOM node as HTML, so effectively a copy of the node. That's
 // okay since to update the time later we look up the node by its id.)
-export function render_date(time: Date): JQuery {
+export function render_date(time: Date): HTMLElement {
     const className = `timerender${next_timerender_id}`;
     next_timerender_id += 1;
     const rendered_time = render_now(time);
@@ -364,7 +365,7 @@ export function render_date(time: Date): JQuery {
         className,
         time,
     });
-    return $node;
+    return util.the($node);
 }
 
 // Renders the timestamp returned by the <time:> Markdown syntax.

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -93,17 +93,6 @@ export const same_recipient = function util_same_recipient(a?: Recipient, b?: Re
     return false;
 };
 
-export const same_sender = function util_same_sender(
-    a: RawMessage | undefined,
-    b: RawMessage | undefined,
-): boolean {
-    return (
-        a !== undefined &&
-        b !== undefined &&
-        a.sender_email.toLowerCase() === b.sender_email.toLowerCase()
-    );
-};
-
 export function normalize_recipients(recipients: string): string {
     // Converts a string listing emails of message recipients
     // into a canonical formatting: emails sorted ASCIIbetically

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -13,7 +13,7 @@ set_global("document", "document-stub");
 // timerender calls setInterval when imported
 mock_esm("../src/timerender", {
     render_date(time) {
-        return [{outerHTML: String(time.getTime())}];
+        return {outerHTML: String(time.getTime())};
     },
     stringify_time(time) {
         return time.toString("h:mm TT");

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -171,8 +171,8 @@ test("msg_moved_var", () => {
             Object.assign(
                 message_container,
                 list._maybe_get_me_message(message_container.is_hidden, message_container.msg),
+                list._get_message_edited_vars(message_container.msg),
             );
-            list._add_msg_edited_vars(message_container);
         }
 
         const result = list._message_groups[0].message_containers;
@@ -200,7 +200,7 @@ test("msg_moved_var", () => {
     })();
 });
 
-test("msg_edited_vars", () => {
+test("message_edited_vars", () => {
     // This is a test to verify that only one of the three bools,
     // `message_edit_notices_in_left_col`, `message_edit_notices_alongside_sender`,
     // `message_edit_notices_for_status_message` is not false; Tests for three
@@ -270,7 +270,7 @@ test("msg_edited_vars", () => {
             include_sender && status_message;
     }
 
-    (function test_msg_edited_vars() {
+    (function test_message_edited_vars() {
         const messages = [
             build_message_context(),
             build_message_context({}, {include_sender: false}),
@@ -283,8 +283,8 @@ test("msg_edited_vars", () => {
             Object.assign(
                 message_container,
                 list._maybe_get_me_message(message_container.is_hidden, message_container.msg),
+                list._get_message_edited_vars(message_container.msg),
             );
-            list._add_msg_edited_vars(message_container);
         }
 
         const result = list._message_groups[0].message_containers;
@@ -361,7 +361,7 @@ test("muted_message_vars", () => {
         ];
         const message_group = build_message_group(messages);
         const list = build_list([message_group]);
-        list._add_msg_edited_vars = noop;
+        list._get_message_edited_vars = noop;
 
         // Sender is not muted.
         let result = calculate_variables(list, messages);

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -330,10 +330,17 @@ test("muted_message_vars", () => {
         return list;
     }
 
-    function calculate_variables(list, messages, is_revealed) {
-        list.set_calculated_message_container_variables(messages[0], is_revealed);
-        list.set_calculated_message_container_variables(messages[1], is_revealed);
-        list.set_calculated_message_container_variables(messages[2], is_revealed);
+    function calculate_variables(list, message_containers, is_revealed) {
+        for (const container of message_containers) {
+            Object.assign(
+                container,
+                list.get_calculated_message_container_variables(
+                    container.msg,
+                    container.include_sender,
+                    is_revealed,
+                ),
+            );
+        }
         return list._message_groups[0].message_containers;
     }
 

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -360,8 +360,14 @@ run_test("render_date_renders_time_html", () => {
         return $span_stub;
     };
 
-    const $actual = timerender.render_date(message_time);
-    assert.equal($actual.text(), expected_text);
+    let actual_text;
+    $span_stub.text = (val) => {
+        actual_text = val;
+        return $span_stub;
+    };
+
+    timerender.render_date(message_time);
+    assert.equal(actual_text, expected_text);
     assert.equal(attrs["data-tippy-content"], "Friday, April 12, 2019");
     assert.equal(attrs.class, "timerender-content timerender0");
 


### PR DESCRIPTION
This is a collection of various changes required for cleanly converting message_list_view. Part 1 (merged) was #31448. A draft for the full conversion (unfinished) can be found at https://github.com/evykassirer/zulip/pull/10