### PR TITLE
Syncing ldap group descriptions

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -386,6 +386,24 @@ groups. To configure this feature:
    created automatically when syncing a user who should be a member of
    that group.
 
+1. Optionally, you can also enable syncing of descriptions of the
+   configured groups. The relevant Zulip groups will have their
+   descriptions updated to match the descriptions in LDAP.
+   To enable this, simply set:
+
+   ```python
+   LDAP_GROUP_DESCRIPTION_ATTR = "description"
+   ```
+
+   in place of `"description"` using the actual attribute name of your
+   LDAP groups that should be synced.
+   If a particular group doesn't have this attribute in your LDAP
+   directory, the Zulip group description will remain unchanged.
+
+   Note that this is a server-level setting, so specifying a different
+   LDAP attribute for the group description for different realms
+   is not supported.
+
 1. Test your configuration and restart the server into the new
    configuration as [documented above](#synchronizing-data).
 

--- a/zerver/management/commands/sync_ldap_user_data.py
+++ b/zerver/management/commands/sync_ldap_user_data.py
@@ -27,11 +27,15 @@ def sync_ldap_user_data(
     try:
         realms = {u.realm.string_id for u in user_profiles}
 
+        # Used for tracking which groups have already been synced across iterations,
+        # to avoid duplicate work.
+        already_synced_group_ids: set[int] = set()
+
         for u in user_profiles:
             # This will save the user if relevant, and will do nothing if the user
             # does not exist.
             try:
-                sync_user_from_ldap(u, logger)
+                sync_user_from_ldap(u, logger, already_synced_group_ids)
             except ZulipLDAPError as e:
                 logger.error("Error attempting to update user %s:", u.delivery_email)
                 logger.error(e.args[0])

--- a/zerver/tests/fixtures/ldap/directory.json
+++ b/zerver/tests/fixtures/ldap/directory.json
@@ -87,7 +87,8 @@
         "cn": ["cool_test_group"],
         "uniqueMember": [
             "uid=hamlet,ou=users,dc=zulip,dc=com"
-        ]
+        ],
+        "description": ["cool_test_group_description"]
     },
     "cn=another_test_group,ou=groups,dc=zulip,dc=com": {
         "objectClass": ["groupOfUniqueNames"],
@@ -95,6 +96,7 @@
         "uniqueMember": [
             "uid=hamlet,ou=users,dc=zulip,dc=com",
             "uid=cordelia,ou=users,dc=zulip,dc=com"
-        ]
+        ],
+        "description": ["another_test_group_description"]
     }
 }

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -9746,15 +9746,30 @@ class LDAPGroupSyncTest(ZulipTestCase):
             ldap_group_description = self.mock_ldap.directory[
                 "cn=cool_test_group,ou=groups,dc=zulip,dc=com"
             ]["description"][0]
-            zulip_group_description = NamedUserGroup.objects.get(
-                realm=realm, name="cool_test_group"
-            ).description
+            zulip_group = NamedUserGroup.objects.get(realm=realm, name="cool_test_group")
+            zulip_group_description = zulip_group.description
 
-            sync_user_from_ldap(hamlet, mock.Mock())
+            already_synced_groups_cache: set[int] = set()
+            sync_user_from_ldap(hamlet, mock.Mock(), already_synced_groups_cache)
 
+            zulip_group.refresh_from_db()
             self.assertEqual(
-                NamedUserGroup.objects.get(realm=realm, name="cool_test_group").description,
+                zulip_group.description,
                 ldap_group_description,
+            )
+            self.assertEqual(already_synced_groups_cache, {zulip_group.id})
+
+            # Groups which have already been synced should not be synced again.
+            # We can test that by changing the description of the Zulip group and
+            # then running the sync again to verify that the description is not
+            # updated.
+            zulip_group.description = "somevalue"
+            zulip_group.save()
+            sync_user_from_ldap(hamlet, mock.Mock(), already_synced_groups_cache)
+            zulip_group.refresh_from_db()
+            self.assertEqual(
+                zulip_group.description,
+                "somevalue",
             )
 
             # If the LDAP group has no description, no changes to the Zulip group should be made.
@@ -9762,9 +9777,10 @@ class LDAPGroupSyncTest(ZulipTestCase):
                 "description"
             ]
             sync_user_from_ldap(hamlet, mock.Mock())
+            zulip_group.refresh_from_db()
             self.assertEqual(
-                NamedUserGroup.objects.get(realm=realm, name="cool_test_group").description,
-                ldap_group_description,
+                zulip_group.description,
+                "somevalue",
             )
 
         self.assertEqual(
@@ -9774,6 +9790,9 @@ class LDAPGroupSyncTest(ZulipTestCase):
                 f"DEBUG:zulip.ldap:intended groups for user <{hamlet.id}>: {{'cool_test_group'}}; current groups: {{'cool_test_group'}}",
                 f"DEBUG:zulip.ldap:Finished group sync for user {hamlet.id}",
                 f"DEBUG:zulip.ldap:Updating group description for cool_test_group from {zulip_group_description} to {ldap_group_description}",
+                f"DEBUG:zulip.ldap:Starting group sync for user {hamlet.id} in realm {realm.string_id}",
+                f"DEBUG:zulip.ldap:intended groups for user <{hamlet.id}>: {{'cool_test_group'}}; current groups: {{'cool_test_group'}}",
+                f"DEBUG:zulip.ldap:Finished group sync for user {hamlet.id}",
                 f"DEBUG:zulip.ldap:Starting group sync for user {hamlet.id} in realm {realm.string_id}",
                 f"DEBUG:zulip.ldap:intended groups for user <{hamlet.id}>: {{'cool_test_group'}}; current groups: {{'cool_test_group'}}",
                 f"DEBUG:zulip.ldap:Finished group sync for user {hamlet.id}",

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -31,7 +31,8 @@ from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
 from django.utils.timezone import now as timezone_now
-from django_auth_ldap.backend import LDAPSearch, _LDAPUser
+from django_auth_ldap.backend import LDAPBackend, LDAPSearch, _LDAPUser
+from django_auth_ldap.config import GroupOfUniqueNamesType
 from jwt.exceptions import PyJWTError
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.logout_request import OneLogin_Saml2_Logout_Request
@@ -8142,6 +8143,109 @@ class TestLDAP(ZulipLDAPTestCase):
             self.assertEqual(user_profile.realm.string_id, "zulip")
 
 
+class TestLDAPGroupDescriptions(ZulipLDAPTestCase):
+    def delete_groups_from_ldap_directory(self) -> None:
+        group_ids = [
+            "cn=cool_test_group,ou=groups,dc=zulip,dc=com",
+            "cn=another_test_group,ou=groups,dc=zulip,dc=com",
+        ]
+        for group_id in group_ids:
+            if group_id in self.mock_ldap.directory:
+                del self.mock_ldap.directory[group_id]
+
+    def delete_group_descriptions_from_ldap_directory(self) -> None:
+        groups_with_descriptions = [
+            "cn=cool_test_group,ou=groups,dc=zulip,dc=com",
+            "cn=another_test_group,ou=groups,dc=zulip,dc=com",
+        ]
+        for group_id in groups_with_descriptions:
+            if (
+                group_id in self.mock_ldap.directory
+                and "description" in self.mock_ldap.directory[group_id]
+            ):
+                del self.mock_ldap.directory[group_id]["description"]
+
+    @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipLDAPAuthBackend",))
+    def test_get_group_descriptions_when_no_ldap_groups(self) -> None:
+        self.delete_groups_from_ldap_directory()
+        realm = get_realm("zulip")
+        backend = LDAPBackend()
+        with self.settings(
+            AUTH_LDAP_GROUP_SEARCH=LDAPSearch(
+                "ou=groups,dc=zulip,dc=com",
+                ldap.SCOPE_ONELEVEL,
+                "(objectClass=groupOfUniqueNames)",
+            ),
+            AUTH_LDAP_GROUP_TYPE=GroupOfUniqueNamesType(),
+            LDAP_GROUP_DESCRIPTION_ATTR="description",
+        ):
+            username = "hamlet"
+            ldap_user = ZulipLDAPUser(backend, username=username, realm=realm)
+            self.assertEqual(ldap_user._get_group_descriptions(), {})
+
+    @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipLDAPAuthBackend",))
+    def test_get_group_descriptions_when_ldap_groups_exist_with_no_descriptions(self) -> None:
+        self.delete_group_descriptions_from_ldap_directory()
+        realm = get_realm("zulip")
+        backend = LDAPBackend()
+        with self.settings(
+            AUTH_LDAP_GROUP_SEARCH=LDAPSearch(
+                "ou=groups,dc=zulip,dc=com",
+                ldap.SCOPE_ONELEVEL,
+                "(objectClass=groupOfUniqueNames)",
+            ),
+            AUTH_LDAP_GROUP_TYPE=GroupOfUniqueNamesType(),
+            LDAP_GROUP_DESCRIPTION_ATTR="description",
+        ):
+            username = "hamlet"
+            ldap_user = ZulipLDAPUser(backend, username=username, realm=realm)
+            self.assertEqual(
+                ldap_user._get_group_descriptions(),
+                {"cool_test_group": None, "another_test_group": None},
+            )
+
+    @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipLDAPAuthBackend",))
+    def test_get_group_descriptions_setting_not_configured(
+        self,
+    ) -> None:
+        realm = get_realm("zulip")
+        backend = LDAPBackend()
+        with self.settings(
+            AUTH_LDAP_GROUP_SEARCH=LDAPSearch(
+                "ou=groups,dc=zulip,dc=com",
+                ldap.SCOPE_ONELEVEL,
+                "(objectClass=groupOfUniqueNames)",
+            ),
+            AUTH_LDAP_GROUP_TYPE=GroupOfUniqueNamesType(),
+        ):
+            username = "hamlet"
+            ldap_user = ZulipLDAPUser(backend, username=username, realm=realm)
+            self.assertEqual(ldap_user._get_group_descriptions(), {})
+
+    @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipLDAPAuthBackend",))
+    def test_get_group_descriptions_when_ldap_groups_exist_with_descriptions(self) -> None:
+        realm = get_realm("zulip")
+        backend = LDAPBackend()
+        with self.settings(
+            AUTH_LDAP_GROUP_SEARCH=LDAPSearch(
+                "ou=groups,dc=zulip,dc=com",
+                ldap.SCOPE_ONELEVEL,
+                "(objectClass=groupOfUniqueNames)",
+            ),
+            AUTH_LDAP_GROUP_TYPE=GroupOfUniqueNamesType(),
+            LDAP_GROUP_DESCRIPTION_ATTR="description",
+        ):
+            username = "hamlet"
+            ldap_user = ZulipLDAPUser(backend, username=username, realm=realm)
+            self.assertEqual(
+                ldap_user._get_group_descriptions(),
+                {
+                    "cool_test_group": "cool_test_group_description",
+                    "another_test_group": "another_test_group_description",
+                },
+            )
+
+
 class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
     def test_authenticate(self) -> None:
         backend = ZulipLDAPUserPopulator()
@@ -9616,6 +9720,64 @@ class LDAPGroupSyncTest(ZulipTestCase):
         self.assertIn(
             'DEBUG:django_auth_ldap:Failed to populate user cordelia: search_s("ou=groups,dc=zulip,dc=com", 1, "(&(objectClass=groupOfUniqueNames(uniqueMember=uid=cordelia,ou=users,dc=zulip,dc=com))", "None", 0)',
             django_ldap_log.output,
+        )
+
+        # Now we'll test syncing of group descriptions. If a Zulip group has a
+        # corresponding LDAP group, and the LDAP group has a description, then
+        # the description of the Zulip group should be updated to match the
+        # description of the LDAP group.
+        with (
+            self.settings(
+                AUTH_LDAP_GROUP_SEARCH=LDAPSearch(
+                    "ou=groups,dc=zulip,dc=com",
+                    ldap.SCOPE_ONELEVEL,
+                    "(objectClass=groupOfUniqueNames)",
+                ),
+                LDAP_SYNCHRONIZED_GROUPS_BY_REALM={
+                    "zulip": [
+                        "cool_test_group",
+                    ]
+                },
+                LDAP_GROUP_DESCRIPTION_ATTR="description",
+                LDAP_APPEND_DOMAIN="zulip.com",
+            ),
+            self.assertLogs("zulip.ldap", "DEBUG") as zulip_ldap_log,
+        ):
+            ldap_group_description = self.mock_ldap.directory[
+                "cn=cool_test_group,ou=groups,dc=zulip,dc=com"
+            ]["description"][0]
+            zulip_group_description = NamedUserGroup.objects.get(
+                realm=realm, name="cool_test_group"
+            ).description
+
+            sync_user_from_ldap(hamlet, mock.Mock())
+
+            self.assertEqual(
+                NamedUserGroup.objects.get(realm=realm, name="cool_test_group").description,
+                ldap_group_description,
+            )
+
+            # If the LDAP group has no description, no changes to the Zulip group should be made.
+            del self.mock_ldap.directory["cn=cool_test_group,ou=groups,dc=zulip,dc=com"][
+                "description"
+            ]
+            sync_user_from_ldap(hamlet, mock.Mock())
+            self.assertEqual(
+                NamedUserGroup.objects.get(realm=realm, name="cool_test_group").description,
+                ldap_group_description,
+            )
+
+        self.assertEqual(
+            zulip_ldap_log.output,
+            [
+                f"DEBUG:zulip.ldap:Starting group sync for user {hamlet.id} in realm {realm.string_id}",
+                f"DEBUG:zulip.ldap:intended groups for user <{hamlet.id}>: {{'cool_test_group'}}; current groups: {{'cool_test_group'}}",
+                f"DEBUG:zulip.ldap:Finished group sync for user {hamlet.id}",
+                f"DEBUG:zulip.ldap:Updating group description for cool_test_group from {zulip_group_description} to {ldap_group_description}",
+                f"DEBUG:zulip.ldap:Starting group sync for user {hamlet.id} in realm {realm.string_id}",
+                f"DEBUG:zulip.ldap:intended groups for user <{hamlet.id}>: {{'cool_test_group'}}; current groups: {{'cool_test_group'}}",
+                f"DEBUG:zulip.ldap:Finished group sync for user {hamlet.id}",
+            ],
         )
 
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -81,6 +81,7 @@ from zerver.actions.user_groups import (
     bulk_add_members_to_user_groups,
     bulk_remove_members_from_user_groups,
     check_add_user_group_core,
+    do_update_user_group_description,
 )
 from zerver.actions.user_settings import (
     do_change_full_name,
@@ -1102,6 +1103,12 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
             raise ZulipLDAPError(str(e)) from e
 
     def sync_groups_from_ldap(self, user_profile: UserProfile, ldap_user: _LDAPUser) -> None:
+        """
+        Syncs the user's memberships in the Zulip groups configured for syncing
+        in LDAP_SYNCHRONIZED_GROUPS_BY_REALM with the corresponding LDAP groups.
+        Additionally, when LDAP_GROUP_DESCRIPTION_ATTR is configured, syncs each
+        Zulip group's description with its LDAP group description.
+        """
         if user_profile.realm.string_id not in settings.LDAP_SYNCHRONIZED_GROUPS_BY_REALM:
             return
 
@@ -1123,6 +1130,43 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
                 # for this note to no longer be helpful.
                 create_missing_groups=True,
             )
+
+            if settings.LDAP_GROUP_DESCRIPTION_ATTR is None:
+                # Syncing of group descriptions is not configured.
+                return
+
+            ldap_group_descriptions_dict = ldap_user._get_group_descriptions()
+            zulip_groups_by_name = {
+                group.name: group
+                for group in NamedUserGroup.objects.filter(
+                    # We only need to fetch the groups for which the user is a member
+                    # of the corresponding LDAP group. We don't have ldap description data for other
+                    # groups, so they won't be subject to syncing anyway.
+                    realm=user_profile.realm,
+                    name__in=intended_group_names,
+                )
+            }
+
+            for group_name, ldap_description in ldap_group_descriptions_dict.items():
+                if group_name not in intended_group_names:
+                    continue
+
+                user_group = zulip_groups_by_name.get(group_name)
+                if user_group is None:
+                    continue
+
+                if ldap_description is not None and user_group.description != ldap_description:
+                    # Sanity assert: make sure we didn't get some strange data from LDAP.
+                    assert isinstance(ldap_description, str)
+
+                    ldap_logger.debug(
+                        "Updating group description for %s from %s to %s",
+                        group_name,
+                        user_group.description,
+                        ldap_description,
+                    )
+                    do_update_user_group_description(user_group, ldap_description, acting_user=None)
+
         except Exception as e:
             raise ZulipLDAPError(str(e)) from e
 
@@ -1435,6 +1479,33 @@ class ZulipLDAPUser(_LDAPUser):
             groups.get_group_dns()
 
         return groups
+
+    def _get_group_descriptions(self) -> dict[str, str | None]:
+        if not settings.LDAP_GROUP_DESCRIPTION_ATTR:
+            return {}
+        ldap_group_descriptions: dict[str, str | None] = {}
+        self._groups: _LDAPUserGroups = self._get_groups()
+        group_infos: list[tuple[str, dict[str, list[str]]]] = self._groups._get_group_infos()
+        for group_info in group_infos:
+            group_name: str = self._groups._group_type.group_name_from_info(group_info)
+            if group_name is not None:
+                group_description = self.group_description_from_info(group_info)
+                ldap_group_descriptions[group_name] = group_description
+        return ldap_group_descriptions
+
+    def group_description_from_info(
+        self, group_info: tuple[str, dict[str, list[str]]]
+    ) -> str | None:
+        assert settings.LDAP_GROUP_DESCRIPTION_ATTR is not None
+        try:
+            description_list = group_info[1][settings.LDAP_GROUP_DESCRIPTION_ATTR]
+            description = description_list[0] if description_list else None
+        except (KeyError, IndexError):
+            description = None
+
+        # Ensure we're returning the correct type.
+        assert description is None or isinstance(description, str)
+        return description
 
 
 class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1136,6 +1136,11 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
                 return
 
             ldap_group_descriptions_dict = ldap_user._get_group_descriptions()
+            # Hack: We don't have a good way of getting already_synced_group_ids passed
+            # as an argument to our function. For that reason, we attach this information to the
+            # ZulipLDAPUser object itself to be read here.
+            already_synced_group_ids: set[int] = ldap_user.already_synced_group_ids
+
             zulip_groups_by_name = {
                 group.name: group
                 for group in NamedUserGroup.objects.filter(
@@ -1145,14 +1150,19 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
                     realm=user_profile.realm,
                     name__in=intended_group_names,
                 )
+                # If we already synced the group, there's no need to fetch it.
+                # This keeps us from fetching a large amount of groups for every
+                # user we're syncing, in a redundant manner.
+                .exclude(id__in=already_synced_group_ids)
             }
 
             for group_name, ldap_description in ldap_group_descriptions_dict.items():
-                if group_name not in intended_group_names:
-                    continue
-
                 user_group = zulip_groups_by_name.get(group_name)
                 if user_group is None:
+                    # For the zulip_groups_by_name dict, we only fetched the
+                    # groups that should be synced and skipped ones already
+                    # synced in this batch. Therefore a group being absent here
+                    # implies it should be skipped.
                     continue
 
                 if ldap_description is not None and user_group.description != ldap_description:
@@ -1166,6 +1176,9 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
                         ldap_description,
                     )
                     do_update_user_group_description(user_group, ldap_description, acting_user=None)
+
+                    # We need to update the cache of already-processed groups.
+                    already_synced_group_ids.add(user_group.id)
 
         except Exception as e:
             raise ZulipLDAPError(str(e)) from e
@@ -1395,11 +1408,22 @@ class ZulipLDAPUser(_LDAPUser):
     populate_user() which will sync the LDAP data with the corresponding
     UserProfile. The realm attribute serves to uniquely identify the UserProfile
     in case the LDAP user is registered to multiple realms.
+
+    Additionally, we can store the already_synced_group_ids attribute, which is
+    used in the sync_ldap_user_data process to avoid re-fetching of groups
+    which have already been processed.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.realm: Realm = kwargs["realm"]
         del kwargs["realm"]
+
+        already_synced_group_ids: set[int] | None = kwargs.get("already_synced_group_ids")
+        if already_synced_group_ids is None:
+            already_synced_group_ids = set()
+        self.already_synced_group_ids: set[int] = already_synced_group_ids
+
+        kwargs.pop("already_synced_group_ids", None)
 
         super().__init__(*args, **kwargs)
 
@@ -1638,7 +1662,10 @@ def sync_delivery_email_if_needed(
 
 
 def prepare_ldap_user_for_sync_by_external_auth_id(
-    backend: ZulipLDAPUserPopulator, user_profile: UserProfile, logger: logging.Logger
+    backend: ZulipLDAPUserPopulator,
+    user_profile: UserProfile,
+    logger: logging.Logger,
+    already_synced_group_ids: set[int] | None = None,
 ) -> ZulipLDAPUser | None:
     """
     The purpose of this function is to take a UserProfile meant for syncing with LDAP,
@@ -1709,7 +1736,12 @@ def prepare_ldap_user_for_sync_by_external_auth_id(
     username = user_attrs[USERNAME_ATTR][0]
     assert isinstance(username, str)
 
-    ldap_user = ZulipLDAPUser(backend, username, realm=user_profile.realm)
+    ldap_user = ZulipLDAPUser(
+        backend,
+        username,
+        realm=user_profile.realm,
+        already_synced_group_ids=already_synced_group_ids,
+    )
     # We've already fetched the user's data, so we can set it on the relevant internal
     # fields of _LDAPUser to avoid django-auth-ldap doing an unnecessary re-fetch.
     ldap_user._user_dn = user_dn
@@ -1737,13 +1769,28 @@ def prepare_ldap_user_for_sync_by_external_auth_id(
     return ldap_user
 
 
-def sync_user_from_ldap(user_profile: UserProfile, logger: logging.Logger) -> bool:
+def sync_user_from_ldap(
+    user_profile: UserProfile,
+    logger: logging.Logger,
+    # This argument can be passed in from sync_ldap_user_data to track
+    # which groups have already had their descriptions synced to avoid
+    # re-fetching them repeatedly in sync_groups_from_ldap on every
+    # per-user iteration.
+    # The set, if passed in, will be mutated to add to it the new ids
+    # of groups which got processed by this function call.
+    already_synced_group_ids: set[int] | None = None,
+) -> bool:
     backend = ZulipLDAPUserPopulator()
     ldap_user = None
     if ldap_external_auth_id_sync_enabled():
         # If we can fetch the LDAP user data based on the ExternalAuthID connection, then that's the best case.
         # This allows us to find the LDAP user even if its email value has changed.
-        ldap_user = prepare_ldap_user_for_sync_by_external_auth_id(backend, user_profile, logger)
+        ldap_user = prepare_ldap_user_for_sync_by_external_auth_id(
+            backend,
+            user_profile,
+            logger,
+            already_synced_group_ids=already_synced_group_ids,
+        )
         if ldap_user is not None:
             logger.info(
                 "Syncing user %s (id=%s) via external auth id. Result DN: %s",
@@ -1767,7 +1814,12 @@ def sync_user_from_ldap(user_profile: UserProfile, logger: logging.Logger) -> bo
             elif user_profile.is_active:
                 logger.warning("Did not find %s in LDAP.", user_profile.delivery_email)
             return False
-        ldap_user = ZulipLDAPUser(backend, ldap_username, realm=user_profile.realm)
+        ldap_user = ZulipLDAPUser(
+            backend,
+            ldap_username,
+            realm=user_profile.realm,
+            already_synced_group_ids=already_synced_group_ids,
+        )
 
     assert ldap_user is not None
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -76,6 +76,8 @@ FAKE_LDAP_NUM_USERS = 8
 AUTH_LDAP_ADVANCED_REALM_ACCESS_CONTROL: dict[str, Any] | None = None
 LDAP_SYNCHRONIZED_GROUPS_BY_REALM: dict[str, list[str]] = {}
 AUTH_LDAP_GROUP_TYPE: LDAPGroupType = GroupOfUniqueNamesType()
+LDAP_GROUP_DESCRIPTION_ATTR: str | None = None
+AUTH_LDAP_GROUP_SEARCH: Optional["LDAPSearch"] = None
 
 # Social auth; we support providing values for some of these
 # settings in zulip-secrets.conf instead of settings.py in development.


### PR DESCRIPTION
Syncing group descriptions with LDAP.

https://github.com/zulip/zulip/issues/31040
https://chat.zulip.org/#narrow/stream/31-production-help/topic/sync.20group.20descriptions.20from.20ldap/near/1892521

Extended ZulipLDAPUser to have function for getting descriptions from LDAP. The function group_description_from_info is similar to that used in https://github.com/django-auth-ldap/django-auth-ldap/blob/master/django_auth_ldap/config.py for getting the group names. 

Group descriptions are now synced as part of the sync_groups_from_ldap process. This ensures that group descriptions for all relevant users are checked during synchronization. However, this method isn't the most efficient, as the descriptions only need to be synced once. Optimizing this would require either modifying the existing sync_groups_from_ldap command or creating a new command specifically for syncing group descriptions.

A new setting, LDAP_GROUP_DESCRIPTION_ATTR, has been introduced to map descriptions to an attribute in an LDAP group. To enable description syncing, this setting must be configured. If left unset, no syncing will occur, meaning organizations that do not explicitly enable this feature will not experience any changes.

TODO:
Documentation of  description syncing.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
