### PR TITLE
stripe: Allow customer to switch license management type.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -565,6 +565,7 @@ class UpdatePlanRequest:
     licenses: int | None
     licenses_at_next_renewal: int | None
     schedule: int | None
+    toggle_license_management: bool
 
 
 @dataclass
@@ -2902,6 +2903,16 @@ class BillingSession(ABC):
 
         if last_ledger_entry is None:
             raise JsonableError(_("Unable to update the plan. The plan has ended."))
+
+        if update_plan_request.toggle_license_management:
+            assert update_plan_request.status is None
+            assert update_plan_request.licenses is None
+            assert update_plan_request.licenses_at_next_renewal is None
+            assert update_plan_request.schedule is None
+
+            plan.automanage_licenses = not plan.automanage_licenses
+            plan.save(update_fields=["automanage_licenses"])
+            return
 
         status = update_plan_request.status
         if status is not None:

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -44,6 +44,7 @@ from corporate.lib.stripe import (
     SupportRequestError,
     SupportType,
     SupportViewRequest,
+    UpdatePlanRequest,
     add_months,
     catch_stripe_errors,
     compute_plan_parameters,
@@ -1000,7 +1001,7 @@ class StripeTest(StripeTestCase):
             "Zulip Cloud Plus",
             str(self.seat_count),
             "Number of licenses",
-            f"{ self.seat_count } (managed automatically)",
+            f"{ self.seat_count }",
             "Your plan will automatically renew on",
             "January 2, 2013",
             f"${120 * self.seat_count}.00",
@@ -1270,7 +1271,7 @@ class StripeTest(StripeTestCase):
             "Zulip Cloud Standard",
             str(self.seat_count),
             "Number of licenses",
-            f"{ self.seat_count } (managed automatically)",
+            f"{ self.seat_count }",
             "Your plan will automatically renew on",
             "January 2, 2013",
             f"${80 * self.seat_count}.00",
@@ -1526,7 +1527,7 @@ class StripeTest(StripeTestCase):
                 "Zulip Cloud Standard <i>(free trial)</i>",
                 str(self.seat_count),
                 "Number of licenses",
-                f"{self.seat_count} (managed automatically)",
+                f"{self.seat_count}",
                 "Your plan will automatically renew on",
                 "March 2, 2012",
                 f"${80 * self.seat_count}.00",
@@ -5877,6 +5878,29 @@ class LicenseLedgerTest(StripeTestCase):
             ],
         )
 
+    def test_toggle_license_management(self) -> None:
+        self.local_upgrade(self.seat_count, True, CustomerPlan.BILLING_SCHEDULE_ANNUAL, True, False)
+        plan = get_current_plan_by_realm(get_realm("zulip"))
+        assert plan is not None
+        self.assertEqual(plan.automanage_licenses, True)
+        self.assertEqual(plan.licenses(), self.seat_count)
+        self.assertEqual(plan.licenses_at_next_renewal(), self.seat_count)
+        billing_session = RealmBillingSession(user=None, realm=get_realm("zulip"))
+        update_plan_request = UpdatePlanRequest(
+            status=None,
+            licenses=None,
+            licenses_at_next_renewal=None,
+            schedule=None,
+            toggle_license_management=True,
+        )
+        billing_session.do_update_plan(update_plan_request)
+        plan.refresh_from_db()
+        self.assertEqual(plan.automanage_licenses, False)
+
+        billing_session.do_update_plan(update_plan_request)
+        plan.refresh_from_db()
+        self.assertEqual(plan.automanage_licenses, True)
+
 
 class InvoiceTest(StripeTestCase):
     def test_invoicing_status_is_started(self) -> None:
@@ -6952,7 +6976,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         for substring in [
             "Zulip Business",
             "Number of licenses",
-            f"{min_licenses} (managed automatically)",
+            f"{min_licenses}",
             "January 2, 2013",
             "Your plan will automatically renew on",
             f"${80 * min_licenses:,.2f}",
@@ -6996,7 +7020,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         for substring in [
             "Zulip Business",
             "Number of licenses",
-            f"{latest_ledger.licenses} (managed automatically)",
+            f"{latest_ledger.licenses}",
             "January 2, 2013",
             "Your plan will automatically renew on",
             f"${80 * latest_ledger.licenses:,.2f}",
@@ -7179,7 +7203,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
                 "Zulip Basic",
                 "(free trial)",
                 "Number of licenses",
-                f"{realm_user_count} (managed automatically)",
+                f"{realm_user_count}",
                 "February 1, 2012",
                 "Your plan will automatically renew on",
                 f"${3.5 * realm_user_count - flat_discount // 100 * 1:,.2f}",
@@ -7223,7 +7247,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             for substring in [
                 "Zulip Basic",
                 "Number of licenses",
-                f"{latest_ledger.licenses} (managed automatically)",
+                f"{latest_ledger.licenses}",
                 "February 1, 2012",
                 "Your plan will automatically renew on",
                 f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
@@ -7387,7 +7411,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         for substring in [
             "Zulip Basic",
             "Number of licenses",
-            f"{realm_user_count} (managed automatically)",
+            f"{realm_user_count}",
             "February 2, 2012",
             "Your plan will automatically renew on",
             f"${3.5 * realm_user_count - flat_discount // 100 * 1:,.2f}",
@@ -7431,7 +7455,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         for substring in [
             "Zulip Basic",
             "Number of licenses",
-            f"{latest_ledger.licenses} (managed automatically)",
+            f"{latest_ledger.licenses}",
             "February 2, 2012",
             "Your plan will automatically renew on",
             f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
@@ -8290,7 +8314,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
         for substring in [
             "Zulip Business",
             "Number of licenses",
-            f"{licenses} (managed automatically)",
+            f"{licenses}",
             "Your plan will automatically renew on",
             "January 2, 2013",
             f"${80 * licenses:,.2f}",
@@ -8639,7 +8663,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         for substring in [
             "Zulip Business",
             "Number of licenses",
-            f"{25} (managed automatically)",
+            f"{25}",
             "Your plan will automatically renew on",
             "January 2, 2013",
             f"${80 * 25:,.2f}",
@@ -9073,7 +9097,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
                 "Zulip Basic",
                 "(free trial)",
                 "Number of licenses",
-                f"{realm_user_count} (managed automatically)",
+                f"{realm_user_count}",
                 "February 1, 2012",
                 "Your plan will automatically renew on",
                 f"${3.5 * realm_user_count - flat_discount // 100 * 1:,.2f}",
@@ -9117,7 +9141,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
             for substring in [
                 "Zulip Basic",
                 "Number of licenses",
-                f"{latest_ledger.licenses} (managed automatically)",
+                f"{latest_ledger.licenses}",
                 "February 1, 2012",
                 "Your plan will automatically renew on",
                 f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",
@@ -9283,7 +9307,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         for substring in [
             "Zulip Basic",
             "Number of licenses",
-            f"{server_user_count} (managed automatically)",
+            f"{server_user_count}",
             "February 2, 2012",
             "Your plan will automatically renew on",
             f"${3.5 * server_user_count - flat_discount // 100 * 1:,.2f}",
@@ -9327,7 +9351,7 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         for substring in [
             "Zulip Basic",
             "Number of licenses",
-            f"{latest_ledger.licenses} (managed automatically)",
+            f"{latest_ledger.licenses}",
             "February 2, 2012",
             "Your plan will automatically renew on",
             f"${3.5 * latest_ledger.licenses - flat_discount // 100 * 1:,.2f}",

--- a/corporate/views/billing_page.py
+++ b/corporate/views/billing_page.py
@@ -245,12 +245,14 @@ def update_plan(
     licenses: Json[int] | None = None,
     licenses_at_next_renewal: Json[int] | None = None,
     schedule: Json[int] | None = None,
+    toggle_license_management: Json[bool] = False,
 ) -> HttpResponse:
     update_plan_request = UpdatePlanRequest(
         status=status,
         licenses=licenses,
         licenses_at_next_renewal=licenses_at_next_renewal,
         schedule=schedule,
+        toggle_license_management=toggle_license_management,
     )
     billing_session = RealmBillingSession(user=user)
     billing_session.do_update_plan(update_plan_request)
@@ -271,12 +273,14 @@ def update_plan_for_remote_realm(
     licenses: Json[int] | None = None,
     licenses_at_next_renewal: Json[int] | None = None,
     schedule: Json[int] | None = None,
+    toggle_license_management: Json[bool] = False,
 ) -> HttpResponse:
     update_plan_request = UpdatePlanRequest(
         status=status,
         licenses=licenses,
         licenses_at_next_renewal=licenses_at_next_renewal,
         schedule=schedule,
+        toggle_license_management=toggle_license_management,
     )
     billing_session.do_update_plan(update_plan_request)
     return json_success(request)
@@ -296,12 +300,14 @@ def update_plan_for_remote_server(
     licenses: Json[int] | None = None,
     licenses_at_next_renewal: Json[int] | None = None,
     schedule: Json[int] | None = None,
+    toggle_license_management: Json[bool] = False,
 ) -> HttpResponse:
     update_plan_request = UpdatePlanRequest(
         status=status,
         licenses=licenses,
         licenses_at_next_renewal=licenses_at_next_renewal,
         schedule=schedule,
+        toggle_license_management=toggle_license_management,
     )
     billing_session.do_update_plan(update_plan_request)
     return json_success(request)

--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -123,7 +123,13 @@
 
                     </label>
                     <div id="automatic-license-count" class="not-editable-realm-field">
-                        {{ licenses }} (managed automatically)
+                        {{ licenses }}
+                        <br />
+                        Licenses are managed
+                        <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-license-management-work">automatically</a>.
+                        You can
+                        <a class="toggle-license-management" type="button">switch</a>
+                        to manual license management.
                     </div>
                 </div>
                 {% else %}
@@ -152,6 +158,13 @@
                         </button>
                     </div>
                     <div id="current-license-change-error" class="alert alert-danger billing-page-error"></div>
+                    <div class="not-editable-realm-field billing-page-license-management-description">
+                        Licenses are managed
+                        <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-license-management-work">manually</a>.
+                        You can
+                        <a class="toggle-license-management" type="button">switch</a>
+                        to automatic license management.
+                    </div>
                 </div>
                 {% endif %}
                 {% if not (downgrade_at_end_of_cycle or downgrade_at_end_of_free_trial) %}
@@ -182,6 +195,10 @@
                 </div>
                 {% endif %}
                 {% endif %}
+                <form id="toggle-license-management-form">
+                    <input name="toggle_license_management" type="hidden" value="true" />
+                </form>
+                <div id="toggle-license-management-error" class="alert alert-danger"></div>
                 <div class="input-box no-validation billing-page-field">
                     <label for="billing-contact" class="inline-block label-title">Billing contact</label>
                     <div id="billing-contact" class="not-editable-realm-field">
@@ -566,6 +583,43 @@
                 <button class="modal__btn dialog_exit_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Never mind') }}</button>
                 <button class="modal__btn dialog_submit_button">
                     <span>{{ _('Cancel upgrade') }}</span>
+                </button>
+            </footer>
+        </div>
+    </div>
+</div>
+<div id="confirm-toggle-license-management-modal" class="micromodal" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1">
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
+            <header class="modal__header">
+                <h1 class="modal__title dialog_heading">
+                    Confirm switching to
+                    {% if automanage_licenses %}
+                    manual
+                    {% else %}
+                    automatic
+                    {% endif %}
+                    license management
+                </h1>
+                <button class="modal__close" aria-label="{{ _('Close modal') }}" data-micromodal-close></button>
+            </header>
+            <main class="modal__content">
+                <p>
+                    Are you sure you want to switch to
+                    <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-license-management-work">
+                        {% if automanage_licenses %}
+                            manual
+                        {% else %}
+                            automatic
+                        {% endif %}
+                        license management
+                    </a>?
+                </p>
+            </main>
+            <footer class="modal__footer">
+                <button class="modal__btn dialog_exit_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Never mind') }}</button>
+                <button class="modal__btn dialog_submit_button">
+                    <span>{{ _('Confirm') }}</span>
                 </button>
             </footer>
         </div>

--- a/web/src/billing/billing.ts
+++ b/web/src/billing/billing.ts
@@ -460,6 +460,24 @@ export function initialize(): void {
             },
         });
     });
+
+    $(".toggle-license-management").on("click", (e) => {
+        e.preventDefault();
+        portico_modals.open("confirm-toggle-license-management-modal");
+    });
+
+    $("#confirm-toggle-license-management-modal").on("click", ".dialog_submit_button", (e) => {
+        helpers.create_ajax_request(
+            `/json${billing_base_url}/billing/plan`,
+            "toggle-license-management",
+            [],
+            "PATCH",
+            () => {
+                window.location.replace(`${billing_base_url}/billing/`);
+            },
+        );
+        e.preventDefault();
+    });
 }
 
 $(() => {

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -748,3 +748,11 @@ input[name="licenses"] {
 .flat-discount-separator {
     border-bottom: 1px solid hsl(0deg 0% 0%);
 }
+
+.toggle-license-management {
+    cursor: pointer;
+}
+
+#billing-page-details .billing-page-license-management-description {
+    padding-top: 5px;
+}


### PR DESCRIPTION
Fixes #28633

Added a button to switch license management type on billing page.

Tested that the plan switch works correctly.

Tested that when switching from manual to automatic license management, customer is only billed for billable users for the next billing cycle.

![Screenshot 2024-09-26 at 11 24 52 AM](https://github.com/user-attachments/assets/e6aed71e-478e-4664-a802-175d7135bae1)
![Screenshot 2024-09-26 at 11 24 37 AM](https://github.com/user-attachments/assets/02092dd4-06f6-43ac-a373-95501fb0331d)
![Screenshot 2024-09-26 at 11 26 40 AM](https://github.com/user-attachments/assets/dcfd30aa-7b47-44c2-aeb6-6a3242d95caa)
![Screenshot 2024-09-26 at 11 26 57 AM](https://github.com/user-attachments/assets/94bc5984-764a-423c-ade6-392c82866cdd)
