### PR TITLE
typeahead: Prevent blue styling from mouse hover on typeahead item in dark mode.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -195,7 +195,7 @@ const HEADER_ELEMENT_HTML =
     '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>';
 const CONTAINER_HTML = '<div class="typeahead dropdown-menu"></div>';
 const MENU_HTML = '<ul class="typeahead-menu" data-simplebar></ul>';
-const ITEM_HTML = "<li><a></a></li>";
+const ITEM_HTML = '<li class="typeahead-item"><a class="typeahead-item-link"></a></li>';
 const MIN_LENGTH = 1;
 
 export type TypeaheadInputElement =

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -31,7 +31,8 @@
             .button,
             .compose_control_button,
             .conversation-partners,
-            .user-presence-link
+            .user-presence-link,
+            .typeahead-item-link
         ):hover {
         color: hsl(200deg 79% 66%);
         text-decoration: none;


### PR DESCRIPTION
reported here https://chat.zulip.org/#narrow/stream/9-issues/topic/unexpected.20search.20typeahead.20highlighting.20.28dark.20theme.29/near/1951962