### PR TITLE
sponsorship: Fix `#organization-type` not found.

### DIFF
--- a/web/src/billing/sponsorship.ts
+++ b/web/src/billing/sponsorship.ts
@@ -85,6 +85,11 @@ function create_ajax_request(): void {
 }
 
 export function initialize(): void {
+    if ($(".sponsorship-status-page").length > 0) {
+        // Sponsorship form is not present on sponsorship status page.
+        return;
+    }
+
     $("#sponsorship-button").on("click", (e) => {
         if (!helpers.is_valid_input($("#sponsorship-form"))) {
             return;


### PR DESCRIPTION
The sponsorship form is not visible once user submits the form, hence we don't to call these functions.
https://zulip.sentry.io/issues/5904364828/events/?project=4504556882821120