### PR TITLE
buddy_list: Fetch *all* subscribers for small channels in big orgs.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -382,6 +382,17 @@ function get_filtered_user_id_list(user_filter_text: string): number[] {
             const base_user_id_set = new Set([...base_user_id_list, ...pm_ids_set]);
             base_user_id_list = [...base_user_id_set];
         }
+
+        // We want to show subscribers even if they're inactive, if there are few
+        // enough subscribers in the channel.
+        const stream_id = narrow_state.stream_id();
+        if (stream_id) {
+            const subscribers = peer_data.get_subscribers(stream_id);
+            if (subscribers.length <= max_channel_size_to_show_all_subscribers) {
+                const base_user_id_set = new Set([...base_user_id_list, ...subscribers]);
+                base_user_id_list = [...base_user_id_set];
+            }
+        }
     }
 
     const user_ids = filter_user_ids(user_filter_text, base_user_id_list);


### PR DESCRIPTION
This is a followup to #31645. I tweaked the filter in `maybe_shrink_list`, but that function works with user ids originally fetched in `get_filtered_user_id_list`, which was only fetching ids of users that had been recently active.


