### PR TITLE
filter: Refactor code path which adjusts the narrow containing `with`.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -389,36 +389,56 @@ export class Filter {
         };
     }
 
-    static ensure_channel_topic_terms(orig_terms: NarrowTerm[]): NarrowTerm[] {
+    static ensure_channel_topic_terms(
+        orig_terms: NarrowTerm[],
+        message: Message,
+    ): NarrowTerm[] | undefined {
         // In presence of `with` term without channel or topic terms in the narrow, the
         // narrow is populated with the channel and toipic terms through this operation,
         // so that `with` can be used as a standalone operator to target conversation.
-        const with_term = orig_terms.find((term: NarrowTerm) => term.operator === "with");
+        const contains_with_operator = orig_terms.some((term) => term.operator === "with");
 
-        if (!with_term) {
-            return orig_terms;
+        if (!contains_with_operator) {
+            return undefined;
         }
 
-        const updated_terms = orig_terms.filter((term: NarrowTerm) => term.operator !== "dm");
+        let contains_channel_term = false;
+        let contains_topic_term = false;
+        let contains_dm_term = false;
 
-        let channel_term = updated_terms.find(
-            (term: NarrowTerm) => Filter.canonicalize_operator(term.operator) === "channel",
-        );
-        let topic_term = updated_terms.find(
-            (term: NarrowTerm) => Filter.canonicalize_operator(term.operator) === "topic",
-        );
-
-        if (!topic_term) {
-            topic_term = {operator: "topic", operand: ""};
-            const with_index = updated_terms.indexOf(with_term);
-            updated_terms.splice(with_index, 0, topic_term);
+        for (const term of orig_terms) {
+            switch (Filter.canonicalize_operator(term.operator)) {
+                case "channel":
+                    contains_channel_term = true;
+                    break;
+                case "topic":
+                    contains_topic_term = true;
+                    break;
+                case "dm":
+                    contains_dm_term = true;
+            }
         }
 
-        if (!channel_term) {
-            channel_term = {operator: "channel", operand: ""};
-            const topic_index = updated_terms.indexOf(topic_term);
-            updated_terms.splice(topic_index, 0, channel_term);
+        // If the narrow is already a channel-topic narrow containing
+        // channel and topic terms, we will return undefined now so that
+        // it can be adjusted further if needed later.
+        if (!contains_dm_term && contains_channel_term && contains_topic_term) {
+            return undefined;
         }
+
+        const conversation_terms = new Set(["channel", "topic", "dm"]);
+
+        const non_conversation_terms = orig_terms.filter((term) => {
+            const operator = Filter.canonicalize_operator(term.operator);
+            return !conversation_terms.has(operator);
+        });
+
+        assert(message.type === "stream");
+
+        const channel_term = {operator: "channel", operand: message.stream_id.toString()};
+        const topic_term = {operator: "topic", operand: message.topic};
+
+        const updated_terms = [channel_term, topic_term, ...non_conversation_terms];
         return updated_terms;
     }
 
@@ -881,7 +901,14 @@ export class Filter {
         const adjusted_terms = [];
         let terms_changed = false;
 
-        raw_terms = Filter.ensure_channel_topic_terms(raw_terms);
+        const adjusted_narrow_containing_with = Filter.ensure_channel_topic_terms(
+            raw_terms,
+            message,
+        );
+
+        if (adjusted_narrow_containing_with !== undefined) {
+            return adjusted_narrow_containing_with;
+        }
 
         for (const term of raw_terms) {
             const adjusted_term = {...term};

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -861,16 +861,42 @@ test("canonicalization", () => {
 });
 
 test("ensure_channel_topic_terms", () => {
-    const channel_term = {operator: "channel", operand: ""};
-    const topic_term = {operator: "topic", operand: ""};
+    const channel_term = {operator: "channel", operand: `${general_sub.stream_id}`};
+    const topic_term = {operator: "topic", operand: "discussion"};
 
-    const term_1 = Filter.ensure_channel_topic_terms([{operator: "with", operand: 12}]);
-    const term_2 = Filter.ensure_channel_topic_terms([topic_term, {operator: "with", operand: 12}]);
-    const term_3 = Filter.ensure_channel_topic_terms([
-        channel_term,
-        {operator: "with", operand: 12},
-    ]);
-    const terms = [term_1, term_2, term_3];
+    const message = {
+        type: "stream",
+        id: 12,
+        stream_id: general_sub.stream_id,
+        display_recipient: "general",
+        topic: "discussion",
+    };
+
+    const term_1 = Filter.ensure_channel_topic_terms(
+        [{operator: "with", operand: message.id}],
+        message,
+    );
+    const term_2 = Filter.ensure_channel_topic_terms(
+        [topic_term, {operator: "with", operand: message.id}],
+        message,
+    );
+    const term_3 = Filter.ensure_channel_topic_terms(
+        [channel_term, {operator: "with", operand: message.id}],
+        message,
+    );
+    const term_4 = Filter.ensure_channel_topic_terms(
+        [
+            {operator: "dm", operand: "foo@example.com"},
+            {operator: "with", operand: message.id},
+        ],
+        message,
+    );
+    const term_5 = Filter.ensure_channel_topic_terms(
+        [{operator: "with", operand: message.id}],
+        message,
+    );
+
+    const terms = [term_1, term_2, term_3, term_4, term_5];
 
     for (const term of terms) {
         assert.deepEqual(term, [channel_term, topic_term, {operator: "with", operand: 12}]);


### PR DESCRIPTION
This commit refactors the `ensure_channel_topic_terms` of `filter.ts`. Previously, this method used to add channel and topic terms, with operands as placeholders in case the `with` narrow doesn't have channel-topic terms.

This commit updates it to rather correct the narrow with the right terms in case the channel-topic terms are missing in the `with` narrow, but leave it as it is in case the channel-topic terms are present, so that it can later be corrected if the channel-topic terms are not pointing to the right conversation.

<!-- Describe your pull request here.-->

Fixes https://github.com/zulip/zulip/pull/31239#discussion_r1752930765

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
