### PR TITLE
Convert Slack zipfiles in a background worker

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -78,7 +78,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 {% endif %}
 
                 <div class="input-box no-validation">
-                    <input type='hidden' name='key' value='{{ key }}' />
+                    <input type='hidden' name='key' value='{{ key }}' id="auth_key" />
                     <input type='hidden' name='timezone' id='timezone'/>
                     <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
                     <div id="id_email">{{ email }}</div>
@@ -197,6 +197,14 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
             {% endif %}
 
             {% if creating_new_realm %}
+            <fieldset class="import">
+                <legend>{{ _('Import from Slack?') }}</legend>
+                <label for="slack-access-token">
+                    {{ _('Slack access token (%(example)s)', example="xoxb-...") }}
+                </label>
+                <input id="slack-access-token" type="text" placeholder="xoxb-..." maxlength="100" name="slack-access-token"/>
+                <div id="slack-import-drag-and-drop"></div>
+            </fieldset>
             <div class="input-group input-box" id="how-realm-creator-found-zulip">
                 <label for="how_realm_creator_found_zulip">
                     {{ _('How did you first hear about Zulip?') }}

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -1,5 +1,6 @@
 # Documented in https://zulip.readthedocs.io/en/latest/subsystems/queuing.html
 import logging
+import shutil
 import tempfile
 import time
 from typing import Any
@@ -12,10 +13,14 @@ from django.utils.translation import gettext as _
 from django.utils.translation import override as override_language
 from typing_extensions import override
 
+from confirmation import settings as confirmation_settings
 from zerver.actions.message_flags import do_mark_stream_messages_as_read
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_export import notify_realm_export
+from zerver.actions.realm_settings import do_delete_all_realm_attachments
+from zerver.data_import.slack import do_convert_zipfile
 from zerver.lib.export import export_realm_wrapper
+from zerver.lib.import_realm import do_import_realm
 from zerver.lib.push_notifications import clear_push_device_tokens
 from zerver.lib.queue import queue_json_publish, retry_event
 from zerver.lib.remote_server import (
@@ -23,8 +28,16 @@ from zerver.lib.remote_server import (
     send_server_data_to_push_bouncer,
 )
 from zerver.lib.soft_deactivation import reactivate_user_if_soft_deactivated
-from zerver.lib.upload import handle_reupload_emojis_event
-from zerver.models import Message, Realm, RealmAuditLog, RealmExport, Stream, UserMessage
+from zerver.lib.upload import handle_reupload_emojis_event, save_attachment_contents
+from zerver.models import (
+    Message,
+    PreregistrationRealm,
+    Realm,
+    RealmAuditLog,
+    RealmExport,
+    Stream,
+    UserMessage,
+)
 from zerver.models.users import get_system_bot, get_user_profile_by_id
 from zerver.worker.base import QueueProcessingWorker, assign_queue
 
@@ -228,6 +241,50 @@ class DeferredWorker(QueueProcessingWorker):
             realm_id = event["realm_id"]
             logger.info("Updating push bouncer with metadata on behalf of realm %s", realm_id)
             send_server_data_to_push_bouncer(consider_usage_statistics=False)
+        elif event["type"] == "import_slack_data":
+            preregistration_realm = PreregistrationRealm.objects.get(
+                id=event["preregistration_realm_id"]
+            )
+            string_id = preregistration_realm.string_id
+            output_dir = tempfile.mkdtemp(
+                prefix=f"import-{preregistration_realm.id}-converted-",
+                dir=settings.IMPORT_TMPFILE_DIRECTORY,
+            )
+            try:
+                with tempfile.NamedTemporaryFile(
+                    prefix=f"import-{preregistration_realm.id}-slack-",
+                    suffix=".zip",
+                    dir=settings.IMPORT_TMPFILE_DIRECTORY,
+                ) as fh:
+                    save_attachment_contents(event["filename"], fh)
+                    fh.flush()
+                    do_convert_zipfile(
+                        fh.name,
+                        output_dir,
+                        event["slack_access_token"],
+                    )
+                    realm = do_import_realm(output_dir, string_id)
+                    realm.org_type = preregistration_realm.org_type
+                    realm.default_language = preregistration_realm.default_language
+                    realm.save()
+
+                    preregistration_realm.status = confirmation_settings.STATUS_USED
+                    preregistration_realm.created_realm = realm
+                    preregistration_realm.save()
+            except Exception:
+                try:
+                    # Clean up the realm if the import failed
+                    preregistration_realm.created_realm = None
+                    preregistration_realm.save()
+
+                    realm = Realm.objects.get(string_id=string_id)
+                    do_delete_all_realm_attachments(realm)
+                    realm.delete()
+                except Realm.DoesNotExist:
+                    pass
+                raise
+            finally:
+                shutil.rmtree(output_dir)
 
         end = time.time()
         logger.info(

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -613,6 +613,9 @@ NAGIOS_BOT_HOST = SYSTEM_BOT_REALM + "." + EXTERNAL_HOST
 # Use half of the available CPUs for data import purposes.
 DEFAULT_DATA_EXPORT_IMPORT_PARALLELISM = (len(os.sched_getaffinity(0)) // 2) or 1
 
+# Use the default tmpfile path for automated imports
+IMPORT_TMPFILE_DIRECTORY: str | None = None
+
 # How long after the last upgrade to nag users that the server needs
 # to be upgraded because of likely security releases in the meantime.
 # Default is 18 months, constructed as 12 months before someone should

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -143,6 +143,7 @@ from zerver.views.registration import (
     find_account,
     get_prereg_key_and_redirect,
     new_realm_send_confirm,
+    realm_import_status,
     realm_redirect,
     realm_register,
     signup_send_confirm,
@@ -591,6 +592,7 @@ i18n_urls = [
     ),
     path("accounts/register/", accounts_register, name="accounts_register"),
     path("realm/register/", realm_register, name="realm_register"),
+    path("realm/import/status", realm_import_status),
     path(
         "accounts/do_confirm/<confirmation_key>",
         get_prereg_key_and_redirect,


### PR DESCRIPTION
Has a bunch of TODOs and other notes in comments.  The import works, and the status endpoint returns some data that a frontend could poll and display.  The upload widget should be sure to pull in any updated options we've started passing to the the standard logged-in Uppy arguments -- we should probably blanket turn off `storeFingerprintForResuming` or whatever the right flag is so that we _do_ re-upload files which it thinks we uploaded once already?  Since they're stored in different places depending what realm is being created, and we delete them server-side in some cases.