### PR TITLE
export_realm: Remove the 'react on consent message' approach.

### DIFF
--- a/zerver/management/commands/export_usermessage_batch.py
+++ b/zerver/management/commands/export_usermessage_batch.py
@@ -18,9 +18,9 @@ class Command(ZulipBaseCommand):
         parser.add_argument("--path", help="Path to find messages.json archives")
         parser.add_argument("--thread", help="Thread ID")
         parser.add_argument(
-            "--consent-message-id",
-            type=int,
-            help="ID of the message advertising users to react with thumbs up",
+            "--export-full-with-consent",
+            action="store_true",
+            help="Whether to export private data of users who consented",
         )
 
     @override
@@ -37,7 +37,9 @@ class Command(ZulipBaseCommand):
                 continue
             logging.info("Thread %s processing %s", options["thread"], output_path)
             try:
-                export_usermessages_batch(locked_path, output_path, options["consent_message_id"])
+                export_usermessages_batch(
+                    locked_path, output_path, options["export_full_with_consent"]
+                )
             except BaseException:
                 # Put the item back in the free pool when we fail
                 os.rename(locked_path, partial_path)

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -1280,3 +1280,14 @@ def get_fake_email_domain(realm_host: str) -> str:
         )
 
     return settings.FAKE_EMAIL_DOMAIN
+
+
+# TODO: Move this into a new ReamExport model.
+EXPORT_PUBLIC = 1
+EXPORT_FULL_WITH_CONSENT = 2
+EXPORT_FULL_WITHOUT_CONSENT = 3
+EXPORT_TYPES = [
+    EXPORT_PUBLIC,
+    EXPORT_FULL_WITH_CONSENT,
+    EXPORT_FULL_WITHOUT_CONSENT,
+]

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -11,17 +11,16 @@ from django.conf import settings
 from django.core.management import call_command, find_commands
 from django.core.management.base import CommandError
 from django.test import override_settings
-from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from confirmation.models import RealmCreationKey, generate_realm_creation_url
 from zerver.actions.create_user import do_create_user
-from zerver.actions.reactions import do_add_reaction
+from zerver.actions.user_settings import do_change_user_setting
 from zerver.lib.management import ZulipBaseCommand, check_config
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message, stdout_suppressed
-from zerver.models import Message, Reaction, Realm, Recipient, UserProfile
-from zerver.models.realms import get_realm
+from zerver.models import Realm, Recipient, UserProfile
+from zerver.models.realms import EXPORT_FULL_WITH_CONSENT, get_realm
 from zerver.models.streams import get_stream
 from zerver.models.users import get_user_profile_by_email
 
@@ -515,90 +514,29 @@ class TestDowngradeSmallRealmsBehindOnPayments(ZulipTestCase):
 class TestExport(ZulipTestCase):
     COMMAND_NAME = "export"
 
-    def test_command_with_consented_message_id(self) -> None:
+    def test_command_to_export_full_with_consent(self) -> None:
         realm = get_realm("zulip")
-        self.send_stream_message(
-            self.example_user("othello"),
-            "Verona",
-            topic_name="Export",
-            content="Outbox emoji for export",
+        do_change_user_setting(
+            self.example_user("iago"), "allow_private_data_export", True, acting_user=None
         )
-        message = Message.objects.last()
-        assert message is not None
-        do_add_reaction(
-            self.example_user("iago"), message, "outbox", "1f4e4", Reaction.UNICODE_EMOJI
-        )
-        do_add_reaction(
-            self.example_user("hamlet"), message, "outbox", "1f4e4", Reaction.UNICODE_EMOJI
+        do_change_user_setting(
+            self.example_user("iago"), "allow_private_data_export", True, acting_user=None
         )
 
         with (
             patch("zerver.management.commands.export.export_realm_wrapper") as m,
             patch("builtins.print") as mock_print,
-            patch("builtins.input", return_value="y") as mock_input,
         ):
-            call_command(self.COMMAND_NAME, "-r=zulip", f"--consent-message-id={message.id}")
+            call_command(self.COMMAND_NAME, "-r=zulip", "--export-full-with-consent")
             m.assert_called_once_with(
                 realm=realm,
-                public_only=False,
-                consent_message_id=message.id,
+                export_type=EXPORT_FULL_WITH_CONSENT,
                 threads=mock.ANY,
                 output_dir=mock.ANY,
                 percent_callback=mock.ANY,
                 upload=False,
                 export_as_active=None,
             )
-            mock_input.assert_called_once_with("Continue? [y/N] ")
-
-        self.assertEqual(
-            mock_print.mock_calls,
-            [
-                call("\033[94mExporting realm\033[0m: zulip"),
-                call("\n\033[94mMessage content:\033[0m\nOutbox emoji for export\n"),
-                call(
-                    "\033[94mNumber of users that reacted outbox:\033[0m 2 / 9 total non-guest users\n"
-                ),
-            ],
-        )
-
-        with (
-            self.assertRaisesRegex(CommandError, "Message with given ID does not"),
-            patch("builtins.print") as mock_print,
-        ):
-            call_command(self.COMMAND_NAME, "-r=zulip", "--consent-message-id=123456")
-        self.assertEqual(
-            mock_print.mock_calls,
-            [
-                call("\033[94mExporting realm\033[0m: zulip"),
-            ],
-        )
-
-        message.last_edit_time = timezone_now()
-        message.save()
-        with (
-            self.assertRaisesRegex(CommandError, "Message was edited. Aborting..."),
-            patch("builtins.print") as mock_print,
-        ):
-            call_command(self.COMMAND_NAME, "-r=zulip", f"--consent-message-id={message.id}")
-        self.assertEqual(
-            mock_print.mock_calls,
-            [
-                call("\033[94mExporting realm\033[0m: zulip"),
-            ],
-        )
-
-        message.last_edit_time = None
-        message.save()
-        do_add_reaction(
-            self.mit_user("sipbtest"), message, "outbox", "1f4e4", Reaction.UNICODE_EMOJI
-        )
-        with (
-            self.assertRaisesRegex(
-                CommandError, "Users from a different realm reacted to message. Aborting..."
-            ),
-            patch("builtins.print") as mock_print,
-        ):
-            call_command(self.COMMAND_NAME, "-r=zulip", f"--consent-message-id={message.id}")
 
         self.assertEqual(
             mock_print.mock_calls,

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -20,6 +20,7 @@ from zerver.lib.test_helpers import (
 )
 from zerver.models import Realm, RealmAuditLog, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
+from zerver.models.realms import EXPORT_PUBLIC
 from zerver.views.realm_export import export_realm
 
 
@@ -60,7 +61,7 @@ class RealmExportTest(ZulipTestCase):
         self.assertFalse(os.path.exists(tarball_path))
         args = mock_export.call_args_list[0][1]
         self.assertEqual(args["realm"], admin.realm)
-        self.assertEqual(args["public_only"], True)
+        self.assertEqual(args["export_type"], EXPORT_PUBLIC)
         self.assertTrue(os.path.basename(args["output_dir"]).startswith("zulip-export-"))
         self.assertEqual(args["threads"], 6)
 
@@ -123,13 +124,12 @@ class RealmExportTest(ZulipTestCase):
             realm: Realm,
             output_dir: str,
             threads: int,
+            export_type: int,
             exportable_user_ids: set[int] | None = None,
-            public_only: bool = False,
-            consent_message_id: int | None = None,
             export_as_active: bool | None = None,
         ) -> str:
             self.assertEqual(realm, admin.realm)
-            self.assertEqual(public_only, True)
+            self.assertEqual(export_type, EXPORT_PUBLIC)
             self.assertTrue(os.path.basename(output_dir).startswith("zulip-export-"))
             self.assertEqual(threads, 6)
 

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -5,14 +5,14 @@ import orjson
 import time_machine
 from django.utils.timezone import now as timezone_now
 
-from zerver.actions.reactions import check_add_reaction
+from zerver.actions.reactions import check_add_reaction, do_add_reaction
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import get_subscription
 from zerver.lib.user_topics import get_topic_mutes, topic_has_visibility_policy
-from zerver.models import UserProfile, UserTopic
+from zerver.models import Message, Reaction, UserProfile, UserTopic
 from zerver.models.constants import MAX_TOPIC_NAME_LENGTH
 from zerver.models.streams import get_stream
 
@@ -1024,6 +1024,28 @@ class AutomaticallyFollowTopicsTests(ZulipTestCase):
             UserTopic.VisibilityPolicy.UNMUTED
         )
         self.assertEqual(user_ids, {cordelia.id})
+
+        # Add test coverage for 'should_change_visibility_policy' when
+        # user from a different realm reacted to the message.
+        starnine_mit = self.mit_user("starnine")
+        do_change_user_setting(
+            starnine_mit,
+            "automatically_follow_topics_policy",
+            UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_ON_PARTICIPATION,
+            acting_user=None,
+        )
+        do_add_reaction(
+            user_profile=starnine_mit,
+            message=Message.objects.get(id=message_id),
+            emoji_name="outbox",
+            emoji_code="1f4e4",
+            reaction_type=Reaction.UNICODE_EMOJI,
+        )
+
+        user_ids = stream_topic_target.user_ids_with_visibility_policy(
+            UserTopic.VisibilityPolicy.FOLLOWED
+        )
+        self.assertNotIn(starnine_mit.id, user_ids)
 
     def test_automatically_follow_topic_on_participation_participate_in_poll(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/worker/deferred_work.py
+++ b/zerver/worker/deferred_work.py
@@ -26,6 +26,7 @@ from zerver.lib.remote_server import (
 from zerver.lib.soft_deactivation import reactivate_user_if_soft_deactivated
 from zerver.lib.upload import handle_reupload_emojis_event
 from zerver.models import Message, Realm, RealmAuditLog, Stream, UserMessage
+from zerver.models.realms import EXPORT_PUBLIC
 from zerver.models.users import get_system_bot, get_user_profile_by_id
 from zerver.worker.base import QueueProcessingWorker, assign_queue
 
@@ -158,7 +159,7 @@ class DeferredWorker(QueueProcessingWorker):
                     output_dir=output_dir,
                     threads=1 if self.threaded else 6,
                     upload=True,
-                    public_only=True,
+                    export_type=EXPORT_PUBLIC,
                 )
             except Exception:
                 extra_data["failed_timestamp"] = timezone_now().timestamp()


### PR DESCRIPTION
For exporting full with consent:

* Earlier, a message advertising users to react with thumbs up was sent and later used to determine the users who consented.

* Now, we no longer need to send such a message. This commit updates the logic to use `allow_private_data_export` user-setting to determine users who consented.

Fixes part of #31201 


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
