### PR TITLE
`GET /users/{email}`: Allow lookup by real email whenever the target allows the requester access to the real email

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 302**
+
+* [`GET /users/{email}`](/api/get-user-by-email): Changed the `email`
+  values by which users can successfully be looked up to match the
+  user email visibility setting's semantics better.
+
 **Feature level 301**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 301  # Last bumped for can_join_group setting.
+API_FEATURE_LEVEL = 302  # Last bumped for changes to {email} requirements for GET /users/{email}
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from email.headerregistry import Address
 
@@ -65,8 +66,29 @@ def copy_default_settings(
     copy_onboarding_steps(settings_source, target_profile)
 
 
+def get_dummy_email_address_for_display_regex(realm: Realm) -> str:
+    """
+    Returns a regex that matches the format of dummy email addresses we
+    generate for the .email of users with limit email_address_visibility.
+
+    The reason we need a regex is that we want something that we can use both
+    for generating the dummy email addresses and recognizing them together with extraction
+    of the user ID.
+    """
+
+    # We can't directly have (\d+) in the username passed to Address, because it gets
+    # mutated by the underlying logic for escaping special characters.
+    # So we use a trick by using $ as a placeholder which will be preserved, and then
+    # replace it with (\d+) to obtain our intended regex.
+    address_template = Address(username="user$", domain=get_fake_email_domain(realm.host)).addr_spec
+    regex = re.escape(address_template).replace(r"\$", r"(\d+)", 1)
+    return regex
+
+
 def get_display_email_address(user_profile: UserProfile) -> str:
     if not user_profile.email_address_is_realm_public():
+        # The format of the dummy email address created here needs to stay consistent
+        # with get_dummy_email_address_for_display_regex.
         return Address(
             username=f"user{user_profile.id}", domain=get_fake_email_domain(user_profile.realm.host)
         ).addr_spec

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -510,20 +510,10 @@ def can_access_delivery_email(
     if target_user_id == user_profile.id:
         return True
 
-    # Bots always have email_address_visibility as EMAIL_ADDRESS_VISIBILITY_EVERYONE.
-    if email_address_visibility == UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
-        return True
-
-    if email_address_visibility == UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS:
-        return user_profile.is_realm_admin
-
-    if email_address_visibility == UserProfile.EMAIL_ADDRESS_VISIBILITY_MODERATORS:
-        return user_profile.is_realm_admin or user_profile.is_moderator
-
-    if email_address_visibility == UserProfile.EMAIL_ADDRESS_VISIBILITY_MEMBERS:
-        return not user_profile.is_guest
-
-    return False
+    return (
+        email_address_visibility
+        in UserProfile.ROLE_TO_ACCESSIBLE_EMAIL_ADDRESS_VISIBILITY_IDS[user_profile.role]
+    )
 
 
 class APIUserDict(TypedDict):

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -523,6 +523,35 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
         ROLE_GUEST,
     ]
 
+    # Maps: user_profile.role -> which email_address_visibility values
+    # allow user_profile to see their email address.
+    ROLE_TO_ACCESSIBLE_EMAIL_ADDRESS_VISIBILITY_IDS = {
+        ROLE_REALM_OWNER: [
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MEMBERS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        ],
+        ROLE_REALM_ADMINISTRATOR: [
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MEMBERS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        ],
+        ROLE_MODERATOR: [
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MEMBERS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        ],
+        ROLE_MEMBER: [
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_MEMBERS,
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        ],
+        ROLE_GUEST: [
+            UserBaseSettings.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        ],
+    }
+
     # Whether the user has been "soft-deactivated" due to weeks of inactivity.
     # For these users we avoid doing UserMessage table work, as an optimization
     # for large Zulip organizations with lots of single-visit users.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12369,9 +12369,17 @@ paths:
         Fetching by user ID is generally recommended when possible,
         as a user might [change their email address](/help/change-your-email-address)
         or change their [email address visibility](/help/configure-email-visibility),
-        either of which could change the value of their Zulip API email address.
+        either of which could change the client's ability to look them up by that
+        email address.
 
-        **Changes**: New in Zulip Server 4.0 (feature level 39).
+        **Changes**: Starting with Zulip 10.0 (feature level 302), the real email
+        address can be used in the `email` parameter and will fetch the target user's
+        data if and only if the target's email visibility setting permits the requester
+        to see the email address.
+        The dummy email addresses of the form `user{id}@{realm.host}` still work, and
+        will now work for **all** users, via identifying them by the embedded user ID.
+
+        New in Zulip Server 4.0 (feature level 39).
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -12388,7 +12396,24 @@ paths:
         - name: email
           in: path
           description: |
-            The Zulip API email address of the user whose details you want to fetch.
+            The email address of the user to fetch. Two forms are supported:
+
+            - The real email address of the user (`delivery_email`). The lookup will
+              succeed if and only if the user exists and their email address visibility
+              setting permits the client to see the email address.
+
+            - The dummy Zulip API email address of the form `user{user_id}@{realm_host}`. This
+              is identical to simply [getting user by ID](/api/get-user). If the server or
+              realm change domains, the dummy email address used has to be adjustment to
+              match the new realm domain. This is legacy behavior for
+              backwards-compatibility, and will be removed in a future release.
+
+            **Changes**: Starting with Zulip 10.0 (feature level 302), lookups by real email
+            address match the semantics of the target's email visibility setting and dummy
+            email addresses work for all users, independently of their email visibility
+            setting.
+
+            Previously, lookups were done only using the Zulip API email addresses.
           schema:
             type: string
           example: iago@zulip.com


### PR DESCRIPTION
Implements the change to `GET /users/{email}` discussed around https://chat.zulip.org/#narrow/stream/378-api-design/topic/Update.20user.2C.20queried.20by.20real.20email.20-.20new.20endpoint/near/1937254 

The old behavior was for this endpoint to just naively lookup the target by the `.email` attribute. This translated to very quirky behavior requiring API users to be aware of implementation details of the email visibility setting:
- If the target had at all restricted email visibility, they couldn't be looked up by their real email, even if the requester **was** allowed to access that user's email. That restriction was logically unnecessary.
- Instead, the user **had** to be looked up via the dummy email `user{id}@{realm.host}`, which was the value of their `.email` attribute. 
- If the target had `EMAIL_ADDRESS_VISIBILITY_EVERYONE`, they had to be looked up by the real email, because that's what both `.email` and `.delivery_email` were  set to.
- Looking up such a user by the dummy email `user{id}@{realm.host}` would fail. This again didn't make much sense - if ``user{id}@{realm.host}`` works for most users, it shouldn't fail for another user just because it has a more liberal email visibility setting.

The new behavior aims to achieve a more natural behavior where:
- Lookups by ``user{id}@{realm.host}`` **always** work and fetch the user by the embedded `id`, regardless of what the implementation made their internal  `.email` attribute happen to be.
- Lookups by real email will return the result when the requester is allowed to see the email address of the target.

(The changes here will be used to next add `update_user_by_email` API (`PATCH /users/{email}`) in #31332)