### PR TITLE
Use overlay specific names for `keyboard_handling_context`.

### DIFF
--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -111,7 +111,7 @@ const keyboard_handling_context = {
     },
     items_container_selector: "drafts-container",
     items_list_selector: "drafts-list",
-    row_item_selector: "overlay-message-row",
+    row_item_selector: "draft-message-row",
     box_item_selector: "draft-message-info-box",
     id_attribute_name: "data-draft-id",
 };

--- a/web/src/drafts_overlay_ui.js
+++ b/web/src/drafts_overlay_ui.js
@@ -112,7 +112,7 @@ const keyboard_handling_context = {
     items_container_selector: "drafts-container",
     items_list_selector: "drafts-list",
     row_item_selector: "overlay-message-row",
-    box_item_selector: "overlay-message-info-box",
+    box_item_selector: "draft-message-info-box",
     id_attribute_name: "data-draft-id",
 };
 

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -63,7 +63,7 @@ const server_message_history_schema = z.object({
 const keyboard_handling_context: messages_overlay_ui.Context = {
     items_container_selector: "message-edit-history-container",
     items_list_selector: "message-edit-history-list",
-    row_item_selector: "overlay-message-row",
+    row_item_selector: "message-edit-message-row",
     box_item_selector: "message-edit-message-info-box",
     id_attribute_name: "data-message-edit-history-id",
     get_items_ids(): number[] {

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -64,7 +64,7 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
     items_container_selector: "message-edit-history-container",
     items_list_selector: "message-edit-history-list",
     row_item_selector: "overlay-message-row",
-    box_item_selector: "overlay-message-info-box",
+    box_item_selector: "message-edit-message-info-box",
     id_attribute_name: "data-message-edit-history-id",
     get_items_ids(): number[] {
         const edited_messages_ids: number[] = [];

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -45,7 +45,7 @@ export const keyboard_handling_context = {
     items_container_selector: "scheduled-messages-container",
     items_list_selector: "scheduled-messages-list",
     row_item_selector: "scheduled-message-row",
-    box_item_selector: "overlay-message-info-box",
+    box_item_selector: "scheduled-message-info-box",
     id_attribute_name: "data-scheduled-message-id",
 };
 
@@ -148,7 +148,7 @@ export function initialize() {
         e.preventDefault();
     });
 
-    $("body").on("focus", ".overlay-message-info-box", (e) => {
+    $("body").on("focus", ".scheduled-message-info-box", (e) => {
         messages_overlay_ui.activate_element(e.target, keyboard_handling_context);
     });
 }

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -42,7 +42,7 @@ export const keyboard_handling_context = {
         $focused_row.remove();
         scheduled_messages.delete_scheduled_message(focused_element_id);
     },
-    items_container_selector: "overlay-messages-container",
+    items_container_selector: "scheduled-messages-container",
     items_list_selector: "overlay-messages-list",
     row_item_selector: "scheduled-message-row",
     box_item_selector: "overlay-message-info-box",

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -43,7 +43,7 @@ export const keyboard_handling_context = {
         scheduled_messages.delete_scheduled_message(focused_element_id);
     },
     items_container_selector: "scheduled-messages-container",
-    items_list_selector: "overlay-messages-list",
+    items_list_selector: "scheduled-messages-list",
     row_item_selector: "scheduled-message-row",
     box_item_selector: "overlay-message-info-box",
     id_attribute_name: "data-scheduled-message-id",

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -1,4 +1,4 @@
-<div class="overlay-message-row" data-draft-id="{{draft_id}}">
+<div class="draft-message-row overlay-message-row" data-draft-id="{{draft_id}}">
     <div class="draft-message-info-box overlay-message-info-box" tabindex="0">
         {{#if is_stream}}
         <div class="message_header message_header_stream">

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -1,5 +1,5 @@
 <div class="overlay-message-row" data-draft-id="{{draft_id}}">
-    <div class="overlay-message-info-box" tabindex="0">
+    <div class="draft-message-info-box overlay-message-info-box" tabindex="0">
         {{#if is_stream}}
         <div class="message_header message_header_stream">
             <div class="message-header-contents" style="background: {{recipient_bar_color}};">

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -1,7 +1,7 @@
 {{! Client-side Handlebars template for viewing message edit history. }}
 
 {{#each edited_messages}}
-    <div class="overlay-message-row" data-message-edit-history-id="{{timestamp}}">
+    <div class="message-edit-message-row overlay-message-row" data-message-edit-history-id="{{timestamp}}">
         <div class="message-edit-message-info-box overlay-message-info-box" tabindex="0">
             {{#if is_stream }}
             <div class="message_header message_header_stream">

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -2,7 +2,7 @@
 
 {{#each edited_messages}}
     <div class="overlay-message-row" data-message-edit-history-id="{{timestamp}}">
-        <div class="overlay-message-info-box" tabindex="0">
+        <div class="message-edit-message-info-box overlay-message-info-box" tabindex="0">
             {{#if is_stream }}
             <div class="message_header message_header_stream">
                 <div class="message-header-contents" style="background: {{recipient_bar_color}};">

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -1,6 +1,6 @@
 {{#each scheduled_messages_data}}
     <div class="scheduled-message-row overlay-message-row" data-scheduled-message-id="{{scheduled_message_id}}">
-        <div class="overlay-message-info-box" tabindex="0">
+        <div class="scheduled-message-info-box overlay-message-info-box" tabindex="0">
             {{#if is_stream}}
             <div class="message_header message_header_stream">
                 <div class="message-header-contents" style="background: {{recipient_bar_color}};">

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -1,6 +1,6 @@
 <div id="scheduled_messages_overlay" class="overlay" data-overlay="scheduled">
     <div class="flex overlay-content">
-        <div class="overlay-messages-container overlay-container">
+        <div class="overlay-messages-container overlay-container scheduled-messages-container">
             <div class="overlay-messages-header">
                 <h1>{{t 'Scheduled messages' }}</h1>
                 <div class="exit">
@@ -13,7 +13,7 @@
                     {{/tr}}
                 </div>
             </div>
-            <div class="overlay-messages-list">
+            <div class="scheduled-messages-list overlay-messages-list">
                 <div class="no-overlay-messages">
                     {{t 'No scheduled messages.'}}
                 </div>


### PR DESCRIPTION
This fixes a bug where when selecting an element using their `class`, items from differnet overlay are selected due to them being not removed from DOM even though they are hidden.

This happens when user tries to open scheduled messages overlay after opening drafts overlay. Drafts overlays is not removed from DOM when hidden. When scheduled messages overlay is open, more than expected number of rows are selected due to usng a generic selector like `overlay-messages-list`.

Sentry - https://zulip.sentry.io/issues/5810649774/?project=4504556882821120