### PR TITLE
export/import: Add assertion to check migration compitability when importing realm.

### DIFF
--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -40,6 +40,7 @@ from zerver.data_import.import_util import (
 from zerver.data_import.sequencer import NEXT_ID, IdMapper
 from zerver.data_import.user_handler import UserHandler
 from zerver.lib.emoji import name_to_codepoint
+from zerver.lib.export import do_common_export_processes
 from zerver.lib.markdown import IMAGE_EXTENSIONS
 from zerver.lib.upload import sanitize_name
 from zerver.lib.utils import process_list_in_batches
@@ -1017,3 +1018,5 @@ def do_convert_data(mattermost_data_dir: str, output_dir: str, masking_content: 
         attachment: dict[str, list[Any]] = {"zerver_attachment": zerver_attachment}
         create_converted_data_files(uploads_list, realm_output_dir, "/uploads/records.json")
         create_converted_data_files(attachment, realm_output_dir, "/attachment.json")
+
+        do_common_export_processes(realm_output_dir)

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -31,6 +31,7 @@ from zerver.data_import.import_util import (
 from zerver.data_import.sequencer import NEXT_ID, IdMapper
 from zerver.data_import.user_handler import UserHandler
 from zerver.lib.emoji import name_to_codepoint
+from zerver.lib.export import do_common_export_processes
 from zerver.lib.markdown import IMAGE_EXTENSIONS
 from zerver.lib.upload import sanitize_name
 from zerver.lib.utils import process_list_in_batches
@@ -1295,3 +1296,5 @@ def do_convert_data(rocketchat_data_dir: str, output_dir: str) -> None:
     attachment: dict[str, list[Any]] = {"zerver_attachment": zerver_attachment}
     create_converted_data_files(attachment, output_dir, "/attachment.json")
     create_converted_data_files(uploads_list, output_dir, "/uploads/records.json")
+
+    do_common_export_processes(output_dir)

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -47,7 +47,7 @@ from zerver.data_import.slack_message_conversion import (
     get_user_full_name,
 )
 from zerver.lib.emoji import codepoint_to_name, get_emoji_file_name
-from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE
+from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE, do_common_export_processes
 from zerver.lib.mime_types import guess_type
 from zerver.lib.storage import static_path
 from zerver.lib.thumbnail import resize_logo
@@ -1508,6 +1508,7 @@ def do_convert_directory(
     create_converted_data_files(uploads_records, output_dir, "/uploads/records.json")
     create_converted_data_files(attachment, output_dir, "/attachment.json")
     create_converted_data_files(realm_icon_records, output_dir, "/realm_icons/records.json")
+    do_common_export_processes(output_dir)
 
     logging.info("######### DATA CONVERSION FINISHED #########\n")
     logging.info("Zulip data dump created at %s", output_dir)

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -31,6 +31,7 @@ from django.utils.timezone import now as timezone_now
 import zerver.lib.upload
 from analytics.models import RealmCount, StreamCount, UserCount
 from scripts.lib.zulip_tools import overwrite_symlink
+from version import ZULIP_VERSION
 from zerver.lib.avatar_hash import user_avatar_base_path_from_ids
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -97,11 +98,18 @@ SourceFilter: TypeAlias = Callable[[Record], bool]
 
 CustomFetch: TypeAlias = Callable[[TableData, Context], None]
 
+AppMigrations: TypeAlias = dict[str, list[str]]
+
 
 class MessagePartial(TypedDict):
     zerver_message: list[Record]
     zerver_userprofile_ids: list[int]
     realm_id: int
+
+
+class MigrationStatusJson(TypedDict):
+    migrations_by_app: AppMigrations
+    zulip_version: str
 
 
 MESSAGE_BATCH_CHUNK_SIZE = 1000
@@ -2093,6 +2101,8 @@ def do_export_realm(
         export_full_with_consent=export_type == RealmExport.EXPORT_FULL_WITH_CONSENT,
     )
 
+    do_common_export_processes(output_dir)
+
     logging.info("Finished exporting %s", realm.string_id)
     create_soft_link(source=output_dir, in_progress=False)
 
@@ -2594,3 +2604,33 @@ def get_realm_exports_serialized(realm: Realm) -> list[dict[str, Any]]:
             export_type=export.type,
         )
     return sorted(exports_dict.values(), key=lambda export_dict: export_dict["id"])
+
+
+def get_migrations_by_app() -> AppMigrations:
+    from django.db import DEFAULT_DB_ALIAS, connections
+    from django.db.migrations.recorder import MigrationRecorder
+
+    recorder = MigrationRecorder(connections[DEFAULT_DB_ALIAS])
+    applied = recorder.applied_migrations()
+    migrations_by_app: AppMigrations = {}
+    for app_name, migration_name in applied:
+        migrations_by_app.setdefault(app_name, []).append(migration_name)
+    return migrations_by_app
+
+
+def export_migration_status(output_dir: str) -> None:
+    migration_status_json = MigrationStatusJson(
+        migrations_by_app=get_migrations_by_app(), zulip_version=ZULIP_VERSION
+    )
+    output_file = os.path.join(output_dir, "migration_status.json")
+    with open(output_file, "wb") as f:
+        f.write(orjson.dumps(migration_status_json, option=orjson.OPT_INDENT_2))
+
+
+def do_common_export_processes(output_dir: str) -> None:
+    # Performs common task(s) necessary for preparing Zulip data exports.
+    # This function is typically shared with migration tools in the
+    # `zerver/data_import` directory.
+
+    logging.info("Exporting migration status")
+    export_migration_status(output_dir)

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timezone
+from difflib import unified_diff
 from typing import Any
 
 import bmemcached
@@ -20,12 +21,22 @@ from psycopg2.extras import execute_values
 from psycopg2.sql import SQL, Identifier
 
 from analytics.models import RealmCount, StreamCount, UserCount
+from version import ZULIP_VERSION
 from zerver.actions.create_realm import set_default_for_realm_permission_group_settings
 from zerver.actions.realm_settings import do_change_realm_plan_type
 from zerver.actions.user_settings import do_change_avatar_fields
 from zerver.lib.avatar_hash import user_avatar_base_path_from_ids
 from zerver.lib.bulk_create import bulk_set_users_or_streams_recipient_fields
-from zerver.lib.export import DATE_FIELDS, Field, Path, Record, TableData, TableName
+from zerver.lib.export import (
+    DATE_FIELDS,
+    Field,
+    MigrationStatusJson,
+    Path,
+    Record,
+    TableData,
+    TableName,
+    get_migrations_by_app,
+)
 from zerver.lib.markdown import markdown_convert
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.message import get_last_message_id
@@ -1124,6 +1135,16 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
     if not os.path.exists(import_dir):
         raise Exception("Missing import directory!")
 
+    migration_status_filename = os.path.join(import_dir, "migration_status.json")
+    if not os.path.exists(migration_status_filename):
+        raise Exception(
+            "Missing migration_status.json file! Make sure you're using the same Zulip version as the exported realm."
+        )
+    logging.info("Checking migration status of exported realm")
+    with open(migration_status_filename) as f:
+        migration_status: MigrationStatusJson = orjson.loads(f.read())
+    check_migration_status(migration_status)
+
     realm_data_filename = os.path.join(import_dir, "realm.json")
     if not os.path.exists(realm_data_filename):
         raise Exception("Missing realm.json file!")
@@ -2080,3 +2101,72 @@ def add_users_to_system_user_groups(
         )
         for membership in usergroup_memberships
     )
+
+
+ZULIP_CLOUD_ONLY_APP_NAMES = ["zilencer", "corporate"]
+
+
+def check_migration_status(exported_migration_status: MigrationStatusJson) -> None:
+    mismatched_migrations_log: dict[str, str] = {}
+    local_migration_status = MigrationStatusJson(
+        migrations_by_app=get_migrations_by_app(), zulip_version=ZULIP_VERSION
+    )
+
+    # Different major versions are the most common form of mismatch
+    # and should get a nice error message focused on that, not
+    # migrations.
+    #
+    # We could split on `-`, to get the maintenance release version,
+    # but unless migrations are different, it should generally be safe
+    # to import across minor release differences.
+    exported_primary_version = exported_migration_status["zulip_version"].split(".")[0]
+    local_primary_version = local_migration_status["zulip_version"].split(".")[0]
+    if exported_primary_version != local_primary_version:
+        raise Exception(
+            "Export was generated on a different Zulip major version.\n"
+            f"Export={exported_migration_status['zulip_version']}\n"
+            f"Server={local_migration_status['zulip_version']}"
+        )
+    exported_migrations_by_app = exported_migration_status["migrations_by_app"]
+    local_migrations_by_app = local_migration_status["migrations_by_app"]
+    all_apps = set(exported_migrations_by_app.keys()).union(set(local_migrations_by_app.keys()))
+
+    for app in all_apps:
+        exported_app_migrations = exported_migrations_by_app.get(app)
+        local_app_migrations = local_migrations_by_app.get(app)
+
+        if app in ZULIP_CLOUD_ONLY_APP_NAMES and (
+            local_app_migrations is None or exported_app_migrations is None
+        ):
+            # This applications are expected to be present only on
+            # Zulip Cloud, so don't warn about them.
+            continue
+
+        if not exported_app_migrations:
+            logging.warning("This server has '%s' app installed, but exported realm does not.", app)
+        elif not local_app_migrations:
+            logging.warning("Exported realm has '%s' app installed, but this server does not.", app)
+        elif local_app_migrations != exported_app_migrations:
+            diff = list(
+                unified_diff(exported_app_migrations, local_app_migrations, lineterm="", n=1)
+            )
+            mismatched_migrations_log[f"\n'{app}' app:\n"] = "\n".join(diff[3:])
+
+    if mismatched_migrations_log:
+        # The order of the list output by the diff is nondeterministic, so the
+        # error logs needs to be sorted first.
+        sorted_error_log: list[str] = [
+            f"{key}{value}" for key, value in sorted(mismatched_migrations_log.items())
+        ]
+
+        error_message = (
+            "Export was generated on a different Zulip version.\n"
+            f"Export={exported_migration_status['zulip_version']}\n"
+            f"Server={local_migration_status['zulip_version']}\n"
+            "\n"
+            "Database formats differ between the exported realm and this server.\n"
+            "Printing migrations that differ between the versions:\n"
+            "--- exported realm\n"
+            "+++ this server"
+        ) + "\n".join(sorted_error_log)
+        raise Exception(error_message)

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_complete_migrations.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_complete_migrations.json
@@ -1,0 +1,65 @@
+{
+    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
+    "auth": [
+        "0001_initial",
+        "0002_alter_permission_name_max_length",
+        "0003_alter_user_email_max_length",
+        "0004_alter_user_username_opts"
+    ],
+    "zerver": [
+        "0001_initial",
+        "0029_realm_subdomain",
+        "0030_realm_org_type",
+        "0031_remove_system_avatar_source"
+    ],
+    "analytics": [
+        "0001_initial",
+        "0002_remove_huddlecount",
+        "0003_fillstate"
+    ],
+    "confirmation": [
+        "0001_initial",
+        "0002_realmcreationkey",
+        "0003_emailchangeconfirmation"
+    ],
+    "zilencer": [
+        "0001_initial",
+        "0002_remote_zulip_server",
+        "0003_add_default_for_remotezulipserver_last_updated_field"
+    ],
+    "corporate": [
+        "0001_initial",
+        "0002_customer_default_discount",
+        "0003_customerplan"
+    ],
+    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
+    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
+    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
+    "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
+    "two_factor": [
+        "0001_initial",
+        "0002_auto_20150110_0810",
+        "0003_auto_20150817_1733",
+        "0004_auto_20160205_1827"
+    ],
+    "sessions": ["0001_initial"],
+    "default": [
+        "0001_initial",
+        "0002_add_related_name",
+        "0003_alter_email_max_length",
+        "0004_auto_20160423_0400"
+    ],
+    "social_auth": [
+        "0001_initial",
+        "0002_add_related_name",
+        "0003_alter_email_max_length",
+        "0004_auto_20160423_0400",
+        "0005_auto_20160727_2333"
+    ],
+    "social_django": [
+        "0006_partial",
+        "0007_code_timestamp",
+        "0008_partial_timestamp",
+        "0009_auto_20191118_0520"
+    ]
+}

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_missing_apps.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_missing_apps.json
@@ -1,0 +1,63 @@
+{
+    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
+    "auth": [
+        "0001_initial",
+        "0002_alter_permission_name_max_length",
+        "0003_alter_user_email_max_length",
+        "0004_alter_user_username_opts"
+    ],
+    "zerver": [
+        "0001_initial",
+        "0029_realm_subdomain",
+        "0030_realm_org_type",
+        "0031_remove_system_avatar_source"
+    ],
+    "analytics": [
+        "0001_initial",
+        "0002_remove_huddlecount",
+        "0003_fillstate"
+    ],
+    "confirmation": [
+        "0001_initial",
+        "0002_realmcreationkey",
+        "0003_emailchangeconfirmation"
+    ],
+    "zilencer": [
+        "0001_initial",
+        "0002_remote_zulip_server",
+        "0003_add_default_for_remotezulipserver_last_updated_field"
+    ],
+    "corporate": [
+        "0001_initial",
+        "0002_customer_default_discount",
+        "0003_customerplan"
+    ],
+    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
+    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
+    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
+    "two_factor": [
+        "0001_initial",
+        "0002_auto_20150110_0810",
+        "0003_auto_20150817_1733",
+        "0004_auto_20160205_1827"
+    ],
+    "default": [
+        "0001_initial",
+        "0002_add_related_name",
+        "0003_alter_email_max_length",
+        "0004_auto_20160423_0400"
+    ],
+    "social_auth": [
+        "0001_initial",
+        "0002_add_related_name",
+        "0003_alter_email_max_length",
+        "0004_auto_20160423_0400",
+        "0005_auto_20160727_2333"
+    ],
+    "social_django": [
+        "0006_partial",
+        "0007_code_timestamp",
+        "0008_partial_timestamp",
+        "0009_auto_20191118_0520"
+    ]
+}

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_unapplied_migrations.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_unapplied_migrations.json
@@ -1,0 +1,61 @@
+{
+    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
+    "auth": [
+        "0001_initial",
+        "0002_alter_permission_name_max_length"
+    ],
+    "zerver": [
+        "0001_initial",
+        "0029_realm_subdomain"
+    ],
+    "analytics": [
+        "0001_initial",
+        "0002_remove_huddlecount",
+        "0003_fillstate"
+    ],
+    "confirmation": [
+        "0001_initial",
+        "0002_realmcreationkey",
+        "0003_emailchangeconfirmation"
+    ],
+    "zilencer": [
+        "0001_initial",
+        "0002_remote_zulip_server",
+        "0003_add_default_for_remotezulipserver_last_updated_field"
+    ],
+    "corporate": [
+        "0001_initial",
+        "0002_customer_default_discount",
+        "0003_customerplan"
+    ],
+    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
+    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
+    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
+    "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
+    "two_factor": [
+        "0001_initial",
+        "0002_auto_20150110_0810",
+        "0003_auto_20150817_1733",
+        "0004_auto_20160205_1827"
+    ],
+    "sessions": ["0001_initial"],
+    "default": [
+        "0001_initial",
+        "0002_add_related_name",
+        "0003_alter_email_max_length",
+        "0004_auto_20160423_0400"
+    ],
+    "social_auth": [
+        "0001_initial",
+        "0002_add_related_name",
+        "0003_alter_email_max_length",
+        "0004_auto_20160423_0400",
+        "0005_auto_20160727_2333"
+    ],
+    "social_django": [
+        "0006_partial",
+        "0007_code_timestamp",
+        "0008_partial_timestamp",
+        "0009_auto_20191118_0520"
+    ]
+}

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
@@ -1,0 +1,17 @@
+Export was generated on a different Zulip version.
+Export=10.0-dev+git
+Server=10.0-dev+git
+
+Database formats differ between the exported realm and this server.
+Printing migrations that differ between the versions:
+--- exported realm
++++ this server
+'auth' app:
+ 0002_alter_permission_name_max_length
+-0003_alter_user_email_max_length
+-0004_alter_user_username_opts
+
+'zerver' app:
+ 0029_realm_subdomain
+-0030_realm_org_type
+-0031_remove_system_avatar_source

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
@@ -1,0 +1,17 @@
+Export was generated on a different Zulip version.
+Export=10.0-dev+git
+Server=10.0-dev+git
+
+Database formats differ between the exported realm and this server.
+Printing migrations that differ between the versions:
+--- exported realm
++++ this server
+'auth' app:
+ 0002_alter_permission_name_max_length
++0003_alter_user_email_max_length
++0004_alter_user_username_opts
+
+'zerver' app:
+ 0029_realm_subdomain
++0030_realm_org_type
++0031_remove_system_avatar_source

--- a/zerver/tests/fixtures/import_fixtures/migration_status.json
+++ b/zerver/tests/fixtures/import_fixtures/migration_status.json
@@ -1,0 +1,68 @@
+{
+    "migrations_by_app": {
+        "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
+        "auth": [
+            "0001_initial",
+            "0002_alter_permission_name_max_length",
+            "0003_alter_user_email_max_length",
+            "0004_alter_user_username_opts"
+        ],
+        "zerver": [
+            "0001_initial",
+            "0029_realm_subdomain",
+            "0030_realm_org_type",
+            "0031_remove_system_avatar_source"
+        ],
+        "analytics": [
+            "0001_initial",
+            "0002_remove_huddlecount",
+            "0003_fillstate"
+        ],
+        "confirmation": [
+            "0001_initial",
+            "0002_realmcreationkey",
+            "0003_emailchangeconfirmation"
+        ],
+        "zilencer": [
+            "0001_initial",
+            "0002_remote_zulip_server",
+            "0003_add_default_for_remotezulipserver_last_updated_field"
+        ],
+        "corporate": [
+            "0001_initial",
+            "0002_customer_default_discount",
+            "0003_customerplan"
+        ],
+        "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
+        "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
+        "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
+        "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
+        "two_factor": [
+            "0001_initial",
+            "0002_auto_20150110_0810",
+            "0003_auto_20150817_1733",
+            "0004_auto_20160205_1827"
+        ],
+        "sessions": ["0001_initial"],
+        "default": [
+            "0001_initial",
+            "0002_add_related_name",
+            "0003_alter_email_max_length",
+            "0004_auto_20160423_0400"
+        ],
+        "social_auth": [
+            "0001_initial",
+            "0002_add_related_name",
+            "0003_alter_email_max_length",
+            "0004_auto_20160423_0400",
+            "0005_auto_20160727_2333"
+        ],
+        "social_django": [
+            "0006_partial",
+            "0007_code_timestamp",
+            "0008_partial_timestamp",
+            "0009_auto_20191118_0520"
+        ]
+    },
+    "zulip_version": "10.0-dev+git"
+ }

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -16,6 +16,7 @@ from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from analytics.models import UserCount
+from version import ZULIP_VERSION
 from zerver.actions.alert_words import do_add_alert_words
 from zerver.actions.create_user import do_create_user
 from zerver.actions.custom_profile_fields import (
@@ -43,6 +44,7 @@ from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.bot_config import set_bot_config
 from zerver.lib.bot_lib import StateHandler
 from zerver.lib.export import (
+    AppMigrations,
     MigrationStatusJson,
     Record,
     do_export_realm,
@@ -339,6 +341,12 @@ class ExportFile(ZulipTestCase):
         # Right now we expect only our user to have an uploaded avatar.
         db_paths = {user_avatar_path(user) + ".original"}
         self.assertEqual(exported_paths, db_paths)
+
+    def get_applied_migrations_fixture(self, fixture_name: str) -> AppMigrations:
+        fixture = orjson.loads(
+            self.fixture_data(fixture_name, "import_fixtures/applied_migrations_fixtures")
+        )
+        return fixture
 
     def verify_migration_status_json(self) -> None:
         # This function asserts that the generated migration_status.json
@@ -2031,6 +2039,174 @@ class RealmImportExportTest(ExportFile):
             if SystemGroups.MEMBERS in expected_group_names:
                 expected_group_names.add(SystemGroups.FULL_MEMBERS)
             self.assertSetEqual(logged_membership_by_user_id[user.id], expected_group_names)
+
+    def test_import_realm_with_unapplied_migrations(self) -> None:
+        realm = get_realm("zulip")
+        with (
+            self.assertRaises(Exception) as e,
+            self.assertLogs(level="INFO"),
+            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
+            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+        ):
+            mock_export.return_value = self.get_applied_migrations_fixture(
+                "with_unapplied_migrations.json"
+            )
+            mock_import.return_value = self.get_applied_migrations_fixture(
+                "with_complete_migrations.json"
+            )
+            self.export_realm(
+                realm,
+                export_type=RealmExport.EXPORT_FULL_WITH_CONSENT,
+            )
+            do_import_realm(get_output_dir(), "test-zulip")
+
+        expected_error_message = self.fixture_data(
+            "unapplied_migrations_error.txt", "import_fixtures/check_migrations_errors"
+        ).strip()
+        error_message = str(e.exception).strip()
+        self.assertEqual(expected_error_message, error_message)
+
+    def test_import_realm_with_extra_migrations(self) -> None:
+        realm = get_realm("zulip")
+        with (
+            self.assertRaises(Exception) as e,
+            self.assertLogs(level="INFO"),
+            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
+            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+        ):
+            mock_export.return_value = self.get_applied_migrations_fixture(
+                "with_complete_migrations.json"
+            )
+            mock_import.return_value = self.get_applied_migrations_fixture(
+                "with_unapplied_migrations.json"
+            )
+            self.export_realm(
+                realm,
+                export_type=RealmExport.EXPORT_FULL_WITH_CONSENT,
+            )
+            do_import_realm(get_output_dir(), "test-zulip")
+        expected_error_message = self.fixture_data(
+            "extra_migrations_error.txt", "import_fixtures/check_migrations_errors"
+        ).strip()
+        error_message = str(e.exception).strip()
+        self.assertEqual(expected_error_message, error_message)
+
+    def test_import_realm_with_extra_exported_apps(self) -> None:
+        realm = get_realm("zulip")
+        with (
+            self.settings(BILLING_ENABLED=False),
+            self.assertLogs(level="WARNING") as mock_log,
+            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
+            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+        ):
+            mock_export.return_value = self.get_applied_migrations_fixture(
+                "with_complete_migrations.json"
+            )
+            mock_import.return_value = self.get_applied_migrations_fixture("with_missing_apps.json")
+            self.export_realm_and_create_auditlog(
+                realm,
+                export_type=RealmExport.EXPORT_FULL_WITH_CONSENT,
+            )
+            do_import_realm(get_output_dir(), "test-zulip")
+        missing_apps_log = [
+            "WARNING:root:Exported realm has 'phonenumber' app installed, but this server does not.",
+            "WARNING:root:Exported realm has 'sessions' app installed, but this server does not.",
+        ]
+        # The log output is sorted because it's order is nondeterministic.
+        self.assertEqual(sorted(mock_log.output), sorted(missing_apps_log))
+        self.assertTrue(Realm.objects.filter(string_id="test-zulip").exists())
+        imported_realm = Realm.objects.get(string_id="test-zulip")
+        self.assertNotEqual(imported_realm.id, realm.id)
+
+    def test_import_realm_with_missing_apps(self) -> None:
+        realm = get_realm("zulip")
+        with (
+            self.settings(BILLING_ENABLED=False),
+            self.assertLogs(level="WARNING") as mock_log,
+            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
+            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+        ):
+            mock_export.return_value = self.get_applied_migrations_fixture("with_missing_apps.json")
+            mock_import.return_value = self.get_applied_migrations_fixture(
+                "with_complete_migrations.json"
+            )
+            self.export_realm_and_create_auditlog(
+                realm,
+                export_type=RealmExport.EXPORT_FULL_WITH_CONSENT,
+            )
+            do_import_realm(get_output_dir(), "test-zulip")
+        missing_apps_log = [
+            "WARNING:root:This server has 'phonenumber' app installed, but exported realm does not.",
+            "WARNING:root:This server has 'sessions' app installed, but exported realm does not.",
+        ]
+        self.assertEqual(sorted(mock_log.output), sorted(missing_apps_log))
+        self.assertTrue(Realm.objects.filter(string_id="test-zulip").exists())
+        imported_realm = Realm.objects.get(string_id="test-zulip")
+        self.assertNotEqual(imported_realm.id, realm.id)
+
+    def test_check_migration_for_zulip_cloud_realm(self) -> None:
+        # This test ensures that `check_migrations_status` correctly handles
+        # checking the migrations of a Zulip Cloud-like realm (with zilencer/
+        # corporate apps installed) when importing into a self-hosted realm
+        # (where these apps are not installed).
+        realm = get_realm("zulip")
+        with (
+            self.settings(BILLING_ENABLED=False),
+            self.assertLogs(level="INFO"),
+            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
+            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+        ):
+            mock_export.return_value = self.get_applied_migrations_fixture(
+                "with_complete_migrations.json"
+            )
+            self_hosted_migrations = self.get_applied_migrations_fixture(
+                "with_complete_migrations.json"
+            )
+            for key in ["zilencer", "corporate"]:
+                self_hosted_migrations.pop(key, None)
+            mock_import.return_value = self_hosted_migrations
+            self.export_realm_and_create_auditlog(
+                realm,
+                export_type=RealmExport.EXPORT_FULL_WITH_CONSENT,
+            )
+            do_import_realm(get_output_dir(), "test-zulip")
+
+        self.assertTrue(Realm.objects.filter(string_id="test-zulip").exists())
+        imported_realm = Realm.objects.get(string_id="test-zulip")
+        self.assertNotEqual(imported_realm.id, realm.id)
+
+    def test_import_realm_without_migration_status_file(self) -> None:
+        realm = get_realm("zulip")
+        with patch("zerver.lib.export.export_migration_status"):
+            self.export_realm_and_create_auditlog(realm)
+
+        with self.assertRaises(Exception) as e, self.assertLogs(level="INFO"):
+            do_import_realm(
+                get_output_dir(),
+                "test-zulip",
+            )
+        expected_error_message = "Missing migration_status.json file! Make sure you're using the same Zulip version as the exported realm."
+        self.assertEqual(expected_error_message, str(e.exception))
+
+    def test_import_realm_with_different_stated_zulip_version(self) -> None:
+        realm = get_realm("zulip")
+        self.export_realm_and_create_auditlog(realm)
+
+        with (
+            patch("zerver.lib.import_realm.ZULIP_VERSION", "8.0"),
+            self.assertRaises(Exception) as e,
+            self.assertLogs(level="INFO"),
+        ):
+            do_import_realm(
+                get_output_dir(),
+                "test-zulip",
+            )
+        expected_error_message = (
+            "Export was generated on a different Zulip major version.\n"
+            f"Export={ZULIP_VERSION}\n"
+            "Server=8.0"
+        )
+        self.assertEqual(expected_error_message, str(e.exception))
 
 
 class SingleUserExportTest(ExportFile):

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -698,6 +698,9 @@ class MatterMostImporter(ZulipTestCase):
         self.assertEqual(
             os.path.exists(os.path.join(harry_team_output_dir, "attachment.json")), True
         )
+        self.assertEqual(
+            os.path.exists(os.path.join(harry_team_output_dir, "migration_status.json")), True
+        )
 
         realm = self.read_file(harry_team_output_dir, "realm.json")
 

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -912,6 +912,7 @@ class RocketChatImporter(ZulipTestCase):
                 "INFO:root:Done processing emoji",
                 "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2', 'os6N2Xg2JkNMCSW9Z']",
                 "INFO:root:skipping direct messages discussion mention: Discussion with Hermione",
+                "INFO:root:Exporting migration status",
             ],
         )
 
@@ -919,6 +920,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(os.path.exists(os.path.join(output_dir, "emoji")), True)
         self.assertEqual(os.path.exists(os.path.join(output_dir, "uploads")), True)
         self.assertEqual(os.path.exists(os.path.join(output_dir, "attachment.json")), True)
+        self.assertTrue(os.path.exists(output_dir + "/migration_status.json"))
 
         realm = self.read_file(output_dir, "realm.json")
 

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1337,6 +1337,7 @@ class SlackImporter(ZulipTestCase):
 
         self.assertTrue(os.path.exists(output_dir))
         self.assertTrue(os.path.exists(output_dir + "/realm.json"))
+        self.assertTrue(os.path.exists(output_dir + "/migration_status.json"))
 
         realm_icons_path = os.path.join(output_dir, "realm_icons")
         realm_icon_records_path = os.path.join(realm_icons_path, "records.json")


### PR DESCRIPTION
## Overview
This PR adds an assertion to check the compatibility between the migration status of the exported realm and the importing server.

<details>

<summary>
Info logs for mismatches in installed apps
</summary>

Each server might have a different set of apps installed (e.g., Zulip Cloud has zilencer/corporate, but self-hosted might not). We only checks for mismatches in apps installed on both servers and log warn on any detected mismatch in installed apps
```
...
2024-09-25 09:49:01.461 WARN [] Local server has 'sessions' app installed, but exported realm does not.
2024-09-25 09:49:01.461 WARN [] Exported realm has 'some_missing_app' app installed, but this server does not.
... 
```
</details>

<details>

<summary>
Error log for Zulip version mismatch
</summary>

```
Processing dump: /tmp/zulip-export-s_ue8uig ...
2024-11-01 12:49:50.984 INFO [] Importing realm dump /tmp/zulip-export-s_ue8uig
2024-11-01 12:49:50.995 INFO [] Checking migration status of exported realm
Traceback (most recent call last):
  File "/srv/zulip/manage.py", line 150, in <module>
    execute_from_command_line(sys.argv)
  File "/srv/zulip/manage.py", line 115, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip/zerver/lib/management.py", line 97, in execute
    super().execute(*args, **options)
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
  File "/srv/zulip/zerver/management/commands/import.py", line 107, in handle
    do_import_realm(path, subdomain, num_processes)
  File "/srv/zulip/zerver/lib/import_realm.py", line 1146, in do_import_realm
    check_migration_status(migration_status)
  File "/srv/zulip/zerver/lib/import_realm.py", line 2118, in check_migration_status
    raise Exception(
Exception: Zulip version mismatch.
Export=10.0-dev+git
Local=11.0-dev+git
```
</details>

<details>

<summary>
Error log for migrations mismatches
</summary>

```
Processing dump: /tmp/zulip-export-s_ue8uig ...
2024-11-01 09:51:56.575 INFO [] Importing realm dump /tmp/zulip-export-s_ue8uig
2024-11-01 09:51:56.575 INFO [] Checking migration status of exported realm
Traceback (most recent call last):
  File "/srv/zulip/manage.py", line 150, in <module>
    execute_from_command_line(sys.argv)
  File "/srv/zulip/manage.py", line 115, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip/zerver/lib/management.py", line 97, in execute
    super().execute(*args, **options)
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
  File "/srv/zulip/zerver/management/commands/import.py", line 107, in handle
    do_import_realm(path, subdomain, num_processes)
  File "/srv/zulip/zerver/lib/import_realm.py", line 1150, in do_import_realm
    raise e
Exception: 
Error: Migration mismatch between the exported realm and the local server; showing diff.
--- exported realm
+++ local server
'social_django' app:
 0004_auto_20160423_0400
+0002_add_related_name
+0003_alter_email_max_length
+0005_auto_20160727_2333
 0001_initial
-0002_add_related_name
-0005_auto_20160727_2333
-0003_alter_email_max_length

'zerver' app:
 0615_system_bot_avatars
+0616_userprofile_can_change_user_emails
 0001_squashed_0569
-0616_userprofile_can_change_user_emails
+0622_backfill_imageattachment_again
 0617_remove_prefix_from_archived_streams
+0618_realm_can_move_messages_between_topics_group
+0619_set_default_value_for_can_move_messages_between_topics_group
+0620_alter_realm_can_move_messages_between_topics_group
+0621_remove_realm_edit_topic_policy
+0623_merge_20241030_1835
```
</details>

<details>

<summary>
Error log for missing migrations_status.json file
</summary>

```
Processing dump: /tmp/zulip-export-s_ue8uig ...
2024-11-01 12:51:06.264 INFO [] Importing realm dump /tmp/zulip-export-s_ue8uig
Traceback (most recent call last):
  File "/srv/zulip/manage.py", line 150, in <module>
    execute_from_command_line(sys.argv)
  File "/srv/zulip/manage.py", line 115, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip/zerver/lib/management.py", line 97, in execute
    super().execute(*args, **options)
  File "/srv/zulip-venv-cache/51edbe5a28c4e25da3ea0284bd8528f248e9198a/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
  File "/srv/zulip/zerver/management/commands/import.py", line 107, in handle
    do_import_realm(path, subdomain, num_processes)
  File "/srv/zulip/zerver/lib/import_realm.py", line 1140, in do_import_realm
    raise Exception(
Exception: Missing migration_status.json file! Make sure you're using the same Zulip version as the exported realm.

```
</details>

Fixes: #28443


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
