### PR TITLE
message_view_header: Remove unnecessary complexity.

### DIFF
--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -3,7 +3,6 @@ import assert from "minimalistic-assert";
 
 import render_message_view_header from "../templates/message_view_header.hbs";
 
-import * as blueslip from "./blueslip";
 import type {Filter} from "./filter";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
@@ -131,17 +130,7 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
 }
 
 export function colorize_message_view_header(): void {
-    const filter = narrow_state.filter();
-    let current_sub;
-    if (filter?.has_operator("channel")) {
-        current_sub = stream_data.get_sub_by_id_string(filter.operands("channel")[0]!);
-        if (current_sub === undefined) {
-            blueslip.error("Unexpected undefined sub", {
-                stream_id: filter.operands("channel")[0],
-                filter,
-            });
-        }
-    }
+    const current_sub = narrow_state.stream_sub();
     if (!current_sub) {
         return;
     }


### PR DESCRIPTION
The narrow_state module has a function that returns what this needs.

This does remove a log statement, but I don't think it was useful; we don't need to or have a useful way to colorize a channel that doesn't exist.
