### PR TITLE
popovers: Increase contrast of deactivated information text.

### DIFF
--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -68,10 +68,6 @@ a.no-underline:hover {
     text-decoration: none;
 }
 
-.half-opacity {
-    opacity: 0.5;
-}
-
 .italic {
     font-style: italic;
 }

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -107,7 +107,7 @@
                 </li>
             {{/if}}
         {{else}}
-            <li role="none" class="popover-menu-list-item text-item half-opacity italic hidden-for-spectators">
+            <li role="none" class="popover-menu-list-item text-item italic hidden-for-spectators">
                 {{#if is_bot}}
                     <span class="popover-menu-label">{{t "This bot has been deactivated." }}</span>
                 {{else}}

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -10,7 +10,7 @@
             </div>
         </li>
         {{#if deactivated}}
-            <li role="none" class="popover-menu-list-item text-item half-opacity italic hidden-for-spectators">
+            <li role="none" class="popover-menu-list-item text-item italic hidden-for-spectators">
                 <span class="popover-menu-label">{{t "This group has been deactivated." }}</span>
             </li>
         {{/if}}


### PR DESCRIPTION
This PR increases the contrast for "This user has been deactivated" text in user popover and "This group has been deactivated" text in group popover in both light and dark mode by making the opacity 1 as this is important information and should be clearly visible.

The text color and opacity matches with the role text shown in user popover.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|Before|After|
|------|------|
|![opacity-0 5](https://github.com/user-attachments/assets/973cd700-f4a4-40b6-b55d-ef3dc4568dc9)|![opacity-1](https://github.com/user-attachments/assets/0da1aa9d-01a5-4f06-b47a-59998035db2c)|
|![Screenshot from 2024-09-19 15-15-00](https://github.com/user-attachments/assets/1e73c9ec-b466-4d09-82e1-f6c5777e1b25)|![Screenshot from 2024-09-19 15-04-20](https://github.com/user-attachments/assets/54b32c9d-add6-40b9-b4ae-839aabbea1fe)|





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
