### PR TITLE
bot_data: Avoid deprecated ZodObject.deepPartial()

### DIFF
--- a/web/src/bot_data.ts
+++ b/web/src/bot_data.ts
@@ -1,6 +1,7 @@
 import type {z} from "zod";
 
-import {server_add_bot_schema, server_update_bot_schema, services_schema} from "./bot_types";
+import type {services_schema} from "./bot_types";
+import {server_add_bot_schema, server_update_bot_schema} from "./bot_types";
 import * as people from "./people";
 import type {StateData} from "./state_data";
 
@@ -35,16 +36,15 @@ export function update(bot_id: number, bot_update: ServerUpdateBotData): void {
     const bot = bots.get(bot_id)!;
     // TODO/typescript: Move validation to the caller when
     // server_events_dispatch.js is converted to TypeScript.
-    Object.assign(bot, server_update_bot_schema.deepPartial().parse(bot_update));
+    const {services: services_update, ...bot_update_rest} =
+        server_update_bot_schema.parse(bot_update);
+
+    Object.assign(bot, bot_update_rest);
 
     // We currently only support one service per bot.
     const service = services.get(bot_id)![0];
-    if (
-        service !== undefined &&
-        bot_update.services !== undefined &&
-        bot_update.services.length > 0
-    ) {
-        Object.assign(service, services_schema.parse(bot_update.services)[0]);
+    if (service !== undefined && services_update !== undefined && services_update.length > 0) {
+        Object.assign(service, services_update[0]);
     }
 }
 

--- a/web/src/bot_types.ts
+++ b/web/src/bot_types.ts
@@ -30,12 +30,13 @@ export const services_schema = z.union([
     z.array(embedded_service_schema),
 ]);
 
-export const server_update_bot_schema = basic_bot_schema.extend({
-    services: services_schema,
+export const server_update_bot_schema = basic_bot_schema.partial().extend({
+    services: services_schema.optional(),
 });
 
-export const server_add_bot_schema = server_update_bot_schema.extend({
+export const server_add_bot_schema = basic_bot_schema.extend({
     bot_type: z.number(),
     email: z.string(),
     is_active: z.boolean(),
+    services: services_schema,
 });


### PR DESCRIPTION
My claim here is that `services` is either a full object satisfying `services_schema` or undefined; there was no reason for this `deepPartial` to be deep in the first place.

https://github.com/zulip/zulip/blob/b0ca32c95525f8056985a9ccf9c901be28e8256e/zerver/lib/event_schema.py#L699-L714

https://github.com/zulip/zulip/blob/b0ca32c95525f8056985a9ccf9c901be28e8256e/zerver/actions/users.py#L559-L570

https://github.com/zulip/zulip/blob/b0ca32c95525f8056985a9ccf9c901be28e8256e/zerver/actions/users.py#L582-L589