### PR TITLE
message_view: Update date on sticky header after rendering narrow.

### DIFF
--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1145,6 +1145,7 @@ export function render_message_list_with_selected_message(opts: {
         // narrowing
         message_lists.current.view.set_message_offset(select_offset);
     }
+    message_lists.current.view.update_sticky_recipient_headers();
     unread_ops.process_visible();
     narrow_history.save_narrow_state_and_flush();
 }

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -31,6 +31,7 @@ const message_lists = mock_esm("../src/message_lists", {
                 removeClass: noop,
                 addClass: noop,
             },
+            update_sticky_recipient_headers: noop,
         },
         data: {
             filter: new Filter([{operator: "in", operand: "all"}]),
@@ -141,6 +142,7 @@ function stub_message_list() {
                 removeClass: noop,
                 addClass: noop,
             },
+            update_sticky_recipient_headers: noop,
         };
 
         get(msg_id) {


### PR DESCRIPTION
On a fresh render of a narrow if the view doesn't scroll, `update_sticky_recipient_headers` is not called. So, we need call it after we have scrolled to the message we want to select.

Populated that database with `./manage.py populate_db --oldest-message-days=10 -n 1000 --max-topics=` and used `ctrl .` hotkey to reproduce the bug.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Jump.20to.20conversation.20keyboard.20shortcut.20bugs
