### PR TITLE
user_groups: Show details in group deactivation error.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 298**
+
+* [`POST /user_groups/{user_group_id}/deactivate`](/api/deactivate-user-group):
+  Server now returns a specific error response (`"code": CANNOT_DEACTIVATE_GROUP_IN_USE`)
+  when a user group cannot be deactivated because it is in use. The
+  error response contains details about where the user group is being used.
+
 **Feature level 297**
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue):

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 297  # Last bumped for saved_snippets
+API_FEATURE_LEVEL = 298  # Last bumped for CANNOT_DEACTIVATE_GROUP_IN_USE error.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -512,6 +512,7 @@ function hashchanged(from_reload, e) {
 
     if (hash_parser.is_overlay_hash(current_hash)) {
         browser_history.state.changing_hash = true;
+        modals.close_active_if_any();
         do_hashchange_overlay(old_hash);
         browser_history.state.changing_hash = false;
         return undefined;

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -886,8 +886,17 @@ function parse_args_for_deactivation_banner(objections) {
         if (objection.type === "channel") {
             const stream_id = objection.channel_id;
             const sub = stream_data.get_sub_by_id(stream_id);
-            const setting_url = hash_util.channels_settings_edit_url(sub, "general");
-            args.streams_using_group_for_setting.push({stream_name: sub.name, setting_url});
+            if (sub !== undefined) {
+                args.streams_using_group_for_setting.push({
+                    stream_name: sub.name,
+                    setting_url: hash_util.channels_settings_edit_url(sub, "general"),
+                });
+            } else {
+                args.streams_using_group_for_setting.push({
+                    stream_name: $t({defaultMessage: "Unknown stream"}),
+                    setting_url: undefined,
+                });
+            }
             continue;
         }
 

--- a/web/templates/user_group_settings/cannot_deactivate_group_banner.hbs
+++ b/web/templates/user_group_settings/cannot_deactivate_group_banner.hbs
@@ -2,7 +2,11 @@
     {{t "This group cannot be deactivated because it is used in following places:"}}
     <ul>
         {{#each streams_using_group_for_setting}}
+            {{#if this.setting_url}}
             <li><a href="{{this.setting_url}}">#{{this.stream_name}}</a></li>
+            {{else}}
+            <li>{{this.stream_name}}</li>
+            {{/if}}
         {{/each}}
         {{#each groups_using_group_for_setting}}
             <li><a href="{{this.setting_url}}">@{{this.group_name}}</a></li>

--- a/web/templates/user_group_settings/cannot_deactivate_group_banner.hbs
+++ b/web/templates/user_group_settings/cannot_deactivate_group_banner.hbs
@@ -1,0 +1,14 @@
+<p>
+    {{t "This group cannot be deactivated because it is used in following places:"}}
+    <ul>
+        {{#each streams_using_group_for_setting}}
+            <li><a href="{{this.setting_url}}">#{{this.stream_name}}</a></li>
+        {{/each}}
+        {{#each groups_using_group_for_setting}}
+            <li><a href="{{this.setting_url}}">@{{this.group_name}}</a></li>
+        {{/each}}
+        {{#if realm_using_group_for_setting}}
+            <li><a href="#organization">{{t "Organization settings"}}</a></li>
+        {{/if}}
+    </ul>
+</p>

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -54,6 +54,7 @@ class ErrorCode(Enum):
     PUSH_NOTIFICATIONS_DISALLOWED = auto()
     EXPECTATION_MISMATCH = auto()
     SYSTEM_GROUP_REQUIRED = auto()
+    CANNOT_DEACTIVATE_GROUP_IN_USE = auto()
 
 
 class JsonableError(Exception):
@@ -715,3 +716,19 @@ class IncompatibleParameterValuesError(JsonableError):
     @override
     def msg_format() -> str:
         return _("Incompatible values for '{first_parameter}' and '{second_parameter}'.")
+
+
+class CannotDeactivateGroupInUseError(JsonableError):
+    code = ErrorCode.CANNOT_DEACTIVATE_GROUP_IN_USE
+    data_fields = ["objections"]
+
+    def __init__(
+        self,
+        objections: list[dict[str, Any]],
+    ) -> None:
+        self.objections = objections
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Cannot deactivate user group in use.")

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20651,6 +20651,44 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Invalid user group",
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response when the user group ID is invalid.
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "CANNOT_DEACTIVATE_GROUP_IN_USE",
+                            "msg": "Cannot deactivate user group in use.",
+                            "objections":
+                              [
+                                {
+                                  "type": "realm",
+                                  "settings":
+                                    ["can_create_public_channel_group"],
+                                },
+                              ],
+                            "result": "error",
+                          }
+                        description: |
+                          An example JSON response when the user group being deactivated
+                          is used for a setting or as a subgroup.
+
+                          **Changes**: New in Zulip 10.0 (feature level 298). Previously,
+                          this error returned the `"BAD_REQUEST"` code.
   /real-time:
     # This entry is a hack; it exists to give us a place to put the text
     # documenting the parameters for call_on_each_event and friends.

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1355,8 +1355,10 @@ class UserGroupAPITestCase(UserGroupTestCase):
         )
         # Check that group that is subgroup of another group cannot be deactivated.
         result = self.client_post(f"/json/user_groups/{leadership_group.id}/deactivate")
-        self.assert_json_error(
-            result, "You cannot deactivate a user group that is subgroup of any user group."
+        self.assert_json_error(result, "Cannot deactivate user group in use.")
+        data = orjson.loads(result.content)
+        self.assertEqual(
+            data["objections"], [{"type": "subgroup", "supergroup_ids": [support_group.id]}]
         )
 
         # If the supergroup is itself deactivated, then subgroup can be deactivated.
@@ -1393,18 +1395,18 @@ class UserGroupAPITestCase(UserGroupTestCase):
             )
 
             result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
-            self.assert_json_error(
-                result, "You cannot deactivate a user group which is used for setting."
-            )
+            self.assert_json_error(result, "Cannot deactivate user group in use.")
+            data = orjson.loads(result.content)
+            self.assertEqual(data["objections"], [{"type": "realm", "settings": [setting_name]}])
 
             do_change_realm_permission_group_setting(
                 realm, setting_name, support_group, acting_user=None
             )
 
             result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
-            self.assert_json_error(
-                result, "You cannot deactivate a user group which is used for setting."
-            )
+            self.assert_json_error(result, "Cannot deactivate user group in use.")
+            data = orjson.loads(result.content)
+            self.assertEqual(data["objections"], [{"type": "realm", "settings": [setting_name]}])
 
             # Reset the realm setting to one of the system group so this setting
             # does not interfere when testing for another setting.
@@ -1419,8 +1421,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
             )
 
             result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
-            self.assert_json_error(
-                result, "You cannot deactivate a user group which is used for setting."
+            self.assert_json_error(result, "Cannot deactivate user group in use.")
+            data = orjson.loads(result.content)
+            self.assertEqual(
+                data["objections"],
+                [{"type": "channel", "channel_id": stream.id, "settings": [setting_name]}],
             )
 
             # Test the group can be deactivated, if the stream which uses
@@ -1444,8 +1449,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
             )
 
             result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
-            self.assert_json_error(
-                result, "You cannot deactivate a user group which is used for setting."
+            self.assert_json_error(result, "Cannot deactivate user group in use.")
+            data = orjson.loads(result.content)
+            self.assertEqual(
+                data["objections"],
+                [{"type": "channel", "channel_id": stream.id, "settings": [setting_name]}],
             )
 
             # Test the group can be deactivated, if the stream which uses
@@ -1473,8 +1481,17 @@ class UserGroupAPITestCase(UserGroupTestCase):
             )
 
             result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
-            self.assert_json_error(
-                result, "You cannot deactivate a user group which is used for setting."
+            self.assert_json_error(result, "Cannot deactivate user group in use.")
+            data = orjson.loads(result.content)
+            self.assertEqual(
+                data["objections"],
+                [
+                    {
+                        "type": "user_group",
+                        "group_id": leadership_group.id,
+                        "settings": [setting_name],
+                    }
+                ],
             )
 
             # Test the group can be deactivated, if the user group which uses
@@ -1499,8 +1516,17 @@ class UserGroupAPITestCase(UserGroupTestCase):
             )
 
             result = self.client_post(f"/json/user_groups/{support_group.id}/deactivate")
-            self.assert_json_error(
-                result, "You cannot deactivate a user group which is used for setting."
+            self.assert_json_error(result, "Cannot deactivate user group in use.")
+            data = orjson.loads(result.content)
+            self.assertEqual(
+                data["objections"],
+                [
+                    {
+                        "type": "user_group",
+                        "group_id": leadership_group.id,
+                        "settings": [setting_name],
+                    }
+                ],
             )
 
             # Test the group can be deactivated, if the user group which uses


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit adds backend code to include the details of supergroups and of the groups and streams for which the group is being used as setting.
- Second commit adds the frontend code to show the details.

Fixes:  <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/stream/101-design/topic/Support.20user.20group.20deactivation/near/1949585

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/33e367f7-845a-4382-87c0-13214bc8a14a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
