### PR TITLE
introduce_zulip_view_modal: Fix small syntax problem

### DIFF
--- a/web/templates/introduce_zulip_view_modal.hbs
+++ b/web/templates/introduce_zulip_view_modal.hbs
@@ -5,7 +5,7 @@
         {{else if (eq zulip_view "recent_conversations")}}
             {{#tr}}You’ll see a list of <b>ongoing conversations</b>.{{/tr}}
         {{/if}}
-        {{#tr}}Each conversation is <b>labeled with a topic</b> by the person started it.{{/tr}}
+        {{#tr}}Each conversation is <b>labeled with a topic</b> by the person who started it.{{/tr}}
     </p>
     <p>
         {{t 'Click on a conversation to view it. To return here, you can:'}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Noticed a small grammatical error in the introduction modal when I registered for a new Zulip instance.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
