### PR TITLE
Left-sidebar - Use -, _ and / as additional word separators in topic filtering

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -187,7 +187,15 @@ export function get_list_info(
     }
 
     if (zoomed) {
-        topic_names = util.filter_by_word_prefix_match(topic_names, search_term, (item) => item);
+        const extended_word_separator_regex = /[\s/_-]/;
+        const filtered_topic_names = util.filter_by_word_prefix_match(
+            topic_names,
+            search_term,
+            (topic) => topic,
+            extended_word_separator_regex,
+        );
+
+        topic_names = filtered_topic_names;
     }
 
     if (stream_muted && !zoomed) {

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,6 +1,16 @@
 <div class="topic_search_section filter-topics">
-    <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
-    <button type="button" class="btn clear_search_button" id="clear_search_topic_button">
+    <input
+        class="topic-list-filter home-page-input filter_text_input"
+        id="filter-topic-input"
+        type="text"
+        autocomplete="off"
+        placeholder="{{t 'Filter topics'}}"
+    />
+    <button
+        type="button"
+        class="btn clear_search_button"
+        id="clear_search_topic_button"
+    >
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>
 </div>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -1,72 +1,118 @@
-<div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
-  aria-label="{{t 'Keyboard shortcuts' }}">
-    <div class="overlay-scroll-container" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+<div
+    class="overlay-modal"
+    id="keyboard-shortcuts"
+    tabindex="-1"
+    role="dialog"
+    aria-label="{{t 'Keyboard shortcuts'}}"
+>
+    <div
+        class="overlay-scroll-container"
+        data-simplebar
+        data-simplebar-tab-index="-1"
+        data-simplebar-auto-hide="false"
+    >
         <div>
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t "The basics" }}</th>
+                        <th colspan="2">{{t "The basics"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
+                    <td class="definition">{{t "Reply to message"}}</td>
+                    <td><span class="hotkey"><kbd>Enter</kbd>
+                            or
+                            <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New channel message' }}</td>
+                    <td class="definition">{{t "New channel message"}}</td>
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New direct message' }}</td>
+                    <td class="definition">{{t "New direct message"}}</td>
                     <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Paste formatted text' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>V</kbd></span></td>
+                    <td class="definition">{{t "Paste formatted text"}}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd>
+                            +
+                            <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Paste as plain text' }}</td>
-                    <td><span class="hotkey"><kbd data-mac-following-key="⌥">Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd></span></td>
+                    <td class="definition">{{t "Paste as plain text"}}</td>
+                    <td><span class="hotkey"><kbd
+                                data-mac-following-key="⌥"
+                            >Ctrl</kbd>
+                            +
+                            <kbd>Shift</kbd>
+                            +
+                            <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
+                    <td class="definition">{{t
+                            "Cancel compose and save draft"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Esc</kbd>
+                            or
+                            <kbd>Ctrl</kbd>
+                            +
+                            <kbd>[</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View drafts' }}</td>
+                    <td class="definition">{{t "View drafts"}}</td>
                     <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
+                    <td class="definition">{{t "Next message"}}</td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd>
+                            or
+                            <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
+                    <td class="definition">{{t "Last message"}}</td>
+                    <td><span class="hotkey"><kbd>End</kbd>
+                            or
+                            <kbd>Shift</kbd>
+                            +
+                            <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next unread topic' }}</td>
+                    <td class="definition">{{t "Next unread topic"}}</td>
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next unread followed topic' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>N</kbd></span></td>
+                    <td class="definition">{{t
+                            "Next unread followed topic"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>N</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next unread direct message' }}</td>
+                    <td class="definition">{{t
+                            "Next unread direct message"
+                        }}</td>
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Initiate a search' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
+                    <td class="definition">{{t "Initiate a search"}}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd>
+                            +
+                            <kbd>K</kbd>
+                            or
+                            <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
+                    <td class="definition">{{t "Show keyboard shortcuts"}}</td>
                     <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to your home view' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>[</kbd><span id="go-to-home-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
+                    <td class="definition">{{t "Go to your home view"}}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd>
+                            +
+                            <kbd>[</kbd><span id="go-to-home-view-hotkey-help">
+                                or
+                                <kbd>Esc</kbd></span></span></td>
                 </tr>
             </table>
         </div>
@@ -74,19 +120,23 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Search' }}</th>
+                        <th colspan="2">{{t "Search"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Initiate a search' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
+                    <td class="definition">{{t "Initiate a search"}}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd>
+                            +
+                            <kbd>K</kbd>
+                            or
+                            <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Filter channels' }}</td>
+                    <td class="definition">{{t "Filter channels"}}</td>
                     <td><span class="hotkey"><kbd>Q</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Search people' }}</td>
+                    <td class="definition">{{t "Search people"}}</td>
                     <td><span class="hotkey"><kbd>W</kbd></span></td>
                 </tr>
             </table>
@@ -95,31 +145,49 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Scrolling' }}</th>
+                        <th colspan="2">{{t "Scrolling"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Previous message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></span></td>
+                    <td class="definition">{{t "Previous message"}}</td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd>
+                            or
+                            <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
+                    <td class="definition">{{t "Next message"}}</td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd>
+                            or
+                            <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Scroll up' }}</td>
-                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd></span></td>
+                    <td class="definition">{{t "Scroll up"}}</td>
+                    <td><span class="hotkey"><kbd>PgUp</kbd>
+                            or
+                            <kbd>Shift</kbd>
+                            +
+                            <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Scroll down' }}</td>
-                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Space</kbd></span></td>
+                    <td class="definition">{{t "Scroll down"}}</td>
+                    <td><span class="hotkey"><kbd>PgDn</kbd>
+                            or
+                            <kbd>Shift</kbd>
+                            +
+                            <kbd>J</kbd>
+                            or
+                            <kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
+                    <td class="definition">{{t "Last message"}}</td>
+                    <td><span class="hotkey"><kbd>End</kbd>
+                            or
+                            <kbd>Shift</kbd>
+                            +
+                            <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'First message' }}</td>
+                    <td class="definition">{{t "First message"}}</td>
                     <td><span class="hotkey"><kbd>Home</kbd></span></td>
                 </tr>
             </table>
@@ -128,68 +196,108 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Navigation' }}</th>
+                        <th colspan="2">{{t "Navigation"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Go back through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
+                    <td class="definition">{{t
+                            "Go back through viewing history"
+                        }}</td>
+                    <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd>
+                            +
+                            <kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go forward through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
+                    <td class="definition">{{t
+                            "Go forward through viewing history"
+                        }}</td>
+                    <td><span class="hotkey"><kbd data-mac-key="⌘">Alt</kbd>
+                            +
+                            <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to topic or DM conversation' }}</td>
+                    <td class="definition">{{t
+                            "Go to topic or DM conversation"
+                        }}</td>
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to channel feed from topic view' }}</td>
+                    <td class="definition">{{t
+                            "Go to channel feed from topic view"
+                        }}</td>
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to direct message feed' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
+                    <td class="definition">{{t
+                            "Go to direct message feed"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>P</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
+                    <td class="definition">{{t
+                            "Zoom to message in conversation context"
+                        }}</td>
                     <td><span class="hotkey"><kbd>Z</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to next unread topic' }}</td>
+                    <td class="definition">{{t "Go to next unread topic"}}</td>
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to next unread followed topic' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>N</kbd></span></td>
+                    <td class="definition">{{t
+                            "Go to next unread followed topic"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>N</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to next unread direct message' }}</td>
+                    <td class="definition">{{t
+                            "Go to next unread direct message"
+                        }}</td>
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cycle between channel views' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
+                    <td class="definition">{{t
+                            "Cycle between channel views"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>A</kbd>
+                            or
+                            <kbd>Shift</kbd>
+                            +
+                            <kbd>D</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to inbox' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>I</kbd></span></td>
+                    <td class="definition">{{t "Go to inbox"}}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>I</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to recent conversations' }}</td>
+                    <td class="definition">{{t
+                            "Go to recent conversations"
+                        }}</td>
                     <td><span class="hotkey"><kbd>T</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to combined feed' }}</td>
+                    <td class="definition">{{t "Go to combined feed"}}</td>
                     <td><span class="hotkey"><kbd>A</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to starred messages' }}</td>
+                    <td class="definition">{{t "Go to starred messages"}}</td>
                     <td><span class="hotkey"><kbd>*</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to the conversation you are composing to' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
+                    <td class="definition">{{t
+                            "Go to the conversation you are composing to"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd>
+                            +
+                            <kbd>.</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -197,48 +305,72 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Composing messages' }}</th>
+                        <th colspan="2">{{t "Composing messages"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'New channel message' }}</td>
+                    <td class="definition">{{t "New channel message"}}</td>
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New direct message' }}</td>
+                    <td class="definition">{{t "New direct message"}}</td>
                     <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
+                    <td class="definition">{{t "Reply to message"}}</td>
+                    <td><span class="hotkey"><kbd>Enter</kbd>
+                            or
+                            <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Quote and reply to message' }}</td>
+                    <td class="definition">{{t
+                            "Quote and reply to message"
+                        }}</td>
                     <td><span class="hotkey"><kbd>></kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Reply directly to sender' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>R</kbd></span></td>
+                    <td class="definition">{{t "Reply directly to sender"}}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Reply @-mentioning sender' }}</td>
+                    <td class="definition">{{t
+                            "Reply @-mentioning sender"
+                        }}</td>
                     <td><span class="hotkey"><kbd>@</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Send message' }}</td>
-                    <td><span class="hotkey"><kbd>Tab</kbd> then <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd></span></td>
+                    <td class="definition">{{t "Send message"}}</td>
+                    <td><span class="hotkey"><kbd>Tab</kbd>
+                            then
+                            <kbd>Enter</kbd>
+                            or
+                            <kbd>Ctrl</kbd>
+                            +
+                            <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Insert new line' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
+                    <td class="definition">{{t "Insert new line"}}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Toggle preview mode' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd>P</kbd></span></td>
+                    <td class="definition">{{t "Toggle preview mode"}}</td>
+                    <td><span class="hotkey"><kbd>Alt</kbd>
+                            +
+                            <kbd>P</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
+                    <td class="definition">{{t
+                            "Cancel compose and save draft"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Esc</kbd>
+                            or
+                            <kbd>Ctrl</kbd>
+                            +
+                            <kbd>[</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -246,66 +378,92 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Message actions' }}</th>
+                        <th colspan="2">{{t "Message actions"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Edit your last message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd></span></td>
+                    <td class="definition">{{t "Edit your last message"}}</td>
+                    <td><span class="hotkey"><kbd
+                                class="arrow-key"
+                            >←</kbd></span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
-                    <td class="definition">{{t 'Edit selected message or view source' }}</td>
+                    <td class="definition">{{t
+                            "Edit selected message or view source"
+                        }}</td>
                     <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t "Show message sender's user card"   }}</td>
+                    <td class="definition">{{t
+                            "Show message sender's user card"
+                        }}</td>
                     <td><span class="hotkey"><kbd>U</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View read receipts' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
+                    <td class="definition">{{t "View read receipts"}}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Show images in thread' }}</td>
+                    <td class="definition">{{t "Show images in thread"}}</td>
                     <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>
                 <tr id="move-message-hotkey-help">
-                    <td class="definition">{{t 'Move messages or topic' }}</td>
+                    <td class="definition">{{t "Move messages or topic"}}</td>
                     <td><span class="hotkey"><kbd>M</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View edit and move history' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>H</kbd></span></td>
+                    <td class="definition">{{t
+                            "View edit and move history"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>H</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Star selected message' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
+                    <td class="definition">{{t "Star selected message"}}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd>
+                            +
+                            <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">
-                        {{t 'React to selected message with' }}
-                        <img alt=":thumbs_up:"
-                          class="emoji"
-                          src="../../static/generated/emoji/images/emoji/unicode/1f44d.png"
-                          title=":thumbs_up:"/>
+                        {{t "React to selected message with"}}
+                        <img
+                            alt=":thumbs_up:"
+                            class="emoji"
+                            src="../../static/generated/emoji/images/emoji/unicode/1f44d.png"
+                            title=":thumbs_up:"
+                        />
                     </td>
                     <td><span class="hotkey"><kbd>+</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Toggle first emoji reaction on selected message' }}</td>
+                    <td class="definition">{{t
+                            "Toggle first emoji reaction on selected message"
+                        }}</td>
                     <td><span class="hotkey"><kbd>=</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Mark as unread from selected message' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>U</kbd></span></td>
+                    <td class="definition">{{t
+                            "Mark as unread from selected message"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>U</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Collapse/show selected message' }}</td>
+                    <td class="definition">{{t
+                            "Collapse/show selected message"
+                        }}</td>
                     <td><span class="hotkey"><kbd>-</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Toggle topic mute' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>M</kbd></span></td>
+                    <td class="definition">{{t "Toggle topic mute"}}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>M</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -313,15 +471,17 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Recent conversations' }}</th>
+                        <th colspan="2">{{t "Recent conversations"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'View recent conversations' }}</td>
+                    <td class="definition">{{t
+                            "View recent conversations"
+                        }}</td>
                     <td><span class="hotkey"><kbd>T</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Filter topics' }}</td>
+                    <td class="definition">{{t "Filter topics"}}</td>
                     <td><span class="hotkey"><kbd>T</kbd></span></td>
                 </tr>
             </table>
@@ -330,19 +490,19 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Drafts' }}</th>
+                        <th colspan="2">{{t "Drafts"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'View drafts' }}</td>
+                    <td class="definition">{{t "View drafts"}}</td>
                     <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Edit selected draft' }}</td>
+                    <td class="definition">{{t "Edit selected draft"}}</td>
                     <td><span class="hotkey"><kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Delete selected draft' }}</td>
+                    <td class="definition">{{t "Delete selected draft"}}</td>
                     <td><span class="hotkey"><kbd>Backspace</kbd></span></td>
                 </tr>
             </table>
@@ -351,31 +511,35 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Menus' }}</th>
+                        <th colspan="2">{{t "Menus"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Toggle the gear menu' }}</td>
+                    <td class="definition">{{t "Toggle the gear menu"}}</td>
                     <td><span class="hotkey"><kbd>G</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Open personal menu' }}</td>
-                    <td><span class="hotkey"><kbd>G</kbd><kbd class="arrow-key">→</kbd></span></td>
+                    <td class="definition">{{t "Open personal menu"}}</td>
+                    <td><span class="hotkey"><kbd>G</kbd><kbd
+                                class="arrow-key"
+                            >→</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Open help menu' }}</td>
-                    <td><span class="hotkey"><kbd>G</kbd><kbd class="arrow-key">←</kbd></span></td>
+                    <td class="definition">{{t "Open help menu"}}</td>
+                    <td><span class="hotkey"><kbd>G</kbd><kbd
+                                class="arrow-key"
+                            >←</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Open message menu' }}</td>
+                    <td class="definition">{{t "Open message menu"}}</td>
                     <td><span class="hotkey"><kbd>I</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Open reactions menu' }}</td>
+                    <td class="definition">{{t "Open reactions menu"}}</td>
                     <td><span class="hotkey"><kbd>:</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
+                    <td class="definition">{{t "Show keyboard shortcuts"}}</td>
                     <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
             </table>
@@ -384,32 +548,46 @@
             <table class="hotkeys_table table table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Channel settings' }}</th>
+                        <th colspan="2">{{t "Channel settings"}}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Scroll through channels' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></span></td>
+                    <td class="definition">{{t "Scroll through channels"}}</td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd>
+                            or
+                            <kbd class="arrow-key">↓</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Switch between tabs' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></span></td>
+                    <td class="definition">{{t "Switch between tabs"}}</td>
+                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd>
+                            or
+                            <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View channel messages' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
+                    <td class="definition">{{t "View channel messages"}}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Subscribe to/unsubscribe from selected channel' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
+                    <td class="definition">{{t
+                            "Subscribe to/unsubscribe from selected channel"
+                        }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd>
+                            +
+                            <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Create new channel' }}</td>
+                    <td class="definition">{{t "Create new channel"}}</td>
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
             </table>
         </div>
         <hr />
-        <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
+        <a
+            href="/help/keyboard-shortcuts"
+            target="_blank"
+            rel="noopener noreferrer"
+        >{{t "Detailed keyboard shortcuts documentation"}}</a>
     </div>
 </div>

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -416,9 +416,11 @@ test("get_list_info with specific topics and searches", () => {
         });
     }
 
+    // Add sample messages
     add_topic_message("Outreachy-2024", 1001);
     add_topic_message("Test topic", 1002);
 
+    // Test search for "Outreachy-2024"
     list_info = get_list_info(true, "2924");
     assert.equal(list_info.items.length, 1);
     assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
@@ -430,15 +432,17 @@ test("get_list_info with specific topics and searches", () => {
     list_info = get_list_info(true, "support");
     assert.equal(list_info.items.length, 1);
     assert.equal(list_info.items[0].topic_name, "Test topic");
-    list_info = get_list_info(true, "zulip");
 
+    list_info = get_list_info(true, "zulip");
     assert.equal(list_info.items.length, 1);
     assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
 
+    // Test search for case-insensitive "SUPPORT"
     list_info = get_list_info(true, "SUPPORT");
     assert.equal(list_info.items.length, 1);
-    assert.equal(list_info.items[0].topic_name, "tech_support/escalation");
+    assert.equal(list_info.items[0].topic_name, "Test topic");
 
+    // Test non-existent search term
     list_info = get_list_info(true, "nonexistent");
     assert.equal(list_info.items.length, 0);
 });

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -405,7 +405,9 @@ test("get_list_info unreads", ({override}) => {
     );
 });
 
-test("get_list_info with specific topics and searches", ({override}) => {
+test("get_list_info with specific topics and searches", () => {
+    let list_info;
+
     function add_topic_message(topic_name, message_id) {
         stream_topic_history.add_message({
             stream_id: general.stream_id,
@@ -414,26 +416,29 @@ test("get_list_info with specific topics and searches", ({override}) => {
         });
     }
 
-    // Add sample messages to the topic history
     add_topic_message("Outreachy-2024", 1001);
     add_topic_message("Test topic", 1002);
 
-    // Helper function to test different search inputs
-    function assertSearchResult(searchTerm, expectedLength, expectedTopicName) {
-        const result = get_list_info(true, searchTerm);
-        assert.equal(result.items.length, expectedLength);
-        if (expectedLength > 0) {
-            assert.equal(result.items[0].topic_name, expectedTopicName);
-        }
-    }
+    list_info = get_list_info(true, "2924");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
 
-    // Testing various search terms and expecting results
-    assertSearchResult("Outreachy", 1, "Outreachy-2024");
-    assertSearchResult("Test topic", 1, "Test topic");
-    assertSearchResult("Test", 1, "Test topic");
-    assertSearchResult("2024", 1, "Outreachy-2024");
-    assertSearchResult("TEST", 1, "Test topic");
+    list_info = get_list_info(true, "Test topic");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Test topic");
 
-    // Testing non-existent search term
-    assertSearchResult("nonexistent", 0);
+    list_info = get_list_info(true, "support");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Test topic");
+    list_info = get_list_info(true, "zulip");
+
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
+
+    list_info = get_list_info(true, "SUPPORT");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "tech_support/escalation");
+
+    list_info = get_list_info(true, "nonexistent");
+    assert.equal(list_info.items.length, 0);
 });

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -404,3 +404,36 @@ test("get_list_info unreads", ({override}) => {
         ],
     );
 });
+
+test("get_list_info with specific topics and searches", ({override}) => {
+    function add_topic_message(topic_name, message_id) {
+        stream_topic_history.add_message({
+            stream_id: general.stream_id,
+            topic_name,
+            message_id,
+        });
+    }
+
+    // Add sample messages to the topic history
+    add_topic_message("Outreachy-2024", 1001);
+    add_topic_message("Test topic", 1002);
+
+    // Helper function to test different search inputs
+    function assertSearchResult(searchTerm, expectedLength, expectedTopicName) {
+        const result = get_list_info(true, searchTerm);
+        assert.equal(result.items.length, expectedLength);
+        if (expectedLength > 0) {
+            assert.equal(result.items[0].topic_name, expectedTopicName);
+        }
+    }
+
+    // Testing various search terms and expecting results
+    assertSearchResult("Outreachy", 1, "Outreachy-2024");
+    assertSearchResult("Test topic", 1, "Test topic");
+    assertSearchResult("Test", 1, "Test topic");
+    assertSearchResult("2024", 1, "Outreachy-2024");
+    assertSearchResult("TEST", 1, "Test topic");
+
+    // Testing non-existent search term
+    assertSearchResult("nonexistent", 0);
+});


### PR DESCRIPTION
Previously only spaces was used as a word separating character when
filtering topics. This meant that searching for "xyz" would not turn
up a topic named "stream-xyz" as one would expect.

To resolve this issue, hyphen (-), underscore (_), and slash (/) have been added as additional word separators for topic filtering in the left sidebar.

Fixes:  https://github.com/zulip/zulip/issues/31844

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2024-10-03 at 10 41 58](https://github.com/user-attachments/assets/4bc45b01-79b8-4205-af1e-9afb98683b59)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
