### PR TITLE
accounts_accept_terms: Check if imported user wants marketing emails.

### DIFF
--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -59,6 +59,16 @@ the registration flow has its own (nearly identical) copy of the fields below in
                         {% endfor %}
                     {% endif %}
                 </div>
+                {% if first_time_terms_of_service_message_template %}
+                <div class="input-group">
+                    <label for="id_enable_marketing_emails_first_login" class="inline-block checkbox marketing_emails_checkbox">
+                        <input id="id_enable_marketing_emails_first_login" type="checkbox" name="enable_marketing_emails"
+                          checked="checked" />
+                        <span class="rendered-checkbox"></span>
+                        {% trans %}Subscribe me to Zulip's low-traffic newsletter (a few emails a year).{% endtrans %}
+                    </label>
+                </div>
+                {% endif %}
                 {% endif %}
                 <div class="controls">
                     <button id="accept_tos_button" type="submit">{{ _('Continue') }}</button>

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -234,6 +234,7 @@ class RegistrationForm(RealmDetailsForm):
 
 class ToSForm(forms.Form):
     terms = forms.BooleanField(required=False)
+    enable_marketing_emails = forms.BooleanField(required=False)
     email_address_visibility = forms.TypedChoiceField(
         required=False,
         coerce=int,

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -57,6 +57,18 @@ def accounts_accept_terms(request: HttpRequest) -> HttpResponse:
                     email_address_visibility,
                     acting_user=request.user,
                 )
+
+            enable_marketing_emails = form.cleaned_data["enable_marketing_emails"]
+            if (
+                enable_marketing_emails is not None
+                and enable_marketing_emails != request.user.enable_marketing_emails
+            ):
+                do_change_user_setting(
+                    request.user,
+                    "enable_marketing_emails",
+                    enable_marketing_emails,
+                    acting_user=request.user,
+                )
             return redirect(home)
     else:
         form = ToSForm()


### PR DESCRIPTION
![Screenshot 2024-09-11 at 2 35 02 PM](https://github.com/user-attachments/assets/4ab8f3e4-318c-42b2-baa7-18b579e93a3d)

Tested by modifying this diff below by checking if the `enable_marketing_emails` value in the db  changed for the logged in user.

```diff
diff --git a/zerver/views/home.py b/zerver/views/home.py
index ffafb969f0..89288d7120 100644
--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -88,7 +88,7 @@ def accounts_accept_terms(request: HttpRequest) -> HttpResponse:
         # HTML template used when agreeing to terms of service the
         # first time, e.g. after data import.
         "first_time_terms_of_service_message_template": None,
-        "first_time_login": first_time_login,
+        "first_time_login": True,
         "default_email_address_visibility": default_email_address_visibility,
         "email_address_visibility_options_dict": UserProfile.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP,
         "email_address_visibility_admins_only": UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS,
@@ -97,7 +97,7 @@ def accounts_accept_terms(request: HttpRequest) -> HttpResponse:
     }
 
     if (
-        request.user.tos_version == UserProfile.TOS_VERSION_BEFORE_FIRST_LOGIN
+        True
         and settings.FIRST_TIME_TERMS_OF_SERVICE_TEMPLATE is not None
     ):
         context["first_time_terms_of_service_message_template"] = (
@@ -222,7 +222,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
     update_last_reminder(user_profile)
 
     # If a user hasn't signed the current Terms of Service, send them there
-    if need_accept_tos(user_profile):
+    if True:
         return accounts_accept_terms(request)
 
     narrow, narrow_stream, narrow_topic_name = detect_narrowed_window(request, user_profile)
diff --git a/zproject/default_settings.py b/zproject/default_settings.py
index dc21cea2ce..bfef32a818 100644
--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -501,7 +501,7 @@ TERMS_OF_SERVICE_VERSION: str | None = None
 # user is to accept the terms of service for the first time, but
 # already has an account. This primarily comes up when doing a data
 # import.
-FIRST_TIME_TERMS_OF_SERVICE_TEMPLATE: str | None = None
+FIRST_TIME_TERMS_OF_SERVICE_TEMPLATE: str | None = "corporate/zulipchat_migration_tos.html"
 # Custom message (HTML allowed) to be displayed to explain why users
 # need to re-accept the terms of service when a new major version is
 # written.
```