### PR TITLE
integration-docs: Limit client-side error reporting to 40x errors.

### DIFF
--- a/web/src/portico/integrations.js
+++ b/web/src/portico/integrations.js
@@ -196,7 +196,7 @@ function hide_catalog_show_integration() {
         dataType: "html",
         success: hide_catalog,
         error(err) {
-            if (err.readyState !== 0) {
+            if (err.readyState !== 0 && err.status >= 400 && err.status < 500) {
                 blueslip.error(`Integration documentation for '${state.integration}' not found.`, {
                     readyState: err.readyState,
                     status: err.status,


### PR DESCRIPTION
We do want to be notified about 40x errors for potential broken links to integration documentation pages.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
