### PR TITLE
[DRAFT] thumbnails: Present inline media in flexbox galleries.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -102,6 +102,8 @@ export function postprocess_content(html: string): string {
                 elt.setAttribute("aria-label", title);
                 elt.removeAttribute("title");
             }
+            // Make it more performant to refer to media links
+            elt.classList.add("media-link");
             // To prevent layout shifts and flexibly size image previews,
             // we read the image's original dimensions, when present, and
             // set those values as `height` and `width` attributes on the

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -380,6 +380,10 @@
             ) /
             2
     );
+    /* Thumbnail images are constrained to a square, ensuring
+       that neither landscape nor portrait images appear larger
+       than the other. */
+    --max-length-thumbnail-image: 150px;
 
     /* Legacy values */
     --legacy-body-line-height-unitless: calc(20 / 14);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1426,6 +1426,18 @@
         hsl(0deg 0% 80%),
         hsl(0deg 0% 33%)
     );
+    --color-background-rendered-markdown-thumbnail: light-dark(
+        hsl(0deg 0% 0% / 3%),
+        hsl(0deg 0% 100% / 3%)
+    );
+    --color-background-rendered-markdown-thumbnail-hover: light-dark(
+        hsl(0deg 0% 0% / 15%),
+        hsl(0deg 0% 100% / 15%)
+    );
+
+    /* Markdown assets */
+    --icon-image-loading-placeholder: content:
+        url("../images/loading/loader-black.svg");
 
     /* Tab-switcher colors */
     /* The non-selected colors here are shared with numerous other
@@ -2572,6 +2584,10 @@
     --color-text-sender-name: hsl(0deg 0% 100% / 85%);
     --color-text-other-mention: hsl(0deg 0% 100% / 80%);
     --color-text-empty-list-message: hsl(0deg 0% 67%);
+
+    /* Markdown assets */
+    --icon-image-loading-placeholder: content:
+        url("../images/loading/loader-white.svg");
 
     /* Settings table colors */
     --color-background-notification-table-thead: hsl(0deg 0% 0% / 20%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -303,18 +303,6 @@
         opacity: 0.4;
     }
 
-    .rendered_markdown .message_inline_image {
-        background: hsl(0deg 0% 100% / 3%);
-
-        img.image-loading-placeholder {
-            content: url("../images/loading/loader-white.svg");
-        }
-
-        &:hover {
-            background: hsl(0deg 0% 100% / 15%);
-        }
-    }
-
     & input[type="text"],
     input[type="email"],
     input[type="password"],

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -409,8 +409,7 @@
         font-weight: bold;
     }
 
-    .twitter-image,
-    .message_inline_image {
+    .twitter-image {
         position: relative;
         margin-bottom: var(--markdown-interelement-space-px);
         margin-right: 5px;
@@ -466,8 +465,7 @@
         }
     }
 
-    &.rtl .twitter-image,
-    &.rtl .message_inline_image {
+    &.rtl .twitter-image {
         margin-left: unset;
         margin-right: 5px;
     }
@@ -571,7 +569,6 @@
     }
 
     .twitter-image img,
-    .message_inline_image img,
     .message_inline_ref img {
         /* We use `scale-down` so that images smaller than the container are
            neither scaled up nor cropped to fit. This preserves
@@ -609,15 +606,10 @@
     }
 
     &.rtl .twitter-image img,
-    &.rtl .message_inline_image img,
     &.rtl .message_inline_ref img {
         float: right;
         margin-right: unset;
         margin-left: 10px;
-    }
-
-    & li .message_inline_image img {
-        float: none;
     }
 
     .message_inline_video,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -404,6 +404,99 @@
         }
     }
 
+    /* Thumbnail galleries for uploaded media */
+
+    .message-thumbnail-gallery {
+        display: flex;
+        gap: 5px;
+        flex-flow: row wrap;
+        align-items: center;
+        margin: 0 0 var(--markdown-interelement-space-px);
+    }
+
+    .message_inline_image {
+        max-width: var(--max-length-thumbnail-image);
+        max-height: var(--max-length-thumbnail-image);
+        flex: 0 0 auto;
+    }
+
+    .landscape-thumbnail {
+        width: var(--max-length-thumbnail-image);
+    }
+
+    .portrait-thumbnail {
+        height: var(--max-length-thumbnail-image);
+    }
+
+    .image-loading-placeholder {
+        content: var(--icon-image-loading-placeholder);
+    }
+
+    .media-link {
+        /* Allow <a> elements to grow to surround their contained media. */
+        display: flex;
+    }
+
+    .message_inline_image img,
+    .message_inline_image video {
+        max-width: 100%;
+        max-height: var(--max-length-thumbnail-image);
+        width: auto;
+        height: auto;
+    }
+
+    .message_inline_video,
+    .message_inline_animated_image_still {
+        /* To position the play button, we'll set up the video
+           as a grid. */
+        display: grid;
+        /* We create a grid area called
+           "media", so that both the inner
+           <a> element and the ::before content
+           can sit there. `auto` will take on
+           the height and width otherwise assigned
+           to the video content. Setting
+           the min value to 0 on minmax() ensures
+           that media larger than those dimensions
+           don't cause a grid blowout. */
+        grid-template: "media" minmax(0, auto) / minmax(0, auto);
+
+        &:hover {
+            &::after {
+                transform: scale(1);
+                transition: transform 0.2s;
+            }
+        }
+
+        &::after {
+            content: "";
+            background-image: url("../images/play_button.svg");
+            display: block;
+            width: 32px;
+            height: 32px;
+            border-radius: 100%;
+            transform: scale(0.8);
+        }
+
+        & video {
+            display: block;
+            object-fit: contain;
+            height: 100%;
+            width: 100%;
+        }
+    }
+
+    .message_inline_video::after,
+    .message_inline_video .media-link,
+    .message_inline_animated_image_still::after,
+    .message_inline_animated_image_still .media-link {
+        /* And we explicitly place the . in the thumbnail
+           area, too. Otherwise, grid would generate a new
+           column track for it to sit in. */
+        grid-area: media;
+        place-self: center center;
+    }
+
     /* embedded link previews */
     .message_inline_image_title {
         font-weight: bold;
@@ -474,10 +567,10 @@
        `.rendered_markdown` out of the baseline group
        formed with EDITED/MOVED markers and the
        timestamp when the first child of the rendered
-       markdown is a horizontal rule, a media element,
+       markdown is a horizontal rule, a media gallery,
        or KaTeX. */
     &:has(> hr:first-child),
-    &:has(> .message_inline_image:first-child),
+    &:has(> .message-thumbnail-gallery:first-child),
     &:has(> p:first-child > .katex-display) {
         align-self: center;
     }
@@ -492,6 +585,8 @@
             width: 100%;
         }
 
+        /* This fallback for `.message_inline_image` continues to
+           work in the context of media galleries. */
         p:first-child > .katex-display,
         .message_inline_image {
             /* We'll display this bit of media as

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -418,6 +418,15 @@
         max-width: var(--max-length-thumbnail-image);
         max-height: var(--max-length-thumbnail-image);
         flex: 0 0 auto;
+        border: solid 1px transparent;
+        transition: background 0.3s ease;
+        background: var(--color-background-rendered-markdown-thumbnail);
+
+        &:hover {
+            background: var(
+                --color-background-rendered-markdown-thumbnail-hover
+            );
+        }
     }
 
     .landscape-thumbnail {
@@ -537,14 +546,16 @@
            container. */
         border: solid 1px transparent;
         transition: background 0.3s ease;
-        background: hsl(0deg 0% 0% / 3%);
+        background: var(--color-background-rendered-markdown-thumbnail);
 
         &:first-child {
             margin-top: var(--markdown-interelement-space-px);
         }
 
         &:hover {
-            background: hsl(0deg 0% 0% / 15%);
+            background: var(
+                --color-background-rendered-markdown-thumbnail-hover
+            );
         }
 
         & a {

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -36,6 +36,7 @@ run_test("postprocess_content", () => {
             "<a>invalid</a> " +
             "<a>unsafe</a> " +
             '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>' +
+            '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image">' +
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
             '<a role="button">button</a> ' +
@@ -44,6 +45,7 @@ run_test("postprocess_content", () => {
             '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
             '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 });
@@ -52,6 +54,56 @@ run_test("ordered_lists", () => {
     assert.equal(
         postprocess_content('<ol start="9"><li>Nine</li><li>Ten</li></ol>'),
         '<ol start="9" class="counter-length-2"><li>Nine</li><li>Ten</li></ol>',
+    );
+});
+
+run_test("inline_image_galleries", ({override}) => {
+    const thumbnail_formats = [
+        {
+            name: "840x560.webp",
+            max_width: 840,
+            max_height: 560,
+            format: "webp",
+            animated: false,
+        },
+    ];
+    override(thumbnail, "preferred_format", thumbnail_formats[0]);
+    assert.equal(
+        postprocess_content(
+            "<p>Message text</p>" +
+                '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>" +
+                '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>" +
+                "<p>Message text</p>" +
+                '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>",
+        ),
+        "<p>Message text</p>" +
+            '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image portrait-thumbnail" style="aspect-ratio: 0.5">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" width="1000" height="2000" loading="lazy">' +
+            "</a></div>" +
+            '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 2">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" width="2000" height="1000" loading="lazy">' +
+            "</a></div></div>" +
+            "<p>Message text</p>" +
+            '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" width="1000" height="1000" loading="lazy">' +
+            "</a></div></div>",
     );
 });
 
@@ -105,10 +157,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -122,10 +176,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -139,10 +195,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -155,16 +213,21 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
     // Broken/invalid source URLs in image previews should be
     // dropped. Inspired by a real message found in chat.zulip.org
     // history.
+
+    // TODO: Correct processing order so that the expected here
+    // is an empty string.
     assert.equal(
         postprocess_content(
             '<div class="message_inline_image">' +
@@ -173,6 +236,6 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        "",
+        '<div class="message-thumbnail-gallery"></div>',
     );
 });

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -38,11 +38,11 @@ run_test("postprocess_content", () => {
             '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>' +
             '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image">' +
-            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
+            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image" class="media-link">upload</a> ' +
             '<a role="button">button</a> ' +
             "</div>" +
             '<div class="youtube-video message_inline_image">' +
-            '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
+            '<a class="media-link" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
             '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" loading="lazy">' +
             "</a>" +
             "</div>" +
@@ -91,17 +91,17 @@ run_test("inline_image_galleries", ({override}) => {
         "<p>Message text</p>" +
             '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image portrait-thumbnail" style="aspect-ratio: 0.5">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" width="1000" height="2000" loading="lazy">' +
             "</a></div>" +
             '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 2">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" width="2000" height="1000" loading="lazy">' +
             "</a></div></div>" +
             "<p>Message text</p>" +
             '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" width="1000" height="1000" loading="lazy">' +
             "</a></div></div>",
     );
@@ -159,7 +159,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>" +
@@ -178,7 +178,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>" +
@@ -197,7 +197,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>" +
@@ -215,7 +215,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png" class="media-link">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>" +

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -105,9 +105,9 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image">' +
+        '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -122,9 +122,9 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image">' +
+        '<div class="message_inline_image landscape-thumbnail" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -139,9 +139,9 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image message_inline_animated_image_still">' +
+        '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -155,9 +155,9 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image message_inline_animated_image_still">' +
+        '<div class="message_inline_image landscape-thumbnail message_inline_animated_image_still" style="aspect-ratio: 1.3333333333333333">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );


### PR DESCRIPTION
This draft PR structures adjacent images into galleries, and presents them with flexbox.

One key part of #31502 remains to be fixed, which is to ensure that images, which now have `height` and `width` attributes assigned, properly hold their allotted space prior to loading--while allowing flexbox to do its thing.

It's possible that part of post-processing will require assessing an image's width and height to determine whether it is portrait, landscape, or square, and setting CSS based on that. (That images are wrapped in a div plus an anchor tag may be complicating things somehow, but I'm puzzled why images with `height` and width` attributes are not holding their place.)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![mixed-thumbs-before](https://github.com/user-attachments/assets/827bf822-660e-4842-aa8a-a1e72e7668ed) | ![mixed-thumbs-after](https://github.com/user-attachments/assets/67c0a9af-26d7-486e-b5f1-6621f409a201) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
