### PR TITLE
docs: Update keyboard shortcuts to always show "Fn" key option.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -69,19 +69,21 @@ in the Zulip app to add more to your repertoire as needed.
 
 ## Scrolling
 
-* **Last message**: <kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd> —
-  Also marks all messages in the current view as read.
+* **Last message**: <kbd>End</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">→</kbd>
+  or <kbd>Shift</kbd> + <kbd>G</kbd> — Also marks all messages in the current view
+  as read.
 
-* **First message**: <kbd>Home</kbd>
+* **First message**: <kbd>Home</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">←</kbd>
 
 * **Previous message**: <kbd class="arrow-key">↑</kbd> or <kbd>K</kbd>
 
 * **Next message**: <kbd class="arrow-key">↓</kbd> or <kbd>J</kbd>
 
-* **Scroll up**: <kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd>
+* **Scroll up**: <kbd>PgUp</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">↑</kbd>
+  or <kbd>Shift</kbd> + <kbd>K</kbd>
 
-* **Scroll down**: <kbd>PgDn</kbd>, <kbd>Shift</kbd> + <kbd>J</kbd>, or
-  <kbd>Spacebar</kbd>
+* **Scroll down**: <kbd>PgDn</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">↓</kbd>
+  or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Spacebar</kbd>
 
 ## Navigation
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -161,12 +161,6 @@ js_rules = RuleList(
                 "web/tests/",
                 "web/src/billing/",
             },
-            "exclude_line": {
-                (
-                    "web/src/common.ts",
-                    '$(this).before($("<kbd>").text("Fn"), $("<span>").text(" + ").contents());',
-                ),
-            },
         },
         {
             "pattern": r"""report.success\(["']""",

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -14,15 +14,9 @@ export function phrase_match(query: string, phrase: string): boolean {
 const keys_map = new Map([
     ["Backspace", "Delete"],
     ["Enter", "Return"],
-    ["Home", "←"],
-    ["End", "→"],
-    ["PgUp", "↑"],
-    ["PgDn", "↓"],
     ["Ctrl", "⌘"],
     ["Alt", "⌥"],
 ]);
-
-const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
 
 export function has_mac_keyboard(): boolean {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -38,11 +32,6 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
 
     $(kbd_elem_class).each(function () {
         let key_text = $(this).text();
-
-        if (fn_shortcuts.has(key_text)) {
-            $(this).before($("<kbd>").text("Fn"), $("<span>").text(" + ").contents());
-            $(this).addClass("arrow-key");
-        }
 
         // We use data-mac-key attribute to override the default key in case
         // of exceptions. Currently, there are 2 shortcuts (for navigating back
@@ -80,10 +69,6 @@ export function adjust_mac_hotkey_hints(hotkeys: string[]): void {
 
         if (replace_key !== undefined) {
             hotkeys[index] = replace_key;
-        }
-
-        if (fn_shortcuts.has(hotkey)) {
-            hotkeys.unshift("Fn");
         }
     }
 }

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -108,19 +108,19 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Scroll up' }}</td>
-                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd></span></td>
+                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">↑</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Scroll down' }}</td>
-                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Space</kbd></span></td>
+                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">↓</kbd> or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Fn</kbd> + <kbd class="arrow-key">→</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'First message' }}</td>
-                    <td><span class="hotkey"><kbd>Home</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Home</kbd >or <kbd>Fn</kbd> + <kbd class="arrow-key">←</kbd></span></td>
                 </tr>
             </table>
         </div>

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -42,10 +42,6 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
         ["Enter", "Return"],
-        ["Home", "←"],
-        ["End", "→"],
-        ["PgUp", "↑"],
-        ["PgDn", "↓"],
         ["Ctrl", "⌘"],
         ["Alt", "⌥"],
         ["#stream_name", "#stream_name"],
@@ -54,8 +50,6 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
         ["X", "X"],
         ["data-mac-following-key", "data-mac-following-key"],
     ]);
-
-    const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
 
     override(navigator, "platform", "MacIntel");
     $("<span>").contents = () => $("<contents-stub>");
@@ -67,12 +61,6 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
         const test_item = {};
         const $stub = $.create("hotkey_" + key_no);
         $stub.text(old_key);
-        assert.equal($stub.hasClass("arrow-key"), false);
-        if (fn_shortcuts.has(old_key)) {
-            $stub.before = ($elem) => {
-                assert.equal($elem.selector, "<kbd>");
-            };
-        }
         if (old_key === "data-mac-following-key") {
             $stub.attr("data-mac-following-key", "⌥");
             $stub.after = ($plus, $elem) => {
@@ -83,7 +71,6 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
         }
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
-        test_item.adds_arrow_key = fn_shortcuts.has(old_key);
         test_items.push(test_item);
         key_no += 1;
     }
@@ -96,7 +83,6 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
 
     for (const test_item of test_items) {
         assert.equal(test_item.$stub.text(), test_item.mac_key);
-        assert.equal(test_item.$stub.hasClass("arrow-key"), test_item.adds_arrow_key);
     }
 });
 
@@ -115,10 +101,6 @@ run_test("adjust_mac_hotkey_hints mac expected", ({override}) => {
     const keys_to_test_mac = new Map([
         [["Backspace"], ["Delete"]],
         [["Enter"], ["Return"]],
-        [["Home"], ["Fn", "←"]],
-        [["End"], ["Fn", "→"]],
-        [["PgUp"], ["Fn", "↑"]],
-        [["PgDn"], ["Fn", "↓"]],
         [["Ctrl"], ["⌘"]],
     ]);
 


### PR DESCRIPTION
Previously, these were only shown for Mac OS users and replaced the "Home", "End", "PgUp" and "PgDn" shortcuts. But as this really depends on the keyboard the user is using (there are Mac keyboards with the above keys), we instead show both options in our web app and help center documentation on keyboard shortcuts.

The tooltip for the "Scroll to bottom" button will now always show "End" for all users. Previously, it showed a "Fn" key option for Mac users.

See [relevant CZO dicussion](https://chat.zulip.org/#narrow/stream/137-feedback/topic/last.20message.20shortcut/near/1953002).

Fixes #31815.

---

**Screenshots and screen captures:**

<details>
<summary>Scroll to bottom button tooltip</summary>

![Screenshot from 2024-10-02 13-18-45](https://github.com/user-attachments/assets/a044644d-3282-49c5-92d2-77fb88e734ae)
</details>
<details>
<summary>Keyboard shortcuts help in web app for non-Mac users</summary>

![Screenshot from 2024-10-02 13-12-05](https://github.com/user-attachments/assets/0b046635-da6b-41b6-97dd-c0d6a0c5bf5c)
</details>
<details>
<summary>Keyboard shortcuts help in web app for Mac users</summary>

![Screenshot from 2024-10-02 13-11-40](https://github.com/user-attachments/assets/2259414e-cdcd-4b60-84c4-17a207352c4a)
</details>
<details>
<summary>Keyboard  shortcuts article in help center for non-Mac users</summary>

[Current documentation](https://zulip.com/help/keyboard-shortcuts#search)
![Screenshot from 2024-10-02 13-10-13](https://github.com/user-attachments/assets/4e0aac49-e2f8-40b2-8263-b7dbd78378df)
</details>
<details>
<summary>Keyboard  shortcuts article in help center for Mac users</summary>

[Current documentation](https://zulip.com/help/keyboard-shortcuts#search)
![Screenshot from 2024-10-02 13-11-02](https://github.com/user-attachments/assets/73d33a68-232e-4085-b590-c3a8bb0182d0)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
