### PR TITLE
contributor docs: Clarify how to ask for an issue to be assigned.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,9 +297,10 @@ labels.
   issue. After that, sure! If
   [Zulipbot](https://github.com/zulip/zulipbot) does not allow you to
   claim an issue, you can post a comment describing the status of your
-  other work on the issue you're interested in, and asking for the
-  issue to be assigned to you. Note that addressing feedback on
-  in-progress PRs should always take priority over starting a new PR.
+  other work on the issue you're interested in (including links to all open
+  PRs), and asking for the issue to be assigned to you. Note that addressing
+  feedback on in-progress PRs should always take priority over starting a new
+  PR.
 - **I think my PR is done, but it hasn't been merged yet. What's going on?**
   1. **Double-check that you have addressed all the feedback**, including any comments
      on [Git commit


### PR DESCRIPTION
This came up recently.