### PR TITLE
portico: Ensure comparison tabs take precedence over plans.

### DIFF
--- a/web/styles/portico/comparison_table.css
+++ b/web/styles/portico/comparison_table.css
@@ -439,7 +439,7 @@
     }
 }
 
-.showing-cloud,
+.showing-cloud:not(:has(div[id^="showing-tab"])),
 #showing-tab-cloud {
     .comparison-tab-cloud {
         background-color: hsl(0deg 0% 100%);
@@ -476,7 +476,7 @@
     }
 }
 
-.showing-self-hosted,
+.showing-self-hosted:not(:has(div[id^="showing-tab"])),
 #showing-tab-hosted {
     .comparison-tab-self-hosted {
         background-color: hsl(0deg 0% 100%);


### PR DESCRIPTION
This PR ensures that once comparison-table tabs are clicked, adding an ID of `showing-tab-xxx`, that those tabs override the classes added for the sake of cloud vs. self-hosted vs. all-plan feature comparisons.

We can't simply remove the problem classes (`.showing-cloud`, `.showing-self-hosted`) when users browse the features table via the comparison tabs, because those classes are necessary for showing the correct plans comparisons and sponsorship and questions boxes.

This has been tested at both /plans/ and /features/

**Screenshots and screen captures:**

Choosing All Plans with Cloud default:

| Before | After |
| --- | --- |
| ![plans-page-before](https://github.com/user-attachments/assets/34300f10-99bf-4cef-acdf-cf66c84aba6a) | ![plans-page-after](https://github.com/user-attachments/assets/6fc23434-6b84-44ad-b3c9-76cac32ae98d) |
| ![features-page-before](https://github.com/user-attachments/assets/6535c163-c506-4782-9e0b-2234388d7512) | ![features-page-after](https://github.com/user-attachments/assets/65b5f41c-e411-43a1-865a-e939e8a1791b) |


