### PR TITLE
feed: Modify the channel feed text for muted topics.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -5,6 +5,7 @@ import assert from "minimalistic-assert";
 import * as compose_validate from "./compose_validate.ts";
 import type {Filter} from "./filter.ts";
 import {$t, $t_html} from "./i18n.ts";
+import * as message_lists from "./message_lists.ts";
 import type {NarrowBannerData, SearchData} from "./narrow_error.ts";
 import {narrow_error} from "./narrow_error.ts";
 import {page_params} from "./page_params.ts";
@@ -58,6 +59,22 @@ const STARRED_MESSAGES_VIEW_EMPTY_BANNER = {
                 `<a target="_blank" rel="noopener noreferrer" href="/help/star-a-message">${content_html.join(
                     "",
                 )}</a>`,
+        },
+    ),
+};
+
+const MUTED_TOPICS_IN_CHANNEL_EMPTY_BANNER = {
+    title: $t({
+        defaultMessage: "You have muted all the topics in this channel.",
+    }),
+    html: $t_html(
+        {
+            defaultMessage:
+                "To view a muted topic, click <b>show all topics</b> in the left sidebar, and select one from the list. <z-link>Learn more</z-link>",
+        },
+        {
+            "z-link": (content_html) =>
+                `<a target="_blank" rel="noopener noreferrer" href="/help/mute-a-topic">${content_html.join("")}</a>`,
         },
     ),
 };
@@ -315,6 +332,12 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                             "This channel doesn't exist, or you are not allowed to view it.",
                     }),
                 };
+            }
+            assert(message_lists.current !== undefined);
+            if (message_lists.current.visibly_empty() && !message_lists.current.empty()) {
+                // The current message list appears empty, but there are
+                // messages in muted topics.
+                return MUTED_TOPICS_IN_CHANNEL_EMPTY_BANNER;
             }
             // else fallthrough to default case
             break;


### PR DESCRIPTION
Fixes #31601

This pull request updates the channel feed to display different text for muted topics. The changes ensure that users can don't get confused when there is a message only in the muted topics.

When the topics are not muted (same): 
|Before|After|
|----|----|
|<img width="1440" alt="Screenshot 2024-09-15 at 9 23 47 PM" src="https://github.com/user-attachments/assets/4e32e365-945a-435e-83e6-2cac28a01c18">|<img width="1440" alt="Screenshot 2024-09-15 at 9 23 47 PM" src="https://github.com/user-attachments/assets/4e32e365-945a-435e-83e6-2cac28a01c18">|

When the topics are muted: 
|Before|After|
|----|----|
|<img width="1440" alt="Screenshot 2024-09-15 at 9 26 57 PM" src="https://github.com/user-attachments/assets/c97274e8-0d57-49fc-b0ea-be56310eff68">|<img width="1440" alt="Screenshot 2024-10-26 at 4 57 53 AM" src="https://github.com/user-attachments/assets/a1fbe9d1-c79e-4139-bf77-a5f1f7d7673b">|
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
