### PR TITLE
Rename some message_type var names to recipient_type in python code

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1082,12 +1082,12 @@ def do_send_messages(
             users.append(user_data)
 
         sender = send_request.message.sender
-        message_type = wide_message_dict["type"]
+        recipient_type = wide_message_dict["type"]
         user_notifications_data_list = [
             UserMessageNotificationsData.from_user_id_sets(
                 user_id=user_id,
                 flags=user_flags.get(user_id, []),
-                private_message=message_type == "private",
+                private_message=recipient_type == "private",
                 disable_external_notifications=send_request.disable_external_notifications,
                 online_push_user_ids=send_request.online_push_user_ids,
                 dm_mention_push_disabled_user_ids=send_request.dm_mention_push_disabled_user_ids,

--- a/zerver/migrations/0377_message_edit_history_format.py
+++ b/zerver/migrations/0377_message_edit_history_format.py
@@ -62,11 +62,11 @@ def backfill_message_edit_history_chunk(
 
     for message in messages:
         legacy_edit_history: list[LegacyEditHistoryEvent] = orjson.loads(message.edit_history)
-        message_type = message.recipient.type
+        recipient_type = message.recipient.type
         modern_edit_history: list[EditHistoryEvent] = []
 
         # Only Stream messages have topic / stream edit history data.
-        if message_type == STREAM:
+        if recipient_type == STREAM:
             topic = message.subject
             stream_id = message.recipient.type_id
 
@@ -83,7 +83,7 @@ def backfill_message_edit_history_chunk(
                     "prev_rendered_content_version"
                 ]
 
-            if message_type == STREAM:
+            if recipient_type == STREAM:
                 if "prev_subject" in edit_history_event:
                     # Add topic edit key/value pairs from legacy format.
                     modern_entry["topic"] = topic

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -488,7 +488,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
         content = "@**FooBot** foo bar!!!"
         recipient = "Denmark"
         trigger = "mention"
-        message_type = Recipient._type_names[Recipient.STREAM]
+        recipient_type = Recipient._type_names[Recipient.STREAM]
 
         def check_values_passed(
             queue_name: Any,
@@ -500,7 +500,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             self.assertEqual(trigger_event["message"]["content"], content)
             self.assertEqual(trigger_event["message"]["display_recipient"], recipient)
             self.assertEqual(trigger_event["message"]["sender_email"], self.user_profile.email)
-            self.assertEqual(trigger_event["message"]["type"], message_type)
+            self.assertEqual(trigger_event["message"]["type"], recipient_type)
             self.assertEqual(trigger_event["trigger"], trigger)
             self.assertEqual(trigger_event["user_profile_id"], self.bot_profile.id)
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1248,17 +1248,17 @@ def generate_and_send_messages(
             and random.randint(1, random_max) * 100.0 / random_max < options["stickiness"]
         ):
             # Use an old recipient
-            message_type, recipient_id, saved_data = recipients[num_messages - 1]
-            if message_type == Recipient.PERSONAL:
+            recipient_type, recipient_id, saved_data = recipients[num_messages - 1]
+            if recipient_type == Recipient.PERSONAL:
                 personals_pair = saved_data["personals_pair"]
                 random.shuffle(personals_pair)
-            elif message_type == Recipient.STREAM:
+            elif recipient_type == Recipient.STREAM:
                 message.subject = saved_data["subject"]
                 message.recipient = get_recipient_by_id(recipient_id)
-            elif message_type == Recipient.DIRECT_MESSAGE_GROUP:
+            elif recipient_type == Recipient.DIRECT_MESSAGE_GROUP:
                 message.recipient = get_recipient_by_id(recipient_id)
         elif randkey <= random_max * options["percent_direct_message_groups"] / 100.0:
-            message_type = Recipient.DIRECT_MESSAGE_GROUP
+            recipient_type = Recipient.DIRECT_MESSAGE_GROUP
             message.recipient = get_recipient_by_id(random.choice(recipient_direct_message_groups))
         elif (
             randkey
@@ -1266,23 +1266,23 @@ def generate_and_send_messages(
             * (options["percent_direct_message_groups"] + options["percent_personals"])
             / 100.0
         ):
-            message_type = Recipient.PERSONAL
+            recipient_type = Recipient.PERSONAL
             personals_pair = random.choice(personals_pairs)
             random.shuffle(personals_pair)
         elif randkey <= random_max * 1.0:
-            message_type = Recipient.STREAM
+            recipient_type = Recipient.STREAM
             message.recipient = get_recipient_by_id(random.choice(recipient_streams))
 
-        if message_type == Recipient.DIRECT_MESSAGE_GROUP:
+        if recipient_type == Recipient.DIRECT_MESSAGE_GROUP:
             sender_id = random.choice(direct_message_group_members[message.recipient.id])
             message.sender = get_user_profile_by_id(sender_id)
-        elif message_type == Recipient.PERSONAL:
+        elif recipient_type == Recipient.PERSONAL:
             message.recipient = Recipient.objects.get(
                 type=Recipient.PERSONAL, type_id=personals_pair[0]
             )
             message.sender = get_user_profile_by_id(personals_pair[1])
             saved_data["personals_pair"] = personals_pair
-        elif message_type == Recipient.STREAM:
+        elif recipient_type == Recipient.STREAM:
             # Pick a random subscriber to the stream
             message.sender = random.choice(
                 list(Subscription.objects.filter(recipient=message.recipient))
@@ -1295,7 +1295,7 @@ def generate_and_send_messages(
         )
         messages.append(message)
 
-        recipients[num_messages] = (message_type, message.recipient.id, saved_data)
+        recipients[num_messages] = (recipient_type, message.recipient.id, saved_data)
         num_messages += 1
 
         if (num_messages % message_batch_size) == 0:


### PR DESCRIPTION
With the addition of `Message.type` column with a completely different meaning, we prefer `recipient_type` for variable names in python code when they're actually about the recipient. Here I clean up the occurences that are easy.

What remains and is not easy:
1. `analytics` context. We have the `messages_sent:message_type` CountStat with lots of references to it. We could rename this, but it'll involve a db migration for the `*Count` objects. Do we want to do that?
2. Most of the occurences of `message_type` is in API and events context. This is obviously much harder to clean up. I assume we'll probably leave it as it is for now?