### PR TITLE
tooltips: Fix hotkey hints wrapping when next to longer tooltip labels.

### DIFF
--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -92,6 +92,7 @@
         color: hsl(225deg 100% 84%);
         padding: 0 5px;
         text-align: center;
+        white-space: nowrap;
     }
 
     .stream-privacy-type-icon {


### PR DESCRIPTION
Earlier, mostly in non-English languages, the tooltip labels would force the tooltip hotkey hints to wrap. This PR adds the `white-space: nowrap` property to ensure that the hotkey hint texts are forced to be in a single line.

<!-- Describe your pull request here.-->

Fixes: [CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/i18n.3A.20popover.20has.20poor.20keyboard.20shortcut.20formatting/near/1900109)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-09-19 at 11 02 55 PM](https://github.com/user-attachments/assets/c44f3bf7-fa66-422f-a68c-7bf0db5976cb) | ![Screenshot 2024-09-19 at 11 02 32 PM](https://github.com/user-attachments/assets/f611cdf9-2fcc-40fa-bf3a-b5efef56efaa) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
