### PR TITLE
Refactor theme colors for `widgets`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -689,6 +689,17 @@
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
 
+    /* Widgets colors */
+    --color-todo-checkbox-border: hsl(156deg 28% 70%);
+    --color-todo-checkbox-border-hover: hsl(156deg 30% 50%);
+    --color-todo-checkbox-background-checked: hsl(156deg 41% 40%);
+    --color-todo-checkbox-outline-focus: hsl(0deg 0% 100% / 0%);
+    --color-poll-vote-text: hsl(156deg 41% 40%);
+    --color-poll-vote-border: hsl(156deg 28% 70%);
+    --color-poll-vote-border-hover: hsl(156deg 30% 50%);
+    --color-poll-vote-background-focus: hsl(156deg 41% 90%);
+    --color-poll-names-text: hsl(0deg 0% 45%);
+
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
     --color-border-rendered-markdown-table: hsl(0deg 0% 80%);
@@ -1139,6 +1150,17 @@
     );
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
+
+    /* Widgets colors */
+    --color-todo-checkbox-border: hsl(185deg 40% 45%);
+    --color-todo-checkbox-border-hover: hsl(185deg 40% 35%);
+    --color-todo-checkbox-background-checked: hsl(185deg 40% 45%);
+    --color-todo-checkbox-outline-focus: hsl(0deg 0% 100% / 0%);
+    --color-poll-vote-text: hsl(185deg 35% 65%);
+    --color-poll-vote-border: hsl(185deg 35% 35%);
+    --color-poll-vote-border-hover: hsl(185deg 40% 40%);
+    --color-poll-vote-background-focus: hsl(185deg 40% 35%);
+    --color-poll-names-text: hsl(236deg 15% 70%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -923,24 +923,15 @@
     /* Widgets: Poll */
     .poll-widget {
         .poll-vote {
-            color: hsl(185deg 35% 65%);
-            border-color: hsl(185deg 35% 35%);
-
             &:hover {
                 color: hsl(185deg 50% 70%);
-                border-color: hsl(185deg 40% 40%);
                 background-color: hsl(185deg 20% 20%);
             }
 
             &:focus {
                 color: hsl(185deg 50% 65%);
                 border-color: hsl(185deg 40% 50%);
-                background-color: hsl(185deg 40% 35%);
             }
-        }
-
-        .poll-names {
-            color: hsl(236deg 15% 70%);
         }
     }
 
@@ -949,21 +940,11 @@
         & label.checkbox {
             & input[type="checkbox"] {
                 ~ .custom-checkbox {
-                    border-color: hsl(185deg 40% 45%);
                     opacity: 0.7;
                 }
 
                 &:hover ~ .custom-checkbox {
                     background-color: hsl(185deg 20% 20%);
-                    border-color: hsl(185deg 40% 35%);
-                }
-
-                &:checked ~ .custom-checkbox {
-                    background-color: hsl(185deg 40% 45%);
-                }
-
-                &:focus ~ .custom-checkbox {
-                    outline-color: hsl(0deg 0% 100% / 0%);
                 }
             }
         }

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -70,7 +70,7 @@
                 line-height: 0.8;
                 font-size: 1.3rem;
                 text-align: center;
-                border: 2px solid hsl(156deg 28% 70%);
+                border: 2px solid var(--color-todo-checkbox-border);
 
                 border-radius: 4px;
                 filter: brightness(1);
@@ -83,7 +83,7 @@
                 background-size: 75%;
                 background-position: 50% 50%;
                 background-repeat: no-repeat;
-                background-color: hsl(156deg 41% 40%);
+                background-color: var(--color-todo-checkbox-background-checked);
                 border: 2px solid hsl(156deg 41% 40%);
             }
 
@@ -93,11 +93,11 @@
             }
 
             &:hover ~ .custom-checkbox {
-                border-color: hsl(156deg 30% 50%);
+                border-color: var(--color-todo-checkbox-border-hover);
             }
 
             &:focus ~ .custom-checkbox {
-                outline-color: hsl(0deg 0% 100% / 0%);
+                outline-color: var(--color-todo-checkbox-outline-focus);
             }
         }
     }
@@ -164,8 +164,8 @@
     }
 
     .poll-vote {
-        color: hsl(156deg 41% 40%);
-        border-color: hsl(156deg 28% 70%);
+        color: var(--color-poll-vote-text);
+        border-color: var(--color-poll-vote-border);
         border-style: solid;
         font-weight: 600;
         border-radius: 3px;
@@ -175,17 +175,17 @@
         background-color: var(--color-background-widget-button);
 
         &:hover {
-            border-color: hsl(156deg 30% 50%);
+            border-color: var(--color-poll-vote-border-hover);
         }
 
         &:focus {
             outline: 0;
-            background-color: hsl(156deg 41% 90%);
+            background-color: var(--color-poll-vote-background-focus);
         }
     }
 
     .poll-names {
-        color: hsl(0deg 0% 45%);
+        color: var(--color-poll-names-text);
         /* Aim for 50% of the flexbox for voting names,
            but also shrink modestly (.5) adjacent a long
            option. */


### PR DESCRIPTION
This PR refactor all the theme colors used in `widgets.css` and `dark_theme.css`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
