### PR TITLE
Fix `message_containers` tracked by `this._message_groups` reset on rerender.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1696,8 +1696,8 @@ export class MessageListView {
         // call; it was introduced in an earlier version of this code
         // where we constructed an artificial message group for this
         // rerendering rather than looking up the original version.
-        Object.assign(
-            group,
+        const temp_group = Object.assign(
+            {...group},
             populate_group_from_message(
                 group.message_containers[0]!.msg,
                 group.date_unchanged,
@@ -1705,7 +1705,7 @@ export class MessageListView {
             ),
         );
 
-        const $rendered_recipient_row = $(render_recipient_row(group));
+        const $rendered_recipient_row = $(render_recipient_row(temp_group));
 
         $header.replaceWith($rendered_recipient_row);
     }


### PR DESCRIPTION
Earlier, in message feed, message group would lose track of message containers from `this._message_groups` on rerenders which would lead to duplicate message groups and not being able to change message properties.

This PR makes a copy for the artificial group used in rerendering message headers.

<!-- Describe your pull request here.-->

Fixes: [czo](https://chat.zulip.org/#narrow/stream/9-issues/topic/Blueslip.20error.20on.20editing.20a.20message)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
