### PR TITLE
buddy list: Create new participants section.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -15,7 +15,6 @@ import type {BuddyUserInfo} from "./buddy_data";
 import {media_breakpoints_num} from "./css_variables";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
-import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
 import * as padded_widget from "./padded_widget";
@@ -90,17 +89,7 @@ function get_render_data(): BuddyListRenderData {
     const total_human_users = people.get_active_human_count();
     const other_users_count = total_human_users - total_human_subscribers_count;
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
-    const participant_ids_set = new Set<number>();
-    if (current_sub && narrow_state.topic() && message_lists.current) {
-        for (const message of message_lists.current.all_messages()) {
-            if (
-                !people.is_valid_bot_user(message.sender_id) &&
-                people.is_person_active(message.sender_id)
-            ) {
-                participant_ids_set.add(message.sender_id);
-            }
-        }
-    }
+    const participant_ids_set = buddy_data.get_conversation_participants();
 
     return {
         current_sub,

--- a/web/src/list_util.ts
+++ b/web/src/list_util.ts
@@ -5,6 +5,7 @@ const list_selectors = [
     "#left-sidebar-navigation-list",
     "#buddy-list-users-matching-view",
     "#buddy-list-other-users",
+    "#buddy-list-participants",
     "#send_later_options",
 ];
 

--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -2,11 +2,13 @@ import autosize from "autosize";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
+import * as activity_ui from "./activity_ui";
 import * as blueslip from "./blueslip";
 import * as compose_tooltips from "./compose_tooltips";
 import type {MessageListData} from "./message_list_data";
 import * as message_list_tooltips from "./message_list_tooltips";
 import {MessageListView} from "./message_list_view";
+import * as message_lists from "./message_lists";
 import type {Message} from "./message_store";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
@@ -200,6 +202,11 @@ export class MessageList {
             const first_unread_message_id = this.first_unread_message_id();
             assert(first_unread_message_id !== undefined);
             this.select_id(first_unread_message_id, {then_scroll: true, use_closest: true});
+        }
+
+        // Rebuild message list, since we might need to shuffle around the participant users.
+        if (this === message_lists.current && narrow_state.stream_sub() && narrow_state.topic()) {
+            activity_ui.build_user_sidebar();
         }
 
         return render_info;
@@ -459,6 +466,11 @@ export class MessageList {
     remove_and_rerender(message_ids: number[]): void {
         this.data.remove(message_ids);
         this.rerender();
+        // Rebuild message list if we're deleting messages from the current list,
+        // since we might need to remove a participant user.
+        if (this.is_current_message_list()) {
+            activity_ui.build_user_sidebar();
+        }
     }
 
     show_edit_message($row: JQuery, $form: JQuery): void {

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -268,6 +268,11 @@ export function initialize_right_sidebar(): void {
         },
     );
 
+    $("#buddy-list-participants-container").on("click", ".buddy-list-subsection-header", (e) => {
+        e.stopPropagation();
+        buddy_list.toggle_participants_section();
+    });
+
     $("#buddy-list-other-users-container").on("click", ".buddy-list-subsection-header", (e) => {
         e.stopPropagation();
         buddy_list.toggle_other_users_section();

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,4 +1,4 @@
-<h5 id="{{id}}" class="buddy-list-heading no-style hidden-for-spectators">
+<h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
     {{header_text}} ({{user_count}})
 </h5>
 <i class="buddy-list-section-toggle {{toggle_class}} fa fa-sm {{#if is_collapsed}}fa-caret-right{{else}}fa-caret-down{{/if}}" aria-hidden="true"></i>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -14,6 +14,10 @@
                 </button>
             </div>
             <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
+                <div id="buddy-list-participants-container" class="buddy-list-section-container">
+                    <div class="buddy-list-subsection-header"></div>
+                    <ul id="buddy-list-participants" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>
+                </div>
                 <div id="buddy-list-users-matching-view-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
                     <ul id="buddy-list-users-matching-view" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -23,6 +23,7 @@ set_global("document", {
     },
 });
 
+const activity_ui = mock_esm("../src/activity_ui");
 const narrow_state = mock_esm("../src/narrow_state");
 const stream_data = mock_esm("../src/stream_data");
 
@@ -43,6 +44,7 @@ mock_esm("../src/message_list_view", {
 const {Filter} = zrequire("filter");
 
 run_test("basics", ({override}) => {
+    override(activity_ui, "build_user_sidebar", noop);
     const filter = new Filter([]);
 
     const list = new MessageList({
@@ -433,7 +435,9 @@ run_test("bookend", ({override}) => {
     }
 });
 
-run_test("add_remove_rerender", () => {
+run_test("add_remove_rerender", ({override}) => {
+    override(activity_ui, "build_user_sidebar", noop);
+
     const filter = new Filter([]);
     const list = new MessageList({
         data: new MessageListData({


### PR DESCRIPTION
Fixes #31129

Note: This is ready for product review, but CI won't pass because I haven't updated unit tests yet.

<details>
<summary>Users in all three sections:</summary>

<img width="908" alt="image" src="https://github.com/user-attachments/assets/0757a0d5-45c5-4a62-a032-da2578002033">

![Kapture 2024-09-18 at 11 37 23](https://github.com/user-attachments/assets/2b2260d9-b25d-4e03-875e-765c52d13ff1)


</details>

<details>
<summary>No "others in this channel"</summary>

<img width="908" alt="image" src="https://github.com/user-attachments/assets/3ebf44f8-612e-4452-b3c6-4f6d24d41165">

![Kapture 2024-09-18 at 11 36 21](https://github.com/user-attachments/assets/f9e26226-4b0c-4ad1-a063-2f8928a1e322)


</details>

<details>
<summary>No "others"</summary>

<img width="920" alt="image" src="https://github.com/user-attachments/assets/679f610e-df64-4562-9eb5-2b36e32f7f3d">
![Kapture 2024-09-18 at 11 35 05](https://github.com/user-attachments/assets/607349b7-f31a-47fa-80da-428b53f287ca)

</details>

<details>
<summary>Collapsed sections</summary>
<img width="252" alt="image" src="https://github.com/user-attachments/assets/b104e2a8-9549-4b4c-ac4b-a2f2815190c2">

</details>

<details>
<summary>Just a bot, so no participants section:</summary>

<img width="921" alt="image" src="https://github.com/user-attachments/assets/b7f71b8d-ceb5-4ff9-9758-438e04a36f5c">
</details>

<details>
<summary>Interleaved view, so no participants section:</summary>

<img width="912" alt="image" src="https://github.com/user-attachments/assets/d2bf4c77-16fc-421a-aac7-1cbbb7a11f8e">
</details>


<details>
<summary>Recent conversations, so no participants section</summary>

<img width="927" alt="image" src="https://github.com/user-attachments/assets/53d8dc92-01ea-4fcc-a9cb-246babf3c625">
</details>

<details>
<summary>DM conversation, so no participants section</summary>

<img width="936" alt="image" src="https://github.com/user-attachments/assets/8cf3b245-68d4-4a7f-8621-60b9df5c459e">
</details>

