### PR TITLE
message_edit: Fix `save/cancel` on message edit form not working.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -512,7 +512,7 @@ function edit_message($row: JQuery, raw_content: string): void {
     // typeahead to call stopPropagation if it can handle the event
     // and prevent the form from submitting.
     $form.on("keydown", (e) => {
-        if (keydown_util.is_enter_event(e)) {
+        if (e.target.classList.contains("message_edit_content") && keydown_util.is_enter_event(e)) {
             handle_message_edit_enter(e, $message_edit_content);
         }
     });


### PR DESCRIPTION
`Enter` keypress on `save/cancel` was not working for users without `should_enter_send` user setting due to it being prevented from triggering default behaviour.

Fixed by only handling enter keypress if pressed inside `message_edit_content` textarea.`

Tested by disabled the `Enter` sends message user setting. Also, tested that tab / enter to typeahead completing works.

This was similarly bugged after 0696e234bd4ae937ffb9d3c1ace004b48f5414fd since we removed
`if ($(e.target).hasClass("message_edit_content")) {`.