### PR TITLE
install: We need postgresql.version with zulip::postgresql_client too.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -443,7 +443,7 @@ EOF
 
     # We only need the PostgreSQL version setting on database hosts; but
     # we don't know if this is a database host until we have the catalog summary.
-    if ! has_class "zulip::postgresql_common" || [ "$package_system" != apt ]; then
+    if (! has_class "zulip::postgresql_common" && ! has_class "zulip::postgresql_client") || [ "$package_system" != apt ]; then
         crudini --del /etc/zulip/zulip.conf postgresql
     fi
 

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -441,8 +441,10 @@ EOF
         --write-catalog-summary \
         --classfile=/var/lib/puppet/classes.txt
 
-    # We only need the PostgreSQL version setting on database hosts; but
-    # we don't know if this is a database host until we have the catalog summary.
+    # We only need the PostgreSQL version setting on database hosts,
+    # or hosts which talk directly to the database (e.g. application
+    # hosts); but we don't know if this is a database host until we
+    # have the catalog summary.
     if (! has_class "zulip::postgresql_common" && ! has_class "zulip::postgresql_client") || [ "$package_system" != apt ]; then
         crudini --del /etc/zulip/zulip.conf postgresql
     fi


### PR DESCRIPTION
5308fbdeacee split out `zulip::postgresql_client`, and 80ef38757aae made it no longer depend on `zulip::postgresql_common`, but directly on `zulipconf('postgresql', 'version', undef)`.  However, the installer depended on recognizing `zulip::postgresql_common` in the list of pulled-in classes to know that we needed to keep the `postgresql.version` setting in `/etc/zulip.conf`.

Update the installer to also recognize `zulip::postgresql_client` as a class which tells us to keep `postgresql.version` in our settings.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
