### PR TITLE
feed_seetings: Modify the channel feed text for muted topics

### DIFF
--- a/web/src/user_topics.ts
+++ b/web/src/user_topics.ts
@@ -27,7 +27,7 @@ export type UserTopic = {
     visibility_policy: number;
 };
 
-const all_user_topics = new Map<
+export const all_user_topics = new Map<
     number,
     FoldDict<{
         stream_name: string;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1340,6 +1340,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     font-size: 1.5em;
     font-weight: 400;
     word-wrap: break-word;
+    line-height: 1.5;
 }
 
 .empty-feed-notice-description {


### PR DESCRIPTION
Overview: This pull request updates the channel feed to display different text for muted topics. The changes ensure that users can don't get confused when there is a message only in the muted topics.

Fixes: #31601


When the topics are not muted (same): 
|Before|After|
|----|----|
|<img width="1440" alt="Screenshot 2024-09-15 at 9 23 47 PM" src="https://github.com/user-attachments/assets/4e32e365-945a-435e-83e6-2cac28a01c18">|<img width="1440" alt="Screenshot 2024-09-15 at 9 23 47 PM" src="https://github.com/user-attachments/assets/4e32e365-945a-435e-83e6-2cac28a01c18">|

When the topics are muted: 
|Before|After|
|----|----|
|<img width="1440" alt="Screenshot 2024-09-15 at 9 26 57 PM" src="https://github.com/user-attachments/assets/c97274e8-0d57-49fc-b0ea-be56310eff68">|<img width="1440" alt="Screenshot 2024-09-15 at 9 28 53 PM" src="https://github.com/user-attachments/assets/09a011fd-c0ff-4063-8ee5-d5d8c261321e">|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
