### PR TITLE
reactions: Optimize DOM cost of message reactions via dynamic rendering.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -121,15 +121,6 @@
             color: var(--color-message-reaction-button-text-hover);
         }
 
-        /* Configure the reaction button to appear if and only if there's an
-           existing reaction to the message. We reference first-child
-           rather than only-child because tooltips may be appended to
-           the DOM after this element, whereas actual reactions are
-           appended before it. */
-        &:first-child {
-            display: none;
-        }
-
         &:hover {
             color: var(--color-message-reaction-button-text-hover);
             background-color: var(

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -69,6 +69,6 @@
 
 <div class="message_length_controller"></div>
 
-{{#unless is_hidden}}
-<div class="message_reactions">{{> message_reactions }}</div>
-{{/unless}}
+{{#if (and (not is_hidden) msg.message_reactions)}}
+    {{> message_reactions }}
+{{/if}}

--- a/web/templates/message_reactions.hbs
+++ b/web/templates/message_reactions.hbs
@@ -1,9 +1,11 @@
-{{#each this/msg/message_reactions}}
-    {{> message_reaction}}
-{{/each}}
-<div class="reaction_button" role="button" aria-haspopup="true" data-tooltip-template-id="add-emoji-tooltip-template" aria-label="{{t 'Add emoji reaction' }} (:)">
-    <div class="emoji-message-control-button-container">
-        <i class="zulip-icon zulip-icon-smile" tabindex="0"></i>
-        <div class="message_reaction_count">+</div>
+<div class="message_reactions">
+    {{#each this/msg/message_reactions}}
+        {{> message_reaction}}
+    {{/each}}
+    <div class="reaction_button" role="button" aria-haspopup="true" data-tooltip-template-id="add-emoji-tooltip-template" aria-label="{{t 'Add emoji reaction' }} (:)">
+        <div class="emoji-message-control-button-container">
+            <i class="zulip-icon zulip-icon-smile" tabindex="0"></i>
+            <div class="message_reaction_count">+</div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Before, the message reactions section along with the add reaction button was being rendered for every message even when there were no reactions present - this led to additional DOM cost.

This PR adds the message reactions section only when there is at least a single reaction on the message, and follows up with a cleanup of the message reactions section when there are no reactions.

Fixes #31137.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![msg_reaction_after](https://github.com/user-attachments/assets/b671fe15-df28-483a-957c-bb3775a49c5d)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
