### PR TITLE
messages_overlay: Fix multiple IDs selected accidentally.

### DIFF
--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -181,5 +181,7 @@ function scroll_to_element($element: JQuery, context: Context): void {
 }
 
 function get_element_by_id(id: number | string, context: Context): JQuery {
-    return $(`[${CSS.escape(context.id_attribute_name)}='${CSS.escape(id.toString())}']`);
+    return $(
+        `.overlay-message-row[${CSS.escape(context.id_attribute_name)}='${CSS.escape(id.toString())}']`,
+    );
 }


### PR DESCRIPTION
Since `success_message_scheduled_banner` and scheduled message overlay both use `data-scheduled-message-id`, `get_element_by_id` needs to be more specific which selector it wants.

Reproducer:
* Clear all scheduled messages.
* Schedule a message.
* Open scheduled message overlay with the compose success banner for scheduled message displayed.

Fixes https://zulip.sentry.io/issues/5807613209/