### PR TITLE
Fix parsing of 'sender:me' into search pill

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -72,7 +72,7 @@ async function test_reload_hash(page: Page): Promise<void> {
 
     await page.evaluate(() => {
         // We haven't converted reload.js to TypeScript yet.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+
         zulip_test.initiate_reload({immediate: true});
     });
     await page.waitForNavigation();

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -780,7 +780,7 @@ function get_sent_by_me_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
     ) {
         return [
             {
-                search_string: sender_query,
+                search_string: last_string.startsWith("sender:me") ? sender_me_query : sender_query,
                 description_html,
                 is_people: false,
             },


### PR DESCRIPTION
This pull request refines the **get_sent_by_me_suggestions** function to enhance search suggestions.

### Key Change:
Dynamic **search_string**: Modified to use **sender_me_query** if last_string starts with **"sender:me";** otherwise, it defaults to **sender_query.**

### Impact:
Improved Relevance: Ensures more accurate search suggestions for queries involving **'sender:me'**, enhancing the overall user search experience.
**Clean Code**: Removal of debugging logs makes the codebase cleaner and more maintainable.

**Code changes:**
``search_string: sender_query,``
 **to**
`` search_string: last_string.startsWith("sender:me") ? sender_me_query : sender_query ``

**output:**
### Before :
![Screenshot 2024-09-05 060532](https://github.com/user-attachments/assets/6da2ecdc-4bff-433c-b66f-29125ea81305)

### After
![Screenshot 2024-09-05 061641](https://github.com/user-attachments/assets/22cc1a41-f842-4a69-9452-a94aa5ee5015)

