### PR TITLE
help-links: Limit billing related relative gear menu links.

### DIFF
--- a/help/zulip-cloud-billing.md
+++ b/help/zulip-cloud-billing.md
@@ -10,7 +10,7 @@ don't hesitate to reach out at [sales@zulip.com](mailto:sales@zulip.com).
 
 {tab|by-card}
 
-{relative|gear|plans}
+{relative|gear-billing|plans}
 
 1. On the page listing Zulip Cloud plans, click the button at the bottom
    of the plan you would like to purchase.
@@ -21,7 +21,7 @@ don't hesitate to reach out at [sales@zulip.com](mailto:sales@zulip.com).
 
 {!pay-by-invoice-warning.md!}
 
-{relative|gear|plans}
+{relative|gear-billing|plans}
 
 1. On the page listing Zulip Cloud plans, click the button at the bottom
    of the plan you would like to purchase.
@@ -38,7 +38,7 @@ don't hesitate to reach out at [sales@zulip.com](mailto:sales@zulip.com).
 
 {tab|desktop-web}
 
-{relative|gear|billing}
+{relative|gear-billing|billing}
 
 {end_tabs}
 
@@ -51,7 +51,7 @@ Free** at the end of the current billing period.
 
 {tab|desktop-web}
 
-{relative|gear|billing}
+{relative|gear-billing|billing}
 
 1. At the bottom of the page, click **Cancel plan**.
 
@@ -190,7 +190,7 @@ tool.
 
 {tab|desktop-web}
 
-{relative|gear|billing}
+{relative|gear-billing|billing}
 
 {!manual-add-license-instructions.md!}
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -38,8 +38,6 @@ gear_info = {
     ],
     "stats": ['<i class="zulip-icon zulip-icon-bar-chart"></i> Usage statistics', "/stats"],
     "integrations": ['<i class="zulip-icon-git-pull-request"></i> Integrations', "/integrations/"],
-    "plans": ['<i class="zulip-icon zulip-icon-rocket"></i> Plans and pricing', "/plans/"],
-    "billing": ['<i class="zulip-icon zulip-icon-credit-card"></i> Billing', "/billing/"],
     "about-zulip": ["About Zulip", "/#about-zulip"],
 }
 
@@ -56,6 +54,25 @@ def gear_handle_match(key: str) -> str:
         item = f"[{gear_info[key][0]}]({gear_info[key][1]})"
     else:
         item = f"**{gear_info[key][0]}**"
+    return gear_instructions.format(item=item)
+
+
+billing_info = {
+    # The pattern is key: [name, link]
+    # key is from REGEXP: `{relative|gear-billing|key}`
+    # name is what the item is called in the help menu: `Select **name**.`
+    # link is used for relative links: `Select [name](link).`
+    # Note that links are only used when billing is enabled.
+    "plans": ['<i class="zulip-icon zulip-icon-rocket"></i> Plans and pricing', "/plans/"],
+    "billing": ['<i class="zulip-icon zulip-icon-credit-card"></i> Billing', "/billing/"],
+}
+
+
+def billing_handle_match(key: str) -> str:
+    if relative_help_links and billing_help_links:
+        item = f"[{billing_info[key][0]}]({billing_info[key][1]})"
+    else:
+        item = f"**{billing_info[key][0]}**"
     return gear_instructions.format(item=item)
 
 
@@ -190,6 +207,7 @@ def message_handle_match(key: str) -> str:
 
 LINK_TYPE_HANDLERS = {
     "gear": gear_handle_match,
+    "gear-billing": billing_handle_match,
     "channel": channel_handle_match,
     "message": message_handle_match,
     "help": help_handle_match,
@@ -208,11 +226,14 @@ class RelativeLinksHelpExtension(Extension):
 
 
 relative_help_links: bool = False
+billing_help_links: bool = False
 
 
-def set_relative_help_links(value: bool) -> None:
+def set_relative_help_links(relative_links: bool, billing_links: bool) -> None:
     global relative_help_links
-    relative_help_links = value
+    global billing_help_links
+    relative_help_links = relative_links
+    billing_help_links = billing_links
 
 
 class RelativeLinks(Preprocessor):

--- a/zerver/lib/templates.py
+++ b/zerver/lib/templates.py
@@ -98,10 +98,12 @@ def render_markdown_path(
     # We set this global hackishly
     from zerver.lib.markdown.help_settings_links import set_relative_settings_links
 
-    set_relative_settings_links(bool(context is not None and context.get("html_settings_links")))
+    relative_links = bool(context is not None and context.get("html_settings_links"))
+    set_relative_settings_links(relative_links)
     from zerver.lib.markdown.help_relative_links import set_relative_help_links
 
-    set_relative_help_links(bool(context is not None and context.get("html_settings_links")))
+    billing_relative_links = bool(context is not None and context.get("corporate_enabled"))
+    set_relative_help_links(relative_links, billing_relative_links)
 
     global md_extensions, md_macro_extension
     if md_extensions is None:

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -424,6 +424,32 @@ class HelpTest(ZulipTestCase):
         )
         self.assertNotIn("/stats", str(result.content))
 
+    def test_help_relative_gear_billing_links(self) -> None:
+        result = self.client_get("/help/zulip-cloud-billing")
+        self.assertIn(
+            '<a href="/plans/"><i class="zulip-icon zulip-icon-rocket"></i> Plans and pricing</a>',
+            str(result.content),
+        )
+        self.assertEqual(result.status_code, 200)
+
+        with self.settings(CORPORATE_ENABLED=False):
+            result = self.client_get("/help/zulip-cloud-billing")
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(
+            '<strong><i class="zulip-icon zulip-icon-rocket"></i> Plans and pricing</strong>',
+            str(result.content),
+        )
+        self.assertNotIn('<a href="/plans/">', str(result.content))
+
+        with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
+            result = self.client_get("/help/zulip-cloud-billing", subdomain="")
+        self.assertEqual(result.status_code, 200)
+        self.assertIn(
+            '<strong><i class="zulip-icon zulip-icon-rocket"></i> Plans and pricing</strong>',
+            str(result.content),
+        )
+        self.assertNotIn('a href="/plans/">', str(result.content))
+
     def test_help_relative_links_for_stream(self) -> None:
         result = self.client_get("/help/message-a-channel-by-email")
         self.assertIn(


### PR DESCRIPTION
In order to only generate relative links for Zulip Cloud billing specific gear menu options in relevant help center articles, we pass down `settings.CORPORATE_ENABLED` to be set as a global variable for `zerver/lib/markdown/help_relative_links.py` so that self-hosted servers' help center documentation will not have these links.

**Notes**:
- Another option would be to never link the billing gear menu instructions in the help center, which is what is done on the self-hosted billing help center article.

@shubham-padia - Flagging your review on these changes in case they'd negatively impact work towards #31253.

---

**Screenshots and screen captures:**

<details>
<summary>Gear menu billing not linked when corporate is not enabled</summary>

![Screenshot from 2024-09-30 13-09-41](https://github.com/user-attachments/assets/2fd94503-96d6-4d12-8b9b-c202b464f16e)
</details>
<details>
<summary>Gear menu billing linked when corporate is enabled</summary>

![Screenshot from 2024-09-30 13-09-18](https://github.com/user-attachments/assets/19305390-606c-4f2e-a6ce-cc747c2ea8f3)
</details>
<details>
<summary>Gear menu billing not linked when root domain is landing page</summary>

![Screenshot from 2024-09-30 13-08-55](https://github.com/user-attachments/assets/2f3ceb1b-77b4-4c35-8807-61066d6f339a)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
