### PR TITLE
help-beta: Add support for images.

### DIFF
--- a/help-beta/src/styles/main.css
+++ b/help-beta/src/styles/main.css
@@ -3,3 +3,37 @@
     pointer-events: none;
     cursor: default;
 }
+
+.sl-markdown-content {
+    img {
+        vertical-align: top;
+        box-shadow: 0 0 4px hsl(0deg 0% 0% / 5%);
+        border: 1px solid hsl(0deg 0% 87%);
+        border-radius: 4px;
+        margin-top: 0;
+
+        &.emoji-small {
+            display: inline-block;
+            width: 1.25em;
+            box-shadow: none;
+            border: none;
+            vertical-align: text-top;
+        }
+
+        &.emoji-big {
+            display: inline-block;
+            width: 1.5em;
+            box-shadow: none;
+            border: none;
+            vertical-align: text-top;
+        }
+
+        &.help-center-icon {
+            display: inline-block;
+            width: 1.25em;
+            box-shadow: none;
+            border: none;
+            vertical-align: text-top;
+        }
+    }
+}

--- a/help/configure-emoticon-translations.md
+++ b/help/configure-emoticon-translations.md
@@ -1,19 +1,7 @@
 # Configure emoticon translations
 
 You can configure whether emoticons like `:)` or `:(` will be automatically
-translated into emoji equivalents like
-<img
-    src="/static/generated/emoji/images-google-64/1f642.png"
-    alt="smile"
-    class="emoji-small"
-/>
-or
-<img
-    src="/static/generated/emoji/images-google-64/1f641.png"
-    alt="slight_frown"
-    class="emoji-small"
-/>
-by Zulip.
+translated into emoji equivalents like 🙂 or 🙁 by Zulip.
 
 ## Configure emoticon translations
 

--- a/help/emoji-and-emoticons.md
+++ b/help/emoji-and-emoticons.md
@@ -47,13 +47,7 @@
 ### Use an emoticon
 
 You can configure Zulip to convert emoticons into emoji, so that, e.g., `:)`
-will be displayed as
-<img
-    src="/static/generated/emoji/images-google-64/1f642.png"
-    alt="smile"
-    class="emoji-small"
-/>
-.
+will be displayed as 🙂 .
 
 {start_tabs}
 

--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -32,9 +32,7 @@ message.
 
 !!! keyboard_tip ""
 
-    You can react to the selected message with <img alt=":thumbs_up:"
-    class="emoji" src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
-    title="thumbs up"/> by using the <kbd>+</kbd> shortcut.
+    You can react to the selected message with 👍 by using the <kbd>+</kbd> shortcut.
 
 {tab|mobile}
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -183,9 +183,7 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>
 
-* **React with <img alt=":thumbs_up:" class="emoji"
-  src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
-  title="thumbs up"/>**: <kbd>+</kbd>
+* **React with 👍**: <kbd>+</kbd>
 
 * **Toggle first emoji reaction**: <kbd>=</kbd>
 

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -41,9 +41,7 @@ Some details to keep in mind:
 - Zulip search ignores very common words like `a`, `the`, and about 100 others.
 - [Emoji](/help/emoji-and-emoticons) in messages (but not [emoji
   reactions](/help/emoji-reactions)) are included in searches, so if you search
-  for `octopus`, your results will include messages with the `:octopus:` emoji (
-  <img src="/static/generated/emoji/images-google-64/1f419.png" alt="octopus"
-  class="emoji-small"/>).
+  for `octopus`, your results will include messages with the `:octopus:` emoji (🐙).
 
 ## Search filters
 

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -41,7 +41,7 @@ Some details to keep in mind:
 - Zulip search ignores very common words like `a`, `the`, and about 100 others.
 - [Emoji](/help/emoji-and-emoticons) in messages (but not [emoji
   reactions](/help/emoji-reactions)) are included in searches, so if you search
-  for `octopus`, your results will include messages with the `:octopus:` emoji (🐙).
+  for `thumbs_up`, your results will include messages with the `:thumbs_up:` emoji (👍).
 
 ## Search filters
 

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -18,6 +18,21 @@ os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
 django.setup()
 
 
+def replace_image_path(markdown_string: str) -> str:
+    """
+    We will point to the existing image folder till
+    the cutover. After that, we will copy the images
+    to src folder for help-beta in order to take
+    advantage of Astro's image optimization.
+    See https://chat.zulip.org/#narrow/stream/6-frontend/topic/Handling.20images.20in.20help.20center.20starlight.20migration.2E/near/1915130
+    """
+    # We do not replace /static/images directly since there are a few
+    # instances in the documentation where zulip.com links are
+    # referenced with that blurb as a part of the url.
+    result = markdown_string.replace("(/static/images/help-beta", "(../../../../static/images/help")
+    return result.replace('="/static/images/help-beta', '="../../../../static/images/help')
+
+
 def escape_curly_braces(markdown_string: str) -> str:
     """
     MDX will treat curly braces as a JS expression,
@@ -54,6 +69,7 @@ def insert_frontmatter(markdown_string: str) -> str:
 def convert_string_to_mdx(markdown_string: str) -> str:
     result = escape_curly_braces(markdown_string)
     result = fix_relative_path(result)
+    result = replace_image_path(result)
     return insert_frontmatter(result)
 
 


### PR DESCRIPTION
Partially fixes #31255. We'll need to copy images to src/ at the time of cutover. See
https://chat.zulip.org/#narrow/stream/6-frontend/topic/Handling.20images.20in.20help.20center.20starlight.20migration.2E/near/1915130 for more details.

We've also copied over css relevant to markdown images, while making some small changes to it so that it works better with existing starlight styling.

Note: It would be good to replace the emojis being used in the emoticon translation table directly with the emoji, but there are some weird alignment issues that happen with it. I'll fix that in #31821 instead. 

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Image with border, all images will have this:
![Screenshot 2024-10-01 at 12 10 20 PM](https://github.com/user-attachments/assets/75f3d825-8286-467a-bd44-ff4752d2bb57)

Help center icon class using the image tag:
![Screenshot 2024-10-01 at 12 17 10 PM](https://github.com/user-attachments/assets/ccb7d89e-da26-468a-939f-56a73064c55b)

.emoji-small example:
![Screenshot 2024-10-03 at 2 15 46 PM](https://github.com/user-attachments/assets/7d804983-1a6d-4e8a-a03d-14c011c78262)


There is no .emoji-big example to display, so the font-size there is a bit arbitrary for now. That can be tackled in #31257.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
