### PR TITLE
typeahead_setting: Fix the show up of user group with 0 active user

### DIFF
--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -1,73 +1,75 @@
 {{! Client-side Handlebars template for rendering subscriptions. }}
 {{#with this}}
-<div class="stream-row" data-stream-id="{{stream_id}}" data-stream-name="{{name}}">
+    {{#if subscriber_count}}
+        <div class="stream-row" data-stream-id="{{stream_id}}" data-stream-name="{{name}}">
+            {{#if subscribed}}
+                <div class="check checked sub_unsub_button tippy-zulip-tooltip" data-tooltip-template-id="unsubscribe-from-{{name}}-stream-tooltip-template">
 
-    {{#if subscribed}}
-        <div class="check checked sub_unsub_button tippy-zulip-tooltip" data-tooltip-template-id="unsubscribe-from-{{name}}-stream-tooltip-template">
+                    <template id="unsubscribe-from-{{name}}-stream-tooltip-template">
+                        <span>
+                            {{#tr}}
+                                Unsubscribe from <z-stream></z-stream>
+                                {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=this}}{{/inline}}
+                            {{/tr}}
+                        </span>
+                    </template>
 
-            <template id="unsubscribe-from-{{name}}-stream-tooltip-template">
-                <span>
-                    {{#tr}}
-                        Unsubscribe from <z-stream></z-stream>
-                        {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=this}}{{/inline}}
-                    {{/tr}}
-                </span>
-            </template>
+                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+                        <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
+                    </svg>
+                    <div class='sub_unsub_status'></div>
+                </div>
+            {{else}}
+                <div class="check sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}} tippy-zulip-tooltip"
+                data-tooltip-template-id="{{#if should_display_subscription_button}}subscribe-to-{{name}}-stream-tooltip-template{{else}}cannot-subscribe-to-{{name}}-stream-tooltip-template{{/if}}">
 
-            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
-                <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
-            </svg>
-            <div class='sub_unsub_status'></div>
-        </div>
-    {{else}}
-        <div class="check sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}} tippy-zulip-tooltip"
-          data-tooltip-template-id="{{#if should_display_subscription_button}}subscribe-to-{{name}}-stream-tooltip-template{{else}}cannot-subscribe-to-{{name}}-stream-tooltip-template{{/if}}">
+                    <template id="subscribe-to-{{name}}-stream-tooltip-template">
+                        <span>
+                            {{#tr}}
+                                Subscribe to <z-stream></z-stream>
+                                {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=this}}{{/inline}}
+                            {{/tr}}
+                        </span>
+                    </template>
 
-            <template id="subscribe-to-{{name}}-stream-tooltip-template">
-                <span>
-                    {{#tr}}
-                        Subscribe to <z-stream></z-stream>
-                        {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=this}}{{/inline}}
-                    {{/tr}}
-                </span>
-            </template>
+                    <template id="cannot-subscribe-to-{{name}}-stream-tooltip-template">
+                        <span>
+                            {{#tr}}
+                                Cannot subscribe to <z-stream></z-stream>
+                                {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=this}}{{/inline}}
+                            {{/tr}}
+                        </span>
+                    </template>
 
-            <template id="cannot-subscribe-to-{{name}}-stream-tooltip-template">
-                <span>
-                    {{#tr}}
-                        Cannot subscribe to <z-stream></z-stream>
-                        {{#*inline "z-stream"}}{{> ../inline_decorated_stream_name stream=this}}{{/inline}}
-                    {{/tr}}
-                </span>
-            </template>
-
-            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
-                <path d="M459.319,229.668c0,22.201-17.992,40.193-40.205,40.193H269.85v149.271c0,22.207-17.998,40.199-40.196,40.193   c-11.101,0-21.149-4.492-28.416-11.763c-7.276-7.281-11.774-17.324-11.769-28.419l-0.006-149.288H40.181   c-11.094,0-21.134-4.492-28.416-11.774c-7.264-7.264-11.759-17.312-11.759-28.413C0,207.471,17.992,189.475,40.202,189.475h149.267   V40.202C189.469,17.998,207.471,0,229.671,0c22.192,0.006,40.178,17.986,40.19,40.187v149.288h149.282   C441.339,189.487,459.308,207.471,459.319,229.668z"/>
-            </svg>
-            <div class='sub_unsub_status'></div>
+                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+                        <path d="M459.319,229.668c0,22.201-17.992,40.193-40.205,40.193H269.85v149.271c0,22.207-17.998,40.199-40.196,40.193   c-11.101,0-21.149-4.492-28.416-11.763c-7.276-7.281-11.774-17.324-11.769-28.419l-0.006-149.288H40.181   c-11.094,0-21.134-4.492-28.416-11.774c-7.264-7.264-11.759-17.312-11.759-28.413C0,207.471,17.992,189.475,40.202,189.475h149.267   V40.202C189.469,17.998,207.471,0,229.671,0c22.192,0.006,40.178,17.986,40.19,40.187v149.288h149.282   C441.339,189.487,459.308,207.471,459.319,229.668z"/>
+                    </svg>
+                    <div class='sub_unsub_status'></div>
+                </div>
+            {{/if}}
+            {{> subscription_setting_icon }}
+            <div class="sub-info-box">
+                <div class="top-bar">
+                    <div class="stream-name">{{name}}</div>
+                    <div class="subscriber-count tippy-zulip-tooltip" data-tippy-content="{{t 'Subscriber count' }}">
+                        {{> subscriber_count}}
+                    </div>
+                </div>
+                <div class="bottom-bar">
+                    <div class="description rendered_markdown" data-no-description="{{t 'No description.'}}">{{rendered_markdown rendered_description}}</div>
+                    {{#if is_old_stream}}
+                    <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Estimated messages per week' }}">
+                        <i class="fa fa-bar-chart"></i>
+                        <span class="stream-message-count-text">{{stream_weekly_traffic}}</span>
+                    </div>
+                    {{else}}
+                    <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Channel created recently' }}">
+                        <span class="stream-message-count-text">{{t "New" }}</span>
+                    </div>
+                    {{/if}}
+                </div>
+            </div>
         </div>
     {{/if}}
-    {{> subscription_setting_icon }}
-    <div class="sub-info-box">
-        <div class="top-bar">
-            <div class="stream-name">{{name}}</div>
-            <div class="subscriber-count tippy-zulip-tooltip" data-tippy-content="{{t 'Subscriber count' }}">
-                {{> subscriber_count}}
-            </div>
-        </div>
-        <div class="bottom-bar">
-            <div class="description rendered_markdown" data-no-description="{{t 'No description.'}}">{{rendered_markdown rendered_description}}</div>
-            {{#if is_old_stream}}
-            <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Estimated messages per week' }}">
-                <i class="fa fa-bar-chart"></i>
-                <span class="stream-message-count-text">{{stream_weekly_traffic}}</span>
-            </div>
-            {{else}}
-            <div class="stream-message-count tippy-zulip-tooltip" data-tippy-content="{{t 'Channel created recently' }}">
-                <span class="stream-message-count-text">{{t "New" }}</span>
-            </div>
-            {{/if}}
-        </div>
-    </div>
 </div>
 {{/with}}

--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -21,7 +21,7 @@
                 </div>
             {{else}}
                 <div class="check sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}} tippy-zulip-tooltip"
-                data-tooltip-template-id="{{#if should_display_subscription_button}}subscribe-to-{{name}}-stream-tooltip-template{{else}}cannot-subscribe-to-{{name}}-stream-tooltip-template{{/if}}">
+                  data-tooltip-template-id="{{#if should_display_subscription_button}}subscribe-to-{{name}}-stream-tooltip-template{{else}}cannot-subscribe-to-{{name}}-stream-tooltip-template{{/if}}">
 
                     <template id="subscribe-to-{{name}}-stream-tooltip-template">
                         <span>
@@ -71,5 +71,4 @@
             </div>
         </div>
     {{/if}}
-</div>
 {{/with}}


### PR DESCRIPTION
Description: 
Fixed the issue that when the user group has 0 current subscriber due to deactivated user or leaving of group, then the user group is now not showing up in the typeahead. 

Fixes: #30890

|Before|After|
|----|----|
|<img width="1440" alt="Screenshot 2024-09-14 at 3 26 18 AM" src="https://github.com/user-attachments/assets/95b6b93e-4807-4704-87bf-547981b97ef1">|<img width="1010" alt="Screenshot 2024-09-14 at 4 11 57 AM" src="https://github.com/user-attachments/assets/3f1f6a82-2ddc-42e6-b157-43082c78a6fb">|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
