### PR TITLE
buddy_data: Add participants to the top of sorted user list.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -776,7 +776,13 @@ export class BuddyList extends BuddyListConf {
 
         const i = user_id_list.findIndex(
             (list_user_id) =>
-                this.compare_function(user_id, list_user_id, current_sub, pm_ids_set) < 0,
+                this.compare_function(
+                    user_id,
+                    list_user_id,
+                    current_sub,
+                    pm_ids_set,
+                    this.render_data.participant_ids_set,
+                ) < 0,
         );
         return i === -1 ? user_id_list.length : i;
     }

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -184,7 +184,7 @@ test("sort_users", () => {
 
     presence.presence_info.delete(alice.user_id);
 
-    buddy_data.sort_users(user_ids);
+    buddy_data.sort_users(user_ids, new Set());
 
     assert.deepEqual(user_ids, [fred.user_id, jill.user_id, alice.user_id]);
 });

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -455,18 +455,18 @@ test("compare_function", () => {
     peer_data.set_subscribers(stream_id, []);
     assert.equal(
         second_user_shown_higher,
-        buddy_data.compare_function(fred.user_id, alice.user_id, sub, new Set()),
+        buddy_data.compare_function(fred.user_id, alice.user_id, sub, new Set(), new Set()),
     );
 
     // Fred is higher because they're in the narrow and Alice isn't.
     peer_data.set_subscribers(stream_id, [fred.user_id]);
     assert.equal(
         first_user_shown_higher,
-        buddy_data.compare_function(fred.user_id, alice.user_id, sub, new Set()),
+        buddy_data.compare_function(fred.user_id, alice.user_id, sub, new Set(), new Set()),
     );
     assert.equal(
         second_user_shown_higher,
-        buddy_data.compare_function(alice.user_id, fred.user_id, sub, new Set()),
+        buddy_data.compare_function(alice.user_id, fred.user_id, sub, new Set(), new Set()),
     );
 
     // Fred is higher because they're in the DM conversation and Alice isn't.
@@ -477,19 +477,49 @@ test("compare_function", () => {
             alice.user_id,
             undefined,
             new Set([fred.user_id]),
+            new Set(),
+        ),
+    );
+
+    // Fred is higher because they're in the conversation and Alice isn't.
+    assert.equal(
+        first_user_shown_higher,
+        buddy_data.compare_function(
+            fred.user_id,
+            alice.user_id,
+            undefined,
+            new Set(),
+            new Set([fred.user_id]),
+        ),
+    );
+
+    assert.equal(
+        second_user_shown_higher,
+        buddy_data.compare_function(
+            alice.user_id,
+            fred.user_id,
+            undefined,
+            new Set(),
+            new Set([fred.user_id]),
         ),
     );
 
     // Alice is higher because of alphabetical sorting.
     assert.equal(
         second_user_shown_higher,
-        buddy_data.compare_function(fred.user_id, alice.user_id, undefined, new Set()),
+        buddy_data.compare_function(fred.user_id, alice.user_id, undefined, new Set(), new Set()),
     );
 
     // The user is part of a DM conversation, though that's not explicitly in the DM list.
     assert.equal(
         first_user_shown_higher,
-        buddy_data.compare_function(me.user_id, alice.user_id, undefined, new Set([fred.user_id])),
+        buddy_data.compare_function(
+            me.user_id,
+            alice.user_id,
+            undefined,
+            new Set([fred.user_id]),
+            new Set(),
+        ),
     );
 });
 


### PR DESCRIPTION
This was causing a bug where the participants weren't necessarily all getting rendered, specifically when there were many subscribers to a channel, because we render users in batches as buddy list scrolls, and those users would only show up after some scrolling.

This fix makes sure we always load the participants first.

Reported here: https://chat.zulip.org/#narrow/stream/101-design/topic/Show.20conversation.20participants.20in.20the.20right.20sidebar.20.2331129/near/1952659

I tested by making an organization with 1000 users and returning early in `maybe_shrink_list` so that there were many users that got in the buddy list populate queue. Before this change, participants only showed up after scrolling, and after this change they always appear in the list.