### PR TITLE
Refactor theme colors for `message_edit_history_content`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -795,6 +795,12 @@
     --color-show-more-less-button-background-hover: hsl(240deg 44% 56% / 15%);
     --color-show-more-less-button-background-active: hsl(240deg 44% 56% / 20%);
 
+    /* Message edit history colors */
+    --color-message-edit-history-text-inserted: hsl(122deg 72% 30%);
+    --color-message-edit-history-background-inserted: hsl(120deg 64% 95%);
+    --color-message-edit-history-text-deleted: hsl(0deg 100% 50%);
+    --color-message-edit-history-background-deleted: hsl(7deg 90% 92%);
+
     /* Mention pill colors */
     --color-background-direct-mention: hsl(240deg 52% 95%);
     --color-background-group-mention: hsl(180deg 40% 94%);
@@ -1246,6 +1252,12 @@
     --color-show-more-less-button-background: hsla(240deg 44% 56% / 15%);
     --color-show-more-less-button-background-hover: hsl(240deg 44% 56% / 25%);
     --color-show-more-less-button-background-active: hsl(240deg 44% 56% / 15%);
+
+    /* Message edit history colors */
+    --color-message-edit-history-text-inserted: hsl(122deg 100% 81%);
+    --color-message-edit-history-background-inserted: hsl(120deg 64% 95% / 30%);
+    --color-message-edit-history-text-deleted: hsl(0deg 90% 67%);
+    --color-message-edit-history-background-deleted: hsl(7deg 54% 62% / 38%);
 
     /* Mention pill colors */
     --color-background-direct-mention: hsl(240deg 13% 20%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -671,20 +671,6 @@
         color: inherit;
     }
 
-    #message-edit-history-overlay-container {
-        .message_edit_history_content {
-            .highlight_text_inserted {
-                color: hsl(122deg 100% 81%);
-                background-color: hsl(120deg 64% 95% / 30%);
-            }
-
-            .highlight_text_deleted {
-                color: hsl(0deg 90% 67%);
-                background-color: hsl(7deg 54% 62% / 38%);
-            }
-        }
-    }
-
     & time {
         background: hsl(0deg 0% 0% / 20%);
         box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);

--- a/web/styles/message_edit_history.css
+++ b/web/styles/message_edit_history.css
@@ -25,13 +25,17 @@
 
     .message_edit_history_content {
         .highlight_text_inserted {
-            color: hsl(122deg 72% 30%);
-            background-color: hsl(120deg 64% 95%);
+            color: var(--color-message-edit-history-text-inserted);
+            background-color: var(
+                --color-message-edit-history-background-inserted
+            );
         }
 
         .highlight_text_deleted {
-            color: hsl(0deg 100% 50%);
-            background-color: hsl(7deg 90% 92%);
+            color: var(--color-message-edit-history-text-deleted);
+            background-color: var(
+                --color-message-edit-history-background-deleted
+            );
             text-decoration: line-through;
             word-break: break-all;
         }


### PR DESCRIPTION
This PR refactor all the theme colors used in `message_edit_history_content.css` and `dark_theme.css`.
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
