### PR TITLE
thumbnail: Fix corrupted email notifications due to HTML5 entities

### DIFF
--- a/zerver/tests/test_markdown_thumbnail.py
+++ b/zerver/tests/test_markdown_thumbnail.py
@@ -150,8 +150,8 @@ class MarkdownThumbnailTest(ZulipTestCase):
             self.assertTrue(ImageAttachment.objects.filter(path_id=path_id).exists())
         message_id = self.send_message_content(f"[I am 95% ± 5% certain!](/user_uploads/{path_id})")
         expected = (
-            f'<p><a href="/user_uploads/{path_id}">I am 95% &plusmn; 5% certain!</a></p>\n'
-            f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="I am 95% &plusmn; 5% certain!">'
+            f'<p><a href="/user_uploads/{path_id}">I am 95% ± 5% certain!</a></p>\n'
+            f'<div class="message_inline_image"><a href="/user_uploads/{path_id}" title="I am 95% ± 5% certain!">'
             f'<img data-original-dimensions="128x128" src="/user_uploads/thumbnail/{path_id}/840x560.webp"></a></div>'
         )
         self.assert_message_content_is(message_id, expected)


### PR DESCRIPTION
BeautifulSoup with `formatter="html5"` unnecessarily escapes many characters with HTML5-specific entities that cannot be correctly parsed by lxml during generation of email notifications.

[Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/HTML.20entities.20in.20email.20notifications/near/1936525).

Cc @alexmv (#30477)