### PR TITLE
sidebars: Introduce new highlight and hover styles.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -338,6 +338,8 @@
     --text-transform-sidebar-action-heading: uppercase;
     --letter-spacing-sidebar-heading: 0.0469em;
     --opacity-sidebar-heading: 0.7;
+    --opacity-sidebar-heading-icon: 0.5;
+    --opacity-sidebar-heading-hover: 0.9;
     --opacity-right-sidebar-subheading: 0.65;
     --opacity-right-sidebar-subheading-hover: 0.9;
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -568,6 +568,9 @@
     --color-shadow-sidebar-row-hover: hsl(0deg 0% 0% / 30%);
     --color-background-sidebar-action-hover: hsl(240deg 100% 93%);
     --color-background-navigation-item-hover: hsl(240deg 100% 50% / 7%);
+    --color-background-sidebar-action-heading-hover: var(
+        --color-background-navigation-item-hover
+    );
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
@@ -713,6 +716,7 @@
     --color-text-personal-menu-some-status: hsl(0deg 0% 40%);
     --color-text-sidebar-heading: hsl(216deg 65% 20%);
     --color-text-sidebar-action-heading: hsl(240deg 30% 40%);
+    --color-text-sidebar-action-heading-hover: hsl(240deg 100% 15%);
     --color-text-sidebar-popover-menu: hsl(0deg 0% 20%);
     --color-text-user-card-secondary: var(--grey-550);
     --color-text-url: hsl(200deg 100% 40%);
@@ -1040,6 +1044,9 @@
     --color-shadow-sidebar-row-hover: hsl(0deg 0% 100% / 30%);
     --color-background-sidebar-action-hover: hsl(240deg 25% 35%);
     --color-background-navigation-item-hover: hsl(240deg 100% 75% / 20%);
+    --color-background-sidebar-action-heading-hover: var(
+        --color-background-navigation-item-hover
+    );
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);
@@ -1193,6 +1200,7 @@
     --color-text-user-card-secondary: var(--grey-400);
     --color-text-sidebar-heading: hsl(216deg 50% 75%);
     --color-text-sidebar-action-heading: hsl(240deg 35% 68%);
+    --color-text-sidebar-action-heading-hover: hsl(240deg 100% 90%);
     --color-text-url-hover: hsl(200deg 79% 66%);
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -553,7 +553,9 @@
     --color-background-widget-input: hsl(0deg 0% 100%);
     --color-background-widget-button: hsl(0deg 0% 100%);
     --color-background-navbar: hsl(0deg 0% 97%);
-    --color-background-active-narrow-filter: hsl(202deg 56% 91%);
+    --color-text-sidebar-row: hsl(0deg 0% 20%);
+    --color-text-active-narrow-filter: hsl(0deg 0% 15%);
+    --color-background-active-narrow-filter: hsl(0deg 0% 100%);
     --color-background-hover-narrow-filter: hsl(120deg 12.3% 71.4% / 38%);
     /* We mix an opaque version with the background for
        replicating the color on .sidebar-topic-check, which
@@ -1011,7 +1013,13 @@
     --color-background-widget-input: hsl(225deg 6% 10%);
     --color-background-widget-button: hsl(0deg 0% 0% / 20%);
     --color-background-navbar: hsl(0deg 0% 13%);
-    --color-background-active-narrow-filter: hsl(200deg 17% 18%);
+    --color-text-sidebar-row: hsl(0deg 0% 100% / 75%);
+    --color-text-active-narrow-filter: hsl(0deg 0% 90%);
+    --color-background-active-narrow-filter: color-mix(
+        in srgb,
+        hsl(0deg 0% 100%) 8%,
+        hsl(0deg 0% 11%)
+    );
     --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
     /* We mix an opaque version with the background for
        replicating the color on .sidebar-topic-check, which

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -567,6 +567,7 @@
     );
     --color-shadow-sidebar-row-hover: hsl(0deg 0% 0% / 30%);
     --color-background-sidebar-action-hover: hsl(240deg 100% 93%);
+    --color-background-navigation-item-hover: hsl(240deg 100% 50% / 7%);
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
@@ -1038,6 +1039,7 @@
     );
     --color-shadow-sidebar-row-hover: hsl(0deg 0% 100% / 30%);
     --color-background-sidebar-action-hover: hsl(240deg 25% 35%);
+    --color-background-navigation-item-hover: hsl(240deg 100% 75% / 20%);
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -566,6 +566,7 @@
         --color-background-hover-narrow-filter
     );
     --color-shadow-sidebar-row-hover: hsl(0deg 0% 0% / 30%);
+    --color-background-sidebar-action-hover: hsl(240deg 100% 93%);
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
@@ -756,13 +757,10 @@
     --color-left-sidebar-follow-icon-hover: hsl(0deg 0% 0%);
     /* The gray on the filter icons is the same as
        what's set on ul.filters, but with 70% opacity. */
-    --color-left-sidebar-navigation-icon: hsl(0deg 0% 20% / 70%);
-    --color-vdots-hint: hsl(0deg 0% 0% / 30%);
-    --color-vdots-visible: hsl(0deg 0% 0% / 53%);
-    --color-vdots-hover: hsl(0deg 0% 0%);
-    --color-left-sidebar-header-vdots-visible: var(
-        --color-left-sidebar-navigation-icon
-    );
+    --color-left-sidebar-navigation-icon: hsl(240deg 30% 40%);
+    --color-vdots-hint: hsl(240deg 30% 20%);
+    --color-vdots-visible: hsl(240deg 30% 40%);
+    --color-vdots-hover: hsl(240deg 100% 15%);
     --color-tab-picker-icon: hsl(200deg 100% 40%);
     --color-user-circle-active: hsl(106deg 74% 44%);
     --color-user-circle-idle: hsl(29deg 84% 51%);
@@ -1039,6 +1037,7 @@
         hsl(0deg 0% 11%)
     );
     --color-shadow-sidebar-row-hover: hsl(0deg 0% 100% / 30%);
+    --color-background-sidebar-action-hover: hsl(240deg 25% 35%);
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);
@@ -1236,10 +1235,10 @@
     --color-message-action-visible: hsl(217deg 41% 90% / 50%);
     --color-message-action-interactive: hsl(217deg 41% 90% / 100%);
     --color-left-sidebar-follow-icon-hover: hsl(0deg 0% 100%);
-    --color-left-sidebar-navigation-icon: hsl(0deg 0% 100% / 56%);
-    --color-vdots-hint: hsl(0deg 0% 100% / 30%);
-    --color-vdots-visible: hsl(236deg 33% 80%);
-    --color-vdots-hover: hsl(0deg 0% 100%);
+    --color-left-sidebar-navigation-icon: hsl(240deg 35% 68%);
+    --color-vdots-hint: hsl(240deg 35% 48%);
+    --color-vdots-visible: hsl(240deg 35% 68%);
+    --color-vdots-hover: hsl(240deg 100% 90%);
     --color-left-sidebar-header-vdots-visible: var(
         --color-left-sidebar-navigation-icon
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -556,15 +556,14 @@
     --color-text-sidebar-row: hsl(0deg 0% 20%);
     --color-text-active-narrow-filter: hsl(0deg 0% 15%);
     --color-background-active-narrow-filter: hsl(0deg 0% 100%);
-    --color-background-hover-narrow-filter: hsl(120deg 12.3% 71.4% / 38%);
+    --color-background-hover-narrow-filter: hsl(0deg 0% 97%);
     /* We mix an opaque version with the background for
        replicating the color on .sidebar-topic-check, which
        will mask a portion of the topic-grouping bracket. */
-    --color-background-opaque-hover-narrow-filter: color-mix(
-        in srgb,
-        hsl(120deg 12.3% 71.4%) 38%,
-        hsl(0deg 0% 94%)
+    --color-background-opaque-hover-narrow-filter: var(
+        --color-background-hover-narrow-filter
     );
+    --color-shadow-sidebar-row-hover: hsl(0deg 0% 0% / 30%);
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
@@ -611,7 +610,9 @@
     --color-background-tab-picker-tab-option-active: hsl(0deg 0% 100% / 35%);
     --color-background-popover: hsl(0deg 0% 100%);
     --color-background-alert-word: hsl(18deg 100% 84%);
-    --color-buddy-list-highlighted-user: hsl(120deg 12.3% 71.4% / 38%);
+    --color-buddy-list-highlighted-user: var(
+        --color-background-hover-narrow-filter
+    );
     --color-border-sidebar: hsl(0deg 0% 87%);
     --color-text-sidebar-base: hsl(0deg 0% 0%);
     --color-border-sidebar-subheader: hsl(0deg 0% 0% / 15%);
@@ -1020,15 +1021,22 @@
         hsl(0deg 0% 100%) 8%,
         hsl(0deg 0% 11%)
     );
-    --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
+    --color-background-hover-narrow-filter: hsl(0deg 0% 97% / 8%);
     /* We mix an opaque version with the background for
        replicating the color on .sidebar-topic-check, which
        will mask a portion of the topic-grouping bracket. */
     --color-background-opaque-hover-narrow-filter: color-mix(
         in srgb,
-        hsl(136deg 25% 73%) 20%,
+        hsl(0deg 0% 97%) 8%,
         hsl(0deg 0% 11%)
     );
+    --color-background-opaque-hover-active-narrow-filter: color-mix(
+        in srgb,
+        hsl(0deg 0% 97%) 8%,
+        hsl(0deg 0% 97%) 8%,
+        hsl(0deg 0% 11%)
+    );
+    --color-shadow-sidebar-row-hover: hsl(0deg 0% 100% / 30%);
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);
@@ -1076,7 +1084,9 @@
     --color-background-tab-picker-tab-option-hover: hsl(0deg 0% 100% / 5%);
     --color-background-tab-picker-tab-option-active: hsl(0deg 0% 100% / 3%);
     --color-background-alert-word: hsl(22deg 70% 35%);
-    --color-buddy-list-highlighted-user: hsl(136deg 25% 73% / 20%);
+    --color-buddy-list-highlighted-user: var(
+        --color-background-hover-narrow-filter
+    );
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
     --color-text-sidebar-base: hsl(0deg 0% 100%);
     --color-border-sidebar-subheader: hsl(0deg 0% 100% / 15%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -26,8 +26,15 @@
         }
     }
 
-    & a:not(.button, .compose_control_button):hover {
+    &
+        a:not(
+            .button,
+            .compose_control_button,
+            .conversation-partners,
+            .user-presence-link
+        ):hover {
         color: hsl(200deg 79% 66%);
+        text-decoration: none;
 
         & code {
             color: hsl(200deg 79% 66%);
@@ -36,8 +43,6 @@
 
     & ul.dm-list,
     & ul.filters {
-        color: hsl(0deg 0% 100% / 80%);
-
         .has-unmuted-mentions .unread_mention_info {
             color: hsl(236deg 33% 90%);
         }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -262,6 +262,16 @@
                count, when one appears there. */
             align-items: baseline;
 
+            &:hover {
+                background-color: var(
+                    --color-background-sidebar-action-heading-hover
+                );
+
+                .dm-name {
+                    color: var(--color-text-sidebar-action-heading-hover);
+                }
+            }
+
             .unread_count {
                 margin-top: 2px;
             }
@@ -328,6 +338,10 @@
                 --color-background-opaque-hover-narrow-filter
             );
         }
+    }
+
+    &:has(.sidebar-topic-action-heading):hover {
+        background-color: var(--color-background-sidebar-action-heading-hover);
     }
 
     &.active-filter,
@@ -1076,9 +1090,8 @@ li.top_left_scheduled_messages {
 
     &:hover {
         text-decoration: none;
-        /* Push back against a:hover color in dark_theme.css
-           Eventually this will take redesigned hover colors. */
-        color: var(--color-text-sidebar-action-heading) !important;
+        /* Push back against a:hover color in dark_theme.css. */
+        color: var(--color-text-sidebar-action-heading-hover) !important;
     }
 }
 
@@ -1373,21 +1386,33 @@ li.topic-list-item {
     top: 0;
     z-index: 2;
     grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
-        max-content 0 42px;
-    grid-template-rows: var(--line-height-sidebar-row-prominent);
+        [topics-content-area-start] var(--left-sidebar-toggle-width-offset)
+        0 0 minmax(0, 1fr)
+        max-content 0 42px [topics-content-area-end];
+    grid-template-rows:
+        [topics-content-area-start] var(--line-height-sidebar-row-prominent)
+        [topics-content-area-end];
     padding-top: var(--left-sidebar-sections-vertical-gutter);
     color: hsl(0deg 0% 43%);
     background-color: var(--color-background);
 
     .show-all-streams {
-        grid-area: row-content;
+        grid-area: topics-content-area;
+        padding-left: var(--left-sidebar-toggle-width-offset);
         font-size: var(--font-size-sidebar-action-heading);
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);
         text-transform: var(--text-transform-sidebar-action-heading);
         color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
+
+        &:hover {
+            background-color: var(
+                --color-background-sidebar-action-heading-hover
+            );
+            box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
+            border-radius: 4px;
+        }
     }
 
     .unread_count {
@@ -1682,7 +1707,10 @@ li.topic-list-item {
         }
 
         &:hover {
-            background-color: hsl(120deg 12.3% 71.4% / 38%);
+            background-color: var(
+                --color-background-sidebar-action-heading-hover
+            );
+            box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
             border-radius: 4px;
         }
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -560,7 +560,7 @@ li.active-sub-filter {
            element within receives focus. */
         &:hover,
         &:focus-within {
-            background: var(--color-background-hover-narrow-filter);
+            background: var(--color-background-navigation-item-hover);
 
             .unread_count {
                 /* 6px at 12px/1em */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -938,7 +938,7 @@ li.top_left_scheduled_messages {
     .left-sidebar-navigation-menu-icon {
         grid-area: ending-anchor-element;
         /* Horizontally center vdots. */
-        justify-self: center;
+        justify-self: stretch;
         /* Properly size vdots. */
         font-size: 17px;
         /* Occupy same clickable height as
@@ -948,10 +948,14 @@ li.top_left_scheduled_messages {
            flexbox. */
         display: flex;
         align-items: center;
-        color: var(--color-left-sidebar-header-vdots-visible);
+        justify-content: center;
+        margin-right: 2px;
+        border-radius: 3px;
+        color: var(--color-vdots-visible);
 
         &:hover {
             color: var(--color-vdots-hover);
+            background-color: var(--color-background-sidebar-action-hover);
         }
     }
 }
@@ -1150,19 +1154,24 @@ li.top_left_scheduled_messages {
 .bottom_left_row .sidebar-menu-icon,
 .top_left_row .sidebar-menu-icon {
     display: none;
-    width: 100%;
     cursor: pointer;
     /* Use a flex container to handle
        icon centering within the grid area.
        :hover actually sets the `display: flex`,
        so it remains hidden otherwise. */
     justify-content: center;
+    align-items: center;
     text-align: center;
     /* Ensure icons are vertically aligned, in
        case they appear in a grid definition,
        like the nav rows, that use a different
        centering regime for the row. */
-    align-self: center;
+    align-self: stretch;
+    border-radius: 3px;
+    margin: 2px 2px 2px 1px;
+    /* This helps horizontally align the vdots,
+       given the reduced margin-left above. */
+    padding-left: 1px;
     /* Set the icon size, which will be inherited
        by .zulip-icon */
     font-size: 17px;
@@ -1211,12 +1220,9 @@ li.top_left_scheduled_messages {
     display: flex;
     color: var(--color-vdots-visible);
 
-    /*
-        If you hover directly over the vdots icon,
-        show it in black.
-    */
     &:hover {
         color: var(--color-vdots-hover);
+        background-color: var(--color-background-sidebar-action-hover);
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -372,13 +372,12 @@
 ul.filters {
     list-style-type: none;
     margin-left: 0;
-    color: hsl(0deg 0% 20% / 100%);
     /* Streams take a standard row height. */
     line-height: var(--line-height-sidebar-row);
 
     .sidebar-topic-name,
     .left-sidebar-navigation-label-container {
-        color: inherit;
+        color: var(--color-text-sidebar-row);
 
         &:hover {
             /* Push back against a:hover color in dark_theme.css */
@@ -489,10 +488,15 @@ li.active-sub-filter {
     font-weight: 600 !important;
     position: relative;
     border-radius: 4px;
+    color: var(--color-text-active-narrow-filter);
     background-color: var(--color-background-active-narrow-filter);
 
     .sidebar-topic-check {
         background-color: var(--color-background-active-narrow-filter);
+    }
+
+    .sidebar-topic-name-inner {
+        color: var(--color-text-active-narrow-filter);
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -223,7 +223,7 @@
         font-weight: 400;
         margin-left: 0;
         margin-bottom: 0;
-        line-height: var(--line-height-sidebar-row);
+        line-height: var(--line-height-sidebar-row-prominent);
 
         & li.dm-list-item {
             & a {
@@ -303,10 +303,16 @@
     }
 }
 
-:not(.active-sub-filter) {
-    &.top_left_row:hover,
-    &.bottom_left_row:hover {
+.top_left_row,
+.bottom_left_row {
+    /* Ensure a border radius on any interactive
+       state that might show a highlight. */
+    border-radius: 4px;
+
+    &:hover,
+    &:has(.left_sidebar_menu_icon_visible) {
         background-color: var(--color-background-hover-narrow-filter);
+        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
 
         .sidebar-topic-check {
             background-color: var(
@@ -314,13 +320,13 @@
             );
         }
     }
-}
 
-.top_left_row,
-.bottom_left_row {
-    /* Ensure a border radius on any interactive
-       state that might show a highlight. */
-    border-radius: 4px;
+    &.active-filter,
+    &.active-sub-filter {
+        &:has(.left_sidebar_menu_icon_visible) {
+            background-color: var(--color-background-active-narrow-filter);
+        }
+    }
 }
 
 #stream_filters .narrow-filter.highlighted_stream {
@@ -381,7 +387,7 @@ ul.filters {
 
         &:hover {
             /* Push back against a:hover color in dark_theme.css */
-            color: inherit !important;
+            color: var(--color-text-sidebar-row) !important;
         }
 
         &:focus {
@@ -491,6 +497,17 @@ li.active-sub-filter {
     color: var(--color-text-active-narrow-filter);
     background-color: var(--color-background-active-narrow-filter);
 
+    &:hover {
+        background-color: var(--color-background-active-narrow-filter);
+
+        .sidebar-topic-check {
+            /* This variable is only set and used in dark mode. */
+            background-color: var(
+                --color-background-opaque-hover-active-narrow-filter
+            );
+        }
+    }
+
     .sidebar-topic-check {
         background-color: var(--color-background-active-narrow-filter);
     }
@@ -505,6 +522,10 @@ li.active-sub-filter {
     > .bottom_left_row {
         background-color: var(--color-background-active-narrow-filter);
         border-radius: 4px;
+
+        &:hover {
+            background-color: var(--color-background-hover-narrow-filter);
+        }
     }
 }
 
@@ -1065,7 +1086,6 @@ li.top_left_scheduled_messages {
        bracket's bottom line. Its value must less than
        the z-index set on the #streams_header selector. */
     z-index: 1;
-    background-color: var(--color-background);
 }
 
 .stream-markers-and-controls,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -12,6 +12,7 @@
 .left-sidebar-title {
     color: var(--color-text-sidebar-heading);
     opacity: var(--opacity-sidebar-heading);
+    transition: opacity 140ms linear;
     font-size: inherit;
     font-weight: var(--font-weight-sidebar-heading);
     letter-spacing: var(--letter-spacing-sidebar-heading);
@@ -180,6 +181,18 @@
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     cursor: pointer;
     white-space: nowrap;
+    border-radius: 4px;
+
+    /* Prevent hover styles set on other rows when zoomed in. */
+    &:not(.zoom-in):hover {
+        background-color: var(--color-background-hover-narrow-filter);
+        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
+
+        .left-sidebar-title,
+        .sidebar-heading-icon {
+            opacity: var(--opacity-sidebar-heading-hover);
+        }
+    }
 
     #toggle-direct-messages-section-icon {
         grid-area: starting-anchor-element;
@@ -273,11 +286,7 @@
 #toggle-direct-messages-section-icon,
 #toggle-top-left-navigation-area-icon {
     color: var(--color-text-sidebar-heading);
-    opacity: var(--opacity-sidebar-heading);
-
-    &:hover {
-        opacity: 1;
-    }
+    opacity: var(--opacity-sidebar-heading-icon);
 
     &:focus {
         outline: 0;
@@ -847,14 +856,26 @@ li.top_left_scheduled_messages {
 }
 
 #views-label-container {
+    margin-right: var(--left-sidebar-right-margin);
     grid-template-columns:
         0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 0.5fr) minmax(
             0,
             1fr
         )
-        30px var(--left-sidebar-right-margin);
-    grid-template-rows: var(--line-height-sidebar-row-prominent);
+        30px 0;
+    grid-template-rows: 28px;
     cursor: pointer;
+    border-radius: 4px;
+
+    &:not(.remove-pointer-for-spectator):hover {
+        background-color: var(--color-background-hover-narrow-filter);
+        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
+
+        .left-sidebar-title,
+        .sidebar-heading-icon {
+            opacity: var(--opacity-sidebar-heading-hover);
+        }
+    }
 
     &.showing-expanded-navigation {
         /* When the expanded navigation is visible,
@@ -1371,22 +1392,41 @@ li.topic-list-item {
 #streams_header {
     grid-template-columns:
         var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
-        minmax(17px, max-content) 30px var(--left-sidebar-right-margin);
+        minmax(17px, max-content) 30px 0;
     /* Keep the stream-search area rows collapsed. */
     grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
     cursor: pointer;
-    padding: var(--left-sidebar-sections-vertical-gutter) 0 3px 0;
+    margin: var(--left-sidebar-sections-vertical-gutter)
+        var(--left-sidebar-right-margin) 3px 0;
     position: sticky;
     /* Keep sticky within SimpleBar context. */
     top: 0;
     z-index: 2;
     background-color: var(--color-background);
+    border-radius: 4px;
+
+    &:hover {
+        background-color: var(--color-background-opaque-hover-narrow-filter);
+        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
+
+        .left-sidebar-title,
+        .sidebar-heading-icon {
+            opacity: var(--opacity-sidebar-heading-hover);
+        }
+    }
 
     &.showing-stream-search-section {
         /* Open up the stream-search rows. The 10px
            row maintains space with the streams list
            below. */
         grid-template-rows: var(--line-height-sidebar-row-prominent) 28px 10px;
+
+        /* When the search section is showing, switch
+           off the hover effects on the row. */
+        &:hover {
+            background-color: var(--color-background);
+            box-shadow: unset;
+        }
     }
 
     .left-sidebar-title {
@@ -1520,7 +1560,8 @@ li.topic-list-item {
 .spectator-view #streams_header {
     grid-template-columns:
         var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
-        minmax(30px, max-content) 0 var(--left-sidebar-right-margin);
+        minmax(30px, max-content) 0 0;
+    margin-right: var(--left-sidebar-right-margin);
 
     /* With markers and controls now sized the same
        as the ordinary vdots area (but allowed to grow,
@@ -1600,6 +1641,12 @@ li.topic-list-item {
         z-index: 2;
         padding-bottom: 1px;
         background-color: var(--color-background);
+
+        &:hover {
+            /* Prevent hover styles set on other rows. */
+            box-shadow: none;
+            background-color: var(--color-background);
+        }
     }
 
     #streams_header,

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -149,11 +149,6 @@ $user_status_emoji_width: 24px;
             color: var(--color-text-url-hover);
         }
     }
-
-    & a {
-        color: inherit;
-        margin-left: 0;
-    }
 }
 
 .buddy-list-subsection-header {
@@ -182,6 +177,7 @@ $user_status_emoji_width: 24px;
 .user-presence-link,
 .user_sidebar_entry .selectable_sidebar_block {
     overflow: hidden;
+    color: var(--color-text-sidebar-row);
 
     .user-name {
         overflow: hidden;
@@ -203,6 +199,12 @@ $user_status_emoji_width: 24px;
 
 .user-presence-link {
     grid-area: row-content;
+
+    &:hover,
+    &:focus {
+        color: var(--color-text-sidebar-row);
+        text-decoration: none;
+    }
 }
 
 .my_user_status {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -106,6 +106,7 @@ $user_status_emoji_width: 24px;
         &:hover,
         &.highlighted_user {
             background-color: var(--color-buddy-list-highlighted-user);
+            box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
         }
     }
 
@@ -135,6 +136,8 @@ $user_status_emoji_width: 24px;
         text-align: left;
 
         &:hover {
+            /* Prevent hover styles set on other rows. */
+            box-shadow: none;
             background-color: inherit;
         }
     }
@@ -146,6 +149,11 @@ $user_status_emoji_width: 24px;
         color: var(--color-text-url);
 
         &:hover {
+            /* Prevent hover styles set on other rows until
+               the right sidebar matches the action-heading typography
+               of the left sidebar. */
+            box-shadow: none;
+            background-color: inherit;
             color: var(--color-text-url-hover);
         }
     }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -65,7 +65,18 @@ $user_status_emoji_width: 24px;
 
         .user-list-sidebar-menu-icon {
             visibility: hidden;
-            justify-self: center;
+            justify-self: stretch;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 2px 2px 2px 1px;
+            /* This helps horizontally align the vdots,
+               given the reduced margin-left above.
+               Vertical centering looks better with an
+               extra pixel of top padding in this area,
+               too. */
+            padding: 1px 0 0 1px;
+            border-radius: 3px;
 
             & i {
                 font-size: 17px;
@@ -99,6 +110,9 @@ $user_status_emoji_width: 24px;
 
                 &:hover {
                     color: var(--color-vdots-hover);
+                    background-color: var(
+                        --color-background-sidebar-action-hover
+                    );
                 }
             }
         }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,7 +1,7 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
         <div id="views-label-container" class="showing-expanded-navigation {{#if is_spectator}}remove-pointer-for-spectator{{/if}}">
-            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
+            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
             {{~!-- squash whitespace --~}}
             <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
@@ -145,7 +145,7 @@
     </div>
 
     <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
-        <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
+        <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
         <div class="heading-markers-and-controls">
             <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">


### PR DESCRIPTION
This PR implements the colors for active filters and hovered elements in both sidebars. There have been some minor adjustments to the geometry of row grids to properly accommodate the new hover styles, especially for vdots, but also collapsed navigation items and other rows where the introduction of the outline hover style introduced some collision issues. There is certainly room for tweaking some of that yet. 

Additionally, this corrects some lingering dark-mode regressions with hover colors on links in the sidebars.

There are still some special effects (e.g., slight scaling downward on click/`:active`) that will be implemented in a follow-up PR. It would also be nice to introduce the new unread background colors, but those will likely happen alongside a PR that introduces the show-on-hover behavior for things like stream controls and the interleaved DMs view.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/sidebar.20hover.20and.20active.20effects/near/1949658)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dark-sidebar-states-before](https://github.com/user-attachments/assets/51ec901c-d44d-4796-b05d-175dcc23faaf) | ![dark-sidebar-states-after](https://github.com/user-attachments/assets/9a41d323-881f-464d-9f27-9e78dd9498f2) |
| ![light-sidebar-states-before](https://github.com/user-attachments/assets/dfec0dee-ffa1-438e-8f02-56c4156282cf) | ![light-sidebar-states-after](https://github.com/user-attachments/assets/13b6ae52-7dab-459d-ac3e-f2f2d48ada6e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>