### PR TITLE
lightbox: Better handle duplicate images, hotkey behavior.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -223,17 +223,16 @@ export function canonical_url_of_media(media: HTMLMediaElement | HTMLImageElemen
     return media_string;
 }
 
-export function render_lightbox_media_list(displayed_source: string): void {
+export function render_lightbox_media_list(): void {
     if (!is_open) {
         const message_media_list = $<HTMLMediaElement | HTMLImageElement>(
             ".focused-message-list .message_inline_image img, .focused-message-list .message_inline_video video",
         ).toArray();
         const $lightbox_media_list = $("#lightbox_overlay .image-list").empty();
-        const canonical_displayed_source = new URL(displayed_source, window.location.origin).href;
         for (const media of message_media_list) {
-            const message_media_list_src = canonical_url_of_media(media);
-            const className =
-                message_media_list_src === canonical_displayed_source ? "image selected" : "image";
+            const className = media.classList.contains("media-to-select-in-lightbox-list")
+                ? "image selected"
+                : "image";
             const is_video = media.tagName === "VIDEO";
 
             // We parse the data for each image to show in the list,
@@ -268,7 +267,7 @@ export function render_lightbox_media_list(displayed_source: string): void {
 }
 
 function display_image(payload: Payload): void {
-    render_lightbox_media_list(payload.source);
+    render_lightbox_media_list();
 
     $(".player-container, .video-player").hide();
     $(".image-preview, .media-actions, .media-description, .download, .lightbox-zoom-reset").show();
@@ -317,7 +316,7 @@ function display_image(payload: Payload): void {
 }
 
 function display_video(payload: Payload): void {
-    render_lightbox_media_list(payload.source);
+    render_lightbox_media_list();
 
     $(
         "#lightbox_overlay .image-preview, .media-description, .download, .lightbox-zoom-reset, .video-player",
@@ -472,7 +471,9 @@ export function show_from_selected_message(): void {
         // Since this function is only called from the "show_lightbox"
         // hotkey, we don't have a selected image to load. Therefore,
         // we show the first one returned from the traversal above.
+        $media.first().addClass("media-to-select-in-lightbox-list");
         open_media($media.first());
+        $media.first().removeClass("media-to-select-in-lightbox-list");
     }
 }
 
@@ -625,7 +626,9 @@ export function initialize(): void {
             // prevent the message compose dialog from happening.
             e.stopPropagation();
             const $img = $(this).find<HTMLImageElement>("img");
+            $img.addClass("media-to-select-in-lightbox-list");
             open_image($img);
+            $img.removeClass("media-to-select-in-lightbox-list");
         },
     );
 
@@ -634,7 +637,9 @@ export function initialize(): void {
         e.stopPropagation();
 
         const $video = $(e.currentTarget).find<HTMLMediaElement>("video");
+        $video.addClass("media-to-select-in-lightbox-list");
         open_video($video);
+        $video.removeClass("media-to-select-in-lightbox-list");
     });
 
     $("#lightbox_overlay .download").on("click", function () {

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -647,6 +647,9 @@ export function initialize(): void {
     });
 
     $("#lightbox_overlay").on("click", ".image-list .image", function (this: HTMLElement) {
+        // Remove any video players so sound does not continue when
+        // navigating away from a video that might be playing
+        remove_video_players();
         const $media_list = $(this).parent();
         let $original_media_element;
         const is_video = $(this).hasClass("lightbox_video");

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -469,7 +469,10 @@ export function show_from_selected_message(): void {
 
     if ($media.length !== 0) {
         const open_media = build_open_media_function(undefined);
-        open_media($media);
+        // Since this function is only called from the "show_lightbox"
+        // hotkey, we don't have a selected image to load. Therefore,
+        // we show the first one returned from the traversal above.
+        open_media($media.first());
     }
 }
 

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -671,7 +671,14 @@ export function initialize(): void {
             return;
         }
 
-        open_image($original_media_element);
+        // Because a user could conceivably copy and paste a media reference
+        // from another message, and because we are selecting the original
+        // element above based on a data-url value that is therefore not
+        // guaranteed to be unique, we pass the first (possibly only) media
+        // element returned. The logic below for removing and adding the
+        // "selected" class ensures that the correct thumbnail will
+        // still be highlighted.
+        open_image($original_media_element.first());
 
         if (!$(".image-list .image.selected").hasClass("lightbox_video") || !is_video) {
             pan_zoom_control.reset();

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -167,7 +167,7 @@
 
     .center {
         display: flex;
-        justify-items: center;
+        justify-content: center;
 
         .arrow {
             display: inline-block;


### PR DESCRIPTION
This PR corrects for some lingering errors with the lightbox.

1. It ensures proper functioning of the `v` hotkey; on `main` and in production, use of the hotkey will always throw an error when there is more than a single image in a topic. This is likely the source of many Sentry errors.
2. It improves the logic for detecting the selected image by avoiding the use of the canonical URL, which may not be unique in a given topic if users copy and paste an image reference from a previous message. Detecting the selected image is now handled by a short-lived class added to an image clicked on in the message area.
3. It removes any open video players when navigating thumbnails, preventing audio from continuing to play ([CZO issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/lightbox.20video.20keeps.20playing.20after.20switching.20to.20image/near/1946003))

There are still improvements that could be made beyond this PR (e.g., this still reaches back into the message area when navigating between lightbox thumbnails), but this should improve functionality and eliminate assertion errors around `util.the($media)`.

Finally, this also makes a tweak to the centering logic for the thumbnail bar.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Opening with `v`, before | Opening with `v`, after |
| --- | --- |
| ![multiple-images-hotkey-before](https://github.com/user-attachments/assets/e2911c48-0186-4dca-9cb5-6299cdbee2a0) | ![multiple-images-hotkey-after](https://github.com/user-attachments/assets/a12d31ac-d25f-4d2f-84c2-00e0ac6ee167) |

| With a duplicate image, before | With a duplicate image, after |
| --- | --- |
| ![duplicate-images-before](https://github.com/user-attachments/assets/79163cf4-30bc-40df-bdf5-892ba8ba6a95) | ![duplicate-images-after](https://github.com/user-attachments/assets/49fea9c1-a717-4cd4-81cf-191bcd4c42d3) |

