### PR TITLE
subscription: Remove unnecessary select_related fields and clean up.

### DIFF
--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -947,8 +947,23 @@ def remote_user_to_email(remote_user: str) -> str:
 post_save.connect(flush_user_profile, sender=UserProfile)
 
 
-@cache_with_key(user_profile_by_id_cache_key, timeout=3600 * 24 * 7)
-def get_user_profile_by_id(user_profile_id: int) -> UserProfile:
+def base_bulk_get_user_queryset() -> QuerySet[UserProfile]:
+    """Base select_related options for UserProfile for general user;
+    prefetches can_access_all_users_group, which is often necessary
+    for calculations of where events should be sent.
+    """
+    return UserProfile.objects.select_related(
+        "realm",
+        "realm__can_access_all_users_group",
+        "realm__can_access_all_users_group__named_user_group",
+    )
+
+
+def base_get_user_queryset() -> QuerySet[UserProfile]:
+    """Base select_related options for fetching a single user object.
+    In contrast with base_bulk_get_user_queryset, additionally fetches
+    fields that are relevant for this user sending a message.
+    """
     return UserProfile.objects.select_related(
         "realm",
         "realm__can_access_all_users_group",
@@ -958,7 +973,12 @@ def get_user_profile_by_id(user_profile_id: int) -> UserProfile:
         "realm__direct_message_permission_group",
         "realm__direct_message_permission_group__named_user_group",
         "bot_owner",
-    ).get(id=user_profile_id)
+    )
+
+
+@cache_with_key(user_profile_by_id_cache_key, timeout=3600 * 24 * 7)
+def get_user_profile_by_id(user_profile_id: int) -> UserProfile:
+    return base_get_user_queryset().get(id=user_profile_id)
 
 
 def get_user_profile_by_email(email: str) -> UserProfile:
@@ -1003,16 +1023,7 @@ def get_user_by_delivery_email(email: str, realm: "Realm") -> UserProfile:
     EMAIL_ADDRESS_VISIBILITY_ADMINS security model.  Use get_user in
     those code paths.
     """
-    return UserProfile.objects.select_related(
-        "realm",
-        "realm__can_access_all_users_group",
-        "realm__can_access_all_users_group__named_user_group",
-        "realm__direct_message_initiator_group",
-        "realm__direct_message_initiator_group__named_user_group",
-        "realm__direct_message_permission_group",
-        "realm__direct_message_permission_group__named_user_group",
-        "bot_owner",
-    ).get(delivery_email__iexact=email.strip(), realm=realm)
+    return base_get_user_queryset().get(delivery_email__iexact=email.strip(), realm=realm)
 
 
 def get_users_by_delivery_email(emails: set[str], realm: "Realm") -> QuerySet[UserProfile]:
@@ -1047,16 +1058,7 @@ def get_user(email: str, realm: "Realm") -> UserProfile:
     EMAIL_ADDRESS_VISIBILITY_ADMINS.  In those code paths, use
     get_user_by_delivery_email.
     """
-    return UserProfile.objects.select_related(
-        "realm",
-        "realm__can_access_all_users_group",
-        "realm__can_access_all_users_group__named_user_group",
-        "realm__direct_message_initiator_group",
-        "realm__direct_message_initiator_group__named_user_group",
-        "realm__direct_message_permission_group",
-        "realm__direct_message_permission_group__named_user_group",
-        "bot_owner",
-    ).get(email__iexact=email.strip(), realm=realm)
+    return base_get_user_queryset().get(email__iexact=email.strip(), realm=realm)
 
 
 def get_active_user(email: str, realm: "Realm") -> UserProfile:
@@ -1069,12 +1071,7 @@ def get_active_user(email: str, realm: "Realm") -> UserProfile:
 
 
 def get_user_profile_by_id_in_realm(uid: int, realm: "Realm") -> UserProfile:
-    return UserProfile.objects.select_related(
-        "realm",
-        "realm__can_access_all_users_group",
-        "realm__can_access_all_users_group__named_user_group",
-        "bot_owner",
-    ).get(id=uid, realm=realm)
+    return base_bulk_get_user_queryset().get(id=uid, realm=realm)
 
 
 def get_active_user_profile_by_id_in_realm(uid: int, realm: "Realm") -> UserProfile:


### PR DESCRIPTION
Follow-up to [create stream: Faster stream creation](https://github.com/zulip/zulip/pull/31168)

Removes the unnecessary fields from bulk_access_users_by_email and
bulk_access_users_id, while also removing duplication of these lists
of fields.

1. `base_bulk_get_user_queryset`, used when fetching a user other than the acting user.

2. `base_get_user_queryset`, used when fetching the acting user, prefetching more fields.

There remains some inconsistency in the models.py functions that may
merit further investigation.
