### PR TITLE
[WIP]Users guest will be able to view 

### DIFF
--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -90,6 +90,7 @@
                 </div>
             </div>
         </div>
+        <div id="guest-info-container"></div>
     </div>
     {{/if}}
 </form>


### PR DESCRIPTION
PR Statement :
Overview :
Zulip’s Invite users modal, when inviting guest users, there is a missing informational message that should appear in specific cases
. The issue arises when:
- Guest role is selected, and
- Guests are restricted from viewing all other users.
In this scenario, the system should display a note below the channel selection input, informing the inviter how many users the guest will be able to see in their subscribed channels. The message should live-update based on the channels and user roles selected, giving an accurate count.
PR will do the following: 
- Add the Informational Note: Insert the note below the channels input field when the guest role is selected and the organizational setting for guest visibility is active.
- Link to Documentation:The note should include a link to the relevant help documentation on guest user visibility: /help/guest-users#configure-whether-guests-can-see-all-other-users.
- Real-Time Updates: Implement live updates to the number {N} based on any changes in the invite modal, such as altering channel subscriptions or user roles.

Fixes:  https://github.com/zulip/zulip/issues/31159

Details
Workflow   
- Frontend: Modify the template that renders the invite modal.
The following files :
 static/templates/invite_users.hbs (if the modal HTML is here)

- Backend: Backend logic may need to be adjusted to pass the number of users visible to guests to the frontend modal. This will ensure the {N} value in the note is dynamically updated.
zerver/views/invite.py     

-  Live-Update Logic:
Any live updates (e.g., dynamically changing the number of users when modifying channels) should likely be handled via JavaScript, ensuring that the message updates in real-time as users and channels change.

##[WIP] 
Find and update frontend templates and look for files that change output dynamically
test the changes locally 