### PR TITLE
Refactor theme colors for `zulip.css`.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -598,6 +598,11 @@
     --color-background-alert-word: hsl(18deg 100% 84%);
     --color-buddy-list-highlighted-user: hsl(120deg 12.3% 71.4% / 38%);
     --color-border-sidebar: hsl(0deg 0% 87%);
+    --color-feedback-container-background: hsl(0deg 0% 98%);
+    --color-small-square-x-background: hsl(0deg 0% 100%);
+    --color-message-border: hsl(0deg 0% 0%);
+    --color-popover-filter-input-focus-background: hsl(0deg 0% 100%);
+    --color-popover-filter-input-focus-border: hsl(229.09deg 21.57% 10% / 80%);
 
     /* Recent view */
     --color-border-recent-view-row: hsl(0deg 0% 87%);
@@ -688,6 +693,11 @@
     --color-text-url: hsl(200deg 100% 40%);
     --color-text-url-hover: hsl(200deg 100% 25%);
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
+    --color-text-small-square-x: hsl(0deg 0% 47%);
+    --color-text-small-square-x-hover: hsl(0deg 0% 18%);
+
+    /* Tippy popover colors */
+    --box-shadow-popover-filter-input-focus: 0 0 6px hsl(228deg 9.8% 20% / 30%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 93%);
@@ -1037,6 +1047,11 @@
     --color-background-alert-word: hsl(22deg 70% 35%);
     --color-buddy-list-highlighted-user: hsl(136deg 25% 73% / 20%);
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
+    --color-feedback-container-background: hsl(212deg 25% 15%);
+    --color-small-square-x-background: hsl(0deg 0% 95%);
+    --color-message-border: hsl(0deg 0% 100%);
+    --color-popover-filter-input-focus-background: hsl(225deg 6% 7%);
+    --color-popover-filter-input-focus-border: hsl(0deg 0% 100% / 50%);
 
     /* Recent view */
     --color-border-recent-view-row: hsl(0deg 0% 0% / 20%);
@@ -1139,6 +1154,11 @@
     );
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
+    --color-text-small-square-x: hsl(0deg 0% 42%);
+    --color-text-small-square-x-hover: hsl(0deg 0% 18%);
+
+    /* Tippy popover colors */
+    --box-shadow-popover-filter-input-focus: 0 0 5px hsl(0deg 0% 100% / 40%);
 
     /* Markdown colors */
     --color-background-rendered-markdown-thead: hsl(0deg 0% 0% / 50%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -390,12 +390,6 @@
         color: inherit;
     }
 
-    .popover-filter-input-wrapper .popover-filter-input:focus {
-        background-color: hsl(225deg 6% 7%);
-        border: 1px solid hsl(0deg 0% 100% / 50%);
-        box-shadow: 0 0 5px hsl(0deg 0% 100% / 40%);
-    }
-
     .dropdown-widget-button {
         border-color: hsl(0deg 0% 0% / 60%);
         background-color: hsl(0deg 0% 0% / 20%);
@@ -832,7 +826,6 @@
     }
 
     #feedback_container {
-        background-color: hsl(212deg 25% 15%);
         border-color: hsl(0deg 0% 0% / 50%);
         color: inherit;
 
@@ -860,7 +853,6 @@
     .date_row span::before,
     .date_row span::after {
         opacity: 0.15;
-        border-bottom: 1px solid hsl(0deg 0% 100%);
     }
 
     .searching-for-more-topics img {
@@ -881,17 +873,6 @@
     #recent_view_loading_messages_indicator {
         & path {
             fill: hsl(0deg 0% 100%);
-        }
-    }
-
-    .small_square_button {
-        &.small_square_x {
-            background-color: hsl(0deg 0% 95%);
-            color: hsl(0deg 0% 42%);
-
-            &:hover {
-                color: hsl(0deg 0% 18%);
-            }
         }
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -218,7 +218,7 @@ p.n-margin {
     top: 0;
     left: calc(50vw - 220px);
     padding: 15px;
-    background-color: hsl(0deg 0% 98%);
+    background-color: var(--color-feedback-container-background);
     border-radius: 5px;
     box-shadow: 0 0 30px hsl(0deg 0% 0% / 25%);
     z-index: 110;
@@ -1246,11 +1246,11 @@ nav {
     }
 
     &.small_square_x {
-        background-color: hsl(0deg 0% 100%);
-        color: hsl(0deg 0% 47%);
+        background-color: var(--color-small-square-x-background);
+        color: var(--color-text-small-square-x);
 
         &:hover {
-            color: hsl(0deg 0% 18%);
+            color: var(--color-text-small-square-x-hover);
         }
     }
 }
@@ -1423,7 +1423,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     vertical-align: middle;
     height: 0;
     opacity: 0.15;
-    border-bottom: 1px solid hsl(0deg 0% 0%);
+    border-bottom: 1px solid var(--color-message-border);
 }
 
 .sub-unsub-message span::before,
@@ -1944,9 +1944,9 @@ body:not(.hide-left-sidebar) {
         margin: 4px 4px 2px;
 
         &:focus {
-            background: hsl(0deg 0% 100%);
-            border: 1px solid hsl(229.09deg 21.57% 10% / 80%);
-            box-shadow: 0 0 6px hsl(228deg 9.8% 20% / 30%);
+            background: var(--color-popover-filter-input-focus-background);
+            border: 1px solid var(--color-popover-filter-input-focus-border);
+            box-shadow: var(--box-shadow-popover-filter-input-focus);
         }
     }
 }


### PR DESCRIPTION
This PR refactor all the theme colors used in `zulip.css` and `dark_theme.css`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
