### PR TITLE
Modification to how user found zulip input.

### DIFF
--- a/corporate/views/installation_activity.py
+++ b/corporate/views/installation_activity.py
@@ -254,6 +254,7 @@ def realm_summary_table(export: bool) -> str:
         if how_found in (
             RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["other"],
             RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["ad"],
+            RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["review_site"],
         ):
             row["how_realm_creator_found_zulip"] += f": {extra_context}"
         elif how_found == RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["existing_user"]:

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -210,9 +210,10 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                     <option value="{{ option_id }}">{{ option_name }}</option>
                     {% endfor %}
                 </select>
-                <input id="how-realm-creator-found-zulip-other" type="text" placeholder="{{ _('Please describe') }}" name="how_realm_creator_found_zulip_other_text" maxlength="100"/>
-                <input id="how-realm-creator-found-zulip-where-ad" type="text" placeholder="{{ _('Where did you see the ad?') }}" name="how_realm_creator_found_zulip_where_ad" maxlength="100"/>
-                <input id="how-realm-creator-found-zulip-which-organization" type="text" placeholder="{{ _('Which organization?') }}" name="how_realm_creator_found_zulip_which_organization" maxlength="100"/>
+                <input id="how-realm-creator-found-zulip-other" class="how-found-zulip-extra-data-input" type="text" placeholder="{{ _('Please describe') }}" name="how_realm_creator_found_zulip_other_text" maxlength="100"/>
+                <input id="how-realm-creator-found-zulip-where-ad" class="how-found-zulip-extra-data-input" type="text" placeholder="{{ _('Where did you see the ad?') }}" name="how_realm_creator_found_zulip_where_ad" maxlength="100"/>
+                <input id="how-realm-creator-found-zulip-which-organization" class="how-found-zulip-extra-data-input" type="text" placeholder="{{ _('Which organization?') }}" name="how_realm_creator_found_zulip_which_organization" maxlength="100"/>
+                <input id="how-realm-creator-found-zulip-review-site" class="how-found-zulip-extra-data-input" type="text" placeholder="{{ _('Which one?') }}" name="how_realm_creator_found_zulip_review_site" maxlength="100"/>
             </div>
             {% endif %}
 

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -312,6 +312,7 @@ $(() => {
             ["other", "how-realm-creator-found-zulip-other"],
             ["ad", "how-realm-creator-found-zulip-where-ad"],
             ["existing_user", "how-realm-creator-found-zulip-which-organization"],
+            ["review_site", "how-realm-creator-found-zulip-review-site"],
         ]);
 
         const hideElement = (element: string): void => {

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1464,9 +1464,7 @@ button#register_auth_button_gitlab {
     top: -5px;
 }
 
-#how-realm-creator-found-zulip-where-ad,
-#how-realm-creator-found-zulip-other,
-#how-realm-creator-found-zulip-which-organization {
+#how-realm-creator-found-zulip .how-found-zulip-extra-data-input {
     margin-top: 5px;
     display: none;
 }

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -206,6 +206,9 @@ class RegistrationForm(RealmDetailsForm):
         self.fields["how_realm_creator_found_zulip_which_organization"] = forms.CharField(
             max_length=100, required=False
         )
+        self.fields["how_realm_creator_found_zulip_review_site"] = forms.CharField(
+            max_length=100, required=False
+        )
 
     def clean_full_name(self) -> str:
         try:

--- a/zerver/models/realm_audit_logs.py
+++ b/zerver/models/realm_audit_logs.py
@@ -173,6 +173,7 @@ class AbstractRealmAuditLog(models.Model):
         "review_site": "Review site",
         "personal_recommendation": "Personal recommendation",
         "hacker_news": "Hacker News",
+        "reddit": "Reddit",
         "ad": "Advertisement",
         "other": "Other",
         "forgot": "Don't remember",

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -506,6 +506,13 @@ def registration_helper(
                 how_realm_creator_found_zulip_extra_context = form.cleaned_data[
                     "how_realm_creator_found_zulip_which_organization"
                 ]
+            elif (
+                how_realm_creator_found_zulip
+                == RealmAuditLog.HOW_REALM_CREATOR_FOUND_ZULIP_OPTIONS["review_site"]
+            ):  # nocoverage
+                how_realm_creator_found_zulip_extra_context = form.cleaned_data[
+                    "how_realm_creator_found_zulip_review_site"
+                ]
 
             realm = do_create_realm(
                 string_id,


### PR DESCRIPTION
- [x] Show Advertisement
- [x]  Show `At an organisation that's using Zulip`? as `Organization`
- [x]  Add Reddit below Hacker News
- [x]  "Which one?" follow-up question when they pick "Review site".

(ignore the empty `advertisement:` fields they were created by mistake and are not actually possible to create by a user filling the form)
![Screenshot 2024-09-27 at 11 21 30 AM](https://github.com/user-attachments/assets/2ad2e884-e96f-4cc8-82b2-1a2d2c02bb59)
![Screenshot 2024-09-27 at 11 23 17 AM](https://github.com/user-attachments/assets/2e63035b-af9a-49f9-8f10-f4ab644501b0)
