### PR TITLE
help: Replace instructions to delete a group with deactivation.

### DIFF
--- a/help/manage-user-groups.md
+++ b/help/manage-user-groups.md
@@ -96,7 +96,7 @@
 
 {end_tabs}
 
-## Delete a user group
+## Deactivate a user group
 
 {start_tabs}
 
@@ -106,14 +106,10 @@
 
 1. Select a user group.
 
-1. Click the **trash** <i class="fa fa-trash-o"></i> icon near the top right
-   corner of the user group settings panel.
+1. Click the **Deactivate group** (<i class="fa fa-trash-o"></i>) button in the
+   upper right corner of the user group settings panel.
 
-1. Approve by clicking **Confirm**.
-
-!!! warn ""
-
-    **Note**: Deleting a user group cannot be undone by anyone.
+1. Click **Confirm**.
 
 {end_tabs}
 


### PR DESCRIPTION
Follow-up to #31614.

Notes:
- We don't currently have any links to the Delete a user group anchor.
- I removed the warning about it not being undoable, as that's already the content of the confirmation modal.
- Other changes are just to better follow current help center patterns.

Current: https://zulip.com/help/manage-user-groups#delete-a-user-group
<details>
<summary>
Updated
</summary>

![Screenshot 2024-09-18 at 15 05 36@2x](https://github.com/user-attachments/assets/c476d27d-a8d8-41ad-99c8-0791e5c64a0d)

</details>


