### PR TITLE
Refactor theme colors for `subscriptions`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -598,6 +598,11 @@
     --color-background-alert-word: hsl(18deg 100% 84%);
     --color-buddy-list-highlighted-user: hsl(120deg 12.3% 71.4% / 38%);
     --color-border-sidebar: hsl(0deg 0% 87%);
+    --color-create-plus-button-background: hsl(0deg 0% 100%);
+    --color-create-plus-button-border: hsl(0deg 0% 80%);
+    --color-search-section-border: hsl(0deg 0% 87%);
+    --color-stream-group-row-plus-sign-svg: hsl(0deg 0% 72%);
+    --color-active-row-background: hsl(0deg 0% 93%);
 
     /* Recent view */
     --color-border-recent-view-row: hsl(0deg 0% 87%);
@@ -688,6 +693,7 @@
     --color-text-url: hsl(200deg 100% 40%);
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
+    --color-text-create-plus-button: hsl(0deg 0% 0%);
 
     /* .settings-sticky-footer colors */
     --color-settings-sticky-footer-shadow: hsl(0deg 0% 100%);
@@ -1040,6 +1046,11 @@
     --color-background-alert-word: hsl(22deg 70% 35%);
     --color-buddy-list-highlighted-user: hsl(136deg 25% 73% / 20%);
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
+    --color-create-plus-button-background: hsl(0deg 0% 0% / 20%);
+    --color-create-plus-button-border: hsl(0deg 0% 0% / 60%);
+    --color-search-section-border: hsl(0deg 0% 0% / 20%);
+    --color-stream-group-row-plus-sign-svg: hsl(218deg 14% 33%);
+    --color-active-row-background: hsl(0deg 0% 0% / 20%);
 
     /* Recent view */
     --color-border-recent-view-row: hsl(0deg 0% 0% / 20%);
@@ -1142,6 +1153,7 @@
     );
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
+    --color-text-create-plus-button: hsl(0deg 0% 100%);
 
     /* .settings-sticky-footer colors */
     --color-settings-sticky-footer-shadow: hsl(0deg 0% 0% / 20%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -689,6 +689,9 @@
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
 
+    /* .settings-sticky-footer colors */
+    --color-settings-sticky-footer-shadow: hsl(0deg 0% 100%);
+
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
@@ -1139,6 +1142,9 @@
     );
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
+
+    /* .settings-sticky-footer colors */
+    --color-settings-sticky-footer-shadow: hsl(0deg 0% 0% / 20%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -84,11 +84,6 @@
         }
     }
 
-    #subscription_overlay #stream-creation .settings-sticky-footer,
-    #groups_overlay #user-group-creation .settings-sticky-footer {
-        box-shadow: inset 0 1px 0 hsl(0deg 0% 0% / 20%);
-    }
-
     .enter_sends_choices,
     #user_enter_sends_label,
     #realm_enter_sends_label {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -425,13 +425,6 @@
         }
     }
 
-    .create_user_group_plus_button,
-    .create_stream_plus_button {
-        color: hsl(0deg 0% 100%);
-        background-color: hsl(0deg 0% 0% / 20%);
-        border-color: hsl(0deg 0% 0% / 60%);
-    }
-
     .table-striped thead th {
         background-color: hsl(0deg 0% 0% / 50%);
         border-color: hsl(0deg 0% 0% / 90%);
@@ -539,19 +532,8 @@
         }
     }
 
-    .group-row.active,
-    .stream-row.active {
-        background-color: hsl(0deg 0% 0% / 20%);
-    }
-
     .stream-row,
     .group-row {
-        /* This is for coluring the plus sign SVGs in stream-list UI */
-        /* public */
-        .check:not(.checked) svg {
-            fill: hsl(218deg 14% 33%);
-        }
-
         /* private */
         .disabled svg {
             opacity: 0.5;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -742,7 +742,7 @@ h4.user_group_setting_subsection_title {
             text-align: right;
             background-color: hsl(0deg 0% 96%);
             border-top: 1px solid hsl(0deg 0% 87%);
-            box-shadow: inset 0 1px 0 hsl(0deg 0% 100%);
+            box-shadow: inset 0 1px 0 var(--color-settings-sticky-footer-shadow);
         }
 
         @media (width > $md_min) {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -77,10 +77,10 @@
     font-weight: 400;
     position: relative;
     top: 2px;
-    border: 1px solid hsl(0deg 0% 80%);
+    border: 1px solid var(--color-create-plus-button-border);
     border-radius: 5px;
-    background-color: hsl(0deg 0% 100%);
-    color: hsl(0deg 0% 0%);
+    background-color: var(--color-create-plus-button-background);
+    color: var(--color-text-create-plus-button);
     margin: 0 0 0 5px;
     height: 27px;
 
@@ -494,7 +494,7 @@ h4.user_group_setting_subsection_title {
     justify-content: center;
     margin-bottom: 0;
     height: auto;
-    border-bottom: 1px solid hsl(0deg 0% 87%);
+    border-bottom: 1px solid var(--color-search-section-border);
 }
 
 .user-groups-list,
@@ -550,7 +550,7 @@ h4.user_group_setting_subsection_title {
         background-position: center center;
 
         & svg {
-            fill: hsl(0deg 0% 72%);
+            fill: var(--color-stream-group-row-plus-sign-svg);
             width: 70%;
             margin: 0% 15%;
         }
@@ -651,7 +651,7 @@ h4.user_group_setting_subsection_title {
     }
 
     &.active {
-        background-color: hsl(0deg 0% 93%);
+        background-color: var(--color-active-row-background);
     }
 
     .check:not(.checked, .disabled):hover svg,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR refactor all the theme colors used in `subscriptions.css` and `dark_theme.css`.


Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
