### PR TITLE
Refactor theme colors for `recent_view`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -696,6 +696,14 @@
     --color-background-recent-view-unread-row-hover: hsl(210deg 100% 97%);
     --color-recent-view-link: hsl(205deg 47% 42%);
     --color-recent-view-link-hover: hsl(214deg 40% 58%);
+    --color-background-recent-filters-button-focus: hsl(0deg 0% 80%);
+    --color-background-recent-filters-button-disabled: hsl(0deg 0% 100%);
+    --color-border-recent-filters-button-disabled: hsl(0deg 0% 80%);
+    --color-recent-view-participant-overflow-text: hsl(0deg 0% 0%);
+    --color-background-recent-view-participant-overflow: hsl(0deg 0% 88%);
+    --color-background-recent-view-selected: hsl(0deg 11% 93%);
+    --color-background-recent-view-table-thead-th: hsl(0deg 0% 100%);
+    --color-background-recent-view-table-thead-sort-header: hsl(0deg 0% 95%);
 
     /* Compose box colors */
     --color-compose-box-background: hsl(232deg 30% 92%);
@@ -1453,6 +1461,14 @@
     --color-background-recent-view-unread-row-hover: hsl(212deg 30% 22% / 60%);
     --color-recent-view-link: hsl(206deg 89% 74%);
     --color-recent-view-link-hover: hsl(208deg 64% 52%);
+    --color-background-recent-filters-button-focus: hsl(0deg 0% 0% / 50%);
+    --color-background-recent-filters-button-disabled: hsl(0deg 0% 0% / 50%);
+    --color-border-recent-filters-button-disabled: hsl(0deg 0% 0%);
+    --color-recent-view-participant-overflow-text: hsl(0deg 0% 100%);
+    --color-background-recent-view-participant-overflow: hsl(211deg 18% 25%);
+    --color-background-recent-view-selected: hsl(228deg 11% 17%);
+    --color-background-recent-view-table-thead-th: hsl(228deg 11% 17%);
+    --color-background-recent-view-table-thead-sort-header: hsl(211deg 29% 14%);
 
     /* Compose box colors */
     --color-compose-box-background: hsl(228deg 11% 17%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -504,33 +504,6 @@
         }
     }
 
-    .recent_view_participant_overflow {
-        color: hsl(0deg 0% 100%) !important;
-        background-color: hsl(211deg 18% 25%) !important;
-    }
-
-    .recent_view_container #recent_view_table .button-recent-filters {
-        &:focus {
-            background-color: hsl(0deg 0% 0% / 50%) !important;
-        }
-
-        &.fake_disabled_button {
-            &:hover {
-                background-color: hsl(0deg 0% 0% / 50%);
-                border-color: hsl(0deg 0% 0%);
-            }
-        }
-    }
-
-    .button-recent-selected,
-    #recent_view_table thead th {
-        background-color: hsl(228deg 11% 17%) !important;
-
-        &[data-sort]:hover {
-            background-color: hsl(211deg 29% 14%) !important;
-        }
-    }
-
     #recent_view_table {
         .zulip-icon-user {
             opacity: 0.7;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -536,8 +536,7 @@
     .subscriber-list-box .subscriber_list_container .subscriber-list td,
     .member-list-box,
     .member-list-box .member_list_container .member-list td,
-    #subscription_overlay .settings-radio-input-parent,
-    #recent_view_table table td {
+    #subscription_overlay .settings-radio-input-parent {
         border-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -179,7 +179,9 @@
         }
 
         &:focus {
-            background-color: hsl(0deg 0% 80%);
+            background-color: var(
+                --color-background-recent-filters-button-focus
+            );
             outline: 0;
         }
 
@@ -188,14 +190,18 @@
             opacity: 0.5;
 
             &:hover {
-                background-color: hsl(0deg 0% 100%);
-                border-color: hsl(0deg 0% 80%);
+                background-color: var(
+                    --color-background-recent-filters-button-disabled
+                );
+                border-color: var(
+                    --color-border-recent-filters-button-disabled
+                );
             }
         }
     }
 
     .button-recent-selected {
-        background-color: hsl(0deg 11% 93%);
+        background-color: var(--color-background-recent-view-selected);
     }
 
     .unread_count {
@@ -314,15 +320,16 @@
     .recent_view_participant_overflow {
         border: 0;
         border-radius: 6px;
-        color: hsl(0deg 0% 100%);
+        color: var(--color-recent-view-participant-overflow-text);
         display: block;
         height: 24px;
         text-align: center;
-        background-color: hsl(0deg 0% 88%);
+        background-color: var(
+            --color-background-recent-view-participant-overflow
+        );
     }
 
     .recent_view_participant_overflow {
-        color: hsl(0deg 0% 0%);
         line-height: 24px;
     }
 
@@ -354,7 +361,7 @@
     }
 
     & thead th {
-        background-color: hsl(0deg 0% 100%);
+        background-color: var(--color-background-recent-view-table-thead-th);
         color: inherit;
         border-top: 1px solid hsl(0deg 0% 0% / 20%) !important;
         border-bottom: 1px solid hsl(0deg 0% 0% / 20%) !important;
@@ -382,7 +389,9 @@
 
         &[data-sort]:hover {
             cursor: pointer;
-            background-color: hsl(0deg 0% 95%);
+            background-color: var(
+                --color-background-recent-view-table-thead-sort-header
+            );
             transition: background-color 100ms ease-in-out;
 
             &:not(.active)::after {


### PR DESCRIPTION
This PR refactor all the theme colors used in `recent_view.css` and `dark_theme.css`.

<!-- Describe your pull request here.-->

Note:
- Screenshots in before column are taken from main branch.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before  | After |
| ------------- | ------------- |
| `.recent_view_participant_overflow`  | `.recent_view_participant_overflow`  |
| ![{45E8352E-2A18-4A55-8359-356CBD77F87D}](https://github.com/user-attachments/assets/fc63cb58-d712-416d-bd5f-dbc6033ec49a)  | ![{E5CBC687-4FEA-4FE4-9690-040C64B94D5E}](https://github.com/user-attachments/assets/ffd4c3dc-3271-4216-adc4-933e5cb1f4b6)  |
| ![{50E96CFB-40DA-4461-916E-AB9F2D98D396}](https://github.com/user-attachments/assets/93680ffe-38d9-4ddc-a0d8-0511ef9d9aac)  | ![{B71B100A-7A1E-4BE7-8AA7-6BFD86272E3D}](https://github.com/user-attachments/assets/64d32868-9f37-4c59-9ab1-15341714d3a2)  |
| `.button-recent-filters`  |  `.button-recent-filters`  |
| ![{25C66E27-D196-4C4C-805E-F5A3D4ECE301}](https://github.com/user-attachments/assets/56485ad0-9236-44f5-82f3-b035b716351f)  | ![{C91ECC44-0988-4DFB-AD64-75ECAEBC4A7A}](https://github.com/user-attachments/assets/39873a48-056e-4162-b34a-3d532d684301)  |
| ![image](https://github.com/user-attachments/assets/70c0f544-2081-4a54-9ba7-aa2ceb0719cd)  | ![{3616558C-1EB9-4377-934E-BE6CCA2A487A}](https://github.com/user-attachments/assets/f90bfbcc-524d-429e-8b54-b91e520c801c)  |
| `.button-recent-filters:focus`  | `.button-recent-filters:focus`  |
| ![{61A7C9DF-3D9C-42FF-A5FA-8E4F196BE69A}](https://github.com/user-attachments/assets/c8e8d7c9-3fe7-4935-8ad1-560a5493eaa4)  | ![{AD35AA5D-1994-497E-9752-4A431B49FAD9}](https://github.com/user-attachments/assets/5976e264-ff92-463b-8a13-1eff4bdb69f5)  |
| ![{8C59AEBC-DB8B-4603-A306-D20D7ED7827F}](https://github.com/user-attachments/assets/06799824-18b1-424e-b488-adc04bc3e0f3)  | ![{3EB77820-68EF-44D5-B090-74C4953987C9}](https://github.com/user-attachments/assets/84e873b5-e23b-40ea-8bab-9b81525751de)  |
| `.button-recent-selected`  | `.button-recent-selected`  |
| ![{E70E7D0F-22B7-4BC8-902C-D510F1EA4CA6}](https://github.com/user-attachments/assets/a8b681a5-7b34-41bd-90e1-41fa226bf636)  | ![{81C71435-8A5F-4DF0-9AD8-C77BC1920017}](https://github.com/user-attachments/assets/3fd6208d-83f6-45e0-af0f-cffb5613a75c)  |
| ![{2C154E21-D13A-4834-94A1-F1C556002CED}](https://github.com/user-attachments/assets/6af7db4d-6458-4ea8-b515-6c850e046bb9)  | ![{97E84AA1-8B91-497C-BF6B-D0399057254D}](https://github.com/user-attachments/assets/d248d35f-f628-42bf-9eaf-39578f007fb3)  |
| `.button-recent-selected.fake_disabled_button`  | `.button-recent-selected.fake_disabled_button`  |
| ![{AAD009FC-D490-4001-B074-D3E0805237ED}](https://github.com/user-attachments/assets/a87e6023-ada0-4aa0-9791-126640838c3f)  | ![{71B46DB7-3718-4EC3-ACA1-23D5CCCD7086}](https://github.com/user-attachments/assets/12ee49e8-d78b-4dab-a24e-58d2351a83d9)  |
| ![{5B8D0E87-E195-47D8-A946-0F052196D0C2}](https://github.com/user-attachments/assets/f079c21d-e4f1-47b8-bde4-ad7f98a95a29)  | ![{5976864C-2EFC-4982-B656-BB2CE84115B5}](https://github.com/user-attachments/assets/d4f17f30-1212-4285-9baa-47b04b41f56b) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
