### PR TITLE
Refactor theme colors for `settings`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -855,6 +855,10 @@
     --color-kbd-text: hsl(0deg 0% 20%);
     --color-kbd-enter-sends: hsl(0deg 0% 40%);
 
+    /* Settings */
+    --color-realm-enable-spectator-access-link: hsl(0deg 0% 20%);
+    --color-unmute-stream-hover: hsl(0deg 0% 20%);
+
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
@@ -1761,6 +1765,10 @@
     --color-kbd-border: hsl(211deg 29% 14%);
     --color-kbd-text: hsl(236deg 33% 90%);
     --color-kbd-enter-sends: hsl(236deg 33% 90%);
+
+    /* Settings */
+    --color-realm-enable-spectator-access-link: hsl(236deg 33% 90%);
+    --color-unmute-stream-hover: hsl(0deg 0% 100%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -791,20 +791,6 @@
         }
     }
 
-    /* Originally the icon inherits the color of label, but when the setting
-    is disabled, the color of the label is changed and thus the icon becomes
-    too light. So, we set the color explicitly to original color of label to
-    keep the color of the icon same even when the setting is disabled. */
-    #id_realm_enable_spectator_access_label a {
-        color: hsl(236deg 33% 90%);
-    }
-
-    #stream-specific-notify-table .unmute_stream {
-        &:hover {
-            color: hsl(0deg 0% 100%);
-        }
-    }
-
     #read_receipts_modal .read_receipts_list li {
         &:hover {
             background-color: hsl(0deg 0% 100% / 5%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -283,7 +283,7 @@ h3,
     too light. So, we set the color explicitly to original color of label to
     keep the color of the icon same even when the setting is disabled. */
     #id_realm_enable_spectator_access_label a {
-        color: hsl(0deg 0% 20%);
+        color: var(--color-realm-enable-spectator-access-link);
     }
 
     .settings_select {
@@ -462,7 +462,7 @@ input[type="checkbox"] {
     top: 2px;
 
     &:hover {
-        color: hsl(0deg 0% 20%);
+        color: var(--color-unmute-stream-hover);
         cursor: pointer;
     }
 }


### PR DESCRIPTION
This PR refactor all the theme colors used in `settings.css` and `dark_theme.css`.

<!-- Describe your pull request here.-->

[CZO](https://chat.zulip.org/#narrow/channel/6-frontend/topic/refactor.20theme.20colors.20in.20.60dark_theme.2Ecss.60/near/1944995).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before  | After |
| ------------- | ------------- |
| `#id_realm_enable_spectator_access_label a`  | `#id_realm_enable_spectator_access_label a`  |
| ![{C7385588-1BC2-49C1-BF70-BC497F9F0AF4}](https://github.com/user-attachments/assets/18d79cb9-ae09-4180-997b-245c273331c2) | ![{3BDE9218-44FF-47C0-A009-D8A62C81E708}](https://github.com/user-attachments/assets/c8777cb8-8eee-4b73-9108-2fb771c6334c) |
| ![{5B3C9F3C-B0AB-45A7-A9DF-11F3383AD7AF}](https://github.com/user-attachments/assets/1d1e1569-d7f9-40fb-9b44-96630d64a12c) | ![{C7B6ECC4-7210-47D0-989C-40ADDB87C48E}](https://github.com/user-attachments/assets/9ff95903-22da-45c1-b3b7-eb24500e7cca) |
| #stream-specific-notify-table .unmute_stream &:hover | #stream-specific-notify-table .unmute_stream &:hover |
| ![{2E625D53-F797-42F2-A1A6-DB8DC6692DAE}](https://github.com/user-attachments/assets/abd49611-2fee-42f2-b4d1-cdac08fd1921) | ![{B1187689-849C-47FB-B258-C97E7FD27411}](https://github.com/user-attachments/assets/23e9fd48-489f-4660-ab8e-0ebe1f961055) |
| ![image](https://github.com/user-attachments/assets/4f3f55c9-c8f7-46b2-a4ce-a63b75ffffa0) | ![image](https://github.com/user-attachments/assets/6883ccc0-2948-41f0-90b5-e5c9312a5dd6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
