### PR TITLE
buttons: Remove .sea-green, introduce redesigned default, warning, and danger buttons.

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -205,7 +205,6 @@ function do_resend_invite({$row, invite_id}: {$row: JQuery; invite_id: string}):
         },
         success() {
             $resend_button.text($t({defaultMessage: "Sent!"}));
-            $resend_button.removeClass("resend btn-warning").addClass("sea-green");
         },
     });
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -178,6 +178,9 @@ input::placeholder {
 
     &:hover {
         background-color: var(--color-background-zulip-button-hover);
+        /* Reset styles on a.button instances. */
+        text-decoration: none;
+        color: inherit;
     }
 
     &:focus {

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -204,22 +204,6 @@ input::placeholder {
         }
     }
 
-    &.sea-green {
-        color: hsl(156deg 41% 40%);
-        border-color: hsl(156deg 28% 70%);
-
-        &:hover,
-        &:focus {
-            border-color: hsl(156deg 30% 50%);
-        }
-
-        &:active {
-            border-color: hsl(156deg 30% 40%);
-            color: hsl(156deg 44% 43%);
-            background-color: hsl(154deg 33% 96%);
-        }
-    }
-
     &.btn-warning {
         color: hsl(35deg 70% 56%);
         border-color: hsl(35deg 98% 84%);

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -238,14 +238,10 @@ input::placeholder {
 
     &:disabled {
         cursor: not-allowed;
-        filter: saturate(0);
-        background-color: var(--color-background-zulip-button-disabled);
-        color: hsl(0deg 3% 52%);
+        opacity: 0.5;
 
         &:hover {
-            background-color: var(--color-background-zulip-button-disabled);
-            color: hsl(156deg 39% 54%);
-            border-color: hsl(156deg 39% 77%);
+            opacity: 0.5;
         }
     }
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -216,7 +216,6 @@ input::placeholder {
         &:active {
             color: hsl(35deg 82% 40%);
             border-color: hsl(35deg 55% 70%);
-            background-color: hsl(33deg 48% 96%);
         }
     }
 
@@ -232,7 +231,6 @@ input::placeholder {
         &:active {
             color: hsl(357deg 55% 63%);
             border-color: hsl(2deg 46% 68%);
-            background-color: hsl(7deg 82% 98%);
         }
     }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -112,7 +112,7 @@ input::placeholder {
 /* -- base button styling -- */
 
 .button {
-    padding: 7px 14px;
+    padding: 8px 15px;
     margin: 0;
     min-width: 130px;
 
@@ -121,12 +121,12 @@ input::placeholder {
     text-align: center;
 
     background-color: var(--color-background-zulip-button);
-    color: inherit;
+    color: var(--color-text-zulip-button);
     outline: none;
-    border: 1px solid var(--color-border-zulip-button);
+    border: 0;
     border-radius: 2px;
 
-    box-shadow: none;
+    box-shadow: 0 0 0.5px 0.5px var(--color-shadow-zulip-button) inset;
 
     cursor: pointer;
 
@@ -167,20 +167,15 @@ input::placeholder {
                variables. */
         font-size: calc(0.9143 * var(--base-font-size-px));
         min-width: inherit;
-        padding: 6px 10px;
-    }
-
-    &:hover,
-    &:focus,
-    &:active {
-        border-color: var(--color-border-zulip-button-interactive);
+        padding: 7px 11px;
     }
 
     &:hover {
         background-color: var(--color-background-zulip-button-hover);
+
         /* Reset styles on a.button instances. */
         text-decoration: none;
-        color: inherit;
+        color: var(--color-text-zulip-button);
     }
 
     &:focus {
@@ -208,32 +203,36 @@ input::placeholder {
     }
 
     &.btn-warning {
-        color: hsl(35deg 70% 56%);
-        border-color: hsl(35deg 98% 84%);
+        color: var(--color-text-zulip-button-warning);
+        background-color: var(--color-background-zulip-button-warning);
 
         &:hover,
         &:focus {
-            border-color: hsl(35deg 55% 70%);
+            background-color: var(
+                --color-background-zulip-button-warning-hover
+            );
         }
 
         &:active {
-            color: hsl(35deg 82% 40%);
-            border-color: hsl(35deg 55% 70%);
+            background-color: var(
+                --color-background-zulip-button-warning-active
+            );
         }
     }
 
     &.btn-danger {
-        color: hsl(357deg 64% 72%);
-        border-color: hsl(4deg 56% 82%);
+        color: var(--color-text-zulip-button-danger);
+        background-color: var(--color-background-zulip-button-danger);
 
         &:hover,
         &:focus {
-            border-color: hsl(2deg 46% 68%);
+            background-color: var(--color-background-zulip-button-danger-hover);
         }
 
         &:active {
-            color: hsl(357deg 55% 63%);
-            border-color: hsl(2deg 46% 68%);
+            background-color: var(
+                --color-background-zulip-button-danger-active
+            );
         }
     }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -987,9 +987,58 @@
        this file is not imported on billing pages. */
 
     /* Zulip-style button colors. */
-    --color-background-zulip-button: hsl(0deg 0% 100%);
-    --color-background-zulip-button-hover: var(--color-background-zulip-button);
-    --color-background-zulip-button-active: hsl(0deg 0% 95%);
+    --color-text-zulip-button: #393c49;
+    --color-text-zulip-button-danger: #ac0508;
+    --color-text-zulip-button-warning: #764607;
+    --color-shadow-zulip-button: color-mix(in srgb, transparent, #000 20%);
+
+    /* color-mix(in srgb, transparent, var(--gray-550) 12%) */
+
+    --color-background-zulip-button: color-mix(
+        in srgb,
+        transparent,
+        #767988 12%
+    );
+    --color-background-zulip-button-hover: color-mix(
+        in srgb,
+        transparent,
+        #767988 17%
+    );
+    --color-background-zulip-button-active: color-mix(
+        in srgb,
+        transparent,
+        #767988 22%
+    );
+    --color-background-zulip-button-danger: color-mix(
+        in srgb,
+        transparent,
+        #e1392e 13%
+    );
+    --color-background-zulip-button-danger-hover: color-mix(
+        in srgb,
+        transparent,
+        #e1392e 18%
+    );
+    --color-background-zulip-button-danger-active: color-mix(
+        in srgb,
+        transparent,
+        #e1392e 23%
+    );
+    --color-background-zulip-button-warning: color-mix(
+        in srgb,
+        transparent,
+        #eba002 18%
+    );
+    --color-background-zulip-button-warning-hover: color-mix(
+        in srgb,
+        transparent,
+        #eba002 23%
+    );
+    --color-background-zulip-button-warning-active: color-mix(
+        in srgb,
+        transparent,
+        #eba002 28%
+    );
     --color-background-zulip-button-disabled: hsl(0deg 0% 93%);
     --color-border-zulip-button: hsl(0deg 0% 80%);
     --color-border-zulip-button-interactive: hsl(0deg 0% 60%);
@@ -1472,10 +1521,54 @@
     --color-exit-button-background-interactive: hsl(226deg 1% 30% / 65%);
 
     /* Zulip-style button colors. */
-    --color-background-zulip-button: hsl(0deg 0% 0% / 20%);
-    --color-background-zulip-button-hover: hsl(0deg 0% 0% / 15%);
-    --color-background-zulip-button-active: var(
-        --color-background-zulip-button-hover
+    --color-text-zulip-button: #bbbdc8;
+    --color-text-zulip-button-danger: #ff8b7c;
+    --color-text-zulip-button-warning: #f8b325;
+    --color-shadow-zulip-button: color-mix(in srgb, transparent, #fff 21%);
+    --color-background-zulip-button: color-mix(
+        in srgb,
+        transparent,
+        #bbbdc8 12%
+    );
+    --color-background-zulip-button-hover: color-mix(
+        in srgb,
+        transparent,
+        #bbbdc8 17%
+    );
+    --color-background-zulip-button-active: color-mix(
+        in srgb,
+        transparent,
+        #bbbdc8 12%
+    );
+    --color-background-zulip-button-danger: color-mix(
+        in srgb,
+        transparent,
+        #fd5f50 12%
+    );
+    --color-background-zulip-button-danger-hover: color-mix(
+        in srgb,
+        transparent,
+        #fd5f50 17%
+    );
+    --color-background-zulip-button-danger-active: color-mix(
+        in srgb,
+        transparent,
+        #fd5f50 12%
+    );
+    --color-background-zulip-button-warning: color-mix(
+        in srgb,
+        transparent,
+        #db920d 12%
+    );
+    --color-background-zulip-button-warning-hover: color-mix(
+        in srgb,
+        transparent,
+        #db920d 17%
+    );
+    --color-background-zulip-button-warning-active: color-mix(
+        in srgb,
+        transparent,
+        #db920d 12%
     );
     --color-background-zulip-button-disabled: var(
         --color-background-zulip-button

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -356,7 +356,6 @@
 
     /* these are converting grey things to "new grey".
        :disabled rules are exploded for CSS selector performance reasons. */
-    button:disabled,
     option:disabled,
     select:disabled,
     textarea:disabled,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -530,9 +530,18 @@ input[type="checkbox"] {
     display: block;
     padding: 6px 9px;
     text-decoration: none;
+    color: hsl(156deg 41% 40%);
+    border-color: hsl(156deg 28% 70%);
 
-    &:hover {
+    &:hover,
+    &:focus {
         color: hsl(156deg 41% 40%);
+        border-color: hsl(156deg 30% 50%);
+    }
+
+    &:active {
+        border-color: hsl(156deg 30% 40%);
+        color: hsl(156deg 44% 43%);
     }
 }
 
@@ -886,7 +895,7 @@ input[type="checkbox"] {
             padding: 4px;
         }
 
-        .sea-green {
+        .download-icon {
             color: hsl(177deg 70% 46%);
         }
 

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -28,7 +28,7 @@
     {{/if}}
     {{#if can_toggle_subscription}}
     <div class="sub_button_row">
-        <button class="button white rounded stream_sub_unsub_button {{#unless subscribed}}sea-green{{/unless}}" type="button" name="subscription">
+        <button class="button white rounded stream_sub_unsub_button" type="button" name="subscription">
             {{#if subscribed}}
             {{t 'Unsubscribe' }}
             {{else}}

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -4,7 +4,7 @@
         <div class="password-input-row">
             <input type="password" autocomplete="off" name="old_password" id="old_password" class="inline-block modal_password_input" value="" />
             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
-            <a href="/accounts/password/reset/" class="settings-forgot-password sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
+            <a href="/accounts/password/reset/" class="settings-forgot-password" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
         </div>
     </div>
     <div class="settings-password-div">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -25,7 +25,7 @@
                             {{#*inline "z-link-convert-demo-organization-help"}}<a href="/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                         {{/tr}}
                     </p>
-                    <button id="demo_organization_add_email_button" type="button" class="button rounded sea-green">
+                    <button id="demo_organization_add_email_button" type="button" class="button rounded">
                         {{t "Add email"}}
                     </button>
                 </div>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -4,7 +4,7 @@
             {{t "Alert words allow you to be notified as if you were @-mentioned when certain words or phrases are used in Zulip. Alert words are not case sensitive."}}
         </p>
     </form>
-    <button class="button rounded sea-green" id="open-add-alert-word-modal" type="button">
+    <button class="button rounded" id="open-add-alert-word-modal" type="button">
         {{t 'Add alert word'}}
     </button>
 

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -9,7 +9,7 @@
                     <i class="fa fa-pencil blue" aria-hidden="true"></i>
                 </button>
                 <a type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download zuliprc' }}" data-email="{{email}}">
-                    <i class="fa fa-download sea-green" aria-hidden="true"></i>
+                    <i class="fa fa-download download-icon" aria-hidden="true"></i>
                 </a>
                 <button type="submit" id="copy_zuliprc" class="btn copy_zuliprc tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Copy zuliprc' }}">
                     <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -11,7 +11,7 @@
         <div class="bot-settings-tip" id="personal-bot-settings-tip">
         </div>
         <div>
-            <button class="button rounded sea-green add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>
+            <button class="button rounded add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>
         </div>
         {{/unless}}
 
@@ -23,7 +23,7 @@
             <div class="config-download-text">
                 <span>{{t 'Download config of all active outgoing webhook bots in Zulip Botserver format.' }}</span>
                 <a type="submit" download="{{botserverrc}}" id= "download_botserverrc" class="btn tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download botserverrc' }}">
-                    <i class="fa fa-download sea-green" aria-hidden="true"></i>
+                    <i class="fa fa-download" aria-hidden="true"></i>
                 </a>
             </div>
             <ol id="active_bots_list" class="bots_list" data-empty="{{t 'You have no active bots.' }}">

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -20,7 +20,7 @@
         <span class="export_status_text"></span>
     </div>
     <form>
-        <button type="submit" class="button rounded sea-green" id="export-data">
+        <button type="submit" class="button rounded" id="export-data">
             {{t 'Start export of public data' }}
         </button>
     </form>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -5,7 +5,7 @@
         <h3>{{t "Default channels"}}</h3>
         <div class="add_default_streams_button_container">
             {{#if is_admin}}
-                <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
+                <button type="submit" id="show-add-default-streams-modal" class="button rounded">{{t "Add channel" }}</button>
             {{/if}}
             <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default channels' }}" aria-label="{{t 'Filter channels' }}"/>
         </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -5,7 +5,7 @@
     <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
         {{t "Add extra emoji for members of the {realm_name} organization." }}
     </p>
-    <button id="add-custom-emoji-button" class="button rounded sea-green {{#unless can_add_emojis}}hide{{/unless}}">
+    <button id="add-custom-emoji-button" class="button rounded {{#unless can_add_emojis}}hide{{/unless}}">
         {{t 'Add a new emoji' }}
     </button>
 

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -46,7 +46,7 @@
                     <input type="text" id="linkifier_template" class="settings_text_input" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" />
                     <div class="alert" id="admin-linkifier-template-status"></div>
                 </div>
-                <button type="submit" class="button rounded sea-green">
+                <button type="submit" class="button rounded">
                     {{t 'Add linkifier' }}
                 </button>
             </div>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -49,7 +49,7 @@
               is_editable_by_current_user = is_admin
               image = realm_icon_url }}
         </div>
-        <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded sea-green block" id="id_org_profile_preview">
+        <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded block" id="id_org_profile_preview">
             {{t 'Preview organization profile' }}
             <i class="fa fa-external-link" aria-hidden="true"></i>
         </a>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -54,7 +54,7 @@
                         <label for="playground_url_template"> {{t "URL template" }}</label>
                         <input type="text" id="playground_url_template" class="settings_text_input" name="url_template" placeholder="https://play.rust-lang.org/?code={code}" />
                     </div>
-                    <button type="submit" id="submit_playground_button" class="button rounded sea-green">
+                    <button type="submit" id="submit_playground_button" class="button rounded">
                         {{t 'Add code playground' }}
                     </button>
                 </div>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -3,7 +3,7 @@
         <h3>{{t "Custom profile fields"}}</h3>
         <div class="alert-notification" id="admin-profile-field-status"></div>
         {{#if is_admin}}
-        <button class="button rounded sea-green" id="add-custom-profile-field-btn">{{t "Add a new profile field" }}</button>
+        <button class="button rounded" id="add-custom-profile-field-btn">{{t "Add a new profile field" }}</button>
         {{/if}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -62,7 +62,7 @@
                     <span class="user-details-desc">{{date_joined_text}}</span>
                 </div>
             </div>
-            <button class="button rounded sea-green" id="show_my_user_profile_modal">
+            <button class="button rounded" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}
                 <i class="show-user-profile-icon fa fa-external-link" aria-hidden="true"></i>
             </button>

--- a/web/templates/settings/realm_domains_modal.hbs
+++ b/web/templates/settings/realm_domains_modal.hbs
@@ -15,7 +15,7 @@
                     <span class="rendered-checkbox"></span>
                 </label>
             </td>
-            <td><button type="button" class="button sea-green small rounded" id="submit-add-realm-domain">{{t "Add" }}</button></td>
+            <td><button type="button" class="button small rounded" id="submit-add-realm-domain">{{t "Add" }}</button></td>
         </tr>
     </tfoot>
 </table>

--- a/web/templates/settings/uploaded_files_list.hbs
+++ b/web/templates/settings/uploaded_files_list.hbs
@@ -20,8 +20,8 @@
     <td class="upload-size" >{{ size_str }}</td>
     <td class="actions">
         <span class="edit-attachment-buttons">
-            <a type="submit" href="/user_uploads/{{path_id}}" class="button rounded small sea-green tippy-zulip-delayed-tooltip download-attachment" data-tippy-content="{{t 'Download' }}" download>
-                <i class="fa fa-download sea-green" aria-hidden="true"></i>
+            <a type="submit" href="/user_uploads/{{path_id}}" class="button rounded small tippy-zulip-delayed-tooltip download-attachment" data-tippy-content="{{t 'Download' }}" download>
+                <i class="fa fa-download" aria-hidden="true"></i>
             </a>
         </span>
         <span class="edit-attachment-buttons">

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -7,7 +7,7 @@
     </div>
     {{#if (not hide_add_button)}}
         <div class="add_subscriber_btn_wrapper inline-block">
-            <button type="submit" name="add_subscriber" class="button add-subscriber-button add-users-button small rounded sea-green" tabindex="0">
+            <button type="submit" name="add_subscriber" class="button add-subscriber-button add-users-button small rounded" tabindex="0">
                 {{t 'Add' }}
             </button>
         </div>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -37,7 +37,7 @@
                             <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
                         </label>
                         <span class="add_all_users_to_stream_btn_container">
-                            <button class="add_all_users_to_stream small button rounded sea-green">{{t 'Add all users'}}</button>
+                            <button class="add_all_users_to_stream small button rounded">{{t 'Add all users'}}</button>
                         </span>
                         <div id="stream_subscription_error" class="stream_creation_error"></div>
                         <div class="controls" id="people_to_add"></div>
@@ -47,12 +47,12 @@
         </div>
         <div class="settings-sticky-footer">
             <div class="settings-sticky-footer-left">
-                <button id="stream_creation_go_to_configure_channel_settings" class="button small sea-green rounded hide">{{t "Back to settings" }}</button>
+                <button id="stream_creation_go_to_configure_channel_settings" class="button small rounded hide">{{t "Back to settings" }}</button>
             </div>
             <div class="settings-sticky-footer-right">
                 <button class="create_stream_cancel button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-                <button class="finalize_create_stream button small sea-green rounded hide" type="submit">{{t "Create" }}</button>
-                <button id="stream_creation_go_to_subscribers" class="button small sea-green rounded">{{t "Continue to add subscribers" }}</button>
+                <button class="finalize_create_stream button small rounded hide" type="submit">{{t "Create" }}</button>
+                <button id="stream_creation_go_to_subscribers" class="button small rounded">{{t "Continue to add subscribers" }}</button>
             </div>
         </div>
     </form>

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -6,7 +6,7 @@
         </div>
     </div>
     <div class="add_member_btn_wrapper inline-block">
-        <button type="submit" name="add_member" class="button add-member-button add-users-button small rounded sea-green" tabindex="0">
+        <button type="submit" name="add_member" class="button add-member-button add-users-button small rounded" tabindex="0">
             {{t 'Add' }}
         </button>
     </div>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -4,7 +4,7 @@
 <br />
 
 {{t "Do you want to add everyone?"}}
-<button class="add_all_users_to_user_group small button rounded sea-green">{{t 'Add all users'}}</button>
+<button class="add_all_users_to_user_group small button rounded">{{t 'Add all users'}}</button>
 
 <div class="create_member_list_header">
     <h4 class="user_group_setting_subsection_title">{{t 'Members' }}</h4>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -47,12 +47,12 @@
         </div>
         <div class="settings-sticky-footer">
             <div class="settings-sticky-footer-left">
-                <button id="user_group_go_to_configure_settings" class="button small sea-green rounded hide">{{t "Back to settings" }}</button>
+                <button id="user_group_go_to_configure_settings" class="button small rounded hide">{{t "Back to settings" }}</button>
             </div>
             <div class="settings-sticky-footer-right">
                 <button class="create_user_group_cancel button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>
-                <button class="finalize_create_user_group button small sea-green rounded hide" type="submit">{{t "Create" }}</button>
-                <button id="user_group_go_to_members" class="button small sea-green rounded">{{t "Continue to add members" }}</button>
+                <button class="finalize_create_user_group button small rounded hide" type="submit">{{t "Create" }}</button>
+                <button id="user_group_go_to_members" class="button small rounded">{{t "Continue to add members" }}</button>
             </div>
         </div>
     </form>


### PR DESCRIPTION
This PR, which contains a commit that should first be merged in #31652, improves the state of buttons following the removal of `.new-style` in #31588:

1. It removes the `.sea-green` class from templates, and accompanying style in CSS.
2. It preserves the `.sea-green` colors in two places where they're used in the interface: on the edit-attachment button in the Personal uploaded files screen; and on the Personal bots screen (which colors had already been pulled out in CSS, but a non-icon class is presented for them here).
3. It corrects a flash-of-white regression from #31588 on `.button:active`, making sure that all Zulip buttons (`.button`) take the `--color-background-zulip-button-active` shared by all other buttons.
4. It avoids some selector-specificity problems inherent in `a.button` instances, particularly in dark theme.
6. It introduces @terpimost's new colors for the medium-attention default, warning, and danger buttons; and also specifies [only an opacity difference](https://chat.zulip.org/#narrow/stream/101-design/topic/removal.20of.20sea-green.20buttons/near/1942955) for `:disabled` buttons

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/removal.20of.20sea-green.20buttons/near/1941047)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Regressions on `:hover` and `:active` in dark mode (note new opacity on disabled button, which allows red from `.btn-danger` to shine through):_

| Before | After |
| --- | --- |
| ![dark-hover-regression-before](https://github.com/user-attachments/assets/c201e30e-883e-44d6-9704-9b8310e984f2) | ![dark-hover-regression-after](https://github.com/user-attachments/assets/171a91af-711b-49d2-aa4a-7999ddcfc457) |
| ![dark-active-regression-before](https://github.com/user-attachments/assets/a90efbbe-8e97-472d-a01d-9253063302ab) | ![dark-active-regression-after](https://github.com/user-attachments/assets/356a74ee-44d7-4c66-a0c6-b5e86bcb2ac9) |

_Bookend Subscribe button:_

| Before | After |
| --- | --- |
| ![bookend-light-before](https://github.com/user-attachments/assets/83cc89ef-aa96-4364-808e-a062d921256a) | ![bookend-light-after](https://github.com/user-attachments/assets/889cb1b7-7d6e-4798-881e-3f19f761d798) |
| ![bookend-dark-before](https://github.com/user-attachments/assets/1f1a6121-5ab0-4fc0-9f2c-b4d639eb99a1) | ![bookend-dark-after](https://github.com/user-attachments/assets/d911a5e7-0e40-433a-abf2-a50a8e90437d) |

_Light mode:_

| Before | After |
| --- | --- |
| ![user-bots-light-before](https://github.com/user-attachments/assets/31dc2d92-78fa-4e83-9ab6-7cdc004f6670) | ![user-bots-light-after](https://github.com/user-attachments/assets/b886b16a-7ed6-4e5e-96ab-81adcaa66be5) |
| ![users-light-before](https://github.com/user-attachments/assets/8d75e90f-da0a-4978-9df0-84d8d526b1fd) | ![users-light-after](https://github.com/user-attachments/assets/5eaaeb53-3423-4574-9dc4-501b9fae1f84) | 
| ![user-settings-light-before](https://github.com/user-attachments/assets/18a03080-3536-49ee-b4bf-2bcdb4b8ffa2) | ![user-settings-light-after](https://github.com/user-attachments/assets/e160e4a9-2f41-44f0-800f-457e91d576eb) |

_Dark mode:_

| Before | After |
| --- | --- |
| ![user-bots-dark-before](https://github.com/user-attachments/assets/707824c5-15ab-4a94-b3b2-bec112298f89) | ![user-bots-dark-after](https://github.com/user-attachments/assets/d9de31ee-d2d2-446b-a740-e89e59ca5356) |
| ![users-dark-before](https://github.com/user-attachments/assets/0261b7df-b275-4037-a8cc-8a58de1d4b0b) | ![users-dark-after](https://github.com/user-attachments/assets/73f0c8aa-5da0-4fdb-950b-861a1979e972) |
| ![user-settings-dark-before](https://github.com/user-attachments/assets/a0935995-c115-4b85-b241-a49fa73915f1) | ![user-settings-dark-after](https://github.com/user-attachments/assets/63e1da56-e7bc-4031-b24c-f79bff7d8335) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>