### PR TITLE
right-sidebar: Others collapsed by default

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -152,7 +152,7 @@ export class BuddyList extends BuddyListConf {
     users_matching_view_ids: number[] = [];
     other_user_ids: number[] = [];
     users_matching_view_is_collapsed = false;
-    other_users_is_collapsed = false;
+    other_users_is_collapsed = true;
     render_count = 0;
     render_data = get_render_data();
     // This is a bit of a hack to make sure we at least have


### PR DESCRIPTION
This PR changes -

"Others" will on default be collapsed. If it is expanded it will be preserved when switching view.

Fixes #31628

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/82557cd8-8820-458f-8409-a90a6d89bb7e

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

