### PR TITLE
Refactor how close buttons are handled in filter topics, filter direct messages and stream message topics.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -374,13 +374,6 @@ export function start(raw_opts: ComposeActionsStartOpts): void {
         drafts.set_compose_draft_id(opts.draft_id);
     }
 
-    const $clear_topic_button = $("#recipient_box_clear_topic_button");
-    if (is_clear_topic_button_triggered || opts.topic.length === 0) {
-        $clear_topic_button.hide();
-    } else {
-        $clear_topic_button.show();
-    }
-
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);
     // Show a warning if the user is in a search narrow when replying to a message

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -512,21 +512,8 @@ export function initialize() {
 
     $("#compose_recipient_box").on("click", "#recipient_box_clear_topic_button", () => {
         const $input = $("input#stream_message_recipient_topic");
-        const $button = $("#recipient_box_clear_topic_button");
-
         $input.val("");
         $input.trigger("focus");
-        $button.hide();
-    });
-
-    $("#compose_recipient_box").on("input", "input#stream_message_recipient_topic", (e) => {
-        const $button = $("#recipient_box_clear_topic_button");
-        const value = $(e.target).val();
-        if (value.length === 0) {
-            $button.hide();
-        } else {
-            $button.show();
-        }
     });
 
     $("input#stream_message_recipient_topic").on("focus", () => {

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -62,11 +62,6 @@ export function _build_direct_messages_list(): vdom.Tag<PMNode> {
     }
     const dom_ast = pm_list_dom.pm_ul(pm_list_nodes);
 
-    if (search_term === "") {
-        $("#clear-direct-messages-search-button").hide();
-    } else {
-        $("#clear-direct-messages-search-button").show();
-    }
     return dom_ast;
 }
 

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -407,7 +407,6 @@ export function zoom_in_topics(options: {stream_id: number | undefined}): void {
             // Add search box for topics list.
             $elt.children("div.bottom_left_row").append($(render_filter_topics()));
             $("#filter-topic-input").trigger("focus");
-            $("#clear_search_topic_button").hide();
         } else {
             $elt.hide();
         }

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -222,12 +222,6 @@ export class TopicListWidget {
         vdom.update(replace_content, find, new_dom, this.prior_dom);
 
         this.prior_dom = new_dom;
-
-        if ($("#filter-topic-input").val() !== "") {
-            $("#clear_search_topic_button").show();
-        } else {
-            $("#clear_search_topic_button").hide();
-        }
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -915,6 +915,10 @@ textarea.new_message_textarea {
         }
     }
 
+    #stream_message_recipient_topic:placeholder-shown
+        + #recipient_box_clear_topic_button {
+        display: none;
+    }
     /* This will reset the bootstrap margin-bottom: 10px value for the inputs */
     & input {
         margin-bottom: 0;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1005,6 +1005,10 @@ li.top_left_scheduled_messages {
     grid-area: row-content;
 }
 
+#filter-topic-input:placeholder-shown + #clear_search_topic_button {
+    display: none;
+}
+
 .searching-for-more-topics img {
     height: 16px;
     grid-area: row-content;
@@ -1447,6 +1451,11 @@ li.topic-list-item {
         /* Flexbox will pull the element open
            to make a generous clickable area. */
         padding: 0;
+    }
+
+    .direct-messages-list-filter:placeholder-shown
+        + #clear-direct-messages-search-button {
+        display: none;
     }
 }
 


### PR DESCRIPTION
As stated by Tim Abbott [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/refactor.20how.20close.20buttons.20are.20handled.20in.20filter.20fields.2E/near/1944067):

>  I think a PR to refactor those 3 would be great.

This PR focuses on refactoring the logic of how close button are handled in Filter topics field in the left sidebar, Filter direct messages field under direct messages and Stream message topic.

| Area | Before | After (no change) |
|--------|--------|--------|
| FIlter topics | ![image](https://github.com/user-attachments/assets/e8960f5a-7d69-4e1c-b121-eaa52153abe7) | ![image](https://github.com/user-attachments/assets/35ab5725-26ed-4e4f-9c63-38ce8fa5d68e) |
| Filter direct messages | ![image](https://github.com/user-attachments/assets/b0e90949-652a-44cf-8915-46066432fb11) | ![image](https://github.com/user-attachments/assets/b5538972-defe-4ba4-bca8-8059e34a5d91) |
| Stream message topic | ![image](https://github.com/user-attachments/assets/ba5103b1-315e-42c9-ada1-876b983a2301) | ![image](https://github.com/user-attachments/assets/615dea91-db78-43b2-ac95-0e5e38d19fbe) | 
<!-- Describe your pull request here.-->

[CZO thread](https://chat.zulip.org/#narrow/stream/6-frontend/topic/refactor.20how.20close.20buttons.20are.20handled.20in.20filter.20fields.2E)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
