### PR TITLE
message_edit: Attach keydown to $form instead of textarea.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1305,7 +1305,9 @@ export function initialize({
 }: {
     on_enter_send: (scheduling_message?: boolean) => boolean | undefined;
 }): void {
-    // These handlers are at the "form" level so that they are called after typeahead
+    // Attach event handlers to `form` instead of `textarea` to allow
+    // typeahead to call stopPropagation if it can handle the event
+    // and prevent the form from submitting.
     $("form#send_message_form").on("keydown", (e) => {
         handle_keydown(e, on_enter_send);
     });

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -508,7 +508,10 @@ function edit_message($row: JQuery, raw_content: string): void {
     currently_editing_messages.set(message.id, $message_edit_content);
     message_lists.current.show_edit_message($row, $form);
 
-    $message_edit_content.on("keydown", (e) => {
+    // Attach event handlers to `form` instead of `textarea` to allow
+    // typeahead to call stopPropagation if it can handle the event
+    // and prevent the form from submitting.
+    $form.on("keydown", (e) => {
         if (keydown_util.is_enter_event(e)) {
             handle_message_edit_enter(e, $message_edit_content);
         }


### PR DESCRIPTION
This allows any event handlers that are attached to textarea like typeahead to handle the keypress and stop propagation if they successfully handle it.

This fixes a bug where message edit form gets saved on enter keypress instead of selecting the active item in the message edit typeahead.

Introduced in 0696e234bd4ae937ffb9d3c1ace004b48f5414fd.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/broken.20typeahead.20while.20editing