### PR TITLE
styles: Fix invalid CSS generated due to @extend misusage

### DIFF
--- a/web/styles/pygments.css
+++ b/web/styles/pygments.css
@@ -500,7 +500,9 @@
 }
 
 @media not screen {
-    @extend %light-theme;
+    :root {
+        @extend %light-theme;
+    }
 }
 
 @media screen {


### PR DESCRIPTION
`@extend` can only be used in an element selector, not directly within `@media`.

(Introduced by #30511, but the incorrect syntax came from [my suggestion](https://chat.zulip.org/#narrow/stream/431-redesign-project/topic/code.20span.20colors.3A.20dark.20theme/near/1832576).)