### PR TITLE
Refactor theme colors for `rendered_markdown`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -692,6 +692,13 @@
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
+    --color-rendered-markdown-inline-image-background: hsl(0deg 0% 0% / 3%);
+    --color-rendered-markdown-inline-image-background-hover: hsl(
+        0deg 0% 0% / 15%
+    );
+    --color-highlight-background: hsl(51deg 100% 79%);
+    --color-time-background: hsl(0deg 0% 93%);
+    --color-time-box-shadow: hsl(0deg 0% 80%);
 
     /* Tab-switcher colors */
     --color-background-tab-switcher-ind-tab: hsl(0deg 0% 100%);
@@ -1143,6 +1150,13 @@
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 33%);
+    --color-rendered-markdown-inline-image-background: hsl(0deg 0% 100% / 3%);
+    --color-rendered-markdown-inline-image-background-hover: hsl(
+        0deg 0% 100% / 15%
+    );
+    --color-highlight-background: hsl(51deg 100% 23%);
+    --color-time-background: hsl(0deg 0% 0% / 20%);
+    --color-time-box-shadow: hsl(0deg 0% 0% / 40%);
 
     /* Tab-switcher colors */
     /* The non-selected colors here are shared with numerous other

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -359,14 +359,8 @@
     }
 
     .rendered_markdown .message_inline_image {
-        background: hsl(0deg 0% 100% / 3%);
-
         img.image-loading-placeholder {
             content: url("../images/loading/loader-white.svg");
-        }
-
-        &:hover {
-            background: hsl(0deg 0% 100% / 15%);
         }
     }
 
@@ -685,11 +679,6 @@
         }
     }
 
-    & time {
-        background: hsl(0deg 0% 0% / 20%);
-        box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);
-    }
-
     .upgrade-tip,
     .upgrade-or-sponsorship-tip,
     .tip,
@@ -839,11 +828,6 @@
         & a:hover {
             color: hsl(0deg 0% 100%);
         }
-    }
-
-    /* Search highlight used in both topics and rendered_markdown */
-    .highlight {
-        background-color: hsl(51deg 100% 23%);
     }
 
     .streams_subheader {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -236,9 +236,9 @@
 
     /* Timestamps */
     & time {
-        background: hsl(0deg 0% 93%);
+        background: var(--color-time-background);
         border-radius: 3px;
-        box-shadow: 0 0 0 1px hsl(0deg 0% 80%);
+        box-shadow: 0 0 0 1px var(--color-time-box-shadow);
         white-space: nowrap;
         margin: 0 2px;
         /* Reduce the font-size to reduce the
@@ -425,10 +425,12 @@
            container. */
         border: solid 1px transparent;
         transition: background 0.3s ease;
-        background: hsl(0deg 0% 0% / 3%);
+        background: var(--color-rendered-markdown-inline-image-background);
 
         &:hover {
-            background: hsl(0deg 0% 0% / 15%);
+            background: var(
+                --color-rendered-markdown-inline-image-background-hover
+            );
         }
 
         & a {
@@ -964,7 +966,7 @@
 
 /* Search highlight used in both topics and rendered_markdown */
 .highlight {
-    background-color: hsl(51deg 100% 79%);
+    background-color: var(--color-highlight-background);
 }
 
 /* For elements where we want to show as much markdown content we can


### PR DESCRIPTION
This PR refactor all the theme colors used in `rendered_markdown.css` and `dark_theme.css`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
