### PR TITLE
custom_emails: Add unsubscribe link in the footer & include mange_preferences block content in the plaintext version.

### DIFF
--- a/templates/zerver/emails/custom_email_base.pre.html
+++ b/templates/zerver/emails/custom_email_base.pre.html
@@ -14,6 +14,7 @@
 {% block manage_preferences %}
     {% if remote_server_email %}
     <p>You are receiving this email to update you about important changes to Zulip's Terms of Service.</p>
+    <a href="{{ unsubscribe_link }}">Unsubscribe</a>
     {% elif unsubscribe_link %}
     <p><a href="{{ realm_url }}/#settings/notifications">{{ _("Manage email preferences") }}</a> | <a href="{{ unsubscribe_link }}">{{ _("Unsubscribe from marketing emails") }}</a></p>
     {% endif %}

--- a/templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+++ b/templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
@@ -1,0 +1,15 @@
+
+---
+{% if remote_server_email %}
+You are receiving this email to update you about important changes to Zulip's Terms of Service.
+
+Unsubscribe: {{ unsubscribe_link }}
+{% elif unsubscribe_link %}
+{{ _("Manage email preferences") }}:
+
+{{ realm_url }}/#settings/notifications
+
+{{ _("Unsubscribe from marketing emails") }}:
+
+{{ unsubscribe_link }}
+{% endif %}

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -560,6 +560,16 @@ def custom_email_sender(
         #     vary user-to-user
         f.write(base_template.read().replace("{{ rendered_input }}", rendered_input))
 
+    # Add the manage_preferences block content in the plain_text template.
+    manage_preferences_block_template_path = (
+        "templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt"
+    )
+    with (
+        open(plain_text_template_path, "a") as f,
+        open(manage_preferences_block_template_path) as manage_preferences_block,
+    ):
+        f.write(manage_preferences_block.read())
+
     with open(subject_path, "w") as f:
         f.write(get_header(subject, parsed_email_template.get("subject"), "subject"))
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -90,6 +90,11 @@ class TestCustomEmails(ZulipTestCase):
             str(msg.alternatives[0][0]),
         )
         self.assertIn("Unsubscribe", str(msg.alternatives[0][0]))
+        # Verify that the Text version contains the footer.
+        self.assertIn(
+            "You are receiving this email to update you about important changes to Zulip", msg.body
+        )
+        self.assertIn("Unsubscribe", msg.body)
 
     def test_send_custom_email_headers(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -107,7 +112,7 @@ class TestCustomEmails(ZulipTestCase):
         msg = mail.outbox[0]
         self.assertEqual(msg.subject, "Test subject")
         self.assertFalse(msg.reply_to)
-        self.assertEqual("Test body", msg.body)
+        self.assertIn("Test body", msg.body)
 
     def test_send_custom_email_context(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -89,6 +89,7 @@ class TestCustomEmails(ZulipTestCase):
             "You are receiving this email to update you about important changes to Zulip",
             str(msg.alternatives[0][0]),
         )
+        self.assertIn("Unsubscribe", str(msg.alternatives[0][0]))
 
     def test_send_custom_email_headers(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
* First commit - remote_server_email: Add 'unsubscribe link' in the mail footer.

  <details><summary>See Footer (Before)</summary>
  <img src="https://github.com/user-attachments/assets/d82f8d1c-bdc2-4989-8d31-aec2cea4d8e5">
  </img>
  </details> 

  <details><summary>See Footer (After)</summary>
  <img width="791" alt="Screenshot 2024-09-06 at 1 21 47 PM" src="https://github.com/user-attachments/assets/fb14db52-033e-4190-a0ae-13dfc1097b26">

  </details> 

* Second commit - custom_email: Add manage_preferences block content to the plaintext version.

  <details><summary>Text only version (Before)</summary>
  <img width="812" alt="Screenshot 2024-09-05 at 4 07 28 PM" src="https://github.com/user-attachments/assets/896352b1-cc7b-4c0d-a197-bbe3c5468eb0">
  </details> 

  <details><summary>Text only version (After)</summary>
  <img width="806" alt="Screenshot 2024-09-06 at 1 21 59 PM" src="https://github.com/user-attachments/assets/58987b4e-1fed-4237-ad58-f29bfa9ea5b6">
  </details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
