### PR TITLE
reload: Handle stream messages without specified stream.

### DIFF
--- a/web/src/reload.ts
+++ b/web/src/reload.ts
@@ -58,9 +58,8 @@ function preserve_state(send_after_reload: boolean, save_compose: boolean): void
         const msg_type = compose_state.get_message_type();
         if (msg_type === "stream") {
             const stream_id = compose_state.stream_id();
-            assert(stream_id !== undefined);
             url += "+msg_type=stream";
-            url += "+stream_id=" + encodeURIComponent(stream_id);
+            url += "+stream_id=" + (stream_id ? encodeURIComponent(stream_id) : undefined);
             url += "+topic=" + encodeURIComponent(compose_state.topic());
         } else if (msg_type === "private") {
             url += "+msg_type=private";


### PR DESCRIPTION
The stream id can be undefined when the compose box is open to start a stream message, but no stream has been selected from the dropdown yet.

Fixes this error introduced in 97ffccb45f85b05c9158ed119c71b6a404afb298
https://chat.zulip.org/#narrow/stream/464-kandra-js-errors/topic/Error.3A.20Failed.20to.20preserve.20state/near/1948680

I tested this manually locally, reproduced the error, and confirmed that undefined and defined stream ids both work now.