### PR TITLE
modal: Add options to selectively mark messages as read.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -68,6 +68,7 @@ IGNORED_PHRASES = [
     r"Topics I participate in",
     r"Topics I send a message to",
     r"Topics I start",
+    r"Topics I don't follow",
     # Specific short words
     r"beta",
     r"and",

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -37,7 +37,7 @@ function common_click_handlers(): void {
     });
 }
 // This callback is called from the popovers on all home views
-function register_mark_all_read_handler(
+function register_mark_messages_as_read_handler(
     event: JQuery.ClickEvent<
         tippy.PopperElement,
         {
@@ -46,7 +46,7 @@ function register_mark_all_read_handler(
     >,
 ): void {
     const {instance} = event.data;
-    unread_ops.confirm_mark_all_as_read();
+    unread_ops.confirm_mark_messages_as_read();
     popover_menus.hide_current_popover_if_visible(instance);
 }
 
@@ -136,7 +136,7 @@ export function initialize(): void {
                 "click",
                 "#mark_all_messages_as_read",
                 {instance},
-                register_mark_all_read_handler,
+                register_mark_messages_as_read_handler,
             );
         },
         onShow(instance) {
@@ -167,7 +167,7 @@ export function initialize(): void {
                 "click",
                 "#mark_all_messages_as_read",
                 {instance},
-                register_mark_all_read_handler,
+                register_mark_messages_as_read_handler,
             );
         },
         onShow(instance) {
@@ -201,7 +201,7 @@ export function initialize(): void {
                 "click",
                 "#mark_all_messages_as_read",
                 {instance},
-                register_mark_all_read_handler,
+                register_mark_messages_as_read_handler,
             );
         },
         onShow(instance) {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -316,6 +316,28 @@ h3,
     }
 }
 
+.modal_select:focus {
+    border-color: hsl(207deg 65% 56%);
+    box-shadow: none;
+}
+
+.message-dropdown {
+    position: relative;
+}
+
+.input-group.message-dropdown .form-control {
+    margin-left: -20px;
+}
+
+.message-count {
+    margin-left: -20px;
+    margin-top: -20px;
+    display: inline-block;
+    padding: 4px;
+    border-radius: 4px;
+    position: relative;
+}
+
 /* For consistent custom select dropdowns that match with dropdown-widget */
 select.modal_select,
 select.list_select,

--- a/web/templates/confirm_dialog/confirm_mark_all_as_read.hbs
+++ b/web/templates/confirm_dialog/confirm_mark_all_as_read.hbs
@@ -1,3 +1,0 @@
-<p>
-    {{t "Are you sure you want to mark all messages as read? This action cannot be undone." }}
-</p>

--- a/web/templates/confirm_dialog/confirm_mark_messages_as_read.hbs
+++ b/web/templates/confirm_dialog/confirm_mark_messages_as_read.hbs
@@ -1,0 +1,15 @@
+<p>
+    {{t "Which messages do you want to mark as read? This action cannot be undone." }}
+</p>
+<div class="new-style settings-section show">
+    <div class="input-group message-dropdown">
+        <select id="mark_as_read_option" class="form-control modal_select">
+            <option value="muted_topics">{{t "Muted topics" }}</option>
+            <option value="topics_not_followed" selected>{{t "Topics I don't follow" }}</option>
+            <option value="all_messages">{{t "All messages" }}</option>
+        </select>
+    </div>
+    <div id="message_count" class="message-count">
+        <span class="counter">{{t "0"}}</span> messages will be marked as read.
+    </div>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
@@ -4,7 +4,7 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                <span class="popover-menu-label">{{t "Mark messages as read" }}</span>
             </a>
         </li>
         {{else}}

--- a/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
@@ -4,7 +4,7 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                <span class="popover-menu-label">{{t "Mark messages as read" }}</span>
             </a>
         </li>
         {{else}}

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -4,7 +4,7 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                <span class="popover-menu-label">{{t "Mark messages as read" }}</span>
             </a>
         </li>
         {{else}}


### PR DESCRIPTION
Added a modal with a dropdown to selectively mark messages as read. The modal includes three dropdown options:

> - [ ] Muted topics
> - [x] Topics I don't follow (default checked)
> - [ ] All messages

Below the select options, there is a line that displays the count of messages that will be marked as read:

> N message/messages will be marked as read. (This updates dynamically when the selection changes.)

</br>

## **Difference between the previous and the present model**

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/75223fd5-afbc-4227-bded-a619730088df" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/7a5d1810-36f9-48fb-b5c1-7c3a4883cef8" width="300"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/9078691c-09ae-46d1-bd9b-30748c4ae431" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/4f6b2400-e4a1-442e-8a61-e688d0a8d46f" width="300"></td>
  </tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d2ba987e-7ebe-4fd6-ba87-9deacb3e1dfa" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/74ac2047-3f24-4cd0-a368-5cbc7458d4a8" width="300"></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/dd9d0dcc-d452-44d5-957d-401258c99e7c" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/58b0d925-692c-4179-b505-27047f752569" width="300"></td>
</tr>
</table>

</br>

## **Demonstrating how the count changes on change of select option**

<table>
  <tr>
    <th>0 messages</th>
    <th>1 message</th>
    <th>More than 1 message</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b555f8f3-5e54-4921-9aa9-445d032189af" width="250"></td>
    <td><img src="https://github.com/user-attachments/assets/3c9ef673-76cf-4719-bcfe-15d85cf8b07f" width="250"></td>
    <td><img src="https://github.com/user-attachments/assets/e01b73e4-94cb-4662-af86-2d5803e49d61" width="250"></td>
  </tr>
</table>

<br/>

## **Tasks completed**

- [x] Rename "Mark all messages as read" -> "Mark messages as read" in the menu.
- [x] Change the confirmation modal.

Fixes : #30025 

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
