### PR TITLE
message_edit: Fix `tab + enter` broken for saving.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -381,7 +381,7 @@ function handle_message_edit_enter(
 ): void {
     // Pressing Enter to save edits is coupled with Enter to send
     if (composebox_typeahead.should_enter_send(e)) {
-        const $row = $(".message_edit_content:focus").closest(".message_row");
+        const $row = $message_edit_content.closest(".message_row");
         const $message_edit_save_button = $row.find(".message_edit_save");
         if ($message_edit_save_button.prop("disabled")) {
             // In cases when the save button is disabled


### PR DESCRIPTION
There is no `.message_edit_content` in `focus` when user does `tab + enter` to save the message. We use the existing text content edit object get identify the row being edited which is more robust and efficient.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/.E2.9C.94.20broken.20typeahead.20while.20editing