### PR TITLE
Gitlab webhook: support release hooks

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -75,6 +75,12 @@ TAG_WITH_URL_TEMPLATE = "[{tag_name}]({tag_url})"
 TAG_WITHOUT_URL_TEMPLATE = "{tag_name}"
 
 RELEASE_MESSAGE_TEMPLATE = "{user_name} {action} release [{release_name}]({url}) for tag {tagname}."
+RELEASE_MESSAGE_TEMPLATE_WITHOUT_USER_NAME = (
+    "Release [{release_name}]({url}) for tag {tagname} was {action}."
+)
+RELEASE_MESSAGE_TEMPLATE_WITHOUT_USER_NAME_WITHOUT_URL = (
+    "Release {release_name} for tag {tagname} was {action}."
+)
 
 
 def get_assignee_string(assignees: list[dict[str, Any]]) -> str:

--- a/zerver/webhooks/gitlab/fixtures/release_hook__create.json
+++ b/zerver/webhooks/gitlab/fixtures/release_hook__create.json
@@ -1,0 +1,69 @@
+{
+    "id": 1,
+    "created_at": "2020-11-02 12:55:12 UTC",
+    "description": "## v1.1 (2024-09-06)\n\n- Feature added",
+    "name": "v1.1",
+    "released_at": "2020-11-02 12:55:12 UTC",
+    "tag": "v1.1",
+    "object_kind": "release",
+    "project": {
+        "id": 2,
+        "name": "release-webhook-example",
+        "description": "",
+        "web_url": "https://example.com/gitlab-org/release-webhook-example",
+        "avatar_url": null,
+        "git_ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "git_http_url": "https://example.com/gitlab-org/release-webhook-example.git",
+        "namespace": "Gitlab",
+        "visibility_level": 0,
+        "path_with_namespace": "gitlab-org/release-webhook-example",
+        "default_branch": "master",
+        "ci_config_path": null,
+        "homepage": "https://example.com/gitlab-org/release-webhook-example",
+        "url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "http_url": "https://example.com/gitlab-org/release-webhook-example.git"
+    },
+    "url": "https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1",
+    "action": "create",
+    "assets": {
+        "count": 5,
+        "links": [
+            {
+                "id": 1,
+                "link_type": "other",
+                "name": "Changelog",
+                "url": "https://example.net/changelog"
+            }
+        ],
+        "sources": [
+            {
+                "format": "zip",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.zip"
+            },
+            {
+                "format": "tar.gz",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.gz"
+            },
+            {
+                "format": "tar.bz2",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.bz2"
+            },
+            {
+                "format": "tar",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar"
+            }
+        ]
+    },
+    "commit": {
+        "id": "ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "message": "Release v1.1",
+        "title": "Release v1.1",
+        "timestamp": "2020-10-31T14:58:32+11:00",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/commit/ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "author": {
+            "name": "Example User",
+            "email": "user@example.com"
+        }
+    }
+}

--- a/zerver/webhooks/gitlab/fixtures/release_hook__delete.json
+++ b/zerver/webhooks/gitlab/fixtures/release_hook__delete.json
@@ -1,0 +1,69 @@
+{
+    "id": 1,
+    "created_at": "2020-11-02 12:55:12 UTC",
+    "description": "## v1.1 (2024-09-06)\n\n- Feature added",
+    "name": "v1.1",
+    "released_at": "2020-11-02 12:55:12 UTC",
+    "tag": "v1.1",
+    "object_kind": "release",
+    "project": {
+        "id": 2,
+        "name": "release-webhook-example",
+        "description": "",
+        "web_url": "https://example.com/gitlab-org/release-webhook-example",
+        "avatar_url": null,
+        "git_ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "git_http_url": "https://example.com/gitlab-org/release-webhook-example.git",
+        "namespace": "Gitlab",
+        "visibility_level": 0,
+        "path_with_namespace": "gitlab-org/release-webhook-example",
+        "default_branch": "master",
+        "ci_config_path": null,
+        "homepage": "https://example.com/gitlab-org/release-webhook-example",
+        "url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "http_url": "https://example.com/gitlab-org/release-webhook-example.git"
+    },
+    "url": "https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1",
+    "action": "delete",
+    "assets": {
+        "count": 5,
+        "links": [
+            {
+                "id": 1,
+                "link_type": "other",
+                "name": "Changelog",
+                "url": "https://example.net/changelog"
+            }
+        ],
+        "sources": [
+            {
+                "format": "zip",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.zip"
+            },
+            {
+                "format": "tar.gz",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.gz"
+            },
+            {
+                "format": "tar.bz2",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.bz2"
+            },
+            {
+                "format": "tar",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar"
+            }
+        ]
+    },
+    "commit": {
+        "id": "ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "message": "Release v1.1",
+        "title": "Release v1.1",
+        "timestamp": "2020-10-31T14:58:32+11:00",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/commit/ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "author": {
+            "name": "Example User",
+            "email": "user@example.com"
+        }
+    }
+}

--- a/zerver/webhooks/gitlab/fixtures/release_hook__update.json
+++ b/zerver/webhooks/gitlab/fixtures/release_hook__update.json
@@ -1,0 +1,69 @@
+{
+    "id": 1,
+    "created_at": "2020-11-02 12:55:12 UTC",
+    "description": "## v1.1 (2024-09-06)\n\n- Feature added",
+    "name": "v1.1",
+    "released_at": "2020-11-02 12:55:12 UTC",
+    "tag": "v1.1",
+    "object_kind": "release",
+    "project": {
+        "id": 2,
+        "name": "release-webhook-example",
+        "description": "",
+        "web_url": "https://example.com/gitlab-org/release-webhook-example",
+        "avatar_url": null,
+        "git_ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "git_http_url": "https://example.com/gitlab-org/release-webhook-example.git",
+        "namespace": "Gitlab",
+        "visibility_level": 0,
+        "path_with_namespace": "gitlab-org/release-webhook-example",
+        "default_branch": "master",
+        "ci_config_path": null,
+        "homepage": "https://example.com/gitlab-org/release-webhook-example",
+        "url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "http_url": "https://example.com/gitlab-org/release-webhook-example.git"
+    },
+    "url": "https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1",
+    "action": "update",
+    "assets": {
+        "count": 5,
+        "links": [
+            {
+                "id": 1,
+                "link_type": "other",
+                "name": "Changelog",
+                "url": "https://example.net/changelog"
+            }
+        ],
+        "sources": [
+            {
+                "format": "zip",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.zip"
+            },
+            {
+                "format": "tar.gz",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.gz"
+            },
+            {
+                "format": "tar.bz2",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.bz2"
+            },
+            {
+                "format": "tar",
+                "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar"
+            }
+        ]
+    },
+    "commit": {
+        "id": "ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "message": "Release v1.1",
+        "title": "Release v1.1",
+        "timestamp": "2020-10-31T14:58:32+11:00",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/commit/ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "author": {
+            "name": "Example User",
+            "email": "user@example.com"
+        }
+    }
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -631,3 +631,28 @@ A trivial change that should probably be ignored.
         self.check_webhook(
             "merge_request_hook__merge_request_unapproved", expected_topic_name, expected_message
         )
+
+    def test_release_created_event_message(self) -> None:
+        expected_topic_name = "release-webhook-example"
+        expected_message = "Release [v1.1](https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1) for tag v1.1 was created.\n~~~ quote\n## v1.1 (2024-09-06)\n\n- Feature added\n~~~"
+
+        self.check_webhook("release_hook__create", expected_topic_name, expected_message)
+
+    def test_release_created_event_message_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url("topic=Specific%20topic")
+        expected_topic_name = "Specific topic"
+        expected_message = "[[release-webhook-example](https://example.com/gitlab-org/release-webhook-example)] Release [v1.1](https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1) for tag v1.1 was created.\n~~~ quote\n## v1.1 (2024-09-06)\n\n- Feature added\n~~~"
+
+        self.check_webhook("release_hook__create", expected_topic_name, expected_message)
+
+    def test_release_update_event_message(self) -> None:
+        expected_topic_name = "release-webhook-example"
+        expected_message = "Release [v1.1](https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1) for tag v1.1 was updated.\n~~~ quote\n## v1.1 (2024-09-06)\n\n- Feature added\n~~~"
+
+        self.check_webhook("release_hook__update", expected_topic_name, expected_message)
+
+    def test_release_delete_event_message(self) -> None:
+        expected_topic_name = "release-webhook-example"
+        expected_message = "Release v1.1 for tag v1.1 was deleted."
+
+        self.check_webhook("release_hook__delete", expected_topic_name, expected_message)

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -16,7 +16,10 @@ from zerver.lib.webhooks.common import (
     validate_extract_webhook_http_header,
 )
 from zerver.lib.webhooks.git import (
+    CONTENT_MESSAGE_TEMPLATE,
     EMPTY_SHA,
+    RELEASE_MESSAGE_TEMPLATE_WITHOUT_USER_NAME,
+    RELEASE_MESSAGE_TEMPLATE_WITHOUT_USER_NAME_WITHOUT_URL,
     TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE,
     get_commits_comment_action_message,
     get_issue_event_message,
@@ -342,6 +345,29 @@ def get_pipeline_event_body(payload: WildValue, include_title: bool) -> str:
     )
 
 
+def get_release_event_body(payload: WildValue, include_title: bool) -> str:
+    action = payload["action"].tame(check_string)
+    name = payload["name"].tame(check_string)
+    tag = payload["tag"].tame(check_string)
+    message_action = f"{action}d"
+
+    if action == "delete":
+        body = RELEASE_MESSAGE_TEMPLATE_WITHOUT_USER_NAME_WITHOUT_URL.format(
+            release_name=name, tagname=tag, action=message_action
+        )
+    else:
+        url = payload["url"].tame(check_string)
+        body = RELEASE_MESSAGE_TEMPLATE_WITHOUT_USER_NAME.format(
+            release_name=name, url=url, tagname=tag, action=message_action
+        )
+
+        if "description" in payload:
+            description = payload["description"].tame(check_string)
+            body += CONTENT_MESSAGE_TEMPLATE.format(message=description)
+
+    return body
+
+
 def get_repo_name(payload: WildValue) -> str:
     if "project" in payload:
         return payload["project"]["name"].tame(check_string)
@@ -411,6 +437,7 @@ EVENT_FUNCTION_MAPPER: dict[str, EventFunction] = {
     "Job Hook": get_build_hook_event_body,
     "Build Hook": get_build_hook_event_body,
     "Pipeline Hook": get_pipeline_event_body,
+    "Release Hook": get_release_event_body,
 }
 
 ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())


### PR DESCRIPTION
This is an improvement to the Gitlab webhook integration to support the `release hook`. It works in the same way as other events processed in the gitlab integration and builds a message with the `release name`, `url` and `description` like this:

Without topic:
![image](https://github.com/user-attachments/assets/d0a65de6-22e5-4757-bf14-f12175ab261d)

Specified topic:
![image](https://github.com/user-attachments/assets/7901c481-e9be-4f57-9878-29caa2b9b720)


It supports all 3 event actions: create, update and delete.

Fixes:
Adds one of the few hooks not yet supported by the gitlab integration.
