### PR TITLE
message_row: Reduce space above collapsed Show More button.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -410,6 +410,12 @@
             }
         }
     }
+
+    .collapsed ~ .message_length_controller .message_length_toggle {
+        /* Collapse top margin to avoid extra space
+           between the button and sender line. */
+        margin-top: 0;
+    }
 }
 
 .message_controls {


### PR DESCRIPTION
This only impacts collapsed Show More buttons in a message with a sender.

Fixes #31221

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![collapsed-show-more-before](https://github.com/user-attachments/assets/866ff73a-471f-446a-be0a-3444ec8c599e) | ![collapsed-show-more-after](https://github.com/user-attachments/assets/a1c17d1f-1819-4cc4-9ef8-74ee94d94bdb) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>