### PR TITLE
data_import: Check for invalid user emails when converting data.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -10,6 +10,8 @@ from typing import Any, Protocol, TypeAlias, TypeVar
 
 import orjson
 import requests
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.forms.models import model_to_dict
 from django.utils.timezone import now as timezone_now
 
@@ -825,3 +827,19 @@ def long_term_idle_helper(
             user_profile_row["last_active_message_id"] = 1
 
     return long_term_idle
+
+
+def validate_user_emails_for_import(user_emails: list[str]) -> None:
+    invalid_emails = []
+    for email in user_emails:
+        try:
+            validate_email(email)
+        except ValidationError:
+            invalid_emails.append(email)
+
+    if invalid_emails:
+        details = ", ".join(invalid_emails)
+        error_log = (
+            f"Invalid email format, please fix the following email(s) and try again: {details}"
+        )
+        raise ValidationError(error_log)

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -132,15 +132,11 @@ def convert_user_data(
     realm_id: int,
     team_name: str,
 ) -> None:
-    user_data_list = []
-    for username in user_data_map:
-        user = user_data_map[username]
-        if check_user_in_team(user, team_name) or user["is_mirror_dummy"]:
-            user_data_list.append(user)
-
-    for raw_item in user_data_list:
-        user = process_user(raw_item, realm_id, team_name, user_id_mapper)
-        user_handler.add_user(user)
+    for user_data in user_data_map.values():
+        if check_user_in_team(user_data, team_name) or user_data["is_mirror_dummy"]:
+            user = process_user(user_data, realm_id, team_name, user_id_mapper)
+            user_handler.add_user(user)
+    user_handler.validate_user_emails()
 
 
 def convert_channel_data(

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -128,6 +128,7 @@ def process_users(
         )
         user_handler.add_user(user)
 
+    user_handler.validate_user_emails()
     # Set the first realm_owner as the owner of
     # all the bots.
     if realm_owners:

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -39,6 +39,7 @@ from zerver.data_import.import_util import (
     process_avatars,
     process_emojis,
     process_uploads,
+    validate_user_emails_for_import,
 )
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.data_import.slack_message_conversion import (
@@ -358,6 +359,7 @@ def users_to_zerver_userprofile(
 
         logging.info("%s: %s -> %s", slack_user_id, user["name"], userprofile_dict["email"])
 
+    validate_user_emails_for_import(list(found_emails))
     process_customprofilefields(zerver_customprofilefield, zerver_customprofilefield_values)
     logging.info("######### IMPORTING USERS FINISHED #########\n")
     return (

--- a/zerver/data_import/user_handler.py
+++ b/zerver/data_import/user_handler.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from zerver.data_import.import_util import validate_user_emails_for_import
+
 
 class UserHandler:
     """
@@ -25,3 +27,7 @@ class UserHandler:
     def get_all_users(self) -> list[dict[str, Any]]:
         users = list(self.id_to_user_map.values())
         return users
+
+    def validate_user_emails(self) -> None:
+        all_users = self.get_all_users()
+        validate_user_emails_for_import([user["delivery_email"] for user in all_users])

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -202,6 +202,16 @@ class MatterMostImporter(ZulipTestCase):
         convert_user_data(user_handler, user_id_mapper, username_to_user, realm_id, team_name)
         self.assert_length(user_handler.get_all_users(), 3)
 
+        # Importer should raise error when user emails are malformed
+        team_name = "gryffindor"
+        bad_email1 = username_to_user["harry"]["email"] = "harry.ceramicist@zuL1[p.c0m"
+        bad_email2 = username_to_user["ron"]["email"] = "ron.ferret@zulup...com"
+        with self.assertRaises(Exception) as e:
+            convert_user_data(user_handler, user_id_mapper, username_to_user, realm_id, team_name)
+        error_message = str(e.exception)
+        expected_error_message = f"['Invalid email format, please fix the following email(s) and try again: {bad_email2}, {bad_email1}']"
+        self.assertEqual(error_message, expected_error_message)
+
     def test_convert_channel_data(self) -> None:
         fixture_file_name = self.fixture_file_name("export.json", "mattermost_fixtures")
         mattermost_data = mattermost_data_file_to_dict(fixture_file_name)

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -180,6 +180,22 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(user["is_mirror_dummy"], True)
         self.assertEqual(user["is_bot"], False)
 
+        # Importer should raise error when user emails are malformed
+        bad_email1 = rocketchat_data["user"][0]["emails"][0]["address"] = "test1@hotmai,l.om"
+        bad_email2 = rocketchat_data["user"][1]["emails"][0]["address"] = "test2@gmail.c"
+        user_id_to_user_map = map_user_id_to_user(rocketchat_data["user"])
+        with self.assertRaises(Exception) as e:
+            process_users(
+                user_id_to_user_map=user_id_to_user_map,
+                realm_id=realm_id,
+                domain_name=domain_name,
+                user_handler=user_handler,
+                user_id_mapper=user_id_mapper,
+            )
+        error_message = str(e.exception)
+        expected_error_message = f"['Invalid email format, please fix the following email(s) and try again: {bad_email1}, {bad_email2}']"
+        self.assertEqual(error_message, expected_error_message)
+
     def test_categorize_channels_and_map_with_id(self) -> None:
         fixture_dir_name = self.fixture_file_name("", "rocketchat_fixtures")
         rocketchat_data = rocketchat_data_to_dict(fixture_dir_name)


### PR DESCRIPTION
This PR makes the third-party data converters check for invalid user emails. If it finds any, it’ll raise an Exception and show an error message with all the bad emails listed out.

<details>

<summary>Error log when there are invalid user emails</summary>

```

Converting data ...
2024-10-10 05:48:17.320 INFO [] ######### IMPORTING USERS STARTED #########

2024-10-10 05:48:17.349 INFO [] USLACKBOT: slackbot -> imported-slackbot-bot@invalid.c
2024-10-10 05:48:17.351 INFO [] U06NU4E26M9: pieterceka123 -> pieterceka123@gmail.com
2024-10-10 05:48:17.363 INFO [] U07NFSVQCAD: pabbly_connect -> pabblyconnect-bot@invalid.c
Traceback (most recent call last):
  File "/srv/zulip/./manage.py", line 150, in <module>
    execute_from_command_line(sys.argv)
  File "/srv/zulip/./manage.py", line 115, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-venv-cache/b477df627afb33e3ce1cd594561fcbb9d3946a14/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-venv-cache/b477df627afb33e3ce1cd594561fcbb9d3946a14/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/zulip/zerver/lib/management.py", line 97, in execute
    super().execute(*args, **options)
  File "/srv/zulip-venv-cache/b477df627afb33e3ce1cd594561fcbb9d3946a14/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
  File "/srv/zulip/zerver/management/commands/convert_slack_data.py", line 79, in handle
    do_convert_zipfile(
  File "/srv/zulip/zerver/data_import/slack.py", line 1416, in do_convert_zipfile
    do_convert_directory(slack_data_dir, output_dir, token, threads, convert_slack_threads)
  File "/srv/zulip/zerver/data_import/slack.py", line 1460, in do_convert_directory
    ) = slack_workspace_to_realm(
  File "/srv/zulip/zerver/data_import/slack.py", line 182, in slack_workspace_to_realm
    ) = users_to_zerver_userprofile(slack_data_dir, user_list, realm_id, int(NOW), domain_name)
  File "/srv/zulip/zerver/data_import/slack.py", line 362, in users_to_zerver_userprofile
    validate_user_emails_for_import(list(found_emails))
  File "/srv/zulip/zerver/data_import/import_util.py", line 845, in validate_user_emails_for_import
    raise ValidationError(error_log)
django.core.exceptions.ValidationError: ['Invalid email format, please fix the following email(s) and try again: imported-slackbot-bot@invalid.c, export-bot-bot@invalid.c, pabblyconnect-bot@invalid.c']

```
</details>
Fixes: #31783


**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
