### PR TITLE
Corrected the label name from area:accessibility to accessibility

### DIFF
--- a/docs/subsystems/accessibility.md
+++ b/docs/subsystems/accessibility.md
@@ -60,7 +60,7 @@ Problems with Zulip's accessibility should be reported as
 label. This label can be added by entering the following text in a separate
 comment on the issue:
 
-> @zulipbot add "area: accessibility"
+> @zulipbot add "accessibility"
 
 If you want to help make Zulip more accessible, here is a list of the
 [currently open accessibility issues][accessibility-issues].


### PR DESCRIPTION
In Documentation (https://zulip.readthedocs.io/en/latest/subsystems/accessibility.html#github-issues) , the label is written as "@zulipbot add “area: accessibility” " whereas it should be written correctly as "@zulipbot add “accessibility” ".

Fixes:  In "docs/subsystems/accessibility.md"  added the correct label.

Previously :-

![image](https://github.com/user-attachments/assets/5e7ed936-1e00-479d-9d39-19078d425474)

After:-

![image](https://github.com/user-attachments/assets/0889511f-59dd-4b4a-9f49-4aac29b2c69e)


