### PR TITLE
left_sidebar: Ensure brackets are not shown while zoomed in.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1197,8 +1197,8 @@ ul.topic-list:has(.show-more-topics)::after {
 
 /* The grouping border should not be shown
    on zoomed-in views. */
-.zoom-in .topic-list::before,
-.zoom-in .topic-list::after {
+.zoom-in .topic-list.topic-list-has-topics::before,
+.zoom-in .topic-list.topic-list-has-topics::after {
     border: 0;
 }
 


### PR DESCRIPTION
This corrects a subtle regression introduced back in #31492.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![filter-brackets-before](https://github.com/user-attachments/assets/3510e5e3-ffc2-4cd2-a95a-f7620c6d9d60) | ![filter-brackets-after](https://github.com/user-attachments/assets/054b5fa1-1630-4868-8073-fc3fcac53430) |


