### PR TITLE
message_fetch: Don't allow undefined narrow term operands.

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -349,10 +349,12 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
                 const sub = stream_data.get_sub_by_id_string(term.operand);
                 server_terms.push({
                     ...term,
-                    // If the sub is undefined, we'll get an error which is handled
-                    // later by showing a "this channel does not exist or is private"
-                    // notice.
-                    operand: sub?.name,
+                    // If we can't find the sub, we shouldn't send `undefined`
+                    // because we want to preserve the NarrowTerm type, so we just
+                    // send the unknown stream id.
+                    // This should show a "this channel does not exist or is private"
+                    // notice (both logged in and logged out).
+                    operand: sub?.name ?? term.operand,
                 });
             } else {
                 server_terms.push({...term});


### PR DESCRIPTION
This was a bug caused by https://github.com/zulip/zulip/pull/31299/files#r1773871463

CZO thread for error: https://chat.zulip.org/#narrow/stream/464-kandra-js-errors/topic/ZodError.3A.20.5B

I double checked that the logged in behavior still works:

<img width="857" alt="image" src="https://github.com/user-attachments/assets/467dd24f-7a22-48c7-a1c6-03ea9f90673a">

And now the logged out behavior doesn't throw an error, just shows this:

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/19908a40-0713-493d-a7ed-9eef0d5af078">
