### PR TITLE
message_view: Fix narrow to compose recipient rerenders in same narrow.

### DIFF
--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -296,6 +296,11 @@ export function try_rendering_locally_for_same_narrow(
         target_scroll_offset = opts.then_select_offset;
     } else if (filter.has_operator("near")) {
         target_id = Number.parseInt(filter.operands("near")[0]!, 10);
+    } else if (filter.equals(current_filter)) {
+        // The caller doesn't want to force rerender and the filter is the same.
+        // Also, we don't have a specific message id we want to select, so we
+        // just keep the same message id selected.
+        return true;
     } else {
         return false;
     }


### PR DESCRIPTION
We don't rerender if we are already narrowed to the compose recipient.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Jump.20to.20conversation.20keyboard.20shortcut.20bugs