### PR TITLE
Fix message pointer out of view sometimes when vising a cached view.

### DIFF
--- a/web/src/condense.ts
+++ b/web/src/condense.ts
@@ -152,6 +152,9 @@ export function toggle_collapse(message: Message): void {
             collapse(message);
         }
     }
+
+    // Select and scroll to the message so that it is in the view.
+    message_lists.current.select_id(message.id, {then_scroll: true});
 }
 
 function get_message_height(elem: HTMLElement): number {
@@ -250,8 +253,6 @@ export function initialize(): void {
         assert(message_lists.current !== undefined);
         const message = message_lists.current.get(id);
         assert(message !== undefined);
-        // Focus on the expanded message.
-        message_lists.current.select_id(id);
         const $content = $row.find(".message_content");
         if (message.collapsed) {
             // Uncollapse.
@@ -261,6 +262,8 @@ export function initialize(): void {
             message.condensed = false;
             uncondense_row($row);
         }
+        // Select and scroll to the message so that it is in the view.
+        message_lists.current.select_id(message.id, {then_scroll: true});
         e.stopPropagation();
         e.preventDefault();
     });
@@ -268,13 +271,13 @@ export function initialize(): void {
     $("#message_feed_container").on("click", ".message_condenser", function (this: HTMLElement, e) {
         const $row = $(this).closest(".message_row");
         const id = rows.id($row);
-        // Focus on the condensed message.
         assert(message_lists.current !== undefined);
-        message_lists.current.select_id(id);
         const message = message_lists.current.get(id);
         assert(message !== undefined);
         message.condensed = true;
         condense_row($row);
+        // Select and scroll to the message so that it is in the view.
+        message_lists.current.select_id(message.id, {then_scroll: true});
         e.stopPropagation();
         e.preventDefault();
     });


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/issue.20with.20message.20links.20when.20message.20not.20loaded.3F

Since both the message reported in https://leanprover.zulipchat.com/#narrow/stream/236604-Zulip-meta/topic/Links.20to.20messages.20don't.20work.3F can be collapsed:
* https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/thoughts.20on.20elliptic.20curves/near/384147037
* https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/lean.2Envim/near/473385145

The reported issue is likely related to collapsing message. This is a bug I found when playing with the message collapsing which is likely the cause.

Easy reproducer is to send a very long message so that you can
see the collapse / expand banner followed by enough messages that
you can scroll past the long message. Then just try collapsing the
message when the bottom of the long message is visible.

This can also cause other bugs like the pointer not visible when
user visits this view again since we cache the scroll offset of
the pointer.
