### PR TITLE
user-groups: Add helper for date_created comparison test.

### DIFF
--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import mock
 
 import orjson
@@ -80,6 +80,9 @@ class UserGroupTestCase(ZulipTestCase):
         return check_add_user_group(get_realm("zulip"), group_name, members, acting_user=None)
 
     def test_user_groups_in_realm_serialized(self) -> None:
+        def convert_date_created_to_timestamp(date_created: datetime | None) -> int | None:
+            return datetime_to_timestamp(date_created) if date_created is not None else None
+
         realm = get_realm("zulip")
         user = self.example_user("iago")
         user_group = NamedUserGroup.objects.filter(realm=realm).first()
@@ -90,7 +93,10 @@ class UserGroupTestCase(ZulipTestCase):
         self.assert_length(user_groups, 10)
         self.assertEqual(user_groups[0]["id"], user_group.id)
         self.assertEqual(user_groups[0]["creator_id"], user_group.creator_id)
-        self.assertEqual(user_groups[0]["date_created"], user_group.date_created)
+        self.assertEqual(
+            user_groups[0]["date_created"],
+            convert_date_created_to_timestamp(user_group.date_created),
+        )
         self.assertEqual(user_groups[0]["name"], SystemGroups.NOBODY)
         self.assertEqual(user_groups[0]["description"], "Nobody")
         self.assertEqual(user_groups[0]["members"], [])
@@ -105,7 +111,10 @@ class UserGroupTestCase(ZulipTestCase):
         )
         self.assertEqual(user_groups[1]["id"], owners_system_group.id)
         self.assertEqual(user_groups[1]["creator_id"], owners_system_group.creator_id)
-        self.assertEqual(user_groups[1]["date_created"], owners_system_group.date_created)
+        self.assertEqual(
+            user_groups[1]["date_created"],
+            convert_date_created_to_timestamp(owners_system_group.date_created),
+        )
         self.assertEqual(user_groups[1]["name"], SystemGroups.OWNERS)
         self.assertEqual(user_groups[1]["description"], "Owners of this organization")
         self.assertEqual(set(user_groups[1]["members"]), set(membership))
@@ -126,9 +135,9 @@ class UserGroupTestCase(ZulipTestCase):
         )
         self.assertEqual(user_groups[9]["id"], empty_user_group.id)
         self.assertEqual(user_groups[9]["creator_id"], empty_user_group.creator_id)
-        assert empty_user_group.date_created is not None
         self.assertEqual(
-            user_groups[9]["date_created"], datetime_to_timestamp(empty_user_group.date_created)
+            user_groups[9]["date_created"],
+            convert_date_created_to_timestamp(empty_user_group.date_created),
         )
         self.assertEqual(user_groups[9]["name"], "newgroup")
         self.assertEqual(user_groups[9]["description"], "")
@@ -155,12 +164,10 @@ class UserGroupTestCase(ZulipTestCase):
         user_groups = user_groups_in_realm_serialized(realm, allow_deactivated=False)
         self.assertEqual(user_groups[10]["id"], new_user_group.id)
         self.assertEqual(user_groups[10]["creator_id"], new_user_group.creator_id)
-        new_user_group_date_created = (
-            datetime_to_timestamp(new_user_group.date_created)
-            if new_user_group.date_created is not None
-            else None
+        self.assertEqual(
+            user_groups[10]["date_created"],
+            convert_date_created_to_timestamp(new_user_group.date_created),
         )
-        self.assertEqual(user_groups[10]["date_created"], new_user_group_date_created)
         self.assertEqual(user_groups[10]["name"], "newgroup2")
         self.assertEqual(user_groups[10]["description"], "")
         self.assertEqual(user_groups[10]["members"], [othello.id])


### PR DESCRIPTION
Follow-up to #30296.

As `user_groups_in_realm_serialized` converts the `NamedUserGroup.date_created` datetime field into a timestamp, we need to do the same conversion/comparison in the test for this function. And we also need to account for it being `None`.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
