### PR TITLE
echo: Update message controls dynamically for failed messages and fix `locally_echoed` flag.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -171,7 +171,6 @@ function resend_message(
     function on_success(raw_data: unknown): void {
         const data = send_message_api_response_schema.parse(raw_data);
         const message_id = data.id;
-        message.locally_echoed = true;
 
         hide_retry_spinner($row);
 

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -2,6 +2,9 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
+import render_message_controls from "../templates/message_controls.hbs";
+import render_message_controls_failed_msg from "../templates/message_controls_failed_msg.hbs";
+
 import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as compose_notifications from "./compose_notifications";
@@ -118,20 +121,22 @@ function hide_retry_spinner($row: JQuery): boolean {
     return true;
 }
 
-function show_message_failed(message_id: number, failed_msg: string): void {
+function show_message_failed(message_id: number, _failed_msg: string): void {
     // Failed to send message, so display inline retry/cancel
     message_live_update.update_message_in_all_views(message_id, ($row) => {
         $row.find(".slow-send-spinner").addClass("hidden");
-        const $failed_div = $row.find(".message_failed");
-        $failed_div.toggleClass("hide", false);
-        $failed_div.find(".failed_text").attr("title", failed_msg);
+        const $message_controls = $row.find(".message_controls");
+        $message_controls.html(render_message_controls_failed_msg());
     });
+    // TODO: Show the `_failed_msg` in the UI, describing the reason for the failure.
 }
 
 function show_failed_message_success(message_id: number): void {
     // Previously failed message succeeded
+    const msg = message_store.get(message_id);
     message_live_update.update_message_in_all_views(message_id, ($row) => {
-        $row.find(".message_failed").toggleClass("hide", true);
+        const $message_controls = $row.find(".message_controls");
+        $message_controls.html(render_message_controls({msg}));
     });
 }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -77,8 +77,7 @@
       padding on either side of the message box. */
     padding: 0 5px 0 3px;
 
-    &:hover .message_controls,
-    &:hover .message_failed {
+    &:hover .message_controls {
         .empty-star:hover {
             cursor: pointer;
         }
@@ -142,8 +141,8 @@
 
         @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
             /* This is intended to target the first message_controls child
-               when there are 3 displayed. 4 = 3 + hidden message_failed element. */
-            .message_control_button:nth-last-child(4) {
+               when there are 3 displayed. */
+            .message_control_button:nth-last-child(3) {
                 display: none;
             }
         }
@@ -504,34 +503,15 @@
         }
     }
 
-    .message_failed {
-        display: inline-flex;
-        justify-content: space-between;
-        cursor: pointer;
-        position: relative;
-        vertical-align: middle;
-        padding-left: 2px;
-
-        &.hide {
-            display: none;
-        }
+    .failed_message_action {
+        color: var(--color-failed-message-send-icon);
+        font-weight: bold;
+        padding: 1px;
+        opacity: 1;
+        visibility: visible;
 
         .rotating {
-            display: inline-block;
-            outline: none;
-
             animation: rotate 1s infinite linear;
-        }
-
-        .failed_message_action {
-            opacity: 1 !important;
-            color: var(--color-failed-message-send-icon);
-            font-weight: bold;
-            padding: 1px;
-        }
-
-        .message_control_button {
-            visibility: inherit;
         }
     }
 

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -37,7 +37,15 @@
     <span data-tooltip-template-id="slow-send-spinner-tooltip-template" class="fa fa-circle-o-notch slow-send-spinner{{#unless msg/show_slow_send_spinner }} hidden{{/unless}}"></span>
 {{/if}}
 
-{{> message_controls}}
+<div class="message_controls no-select">
+    {{#if msg/locally_echoed}}
+        {{#if msg/failed_request}}
+            {{> message_controls_failed_msg}}
+        {{/if}}
+    {{else}}
+        {{> message_controls}}
+    {{/if}}
+</div>
 
 {{#unless status_message}}
     {{#unless is_hidden}}

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -1,36 +1,19 @@
-<div class="message_controls no-select">
-    {{#if msg/sent_by_me}}
+{{#if msg/sent_by_me}}
     <div class="edit_content message_control_button"></div>
-    {{/if}}
+{{/if}}
 
-    {{#unless msg/sent_by_me}}
+{{#unless msg/sent_by_me}}
     <div class="reaction_button message_control_button" data-tooltip-template-id="add-emoji-tooltip-template">
         <div class="emoji-message-control-button-container">
             <i class="message-controls-icon zulip-icon zulip-icon-smile" aria-label="{{t 'Add emoji reaction' }} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
         </div>
     </div>
-    {{/unless}}
+{{/unless}}
 
-    {{#unless msg/locally_echoed}}
-    <div class="actions_hover message_control_button" data-tooltip-template-id="message-actions-tooltip-template" >
-        <i class="message-controls-icon message-actions-menu-button zulip-icon zulip-icon-more-vertical-spread" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Message actions' }}"></i>
-    </div>
-    {{/unless}}
+<div class="actions_hover message_control_button" data-tooltip-template-id="message-actions-tooltip-template" >
+    <i class="message-controls-icon message-actions-menu-button zulip-icon zulip-icon-more-vertical-spread" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Message actions' }}"></i>
+</div>
 
-    <div class="message_failed {{#unless msg.failed_request}}hide{{/unless}}">
-        <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
-            <i class="message-controls-icon fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
-        </div>
-
-        <div class="message_control_button failed_message_action" data-tooltip-template-id="dismiss-failed-send-button-tooltip-template">
-            <i class="message-controls-icon fa fa-times-circle remove-failed-message" aria-label="{{t 'Dismiss' }}" role="button" tabindex="0"></i>
-        </div>
-    </div>
-
-    {{#unless msg/locally_echoed}}
-    <div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tooltip-template-id="{{#if msg/starred}}unstar{{else}}star{{/if}}-message-tooltip-template">
-        <i role="button" tabindex="0" class="message-controls-icon star zulip-icon {{#if msg/starred}}zulip-icon-star-filled{{else}}zulip-icon-star{{/if}}"></i>
-    </div>
-    {{/unless}}
-
+<div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tooltip-template-id="{{#if msg/starred}}unstar{{else}}star{{/if}}-message-tooltip-template">
+    <i role="button" tabindex="0" class="message-controls-icon star zulip-icon {{#if msg/starred}}zulip-icon-star-filled{{else}}zulip-icon-star{{/if}}"></i>
 </div>

--- a/web/templates/message_controls_failed_msg.hbs
+++ b/web/templates/message_controls_failed_msg.hbs
@@ -1,0 +1,7 @@
+<div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
+    <i class="message-controls-icon fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
+</div>
+
+<div class="message_control_button failed_message_action" data-tooltip-template-id="dismiss-failed-send-button-tooltip-template">
+    <i class="message-controls-icon fa fa-times-circle remove-failed-message" aria-label="{{t 'Dismiss' }}" role="button" tabindex="0"></i>
+</div>


### PR DESCRIPTION
This PR addresses two key issues related to handling failed message controls and the `locally_echoed` flag during message resends:

1. **Dynamic Rendering of Failed Message Controls**:
Previously, message controls for failed messages were rendered for all messages regardless of their status and only hidden for successfully sent messages. This behavior led to unnecessary rendering. The update introduces dynamic rendering of message controls, ensuring that the controls are only displayed when a message is confirmed to have failed. This is achieved through conditional logic in the Handlebars template.

2. **Fix for `locally_echoed` Flag on Successful Message Resend**:
The `on_success` function within `echo.resend_message` was incorrectly setting the `locally_echoed` flag to `true` after a successful message resend, causing issues with message controls disappearing on slow networks. This behavior was redundant, as the flag is already set correctly in `echo.reify_message_id()` via the `compose.send_message_success()` flow. This commit removes the erroneous line to ensure the flag is properly managed after a successful resend, resolving the bug.

Fixes: #31132

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Before 
https://github.com/user-attachments/assets/35bfe297-6a01-4188-bfaa-48e104136a2b

### After
https://github.com/user-attachments/assets/4f7a17f1-6ac4-4b3f-98f9-6165637c692d

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
