### PR TITLE
Sagging compose box topic w/ emoji at 16px

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -931,9 +931,17 @@ textarea.new_message_textarea {
         box-shadow: none;
         outline: none;
 
-        padding: 4px 6px;
+        /* Top and bottom padding needs to be a dynamic value to
+           fit emojis in both compact (14px) and regular mode (16px)
+           on all monitors. 0.15em is 2.4px at 16px/1em and
+           0.15em is 2.1px at 14px/1em. */
+        padding: 0.15em 6px;
         /* Reset height to let `align-items: stretch` on the grid parent handle this. */
         height: auto;
+        /* Line-height needed to stop text from sagging on low-resolution
+           monitors on Safari and Chrome. 1.6em is 25.6px at 16px.
+           1.6em is 22.4px at 14px. */
+        line-height: 1.6em;
     }
 
     /* Styles for new conversation button in the recipient_box */


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #31153  <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

All screenshots were captured on the external monitor using Chrome.

**Regular mode:**

| Before | After |
| --- | --- |
| ![before_fix_regular_mode_text](https://github.com/user-attachments/assets/38d38acb-2441-46ca-bb6e-d04a20f84f40) | ![after_fix_regular_mode_text](https://github.com/user-attachments/assets/ec94e7ca-d88e-4768-82b3-2a5b3ad7a622)
| ![before_fix_regular_mode_emoji](https://github.com/user-attachments/assets/dff497e6-0187-4e14-99e8-fa3430dad4c3) | ![after_fix_regular_mode_emoji](https://github.com/user-attachments/assets/97ccbad8-07ed-4711-be0f-26dbba1dea95)


**Compact mode:**

| Before | After |
| --- | --- |
| ![before_fix_compact_mode_text](https://github.com/user-attachments/assets/5fbefd11-56d6-4431-925c-88f4e201f43d) | ![after_fix_compact_mode_text](https://github.com/user-attachments/assets/543ec5d2-eccb-4c17-8e82-08c4b4e55367)
| ![before_fix_compact_mode_emoji](https://github.com/user-attachments/assets/771bb91e-d8ec-412f-bf0a-488b40787257) | ![after_fix_compact_mode_emoji](https://github.com/user-attachments/assets/0ef2b7e7-5c2b-4a5e-a5b8-7009c8436b7f)

I was able to recreate the issue on Safari and Chrome for my external monitor. Specifying the line-height solves this problem. The padding has to be reduced slightly in order to fit the emoji which is being rendered larger on low-resolution screens by the browser in order to retain the detail. The line-height value and the top and bottom padding has to be set using em for the solution to work in both regular and compact mode. 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
