### PR TITLE
message_store: Fix type of topic_links.

### DIFF
--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -87,7 +87,7 @@ export const raw_message_schema = z.intersection(
         z.discriminatedUnion("type", [
             z.object({
                 type: z.literal("private"),
-                topic_links: z.optional(z.array(z.undefined())),
+                topic_links: z.optional(z.undefined()),
             }),
             z.object({
                 type: z.literal("stream"),


### PR DESCRIPTION
This was a bug introduced in a previous commit to convert to using Zod.

See my comment on that diff for context:
https://github.com/zulip/zulip/commit/17e2d46760cf19e9b10a9e470452cd6632fb6bb0#r146318062
