### PR TITLE
settings: Deduplicate show and hide spinner functions.

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -88,12 +88,11 @@ type RequestOpts = {
 };
 
 export function hide_dialog_spinner(): void {
-    $(".dialog_submit_button span").show();
     const dialog_widget_selector = current_dialog_widget_selector();
+    const $spinner = $(`${dialog_widget_selector} .modal__spinner`);
     $(`${dialog_widget_selector} .modal__btn`).prop("disabled", false);
 
-    const $spinner = $(`${dialog_widget_selector} .modal__spinner`);
-    loading.destroy_indicator($spinner);
+    loading.hide_spinner($(".dialog_submit_button"), $spinner);
 }
 
 export function show_dialog_spinner(): void {

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -102,17 +102,8 @@ export function show_dialog_spinner(): void {
     $(`${dialog_widget_selector} .modal__btn`).prop("disabled", true);
 
     const $spinner = $(`${dialog_widget_selector} .modal__spinner`);
-    const dialog_submit_button_span_width = $(".dialog_submit_button span").width();
-    const dialog_submit_button_span_height = $(".dialog_submit_button span").height();
 
-    // Hide the submit button after computing its height, since submit
-    // buttons with long text might affect the size of the button.
-    $(".dialog_submit_button span").hide();
-
-    loading.make_indicator($spinner, {
-        width: dialog_submit_button_span_width,
-        height: dialog_submit_button_span_height,
-    });
+    loading.show_spinner($(".dialog_submit_button"), $spinner);
 }
 
 // Supports a callback to be called once the modal finishes closing.

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -106,3 +106,11 @@ export function show_spinner($button_element: JQuery, $spinner: JQuery): void {
         height: span_height,
     });
 }
+
+export function hide_spinner($button_element: JQuery, $spinner: JQuery): void {
+    // Show the span
+    $button_element.find(".submit-button-text").show();
+
+    // Destroy the loading indicator
+    destroy_indicator($spinner);
+}

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -91,3 +91,18 @@ export function show_button_spinner($elt: JQuery, using_dark_theme: boolean): vo
     }
     $elt.css("display", "inline-block");
 }
+
+export function show_spinner($button_element: JQuery, $spinner: JQuery): void {
+    const span_width = $button_element.find(".submit-button-text").width();
+    const span_height = $button_element.find(".submit-button-text").height();
+
+    // Hide the submit button after computing its height, since submit
+    // buttons with long text might affect the size of the button.
+    $button_element.find(".submit-button-text").hide();
+
+    // Create the loading indicator
+    make_indicator($spinner, {
+        width: span_width,
+        height: span_height,
+    });
+}

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -88,14 +88,8 @@ const EMBEDDED_BOT_TYPE = "4";
 
 export function show_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");
-    const dialog_submit_button_span_width = $button.find("span").width();
-    const dialog_submit_button_span_height = $button.find("span").height();
     $button.prop("disabled", true);
-    $button.find("span").hide();
-    loading.make_indicator($spinner, {
-        width: dialog_submit_button_span_width,
-        height: dialog_submit_button_span_height,
-    });
+    loading.show_spinner($button, $spinner);
 }
 
 export function hide_button_spinner($button: JQuery): void {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -95,8 +95,7 @@ export function show_button_spinner($button: JQuery): void {
 export function hide_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");
     $button.prop("disabled", false);
-    $button.find("span").show();
-    loading.destroy_indicator($spinner);
+    loading.hide_spinner($button, $spinner);
 }
 
 function compare_by_name(

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -20,7 +20,7 @@
                 {{/unless}}
                 <div class="dialog_submit_button_container">
                     <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
-                        <span>{{{ html_submit_button }}}</span>
+                        <span class="submit-button-text">{{{ html_submit_button }}}</span>
                         <div class="modal__spinner"></div>
                     </button>
                 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -140,7 +140,7 @@
                     <div class="save-success"></div>
                     <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                     <button type="button" class="modal__btn dialog_submit_button">
-                        <span>{{t "Save changes"}}</span>
+                        <span class="submit-button-text">{{t "Save changes"}}</span>
                         <div class="modal__spinner"></div>
                     </button>
                 </footer>


### PR DESCRIPTION
This PR refactors the duplicated spinner logic from the `dialog_widget` and `user_profile` modules by extracting the functionality for loading indicators in a button into reusable components, defined in `loading.ts`.

### Summary of Changes:
- Extracted loading spinner logic from the following functions:
  - `dialog_widget.show_dialog_spinner`
  - `user_profile.show_button_spinner`
  - `dialog_widget.hide_dialog_spinner`
  - `user_profile.hide_button_spinner`

- Introduced two new reusable components:
  - `show_spinner` for displaying the spinner
  - `hide_spinner` for hiding the spinner
  
This refactoring reduces redundancy and centralizes the logic for showing and hiding spinners, improving code reusability, maintainability, and making future updates easier.

Fixes: https://github.com/zulip/zulip/issues/26691

### Self-review checklist
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

### Communicate decisions, questions, and potential concerns:
- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

### Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)):
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

### Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
