### PR TITLE
typeahead: Fix showing of user groups with 0 active users.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -22,6 +22,7 @@ import * as stream_list_sort from "./stream_list_sort";
 import type {StreamPill, StreamPillData} from "./stream_pill";
 import type {StreamSubscription} from "./sub_store";
 import type {UserGroupPill, UserGroupPillData} from "./user_group_pill";
+import * as user_group_pill from "./user_group_pill";
 import * as user_groups from "./user_groups";
 import type {UserGroup} from "./user_groups";
 import type {UserPill, UserPillData} from "./user_pill";
@@ -527,7 +528,9 @@ export function sort_recipients<UserType extends UserOrMentionPillData | UserPil
 
     function add_group_recipients(items: UserGroupPillData[]): void {
         for (const item of items) {
-            recipients.push(item);
+            if (!user_group_pill.are_all_members_deactivated(item)) {
+                recipients.push(item);
+            }
         }
     }
 

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -81,6 +81,16 @@ function get_group_members(user_group: UserGroup): number[] {
     return user_ids.filter((user_id) => people.is_person_active(user_id));
 }
 
+export function are_all_members_deactivated(user_group: UserGroup): boolean {
+    const user_ids = [...user_groups.get_recursive_group_members(user_group)];
+    for (const user_id of user_ids) {
+        if (people.is_person_active(user_id)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export function append_user_group(
     group: UserGroup,
     pill_widget: CombinedPillContainer | GroupSettingPillContainer,

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -44,6 +44,13 @@ const user5 = {
 };
 people.add_active_user(user5);
 
+const user6 = {
+    user_id: 60,
+    email: "user6@example.com",
+    full_name: "User Five",
+};
+people.add_active_user(user6);
+
 const admins = {
     name: "Admins",
     description: "foo",
@@ -64,6 +71,15 @@ const everyone = {
     direct_subgroup_ids: [101, 102],
 };
 
+// We're testing a case where user_group_pill.all_members_are_deactivated returns true, as user6 has been deactivated.
+const testers2 = {
+    name: "Testers2",
+    description: "test for all deactivated members",
+    id: 104,
+    members: [60],
+};
+people.deactivate(user6);
+
 const admins_pill = {
     group_id: admins.id,
     group_name: admins.name,
@@ -83,7 +99,7 @@ const everyone_pill = {
     // here, reducing the usefulness of the test.
 };
 
-const groups = [admins, testers, everyone];
+const groups = [admins, testers, everyone, testers2];
 for (const group of groups) {
     user_groups.add(group);
 }
@@ -146,6 +162,13 @@ run_test("get_group_ids", () => {
     // Subgroups should not be part of the results, we use `everyone_pill` to test that.
     const group_ids = user_group_pill.get_group_ids(widget);
     assert.deepEqual(group_ids, [101, 103]);
+});
+
+run_test("are_all_members_deactivated", () => {
+    assert.equal(user_group_pill.are_all_members_deactivated(everyone), false);
+    assert.equal(user_group_pill.are_all_members_deactivated(admins), false);
+    assert.equal(user_group_pill.are_all_members_deactivated(testers), false);
+    assert.equal(user_group_pill.are_all_members_deactivated(testers2), true);
 });
 
 run_test("append_user_group", () => {


### PR DESCRIPTION
This hides user groups with no active members from typeahead by adding a function `are_all_members_deactivated` in `user_group_pill.ts`.

Fixes #30890.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
