### PR TITLE
settings: Fix live-update bug for privacy settings. 

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -733,6 +733,7 @@ export function dispatch_normal_event(event) {
                 "send_private_typing_notifications",
                 "send_read_receipts",
                 "web_navigate_to_sent_message",
+                "enter_sends",
             ];
 
             const original_home_view = user_settings.web_home_view;
@@ -850,9 +851,6 @@ export function dispatch_normal_event(event) {
             }
             if (event.property === "web_escape_navigates_to_home_view") {
                 $("#go-to-home-view-hotkey-help").toggleClass("notdisplayed", !event.value);
-            }
-            if (event.property === "enter_sends") {
-                user_settings.enter_sends = event.value;
             }
             if (event.property === "presence_enabled") {
                 user_settings.presence_enabled = event.value;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -710,11 +710,16 @@ export function dispatch_normal_event(event) {
                 "send_stream_typing_notifications",
                 "send_private_typing_notifications",
                 "send_read_receipts",
+                "presence_enabled",
+                "email_address_visibility",
             ];
 
             if (privacy_settings.includes(event.property)) {
                 user_settings[event.property] = event.value;
                 settings_account.update_privacy_settings_box(event.property);
+                if (event.property === "presence_enabled") {
+                    activity_ui.redraw_user(current_user.user_id);
+                }
                 break;
             }
 
@@ -860,17 +865,6 @@ export function dispatch_normal_event(event) {
             }
             if (event.property === "web_escape_navigates_to_home_view") {
                 $("#go-to-home-view-hotkey-help").toggleClass("notdisplayed", !event.value);
-            }
-            if (event.property === "presence_enabled") {
-                user_settings.presence_enabled = event.value;
-                $("#user_presence_enabled").prop("checked", user_settings.presence_enabled);
-                activity_ui.redraw_user(current_user.user_id);
-                break;
-            }
-            if (event.property === "email_address_visibility") {
-                user_settings.email_address_visibility = event.value;
-                $("#user_email_address_visibility").val(event.value);
-                break;
             }
             settings_preferences.update_page(event.property);
             break;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -706,6 +706,18 @@ export function dispatch_normal_event(event) {
                 break;
             }
 
+            const privacy_settings = [
+                "send_stream_typing_notifications",
+                "send_private_typing_notifications",
+                "send_read_receipts",
+            ];
+
+            if (privacy_settings.includes(event.property)) {
+                user_settings[event.property] = event.value;
+                settings_account.update_privacy_settings_box(event.property);
+                break;
+            }
+
             const user_preferences = [
                 "color_scheme",
                 "web_font_size_px",
@@ -729,9 +741,6 @@ export function dispatch_normal_event(event) {
                 "web_animate_image_previews",
                 "web_stream_unreads_count_display_policy",
                 "starred_message_counts",
-                "send_stream_typing_notifications",
-                "send_private_typing_notifications",
-                "send_read_receipts",
                 "web_navigate_to_sent_message",
                 "enter_sends",
             ];

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -20,6 +20,7 @@ import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_bots from "./settings_bots";
+import * as settings_components from "./settings_components";
 import * as settings_data from "./settings_data";
 import * as settings_org from "./settings_org";
 import * as settings_ui from "./settings_ui";
@@ -248,6 +249,16 @@ export function hide_confirm_email_banner() {
         return;
     }
     $("#account-settings-status").hide();
+}
+
+export function update_privacy_settings_box(property) {
+    if (!overlays.settings_open()) {
+        return;
+    }
+
+    const $container = $("#account-settings");
+    const $input_elem = $container.find(`[name=${CSS.escape(property)}]`);
+    settings_components.set_input_element_value($input_elem, user_settings[property]);
 }
 
 export function set_up() {

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -1117,6 +1117,7 @@ run_test("user_settings", ({override}) => {
     event = event_fixtures.user_settings__presence_disabled;
     user_settings.presence_enabled = true;
     override(activity_ui, "redraw_user", noop);
+    override(settings_account, "update_privacy_settings_box", noop);
     dispatch(event);
     assert_same(user_settings.presence_enabled, false);
 


### PR DESCRIPTION
This PR fixes the live-update bug in [the "Privacy" subsection of  user-settings.](https://chat.zulip.org/#settings/account-and-privacy)

These three were not live-updated:
* Let recipients see when I'm typing direct messages
* Let recipients see when I'm typing messages in channels
* Let others see when I've read messages 

Also, includes small code restructuring to better organise the code.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
