### PR TITLE
dark_theme: Adjust message colors for higher contrast.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1338,7 +1338,7 @@
     --color-background-widget-input: hsl(225deg 6% 10%);
     --color-background-widget-button: hsl(0deg 0% 0% / 20%);
     --color-background-navbar: hsl(0deg 0% 13%);
-    --color-text-sidebar-row: hsl(0deg 0% 100% / 75%);
+    --color-text-sidebar-row: hsl(0deg 0% 100% / 85%);
     --color-text-active-narrow-filter: hsl(0deg 0% 90%);
     --color-background-active-narrow-filter: color-mix(
         in srgb,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1325,7 +1325,7 @@
     --color-date: hsl(0deg 0% 100% / 75%);
     --color-background-private-message-header: hsl(46deg 15% 20%);
     --color-background-private-message-content: hsl(46deg 7% 16%);
-    --color-background-stream-message-content: hsl(0deg 0% 15%);
+    --color-background-stream-message-content: hsl(0deg 0% 13.5%);
     --color-message-header-icon-non-interactive: hsl(0deg 0% 100% / 30%);
     --color-message-header-icon-interactive: hsl(0deg 0% 100%);
     --color-message-header-contents-border: hsl(0deg 0% 0% / 60%);
@@ -1522,12 +1522,12 @@
     --color-compose-focus-ring: hsl(0deg 0% 67%);
 
     /* Text colors */
-    --color-text-default: hsl(0deg 0% 85%);
+    --color-text-default: hsl(0deg 0% 87%);
     /* Unlike the light theme, the dark theme renders message
        text in the default color. */
     --color-text-message-default: var(--color-text-default);
-    --color-text-message-view-header: hsl(0deg 0% 100% / 80%);
-    --color-text-message-header: hsl(0deg 0% 100% / 80%);
+    --color-text-message-view-header: hsl(0deg 0% 100% / 85%);
+    --color-text-message-header: hsl(0deg 0% 100% / 85%);
     --color-text-sender-name: hsl(0deg 0% 100% / 85%);
     --color-text-dropdown-input: hsl(0deg 0% 95%);
     --color-text-other-mention: hsl(0deg 0% 100% / 80%);
@@ -1708,8 +1708,8 @@
     --color-message-edit-history-background-deleted: hsl(7deg 54% 62% / 38%);
 
     /* Mention pill colors */
-    --color-background-direct-mention: hsl(240deg 13% 20%);
-    --color-background-group-mention: hsl(180deg 13% 15%);
+    --color-background-direct-mention: hsl(240deg 13% 16%);
+    --color-background-group-mention: hsl(180deg 13% 14%);
     --color-background-text-direct-mention: hsl(240deg 52% 60% / 25%);
     --color-background-text-hover-direct-mention: hsl(240deg 52% 60% / 45%);
     --color-background-text-group-mention: hsl(183deg 52% 40% / 20%);


### PR DESCRIPTION
This PR includes color adjustments suggested by @terpimost.

[CZO discussion](https://chat.zulip.org/#narrow/stream/137-feedback/topic/design.20feedback/near/1950672)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dark-mode-message-area-before](https://github.com/user-attachments/assets/146eda5a-48b9-4486-9fa1-cd8b12eee492) | ![dark-mode-message-area-after](https://github.com/user-attachments/assets/f3470600-2d72-44b6-b94c-2b9cf3254854) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>