### PR TITLE
search: Prevent blue styling from mouse hover on typeahead item.  #

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -195,7 +195,7 @@ const HEADER_ELEMENT_HTML =
     '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>';
 const CONTAINER_HTML = '<div class="typeahead dropdown-menu"></div>';
 const MENU_HTML = '<ul class="typeahead-menu" data-simplebar></ul>';
-const ITEM_HTML = "<li><a></a></li>";
+const ITEM_HTML = '<li><a class="typeahead-item-link"></a></li>';
 const MIN_LENGTH = 1;
 
 export type TypeaheadInputElement =

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -31,7 +31,8 @@
             .button,
             .compose_control_button,
             .conversation-partners,
-            .user-presence-link
+            .user-presence-link,
+            #searchbox .typehead-item-link
         ):hover {
         color: hsl(200deg 79% 66%);
         text-decoration: none;


### PR DESCRIPTION
Made changes for  blue styling from mouse hover on typeahead item

Fixes: Issue #31817
Reported here :https://chat.zulip.org/#narrow/stream/9-issues/topic/unexpected.20search.20typeahead.20highlighting.20.28dark.20theme.29/near/1951962 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
