### PR TITLE
Prevent adding yourself as a DM recipient when other recipients are present.

### DIFF
--- a/web/src/compose_pm_pill.ts
+++ b/web/src/compose_pm_pill.ts
@@ -51,6 +51,12 @@ export function clear(): void {
 }
 
 export function set_from_typeahead(person: User): void {
+    const current_user_ids = get_user_ids();
+
+    // Remove current user from recipient if user adds other recipient
+    if (current_user_ids.length === 1 && current_user_ids.at(0) === people.my_current_user_id()) {
+        clear();
+    }
     user_pill.append_person({
         pill_widget: widget,
         person,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -589,11 +589,22 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         filter_groups_for_guests: true,
     };
     const suggestions = get_person_suggestions(query, opts);
+    const current_user_ids = compose_pm_pill.get_user_ids();
+    const my_user_id = people.my_current_user_id();
     // We know these aren't mentions because `want_broadcast` was `false`.
     // TODO: In the future we should separate user and mention so we don't have
     // to do this.
     const user_suggestions: (UserGroupPillData | UserPillData)[] = [];
     for (const suggestion of suggestions) {
+        if (
+            suggestion.type === "user" &&
+            suggestion.user.user_id === my_user_id &&
+            current_user_ids.length > 0
+        ) {
+            // We don't show current user in typeahead suggestion if recipient
+            // box already has a user pill to avoid fading conversation
+            continue;
+        }
         assert(suggestion.type !== "broadcast");
         user_suggestions.push(suggestion);
     }

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -16,6 +16,13 @@ let pills = {
 };
 
 run_test("pills", ({override, override_rewire}) => {
+    const me = {
+        email: "me@example.com",
+        user_id: 30,
+        full_name: "Me Myself",
+        date_joined: new Date(),
+    };
+
     const othello = {
         user_id: 1,
         email: "othello@example.com",
@@ -34,6 +41,8 @@ run_test("pills", ({override, override_rewire}) => {
         full_name: "Hamlet",
     };
 
+    people.initialize_current_user(me.user_id);
+    people.add_active_user(me);
     people.add_active_user(othello);
     people.add_active_user(iago);
     people.add_active_user(hamlet);
@@ -161,7 +170,7 @@ run_test("pills", ({override, override_rewire}) => {
     compose_pm_pill.set_from_typeahead(othello);
     compose_pm_pill.set_from_typeahead(hamlet);
 
-    const user_ids = compose_pm_pill.get_user_ids();
+    let user_ids = compose_pm_pill.get_user_ids();
     assert.deepEqual(user_ids, [othello.user_id, hamlet.user_id]);
 
     const user_ids_string = compose_pm_pill.get_user_ids_string();
@@ -185,6 +194,12 @@ run_test("pills", ({override, override_rewire}) => {
     assert.ok(pills_cleared);
     assert.ok(appendValue_called);
     assert.ok(text_cleared);
+
+    compose_pm_pill.set_from_typeahead(me);
+    compose_pm_pill.set_from_typeahead(othello);
+
+    user_ids = compose_pm_pill.get_user_ids();
+    assert.deepEqual(user_ids, [othello.user_id]);
 });
 
 run_test("has_unconverted_data", ({override}) => {


### PR DESCRIPTION
This PR changes -

- When composing a DM, if there are already addressees present, we restrict own user suggestion in the typeahead, and not pillify name if you type it out. It should not be possible to add own user to the list of recipients in this case.
- If there are no addressees present, it should be possible to add own user as it is now (so that you can DM yourself). However, if user then adds any other addressees, we clear the current `user_pill` widget.


Fixes: zulip#31629

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 18-09-24 04:12:21 AM IST.webm](https://github.com/user-attachments/assets/4b95c520-7aae-4ad0-8355-7e448abffda2)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
