### PR TITLE
left-sidebar: Use -, _ and / as word separators in topic filtering

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -187,7 +187,15 @@ export function get_list_info(
     }
 
     if (zoomed) {
-        topic_names = util.filter_by_word_prefix_match(topic_names, search_term, (item) => item);
+        const extended_word_separator_regex = /[\s/_-]/;
+        const filtered_topic_names = util.filter_by_word_prefix_match(
+            topic_names,
+            search_term,
+            (topic) => topic,
+            extended_word_separator_regex,
+        );
+
+        topic_names = filtered_topic_names;
     }
 
     if (stream_muted && !zoomed) {

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -416,33 +416,29 @@ test("get_list_info with specific topics and searches", () => {
         });
     }
 
-    // Add sample messages
-    add_topic_message("Outreachy-2024", 1001);
-    add_topic_message("Test topic", 1002);
+    add_topic_message("BF-2924 zulip", 1001);
+    add_topic_message("tech_support/escalation", 1002);
 
-    // Test search for "Outreachy-2024"
     list_info = get_list_info(true, "2924");
     assert.equal(list_info.items.length, 1);
-    assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
+    assert.equal(list_info.items[0].topic_name, "BF-2924 zulip");
 
-    list_info = get_list_info(true, "Test topic");
+    list_info = get_list_info(true, "support/escalation");
     assert.equal(list_info.items.length, 1);
-    assert.equal(list_info.items[0].topic_name, "Test topic");
+    assert.equal(list_info.items[0].topic_name, "tech_support/escalation");
 
     list_info = get_list_info(true, "support");
     assert.equal(list_info.items.length, 1);
-    assert.equal(list_info.items[0].topic_name, "Test topic");
+    assert.equal(list_info.items[0].topic_name, "tech_support/escalation");
 
     list_info = get_list_info(true, "zulip");
     assert.equal(list_info.items.length, 1);
-    assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
+    assert.equal(list_info.items[0].topic_name, "BF-2924 zulip");
 
-    // Test search for case-insensitive "SUPPORT"
     list_info = get_list_info(true, "SUPPORT");
     assert.equal(list_info.items.length, 1);
-    assert.equal(list_info.items[0].topic_name, "Test topic");
+    assert.equal(list_info.items[0].topic_name, "tech_support/escalation");
 
-    // Test non-existent search term
     list_info = get_list_info(true, "nonexistent");
     assert.equal(list_info.items.length, 0);
 });

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -404,3 +404,45 @@ test("get_list_info unreads", ({override}) => {
         ],
     );
 });
+
+test("get_list_info with specific topics and searches", () => {
+    let list_info;
+
+    function add_topic_message(topic_name, message_id) {
+        stream_topic_history.add_message({
+            stream_id: general.stream_id,
+            topic_name,
+            message_id,
+        });
+    }
+
+    // Add sample messages
+    add_topic_message("Outreachy-2024", 1001);
+    add_topic_message("Test topic", 1002);
+
+    // Test search for "Outreachy-2024"
+    list_info = get_list_info(true, "2924");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
+
+    list_info = get_list_info(true, "Test topic");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Test topic");
+
+    list_info = get_list_info(true, "support");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Test topic");
+
+    list_info = get_list_info(true, "zulip");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Outreachy-2024");
+
+    // Test search for case-insensitive "SUPPORT"
+    list_info = get_list_info(true, "SUPPORT");
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "Test topic");
+
+    // Test non-existent search term
+    list_info = get_list_info(true, "nonexistent");
+    assert.equal(list_info.items.length, 0);
+});


### PR DESCRIPTION
Previously only spaces was used as a word separating character when
filtering topics. This meant that searching for "xyz" would not turn
up a topic named "stream-xyz" as one would expect.

To resolve this issue, hyphen (-), underscore (_), and slash (/) have been added as additional word separators for topic filtering in the left sidebar.

Fixes:  https://github.com/zulip/zulip/issues/31844

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2024-10-03 at 10 41 58](https://github.com/user-attachments/assets/4bc45b01-79b8-4205-af1e-9afb98683b59)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
