### PR TITLE
message_edit: Use display: flex instead of relative positioning.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -655,13 +655,16 @@
 }
 
 .edit-content-container {
-    position: relative;
     border-radius: 4px;
     border: 1px solid var(--color-message-content-container-border);
     transition: border 0.2s ease;
 
     &:has(.message_edit_content:focus) {
         border-color: var(--color-message-content-container-border-focus);
+    }
+
+    .message-edit-textbox {
+        position: relative;
     }
 }
 

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -4,10 +4,12 @@
         <form id="edit_form_{{message_id}}">
             <div class="edit_form_banners"></div>
             <div class="edit-controls edit-content-container {{#if is_editable}}surround-formatting-buttons-row{{/if}}">
-                <span class="copy_message copy-btn copy-btn-square tippy-zulip-tooltip" data-tippy-content="{{t 'Copy and close' }}" aria-label="{{t 'Copy and close' }}" role="button">
-                    <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
-                </span>
-                <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
+                <div class="message-edit-textbox">
+                    <span class="copy_message copy-btn copy-btn-square tippy-zulip-tooltip" data-tippy-content="{{t 'Copy and close' }}" aria-label="{{t 'Copy and close' }}" role="button">
+                        <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
+                    </span>
+                    <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
+                </div>
                 <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
                     <div class="markdown_preview_spinner"></div>
                     <div class="preview_content rendered_markdown"></div>


### PR DESCRIPTION
Fixes #31750.
The control buttons of the edit box were flickering b/w default cursor and pointer cursor after c1d155d923f95b264397344651ef79e59f68e549. The addition of `position: relative` to `.edit-content-container` was causing that.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

No flicker in final state:
![edit box final state](https://github.com/user-attachments/assets/388d12e0-2a9d-47e6-8beb-4766f2f2db1e)




Copy message comparison for regression:

| Before | After |
| --- | --- |
| ![Screenshot 2024-09-27 at 9 12 55 AM](https://github.com/user-attachments/assets/c632d8b7-3f4d-4497-9521-34ed1ad2a47d) | ![Screenshot 2024-09-27 at 9 11 44 AM](https://github.com/user-attachments/assets/2145115f-2f2c-4709-a3ca-fb7958623a26)| 



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
