### PR TITLE
Activity: Add export version of installation activity chart.

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -132,7 +132,7 @@ def realm_activity_link(realm_str: str) -> Markup:
     from corporate.views.realm_activity import get_realm_activity
 
     url = reverse(get_realm_activity, kwargs=dict(realm_str=realm_str))
-    return Markup('<a href="{url}">{realm_str}</a>').format(url=url, realm_str=realm_str)
+    return Markup('<a href="{url}"><i class="fa fa-table"></i></a>').format(url=url)
 
 
 def realm_stats_link(realm_str: str) -> Markup:
@@ -153,7 +153,7 @@ def realm_support_link(realm_str: str) -> Markup:
     support_url = reverse("support")
     query = urlencode({"q": realm_str})
     url = append_url_query_string(support_url, query)
-    return Markup('<a href="{url}"><i class="fa fa-gear"></i></a>').format(url=url)
+    return Markup('<a href="{url}">{realm}</i></a>').format(url=url, realm=realm_str)
 
 
 def realm_url_link(realm_str: str) -> Markup:

--- a/corporate/views/installation_activity.py
+++ b/corporate/views/installation_activity.py
@@ -371,17 +371,17 @@ def get_integrations_activity(request: HttpRequest) -> HttpResponse:
     """
     )
 
-    cols = [
-        "Client",
-        "Realm",
-        "Hits",
-        "Last time (UTC)",
-    ]
-
+    cols = ["Client", "Realm", "Hits", "Last time (UTC)", "Links"]
     rows = get_query_data(query)
+    for row in rows:
+        realm_str = row[1]
+        activity = realm_activity_link(realm_str)
+        stats = realm_stats_link(realm_str)
+        row.append(activity + " " + stats)
+
     for i, col in enumerate(cols):
         if col == "Realm":
-            fix_rows(rows, i, realm_activity_link)
+            fix_rows(rows, i, realm_support_link)
         elif col == "Last time (UTC)":
             fix_rows(rows, i, format_optional_datetime)
 

--- a/templates/corporate/activity/installation_activity_table.html
+++ b/templates/corporate/activity/installation_activity_table.html
@@ -71,11 +71,11 @@
             <td>
                 {{ row.realm_url }}
                 {{ row.stats_link }}
-                {{ row.support_link }}
+                {{ row.activity_link }}
             </td>
             {% endif %}
             <td>
-                {{ row.activity_link }}
+                {{ row.support_link }}
             </td>
 
             <td {% if row.is_new %}

--- a/templates/corporate/activity/installation_activity_table.html
+++ b/templates/corporate/activity/installation_activity_table.html
@@ -63,7 +63,7 @@
             </td>
 
             <td>
-                {{ row.string_id }}
+                {{ row.activity_link }}
             </td>
 
             <td {% if row.is_new %}

--- a/templates/corporate/activity/installation_activity_table.html
+++ b/templates/corporate/activity/installation_activity_table.html
@@ -2,11 +2,16 @@
 
 <p class="installation-activity-header">{{ utctime }}</p>
 
-<h4>Installation information:</h4>
+<h4>Other views:</h4>
 <ul>
     <li><a href="/stats/installation">Server total /stats style graphs</a></li>
     <li><a href="/activity/remote">Remote servers</a></li>
     <li><a href="/activity/integrations">Integrations by client</a></li>
+    {% if not export %}
+    <li><a href="/activity?export=true">Export installation chart</a></li>
+    {% else %}
+    <li><a href="/activity">Non-export installation chart</a></li>
+    {% endif %}
 </ul>
 
 <h4>Counts chart key:</h4>
@@ -33,7 +38,9 @@
 
     <thead class="activity-head">
         <tr>
+            {% if not export %}
             <th>Links</th>
+            {% endif %}
             <th>Realm</th>
             <th>Created (green if ≤12wk)</th>
             {% if billing_enabled %}
@@ -47,21 +54,26 @@
             <th>WAU</th>
             <th>Total users</th>
             <th>Bots</th>
+            {% if not export %}
             <th></th>
+            {% endif %}
             <th colspan=8>Human messages sent, last 8 UTC days (today-so-far first)</th>
+            {% if export %}
+            <th>Admin emails</th>
+            {% endif %}
         </tr>
     </thead>
 
     <tbody>
         {% for row in rows %}
         <tr>
-
+            {% if not export %}
             <td>
                 {{ row.realm_url }}
                 {{ row.stats_link }}
                 {{ row.support_link }}
             </td>
-
+            {% endif %}
             <td>
                 {{ row.activity_link }}
             </td>
@@ -113,13 +125,19 @@
             <td class="number">
                 {{ row.bot_count }}
             </td>
-
+            {% if not export %}
             <td>&nbsp;</td>
-
+            {% endif %}
             {% if row.history %}
             {{ row.history|safe }}
             {% else %}
             <td colspan=8></td>
+            {% endif %}
+
+            {% if export %}
+            <td>
+                {{ row.admin_emails }}
+            </td>
             {% endif %}
         </tr>
         {% endfor %}


### PR DESCRIPTION
Adds an optional boolean parameter for the installation activity view to make the chart more export friendly.

**Notes**:
- There's a prep commit that refactors the installation view to loop over the realm data returned from the query only once. Previously, it was looping over the data multiple times.
- Adding the realm admin emails to the query for the installation activity chart means that the initial data needs to be processed/looped through once to collect the admin emails into one string and to deduplicate realm data.
- The export version of the installation activity chart:
  - Removes the initial links column.
  - Removes the blank column before the human message counts.
  - Adds a final column with the realm owner and admin user emails.
- The realm name in the installation and integrations activity charts now links to the support view for the realm.
  - The integrations activity chart now has a links column with links to the realm activity and stats pages.
  - The installation activity chart now has a link to the realm activity page in the links column ('fa fa-table' icon) and the support link ('fa fa-gear' icon) is removed from the links column.

---

**Screenshots and screen captures:**

<details>
<summary>New export installation activity view</summary>

![Screenshot from 2024-09-24 17-25-11](https://github.com/user-attachments/assets/d5e9168c-612d-4cf0-89de-fd2e8719e814)
</details>
<details>
<summary>Updated non-export installation activity view</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-09-24 17-23-37](https://github.com/user-attachments/assets/04544dae-a0c4-4b74-a0e1-8176f0cb7d95) | ![Screenshot from 2024-09-24 17-24-06](https://github.com/user-attachments/assets/62b305e5-31d6-48b4-b44e-d2d782a75dc0)
</details>
<details>
<summary>Updated integrations activity view</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-09-24 17-24-27](https://github.com/user-attachments/assets/988abbe2-1939-47e7-9960-f14c303f7acb) | ![Screenshot from 2024-09-24 17-24-46](https://github.com/user-attachments/assets/ee7ac5c8-82d7-4ca6-8952-11c6fd4cf027)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
