### PR TITLE
left_sidebar: Show tooltip only for truncated channel names.

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -92,7 +92,6 @@ async function navigation_tests(page: Page): Promise<void> {
     await common.log_in(page);
 
     await navigate_to_settings(page);
-
     await navigate_using_left_sidebar(page, "Verona");
 
     await page.click("#left-sidebar-navigation-list .home-link");

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -185,6 +185,24 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".subscription_block",
+        trigger: "mouseenter",
+        delay: LONG_HOVER_DELAY,
+        placement: "right",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const stream_name = instance.reference.querySelector(".stream-name");
+            assert(stream_name instanceof HTMLElement);
+            if (stream_name.offsetWidth >= stream_name.scrollWidth) {
+                return false;
+            }
+            const truncated_stream_name = stream_name.textContent ?? "";
+            instance.setContent(truncated_stream_name);
+            return undefined;
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,


### PR DESCRIPTION
This commit replaces the default HTML title attribute with a Tippy.js tooltip for stream names in the subscription block, ensuring that tooltips are shown only when the name is truncated.

Fixes #31807

|Before(Big Channel name)|After(Big Channel name)|
|----|----|
|<img width="304" alt="Screenshot 2024-10-04 at 5 50 45 AM" src="https://github.com/user-attachments/assets/705996ab-cd5f-4ecd-8517-86a37a4e8cf3">|<img width="322" alt="Screenshot 2024-10-03 at 5 31 09 AM" src="https://github.com/user-attachments/assets/227a8ed3-d1dc-4478-a8ff-685755d3a4b4">|

|Before(Small Channel name)|After(Small Channel name)|
|----|-----|
|<img width="331" alt="Screenshot 2024-10-03 at 5 29 42 AM" src="https://github.com/user-attachments/assets/fc930dc8-02aa-4d98-9b14-bb8fa894ecae">|<img width="322" alt="Screenshot 2024-10-04 at 5 47 08 AM" src="https://github.com/user-attachments/assets/43ecfb18-146d-4e2a-962a-748c56abf2f0">|


This tooltip only shows when the stream name is big such that it will get truncated. 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
