### PR TITLE
message_events: Fix live update for views based on message property.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -1,7 +1,10 @@
 import $ from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as alert_words from "./alert_words";
+import {all_messages_data} from "./all_messages_data";
+import * as channel from "./channel";
 import * as compose_fade from "./compose_fade";
 import * as compose_notifications from "./compose_notifications";
 import * as compose_recipient from "./compose_recipient";
@@ -16,6 +19,7 @@ import * as message_helper from "./message_helper";
 import * as message_list_data_cache from "./message_list_data_cache";
 import * as message_lists from "./message_lists";
 import * as message_notifications from "./message_notifications";
+import * as message_parser from "./message_parser";
 import * as message_store from "./message_store";
 import * as message_util from "./message_util";
 import * as message_view from "./message_view";
@@ -34,6 +38,137 @@ import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
+
+export function update_views_filtered_on_message_property(
+    message_ids,
+    property_term_type,
+    property_value,
+) {
+    // NOTE: Call this function after updating the message property locally.
+    assert(!property_term_type.includes("not-"));
+
+    // List of narrow terms whose msg list doesn't get updated elsewhere but
+    // can be applied locally.
+    const supported_term_types = [
+        "has-image",
+        "has-link",
+        "has-reaction",
+        "has-attachment",
+        "is-starred",
+        "is-unread",
+        "is-mentioned",
+        "is-alerted",
+        // TODO: Implement support for these terms.
+        // "is-followed",
+    ];
+
+    if (message_ids.length === 0 || !supported_term_types.includes(property_term_type)) {
+        return;
+    }
+
+    for (const msg_list of message_lists.all_rendered_message_lists()) {
+        const filter = msg_list.data.filter;
+        const filter_term_types = filter.sorted_term_types();
+        if (
+            // Check if current filter relies on the changed message property.
+            !filter_term_types.includes(property_term_type) &&
+            !filter_term_types.includes(`not-${property_term_type}`)
+        ) {
+            continue;
+        }
+
+        // We need the message objects to determine if they match the filter.
+        const messages_to_fetch = [];
+        const messages = [];
+        for (const message_id of message_ids) {
+            const message = message_store.get(message_id);
+            if (message !== undefined) {
+                messages.push(message);
+            } else {
+                if (
+                    (filter_term_types.includes(property_term_type) && !property_value) ||
+                    (filter_term_types.includes(`not-${property_term_type}`) && property_value)
+                ) {
+                    // If the message is not cached, that means it is not present in the message list.
+                    // Also, the message is not supposed to be in the message list as per the filter and
+                    // it's property value. So, we don't need to fetch the message.
+                    continue;
+                }
+
+                const first_id = msg_list.first().id;
+                const last_id = msg_list.last().id;
+                const has_found_newest = msg_list.data.fetch_status.has_found_newest();
+                const has_found_oldest = msg_list.data.fetch_status.has_found_oldest();
+
+                if (message_id > first_id && message_id < last_id) {
+                    // Need to insert message middle of the list.
+                    messages_to_fetch.push(message_id);
+                } else if (message_id < first_id && has_found_oldest) {
+                    // Need to insert message at the start of list.
+                    messages_to_fetch.push(message_id);
+                } else if (message_id > last_id && has_found_newest) {
+                    // Need to insert message at the end of list.
+                    messages_to_fetch.push(message_id);
+                }
+            }
+        }
+
+        // In most cases, we will only have one message to fetch which
+        // can happen without rerendering the view.
+        // In case of multiple messages, we just rerender the view
+        // since it is likely to use similar amount of resources to
+        // fetching the messages and rerendering the view.
+        if (messages_to_fetch.length > 1 || !filter.can_apply_locally()) {
+            // TODO: Might be better to check if `/messages/matches_narrow`
+            // rather than doing a full rerender.
+            message_view.show(filter.terms(), {
+                then_select_id: msg_list.selected_id(),
+                then_select_offset: msg_list.selected_row().get_offset_to_window().top,
+                trigger: "message property update",
+                force_rerender: true,
+            });
+        } else if (messages_to_fetch.length === 1) {
+            // Fetch the message and update the view.
+            channel.get({
+                url: "/json/messages/" + messages_to_fetch[0],
+                success(data) {
+                    message_helper.process_new_message(data.message);
+                    update_views_filtered_on_message_property(message_ids, property_term_type);
+                },
+            });
+        } else {
+            // We have all the messages locally, so we can update the view.
+            //
+            // Special case: For starred messages view, we don't remove
+            // messages that are no longer starred to avoid
+            // implementing an undo mechanism for that view.
+            // TODO: A cleaner way to implement this might be to track which things
+            // have been unstarred in the starred messages view in this visit
+            // to the view, and have those stay.
+            if (
+                property_term_type === "is-starred" &&
+                _.isEqual(filter.sorted_term_types(), ["is-starred"])
+            ) {
+                msg_list.add_messages(messages);
+                continue;
+            }
+
+            // In most cases, we are only working to update a single message.
+            if (messages.length === 1) {
+                const message = messages[0];
+                if (filter.predicate()(message)) {
+                    msg_list.add_messages(messages);
+                } else {
+                    msg_list.remove_and_rerender(message_ids);
+                }
+            } else {
+                msg_list.data.remove(message_ids);
+                msg_list.data.add_messages(messages);
+                msg_list.rerender();
+            }
+        }
+    }
+}
 
 export function insert_new_messages(messages, sent_by_this_client, deliver_locally) {
     messages = messages.map((message) => message_helper.process_new_message(message));
@@ -516,6 +651,39 @@ export function update_messages(events) {
             anchor_message.id === Number.parseInt($("#message-history").attr("data-message-id"), 10)
         ) {
             message_edit_history.fetch_and_render_message_history(anchor_message);
+        }
+
+        if (event.rendered_content !== undefined) {
+            // It is fine to call this in a loop since most of the time we are
+            // only working with a single message content edit.
+            update_views_filtered_on_message_property(
+                [event.message_id],
+                "has-image",
+                message_parser.message_has_image(event.rendered_content),
+            );
+            update_views_filtered_on_message_property(
+                [event.message_id],
+                "has-link",
+                message_parser.message_has_link(event.rendered_content),
+            );
+            update_views_filtered_on_message_property(
+                [event.message_id],
+                "has-attachment",
+                message_parser.message_has_attachment(event.rendered_content),
+            );
+
+            const is_mentioned = event.flags.some((flag) =>
+                ["mentioned", "stream_wildcard_mentioned", "topic_wildcard_mentioned"].includes(
+                    flag,
+                ),
+            );
+            update_views_filtered_on_message_property(
+                [event.message_id],
+                "is-mentioned",
+                is_mentioned,
+            );
+            const is_alerted = event.flags.includes("has_alert_word");
+            update_views_filtered_on_message_property([event.message_id], "is-alerted", is_alerted);
         }
     }
 

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -193,6 +193,11 @@ export function dispatch_normal_event(event) {
                     blueslip.error("Unexpected event type reaction/" + event.op);
                     break;
             }
+            message_events.update_views_filtered_on_message_property(
+                [event.message_id],
+                "has-reaction",
+                event.op === "add",
+            );
             break;
 
         case "realm": {
@@ -885,6 +890,11 @@ export function dispatch_normal_event(event) {
                         starred_messages.remove(event.messages);
                         starred_messages_ui.rerender_ui();
                     }
+                    message_events.update_views_filtered_on_message_property(
+                        event.messages,
+                        "is-starred",
+                        new_value,
+                    );
                     break;
                 case "read":
                     if (event.op === "add") {
@@ -895,6 +905,11 @@ export function dispatch_normal_event(event) {
                             message_details: event.message_details,
                         });
                     }
+                    message_events.update_views_filtered_on_message_property(
+                        event.messages,
+                        "is-unread",
+                        new_value,
+                    );
                     break;
             }
             break;

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -35,7 +35,9 @@ const emoji_picker = mock_esm("../src/emoji_picker");
 const gear_menu = mock_esm("../src/gear_menu");
 const information_density = mock_esm("../src/information_density");
 const linkifiers = mock_esm("../src/linkifiers");
-const message_events = mock_esm("../src/message_events");
+const message_events = mock_esm("../src/message_events", {
+    update_views_filtered_on_message_property: noop,
+});
 const message_lists = mock_esm("../src/message_lists");
 const user_topics_ui = mock_esm("../src/user_topics_ui");
 const muted_users_ui = mock_esm("../src/muted_users_ui");

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -3,7 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {realm} = require("./lib/zpage_params");
 
@@ -13,11 +13,17 @@ const message_notifications = mock_esm("../src/message_notifications");
 const pm_list = mock_esm("../src/pm_list");
 const stream_list = mock_esm("../src/stream_list");
 const unread_ui = mock_esm("../src/unread_ui");
+mock_esm("../src/message_parser", {
+    message_has_attachment: noop,
+    message_has_image: noop,
+    message_has_link: noop,
+});
 message_lists.current = {};
 message_lists.all_rendered_message_lists = () => [message_lists.current];
 
 const people = zrequire("people");
 const message_events = zrequire("message_events");
+message_events.__Rewire__("update_views_filtered_on_message_property", () => {});
 const message_helper = zrequire("message_helper");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");


### PR DESCRIPTION
Fixes #31208
Fixes #14510

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/live.20update.20for.20views.20based.20on.20message.20property

Tested by adding / removing the message property for the following views:
```js
const supported_term_types = [
        "has-image",
        "has-link",
        "has-reaction",
        "has-attachment",
        "is-starred",
        "is-unread",
        "is-mentioned",
        "is-alerted",
        // TODO: Implement support for these terms.
        // "is-followed",
    ];
```

Left to implement `is-followed` as a followup since it is not straighforword to implement correctly.
