### PR TITLE
Remove incorrect preservation of # symbol when pasting text which is in single element

### DIFF
--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -360,12 +360,29 @@ function image_to_zulip_markdown(
     // Using Zulip's link like syntax for images
     return src ? "[" + title + "](" + src + ")" : (node.getAttribute("alt") ?? "");
 }
-
 function within_single_element(html_fragment: HTMLElement): boolean {
+    // Filter out non-element nodes by checking if the node is an HTMLElement or TextNode with non-whitespace content
+    const validElements = [...html_fragment.childNodes].filter((node) => {
+        if (node instanceof HTMLElement) {
+            return node.nodeName !== "BR" && node.nodeName !== "META";
+        } else if (node.nodeType === (globalThis.Node ? globalThis.Node.TEXT_NODE : 3)) {
+            // Check if textContent is not null and contains non-whitespace content
+            return node.textContent?.trim() !== "";
+        }
+        return false;
+    });
+
+    // Calculate the total count without considering <meta> tags
+    const totalElementsCount = validElements.length;
+
+    // Ensure that validElements[0] exists before accessing innerHTML/textContent
+    const firstElement = validElements[0];
     return (
-        html_fragment.childNodes.length === 1 &&
-        html_fragment.firstElementChild !== null &&
-        html_fragment.firstElementChild.innerHTML !== ""
+        totalElementsCount === 1 &&
+        firstElement !== undefined &&
+        (firstElement instanceof HTMLElement
+            ? firstElement.innerHTML.trim() !== ""
+            : firstElement.textContent?.trim() !== "")
     );
 }
 
@@ -400,17 +417,14 @@ export function paste_handler_converter(paste_html: string): string {
     assert(copied_html_fragment !== null);
     const copied_within_single_element = within_single_element(copied_html_fragment);
     const outer_elements_to_retain = ["PRE", "UL", "OL", "A", "CODE"];
-    // If the entire selection copied is within a single HTML element (like an
-    // `h1`), we don't want to retain its styling, except when it is needed to
-    // identify the intended structure of the copied content.
+    const firstChild = copied_html_fragment.firstElementChild;
     if (
         copied_within_single_element &&
-        copied_html_fragment.firstElementChild !== null &&
-        !outer_elements_to_retain.includes(copied_html_fragment.firstElementChild.nodeName)
+        firstChild !== null &&
+        !outer_elements_to_retain.includes(firstChild.nodeName)
     ) {
-        paste_html = copied_html_fragment.firstElementChild.innerHTML;
+        paste_html = firstChild.innerHTML;
     }
-
     // turning off escaping (for now) to remove extra `/`
     TurndownService.prototype.escape = (string) => string;
 
@@ -515,7 +529,6 @@ export function paste_handler_converter(paste_html: string): string {
             return "";
         },
     });
-
     // We override the original upstream implementation of this rule to make
     // several tweaks:
     // - We turn any single line code blocks into inline markdown code.

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -129,6 +129,15 @@ run_test("paste_handler_converter", () => {
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><h1 style="box-sizing: border-box; font-size: 2em; margin-top: 0px !important; margin-right: 0px; margin-bottom: 16px; margin-left: 0px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid hsl(216, 14%, 93%); color: hsl(210, 12%, 16%); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-style: initial; text-decoration-color: initial;">Zulip overview</h1>';
     assert.equal(copy_and_paste.paste_handler_converter(input), "Zulip overview");
 
+    // Only heading (when selected and copy)
+    input = "<body><!--StartFragment--><h1>Zulip overview</h1><!--EndFragment--></body>";
+    assert.equal(copy_and_paste.paste_handler_converter(input), "Zulip overview");
+
+    // Only heading (when triple clicked and copied)
+    input =
+        '<body><!--StartFragment--><h1>Zulip overview</h1><br class="Apple-interchange-newline"><!--EndFragment--></body>';
+    assert.equal(copy_and_paste.paste_handler_converter(input), "Zulip overview");
+
     // Italic text
     input =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8">normal text <i style="box-sizing: inherit; color: hsl(0, 0%, 0%); font-family: Verdana, sans-serif; font-size: 15px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 100%); text-decoration-style: initial; text-decoration-color: initial;">This text is italic</i>';


### PR DESCRIPTION
Fixes issue : #31218 where pasting a title selected by triple-clicking incorrectly preserved the # symbol in some websites, such as NY Times articles (in Chrome on a Mac).

<!-- Describe your pull request here.-->
The issue occurred because when selecting and copying text, it's represented as:
![image](https://github.com/user-attachments/assets/1f056208-29bf-448d-ac43-7e70bc479f92)
But when triple-clicking to select, it's represented as:
![image](https://github.com/user-attachments/assets/7854fefa-b963-41d5-867e-0ceb8787e33b)
The previous code detected the first case as having 4 elements and the second case as 5 elements, instead of 1. I updated the code to ignore ![image](https://github.com/user-attachments/assets/90aa0a24-b2a4-4aff-ba22-44115a7fe972) when counting elements.
I have updated within_single_element function to work accordingly which solves the issue and added tests for the above solution.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
