### PR TITLE
Display current year in header on year change.

### DIFF
--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -175,7 +175,7 @@ export type TimeRender = {
     needs_update: boolean;
 };
 
-export function render_now(time: Date, today = new Date()): TimeRender {
+export function render_now(time: Date, today = new Date(), display_year?: boolean): TimeRender {
     let time_str = "";
     let needs_update = false;
     // render formal time to be used for tippy tooltip
@@ -194,7 +194,7 @@ export function render_now(time: Date, today = new Date()): TimeRender {
     } else if (days_old === 1) {
         time_str = $t({defaultMessage: "Yesterday"});
         needs_update = true;
-    } else if (time.getFullYear() !== today.getFullYear()) {
+    } else if (time.getFullYear() !== today.getFullYear() || display_year) {
         // For long running servers, searching backlog can get ambiguous
         // without a year stamp. Only show year if message is from an older year
         time_str = get_localized_date_or_time_for_format(time, "dayofyear_year");
@@ -354,10 +354,11 @@ function render_date_span($elem: JQuery, rendered_time: TimeRender): JQuery {
 // (What's actually spliced into the message template is the contents
 // of this DOM node as HTML, so effectively a copy of the node. That's
 // okay since to update the time later we look up the node by its id.)
-export function render_date(time: Date): HTMLElement {
+export function render_date(time: Date, display_year?: boolean): HTMLElement {
     const className = `timerender${next_timerender_id}`;
     next_timerender_id += 1;
-    const rendered_time = render_now(time);
+    const today = new Date();
+    const rendered_time = render_now(time, today, display_year);
     let $node = $("<span>").attr("class", `timerender-content ${className}`);
     $node = render_date_span($node, rendered_time);
     maybe_add_update_list_entry({


### PR DESCRIPTION
Earlier messages would not display year if it were from current year. This would lead to confusion when the date in a date divider is in a different year from the date in the message header bar above it.

This PR adds

- Show the year in date dividers if it's different from the year of the previous date displayed.
- Show the year in message header bars if it's different from the year of the previous date displayed.

Fixes: zulip#26673.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2024-09-04 02-17-35](https://github.com/user-attachments/assets/d550a8f1-822b-46f7-b301-43f0ef5ef9e8)

[Screencast from 08-09-24 03:03:01 AM IST.webm](https://github.com/user-attachments/assets/5cbd3d2d-287c-444e-8fbe-29f6240ccb78)

[Screencast from 08-09-24 03:04:05 AM IST.webm](https://github.com/user-attachments/assets/2a1da74c-462f-4b8c-b949-21a51e48c9cc)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
