### PR TITLE
Refactor theme colors for `compose`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -661,6 +661,11 @@
     --color-message-content-container-border-focus: hsl(0deg 0% 57%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 0% / 5%);
     --color-compose-focus-ring: var(--color-outline-focus);
+    --color-compose-content-border: hsl(0deg 0% 0% / 10%);
+    --color-compose-table-stream-selection-header-border: hsl(0deg 0% 80%);
+    --color-message-content-container-invalid-border: hsl(3deg 57% 33%);
+    --color-message-content-container-invalid-box-shadow: hsl(3deg 57% 33%);
+    --color-compose-control-buttons-divider: hsl(0deg 0% 75%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -1172,6 +1177,11 @@
     --color-message-content-container-border-focus: hsl(0deg 0% 100% / 27%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 100% / 5%);
     --color-compose-focus-ring: hsl(0deg 0% 67%);
+    --color-compose-content-border: hsl(0deg 0% 0% / 60%);
+    --color-compose-table-stream-selection-header-border: hsl(240deg 11% 5%);
+    --color-message-content-container-invalid-border: hsl(3deg 73% 74%);
+    --color-message-content-container-invalid-box-shadow: hsl(3deg 73% 74%);
+    --color-compose-control-buttons-divider: hsl(236deg 33% 90% / 25%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 85%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -689,6 +689,75 @@
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
 
+    /* Banner colors */
+    --color-main-view-banner-success-background: hsl(147deg 43% 92%);
+    --color-main-view-banner-success-border: hsl(147deg 57% 25% / 40%);
+    --color-main-view-banner-success-text: hsl(147deg 57% 25%);
+    --color-main-view-banner-success-close-button: hsl(120deg 1% 15% / 50%);
+    --color-main-view-banner-success-close-button-hover: hsl(147deg 57% 25%);
+    --color-main-view-banner-success-close-button-active: hsl(
+        147deg 57% 25% / 75%
+    );
+    --color-main-view-banner-success-action-button-background: hsl(
+        147deg 57% 25% / 10%
+    );
+    --color-main-view-banner-success-action-button-hover-background: hsl(
+        147deg 57% 25% / 12%
+    );
+    --color-main-view-banner-success-action-button-active-background: hsl(
+        147deg 57% 25% / 15%
+    );
+    --color-main-view-banner-warning-background: hsl(50deg 75% 92%);
+    --color-main-view-banner-warning-border: hsl(38deg 44% 27% / 40%);
+    --color-main-view-banner-warning-text: hsl(38deg 44% 27%);
+    --color-main-view-banner-warning-close-button: hsl(38deg 44% 27% / 50%);
+    --color-main-view-banner-warning-close-button-hover: hsl(38deg 44% 27%);
+    --color-main-view-banner-warning-close-button-active: hsl(
+        38deg 44% 27% / 75%
+    );
+    --color-main-view-banner-warning-action-button-background: hsl(
+        38deg 44% 27% / 10%
+    );
+    --color-main-view-banner-warning-action-button-hover-background: hsl(
+        38deg 44% 27% / 12%
+    );
+    --color-main-view-banner-warning-action-button-active-background: hsl(
+        38deg 44% 27% / 15%
+    );
+    --color-main-view-banner-error-background: hsl(4deg 35% 90%);
+    --color-main-view-banner-error-border: hsl(3deg 57% 33% / 40%);
+    --color-main-view-banner-error-text: hsl(4deg 58% 33%);
+    --color-main-view-banner-error-close-button: hsl(4deg 58% 33% / 50%);
+    --color-main-view-banner-error-close-button-hover: hsl(4deg 58% 33%);
+    --color-main-view-banner-error-close-button-active: hsl(4deg 58% 33% / 75%);
+    --color-main-view-banner-error-action-button-background: hsl(
+        3deg 57% 33% / 10%
+    );
+    --color-main-view-banner-error-action-button-hover-background: hsl(
+        3deg 57% 33% / 12%
+    );
+    --color-main-view-banner-error-action-button-active-background: hsl(
+        3deg 57% 33% / 15%
+    );
+    --color-main-view-banner-info-background: hsl(204deg 58% 92%);
+    --color-main-view-banner-info-border: hsl(204deg 49% 29% / 40%);
+    --color-main-view-banner-info-text: hsl(204deg 49% 29%);
+    --color-main-view-banner-info-close-button: hsl(204deg 49% 29% / 50%);
+    --color-main-view-banner-info-close-button-hover: hsl(204deg 49% 29%);
+    --color-main-view-banner-info-close-button-active: hsl(
+        204deg 49% 29% / 75%
+    );
+    --color-main-view-banner-info-action-button-background: hsl(
+        204deg 49% 29% / 10%
+    );
+    --color-main-view-banner-info-action-button-hover-background: hsl(
+        204deg 49% 29% / 12%
+    );
+    --color-main-view-banner-info-action-button-active-background: hsl(
+        204deg 49% 29% / 15%
+    );
+    --color-upload-banner-moving-bar-background: hsl(204deg 63% 85%);
+
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
@@ -1139,6 +1208,75 @@
     );
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
+
+    /* Banner colors */
+    --color-main-view-banner-success-background: hsl(147deg 100% 8%);
+    --color-main-view-banner-success-border: hsl(149deg 48% 52% / 40%);
+    --color-main-view-banner-success-text: hsl(147deg 51% 80%);
+    --color-main-view-banner-success-close-button: hsl(147deg 51% 55% / 50%);
+    --color-main-view-banner-success-close-button-hover: hsl(147deg 51% 55%);
+    --color-main-view-banner-success-close-button-active: hsl(
+        147deg 51% 55% / 75%
+    );
+    --color-main-view-banner-success-action-button-background: hsl(
+        147deg 51% 55% / 10%
+    );
+    --color-main-view-banner-success-action-button-hover-background: hsl(
+        147deg 51% 55% / 15%
+    );
+    --color-main-view-banner-success-action-button-active-background: hsl(
+        147deg 51% 55% / 20%
+    );
+    --color-main-view-banner-warning-background: hsl(53deg 100% 11%);
+    --color-main-view-banner-warning-border: hsl(38deg 44% 60% / 40%);
+    --color-main-view-banner-warning-text: hsl(50deg 45% 80%);
+    --color-main-view-banner-warning-close-button: hsl(50deg 45% 61% / 50%);
+    --color-main-view-banner-warning-close-button-hover: hsl(50deg 45% 61%);
+    --color-main-view-banner-warning-close-button-active: hsl(
+        50deg 45% 61% / 75%
+    );
+    --color-main-view-banner-warning-action-button-background: hsl(
+        50deg 45% 61% / 10%
+    );
+    --color-main-view-banner-warning-action-button-hover-background: hsl(
+        50deg 45% 61% / 15%
+    );
+    --color-main-view-banner-warning-action-button-active-background: hsl(
+        50deg 45% 61% / 20%
+    );
+    --color-main-view-banner-error-background: hsl(0deg 60% 19%);
+    --color-main-view-banner-error-border: hsl(3deg 73% 74% / 40%);
+    --color-main-view-banner-error-text: hsl(3deg 73% 80%);
+    --color-main-view-banner-error-close-button: hsl(3deg 73% 74% / 50%);
+    --color-main-view-banner-error-close-button-hover: hsl(3deg 73% 74%);
+    --color-main-view-banner-error-close-button-active: hsl(3deg 73% 74% / 75%);
+    --color-main-view-banner-error-action-button-background: hsl(
+        3deg 73% 74% / 10%
+    );
+    --color-main-view-banner-error-action-button-hover-background: hsl(
+        3deg 73% 74% / 15%
+    );
+    --color-main-view-banner-error-action-button-active-background: hsl(
+        3deg 73% 74% / 20%
+    );
+    --color-main-view-banner-info-background: hsl(204deg 100% 12%);
+    --color-main-view-banner-info-border: hsl(205deg 58% 69% / 40%);
+    --color-main-view-banner-info-text: hsl(205deg 58% 80%);
+    --color-main-view-banner-info-close-button: hsl(205deg 58% 69% / 50%);
+    --color-main-view-banner-info-close-button-hover: hsl(205deg 58% 69%);
+    --color-main-view-banner-info-close-button-active: hsl(
+        205deg 58% 69% / 75%
+    );
+    --color-main-view-banner-info-action-button-background: hsl(
+        205deg 58% 69% / 10%
+    );
+    --color-main-view-banner-info-action-button-hover-background: hsl(
+        205deg 58% 69% / 15%
+    );
+    --color-main-view-banner-info-action-button-active-background: hsl(
+        205deg 58% 69% / 20%
+    );
+    --color-upload-banner-moving-bar-background: hsl(204deg 63% 18%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -121,7 +121,7 @@
 #compose-content {
     background-color: var(--color-compose-box-background);
     padding: 7px 7px 8px;
-    border: 1px solid hsl(0deg 0% 0% / 10%);
+    border: 1px solid var(--color-compose-content-border);
     border-radius: 9px 9px 0 0;
     box-shadow: 0 0 0 hsl(236deg 11% 28%);
     height: 100%;
@@ -156,7 +156,8 @@
 
     .stream-selection-header-colorblock {
         box-shadow: none;
-        border: 1px solid hsl(0deg 0% 80%);
+        border: 1px solid
+            var(--color-compose-table-stream-selection-header-border);
         border-right: none;
 
         &.message_header_private_message {
@@ -292,8 +293,9 @@
 
     &:has(.new_message_textarea.invalid),
     &:has(.new_message_textarea.invalid:focus) {
-        border-color: hsl(3deg 57% 33%);
-        box-shadow: 0 0 2px hsl(3deg 57% 33%);
+        border-color: var(--color-message-content-container-invalid-border);
+        box-shadow: 0 0 2px
+            var(--color-message-content-container-invalid-box-shadow);
     }
 }
 
@@ -1222,7 +1224,7 @@ textarea.new_message_textarea {
     }
 
     .divider {
-        color: hsl(0deg 0% 75%);
+        color: var(--color-compose-control-buttons-divider);
         /* 20px at 14px/1em */
         font-size: 1.4286em;
         margin: 0 3px;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -652,32 +652,40 @@
     }
 
     &.success {
-        background-color: hsl(147deg 43% 92%);
-        border: 1px solid hsl(147deg 57% 25% / 40%);
-        color: hsl(147deg 57% 25%);
+        background-color: var(--color-main-view-banner-success-background);
+        border: 1px solid var(--color-main-view-banner-success-border);
+        color: var(--color-main-view-banner-success-text);
 
         .main-view-banner-close-button {
-            color: hsl(147deg 57% 25% / 50%);
+            color: var(--color-main-view-banner-success-close-button);
 
             &:hover {
-                color: hsl(147deg 57% 25%);
+                color: var(--color-main-view-banner-success-close-button-hover);
             }
 
             &:active {
-                color: hsl(147deg 57% 25% / 75%);
+                color: var(
+                    --color-main-view-banner-success-close-button-active
+                );
             }
         }
 
         .main-view-banner-action-button {
-            background-color: hsl(147deg 57% 25% / 10%);
+            background-color: var(
+                --color-main-view-banner-success-action-button-background
+            );
             color: inherit;
 
             &:hover {
-                background-color: hsl(147deg 57% 25% / 12%);
+                background-color: var(
+                    --color-main-view-banner-success-action-button-hover-background
+                );
             }
 
             &:active {
-                background-color: hsl(147deg 57% 25% / 15%);
+                background-color: var(
+                    --color-main-view-banner-success-action-button-active-background
+                );
             }
         }
     }
@@ -687,96 +695,116 @@
     for some of the banners, for which we use the warning-style class. */
     &.warning,
     &.warning-style {
-        background-color: hsl(50deg 75% 92%);
-        border-color: hsl(38deg 44% 27% / 40%);
-        color: hsl(38deg 44% 27%);
+        background-color: var(--color-main-view-banner-warning-background);
+        border-color: var(--color-main-view-banner-warning-border);
+        color: var(--color-main-view-banner-warning-text);
 
         .main-view-banner-close-button {
-            color: hsl(38deg 44% 27% / 50%);
+            color: var(--color-main-view-banner-warning-close-button);
 
             &:hover {
-                color: hsl(38deg 44% 27%);
+                color: var(--color-main-view-banner-warning-close-button-hover);
             }
 
             &:active {
-                color: hsl(38deg 44% 27% / 75%);
+                color: var(
+                    --color-main-view-banner-warning-close-button-active
+                );
             }
         }
 
         .main-view-banner-action-button {
-            background-color: hsl(38deg 44% 27% / 10%);
+            background-color: var(
+                --color-main-view-banner-warning-action-button-background
+            );
             color: inherit;
 
             &:hover {
-                background-color: hsl(38deg 44% 27% / 12%);
+                background-color: var(
+                    --color-main-view-banner-warning-action-button-hover-background
+                );
             }
 
             &:active {
-                background-color: hsl(38deg 44% 27% / 15%);
+                background-color: var(
+                    --color-main-view-banner-warning-action-button-active-background
+                );
             }
         }
     }
 
     &.error {
-        background-color: hsl(4deg 35% 90%);
-        border-color: hsl(3deg 57% 33% / 40%);
-        color: hsl(4deg 58% 33%);
+        background-color: var(--color-main-view-banner-error-background);
+        border-color: var(--color-main-view-banner-error-border);
+        color: var(--color-main-view-banner-error-text);
 
         .main-view-banner-close-button {
-            color: hsl(4deg 58% 33% / 50%);
+            color: var(--color-main-view-banner-error-close-button);
 
             &:hover {
-                color: hsl(4deg 58% 33%);
+                color: var(--color-main-view-banner-error-close-button-hover);
             }
 
             &:active {
-                color: hsl(4deg 58% 33% / 75%);
+                color: var(--color-main-view-banner-error-close-button-active);
             }
         }
 
         .main-view-banner-action-button {
-            background-color: hsl(3deg 57% 33% / 10%);
+            background-color: var(
+                --color-main-view-banner-error-action-button-background
+            );
             color: inherit;
 
             &:hover {
-                background-color: hsl(3deg 57% 33% / 12%);
+                background-color: var(
+                    --color-main-view-banner-error-action-button-hover-background
+                );
             }
 
             &:active {
-                background-color: hsl(3deg 57% 33% / 15%);
+                background-color: var(
+                    --color-main-view-banner-error-action-button-active-background
+                );
             }
         }
     }
 
     &.info {
-        background-color: hsl(204deg 58% 92%);
-        border-color: hsl(204deg 49% 29% / 40%);
+        background-color: var(--color-main-view-banner-info-background);
+        border-color: var(--color-main-view-banner-info-border);
         position: relative;
-        color: hsl(204deg 49% 29%);
+        color: var(--color-main-view-banner-info-text);
 
         .main-view-banner-close-button {
-            color: hsl(204deg 49% 29% / 50%);
+            color: var(--color-main-view-banner-info-close-button);
 
             &:hover {
-                color: hsl(204deg 49% 29%);
+                color: var(--color-main-view-banner-info-close-button-hover);
             }
 
             &:active {
-                color: hsl(204deg 49% 29% / 75%);
+                color: var(--color-main-view-banner-info-close-button-active);
             }
         }
 
         .main-view-banner-action-button,
         .upload_banner_cancel_button {
-            background-color: hsl(204deg 49% 29% / 10%);
+            background-color: var(
+                --color-main-view-banner-info-action-button-background
+            );
             color: inherit;
 
             &:hover {
-                background-color: hsl(204deg 49% 29% / 12%);
+                background-color: var(
+                    --color-main-view-banner-info-action-button-hover-background
+                );
             }
 
             &:active {
-                background-color: hsl(204deg 49% 29% / 15%);
+                background-color: var(
+                    --color-main-view-banner-info-action-button-active-background
+                );
             }
         }
     }
@@ -795,7 +823,7 @@
         /* The progress updates seem to come every second or so,
         so this is the smoothest it can probably get. */
         transition: width 1s ease-in-out;
-        background: hsl(204deg 63% 85%);
+        background: var(--color-upload-banner-moving-bar-background);
         top: 0;
         bottom: 0;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -171,138 +171,25 @@
             color: hsl(200deg 100% 50%);
         }
 
-        &.success {
-            background-color: hsl(147deg 100% 8%);
-            border-color: hsl(149deg 48% 52% / 40%);
-            color: hsl(147deg 51% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(147deg 51% 55% / 50%);
-
-                &:hover {
-                    color: hsl(147deg 51% 55%);
-                }
-
-                &:active {
-                    color: hsl(147deg 51% 55% / 75%);
-                }
-            }
-
-            .main-view-banner-action-button {
-                background-color: hsl(147deg 51% 55% / 10%);
-                color: inherit;
-
-                &:hover {
-                    background-color: hsl(147deg 51% 55% / 15%);
-                }
-
-                &:active {
-                    background-color: hsl(147deg 51% 55% / 20%);
-                }
-            }
-        }
-
         &.warning,
         &.warning-style {
-            background-color: hsl(53deg 100% 11%);
-            border-color: hsl(38deg 44% 60% / 40%);
-            color: hsl(50deg 45% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(50deg 45% 61% / 50%);
-
-                &:hover {
-                    color: hsl(50deg 45% 61%);
-                }
-
-                &:active {
-                    color: hsl(50deg 45% 61% / 75%);
-                }
-            }
-
             .main-view-banner-action-button {
-                background-color: hsl(50deg 45% 61% / 10%);
                 color: hsl(50deg 45% 61%);
-
-                &:hover {
-                    background-color: hsl(50deg 45% 61% / 15%);
-                }
-
-                &:active {
-                    background-color: hsl(50deg 45% 61% / 20%);
-                }
             }
         }
 
         &.error {
-            background-color: hsl(0deg 60% 19%);
-            border-color: hsl(3deg 73% 74% / 40%);
-            color: hsl(3deg 73% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(3deg 73% 74% / 50%);
-
-                &:hover {
-                    color: hsl(3deg 73% 74%);
-                }
-
-                &:active {
-                    color: hsl(3deg 73% 74% / 75%);
-                }
-            }
-
             .main-view-banner-action-button {
-                background-color: hsl(3deg 73% 74% / 10%);
                 color: hsl(3deg 73% 74%);
-
-                &:hover {
-                    background: hsl(3deg 73% 74% / 15%);
-                }
-
-                &:active {
-                    background: hsl(3deg 73% 74% / 20%);
-                }
             }
         }
 
         &.info {
-            background-color: hsl(204deg 100% 12%);
-            border-color: hsl(205deg 58% 69% / 40%);
-            position: relative;
-            color: hsl(205deg 58% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(205deg 58% 69% / 50%);
-
-                &:hover {
-                    color: hsl(205deg 58% 69%);
-                }
-
-                &:active {
-                    color: hsl(205deg 58% 69% / 75%);
-                }
-            }
-
             .main-view-banner-action-button,
             .upload_banner_cancel_button {
-                background-color: hsl(205deg 58% 69% / 10%);
                 border-color: transparent;
                 color: hsl(205deg 58% 69%);
-
-                &:hover {
-                    background-color: hsl(205deg 58% 69% / 15%);
-                }
-
-                &:active {
-                    background-color: hsl(205deg 58% 69% / 20%);
-                }
             }
-        }
-    }
-
-    .upload_banner {
-        .moving_bar {
-            background: hsl(204deg 63% 18%);
         }
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -193,14 +193,6 @@
         }
     }
 
-    #message-content-container {
-        &:has(textarea.new_message_textarea.invalid),
-        &:has(textarea.new_message_textarea.invalid:focus) {
-            border-color: hsl(3deg 73% 74%);
-            box-shadow: 0 0 2px hsl(3deg 73% 74%);
-        }
-    }
-
     .stream_name_search_section,
     .group_name_search_section {
         border-color: hsl(0deg 0% 0% / 20%);
@@ -338,20 +330,8 @@
         border-color: hsl(0deg 0% 0% / 90%);
     }
 
-    .compose-control-buttons-container .divider {
-        color: hsl(236deg 33% 90% / 25%);
-    }
-
     .compose_control_button:hover {
         color: inherit;
-    }
-
-    #compose-content {
-        border-color: hsl(0deg 0% 0% / 60%);
-    }
-
-    .compose_table .stream-selection-header-colorblock {
-        border-color: hsl(240deg 11% 5%);
     }
 
     /* Not that .message_row (below) needs to be more contrast on dark theme */


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR refactor all the theme colors used in `compose.css` and `dark_theme.css`.

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
