### PR TITLE
OIDC auth: when config is not correct, log the reason

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5234,8 +5234,13 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
         mock_oidc_setting_dict = copy.deepcopy(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS)
         [idp_config_dict] = mock_oidc_setting_dict.values()
         del idp_config_dict["client_id"]
+        missing_keys_log = self.logger_output(
+            "OIDC IdP 'testoidc' is missing required configuration keys: ['client_id']",
+            "error",
+        )
         with (
             self.settings(SOCIAL_AUTH_OIDC_ENABLED_IDPS=mock_oidc_setting_dict),
+            self.assertLogs(self.logger_string, level="ERROR") as oidc_log,
             self.assertLogs("django.request", level="ERROR") as m,
         ):
             result = self.social_auth_test(
@@ -5248,9 +5253,11 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
                 m.output,
                 [f"ERROR:django.request:Internal Server Error: {self.LOGIN_URL}"],
             )
+            self.assertEqual(oidc_log.output, [missing_keys_log])
 
         with (
             self.settings(SOCIAL_AUTH_OIDC_ENABLED_IDPS=mock_oidc_setting_dict),
+            self.assertLogs(self.logger_string, level="ERROR") as oidc_log,
             self.assertLogs("django.request", level="ERROR") as m,
         ):
             result = self.social_auth_test(
@@ -5262,6 +5269,7 @@ class GenericOpenIdConnectTest(SocialAuthBaseWithSyncAttrTest):
             self.assertEqual(
                 m.output, [f"ERROR:django.request:Internal Server Error: {self.SIGNUP_URL}"]
             )
+            self.assertEqual(oidc_log.output, [missing_keys_log])
 
     def test_social_auth_oidc_multiple_idps_configured(self) -> None:
         idps_dict = copy.deepcopy(settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -4328,8 +4328,15 @@ class GenericOpenIdConnectBackend(SocialAuthMixin, OpenIdConnectAuth):
     @classmethod
     def check_config(cls) -> bool:
         mandatory_config_keys = ["oidc_url", "client_id", "secret"]
-        for idp_config_dict in settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS.values():
-            if not all(idp_config_dict.get(key) for key in mandatory_config_keys):
+        logger = logging.getLogger(f"zulip.auth.{cls.name}")
+        for idp_name, idp_config_dict in settings.SOCIAL_AUTH_OIDC_ENABLED_IDPS.items():
+            missing_keys = [key for key in mandatory_config_keys if not idp_config_dict.get(key)]
+            if missing_keys:
+                logger.error(
+                    "OIDC IdP %r is missing required configuration keys: %r",
+                    idp_name,
+                    missing_keys,
+                )
                 return False
 
         return True


### PR DESCRIPTION
When an OpenID Connect identity provider is misconfigured, the user just gets a generic error saying it's misconfigured, and the log shows nothing useful. This change logs the actual reason why the configuration check returned False.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
