### PR TITLE
send_later_popover: Improve on-focus styling of enter send choices.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1071,6 +1071,13 @@ textarea.new_message_textarea {
             background: var(--color-background-active-popover-menu);
         }
 
+        &:focus-visible {
+            background: var(--color-background-hover-popover-menu);
+            border-radius: 4px;
+            outline: 1px solid var(--color-outline-focus) !important;
+            outline-offset: -1px;
+        }
+
         & .enter_sends_choice_radio {
             width: auto;
             cursor: pointer;


### PR DESCRIPTION
Previously, no custom styling was being applied to the enter send choice options, which led to uneven styling from the other popover options, as well as the outline ring being cut-off from the edges of the popover. This PPR fixes these issues by adding custom styling for the outline ring when the enter send choice options are focused.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/selection.20box.20cut.20off.20in.20send.20menu/near/1950294)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-10-02 at 2 55 20 PM](https://github.com/user-attachments/assets/5967e614-b23e-44b2-a1b0-31fc8f4b62c0) | ![Screenshot 2024-10-02 at 2 54 48 PM](https://github.com/user-attachments/assets/76866bd3-ed13-49ce-bb0f-1efcf543c26e) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
