### PR TITLE
docs: Add "Go to inbox" and "Go to recent conversations" navigation shortcuts

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -108,6 +108,10 @@ in the Zulip app to add more to your repertoire as needed.
 * **Cycle between channel views**: <kbd>Shift</kbd> + <kbd>A</kbd>
   (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 
+* **Go to inbox**: <kbd>Shift</kbd> + <kbd>I</kbd> — Shows conversations with unread messages.
+
+* **Go to recent conversations**: <kbd>T</kbd>
+
 * **Go to combined feed**: <kbd>A</kbd> — Shows all unmuted messages.
 
 * **Go to starred messages**: <kbd>*</kbd>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -172,6 +172,14 @@
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Go to inbox' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>I</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go to recent conversations' }}</td>
+                    <td><span class="hotkey"><kbd>T</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Go to combined feed' }}</td>
                     <td><span class="hotkey"><kbd>A</kbd></span></td>
                 </tr>


### PR DESCRIPTION
Add "Go to inbox" and "Go to recent conversations" entries to the Navigation section of both the in-app shortcuts overlay and the more detailed help center reference.

<!-- Describe your pull request here.-->

Fixes: Some "Go to <view>" shortcuts not appearing in the list of navigation shortcuts. See also [this thread in #documentation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/.22Go.20to.20inbox.22.20shortcut/near/1946981).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/user-attachments/assets/8bdc04c1-b927-49ca-9f64-980702eda563)
![image](https://github.com/user-attachments/assets/83ea95ea-13c7-437d-a6ac-243b127ba749)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
