### PR TITLE
user_groups: Show deactivation error in modal itself.

### DIFF
--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -26,7 +26,6 @@ import * as settings_org from "./settings_org";
 import {current_user, realm} from "./state_data";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
-import * as ui_report from "./ui_report";
 import * as user_group_components from "./user_group_components";
 import * as user_group_create from "./user_group_create";
 import * as user_group_edit_members from "./user_group_edit_members";
@@ -919,19 +918,13 @@ export function initialize() {
             return;
         }
         function deactivate_user_group() {
-            channel.post({
-                url: "/json/user_groups/" + group_id + "/deactivate",
-                success() {
+            const url = "/json/user_groups/" + group_id + "/deactivate";
+            const opts = {
+                success_continuation() {
                     active_group_data.$row.remove();
                 },
-                error(xhr) {
-                    ui_report.error(
-                        $t_html({defaultMessage: "Failed"}),
-                        xhr,
-                        $(".group_change_property_info"),
-                    );
-                },
-            });
+            };
+            dialog_widget.submit_api_request(channel.post, url, {}, opts);
         }
 
         const html_body = render_confirm_delete_user({
@@ -947,6 +940,8 @@ export function initialize() {
             ),
             html_body,
             on_click: deactivate_user_group,
+            close_on_submit: false,
+            loading_spinner: true,
         });
     });
 


### PR DESCRIPTION
Previously, the error was shown besides the group name after the modal was closed, but it did not look good for long error messages like the one we get when the group being deactivated is being used for a setting.

Updated the code to use dialog_widget.submit_api_request since it takes care of showing the error inside the modal and also added code to show loading spinner as the modal is not closed immediately to show the error.

[Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Support.20user.20group.20deactivation/near/1946852)
<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/0c5799bb-69fd-4edc-ae30-57eb0fb06a01)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
