### PR TITLE
Add internationalization support to search typeahead suggestion strings.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -772,14 +772,11 @@ export class Filter {
                 return verb + "messages in a specific channel";
             }
             const stream = stream_data.get_sub_by_id_string(term.operand);
-            if (stream) {
-                return render_search_description({
-                    type: "plain_text",
-                    content: verb + "messages in #" + stream.name,
-                });
-            }
-            // Assume the operand is a partially formed name and return
-            // the operator as the channel name in the next block.
+            assert(stream !== undefined);
+            return render_search_description({
+                type: "plain_text",
+                content: verb + "messages in #" + stream.name,
+            });
         }
         const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
         if (prefix_for_operator !== "") {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -766,21 +766,23 @@ export class Filter {
                 content: this.describe_channels_operator(term.negated ?? false, term.operand),
             });
         }
+        if (term.operator === "channel") {
+            const verb = term.negated ? "exclude " : "";
+            if (!term.operand) {
+                return verb + "messages in a specific channel";
+            }
+            const stream = stream_data.get_sub_by_id_string(term.operand);
+            if (stream) {
+                return render_search_description({
+                    type: "plain_text",
+                    content: verb + "messages in #" + stream.name,
+                });
+            }
+            // Assume the operand is a partially formed name and return
+            // the operator as the channel name in the next block.
+        }
         const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
         if (prefix_for_operator !== "") {
-            if (term.operator === "channel") {
-                const stream = stream_data.get_sub_by_id_string(term.operand);
-                const verb = term.negated ? "exclude " : "";
-                if (stream) {
-                    return render_search_description({
-                        type: "channel",
-                        prefix_for_operator: verb + "messages in #",
-                        operand: stream.name,
-                    });
-                }
-                // Assume the operand is a partially formed name and return
-                // the operator as the channel name in the next block.
-            }
             if (term.operator === "topic" && !is_operator_suggestion) {
                 return render_search_description({
                     type: "prefix_for_operator",

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -672,105 +672,78 @@ export class Filter {
         // Calling canonicalize_term on the terms is not easy here,
         // and so it's expected that callers already do those conversions,
         // and the current only callpath (generate_pills_html) does.
-        const verb = term.negated ? "exclude " : "";
-        if (term.operator === "is") {
-            // Some operands have their own negative words, like
-            // unresolved, rather than the default "exclude " prefix.
-            const custom_negated_operand_phrases: Record<string, string> = {
-                resolved: "unresolved",
-            };
-            const negated_phrase = custom_negated_operand_phrases[term.operand];
-            if (term.negated && negated_phrase !== undefined) {
-                return render_search_description({
-                    type: "is_operator",
-                    verb: "",
-                    operand: negated_phrase,
-                });
-            }
-
-            return render_search_description({
-                type: "is_operator",
-                verb,
-                operand: term.operand,
-            });
-        }
-        if (term.operator === "has") {
-            // search_suggestion.get_suggestions takes care that this message will
-            // only be shown if the `has` operator is not at the last.
-            switch(term.operand) {
-                case "link":
-                case "links":
-                    return verb + "messages with links";
-                case "image":
-                case "images":
-                    return verb + "messages with images";
-                case "attachment":
-                case "attachments":
-                    return verb + "messages with attachments";
-                case "reaction":
-                case "reactions":
-                    return verb + "messages with reactions";
-            }
-            return render_search_description({
-                type: "invalid_has",
-                operand: term.operand,
-            });
-        }
-        if (term.operator === "channels" && channels_operands.has(term.operand)) {
-            return render_search_description({
-                type: "plain_text",
-                content: this.describe_channels_operator(term.negated ?? false, term.operand),
-            });
-        }
-        if (term.operator === "channel") {
-            if (!term.operand) {
-                return verb + "messages in a specific channel";
-            }
-            const stream = stream_data.get_sub_by_id_string(term.operand);
-            assert(stream !== undefined);
-            return render_search_description({
-                type: "plain_text",
-                content: verb + "messages in #" + stream.name,
-            });
-        }
-        if (term.operator === "topic") {
-            if (!is_operator_suggestion) {
-                return render_search_description({
-                    type: "prefix_for_operator",
-                    prefix_for_operator: verb + "topic",
-                    operand: util.get_final_topic_display_name(term.operand),
-                    is_empty_string_topic: term.operand === "",
-                });
-            }
-            return render_search_description({
-                type: "plain_text",
-                content: verb + "topic",
-            });
-        }
         const operator = filter_util.canonicalize_operator(term.operator);
+        const verb = term.negated ? "exclude " : "";
         let operand = "";
 
         if (term.operand !== "") {
             operand = ` ${term.operand}`;
         }
 
-        if (operator === "search") {
-            return term.negated ? "exclude" + operand : "search for" + operand;
-        }
-
         switch (operator) {
-            case "channel":
-                return verb + "messages in a specific channel" + operand;
-            case "channels":
+            case "channel": {
+                if (!term.operand) {
+                    return verb + "messages in a specific channel";
+                }
+                const stream = stream_data.get_sub_by_id_string(term.operand);
+                assert(stream !== undefined);
+                return render_search_description({
+                    type: "plain_text",
+                    content: verb + "messages in #" + stream.name,
+                });
+            }
+            case "channels": {
+                if (channels_operands.has(term.operand)) {
+                    return render_search_description({
+                        type: "plain_text",
+                        content: this.describe_channels_operator(
+                            term.negated ?? false,
+                            term.operand,
+                        ),
+                    });
+                }
                 return verb + "channel type" + operand;
+            }
             case "near":
                 return verb + "messages around" + operand;
-            case "has":
-                return verb + "messages with" + operand;
+            case "has": {
+                // search_suggestion.get_suggestions takes care that this message will
+                // only be shown if the `has` operator is not at the last.
+                switch (term.operand) {
+                    case "link":
+                    case "links":
+                        return verb + "messages with links";
+                    case "image":
+                    case "images":
+                        return verb + "messages with images";
+                    case "attachment":
+                    case "attachments":
+                        return verb + "messages with attachments";
+                    case "reaction":
+                    case "reactions":
+                        return verb + "messages with reactions";
+                }
+                return render_search_description({
+                    type: "invalid_has",
+                    operand: term.operand,
+                });
+            }
             case "id":
                 return verb + "message ID" + operand;
-            case "topic":
-                return verb + "topic" + operand;
+            case "topic": {
+                if (!is_operator_suggestion) {
+                    return render_search_description({
+                        type: "prefix_for_operator",
+                        prefix_for_operator: verb + "topic",
+                        operand: util.get_final_topic_display_name(term.operand),
+                        is_empty_string_topic: term.operand === "",
+                    });
+                }
+                return render_search_description({
+                    type: "plain_text",
+                    content: verb + "topic",
+                });
+            }
             case "sender":
                 return verb + "sent by" + operand;
             case "dm":
@@ -779,9 +752,30 @@ export class Filter {
                 return verb + "direct messages including" + operand;
             case "in":
                 return verb + "messages in" + operand;
-            // Note: We hack around using this above.
-            case "is":
-                return verb + "messages that are" + operand;
+            case "is": {
+                // Some operands have their own negative words, like
+                // unresolved, rather than the default "exclude " prefix.
+                const custom_negated_operand_phrases: Record<string, string> = {
+                    resolved: "unresolved",
+                };
+                const negated_phrase = custom_negated_operand_phrases[term.operand];
+                if (term.negated && negated_phrase !== undefined) {
+                    return render_search_description({
+                        type: "is_operator",
+                        verb: "",
+                        operand: negated_phrase,
+                    });
+                }
+
+                return render_search_description({
+                    type: "is_operator",
+                    verb,
+                    operand: term.operand,
+                });
+            }
+            case "search": {
+                return term.negated ? "exclude" + operand : "search for" + operand;
+            }
         }
         return "unknown operator";
     }

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -746,128 +746,91 @@ export class Filter {
     }
 
     // Convert a list of terms to a human-readable description.
-    static parts_for_describe(
-        terms: NarrowTermSuggestion[],
-        is_operator_suggestion: boolean,
-    ): Part[] {
+    static parts_for_describe(term: NarrowTermSuggestion, is_operator_suggestion: boolean): Part {
         // Calling canonicalize_term on the terms is not easy here,
         // and so it's expected that callers already do those conversions,
         // and the current only callpath (generate_pills_html) does.
-        const parts: Part[] = [];
-
-        if (terms.length === 0) {
-            parts.push({type: "plain_text", content: "combined feed"});
-            return parts;
-        }
-
-        if (terms[0] !== undefined && terms[1] !== undefined) {
-            const term_0 = terms[0];
-            const term_1 = terms[1];
-            if (
-                term_0.operator === "channel" &&
-                !term_0.negated &&
-                term_1.operator === "topic" &&
-                !term_1.negated
-            ) {
-                // `channel` might be undefined if it's coming from a text query
-                const channel = stream_data.get_sub_by_id_string(term_0.operand)?.name;
-                if (channel) {
-                    const topic = term_1.operand;
-                    parts.push({
-                        type: "channel_topic",
-                        channel,
-                        topic_display_name: util.get_final_topic_display_name(topic),
-                        is_empty_string_topic: topic === "",
-                    });
-                    terms = terms.slice(2);
-                }
-            }
-        }
-
-        const more_parts = terms.map((term): Part => {
-            if (term.operator === "is") {
-                // Some operands have their own negative words, like
-                // unresolved, rather than the default "exclude " prefix.
-                const custom_negated_operand_phrases: Record<string, string> = {
-                    resolved: "unresolved",
-                };
-                const negated_phrase = custom_negated_operand_phrases[term.operand];
-                if (term.negated && negated_phrase !== undefined) {
-                    return {
-                        type: "is_operator",
-                        verb: "",
-                        operand: negated_phrase,
-                    };
-                }
-
-                const verb = term.negated ? "exclude " : "";
+        if (term.operator === "is") {
+            // Some operands have their own negative words, like
+            // unresolved, rather than the default "exclude " prefix.
+            const custom_negated_operand_phrases: Record<string, string> = {
+                resolved: "unresolved",
+            };
+            const negated_phrase = custom_negated_operand_phrases[term.operand];
+            if (term.negated && negated_phrase !== undefined) {
                 return {
                     type: "is_operator",
-                    verb,
+                    verb: "",
+                    operand: negated_phrase,
+                };
+            }
+
+            const verb = term.negated ? "exclude " : "";
+            return {
+                type: "is_operator",
+                verb,
+                operand: term.operand,
+            };
+        }
+        if (term.operator === "has") {
+            // search_suggestion.get_suggestions takes care that this message will
+            // only be shown if the `has` operator is not at the last.
+            const valid_has_operands = [
+                "image",
+                "images",
+                "link",
+                "links",
+                "attachment",
+                "attachments",
+                "reaction",
+                "reactions",
+            ];
+            if (!valid_has_operands.includes(term.operand)) {
+                return {
+                    type: "invalid_has",
                     operand: term.operand,
                 };
             }
-            if (term.operator === "has") {
-                // search_suggestion.get_suggestions takes care that this message will
-                // only be shown if the `has` operator is not at the last.
-                const valid_has_operands = [
-                    "image",
-                    "images",
-                    "link",
-                    "links",
-                    "attachment",
-                    "attachments",
-                    "reaction",
-                    "reactions",
-                ];
-                if (!valid_has_operands.includes(term.operand)) {
+        }
+        if (term.operator === "channels" && channels_operands.has(term.operand)) {
+            return {
+                type: "plain_text",
+                content: this.describe_channels_operator(term.negated ?? false, term.operand),
+            };
+        }
+        const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
+        if (prefix_for_operator !== "") {
+            if (term.operator === "channel") {
+                const stream = stream_data.get_sub_by_id_string(term.operand);
+                const verb = term.negated ? "exclude " : "";
+                if (stream) {
                     return {
-                        type: "invalid_has",
-                        operand: term.operand,
+                        type: "channel",
+                        prefix_for_operator: verb + "messages in #",
+                        operand: stream.name,
                     };
                 }
+                // Assume the operand is a partially formed name and return
+                // the operator as the channel name in the next block.
             }
-            if (term.operator === "channels" && channels_operands.has(term.operand)) {
-                return {
-                    type: "plain_text",
-                    content: this.describe_channels_operator(term.negated ?? false, term.operand),
-                };
-            }
-            const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
-            if (prefix_for_operator !== "") {
-                if (term.operator === "channel") {
-                    const stream = stream_data.get_sub_by_id_string(term.operand);
-                    const verb = term.negated ? "exclude " : "";
-                    if (stream) {
-                        return {
-                            type: "channel",
-                            prefix_for_operator: verb + "messages in #",
-                            operand: stream.name,
-                        };
-                    }
-                    // Assume the operand is a partially formed name and return
-                    // the operator as the channel name in the next block.
-                }
-                if (term.operator === "topic" && !is_operator_suggestion) {
-                    return {
-                        type: "prefix_for_operator",
-                        prefix_for_operator,
-                        operand: util.get_final_topic_display_name(term.operand),
-                        is_empty_string_topic: term.operand === "",
-                    };
-                }
+            if (term.operator === "topic" && !is_operator_suggestion) {
                 return {
                     type: "prefix_for_operator",
                     prefix_for_operator,
-                    operand: term.operand,
+                    operand: util.get_final_topic_display_name(term.operand),
+                    is_empty_string_topic: term.operand === "",
                 };
             }
             return {
-                type: "plain_text",
-                content: "unknown operator",
+                type: "prefix_for_operator",
+                prefix_for_operator,
+                operand: term.operand,
             };
-        });
-        return [...parts, ...more_parts];
+        }
+        return {
+            type: "plain_text",
+            content: "unknown operator",
+        };
     }
 
     static describe_channels_operator(negated: boolean, operand: string): string {
@@ -885,12 +848,10 @@ export class Filter {
     }
 
     static search_description_as_html(
-        terms: NarrowTermSuggestion[],
+        term: NarrowTermSuggestion,
         is_operator_suggestion: boolean,
     ): string {
-        return render_search_description({
-            parts: Filter.parts_for_describe(terms, is_operator_suggestion),
-        });
+        return render_search_description(Filter.parts_for_describe(term, is_operator_suggestion));
     }
 
     static is_spectator_compatible(terms: NarrowTerm[]): boolean {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -13,7 +13,12 @@ import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as resolved_topic from "./resolved_topic.ts";
 import {current_user, narrow_canonical_term_schema, narrow_operator_schema} from "./state_data.ts";
-import type {NarrowCanonicalTerm, NarrowTerm, NarrowTermSuggestion} from "./state_data.ts";
+import type {
+    NarrowCanonicalOperator,
+    NarrowCanonicalTerm,
+    NarrowTerm,
+    NarrowTermSuggestion,
+} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
 import * as user_topics from "./user_topics.ts";
@@ -33,6 +38,146 @@ type IconData = {
 );
 
 const channels_operands = new Set(["public", "web-public"]);
+const static_filter_descriptions: Record<string, string> = {
+    "channels:public": $t({defaultMessage: "all public channels"}),
+    "-channels:public": $t({defaultMessage: "exclude all public channels"}),
+    "channels:web-public": $t({defaultMessage: "all web-public channels"}),
+    "-channels:web-public": $t({defaultMessage: "exclude all web-public channels"}),
+    "has:link": $t({defaultMessage: "messages with links"}),
+    "-has:link": $t({defaultMessage: "exclude messages with links"}),
+    "has:image": $t({defaultMessage: "messages with images"}),
+    "-has:image": $t({defaultMessage: "messages with images"}),
+    "has:attachment": $t({defaultMessage: "messages with attachments"}),
+    "-has:attachment": $t({defaultMessage: "exclude messages with attachments"}),
+    "has:reaction": $t({defaultMessage: "messages with reactions"}),
+    "-has:reaction": $t({defaultMessage: "exclude messages with reactions"}),
+    "is:mentioned": $t({defaultMessage: "messages that mention you"}),
+    "-is:mentioned": $t({defaultMessage: "exclude messages that mention you"}),
+    "is:starred": $t({defaultMessage: "starred messages"}),
+    "-is:starred": $t({defaultMessage: "exclude starred messages"}),
+    "is:alerted": $t({defaultMessage: "starred messages"}),
+    "-is:alerted": $t({defaultMessage: "exclude starred messages"}),
+    "is:unread": $t({defaultMessage: "unread messages"}),
+    "-is:unread": $t({defaultMessage: "exclude unread messages"}),
+    "is:dm": $t({defaultMessage: "direct messages"}),
+    "-is:dm": $t({defaultMessage: "exclude direct messages"}),
+    "is:resolved": $t({defaultMessage: "resolved topics"}),
+    "-is:resolved": $t({defaultMessage: "unresolved topics"}),
+    "is:followed": $t({defaultMessage: "followed topics"}),
+    "-is:followed": $t({defaultMessage: "exclude followed topics"}),
+    "is:muted": $t({defaultMessage: "muted messages"}),
+    "-is:muted": $t({defaultMessage: "exclude muted messages"}),
+};
+
+const operator_suggestion_descriptions: Partial<
+    Record<NarrowCanonicalOperator, (negated: boolean) => string>
+> = {
+    channel: (negated: boolean) =>
+        negated
+            ? $t({defaultMessage: "exclude messages in a specific channel"})
+            : $t({defaultMessage: "messages in a specific channel"}),
+    channels: (negated: boolean) =>
+        negated
+            ? $t({defaultMessage: "exclude channel type"})
+            : $t({defaultMessage: "channel type"}),
+    near: (negated: boolean) =>
+        negated
+            ? $t({defaultMessage: "exclude messages around"})
+            : $t({defaultMessage: "messages around"}),
+    id: (negated: boolean) =>
+        negated ? $t({defaultMessage: "exclude message ID"}) : $t({defaultMessage: "message ID"}),
+    topic: (negated: boolean) =>
+        negated ? $t({defaultMessage: "exclude topic"}) : $t({defaultMessage: "topic"}),
+    sender: (negated: boolean) =>
+        negated ? $t({defaultMessage: "exclude sent by"}) : $t({defaultMessage: "sent by"}),
+    dm: (negated: boolean) =>
+        negated
+            ? $t({defaultMessage: "exclude direct messages with"})
+            : $t({defaultMessage: "direct messages with"}),
+    "dm-including": (negated: boolean) =>
+        negated
+            ? $t({defaultMessage: "exclude direct messages including"})
+            : $t({defaultMessage: "direct messages including"}),
+    in: (negated: boolean) =>
+        negated ? $t({defaultMessage: "exclude messages in"}) : $t({defaultMessage: "messages in"}),
+    search: (negated: boolean) =>
+        negated ? $t({defaultMessage: "exclude"}) : $t({defaultMessage: "search for"}),
+};
+
+const variable_suggestion_descriptions: Partial<
+    Record<NarrowCanonicalOperator, (operand: string, negated: boolean) => string>
+> = {
+    channel(operand: string, negated: boolean) {
+        const stream = stream_data.get_sub_by_id_string(operand);
+        assert(stream !== undefined);
+        return negated
+            ? $t_html(
+                  {defaultMessage: "exclude messages in #{stream_name}"},
+                  {stream_name: stream.name},
+              )
+            : $t_html({defaultMessage: "messages in #{stream_name}"}, {stream_name: stream.name});
+    },
+    near: (operand: string, negated: boolean) =>
+        negated
+            ? $t_html({defaultMessage: "exclude messages around {operand}"}, {operand})
+            : $t_html({defaultMessage: "messages around {operand}"}, {operand}),
+    id: (operand: string, negated: boolean) =>
+        negated
+            ? $t_html(
+                  {
+                      defaultMessage: "exclude message ID {operand}",
+                  },
+                  {operand},
+              )
+            : $t_html({defaultMessage: "message ID {operand}"}, {operand}),
+    topic(operand: string, negated: boolean) {
+        const topic_name = util.get_final_topic_display_name(operand);
+        if (operand === "") {
+            return negated
+                ? $t_html(
+                      {defaultMessage: "exclude topic <z-topic>{topic_name}</z-topic>"},
+                      {
+                          topic_name,
+                          "z-topic": (content_html) =>
+                              `<span class="empty-topic-display">${content_html.join("")}</span>`,
+                      },
+                  )
+                : $t_html(
+                      {defaultMessage: "topic <z-topic>{topic_name}</z-topic>"},
+                      {
+                          topic_name,
+                          "z-topic": (content_html) =>
+                              `<span class="empty-topic-display">${content_html.join("")}</span>`,
+                      },
+                  );
+        }
+        return negated
+            ? $t_html({defaultMessage: "exclude topic {operand}"}, {operand})
+            : $t_html({defaultMessage: "topic {operand}"}, {operand});
+    },
+    sender: (operand: string, negated: boolean) =>
+        negated
+            ? $t_html({defaultMessage: "exclude sent by {operand}"}, {operand})
+            : $t_html({defaultMessage: "sent by {operand}"}, {operand}),
+    dm: (operand: string, negated: boolean) =>
+        negated
+            ? $t_html({defaultMessage: "exclude direct messages with {operand}"}, {operand})
+            : $t_html({defaultMessage: "direct messages with {operand}"}, {operand}),
+    "dm-including": (operand: string, negated: boolean) =>
+        negated
+            ? $t_html({defaultMessage: "exclude direct messages including {operand}"}, {operand})
+            : $t_html({defaultMessage: "direct messages including {operand}"}, {operand}),
+    in: (operand: string, negated: boolean) =>
+        negated
+            ? $t_html({defaultMessage: "exclude messages in {operand}"}, {operand})
+            : $t_html({defaultMessage: "messages in {operand}"}, {operand}),
+    is: (operand: string, _negated: boolean) =>
+        $t_html({defaultMessage: "invalid {operand} operand for is operator"}, {operand}),
+    search: (operand: string, negated: boolean) =>
+        negated
+            ? $t_html({defaultMessage: "exclude {operand}"}, {operand})
+            : $t_html({defaultMessage: "search for {operand}"}, {operand}),
+};
 
 function message_in_home(message: Message): boolean {
     // The home view contains messages not sent to muted channels,
@@ -666,200 +811,30 @@ export class Filter {
     }
 
     // Convert a list of terms to a human-readable description.
-    static parts_for_describe(term: NarrowTermSuggestion, is_operator_suggestion: boolean): string {
+    static parts_for_describe(
+        term: NarrowTermSuggestion,
+        is_operator_suggestion: boolean,
+        search_string: string,
+    ): string {
+        const static_filter_description = static_filter_descriptions[search_string];
+        if (static_filter_description !== undefined) {
+            return static_filter_description;
+        }
         // Calling canonicalize_term on the terms is not easy here,
         // and so it's expected that callers already do those conversions,
         // and the current only callpath (generate_pills_html) does.
         const operator = filter_util.canonicalize_operator(term.operator);
-        const is_negated = term.negated;
+        const negated = Boolean(term.negated);
         const operand = term.operand;
-
-        switch (operator) {
-            case "channel": {
-                if (!term.operand) {
-                    return is_negated
-                        ? $t({defaultMessage: "exclude messages in a specific channel"})
-                        : $t({defaultMessage: "messages in a specific channel"});
-                }
-                const stream = stream_data.get_sub_by_id_string(term.operand);
-                assert(stream !== undefined);
-                return is_negated
-                    ? $t(
-                          {defaultMessage: "exclude messages in #{stream_name}"},
-                          {stream_name: stream.name},
-                      )
-                    : $t(
-                          {defaultMessage: "messages in #{stream_name}"},
-                          {stream_name: stream.name},
-                      );
+        if (is_operator_suggestion && operand === "") {
+            const operator_suggestion_description = operator_suggestion_descriptions[operator];
+            if (operator_suggestion_description !== undefined) {
+                return operator_suggestion_description(negated);
             }
-            case "channels": {
-                if (channels_operands.has(operand)) {
-                    return this.describe_channels_operator(term.negated ?? false, operand);
-                }
-                return is_negated
-                    ? $t({defaultMessage: "exclude channel type"})
-                    : $t({defaultMessage: "channel type"});
-            }
-            case "near":
-                if (operand) {
-                    return is_negated
-                        ? $t({defaultMessage: "exclude messages around {operand}"}, {operand})
-                        : $t({defaultMessage: "messages around {operand}"}, {operand});
-                }
-                return is_negated
-                    ? $t({defaultMessage: "exclude messages around"})
-                    : $t({defaultMessage: "messages around"});
-            case "has": {
-                // search_suggestion.get_suggestions takes care that this message will
-                // only be shown if the `has` operator is not at the last.
-                switch (term.operand) {
-                    case "link":
-                    case "links":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude messages with links"})
-                            : $t({defaultMessage: "messages with links"});
-                    case "image":
-                    case "images":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude messages with images"})
-                            : $t({defaultMessage: "messages with images"});
-                    case "attachment":
-                    case "attachments":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude messages with attachments"})
-                            : $t({defaultMessage: "messages with attachments"});
-                    case "reaction":
-                    case "reactions":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude messages with reactions"})
-                            : $t({defaultMessage: "messages with reactions"});
-                }
-                return $t(
-                    {defaultMessage: "invalid {operand} operand for has operator"},
-                    {operand},
-                );
-            }
-            case "id":
-                if (operand) {
-                    return is_negated
-                        ? $t({defaultMessage: "exclude message ID {operand}"}, {operand})
-                        : $t({defaultMessage: "message ID {operand}"}, {operand});
-                }
-                return is_negated
-                    ? $t({defaultMessage: "exclude message ID"})
-                    : $t({defaultMessage: "message ID"});
-            case "topic": {
-                const operand = util.get_final_topic_display_name(term.operand);
-                if (!is_operator_suggestion && term.operand === "") {
-                    return is_negated
-                        ? $t_html(
-                              {defaultMessage: "exclude topic <z-topic>{topic}</z-topic>"},
-                              {
-                                  topic: operand,
-                                  "z-topic": (content_html) =>
-                                      `<span class="empty-topic-display">${content_html.join("")}</span>`,
-                              },
-                          )
-                        : $t_html(
-                              {defaultMessage: "topic <z-topic>{topic}</z-topic>"},
-                              {
-                                  topic: operand,
-                                  "z-topic": (content_html) =>
-                                      `<span class="empty-topic-display">${content_html.join("")}</span>`,
-                              },
-                          );
-                } else if (!is_operator_suggestion) {
-                    return is_negated
-                        ? $t({defaultMessage: "exclude topic {operand}"}, {operand})
-                        : $t({defaultMessage: "topic {operand}"}, {operand});
-                }
-                return is_negated
-                    ? $t({defaultMessage: "exclude topic"})
-                    : $t({defaultMessage: "topic"});
-            }
-            case "sender":
-                return is_negated
-                    ? $t({defaultMessage: "exclude sent by {operand}"}, {operand})
-                    : $t({defaultMessage: "sent by {operand}"}, {operand});
-            case "dm":
-                return is_negated
-                    ? $t({defaultMessage: "exclude direct messages with {operand}"}, {operand})
-                    : $t({defaultMessage: "direct messages with {operand}"}, {operand});
-            case "dm-including":
-                return is_negated
-                    ? $t({defaultMessage: "exclude direct messages including {operand}"}, {operand})
-                    : $t({defaultMessage: "direct messages including {operand}"}, {operand});
-            case "in":
-                return is_negated
-                    ? $t({defaultMessage: "exclude messages in {operand}"}, {operand})
-                    : $t({defaultMessage: "messages in {operand}"}, {operand});
-            case "is": {
-                // Some operands have their own negative words, like
-                // unresolved, rather than the default "exclude " prefix.
-                const custom_negated_operand_phrases: Record<string, string> = {
-                    resolved: "unresolved",
-                };
-                const negated_phrase = custom_negated_operand_phrases[term.operand];
-
-                if (term.negated && negated_phrase !== undefined) {
-                    switch (negated_phrase) {
-                        case "unresolved":
-                            return $t({defaultMessage: "unresolved topics"});
-                    }
-                }
-
-                switch (term.operand) {
-                    case "mentioned":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude messages that mention you"})
-                            : $t({defaultMessage: "messages that mention you"});
-                    case "starred":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude starred messages"})
-                            : $t({defaultMessage: "starred messages"});
-                    case "alerted":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude alerted messages"})
-                            : $t({defaultMessage: "alerted messages"});
-                    case "unread":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude unread messages"})
-                            : $t({defaultMessage: "unread messages"});
-                    case "dm":
-                    case "private":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude direct messages"})
-                            : $t({defaultMessage: "direct messages"});
-                    case "resolved":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude resolved topics"})
-                            : $t({defaultMessage: "resolved topics"});
-                    case "followed":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude followed topics"})
-                            : $t({defaultMessage: "followed topics"});
-                    case "muted":
-                        return is_negated
-                            ? $t({defaultMessage: "exclude muted messages"})
-                            : $t({defaultMessage: "muted messages"});
-                    default:
-                        return $t(
-                            {defaultMessage: "invalid {operand} operand for is operator"},
-                            {operand},
-                        );
-                }
-            }
-            case "search": {
-                if (operand) {
-                    return is_negated
-                        ? $t({defaultMessage: "exclude {operand}"}, {operand})
-                        : $t({defaultMessage: "search for {operand}"}, {operand});
-                }
-                return is_negated
-                    ? $t({defaultMessage: "exclude"})
-                    : $t({defaultMessage: "search for"});
-            }
+        }
+        const variable_suggestion_description = variable_suggestion_descriptions[operator];
+        if (variable_suggestion_description !== undefined) {
+            return variable_suggestion_description(operand, negated);
         }
         return $t({defaultMessage: "unknown operator"});
     }
@@ -886,8 +861,9 @@ export class Filter {
     static search_description_as_html(
         term: NarrowTermSuggestion,
         is_operator_suggestion: boolean,
+        search_string: string,
     ): string {
-        return Filter.parts_for_describe(term, is_operator_suggestion);
+        return Filter.parts_for_describe(term, is_operator_suggestion, search_string);
     }
 
     static is_spectator_compatible(terms: NarrowTerm[]): boolean {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -718,6 +718,7 @@ export class Filter {
         // Calling canonicalize_term on the terms is not easy here,
         // and so it's expected that callers already do those conversions,
         // and the current only callpath (generate_pills_html) does.
+        const verb = term.negated ? "exclude " : "";
         if (term.operator === "is") {
             // Some operands have their own negative words, like
             // unresolved, rather than the default "exclude " prefix.
@@ -733,7 +734,6 @@ export class Filter {
                 });
             }
 
-            const verb = term.negated ? "exclude " : "";
             return render_search_description({
                 type: "is_operator",
                 verb,
@@ -743,22 +743,24 @@ export class Filter {
         if (term.operator === "has") {
             // search_suggestion.get_suggestions takes care that this message will
             // only be shown if the `has` operator is not at the last.
-            const valid_has_operands = [
-                "image",
-                "images",
-                "link",
-                "links",
-                "attachment",
-                "attachments",
-                "reaction",
-                "reactions",
-            ];
-            if (!valid_has_operands.includes(term.operand)) {
-                return render_search_description({
-                    type: "invalid_has",
-                    operand: term.operand,
-                });
+            switch(term.operand) {
+                case "link":
+                case "links":
+                    return verb + "messages with links";
+                case "image":
+                case "images":
+                    return verb + "messages with images";
+                case "attachment":
+                case "attachments":
+                    return verb + "messages with attachments";
+                case "reaction":
+                case "reactions":
+                    return verb + "messages with reactions";
             }
+            return render_search_description({
+                type: "invalid_has",
+                operand: term.operand,
+            });
         }
         if (term.operator === "channels" && channels_operands.has(term.operand)) {
             return render_search_description({
@@ -767,7 +769,6 @@ export class Filter {
             });
         }
         if (term.operator === "channel") {
-            const verb = term.negated ? "exclude " : "";
             if (!term.operand) {
                 return verb + "messages in a specific channel";
             }
@@ -778,16 +779,22 @@ export class Filter {
                 content: verb + "messages in #" + stream.name,
             });
         }
-        const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
-        if (prefix_for_operator !== "") {
-            if (term.operator === "topic" && !is_operator_suggestion) {
+        if (term.operator === "topic") {
+            if (!is_operator_suggestion) {
                 return render_search_description({
                     type: "prefix_for_operator",
-                    prefix_for_operator,
+                    prefix_for_operator: verb + "topic",
                     operand: util.get_final_topic_display_name(term.operand),
                     is_empty_string_topic: term.operand === "",
                 });
             }
+            return render_search_description({
+                type: "plain_text",
+                content: verb + "topic",
+            });
+        }
+        const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
+        if (prefix_for_operator !== "") {
             return render_search_description({
                 type: "prefix_for_operator",
                 prefix_for_operator,

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -834,16 +834,21 @@ export class Filter {
     }
 
     static describe_channels_operator(negated: boolean, operand: string): string {
-        const possible_prefix = negated ? "exclude " : "";
         assert(channels_operands.has(operand));
         if ((page_params.is_spectator || current_user.is_guest) && operand === "public") {
-            return possible_prefix + "all public channels that you can view";
+            return negated
+                ? $t({defaultMessage: "exclude all public channels that you can view"})
+                : $t({defaultMessage: "all public channels that you can view"});
         }
         switch (operand) {
             case "web-public":
-                return possible_prefix + "all web-public channels";
+                return negated
+                    ? $t({defaultMessage: "exclude all web-public channels"})
+                    : $t({defaultMessage: "all web-public channels"});
             default:
-                return possible_prefix + "all public channels";
+                return negated
+                    ? $t({defaultMessage: "exclude all public channels"})
+                    : $t({defaultMessage: "all public channels"});
         }
     }
 

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -34,38 +34,6 @@ type IconData = {
       }
 );
 
-type Part =
-    | {
-          type: "plain_text";
-          content: string;
-      }
-    | {
-          type: "channel_topic";
-          channel: string;
-          topic_display_name: string;
-          is_empty_string_topic: boolean;
-      }
-    | {
-          type: "channel";
-          prefix_for_operator: string;
-          operand: string;
-      }
-    | {
-          type: "is_operator";
-          verb: string;
-          operand: string;
-      }
-    | {
-          type: "invalid_has";
-          operand: string;
-      }
-    | {
-          type: "prefix_for_operator";
-          prefix_for_operator: string;
-          operand: string;
-          is_empty_string_topic?: boolean;
-      };
-
 const channels_operands = new Set(["public", "web-public"]);
 
 function message_in_home(message: Message): boolean {
@@ -746,7 +714,7 @@ export class Filter {
     }
 
     // Convert a list of terms to a human-readable description.
-    static parts_for_describe(term: NarrowTermSuggestion, is_operator_suggestion: boolean): Part {
+    static parts_for_describe(term: NarrowTermSuggestion, is_operator_suggestion: boolean): string {
         // Calling canonicalize_term on the terms is not easy here,
         // and so it's expected that callers already do those conversions,
         // and the current only callpath (generate_pills_html) does.
@@ -758,19 +726,19 @@ export class Filter {
             };
             const negated_phrase = custom_negated_operand_phrases[term.operand];
             if (term.negated && negated_phrase !== undefined) {
-                return {
+                return render_search_description({
                     type: "is_operator",
                     verb: "",
                     operand: negated_phrase,
-                };
+                });
             }
 
             const verb = term.negated ? "exclude " : "";
-            return {
+            return render_search_description({
                 type: "is_operator",
                 verb,
                 operand: term.operand,
-            };
+            });
         }
         if (term.operator === "has") {
             // search_suggestion.get_suggestions takes care that this message will
@@ -786,17 +754,17 @@ export class Filter {
                 "reactions",
             ];
             if (!valid_has_operands.includes(term.operand)) {
-                return {
+                return render_search_description({
                     type: "invalid_has",
                     operand: term.operand,
-                };
+                });
             }
         }
         if (term.operator === "channels" && channels_operands.has(term.operand)) {
-            return {
+            return render_search_description({
                 type: "plain_text",
                 content: this.describe_channels_operator(term.negated ?? false, term.operand),
-            };
+            });
         }
         const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
         if (prefix_for_operator !== "") {
@@ -804,33 +772,33 @@ export class Filter {
                 const stream = stream_data.get_sub_by_id_string(term.operand);
                 const verb = term.negated ? "exclude " : "";
                 if (stream) {
-                    return {
+                    return render_search_description({
                         type: "channel",
                         prefix_for_operator: verb + "messages in #",
                         operand: stream.name,
-                    };
+                    });
                 }
                 // Assume the operand is a partially formed name and return
                 // the operator as the channel name in the next block.
             }
             if (term.operator === "topic" && !is_operator_suggestion) {
-                return {
+                return render_search_description({
                     type: "prefix_for_operator",
                     prefix_for_operator,
                     operand: util.get_final_topic_display_name(term.operand),
                     is_empty_string_topic: term.operand === "",
-                };
+                });
             }
-            return {
+            return render_search_description({
                 type: "prefix_for_operator",
                 prefix_for_operator,
                 operand: term.operand,
-            };
+            });
         }
-        return {
+        return render_search_description({
             type: "plain_text",
             content: "unknown operator",
-        };
+        });
     }
 
     static describe_channels_operator(negated: boolean, operand: string): string {
@@ -856,7 +824,7 @@ export class Filter {
         term: NarrowTermSuggestion,
         is_operator_suggestion: boolean,
     ): string {
-        return render_search_description(Filter.parts_for_describe(term, is_operator_suggestion));
+        return Filter.parts_for_describe(term, is_operator_suggestion);
     }
 
     static is_spectator_compatible(terms: NarrowTerm[]): boolean {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1,11 +1,9 @@
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
-import render_search_description from "../templates/search_description.hbs";
-
 import * as filter_util from "./filter_util.ts";
 import * as hash_parser from "./hash_parser.ts";
-import {$t} from "./i18n.ts";
+import {$t, $t_html} from "./i18n.ts";
 import * as internal_url from "./internal_url.ts";
 import * as message_parser from "./message_parser.ts";
 import * as message_store from "./message_store.ts";
@@ -673,85 +671,129 @@ export class Filter {
         // and so it's expected that callers already do those conversions,
         // and the current only callpath (generate_pills_html) does.
         const operator = filter_util.canonicalize_operator(term.operator);
-        const verb = term.negated ? "exclude " : "";
-        let operand = "";
-
-        if (term.operand !== "") {
-            operand = ` ${term.operand}`;
-        }
+        const is_negated = term.negated;
+        const operand = term.operand;
 
         switch (operator) {
             case "channel": {
                 if (!term.operand) {
-                    return verb + "messages in a specific channel";
+                    return is_negated
+                        ? $t({defaultMessage: "exclude messages in a specific channel"})
+                        : $t({defaultMessage: "messages in a specific channel"});
                 }
                 const stream = stream_data.get_sub_by_id_string(term.operand);
                 assert(stream !== undefined);
-                return render_search_description({
-                    type: "plain_text",
-                    content: verb + "messages in #" + stream.name,
-                });
+                return is_negated
+                    ? $t(
+                          {defaultMessage: "exclude messages in #{stream_name}"},
+                          {stream_name: stream.name},
+                      )
+                    : $t(
+                          {defaultMessage: "messages in #{stream_name}"},
+                          {stream_name: stream.name},
+                      );
             }
             case "channels": {
-                if (channels_operands.has(term.operand)) {
-                    return render_search_description({
-                        type: "plain_text",
-                        content: this.describe_channels_operator(
-                            term.negated ?? false,
-                            term.operand,
-                        ),
-                    });
+                if (channels_operands.has(operand)) {
+                    return this.describe_channels_operator(term.negated ?? false, operand);
                 }
-                return verb + "channel type" + operand;
+                return is_negated
+                    ? $t({defaultMessage: "exclude channel type"})
+                    : $t({defaultMessage: "channel type"});
             }
             case "near":
-                return verb + "messages around" + operand;
+                if (operand) {
+                    return is_negated
+                        ? $t({defaultMessage: "exclude messages around {operand}"}, {operand})
+                        : $t({defaultMessage: "messages around {operand}"}, {operand});
+                }
+                return is_negated
+                    ? $t({defaultMessage: "exclude messages around"})
+                    : $t({defaultMessage: "messages around"});
             case "has": {
                 // search_suggestion.get_suggestions takes care that this message will
                 // only be shown if the `has` operator is not at the last.
                 switch (term.operand) {
                     case "link":
                     case "links":
-                        return verb + "messages with links";
+                        return is_negated
+                            ? $t({defaultMessage: "exclude messages with links"})
+                            : $t({defaultMessage: "messages with links"});
                     case "image":
                     case "images":
-                        return verb + "messages with images";
+                        return is_negated
+                            ? $t({defaultMessage: "exclude messages with images"})
+                            : $t({defaultMessage: "messages with images"});
                     case "attachment":
                     case "attachments":
-                        return verb + "messages with attachments";
+                        return is_negated
+                            ? $t({defaultMessage: "exclude messages with attachments"})
+                            : $t({defaultMessage: "messages with attachments"});
                     case "reaction":
                     case "reactions":
-                        return verb + "messages with reactions";
+                        return is_negated
+                            ? $t({defaultMessage: "exclude messages with reactions"})
+                            : $t({defaultMessage: "messages with reactions"});
                 }
-                return render_search_description({
-                    type: "invalid_has",
-                    operand: term.operand,
-                });
+                return $t(
+                    {defaultMessage: "invalid {operand} operand for has operator"},
+                    {operand},
+                );
             }
             case "id":
-                return verb + "message ID" + operand;
-            case "topic": {
-                if (!is_operator_suggestion) {
-                    return render_search_description({
-                        type: "prefix_for_operator",
-                        prefix_for_operator: verb + "topic",
-                        operand: util.get_final_topic_display_name(term.operand),
-                        is_empty_string_topic: term.operand === "",
-                    });
+                if (operand) {
+                    return is_negated
+                        ? $t({defaultMessage: "exclude message ID {operand}"}, {operand})
+                        : $t({defaultMessage: "message ID {operand}"}, {operand});
                 }
-                return render_search_description({
-                    type: "plain_text",
-                    content: verb + "topic",
-                });
+                return is_negated
+                    ? $t({defaultMessage: "exclude message ID"})
+                    : $t({defaultMessage: "message ID"});
+            case "topic": {
+                const operand = util.get_final_topic_display_name(term.operand);
+                if (!is_operator_suggestion && term.operand === "") {
+                    return is_negated
+                        ? $t_html(
+                              {defaultMessage: "exclude topic <z-topic>{topic}</z-topic>"},
+                              {
+                                  topic: operand,
+                                  "z-topic": (content_html) =>
+                                      `<span class="empty-topic-display">${content_html.join("")}</span>`,
+                              },
+                          )
+                        : $t_html(
+                              {defaultMessage: "topic <z-topic>{topic}</z-topic>"},
+                              {
+                                  topic: operand,
+                                  "z-topic": (content_html) =>
+                                      `<span class="empty-topic-display">${content_html.join("")}</span>`,
+                              },
+                          );
+                } else if (!is_operator_suggestion) {
+                    return is_negated
+                        ? $t({defaultMessage: "exclude topic {operand}"}, {operand})
+                        : $t({defaultMessage: "topic {operand}"}, {operand});
+                }
+                return is_negated
+                    ? $t({defaultMessage: "exclude topic"})
+                    : $t({defaultMessage: "topic"});
             }
             case "sender":
-                return verb + "sent by" + operand;
+                return is_negated
+                    ? $t({defaultMessage: "exclude sent by {operand}"}, {operand})
+                    : $t({defaultMessage: "sent by {operand}"}, {operand});
             case "dm":
-                return verb + "direct messages with" + operand;
+                return is_negated
+                    ? $t({defaultMessage: "exclude direct messages with {operand}"}, {operand})
+                    : $t({defaultMessage: "direct messages with {operand}"}, {operand});
             case "dm-including":
-                return verb + "direct messages including" + operand;
+                return is_negated
+                    ? $t({defaultMessage: "exclude direct messages including {operand}"}, {operand})
+                    : $t({defaultMessage: "direct messages including {operand}"}, {operand});
             case "in":
-                return verb + "messages in" + operand;
+                return is_negated
+                    ? $t({defaultMessage: "exclude messages in {operand}"}, {operand})
+                    : $t({defaultMessage: "messages in {operand}"}, {operand});
             case "is": {
                 // Some operands have their own negative words, like
                 // unresolved, rather than the default "exclude " prefix.
@@ -759,25 +801,67 @@ export class Filter {
                     resolved: "unresolved",
                 };
                 const negated_phrase = custom_negated_operand_phrases[term.operand];
+
                 if (term.negated && negated_phrase !== undefined) {
-                    return render_search_description({
-                        type: "is_operator",
-                        verb: "",
-                        operand: negated_phrase,
-                    });
+                    switch (negated_phrase) {
+                        case "unresolved":
+                            return $t({defaultMessage: "unresolved topics"});
+                    }
                 }
 
-                return render_search_description({
-                    type: "is_operator",
-                    verb,
-                    operand: term.operand,
-                });
+                switch (term.operand) {
+                    case "mentioned":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude messages that mention you"})
+                            : $t({defaultMessage: "messages that mention you"});
+                    case "starred":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude starred messages"})
+                            : $t({defaultMessage: "starred messages"});
+                    case "alerted":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude alerted messages"})
+                            : $t({defaultMessage: "alerted messages"});
+                    case "unread":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude unread messages"})
+                            : $t({defaultMessage: "unread messages"});
+                    case "dm":
+                    case "private":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude direct messages"})
+                            : $t({defaultMessage: "direct messages"});
+                    case "resolved":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude resolved topics"})
+                            : $t({defaultMessage: "resolved topics"});
+                    case "followed":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude followed topics"})
+                            : $t({defaultMessage: "followed topics"});
+                    case "muted":
+                        return is_negated
+                            ? $t({defaultMessage: "exclude muted messages"})
+                            : $t({defaultMessage: "muted messages"});
+                    default:
+                        return $t(
+                            {defaultMessage: "invalid {operand} operand for is operator"},
+                            {operand},
+                        );
+                }
             }
             case "search": {
-                return term.negated ? "exclude" + operand : "search for" + operand;
+                if (operand) {
+                    return is_negated
+                        ? $t({defaultMessage: "exclude {operand}"}, {operand})
+                        : $t({defaultMessage: "search for {operand}"}, {operand});
+                }
+                return is_negated
+                    ? $t({defaultMessage: "exclude"})
+                    : $t({defaultMessage: "search for"});
             }
         }
-        return "unknown operator";
+        return $t({defaultMessage: "unknown operator"});
     }
 
     static describe_channels_operator(negated: boolean, operand: string): string {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -667,52 +667,6 @@ export class Filter {
         return term_types.toSorted(compare);
     }
 
-    static operator_to_prefix(operator: NarrowTerm["operator"], negated?: boolean): string {
-        operator = filter_util.canonicalize_operator(operator);
-
-        if (operator === "search") {
-            return negated ? "exclude" : "search for";
-        }
-
-        const verb = negated ? "exclude " : "";
-
-        switch (operator) {
-            case "channel":
-                return verb + "messages in a specific channel";
-            case "channels":
-                return verb + "channel type";
-            case "near":
-                return verb + "messages around";
-
-            // Note: We hack around using this in "describe" below.
-            case "has":
-                return verb + "messages with";
-
-            case "id":
-                return verb + "message ID";
-
-            case "topic":
-                return verb + "topic";
-
-            case "sender":
-                return verb + "sent by";
-
-            case "dm":
-                return verb + "direct messages with";
-
-            case "dm-including":
-                return verb + "direct messages including";
-
-            case "in":
-                return verb + "messages in";
-
-            // Note: We hack around using this in "describe" below.
-            case "is":
-                return verb + "messages that are";
-        }
-        return "";
-    }
-
     // Convert a list of terms to a human-readable description.
     static parts_for_describe(term: NarrowTermSuggestion, is_operator_suggestion: boolean): string {
         // Calling canonicalize_term on the terms is not easy here,
@@ -793,18 +747,43 @@ export class Filter {
                 content: verb + "topic",
             });
         }
-        const prefix_for_operator = Filter.operator_to_prefix(term.operator, term.negated);
-        if (prefix_for_operator !== "") {
-            return render_search_description({
-                type: "prefix_for_operator",
-                prefix_for_operator,
-                operand: term.operand,
-            });
+        const operator = filter_util.canonicalize_operator(term.operator);
+        let operand = "";
+
+        if (term.operand !== "") {
+            operand = ` ${term.operand}`;
         }
-        return render_search_description({
-            type: "plain_text",
-            content: "unknown operator",
-        });
+
+        if (operator === "search") {
+            return term.negated ? "exclude" + operand : "search for" + operand;
+        }
+
+        switch (operator) {
+            case "channel":
+                return verb + "messages in a specific channel" + operand;
+            case "channels":
+                return verb + "channel type" + operand;
+            case "near":
+                return verb + "messages around" + operand;
+            case "has":
+                return verb + "messages with" + operand;
+            case "id":
+                return verb + "message ID" + operand;
+            case "topic":
+                return verb + "topic" + operand;
+            case "sender":
+                return verb + "sent by" + operand;
+            case "dm":
+                return verb + "direct messages with" + operand;
+            case "dm-including":
+                return verb + "direct messages including" + operand;
+            case "in":
+                return verb + "messages in" + operand;
+            // Note: We hack around using this above.
+            case "is":
+                return verb + "messages that are" + operand;
+        }
+        return "unknown operator";
     }
 
     static describe_channels_operator(negated: boolean, operand: string): string {

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -811,7 +811,7 @@ export class Filter {
     }
 
     // Convert a list of terms to a human-readable description.
-    static parts_for_describe(
+    static search_description_as_html(
         term: NarrowTermSuggestion,
         is_operator_suggestion: boolean,
         search_string: string,
@@ -856,14 +856,6 @@ export class Filter {
                     ? $t({defaultMessage: "exclude all public channels"})
                     : $t({defaultMessage: "all public channels"});
         }
-    }
-
-    static search_description_as_html(
-        term: NarrowTermSuggestion,
-        is_operator_suggestion: boolean,
-        search_string: string,
-    ): string {
-        return Filter.parts_for_describe(term, is_operator_suggestion, search_string);
     }
 
     static is_spectator_compatible(terms: NarrowTerm[]): boolean {

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -320,13 +320,11 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
             const is_operator_suggestion =
                 search_terms[0]!.operator !== "" && !text_query.includes(":");
             description_html = Filter.search_description_as_html(
-                [
-                    {
-                        operator: render_data.operator,
-                        operand: render_data.operand,
-                        negated: render_data.negated,
-                    },
-                ],
+                {
+                    operator: render_data.operator,
+                    operand: render_data.operand,
+                    negated: render_data.negated,
+                },
                 is_operator_suggestion,
             );
             const capitalized_first_letter = description_html.charAt(0).toUpperCase();

--- a/web/src/search_pill.ts
+++ b/web/src/search_pill.ts
@@ -326,6 +326,7 @@ export function generate_pills_html(suggestion: Suggestion, text_query: string):
                     negated: render_data.negated,
                 },
                 is_operator_suggestion,
+                suggestion,
             );
             const capitalized_first_letter = description_html.charAt(0).toUpperCase();
             description_html = capitalized_first_letter + description_html.slice(1);

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -1,64 +1,59 @@
-{{~#each parts ~}}
-
-    {{#if (eq this.type "plain_text")~}}
-        {{~this.content~}}
-    {{else if (eq this.type "channel_topic")}}
-        {{~#if is_empty_string_topic~}}
-        messages in #{{this.channel}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
-        {{~else~}}
-        messages in #{{this.channel}} > {{this.topic_display_name}}
-        {{~/if~}}
-    {{else if (eq this.type "channel")}}
-        {{~!-- squash whitespace --~}}
-        {{this.prefix_for_operator}}{{this.operand}}
-        {{~!-- squash whitespace --~}}
-    {{else if (eq this.type "invalid_has")}}
-        {{~!-- squash whitespace --~}}
-        invalid {{this.operand}} operand for has operator
-        {{~!-- squash whitespace --~}}
-    {{else if (eq this.type "prefix_for_operator")}}
-        {{~#if is_empty_string_topic~}}
-        {{this.prefix_for_operator}} <span class="empty-topic-display">{{this.operand}}</span>
-        {{~ else if this.operand ~}}
-        {{this.prefix_for_operator}} {{this.operand}}{{#if (or (eq this.operand "link") (eq this.operand "image") (eq this.operand "attachment") (eq this.operand "reaction"))}}s{{/if}}
-        {{~ else ~}}
-        {{this.prefix_for_operator}}
-        {{~/if~}}
-    {{else if (eq this.type "is_operator")}}
-        {{#if (eq this.operand "mentioned")}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}messages that mention you
-            {{~!-- squash whitespace --~}}
-        {{else if (or (eq this.operand "starred") (eq this.operand "alerted") (eq this.operand "unread"))}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}{{this.operand}} messages
-            {{~!-- squash whitespace --~}}
-        {{else if (or (eq this.operand "dm") (eq this.operand "private"))}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}direct messages
-            {{~!-- squash whitespace --~}}
-        {{else if (eq this.operand "resolved")}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}resolved topics
-            {{~!-- squash whitespace --~}}
-        {{else if (eq this.operand "followed")}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}followed topics
-            {{~!-- squash whitespace --~}}
-        {{else if (eq this.operand "muted")}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}muted messages
-            {{~!-- squash whitespace --~}}
-        {{else if (eq this.operand "unresolved")}}
-            {{~!-- squash whitespace --~}}
-            {{this.verb}}unresolved topics
-            {{~!-- squash whitespace --~}}
-        {{else}}
-            {{~!-- squash whitespace --~}}
-            invalid {{this.operand}} operand for is operator
-            {{~!-- squash whitespace --~}}
-        {{~/if~}}
+{{#if (eq this.type "plain_text")~}}
+    {{~this.content~}}
+{{else if (eq this.type "channel_topic")}}
+    {{~#if is_empty_string_topic~}}
+    messages in #{{this.channel}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
+    {{~else~}}
+    messages in #{{this.channel}} > {{this.topic_display_name}}
     {{~/if~}}
-    {{~#if (not @last)~}}, {{/if~}}
-
-{{~/each~}}
+{{else if (eq this.type "channel")}}
+    {{~!-- squash whitespace --~}}
+    {{this.prefix_for_operator}}{{this.operand}}
+    {{~!-- squash whitespace --~}}
+{{else if (eq this.type "invalid_has")}}
+    {{~!-- squash whitespace --~}}
+    invalid {{this.operand}} operand for has operator
+    {{~!-- squash whitespace --~}}
+{{else if (eq this.type "prefix_for_operator")}}
+    {{~#if is_empty_string_topic~}}
+    {{this.prefix_for_operator}} <span class="empty-topic-display">{{this.operand}}</span>
+    {{~ else if this.operand ~}}
+    {{this.prefix_for_operator}} {{this.operand}}{{#if (or (eq this.operand "link") (eq this.operand "image") (eq this.operand "attachment") (eq this.operand "reaction"))}}s{{/if}}
+    {{~ else ~}}
+    {{this.prefix_for_operator}}
+    {{~/if~}}
+{{else if (eq this.type "is_operator")}}
+    {{#if (eq this.operand "mentioned")}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}messages that mention you
+        {{~!-- squash whitespace --~}}
+    {{else if (or (eq this.operand "starred") (eq this.operand "alerted") (eq this.operand "unread"))}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}{{this.operand}} messages
+        {{~!-- squash whitespace --~}}
+    {{else if (or (eq this.operand "dm") (eq this.operand "private"))}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}direct messages
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.operand "resolved")}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}resolved topics
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.operand "followed")}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}followed topics
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.operand "muted")}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}muted messages
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.operand "unresolved")}}
+        {{~!-- squash whitespace --~}}
+        {{this.verb}}unresolved topics
+        {{~!-- squash whitespace --~}}
+    {{else}}
+        {{~!-- squash whitespace --~}}
+        invalid {{this.operand}} operand for is operator
+        {{~!-- squash whitespace --~}}
+    {{~/if~}}
+{{~/if~}}


### PR DESCRIPTION
Earlier, the search suggestion strings were constructed by concatenating operators and operands which couldn't be internationalized.

This PR adds internationalization support for suggestion strings by returning full suggestion strings from `search_description_as_html`.

Fixes: zulip#30931.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
