### PR TITLE
billing: Use relative links for help references.

### DIFF
--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -112,7 +112,7 @@
                     <label for="automatic-license-count" class="inline-block label-title">
                         Number of licenses
                         {% if is_self_hosted_billing %}
-                        <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">
+                        <a href="/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
                         {% else %}
@@ -126,7 +126,7 @@
                         {{ licenses }}
                         <br />
                         Licenses are managed
-                        <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-license-management-work">automatically</a>.
+                        <a href="/help/self-hosted-billing#how-does-automatic-license-management-work">automatically</a>.
                         You can
                         <a class="toggle-license-management" type="button">switch</a>
                         to manual license management.
@@ -138,7 +138,7 @@
                     <label for="current-manual-license-count" class="inline-block label-title">
                         Number of licenses for current billing period
                         {% if is_self_hosted_billing %}
-                        <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
+                        <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
                         {% else %}
@@ -160,7 +160,7 @@
                     <div id="current-license-change-error" class="alert alert-danger billing-page-error"></div>
                     <div class="not-editable-realm-field billing-page-license-management-description">
                         Licenses are managed
-                        <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-license-management-work">manually</a>.
+                        <a href="/help/self-hosted-billing#how-does-manual-license-management-work">manually</a>.
                         You can
                         <a class="toggle-license-management" type="button">switch</a>
                         to automatic license management.
@@ -172,7 +172,7 @@
                     <label for="next-manual-license-count" class="inline-block label-title">
                         Number of licenses for next billing period
                         {% if is_self_hosted_billing %}
-                        <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
+                        <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
                         {% else %}
@@ -606,7 +606,7 @@
             <main class="modal__content">
                 <p>
                     Are you sure you want to switch to
-                    <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-license-management-work">
+                    <a href="/help/self-hosted-billing#how-does-automatic-license-management-work">
                         {% if automanage_licenses %}
                             manual
                         {% else %}

--- a/templates/corporate/billing/sponsorship.html
+++ b/templates/corporate/billing/sponsorship.html
@@ -123,7 +123,7 @@
                         <label for="organization_type" class="inline-block label-title">
                             Organization type
                             {% if is_remotely_hosted %}
-                            <a href="https://zulip.com/help/self-hosted-billing#free-community-plan" target="_blank" rel="noopener noreferrer">
+                            <a href="/help/self-hosted-billing#free-community-plan" target="_blank" rel="noopener noreferrer">
                                 <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                             </a>
                             {% endif %}

--- a/templates/corporate/billing/upgrade.html
+++ b/templates/corporate/billing/upgrade.html
@@ -208,7 +208,7 @@
                             Your subscription will renew automatically. Your bill will vary based on the number of active users in your organization.
                             You can also <a href="{{ page_params.billing_base_url }}/upgrade/?manual_license_management=true&tier={{ page_params.tier }}">purchase a fixed number of licenses</a> instead.
                             {% if is_self_hosting_management_page %}
-                                See <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                See <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
                             {% else %}
                                 See <a href="/help/zulip-cloud-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
                             {% endif %}
@@ -220,13 +220,13 @@
                             {% if not page_params.setup_payment_by_invoice %}
                                 You can also <a href="{{ page_params.billing_base_url }}/upgrade/?tier={{ page_params.tier }}">choose automatic license management</a> instead.
                                 {% if is_self_hosting_management_page %}
-                                    See <a href="https://zulip.com/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                    See <a href="/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
                                 {% else %}
                                     See <a href="/help/zulip-cloud-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
                                 {% endif %}
                             {% else %}
                                 {% if is_self_hosting_management_page %}
-                                    See <a href="https://zulip.com/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
+                                    See <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
                                 {% else %}
                                     See <a href="/help/zulip-cloud-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">here</a> for details.
                                 {% endif %}


### PR DESCRIPTION
Logged in users can use the relative links to access the help document. Didn't convert the `zulip.com` links on error pages since the user might not be able to login to see the page.
