### PR TITLE
retention: Remove outdated compat block for delete_message events.

### DIFF
--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -45,7 +45,6 @@ from zerver.models.streams import get_stream
 from zerver.models.users import get_system_bot
 
 # Class with helper functions useful for testing archiving of reactions:
-from zerver.tornado.django_api import send_event
 
 ZULIP_REALM_DAYS = 30
 MIT_REALM_DAYS = 100
@@ -1152,28 +1151,3 @@ class TestDoDeleteMessages(ZulipTestCase):
         archived_messages = ArchivedMessage.objects.filter(id__in=message_ids)
         self.assertEqual(archived_messages.count(), len(message_ids))
         self.assert_length({message.archive_transaction_id for message in archived_messages}, 1)
-
-    def test_old_event_format_processed_correctly(self) -> None:
-        """
-        do_delete_messages used to send events with users in dict format {"id": <int>}.
-        We have a block in process_notification to deal with that old format, that should be
-        deleted in a later release. This test is meant to ensure correctness of that block.
-        """
-        realm = get_realm("zulip")
-        cordelia = self.example_user("cordelia")
-        hamlet = self.example_user("hamlet")
-        message_id = self.send_personal_message(cordelia, hamlet)
-        message = Message.objects.get(id=message_id)
-
-        event = {
-            "type": "delete_message",
-            "sender": message.sender.email,
-            "sender_id": message.sender_id,
-            "message_id": message.id,
-            "message_type": "private",
-            "recipient_id": message.recipient_id,
-        }
-        move_messages_to_archive([message_id])
-        # We only send the event to see no exception is thrown - as it would be if the block
-        # in process_notification to handle this old format of "users to notify" wasn't correct.
-        send_event(realm, event, [{"id": cordelia.id}, {"id": hamlet.id}])

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -44,8 +44,6 @@ from zerver.models.realms import get_realm
 from zerver.models.streams import get_stream
 from zerver.models.users import get_system_bot
 
-# Class with helper functions useful for testing archiving of reactions:
-
 ZULIP_REALM_DAYS = 30
 MIT_REALM_DAYS = 100
 

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1572,18 +1572,7 @@ def process_notification(notice: Mapping[str, Any]) -> None:
     elif event["type"] == "update_message":
         process_message_update_event(event, cast(list[Mapping[str, Any]], users))
     elif event["type"] == "delete_message":
-        if len(users) > 0 and isinstance(users[0], dict):
-            # do_delete_messages used to send events with users in
-            # dict format {"id": <int>} This block is here for
-            # compatibility with events in that format still in the
-            # queue at the time of upgrade.
-            #
-            # TODO/compatibility: Remove this block once you can no
-            # longer directly upgrade directly from 4.x to main.
-            user_ids: list[int] = [user["id"] for user in cast(list[Mapping[str, Any]], users)]
-        else:
-            user_ids = cast(list[int], users)
-        process_deletion_event(event, user_ids)
+        process_deletion_event(event, cast(list[int], users))
     elif event["type"] == "presence":
         process_presence_event(event, cast(list[int], users))
     elif event["type"] == "custom_profile_fields":


### PR DESCRIPTION
As noted in the comment in that block, this is no longer useful.

