### PR TITLE
buddy_list: Rotate the header triangle when collapsing a section.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -354,22 +354,59 @@ export class BuddyList extends BuddyListConf {
         }
     }
 
-    render_section_headers(): void {
-        const {
-            current_sub,
-            total_human_subscribers_count,
+    update_section_header_counts(): void {
+        const {total_human_subscribers_count, other_users_count, participant_ids_set} =
+            this.render_data;
+        const subscriber_section_user_count =
+            total_human_subscribers_count - this.participant_user_ids.length;
+
+        const formatted_participants_count = get_formatted_sub_count(participant_ids_set.size);
+        const formatted_sub_users_count = get_formatted_sub_count(subscriber_section_user_count);
+        const formatted_other_users_count = get_formatted_sub_count(other_users_count);
+
+        $("#buddy-list-participants-container .buddy-list-heading-user-count").text(
+            formatted_participants_count,
+        );
+        $("#buddy-list-users-matching-view-container .buddy-list-heading-user-count").text(
+            formatted_sub_users_count,
+        );
+        $("#buddy-list-other-users-container .buddy-list-heading-user-count").text(
+            formatted_other_users_count,
+        );
+
+        $("#buddy-list-participants-section-heading").attr(
+            "data-user-count",
+            participant_ids_set.size,
+        );
+        $("#buddy-list-users-matching-view-section-heading").attr(
+            "data-user-count",
+            subscriber_section_user_count,
+        );
+        $("#buddy-list-users-other-users-section-heading").attr(
+            "data-user-count",
             other_users_count,
-            total_human_users,
-            hide_headers,
-            participant_ids_set,
-        } = this.render_data;
+        );
+    }
+
+    render_section_headers(): void {
+        const {hide_headers, participant_ids_set} = this.render_data;
+        // We only show the participants list if it has members, so updating even if we're updating
+        // the count, that can affect if we show/hide this section.
+        const show_participants_list = !hide_headers && participant_ids_set.size;
+        $("#buddy-list-participants-container").toggleClass("no-display", !show_participants_list);
+        if ($(".buddy-list-subsection-header").children().length) {
+            this.update_section_header_counts();
+            return;
+        }
+
+        const {current_sub, total_human_subscribers_count, other_users_count, total_human_users} =
+            this.render_data;
         $(".buddy-list-subsection-header").empty();
 
         // If we're in the mode of hiding headers, that means we're only showing the "other users"
         // section, so hide the other two sections.
         $("#buddy-list-users-matching-view-container").toggleClass("no-display", hide_headers);
-        const show_participants_list = !hide_headers && participant_ids_set.size;
-        $("#buddy-list-participants-container").toggleClass("no-display", !show_participants_list);
+
         // This is the case where every subscriber is in the participants list. In this case, we
         // hide the "others in this channel" section.
         if (

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -484,11 +484,11 @@ export class BuddyList extends BuddyListConf {
             this.participants_is_collapsed,
         );
         $("#buddy-list-participants-container .toggle-participants").toggleClass(
-            "fa-caret-down",
+            "rotate-icon-down",
             !this.participants_is_collapsed,
         );
         $("#buddy-list-participants-container .toggle-participants").toggleClass(
-            "fa-caret-right",
+            "rotate-icon-right",
             this.participants_is_collapsed,
         );
 
@@ -504,11 +504,11 @@ export class BuddyList extends BuddyListConf {
             this.users_matching_view_is_collapsed,
         );
         $("#buddy-list-users-matching-view-container .toggle-users-matching-view").toggleClass(
-            "fa-caret-down",
+            "rotate-icon-down",
             !this.users_matching_view_is_collapsed,
         );
         $("#buddy-list-users-matching-view-container .toggle-users-matching-view").toggleClass(
-            "fa-caret-right",
+            "rotate-icon-right",
             this.users_matching_view_is_collapsed,
         );
 
@@ -524,11 +524,11 @@ export class BuddyList extends BuddyListConf {
             this.other_users_is_collapsed,
         );
         $("#buddy-list-other-users-container .toggle-other-users").toggleClass(
-            "fa-caret-down",
+            "rotate-icon-down",
             !this.other_users_is_collapsed,
         );
         $("#buddy-list-other-users-container .toggle-other-users").toggleClass(
-            "fa-caret-right",
+            "rotate-icon-right",
             this.other_users_is_collapsed,
         );
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -26,8 +26,21 @@ $user_status_emoji_width: 24px;
     overflow: auto;
 }
 
-.buddy-list-section-toggle {
+.buddy-list-section-toggle.fa-caret-right {
     width: 7px;
+    transition: rotate 140ms linear;
+    /* The triangle icon has asymmetrical padding on it, so
+       when it rotates down it would be too high without
+       this padding. */
+    padding-left: 2px;
+
+    &.rotate-icon-down {
+        rotate: 90deg;
+    }
+
+    &.rotate-icon-right {
+        rotate: 0deg;
+    }
 }
 
 .buddy-list-section-container {

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,4 +1,4 @@
 <h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
-    {{header_text}} ({{user_count}})
+    {{header_text}} (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
 </h5>
 <i class="buddy-list-section-toggle {{toggle_class}} fa fa-sm {{#if is_collapsed}}fa-caret-right{{else}}fa-caret-down{{/if}}" aria-hidden="true"></i>

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,4 +1,4 @@
 <h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
     {{header_text}} (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
 </h5>
-<i class="buddy-list-section-toggle {{toggle_class}} fa fa-sm {{#if is_collapsed}}fa-caret-right{{else}}fa-caret-down{{/if}}" aria-hidden="true"></i>
+<i class="buddy-list-section-toggle {{toggle_class}} fa fa-sm fa-caret-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>

--- a/web/tests/lib/buddy_list.js
+++ b/web/tests/lib/buddy_list.js
@@ -44,4 +44,5 @@ exports.stub_buddy_list_elements = () => {
     $("#buddy-list-other-users-container .view-all-users-link").length = 0;
     $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove = noop;
     $("#buddy-list-other-users-container .view-all-users-link").remove = noop;
+    $(".buddy-list-subsection-header").children = () => [];
 };


### PR DESCRIPTION

<details>
<summary>screen capture</summary>

![Kapture 2024-09-30 at 17 10 26](https://github.com/user-attachments/assets/1dee23f5-7c86-4274-bbc2-5fbe0820df74)

</details>

To better match Vlad's designs: https://terpimost.github.io/zulip-sidebar/