### PR TITLE
stream_data: Simplify ApiGenericStreamSubscription type

### DIFF
--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -25,10 +25,7 @@ import {user_settings} from "./user_settings";
 import * as util from "./util";
 
 // Type for the parameter of `create_sub_from_server_data` function.
-type ApiGenericStreamSubscription =
-    | NeverSubscribedStream
-    | ApiStreamSubscription
-    | (Stream & {stream_weekly_traffic: number | null; subscribers: number[]});
+type ApiGenericStreamSubscription = NeverSubscribedStream | ApiStreamSubscription;
 
 export type InviteStreamData = {
     name: string;


### PR DESCRIPTION
The removed alternative is a subtype of `NeverSubscribedStream` and thus already included.