### PR TITLE
buddy_list: Change how "Invite users to organization" link is shown.

### DIFF
--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -17,13 +17,6 @@ function get_new_heights(): {
 } {
     const viewport_height = message_viewport.height();
 
-    // If invite user link is not displayed, `.right-sidebar-shortcuts` is displayed with just
-    // margin which we don't want to consider in height calculation of buddy list.
-    let right_sidebar_shortcuts_height = 0;
-    if ($("#right-sidebar .invite-user-link").css("display") !== "none") {
-        right_sidebar_shortcuts_height = $(".right-sidebar-shortcuts").outerHeight(true) ?? 0;
-    }
-
     let stream_filters_max_height =
         viewport_height -
         Number.parseInt($("#left-sidebar").css("paddingTop"), 10) -
@@ -41,8 +34,7 @@ function get_new_heights(): {
         viewport_height -
         Number.parseInt($("#right-sidebar").css("paddingTop"), 10) -
         ($("#userlist-header").outerHeight(true) ?? 0) -
-        ($("#user_search_section:not(.notdisplayed)").outerHeight(true) ?? 0) -
-        right_sidebar_shortcuts_height;
+        ($("#user_search_section:not(.notdisplayed)").outerHeight(true) ?? 0);
 
     const buddy_list_wrapper_max_height = Math.max(80, usable_height);
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -679,7 +679,7 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: "#userlist-header",
+        target: "#userlist-header-search",
         placement: "top",
         appendTo: () => document.body,
         onShow(instance) {

--- a/web/src/user_search.ts
+++ b/web/src/user_search.ts
@@ -25,7 +25,7 @@ export class UserSearch {
         $("#clear_search_people_button").on("click", () => {
             this.clear_search();
         });
-        $("#userlist-header").on("click", () => {
+        $("#userlist-header-search").on("click", () => {
             this.toggle_filter_displayed();
         });
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -49,9 +49,9 @@ $user_status_emoji_width: 24px;
     }
 }
 
-.buddy-list-section li {
+.buddy-list-section li,
+#userlist-header {
     .user-list-sidebar-menu-icon {
-        visibility: hidden;
         justify-self: stretch;
         display: flex;
         align-items: center;
@@ -91,7 +91,6 @@ $user_status_emoji_width: 24px;
 
     &:hover {
         .user-list-sidebar-menu-icon {
-            visibility: visible;
             cursor: pointer;
             color: var(--color-vdots-visible);
 
@@ -108,6 +107,16 @@ $user_status_emoji_width: 24px;
     overflow-x: hidden;
     list-style-position: inside; /* Draw the bullets inside our box */
     line-height: var(--line-height-sidebar-row);
+
+    .user-list-sidebar-menu-icon {
+        visibility: hidden;
+    }
+
+    li:hover {
+        .user-list-sidebar-menu-icon {
+            visibility: visible;
+        }
+    }
 
     & li {
         overflow: hidden;
@@ -339,7 +348,7 @@ $user_status_emoji_width: 24px;
     cursor: pointer;
     display: grid;
     grid-template-rows: var(--line-height-sidebar-row-prominent);
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     margin-right: var(--width-simplebar-scroll-hover);
 
@@ -368,6 +377,11 @@ $user_status_emoji_width: 24px;
     &:hover > #user_filter_icon {
         opacity: 1;
         cursor: pointer;
+    }
+
+    #buddy-list-menu-icon {
+        justify-content: center;
+        display: grid;
     }
 }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -339,9 +339,16 @@ $user_status_emoji_width: 24px;
     cursor: pointer;
     display: grid;
     grid-template-rows: var(--line-height-sidebar-row-prominent);
-    grid-template-columns: minmax(0, 1fr) 20px;
+    grid-template-columns: minmax(0, 1fr);
     align-items: center;
     margin-right: var(--width-simplebar-scroll-hover);
+
+    #userlist-header-search {
+        display: grid;
+        grid-template-rows: var(--line-height-sidebar-row-prominent);
+        grid-template-columns: minmax(0, 1fr) 20px;
+        align-items: center;
+    }
 
     #userlist-title {
         margin: 0;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -49,6 +49,60 @@ $user_status_emoji_width: 24px;
     }
 }
 
+.buddy-list-section li {
+    .user-list-sidebar-menu-icon {
+        visibility: hidden;
+        justify-self: stretch;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 2px 2px 2px 1px;
+        /* This helps horizontally align the vdots,
+           given the reduced margin-left above.
+           Vertical centering looks better with an
+           extra pixel of top padding in this area,
+           too. */
+        padding: 1px 0 0 1px;
+        border-radius: 3px;
+
+        & i {
+            font-size: 17px;
+            /* Ensure the icon takes the same baseline
+               as the rest of the row, for perfect
+               vertical alignment with the username and
+               status circle. */
+            line-height: inherit;
+        }
+
+        /*
+        Hover does not work for touch-based devices like mobile phones.
+        Hence the icons does not appear, making the user unaware of its
+        presence on such devices. The following media property displays the
+        icon by default for such behaviour.
+        */
+
+        @media (hover: none) {
+            visibility: visible;
+            /* Show dots on touchscreens in a less distracting,
+               lighter shade. */
+            color: var(--color-vdots-hint);
+        }
+    }
+
+    &:hover {
+        .user-list-sidebar-menu-icon {
+            visibility: visible;
+            cursor: pointer;
+            color: var(--color-vdots-visible);
+
+            &:hover {
+                color: var(--color-vdots-hover);
+                background-color: var(--color-background-sidebar-action-hover);
+            }
+        }
+    }
+}
+
 .buddy-list-section {
     margin-bottom: 0;
     overflow-x: hidden;
@@ -62,60 +116,6 @@ $user_status_emoji_width: 24px;
         list-style-type: none;
         border-radius: 4px;
         padding: 0;
-
-        .user-list-sidebar-menu-icon {
-            visibility: hidden;
-            justify-self: stretch;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 2px 2px 2px 1px;
-            /* This helps horizontally align the vdots,
-               given the reduced margin-left above.
-               Vertical centering looks better with an
-               extra pixel of top padding in this area,
-               too. */
-            padding: 1px 0 0 1px;
-            border-radius: 3px;
-
-            & i {
-                font-size: 17px;
-                /* Ensure the icon takes the same baseline
-                   as the rest of the row, for perfect
-                   vertical alignment with the username and
-                   status circle. */
-                line-height: inherit;
-            }
-
-            /*
-            Hover does not work for touch-based devices like mobile phones.
-            Hence the icons does not appear, making the user unaware of its
-            presence on such devices. The following media property displays the
-            icon by default for such behaviour.
-            */
-
-            @media (hover: none) {
-                visibility: visible;
-                /* Show dots on touchscreens in a less distracting,
-                   lighter shade. */
-                color: var(--color-vdots-hint);
-            }
-        }
-
-        &:hover {
-            .user-list-sidebar-menu-icon {
-                visibility: visible;
-                cursor: pointer;
-                color: var(--color-vdots-visible);
-
-                &:hover {
-                    color: var(--color-vdots-hover);
-                    background-color: var(
-                        --color-background-sidebar-action-hover
-                    );
-                }
-            }
-        }
 
         &:hover,
         &.highlighted_user {

--- a/web/templates/popovers/buddy_list_popover.hbs
+++ b/web/templates/popovers/buddy_list_popover.hbs
@@ -1,0 +1,12 @@
+<div class="popover-menu" id="stream-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item">
+            <a class="invite-user-link popover-menu-link" role="button">
+            <i class="popover-menu-icon zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
+            <span class="popover-menu-label">
+                {{t 'Invite users to organization' }}
+            </span>
+            </a>
+        </li>
+    </ul>
+</div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -32,10 +32,10 @@
                     <ul id="buddy-list-other-users" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>
                 </div>
                 <div id="buddy_list_wrapper_padding"></div>
+                <div class="right-sidebar-shortcuts">
+                    <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t 'Invite users to organization' }}</a>
+                </div>
             </div>
-        </div>
-        <div class="right-sidebar-shortcuts">
-            <a class="invite-user-link" role="button"><i class="fa fa-user-plus" aria-hidden="true"></i>{{t 'Invite users to organization' }}</a>
         </div>
     </div>
 </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -8,6 +8,9 @@
                     </h4>
                     <i id="user_filter_icon" class="fa fa-search"></i>
                 </span>
+                <span id="buddy-list-menu-icon" class="user-list-sidebar-menu-icon">
+                    <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
+                </span>
             </div>
             <div class="notdisplayed" id="user_search_section">
                 <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -2,10 +2,12 @@
     <div class="right-sidebar-items">
         <div id="user-list">
             <div id="userlist-header">
-                <h4 class='right-sidebar-title' id='userlist-title'>
-                    {{t 'USERS' }}
-                </h4>
-                <i id="user_filter_icon" class="fa fa-search"></i>
+                <span id="userlist-header-search">
+                    <h4 class='right-sidebar-title' id='userlist-title'>
+                        {{t 'USERS' }}
+                    </h4>
+                    <i id="user_filter_icon" class="fa fa-search"></i>
+                </span>
             </div>
             <div class="notdisplayed" id="user_search_section">
                 <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -365,7 +365,7 @@ test("handlers", ({override, override_rewire, mock_template}) => {
     (function test_click_header_filter() {
         init();
         const e = {};
-        const handler = $("#userlist-header").get_on_handler("click");
+        const handler = $("#userlist-header-search").get_on_handler("click");
 
         simulate_right_column_buddy_list();
 

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -239,7 +239,7 @@ test("click on user header to toggle display", ({override}) => {
 
     $user_filter.val("bla");
 
-    $("#userlist-header").trigger("click");
+    $("#userlist-header-search").trigger("click");
     assert.ok($("#user_search_section").hasClass("notdisplayed"));
     assert.equal($user_filter.val(), "");
 
@@ -248,7 +248,7 @@ test("click on user header to toggle display", ({override}) => {
         return $.create("sidebar").addClass("column-right");
     };
 
-    $("#userlist-header").trigger("click");
+    $("#userlist-header-search").trigger("click");
     assert.equal($("#user_search_section").hasClass("notdisplayed"), false);
 });
 


### PR DESCRIPTION
Fixes #31653

**part (1)**

> Add a three-dot menu to the right of the search button, with the "Invite users to organization" link as the only menu item to start with. We should use the same icon as we have in the gear menu. If a user doesn't have permission to send invites, the three-dot menu button should not be shown.

![Kapture 2024-09-30 at 16 19 48](https://github.com/user-attachments/assets/f8dc888e-700f-4b54-ba4d-eb493e20ef19)

guest has no three-dot menu:

<img width="261" alt="image" src="https://github.com/user-attachments/assets/daac611f-051d-4e69-af7d-fdff9a84e546">


**part (2)**

> Make the "Invite users to organization" link be scrollable, rather than pinning it to the bottom of the sidebar.

![Kapture 2024-09-30 at 16 21 17](https://github.com/user-attachments/assets/af04a23b-0b21-4eff-97e0-694ebdecc4d6)
