### PR TITLE
Fix parsing of 'sender:me' into search pill

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -72,7 +72,7 @@ async function test_reload_hash(page: Page): Promise<void> {
 
     await page.evaluate(() => {
         // We haven't converted reload.js to TypeScript yet.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+
         zulip_test.initiate_reload({immediate: true});
     });
     await page.waitForNavigation();

--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -72,7 +72,7 @@ async function test_reload_hash(page: Page): Promise<void> {
 
     await page.evaluate(() => {
         // We haven't converted reload.js to TypeScript yet.
-
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         zulip_test.initiate_reload({immediate: true});
     });
     await page.waitForNavigation();

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -780,7 +780,7 @@ function get_sent_by_me_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugg
     ) {
         return [
             {
-                search_string: sender_query,
+                search_string: last_string.startsWith("sender:me") ? sender_me_query : sender_query,
                 description_html,
                 is_people: false,
             },


### PR DESCRIPTION
This commit fixes an issue with the 'sender' search filter not being properly converted into a search pill, which impacted the display of the filter in the search UI.

Fixes: bug from https://github.com/zulip/zulip/pull/31553

**Changes Made:**

- Updated the `get_sent_by_me_suggestions` function in `search_suggestion.ts` to ensure that the 'sender:me' filter is correctly transformed into a search pill.
- Improved handling of the 'sender:me' filter to ensure it appears consistently in the search UI as a pill when not selected from typeahead options.

**Testing:**

- Verified that the 'sender:me' filter is now correctly converted into a search pill.
- Ensured that the search functionality behaves as expected with the updated filter.

**Issue Reference:**

Fixes issue #31315.

**Screenshots and screen captures:**

### Before Changes:
![Screenshot 2024-09-05 060532](https://github.com/user-attachments/assets/67a3dbdf-2102-487f-8625-4bac48d0122d)

### After Changes:
![Screenshot 2024-09-05 061641](https://github.com/user-attachments/assets/27d16a4c-c937-4fb1-95e1-b8643de8c17b)

### Code changes:
![Screenshot 2024-09-05 063743](https://github.com/user-attachments/assets/8d03865c-22c5-45ef-a409-6af8d0ee68d1)


<details>
  <summary><strong>Self-review checklist:</strong></summary>

- [ ] **Self-reviewed** the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
  
- Communicate decisions, questions, and potential concerns:
  - [ ] Explains differences from previous plans (e.g., issue description).
  - [ ] Highlights technical choices and bugs encountered.
  - [ ] Calls out remaining decisions and concerns.
  - [ ] Automated tests verify logic where appropriate.

- **Individual commits are ready for review** (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)):
  - [ ] Each commit is a coherent idea.
  - [ ] Commit message(s) explain reasoning and motivation for changes.

- **Completed manual review and testing of the following:**
  - [ ] Visual appearance of the changes.
  - [ ] Responsiveness and internationalization.
  - [ ] Strings and tooltips.
  - [ ] End-to-end functionality of buttons, interactions, and flows.
  - [ ] Corner cases, error conditions, and easily imagined bugs.
</details>


