### PR TITLE
web: Add missing CSS.escape calls

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -21,7 +21,7 @@ function current_dialog_widget_id(): string {
 }
 
 function current_dialog_widget_selector(): string {
-    return `#${current_dialog_widget_id()}`;
+    return `#${CSS.escape(current_dialog_widget_id())}`;
 }
 
 /*

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -316,14 +316,14 @@ $(() => {
         ]);
 
         const hideElement = (element: string): void => {
-            const $element = $(`#${element}`);
+            const $element = $(`#${CSS.escape(element)}`);
             $element.hide();
             $element.removeAttr("required");
-            $(`#${element}-error`).hide();
+            $(`#${CSS.escape(element)}-error`).hide();
         };
 
         const showElement = (element: string): void => {
-            const $element = $(`#${element}`);
+            const $element = $(`#${CSS.escape(element)}`);
             $element.show();
             $element.attr("required", "required");
         };

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -50,7 +50,7 @@ function open_linkifier_edit_form(linkifier_id: number): void {
     });
 
     function submit_linkifier_form(dialog_widget_id: string): void {
-        const $modal = $(`#${dialog_widget_id}`);
+        const $modal = $(`#${CSS.escape(dialog_widget_id)}`);
         const $change_linkifier_button = $modal.find(".dialog_submit_button");
         $change_linkifier_button.prop("disabled", true);
 

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -54,7 +54,7 @@ export const show_subs_pane = {
             $("#subscription_overlay .stream-info-title").html(render_selected_stream_title({sub}));
         }
         update_footer_buttons(container_name);
-        $(`.${container_name}`).show();
+        $(`.${CSS.escape(container_name)}`).show();
         $(".nothing-selected, .settings, #stream-creation").hide();
         $("#stream-creation").show();
     },

--- a/web/src/user_deactivation_ui.ts
+++ b/web/src/user_deactivation_ui.ts
@@ -65,7 +65,7 @@ export function confirm_deactivation(
             const html_body = render_settings_deactivation_user_modal(opts);
 
             function set_email_field_visibility(dialog_widget_id: string): void {
-                const $modal = $(`#${dialog_widget_id}`);
+                const $modal = $(`#${CSS.escape(dialog_widget_id)}`);
                 const $send_email_checkbox = $modal.find(".send_email");
                 const $email_field = $modal.find(".email_field");
 

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -100,7 +100,7 @@ export const show_user_group_settings_pane = {
             );
         }
         update_footer_buttons(container_name);
-        $(`.${container_name}`).show();
+        $(`.${CSS.escape(container_name)}`).show();
         $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
         reset_active_group_id();
         $("#user-group-creation").show();


### PR DESCRIPTION
Any string interpolated into a CSS selector must be CSS escaped.