### PR TITLE
ui_update: Use same @ symbol everywhere.

### DIFF
--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -139,13 +139,11 @@ export function update_unread_mention_info_in_dom(
 ): void {
     const $unread_mention_info_span = $unread_mention_info_elem.find(".unread_mention_info");
     if (!stream_has_any_unread_mention_messages) {
-        $unread_mention_info_span.hide();
-        $unread_mention_info_span.text("");
+        $unread_mention_info_span.addClass("hide");
         return;
     }
 
-    $unread_mention_info_span.show();
-    $unread_mention_info_span.text("@");
+    $unread_mention_info_span.removeClass("hide");
 }
 
 /**

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -626,6 +626,12 @@ input.settings_text_input {
     margin-right: 5px;
     margin-left: 2px;
     opacity: 0.7;
+
+    .zulip-icon {
+        font-size: 1em;
+        position: relative;
+        top: 0.22em;
+    }
 }
 
 /* Implement the web app's default-hidden convention for alert

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1461,5 +1461,11 @@ ul.popover-menu-list {
         padding: 2px 4px;
         border-radius: 3px;
         border: 1px solid var(--color-border-popover-hotkey-hint);
+
+        .zulip-icon {
+            font-size: 0.8em;
+            position: relative;
+            top: 0.13em;
+        }
     }
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -633,6 +633,12 @@ input[type="checkbox"] {
             font-weight: bold;
             word-break: break-all;
         }
+
+        .zulip-icon {
+            font-size: 0.93em;
+            top: 2px;
+            position: relative;
+        }
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -635,7 +635,7 @@ input[type="checkbox"] {
         }
 
         .zulip-icon {
-            font-size: 0.93em;
+            font-size: 0.8em;
             top: 2px;
             position: relative;
         }

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -32,7 +32,7 @@
                         </div>
                         <span class="unread_mention_info tippy-zulip-tooltip
                           {{#unless mention_in_unread}}hidden{{/unless}}"
-                          data-tippy-content="{{t 'You have mentions'}}">@</span>
+                          data-tippy-content="{{t 'You have mentions'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i></span>
                         <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                             <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                               data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -13,7 +13,7 @@
                 </div>
                 <span class="unread_mention_info tippy-zulip-tooltip
                   {{#unless mention_in_unread}}hidden{{/unless}}"
-                  data-tippy-content="{{t 'You have mentions'}}">@</span>
+                  data-tippy-content="{{t 'You have mentions'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i></span>
                 <div class="unread-count-focus-outline" tabindex="0">
                     <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                       data-stream-id="{{stream_id}}" data-tippy-content="{{t 'Mark as read' }}"

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -6,7 +6,7 @@
         <div class="topic-markers-and-unreads">
             {{#if more_topics_have_unread_mention_messages}}
                 <span class="unread_mention_info">
-                    @
+                    <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                 </span>
             {{/if}}
             <span class="unread_count {{#unless more_topics_unreads}}zero_count{{/unless}}">

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -172,7 +172,7 @@
                             <span class="popover-menu-label">{{t "Reply mentioning user" }}</span>
                         {{/if}}
                         {{#if is_sender_popover}}
-                            {{popover_hotkey_hints "@"}}
+                            {{popover_hotkey_hints '<i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>'}}
                         {{/if}}
                     </a>
                 {{else}}
@@ -180,7 +180,7 @@
                         <i class="popover-menu-icon fa zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t "Copy mention syntax" }}</span>
                         {{#if is_sender_popover}}
-                            {{popover_hotkey_hints "@"}}
+                            {{popover_hotkey_hints '<i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>'}}
                         {{/if}}
                     </a>
                 {{/if}}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -52,7 +52,7 @@
                 </div>
                 {{else}}
                 <span class="unread_mention_info tippy-zulip-tooltip {{#unless mention_in_unread}}unread_hidden{{/unless}}"
-                  data-tippy-content="{{t 'You have mentions'}}">@</span>
+                  data-tippy-content="{{t 'You have mentions'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i></span>
                 <div class="recent_topic_actions">
                     <div class="recent_view_focusable hidden-for-spectators" data-col-index="{{ column_indexes.read }}">
                         <span class="unread_count recent-view-table-unread-count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -17,7 +17,7 @@
                         {{> ../help_link_widget link="/help/mobile-notifications#enabling-push-notifications-for-self-hosted-servers" }}
                     </th>
                     <th rowspan="2" width="14%">{{t "Email"}}</th>
-                    <th rowspan="2" width="14%">@all
+                    <th rowspan="2" width="14%"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>all
                         <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
                     </th>
                 </tr>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -15,9 +15,11 @@
                     <i class="channel-new-topic-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                 </div>
             </div>
-
             <div class="stream-markers-and-unreads">
                 <span class="unread_mention_info"></span>
+            </div>
+            <div class="stream-markers-and-controls">
+                <span class="unread_mention_info"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i></span>
                 <span class="unread_count"></span>
                 <span class="masked_unread_count">
                     <i class="zulip-icon zulip-icon-masked-unread"></i>

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -79,7 +79,7 @@ function create_devel_sidebar_row({mock_template}) {
     stream_has_any_unread_mentions = false;
     stream_list.create_sidebar_row(devel);
     assert.equal($devel_count.text(), "42");
-    assert.equal($devel_unread_mention_info.text(), "");
+    assert.equal($devel_unread_mention_info.text(), "never-been-set");
 }
 
 function create_social_sidebar_row({mock_template}) {
@@ -102,7 +102,7 @@ function create_social_sidebar_row({mock_template}) {
     stream_has_any_unread_mentions = true;
     stream_list.create_sidebar_row(social);
     assert.equal($social_count.text(), "99");
-    assert.equal($social_unread_mention_info.text(), "@");
+    assert.equal($social_unread_mention_info.text(), "never-been-set");
 }
 
 function create_stream_subheader({mock_template}) {


### PR DESCRIPTION
Updated the 'zulip-icon-at-sign' @ icon everywhere.

I made the use of 

```html
<i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>.
```

Below areas needed the changes:
-mention pills
-/#settings/notifications
-user popovers 'copy ention syntax'
-unread mention indicator

Below area did not need changes:
-left sidebar mention view

Fixes : #22816

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots:**

**1. Unread mention indicator : changed**
![Screenshot from 2024-10-04 02-14-54](https://github.com/user-attachments/assets/eac862c6-c32e-441e-b5e4-3788add216a1)

![Screenshot from 2024-10-04 02-39-31](https://github.com/user-attachments/assets/bba2a0db-6c25-488b-94e0-bb5ce1eda755)


**2. left sidebar mention view: not changed**

![Screenshot from 2024-10-04 02-15-12](https://github.com/user-attachments/assets/5cf48855-28f4-4634-b641-7ade7c687803)

![Screenshot from 2024-10-04 02-39-36](https://github.com/user-attachments/assets/2e69df88-6513-4001-81c0-125ad3b9fb32)

**3.mention pills: changed**

![Screenshot from 2024-10-04 02-15-22](https://github.com/user-attachments/assets/5d606140-eeda-44b5-8964-93d27838e135)

![Screenshot from 2024-10-04 02-39-47](https://github.com/user-attachments/assets/67206fc7-0451-40ba-b37a-9869956f150d)


**4. /#settings/notifications: changed**

![Screenshot from 2024-10-04 02-19-33](https://github.com/user-attachments/assets/aad5ebcf-5299-48fd-bee0-60527d1d14a9)

![Screenshot from 2024-10-04 02-40-16](https://github.com/user-attachments/assets/b6c7fad3-745c-463f-86ca-b185778b736b)

**5. user popovers 'copy ention syntax: changed'**

![Screenshot from 2024-10-04 02-20-03](https://github.com/user-attachments/assets/9b2d6c85-6880-4711-93cb-fbdf46ecfe5c)

![Screenshot from 2024-10-04 02-40-04](https://github.com/user-attachments/assets/c3fb034a-83e7-40b9-b251-88d1bcc97de9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
