### PR TITLE
Left sidebar: Add hover controls to heading and stream rows.

### DIFF
--- a/web/shared/icons/masked-unread.svg
+++ b/web/shared/icons/masked-unread.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8' fill='none' viewBox='0 0 8 8'><circle cx='4' cy='4' r='4' fill='black'/></svg>

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -603,6 +603,20 @@ export function initialize() {
         });
     });
 
+    // Left sidebar channel rows
+    $("body").on("click", ".channel-new-topic-button", (e) => {
+        e.stopPropagation();
+        const elem = e.currentTarget;
+        const stream_id = Number.parseInt(elem.dataset.streamId, 10);
+        compose_actions.start({
+            message_type: "stream",
+            stream_id,
+            topic: "",
+            trigger: "clear topic button",
+            keep_composebox_empty: true,
+        });
+    });
+
     // Recent conversations direct messages (Not displayed on small widths)
     $("body").on("mouseenter", ".recent_topic_stream .pm_status_icon", (e) => {
         e.stopPropagation();

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -8,7 +8,6 @@ import render_left_sidebar_stream_actions_popover from "../templates/popovers/le
 
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
-import * as compose_actions from "./compose_actions";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as dialog_widget from "./dialog_widget";
 import * as dropdown_widget from "./dropdown_widget";
@@ -185,21 +184,6 @@ function build_stream_popover(opts) {
                     property: "is_muted",
                     value: !sub.is_muted,
                 });
-                e.stopPropagation();
-            });
-
-            // New topic in stream menu
-            $popper.on("click", ".popover_new_topic_button", (e) => {
-                const sub = stream_popover_sub(e);
-                hide_stream_popover();
-
-                compose_actions.start({
-                    message_type: "stream",
-                    trigger: "popover new topic button",
-                    stream_id: sub.stream_id,
-                    topic: "",
-                });
-                e.preventDefault();
                 e.stopPropagation();
             });
 

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -338,7 +338,7 @@ export function initialize({
 }): void {
     $("#stream_filters").on(
         "click",
-        ".sidebar-topic-check, .sidebar-topic-name, .topic-markers-and-controls",
+        ".sidebar-topic-check, .sidebar-topic-name, .topic-markers-and-unreads",
         (e) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey) {
                 return;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -628,15 +628,6 @@ input.settings_text_input {
     opacity: 0.7;
 }
 
-.masked_unread_count {
-    float: right;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: var(--color-masked-unread-marker);
-    display: none;
-}
-
 /* Implement the web app's default-hidden convention for alert
    elements.  Portico pages lack this CSS and thus show them by
    default. */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -236,6 +236,8 @@
     /* This represents the space in the sidebar reserved for symbols like
        the #; labels like the stream name go to the right of this. */
     --left-sidebar-icon-column-width: 16px;
+    /* Offset on unreads to make New topic button appear centered. */
+    --left-sidebar-unread-offset: 6.5px;
     /* space direct message / stream / topic names from unread counters
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -227,6 +227,7 @@
     --left-sidebar-icon-content-gap: 0.4375em;
     /* The space allotted in gridded rows for the toggle icon. */
     --left-sidebar-header-icon-toggle-width: 20px;
+    --left-sidebar-vdots-width: 26px;
     /* Other rows need an offset to preserve a column the
        entire height of the left sidebar for where toggles sit. */
     --left-sidebar-toggle-width-offset: var(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -344,6 +344,8 @@
     --opacity-sidebar-heading: 0.7;
     --opacity-sidebar-heading-icon: 0.5;
     --opacity-sidebar-heading-hover: 0.9;
+    --opacity-left-sidebar-muted: 0.55;
+    --opacity-left-sidebar-muted-hover: 0.75;
     --opacity-right-sidebar-subheading: 0.65;
     --opacity-right-sidebar-subheading-hover: 0.9;
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -239,6 +239,9 @@
     /* space direct message / stream / topic names from unread counters
     and @ mention indicators by 3px on the right */
     --left-sidebar-before-unread-count-padding: 3px;
+    /* 15px is the approximate width of a single-digit
+       unread marker. */
+    --left-sidebar-single-digit-unread-width: 15px;
     --left-sidebar-right-margin: 12px;
     /* 289px at 14px/1em */
     --left-sidebar-max-width: calc(
@@ -396,7 +399,6 @@
     it doesn't leak through message header.
     */
     --unread-marker-left: -1px;
-    --masked-unread-count-margin-right: 3px;
 
     /*
     Compose-recipient box minimum height. Used in a flexbox context to

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -801,7 +801,7 @@
     --background-color-left-sidebar-heads-up-icon-hover: hsl(
         240deg 100% 50% / 7%
     );
-    --color-vdots-hint: hsl(240deg 30% 20%);
+    --color-vdots-hint: hsl(240deg 30% 80%);
     --color-vdots-visible: hsl(240deg 30% 40%);
     --color-vdots-hover: hsl(240deg 100% 15%);
     --color-tab-picker-icon: hsl(200deg 100% 40%);
@@ -1322,7 +1322,7 @@
     --background-color-left-sidebar-heads-up-icon-hover: hsl(
         240deg 100% 75% / 20%
     );
-    --color-vdots-hint: hsl(240deg 35% 48%);
+    --color-vdots-hint: hsl(240deg 35% 38%);
     --color-vdots-visible: hsl(240deg 35% 68%);
     --color-vdots-hover: hsl(240deg 100% 90%);
     --color-left-sidebar-header-vdots-visible: var(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -253,7 +253,10 @@
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
     --right-sidebar-width: 250px;
-    --left-sidebar-header-icon-width: 15px;
+    /* The width of the icon is reduced by 2px, to account for 2px
+       of top and bottom margin needed for hover backgrounds to
+       not touch the row outline. */
+    --left-sidebar-header-icon-width: calc(1.7142em - 2px); /* 24px / 14px em */
     /* Space between section in the left sidebar. */
     --left-sidebar-sections-vertical-gutter: 8px;
     /* The legacy value here is 25px; that's the unitless legacy line-height
@@ -793,6 +796,11 @@
     /* The gray on the filter icons is the same as
        what's set on ul.filters, but with 70% opacity. */
     --color-left-sidebar-navigation-icon: hsl(240deg 30% 40%);
+    --color-left-sidebar-heads-up-icon: hsl(240deg 30% 40%);
+    --color-left-sidebar-heads-up-icon-hover: hsl(240deg 100% 15%);
+    --background-color-left-sidebar-heads-up-icon-hover: hsl(
+        240deg 100% 50% / 7%
+    );
     --color-vdots-hint: hsl(240deg 30% 20%);
     --color-vdots-visible: hsl(240deg 30% 40%);
     --color-vdots-hover: hsl(240deg 100% 15%);
@@ -1309,6 +1317,11 @@
     --color-message-action-interactive: hsl(217deg 41% 90% / 100%);
     --color-left-sidebar-follow-icon-hover: hsl(0deg 0% 100%);
     --color-left-sidebar-navigation-icon: hsl(240deg 35% 68%);
+    --color-left-sidebar-heads-up-icon: hsl(240deg 35% 68%);
+    --color-left-sidebar-heads-up-icon-hover: hsl(240deg 100% 90%);
+    --background-color-left-sidebar-heads-up-icon-hover: hsl(
+        240deg 100% 75% / 20%
+    );
     --color-vdots-hint: hsl(240deg 35% 48%);
     --color-vdots-visible: hsl(240deg 35% 68%);
     --color-vdots-hover: hsl(240deg 100% 90%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -730,6 +730,9 @@
     --color-text-settings-field-hint: hsl(0deg 0% 57%);
     --color-text-clear-search-button: hsl(0deg 0% 80%);
     --color-text-clear-search-button-hover: hsl(0deg 0% 0%);
+    /* These colors are from Bootstrap. */
+    --color-text-generic-link: #08c;
+    --color-text-generic-link-interactive: #005580;
 
     /* Demo Organization colors */
     --color-text-settings-demo-organization-warning: hsl(4deg 58% 33%);
@@ -1237,6 +1240,8 @@
     --color-text-settings-field-hint: hsl(0deg 0% 52%);
     --color-text-clear-search-button: hsl(236deg 33% 80%);
     --color-text-clear-search-button-hover: hsl(0deg 0% 100%);
+    --color-text-generic-link: #08c;
+    --color-text-generic-link-interactive: hsl(200deg 79% 66%);
 
     /* Demo Organization colors */
     --color-text-settings-demo-organization-warning: hsl(3deg 73% 80%);
@@ -1292,6 +1297,10 @@
     --color-markdown-pre-background: hsl(0deg 0% 100% / 4%);
     --color-markdown-pre-background-mentions: hsl(0deg 0% 100% / 5%);
     --color-markdown-pre-border-mentions: var(--color-markdown-pre-border);
+    --color-markdown-link: var(--color-text-generic-link);
+    --color-markdown-code-link: var(--color-markdown-link);
+    --color-markdown-link-hover: var(--color-text-generic-link-interactive);
+    --color-markdown-code-link-hover: var(--color-markdown-link-hover);
 
     /* Icon colors */
     --color-icon-bot: hsl(180deg 5% 50% / 100%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -537,13 +537,6 @@
         }
     }
 
-    #topics_header {
-        .show-all-streams {
-            color: hsl(0deg 0% 100% / 75%);
-            opacity: 0.75;
-        }
-    }
-
     .group-row.active,
     .stream-row.active {
         background-color: hsl(0deg 0% 0% / 20%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -13,24 +13,6 @@
         @extend .placeholder;
     }
 
-    & ul.dm-list,
-    & ul.filters {
-        .has-unmuted-mentions .unread_mention_info {
-            color: hsl(236deg 33% 90%);
-        }
-
-        & li.muted_topic,
-        li.out_of_home_view {
-            color: hsl(236deg 33% 90%/50%);
-        }
-
-        & li.out_of_home_view {
-            &:hover {
-                color: hsl(236deg 33% 90%/ 75%);
-            }
-        }
-    }
-
     kbd {
         text-shadow: none;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -13,22 +13,6 @@
         @extend .placeholder;
     }
 
-    &
-        a:not(
-            .button,
-            .compose_control_button,
-            .conversation-partners,
-            .user-presence-link,
-            .typeahead-item-link
-        ):hover {
-        color: hsl(200deg 79% 66%);
-        text-decoration: none;
-
-        & code {
-            color: hsl(200deg 79% 66%);
-        }
-    }
-
     & ul.dm-list,
     & ul.filters {
         .has-unmuted-mentions .unread_mention_info {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -41,10 +41,14 @@
 
 #streams_inline_icon,
 .streams_filter_icon {
-    opacity: 0.5;
+    color: var(--color-left-sidebar-heads-up-icon);
+    border-radius: 3px;
 
     &:hover {
-        opacity: 1;
+        color: var(--color-left-sidebar-heads-up-icon-hover);
+        background-color: var(
+            --background-color-left-sidebar-heads-up-icon-hover
+        );
         cursor: pointer;
     }
 }
@@ -215,16 +219,19 @@
     }
 
     #show-all-direct-messages {
-        width: var(--left-sidebar-header-icon-width);
+        color: var(--color-left-sidebar-heads-up-icon);
         display: flex;
         align-items: center;
         justify-content: center;
-        opacity: 0.7;
         text-decoration: none;
-        color: inherit;
+        margin: 2px 0;
+        border-radius: 3px;
 
         &:hover {
-            opacity: 1;
+            color: var(--color-left-sidebar-heads-up-icon-hover);
+            background-color: var(
+                --background-color-left-sidebar-heads-up-icon-hover
+            );
         }
     }
 }
@@ -1140,6 +1147,18 @@ li.top_left_scheduled_messages {
     z-index: 1;
 }
 
+.left-sidebar-controls {
+    grid-area: controls;
+    display: grid;
+    /* We won't know in advance how many controls a given
+       row has, but this allows grid to generate as many
+       as needed, sized to a shared icon width. */
+    grid-auto-columns: var(--left-sidebar-header-icon-width);
+    grid-template-rows: var(--line-height-sidebar-row-prominent);
+    place-content: stretch stretch;
+    margin-right: 1px;
+}
+
 .stream-markers-and-unreads,
 .topic-markers-and-unreads {
     grid-area: markers-and-unreads;
@@ -1494,14 +1513,22 @@ li.topic-list-item {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: var(--left-sidebar-header-icon-width);
+        grid-row: 1 / 1;
+        margin: 2px 0;
     }
 
     #add_streams_tooltip {
+        grid-row: 1 / 1;
+        margin: 2px 0;
+    }
+
+    #streams_inline_icon {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: var(--left-sidebar-header-icon-width);
+        /* Ensure the clickable area grows to
+           the height of the controls grid. */
+        height: 100%;
     }
 
     .stream_search_section {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -127,6 +127,11 @@
             display: flex;
         }
 
+        .subscription_block .sidebar-menu-icon {
+            display: flex;
+            color: var(--color-vdots-visible);
+        }
+
         .stream-with-count.hide_unread_counts {
             .masked_unread_count {
                 display: none;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -123,6 +123,10 @@
     }
 
     .stream-expanded {
+        .channel-new-topic-button {
+            display: flex;
+        }
+
         .stream-with-count.hide_unread_counts {
             .masked_unread_count {
                 display: none;
@@ -1188,6 +1192,30 @@ li.top_left_scheduled_messages {
     }
 }
 
+.channel-new-topic-button {
+    /* display: flex; is set on visible channels and
+       channel-row hovers. */
+    display: none;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-left-sidebar-heads-up-icon);
+    margin: 2px 0;
+    border-radius: 3px;
+
+    &:hover {
+        color: var(--color-left-sidebar-heads-up-icon-hover);
+        background-color: var(
+            --background-color-left-sidebar-heads-up-icon-hover
+        );
+    }
+}
+
+.narrow-filter:hover {
+    .channel-new-topic-button {
+        display: flex;
+    }
+}
+
 .bottom_left_row .sidebar-menu-icon {
     grid-area: ending-anchor-element;
 }
@@ -1545,7 +1573,6 @@ li.topic-list-item {
         /* Ensure the clickable area grows to
            the height of the controls grid. */
         height: 100%;
-
 
         @media (hover: none) {
             display: flex;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -26,7 +26,7 @@
 }
 
 .sidebar-topic-check,
-.topic-markers-and-controls {
+.topic-markers-and-unreads {
     cursor: pointer;
 }
 
@@ -177,7 +177,10 @@
 #direct-messages-section-header {
     grid-template-columns:
         0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 1fr)
-        max-content 30px 0;
+        minmax(0, max-content) minmax(0, max-content) var(
+            --left-sidebar-vdots-width
+        )
+        0;
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     cursor: pointer;
     white-space: nowrap;
@@ -204,8 +207,8 @@
         grid-area: row-content;
     }
 
-    .heading-markers-and-controls {
-        grid-area: markers-and-controls;
+    .heading-markers-and-unreads {
+        grid-area: markers-and-unreads;
         display: flex;
         gap: 5px;
         align-items: center;
@@ -401,8 +404,7 @@
 ul.filters {
     list-style-type: none;
     margin-left: 0;
-    /* Streams take a standard row height. */
-    line-height: var(--line-height-sidebar-row);
+    line-height: var(--line-height-sidebar-row-prominent);
 
     .sidebar-topic-name,
     .left-sidebar-navigation-label-container {
@@ -714,7 +716,11 @@ li.top_left_scheduled_messages {
         var(--left-sidebar-toggle-width-offset) var(
             --left-sidebar-icon-column-width
         )
-        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) max-content 0 0;
+        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) minmax(
+            0,
+            max-content
+        )
+        minmax(0, max-content) 0 0;
 
     .filter-icon {
         grid-area: starting-anchor-element;
@@ -730,7 +736,7 @@ li.top_left_scheduled_messages {
     }
 
     .unread_count {
-        grid-area: markers-and-controls;
+        grid-area: markers-and-unreads;
     }
 }
 
@@ -738,7 +744,7 @@ li.top_left_scheduled_messages {
     &.hide_starred_message_count {
         .masked_unread_count {
             display: block;
-            grid-area: markers-and-controls;
+            grid-area: markers-and-unreads;
             /* Adding margin-right aligns the .masked_unread_count with the rest of the masked unread counts in the channel list. */
             margin-right: var(--masked-unread-count-margin-right);
         }
@@ -833,7 +839,7 @@ li.top_left_scheduled_messages {
        modified or reassigned as needed, without running up against `padding`
        (which alters the box size) or `margin` (which notoriously bleeds outside
        of the element it's defined on). */
-    grid-template-areas: "starting-offset starting-anchor-element icon-content-gap row-content markers-and-controls ending-anchor-element ending-offset";
+    grid-template-areas: "starting-offset starting-anchor-element icon-content-gap row-content controls markers-and-unreads ending-anchor-element ending-offset";
 }
 
 .top_left_row {
@@ -844,7 +850,9 @@ li.top_left_scheduled_messages {
     /* The row grid for the outer .top_left_row
        is chiefly for lefthand spacing and placing
        the inner row content and vdots. */
-    grid-template-columns: 0 0 0 minmax(0, 1fr) 0 30px 0;
+    grid-template-columns:
+        0 0 0 minmax(0, 1fr) 0 0 var(--left-sidebar-vdots-width)
+        0;
 
     .sidebar-menu-icon {
         grid-area: ending-anchor-element;
@@ -865,18 +873,18 @@ li.top_left_scheduled_messages {
        that now by having it share this grid template. Its row and column
        definitions have the final say about dimensions and placement. */
     grid-template-areas:
-        "starting-offset starting-anchor-element icon-content-gap row-content markers-and-controls ending-anchor-element ending-offset"
-        ".               .                       filter-box       filter-box  filter-box           filter-box            .            ";
+        "starting-offset starting-anchor-element icon-content-gap row-content controls   markers-and-unreads ending-anchor-element ending-offset"
+        ".               .                       filter-box       filter-box  filter-box filter-box          filter-box            .            ";
 }
 
 #views-label-container {
     margin-right: var(--left-sidebar-right-margin);
     grid-template-columns:
-        0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 0.5fr) minmax(
+        0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 0.5fr) 0 minmax(
             0,
             1fr
         )
-        30px 0;
+        var(--left-sidebar-vdots-width) 0;
     grid-template-rows: 28px;
     cursor: pointer;
     border-radius: 4px;
@@ -901,7 +909,7 @@ li.top_left_scheduled_messages {
         /* Give the sidebar title through the end of the markers
            area, if needed. */
         .left-sidebar-title {
-            grid-column: row-content-start / markers-and-controls-end;
+            grid-column: row-content-start / markers-and-unreads-end;
         }
     }
 
@@ -946,7 +954,7 @@ li.top_left_scheduled_messages {
 
     #left-sidebar-navigation-list-condensed {
         margin: 0;
-        grid-area: markers-and-controls;
+        grid-area: markers-and-unreads;
     }
 
     .left-sidebar-navigation-menu-icon {
@@ -991,7 +999,8 @@ li.top_left_scheduled_messages {
             0,
             max-content
         )
-        30px 0;
+        minmax(0, max-content)
+        var(--left-sidebar-vdots-width) 0;
     white-space: nowrap;
 
     .stream-privacy {
@@ -1031,8 +1040,8 @@ li.top_left_scheduled_messages {
         0 var(--left-sidebar-icon-column-width) var(
             --left-sidebar-icon-content-gap
         )
-        minmax(0, 1fr) minmax(0, max-content)
-        30px 0;
+        minmax(0, 1fr) minmax(0, max-content) minmax(0, max-content)
+        var(--left-sidebar-vdots-width) 0;
 }
 
 .searching-for-more-topics {
@@ -1131,9 +1140,9 @@ li.top_left_scheduled_messages {
     z-index: 1;
 }
 
-.stream-markers-and-controls,
-.topic-markers-and-controls {
-    grid-area: markers-and-controls;
+.stream-markers-and-unreads,
+.topic-markers-and-unreads {
+    grid-area: markers-and-unreads;
     display: flex;
     /* Present a uniform space between icons */
     gap: 5px;
@@ -1317,11 +1326,11 @@ li.topic-list-item {
         var(--left-sidebar-toggle-width-offset) [action-heading-start] var(
             --left-sidebar-icon-column-width
         )
-        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) [action-heading-end] minmax(
+        var(--left-sidebar-icon-content-gap) minmax(0, 1fr) [action-heading-end] 0 minmax(
             0,
             max-content
         )
-        30px 0;
+        var(--left-sidebar-vdots-width) 0;
     grid-template-rows: [action-heading-start] auto [action-heading-end];
 
     .conversation-partners-icon {
@@ -1349,7 +1358,7 @@ li.topic-list-item {
     }
 
     .unread_count {
-        grid-area: markers-and-controls;
+        grid-area: markers-and-unreads;
         /* TODO: This is an alternative method
            for presenting a 16px-tall unread
            counter, regardless of context. This
@@ -1392,8 +1401,9 @@ li.topic-list-item {
     z-index: 2;
     grid-template-columns:
         [topics-content-area-start] var(--left-sidebar-toggle-width-offset)
-        0 0 minmax(0, 1fr)
-        max-content 0 42px [topics-content-area-end];
+        0 0 minmax(0, 1fr) 0
+        max-content 0 var(--left-sidebar-vdots-width)
+        [topics-content-area-end] var(--left-sidebar-right-margin);
     grid-template-rows:
         [topics-content-area-start] var(--line-height-sidebar-row-prominent)
         [topics-content-area-end];
@@ -1421,14 +1431,17 @@ li.topic-list-item {
     }
 
     .unread_count {
-        grid-area: markers-and-controls;
+        grid-area: markers-and-unreads;
     }
 }
 
 #streams_header {
     grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
-        minmax(17px, max-content) 30px 0;
+        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr) minmax(
+            0,
+            max-content
+        )
+        minmax(17px, max-content) var(--left-sidebar-vdots-width) 0;
     /* Keep the stream-search area rows collapsed. */
     grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
     cursor: pointer;
@@ -1469,8 +1482,8 @@ li.topic-list-item {
         grid-area: row-content;
     }
 
-    .heading-markers-and-controls {
-        grid-area: markers-and-controls;
+    .heading-markers-and-unreads {
+        grid-area: markers-and-unreads;
         height: 100%;
         display: flex;
         align-items: center;
@@ -1595,8 +1608,8 @@ li.topic-list-item {
    controls. */
 .spectator-view #streams_header {
     grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr)
-        minmax(30px, max-content) 0 0;
+        var(--left-sidebar-toggle-width-offset) 0 0 minmax(0, 1fr) 0
+        minmax(var(--left-sidebar-vdots-width), max-content) 0 0;
     margin-right: var(--left-sidebar-right-margin);
 
     /* With markers and controls now sized the same
@@ -1605,7 +1618,7 @@ li.topic-list-item {
        additional logged-out icons be added in the
        future), let's center the icon in that area,
        just like vdots would be. */
-    .heading-markers-and-controls {
+    .heading-markers-and-unreads {
         justify-content: center;
     }
 }
@@ -1722,7 +1735,7 @@ li.topic-list-item {
 
     .direct-messages-search-section {
         display: flex;
-        grid-column: row-content / markers-and-controls;
+        grid-column: row-content / markers-and-unreads;
         margin-top: 5px;
         margin-bottom: 5px;
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1017,6 +1017,11 @@ li.top_left_scheduled_messages {
 
     .stream-name {
         grid-area: row-content;
+        color: inherit;
+
+        &:hover {
+            text-decoration: none;
+        }
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -220,7 +220,7 @@
 
     #show-all-direct-messages {
         color: var(--color-left-sidebar-heads-up-icon);
-        display: flex;
+        display: none;
         align-items: center;
         justify-content: center;
         text-decoration: none;
@@ -233,6 +233,14 @@
                 --background-color-left-sidebar-heads-up-icon-hover
             );
         }
+
+        @media (hover: none) {
+            display: flex;
+        }
+    }
+
+    &:hover #show-all-direct-messages {
+        display: flex;
     }
 }
 
@@ -1510,11 +1518,19 @@ li.topic-list-item {
     }
 
     #filter_streams_tooltip {
-        display: flex;
+        display: none;
         align-items: center;
         justify-content: center;
         grid-row: 1 / 1;
         margin: 2px 0;
+
+        @media (hover: none) {
+            display: flex;
+        }
+    }
+
+    &:hover #filter_streams_tooltip {
+        display: flex;
     }
 
     #add_streams_tooltip {
@@ -1523,12 +1539,21 @@ li.topic-list-item {
     }
 
     #streams_inline_icon {
-        display: flex;
+        display: none;
         align-items: center;
         justify-content: center;
         /* Ensure the clickable area grows to
            the height of the controls grid. */
         height: 100%;
+
+
+        @media (hover: none) {
+            display: flex;
+        }
+    }
+
+    &:hover #streams_inline_icon {
+        display: flex;
     }
 
     .stream_search_section {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -928,7 +928,8 @@ li.top_left_scheduled_messages {
     cursor: pointer;
     border-radius: 4px;
 
-    &:not(.remove-pointer-for-spectator):hover {
+    &:not(.remove-pointer-for-spectator):hover,
+    &:has(.left-sidebar-navigation-menu-icon[aria-expanded="true"]) {
         background-color: var(--color-background-hover-narrow-filter);
         box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -228,6 +228,12 @@
         display: flex;
         gap: 5px;
         align-items: center;
+        /* Extra margin for unreads. */
+        margin-right: var(--left-sidebar-unread-offset);
+
+        &:has(.unread_count:empty) {
+            margin-right: 0;
+        }
     }
 
     #show-all-direct-messages {
@@ -764,6 +770,12 @@ li.top_left_scheduled_messages {
 
     .unread_count {
         grid-area: markers-and-unreads;
+        /* Extra margin for unreads. */
+        margin-right: var(--left-sidebar-unread-offset);
+
+        &:empty {
+            margin-right: 0;
+        }
     }
 }
 
@@ -772,6 +784,8 @@ li.top_left_scheduled_messages {
         .masked_unread_count {
             display: flex;
             grid-area: markers-and-unreads;
+            /* Extra margin for unreads. */
+            margin-right: var(--left-sidebar-unread-offset);
         }
 
         .unread_count {
@@ -1185,6 +1199,12 @@ li.top_left_scheduled_messages {
     gap: 5px;
     align-items: center;
     justify-content: center;
+    /* Extra margin for unreads. */
+    margin-right: var(--left-sidebar-unread-offset);
+
+    &:has(.unread_count:empty) {
+        margin-right: 0;
+    }
 
     .unread_mention_info {
         /* Unset margin in favor of flex gap. */
@@ -1437,6 +1457,12 @@ li.topic-list-item {
            16px-high unread box. */
         display: flex;
         align-items: center;
+        /* Extra margin for unreads. */
+        margin-right: var(--left-sidebar-unread-offset);
+
+        &:empty {
+            margin-right: 0;
+        }
     }
 }
 
@@ -1494,6 +1520,12 @@ li.topic-list-item {
 
     .unread_count {
         grid-area: markers-and-unreads;
+        /* Extra margin for unreads. */
+        margin-right: var(--left-sidebar-unread-offset);
+
+        &:empty {
+            margin-right: 0;
+        }
     }
 }
 
@@ -1551,6 +1583,12 @@ li.topic-list-item {
         display: flex;
         align-items: center;
         grid-gap: 5px;
+        /* Extra margin for unreads. */
+        margin-right: var(--left-sidebar-unread-offset);
+
+        &:has(.unread_count:empty) {
+            margin-right: 0;
+        }
     }
 
     #filter_streams_tooltip {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -61,6 +61,16 @@
     max-width: 18em;
 }
 
+.masked_unread_count {
+    font-size: 8px;
+    display: none;
+    /* Masked unreads display as flex when revealed. */
+    align-items: center;
+    justify-content: center;
+    color: var(--color-masked-unread-marker);
+    width: var(--left-sidebar-single-digit-unread-width);
+}
+
 #stream_filters {
     overflow: visible;
     margin-bottom: 5px;
@@ -95,14 +105,7 @@
 
     .stream-with-count.hide_unread_counts {
         .masked_unread_count {
-            display: block;
-            /* Shift masked dot to align with
-               the least-significant digit on
-               unreads in other rows.
-               We have to do this with margin,
-               because width or padding will
-               distort the CSS-created dot. */
-            margin-right: var(--masked-unread-count-margin-right);
+            display: flex;
         }
 
         .unread_count {
@@ -767,10 +770,8 @@ li.top_left_scheduled_messages {
 .top_left_starred_messages {
     &.hide_starred_message_count {
         .masked_unread_count {
-            display: block;
+            display: flex;
             grid-area: markers-and-unreads;
-            /* Adding margin-right aligns the .masked_unread_count with the rest of the masked unread counts in the channel list. */
-            margin-right: var(--masked-unread-count-margin-right);
         }
 
         .unread_count {
@@ -1183,6 +1184,7 @@ li.top_left_scheduled_messages {
     /* Present a uniform space between icons */
     gap: 5px;
     align-items: center;
+    justify-content: center;
 
     .unread_mention_info {
         /* Unset margin in favor of flex gap. */
@@ -1501,7 +1503,8 @@ li.topic-list-item {
             0,
             max-content
         )
-        minmax(17px, max-content) var(--left-sidebar-vdots-width) 0;
+        minmax(0, max-content) var(--left-sidebar-vdots-width)
+        0;
     /* Keep the stream-search area rows collapsed. */
     grid-template-rows: var(--line-height-sidebar-row-prominent) 0 0;
     cursor: pointer;
@@ -1612,10 +1615,7 @@ li.topic-list-item {
         }
 
         .masked_unread_count {
-            display: block;
-            /* Hold space enough so single-digit
-               unreads don't shift on hover. */
-            margin: 0 3px;
+            display: flex;
         }
 
         &:hover {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -451,19 +451,29 @@ ul.filters {
 
     .has-only-muted-unreads {
         .unread_count {
-            opacity: 0.5;
+            opacity: var(--opacity-left-sidebar-muted);
+        }
+
+        &:hover .unread_count {
+            opacity: var(--opacity-left-sidebar-muted-hover);
         }
     }
 
-    .has-only-muted-mentions .unread_mention_info {
-        opacity: 0.5;
+    .has-only-muted-mentions {
+        .unread_mention_info {
+            opacity: var(--opacity-left-sidebar-muted);
+        }
+
+        &:hover .unread_mention_info {
+            opacity: var(--opacity-left-sidebar-muted-hover);
+        }
     }
 
     /* This is a noop in the current design, because unread counts for
        muted streams have the same opacity, but the logic is here to
        be explicit and because the design may change in the future. */
     .more_topic_unreads_muted_only .unread_count {
-        opacity: 0.5;
+        opacity: var(--opacity-left-sidebar-muted);
     }
 
     .zulip-icon-follow {
@@ -475,24 +485,41 @@ ul.filters {
         }
     }
 
-    & li.muted_topic,
-    li.out_of_home_view {
-        color: hsl(0deg 0% 20% / 50%);
-
-        .has-unmuted-mentions .unread_mention_info {
-            color: hsl(0deg 0% 20%);
+    & li.muted_topic {
+        .sidebar-topic-check,
+        .sidebar-topic-name,
+        .unread_count {
+            opacity: var(--opacity-left-sidebar-muted);
         }
 
-        .stream-privacy {
-            opacity: 0.5;
+        &:hover {
+            .sidebar-topic-check,
+            .sidebar-topic-name,
+            .unread_count {
+                opacity: var(--opacity-left-sidebar-muted-hover);
+            }
+        }
+    }
+
+    & li.out_of_home_view {
+        .stream-privacy,
+        .stream-name,
+        .channel-new-topic-button,
+        .unread_count,
+        .masked_unread_count,
+        .sidebar-menu-icon {
+            opacity: var(--opacity-left-sidebar-muted);
         }
 
-        & .unread_count {
-            opacity: 0.5;
-        }
-
-        & .masked_unread_count {
-            opacity: 0.5;
+        &:hover {
+            .stream-privacy,
+            .stream-name,
+            .channel-new-topic-button,
+            .unread_count,
+            .masked_unread_count,
+            .sidebar-menu-icon {
+                opacity: var(--opacity-left-sidebar-muted-hover);
+            }
         }
 
         .has-unmuted-unreads {
@@ -507,33 +534,6 @@ ul.filters {
             .unread_count {
                 opacity: 1;
             }
-        }
-    }
-
-    & li.out_of_home_view {
-        &:hover {
-            color: hsla(0deg 0% 20% / 75%);
-
-            .stream-privacy {
-                opacity: 0.75;
-            }
-
-            .unread_count {
-                opacity: 0.75;
-            }
-
-            .has-unmuted-unreads {
-                .unread_count {
-                    opacity: 1;
-                }
-            }
-        }
-
-        & li.muted_topic {
-            /* If stream is muted, this resets opacity of muted topics in muted
-            stream to 1; since opacity is multiplied down through child
-            elements, this avoids an unreadably low opacity. */
-            opacity: 1;
         }
     }
 }

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -34,7 +34,7 @@
             color: var(--color-text-message-header);
 
             &:hover {
-                color: var(--color-text-message-header) !important;
+                color: var(--color-text-message-header);
                 text-decoration: none;
             }
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -68,12 +68,23 @@ blockquote p {
     font-weight: normal;
 }
 
+/* These colors are typically overridden,
+   but referencing them as variables prevents
+   specificity wars and ugly :not() selectors,
+   especially in dark theme. */
 a {
     cursor: pointer;
+    color: var(--color-text-generic-link);
+    text-decoration: none;
+}
 
-    &.message_label_clickable:hover {
-        cursor: pointer;
-        color: hsl(200deg 100% 40%);
+a:hover,
+a:focus {
+    color: var(--color-text-generic-link-interactive);
+    text-decoration: underline;
+
+    & code {
+        color: var(--color-text-generic-link-interactive);
     }
 }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -147,7 +147,7 @@
     <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
         <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
-        <div class="heading-markers-and-controls">
+        <div class="heading-markers-and-unreads">
             <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                 <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
             </a>
@@ -172,7 +172,7 @@
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide {{#if hide_unread_counts}}hide_unread_counts{{/if}}">
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'CHANNELS' }}</span></h4>
-                <div class="heading-markers-and-controls">
+                <div class="heading-markers-and-unreads">
                     <i id="filter_streams_tooltip" class="streams_filter_icon zulip-icon zulip-icon-search" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                     <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
                         <i id="streams_inline_icon" class="zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -116,7 +116,9 @@
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
-                    <span class="masked_unread_count"></span>
+                    <span class="masked_unread_count">
+                        <i class="zulip-icon zulip-icon-masked-unread"></i>
+                    </span>
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
@@ -182,7 +184,9 @@
                 </div>
                 <div class="heading-markers-and-unreads">
                     <span class="unread_count"></span>
-                    <span class="masked_unread_count"></span>
+                    <span class="masked_unread_count">
+                        <i class="zulip-icon zulip-icon-masked-unread"></i>
+                    </span>
                 </div>
 
                 <div class="notdisplayed stream_search_section">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -147,10 +147,12 @@
     <div id="direct-messages-section-header" class="direct-messages-container hidden-for-spectators zoom-out zoom-in-sticky">
         <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
-        <div class="heading-markers-and-unreads">
+        <div class="left-sidebar-controls">
             <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                 <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
             </a>
+        </div>
+        <div class="heading-markers-and-unreads">
             <span class="unread_count"></span>
         </div>
         <a class="zoom-out-hide" id="hide-more-direct-messages">
@@ -172,11 +174,13 @@
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide {{#if hide_unread_counts}}hide_unread_counts{{/if}}">
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'CHANNELS' }}</span></h4>
-                <div class="heading-markers-and-unreads">
+                <div class="left-sidebar-controls">
                     <i id="filter_streams_tooltip" class="streams_filter_icon zulip-icon zulip-icon-search" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                     <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
                         <i id="streams_inline_icon" class="zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
                     </span>
+                </div>
+                <div class="heading-markers-and-unreads">
                     <span class="unread_count"></span>
                     <span class="masked_unread_count"></span>
                 </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -149,7 +149,7 @@
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
         <div class="heading-markers-and-controls">
             <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
-                <i class="fa fa-align-right" aria-label="{{t 'Direct message feed' }}"></i>
+                <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
             </a>
             <span class="unread_count"></span>
         </div>
@@ -173,9 +173,9 @@
             <div id="streams_header" class="zoom-in-hide {{#if hide_unread_counts}}hide_unread_counts{{/if}}">
                 <h4 class="left-sidebar-title"><span class="streams-tooltip-target" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'CHANNELS' }}</span></h4>
                 <div class="heading-markers-and-controls">
-                    <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
+                    <i id="filter_streams_tooltip" class="streams_filter_icon zulip-icon zulip-icon-search" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                     <span id="add_streams_tooltip" class="hidden-for-spectators" data-tippy-content="{{t 'Add channels' }}">
-                        <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
+                        <i id="streams_inline_icon" class="zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
                     </span>
                     <span class="unread_count"></span>
                     <span class="masked_unread_count"></span>

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -3,7 +3,7 @@
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <div class="topic-box">
         <a class="sidebar-topic-action-heading" tabindex="0">{{t "Show all topics" }}</a>
-        <div class="topic-markers-and-controls">
+        <div class="topic-markers-and-unreads">
             {{#if more_topics_have_unread_mention_messages}}
                 <span class="unread_mention_info">
                     @

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -10,12 +10,6 @@
         </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="popover_new_topic_button popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "New topic"}}</span>
-            </a>
-        </li>
-        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="mark_stream_as_read popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Mark all messages as read"}}</span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -8,7 +8,7 @@
                 {{> stream_privacy }}
             </span>
 
-            <span title="{{name}}" class="stream-name">{{name}}</span>
+            <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
 
             <div class="stream-markers-and-controls">
                 <span class="unread_mention_info"></span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -10,7 +10,7 @@
 
             <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
 
-            <div class="stream-markers-and-controls">
+            <div class="stream-markers-and-unreads">
                 <span class="unread_mention_info"></span>
                 <span class="unread_count"></span>
                 <span class="masked_unread_count"></span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -19,7 +19,9 @@
             <div class="stream-markers-and-unreads">
                 <span class="unread_mention_info"></span>
                 <span class="unread_count"></span>
-                <span class="masked_unread_count"></span>
+                <span class="masked_unread_count">
+                    <i class="zulip-icon zulip-icon-masked-unread"></i>
+                </span>
             </div>
 
             <span class="sidebar-menu-icon stream-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -10,6 +10,12 @@
 
             <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
 
+            <div class="left-sidebar-controls">
+                <div class="channel-new-topic-button tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{t 'New topic'}}" data-stream-id="{{id}}">
+                    <i class="channel-new-topic-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                </div>
+            </div>
+
             <div class="stream-markers-and-unreads">
                 <span class="unread_mention_info"></span>
                 <span class="unread_count"></span>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -6,7 +6,7 @@
         <a href="{{url}}" class="sidebar-topic-name" title="{{topic_name}}">
             <span class="sidebar-topic-name-inner">{{topic_display_name}}</span>
         </a>
-        <div class="topic-markers-and-controls change_visibility_policy" data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}">
+        <div class="topic-markers-and-unreads change_visibility_policy" data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}">
             {{#if contains_unread_mention}}
                 <span class="unread_mention_info">
                     @

--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -57,15 +57,6 @@ label,
 button {
   cursor: pointer;
 }
-a {
-  color: #0088cc;
-  text-decoration: none;
-}
-a:hover,
-a:focus {
-  color: #005580;
-  text-decoration: underline;
-}
 p {
   margin: 0 0 10px;
 }


### PR DESCRIPTION
This PR does the following:

1. It implements @terpimost's design for showing icons in DM and Channel heading rows only upon hover (controls remain visible for touchscreen devices).
2. It updates the icons and colors for the heading-row controls.
3. It moves the New topic icon and functionality to stream rows from their previous location in the channel popover. The New topic icon is always shown on the active channel, and available as a hover control on all other channel rows.
4. It adjusts the `--color-vdots-hint` values to be more subtle, and therefore less distracting, on touchscreens.
5. It refactors opacity and hover opacity for muted channels and muted topics, including restoring missing opacity value on muted topics that was lost in a recent regression.
6. It presents unread markers as icons, rather than CSS-drawn circles, in part to correct an alignment issue introduced by the unread-offset for the New topic icon.
7. It falls back to variables for styling generic links on `<a>`
8. It restores `<a>` to channel rows, making them responsive to Cmd/Control-clicks.

Fixes #31801.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/.22New.20topic.22.20in.20stream.20menu/near/1957738)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dark-mode-new-topic-icons-before](https://github.com/user-attachments/assets/ad0053ab-a935-4da6-94d4-e9dd9a3c245b) | ![dark-mode-new-topic-icons-after](https://github.com/user-attachments/assets/3c58d9a3-dcab-4f62-a743-7ce85b4ff80c) |

| Touchscreen, light | Touchscreen, dark |
| --- | --- |
| ![ipad-showing-icons-light](https://github.com/user-attachments/assets/c2d742c9-fd39-4c6c-b4e1-8cacdea3eb8d) | ![ipad-showing-icons-dark](https://github.com/user-attachments/assets/012bcd71-4819-44cb-9153-cb4b2b3782a8) |

Interactivity:

![hover-icons-after](https://github.com/user-attachments/assets/7c946060-512b-4edc-9376-543e9cef39b1)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>