### PR TITLE
compose: Decouple compose buttons from button classes.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -643,6 +643,12 @@
     --color-compose-embedded-button-background-interactive: hsl(
         231deg 100% 90% / 90%
     );
+    --color-background-compose-new-message-button: hsl(0deg 0% 100%);
+    --color-background-compose-new-message-button-hover: hsl(0deg 0% 100%);
+    --color-background-compose-new-message-button-active: hsl(0deg 0% 95%);
+    --color-border-compose-new-message-button: hsl(0deg 0% 80%);
+    --color-border-compose-new-message-button-hover: hsl(0deg 0% 60%);
+    --color-border-compose-new-message-button-active: hsl(0deg 0% 60%);
     --color-compose-chevron-arrow: hsl(0deg 0% 58%);
     --color-limit-indicator: hsl(38deg 100% 36%);
     --color-limit-indicator-over-limit: hsl(3deg 80% 40%);
@@ -1086,6 +1092,12 @@
     --color-compose-embedded-button-background-interactive: hsl(
         235deg 100% 70% / 20%
     );
+    --color-background-compose-new-message-button: hsl(0deg 0% 0% / 20%);
+    --color-background-compose-new-message-button-hover: hsl(0deg 0% 0% / 15%);
+    --color-background-compose-new-message-button-active: hsl(0deg 0% 0% / 20%);
+    --color-border-compose-new-message-button: hsl(0deg 0% 0% / 60%);
+    --color-border-compose-new-message-button-hover: hsl(0deg 0% 0% / 60%);
+    --color-border-compose-new-message-button-active: hsl(0deg 0% 0% / 60%);
     --color-background-popover: hsl(212deg 32% 14%);
     --color-limit-indicator: hsl(38deg 100% 70%);
     --color-limit-indicator-over-limit: hsl(3deg 80% 60%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -9,27 +9,39 @@
        reply button and the new-message button. */
     align-items: stretch;
 
-    .new_message_button {
-        .button {
-            /* Keep the new message button sized to match
-               adjacent buttons. */
-            font-size: inherit;
-            min-width: inherit;
-            line-height: var(--line-height-compose-buttons);
-            padding: 3px 10px;
+    .compose_mobile_button {
+        /* Keep the new message button sized to match
+           adjacent buttons. */
+        min-width: inherit;
+        padding: 3px 10px;
+        border-radius: 4px;
+        outline: none;
+        /* This is ugly, but necessary to use the
+           text + for the compose button. An icon
+           would likely be a better choice here.
+           1.2em is 16.8px at 14px em. */
+        font-size: 1.2em;
+        /* 1.2em is 16.8px at 14px em; this
+           maintains the 20px em-equivalent compose
+           line height, but at a 16.8px em. */
+        line-height: 1.19em;
+        font-weight: 400;
+        color: var(--color-text-default);
+        background-color: var(--color-background-compose-new-message-button);
+        border: 1px solid var(--color-border-compose-new-message-button);
+
+        &:hover {
+            background-color: var(
+                --color-background-compose-new-message-button-hover
+            );
+            border-color: var(--color-border-compose-new-message-button-hover);
         }
 
-        .compose_mobile_button {
-            /* This is ugly, but necessary to use the
-               text + for the compose button. An icon
-               would likely be a better choice here.
-               1.2em is 16.8px at 14px em. */
-            font-size: 1.2em !important;
-            /* 1.2em is 16.8px at 14px em; this
-               maintains the 20px em-equivalent compose
-               line height, but at a 16.8px em. */
-            line-height: 1.19em !important;
-            font-weight: 400;
+        &:active {
+            background-color: var(
+                --color-background-compose-new-message-button-active
+            );
+            border-color: var(--color-border-compose-new-message-button-hover);
         }
     }
 
@@ -60,8 +72,14 @@
 
         #left_bar_compose_reply_button_big,
         #new_conversation_button {
-            /* Remove the border inherited from `.button` styles. */
+            /* Keep the new message button sized to match
+               adjacent buttons. */
+            font-size: inherit;
+            min-width: inherit;
+            padding: 3px 10px;
+            outline: none;
             border: none;
+            color: var(--color-text-default);
             background: var(--color-compose-embedded-button-background);
             border-radius: 3px;
             line-height: var(--line-height-compose-buttons);
@@ -83,7 +101,6 @@
         #new_conversation_button {
             /* Remove the  `padding` to prevent margin from affecting parent height. */
             padding: 0 10px;
-            /* Removing the `min-width` inherited from the `.button` styles. */
             min-width: inherit;
             margin: 1px;
             flex-shrink: 0;
@@ -113,6 +130,34 @@
         @media (width < $sm_min) {
             /* Override inline style injected by jQuery hide() */
             display: none !important;
+        }
+    }
+
+    #new_direct_message_button {
+        /* Keep the new message button sized to match
+           adjacent buttons. */
+        font-size: inherit;
+        min-width: inherit;
+        line-height: var(--line-height-compose-buttons);
+        padding: 3px 10px;
+        border-radius: 4px;
+        outline: none;
+        color: var(--color-text-default);
+        background-color: var(--color-background-compose-new-message-button);
+        border: 1px solid var(--color-border-compose-new-message-button);
+
+        &:hover {
+            background-color: var(
+                --color-background-compose-new-message-button-hover
+            );
+            border-color: var(--color-border-compose-new-message-button-hover);
+        }
+
+        &:active {
+            background-color: var(
+                --color-background-compose-new-message-button-active
+            );
+            border-color: var(--color-border-compose-new-message-button-hover);
         }
     }
 }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -26,7 +26,7 @@
         }
     }
 
-    & a:hover {
+    & a:not(.button, .compose_control_button):hover {
         color: hsl(200deg 79% 66%);
 
         & code {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -12,29 +12,29 @@
     </div>
     <div id="compose_controls">
         <div id="compose_buttons">
-            <div class="new_message_button reply_button_container">
+            <div class="reply_button_container">
                 <div class="compose-reply-button-wrapper" data-reply-button-type="selected_message">
-                    <button type="button" class="button compose_reply_button"
+                    <button type="button" class="compose_reply_button"
                       id="left_bar_compose_reply_button_big">
                         {{t 'Compose message' }}
                     </button>
                 </div>
-                <button type="button" class="button compose_new_conversation_button"
+                <button type="button" class="compose_new_conversation_button"
                   id="new_conversation_button"
                   data-tooltip-template-id="new_stream_message_button_tooltip_template">
                     {{t 'Start new conversation' }}
                 </button>
             </div>
-            <span class="new_message_button mobile_button_container">
-                <button type="button" class="button rounded compose_mobile_button"
+            <span class="mobile_button_container">
+                <button type="button" class="compose_mobile_button"
                   id="left_bar_compose_mobile_button_big"
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
                     +
                 </button>
             </span>
             {{#unless embedded }}
-            <span class="new_message_button new_direct_message_button_container">
-                <button type="button" class="button rounded compose_new_direct_message_button"
+            <span class="new_direct_message_button_container">
+                <button type="button" class="compose_new_direct_message_button"
                   id="new_direct_message_button"
                   data-tooltip-template-id="new_direct_message_button_tooltip_template">
                     {{t 'New direct message' }}
@@ -57,7 +57,7 @@
                             </div>
                             <div id="compose_recipient_box">
                                 <input type="text" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
-                                <button type="button" id="recipient_box_clear_topic_button" class="button tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Clear topic' }}" tabindex="-1">
+                                <button type="button" id="recipient_box_clear_topic_button" class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Clear topic' }}" tabindex="-1">
                                     <i class="zulip-icon zulip-icon-close"></i>
                                 </button>
                             </div>


### PR DESCRIPTION
In the 2024 redesigned button configurations, the compose buttons become outliers. This retains their previous style inherited from .button, allowing that base component class to move forward in #31595, for which this PR serves as prep.

This PR also corrects a regression from the removal of `.new-style` that introduced an undesired `min-width` on the clear-topic button in the compose box.

CZO discussion

**Screenshots and screen captures:**

_Expanded compose box:_

| Before | After |
| --- | --- |
| ![light-expanded-before](https://github.com/user-attachments/assets/edcc119a-d135-429b-9902-22a14ced5ee5) | ![light-expanded-after](https://github.com/user-attachments/assets/65a9c25a-4ffa-4a23-9078-488f5a6ada53) |
|  ![dark-expanded-before](https://github.com/user-attachments/assets/4b8edbf5-7d55-458d-83ff-3ba8535abcee) | ![dark-expanded-after](https://github.com/user-attachments/assets/918289cb-0313-4e0a-94f4-ea12c1f27a1f) |

_Collapsed compose box (no change):_

| Before | After |
| --- | --- |
| ![light-collapsed-before](https://github.com/user-attachments/assets/675cd719-648f-47ad-8c44-23a26d99a82e) | ![light-collapsed-after](https://github.com/user-attachments/assets/67dec9a7-cfcf-4802-9673-6acc71367783) |
| ![dark-collapsed-before](https://github.com/user-attachments/assets/e815d473-6285-4494-8cff-6f5ee8032c22) | ![dark-collapsed-after](https://github.com/user-attachments/assets/8dffc27f-0f0e-4adc-ba9b-d84d097a8bfc) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
