### PR TITLE
docs: Mention Debian as a supported distro

### DIFF
--- a/docs/subsystems/dependencies.md
+++ b/docs/subsystems/dependencies.md
@@ -95,8 +95,8 @@ that are documented in the
 [architecture overview](../overview/architecture-overview.md), we rely on the
 versions of those packages provided alongside the Linux distribution
 on which Zulip is deployed. Because Zulip
-[only supports Ubuntu in production](../production/requirements.md), this
-usually means `apt`, though we do support
+[only supports Debian or Ubuntu in production](../production/requirements.md),
+this usually means `apt`, though we do support
 [other platforms in development](../development/setup-advanced.md). Since
 we don't control the versions of these dependencies, we avoid relying
 on specific versions of these packages wherever possible.


### PR DESCRIPTION
According to the production requirements page, Debian (not just Ubuntu) is a supported OS, so the dependencies page should also reflect that.

Fixes: Inconsistent documentation between https://zulip.readthedocs.io/en/latest/subsystems/dependencies.html and https://zulip.readthedocs.io/en/latest/production/requirements.html

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
