### PR TITLE
todo_widget: Add `type`` as Optional in `new_task_inbound_data_schema`.

### DIFF
--- a/web/src/todo_widget.ts
+++ b/web/src/todo_widget.ts
@@ -31,7 +31,7 @@ const todo_widget_inbound_data = z.intersection(
 );
 
 const new_task_inbound_data_schema = z.object({
-    type: z.literal("new_task"),
+    type: z.literal("new_task").optional(),
     key: z.number().int().nonnegative().max(MAX_IDX),
     task: z.string(),
     desc: z.string(),


### PR DESCRIPTION
This commit corrects the `type` parameter in
`new_task_inbound_data_schema`, which was previously optional but not added as such.

[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.93.82.20todo_list.20tasks.20are.20ignored.20.2331611/near/1942435)

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Self-reviewed the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

Communicated decisions, questions, and potential concerns.

- [] Explained differences from previous plans (e.g., issue description).
- [] Highlighted technical choices and bugs encountered.
- [x] Called out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review.

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [] Responsiveness and internationalization.
- [] Strings and tooltips.
- [] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

Citations:
[1] https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html
</details>
