### PR TITLE
Show link previews in message preview.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1210,23 +1210,7 @@ export function render_and_show_preview(
         rendered_markdown.update_elements($preview_content_box);
     }
 
-    if (content.length === 0) {
-        show_preview($t_html({defaultMessage: "Nothing to preview"}));
-    } else {
-        if (markdown.contains_backend_only_syntax(content)) {
-            const $spinner = $preview_spinner.expectOne();
-            loading.make_indicator($spinner);
-        } else {
-            // For messages that don't appear to contain syntax that
-            // is only supported by our backend Markdown processor, we
-            // render using the frontend Markdown processor (but still
-            // render server-side to ensure the preview is accurate;
-            // if the `markdown.contains_backend_only_syntax` logic is
-            // wrong, users will see a brief flicker of the locally
-            // echoed frontend rendering before receiving the
-            // authoritative backend rendering from the server).
-            markdown.render(content);
-        }
+    function render_message(content: string): void {
         void channel.post({
             url: "/json/messages/render",
             data: {content},
@@ -1244,5 +1228,25 @@ export function render_and_show_preview(
                 show_preview($t_html({defaultMessage: "Failed to generate preview"}));
             },
         });
+    }
+
+    if (content.length === 0) {
+        show_preview($t_html({defaultMessage: "Nothing to preview"}));
+    } else {
+        if (markdown.contains_backend_only_syntax(content)) {
+            const $spinner = $preview_spinner.expectOne();
+            loading.make_indicator($spinner);
+        } else {
+            // For messages that don't appear to contain syntax that
+            // is only supported by our backend Markdown processor, we
+            // render using the frontend Markdown processor (but still
+            // render server-side to ensure the preview is accurate;
+            // if the `markdown.contains_backend_only_syntax` logic is
+            // wrong, users will see a brief flicker of the locally
+            // echoed frontend rendering before receiving the
+            // authoritative backend rendering from the server).
+            markdown.render(content);
+        }
+        render_message(content);
     }
 }

--- a/zerver/worker/embed_links.py
+++ b/zerver/worker/embed_links.py
@@ -18,6 +18,15 @@ from zerver.worker.base import InterruptConsumeError, QueueProcessingWorker, ass
 logger = logging.getLogger(__name__)
 
 
+def get_url_embed_data(urls: Any) -> dict[str, UrlEmbedData | None]:
+    url_embed_data: dict[str, UrlEmbedData | None] = {}
+    for url in urls:
+        start_time = time.time()
+        url_embed_data[url] = url_preview.get_link_embed_data(url)
+        logging.info("Time spent on get_link_embed_data for %s: %s", url, time.time() - start_time)
+    return url_embed_data
+
+
 @assign_queue("embed_links")
 class FetchLinksEmbedData(QueueProcessingWorker):
     # This is a slow queue with network requests, so a disk write is negligible.
@@ -26,13 +35,7 @@ class FetchLinksEmbedData(QueueProcessingWorker):
 
     @override
     def consume(self, event: Mapping[str, Any]) -> None:
-        url_embed_data: dict[str, UrlEmbedData | None] = {}
-        for url in event["urls"]:
-            start_time = time.time()
-            url_embed_data[url] = url_preview.get_link_embed_data(url)
-            logging.info(
-                "Time spent on get_link_embed_data for %s: %s", url, time.time() - start_time
-            )
+        url_embed_data: dict[str, UrlEmbedData | None] = get_url_embed_data(event["urls"])
 
         with transaction.atomic():
             try:


### PR DESCRIPTION
At present, message previews do not show link previews. This gives an inaccurate view of the message in organizations that have [link previews enabled](https://zulip.com/help/allow-image-link-previews).

This renders the message preview without any link embeds at first. If during the rendering, it comes across any links, we render the message again with link previews. This avoids slowing down the message preview since rendering link previews take time.

Fixes: zulip#19465.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
