### PR TITLE
search: Fix cutoff focus outline.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -52,6 +52,10 @@
             opacity: 1;
         }
 
+        &:focus-visible {
+            outline-offset: -3px;
+        }
+
         &:disabled {
             visibility: hidden;
         }


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/f5b3726f-6e6f-453d-b270-2b431363407c)

after:

![image](https://github.com/user-attachments/assets/8db1aabc-3498-49dd-aa62-9d162d8120da)

reported on CZO here:

https://chat.zulip.org/#narrow/stream/9-issues/topic/clear.20navbar.20search.2C.20keyboard.20navigation/near/1937903