### PR TITLE
icons: Update bot icon in Settings UI.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1369,10 +1369,6 @@ $option_title_width: 180px;
                 hyphens: auto;
             }
 
-            .zulip-icon-smart-toy {
-                font-size: 1.6em;
-            }
-
             .locked {
                 font-size: 1em;
                 text-align: center;

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -30,7 +30,7 @@
                     </li>
                     {{#unless is_guest}}
                     <li class="sidebar-item" tabindex="0" data-section="your-bots">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-smart-toy" aria-hidden="true"></i>
+                        <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
                     </li>
                     {{/unless}}
@@ -94,7 +94,7 @@
                     {{/unless}}
                     {{#unless is_guest}}
                     <li class="sidebar-item" tabindex="0" data-section="bot-list-admin">
-                        <i class="sidebar-item-icon zulip-icon zulip-icon-smart-toy" aria-hidden="true"></i>
+                        <i class="sidebar-item-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
                         <i class="locked fa fa-lock tippy-zulip-tooltip" {{#if can_create_new_bots}}style="display: none;"{{/if}} data-tippy-content="{{t 'Only organization administrators can edit these settings.' }}"></i>
                     </li>


### PR DESCRIPTION
As a follow-up to cca891689cb5d1168f59f385bdc45cf672c3aeb3, this updates the old bot icon in the Settings UI with the new one antenna bot icon.

<!-- Describe your pull request here.-->

[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/org.20settings.20-.20show.20more.20-.20icon.20alignment/near/1946176)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-09-24 at 1 06 02 AM](https://github.com/user-attachments/assets/272d4e08-d011-4218-abc7-f8251242c14d) | ![Screenshot 2024-09-24 at 1 05 06 AM](https://github.com/user-attachments/assets/0a61aa00-d2a1-47f6-b4a5-d506afae3097) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
