### PR TITLE
bot: Fix extra spacing for bot avatar.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -682,7 +682,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
         full_name: bot.full_name,
         user_role_values: settings_config.user_role_values,
         disable_role_dropdown: !current_user.is_admin || (bot.is_owner && !current_user.is_owner),
-        bot_avatar_url: bot.avatar_url,
+        bot_avatar_url: bot.avatar_url ?? people.medium_avatar_url_for_person(bot),
         owner_full_name,
         current_bot_owner: bot.bot_owner_id,
         is_incoming_webhook_bot: bot.bot_type === INCOMING_WEBHOOK_BOT_TYPE,
@@ -873,7 +873,6 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
         // Show the avatar if the user has cleared the image
         $("#bot-edit-form").on("click", ".edit_bot_avatar_clear_button", () => {
             $("#current_bot_avatar_image").show();
-            $(".edit_bot_avatar_file_input").trigger("input");
         });
 
         $("#bot-edit-form").on("click", ".deactivate_bot_button", (e) => {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1513,6 +1513,9 @@
         226.35deg 82.53% 55.1% / 38.82%
     );
     --color-typeahead-option-label: var(--grey-400);
+
+    /* Bot avatar */
+    --bot-avatar-size: 100px; /* Define the avatar size */
 }
 
 @media screen {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -983,6 +983,8 @@ input[type="checkbox"] {
 
     #current_bot_avatar_image {
         margin: 5px 0 8px;
+        width: var(--bot-avatar-size);
+        height: var(--bot-avatar-size);
     }
 
     .edit_bot_avatar_preview_text {
@@ -996,8 +998,8 @@ input[type="checkbox"] {
 
 .edit_bot_avatar_preview_image,
 #add_bot_preview_image {
-    height: 100px;
-    width: 100px;
+    height: var(--bot-avatar-size);
+    width: var(--bot-avatar-size);
     margin: 2px 0 8px;
 }
 


### PR DESCRIPTION
The issue of excessive spacing between the bot avatar heading and the button has been fixed.

Before
![image](https://github.com/user-attachments/assets/cc89aa85-dbf1-4d84-86aa-117f3410e4b2)

After
![image](https://github.com/user-attachments/assets/ab363070-f8de-4690-b624-b78eadcab63d)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
