### PR TITLE
saved_snippet: Prepopulate new saved snippet content.

### DIFF
--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -6,6 +6,7 @@ import render_add_saved_snippet_modal from "../templates/add_saved_snippet_modal
 import render_confirm_delete_saved_snippet from "../templates/confirm_dialog/confirm_delete_saved_snippet.hbs";
 
 import * as channel from "./channel";
+import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
@@ -91,7 +92,9 @@ function item_click_callback(
     if (current_value === saved_snippets.ADD_SAVED_SNIPPET_OPTION_ID) {
         dialog_widget.launch({
             html_heading: $t_html({defaultMessage: "Add a new saved snippet"}),
-            html_body: render_add_saved_snippet_modal(),
+            html_body: render_add_saved_snippet_modal({
+                prepopulated_content: compose_state.message_content(),
+            }),
             html_submit_button: $t_html({defaultMessage: "Save"}),
             id: "add-new-saved-snippet-modal",
             form_id: "add-new-saved-snippet-form",

--- a/web/templates/add_saved_snippet_modal.hbs
+++ b/web/templates/add_saved_snippet_modal.hbs
@@ -3,6 +3,8 @@
         <label for="title" class="modal-field-label">{{t "Title" }}</label>
         <input id="new-saved-snippet-title" type="text" name="title" class="modal_text_input saved-snippet-title" value="" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
         <div>{{t "Content" }}</div>
-        <textarea class="settings_textarea saved-snippet-content" rows="4"></textarea>
+        <textarea class="settings_textarea saved-snippet-content" rows="4">
+            {{~prepopulated_content~}}
+        </textarea>
     </form>
 </div>


### PR DESCRIPTION
This PR prepopulates the 'content' block of the saved snippet with the compose box content.

Fixes #31827.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details><summary>GIF</summary>
<p>

![saved snippet prepopulate](https://github.com/user-attachments/assets/d1bac82e-3054-4483-a37a-b41771f1372e)


</p>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
