### PR TITLE
Refactor theme colors for `input_pill`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -761,6 +761,7 @@
     --color-kbd-background: hsl(0deg 0% 98%);
     --color-kbd-border: hsl(0deg 0% 80%);
     --color-kbd-text: hsl(0deg 0% 20%);
+    --color-kbd-enter-sends: hsl(0deg 0% 40%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
@@ -1276,6 +1277,7 @@
     --color-kbd-background: hsl(211deg 29% 14%);
     --color-kbd-border: hsl(211deg 29% 14%);
     --color-kbd-text: hsl(236deg 33% 90%);
+    --color-kbd-enter-sends: hsl(236deg 33% 90%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -901,6 +901,9 @@
         4deg 75% 53% / 15%
     );
     --color-background-user-pill: hsla(0deg 0% 100% / 85%);
+    --color-background-compose-direct-recipient-pill-container: hsl(
+        0deg 0% 100%
+    );
 
     /* Inbox view constants - Values from Figma design */
     --height-inbox-search: 26px;
@@ -1423,6 +1426,9 @@
     --color-close-deactivated-user-pill: hsl(7deg 100% 74%);
     --color-background-exit-hover-deactivated-user-pill: hsl(0deg 0% 100% / 7%);
     --color-background-user-pill: hsl(0deg 0% 0% / 40%);
+    --color-background-compose-direct-recipient-pill-container: hsl(
+        0deg 0% 0% / 20%
+    );
 
     /* Inbox view */
     --color-background-inbox: var(--color-background);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -48,13 +48,6 @@
         box-shadow: inset 0 1px 0 hsl(0deg 0% 0% / 20%);
     }
 
-    #user_enter_sends_label,
-    #realm_enter_sends_label {
-        & kbd {
-            color: var(--color-kbd-text);
-        }
-    }
-
     #message-formatting,
     #keyboard-shortcuts {
         & kbd {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -386,10 +386,6 @@
         border-color: hsl(3deg 73% 74%);
     }
 
-    #compose-direct-recipient .pill-container {
-        background-color: hsl(0deg 0% 0% / 20%);
-    }
-
     #searchbox {
         /* Light theme shows hover mostly through box-shadow,
           and dark theme shows it mostly through changing color

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -181,7 +181,9 @@
 
 #compose-direct-recipient .pill-container {
     border: 1px solid hsl(0deg 0% 0% / 20%);
-    background-color: hsl(0deg 0% 100%);
+    background-color: var(
+        --color-background-compose-direct-recipient-pill-container
+    );
 
     .input:first-child:empty::before {
         content: attr(data-no-recipients-text);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -510,7 +510,7 @@ input[type="checkbox"] {
     font-size: 0.9333em;
     font-style: normal;
     font-weight: 500;
-    color: hsl(0deg 0% 40%);
+    color: var(--color-kbd-enter-sends);
     position: relative;
     bottom: 1px;
     margin: 0 2px;


### PR DESCRIPTION
This PR refactor all the theme colors used in `input_pill.css` and `dark_theme.css`.

<!-- Describe your pull request here.-->

Note:
- The first commit fixes the issue described in this [comment](https://github.com/zulip/zulip/pull/31544/files#r1783231857) of PR #31544.

- Screenshots in before column are taken from main branch.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before  | After |
| ------------- | ------------- |
| `#compose-direct-recipient .pill-container`  | `#compose-direct-recipient .pill-container`  |
| ![{7AE026D0-D01C-4CB0-992D-81732761D917}](https://github.com/user-attachments/assets/c985e38a-ff8f-4ff3-8caf-31d90aaed5e2)  | ![image](https://github.com/user-attachments/assets/3cf29064-e12c-4202-9e75-a0ca2ec41c85) |
| ![{B36D08A9-101C-40B3-8E00-B249A36D6566}](https://github.com/user-attachments/assets/9adfbd01-17c1-4e55-b53d-9b10df4e2371)  | ![{046008CC-39D2-4005-8F14-A2A0BC739425}](https://github.com/user-attachments/assets/a7dc33dc-6166-4d21-830d-e2b4669f0c32)  |
| `#user_enter_sends_label, #realm_enter_sends_label`  | `#user_enter_sends_label, #realm_enter_sends_label`  |
| ![{DD57C043-4711-4FEB-A14F-5918705817EB}](https://github.com/user-attachments/assets/25d60fc4-bd2d-4079-bfcc-0e16b4086a33) | ![{72F75A5A-6A1E-47A7-88F1-4BD15776B1C3}](https://github.com/user-attachments/assets/9490bec1-bd16-4bc0-b12a-eb2d41361194)  |
| ![{9B235FCE-1E35-47AD-9810-44048B92B25A}](https://github.com/user-attachments/assets/9d5cae1b-b7e6-42fe-a8b1-819c95875bc8)  | ![image](https://github.com/user-attachments/assets/ee7a0c21-5416-4249-935f-c3234efadaa9) |
| ![{A9CC10CC-1A76-443B-B23D-EAE6E60DFDA6}](https://github.com/user-attachments/assets/106a7d0f-9bb6-48ee-820f-a2cf67dd2005)  | ![{C0D81EDE-E622-4300-89EF-790662D38D89}](https://github.com/user-attachments/assets/89748b81-6910-49c0-965d-47430d70797e)  |
| ![{DEB600CF-A2C6-4CFC-9967-F7BF8077894C}](https://github.com/user-attachments/assets/090a9e0e-617d-4a61-b79c-9f27ccf5161e)  | ![{1F90353D-E58D-47C7-9B2A-2FF0F24771E6}](https://github.com/user-attachments/assets/a59732aa-2144-4978-9caa-f21b04940d4d)  |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
