### PR TITLE
left_sidebar: Fix keyboard accessibility.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -207,11 +207,31 @@ export function highlight_all_messages_view(): void {
     }, 0);
 }
 
+// Reorder the first 3 views in navigation list (Inbox, Recent conversations and Combined feed), based on current home view.
+function reorder_left_sidebar_navigation_list(
+    $first_view: JQuery,
+    $second_view: JQuery,
+    $third_view: JQuery,
+    $first_view_condensed: JQuery,
+    $second_view_condensed: JQuery,
+    $third_view_condensed: JQuery,
+): void {
+    const $left_sidebar = $("#left-sidebar-navigation-list");
+    const $left_sidebar_condensed = $("#left-sidebar-navigation-list-condensed");
+
+    $left_sidebar.children().eq(0).replaceWith($first_view);
+    $left_sidebar.children().eq(1).replaceWith($second_view);
+    $left_sidebar.children().eq(2).replaceWith($third_view);
+
+    $left_sidebar_condensed.children().eq(0).replaceWith($first_view_condensed);
+    $left_sidebar_condensed.children().eq(1).replaceWith($second_view_condensed);
+    $left_sidebar_condensed.children().eq(2).replaceWith($third_view_condensed);
+}
+
 function handle_home_view_order(home_view: string): void {
-    // Remove class and tabindex from current home view
+    // Remove class from current home view
     const $current_home_view = $(".selected-home-view");
     $current_home_view.removeClass("selected-home-view");
-    $current_home_view.find("a").removeAttr("tabindex");
 
     const $all_messages_rows = $(".top_left_all_messages");
     const $recent_views_rows = $(".top_left_recent_view");
@@ -219,17 +239,51 @@ function handle_home_view_order(home_view: string): void {
 
     const res = unread.get_counts();
 
-    // Add the class and tabindex to the matching home view
+    // Since replaceWith() removes the replacing element
+    // from its original position (which can disrubt the original navigation list elements),
+    // we use clone() to create a copy.
+    const $inbox_condensed = $inbox_rows.eq(0).clone();
+    const $recent_condensed = $recent_views_rows.eq(0).clone();
+    const $feed_condensed = $all_messages_rows.eq(0).clone();
+
+    const $inbox = $inbox_rows.eq(1).clone();
+    const $recent = $recent_views_rows.eq(1).clone();
+    const $feed = $all_messages_rows.eq(1).clone();
+
+    // Reorder navigation list and Add class to matching home view.
     if (home_view === settings_config.web_home_view_values.all_messages.code) {
+        // Combined feed is home view.
         $all_messages_rows.addClass("selected-home-view");
-        $all_messages_rows.find("a").attr("tabindex", 0);
+        reorder_left_sidebar_navigation_list(
+            $feed,
+            $inbox,
+            $recent,
+            $feed_condensed,
+            $inbox_condensed,
+            $recent_condensed,
+        );
     } else if (home_view === settings_config.web_home_view_values.recent_topics.code) {
+        // Recent conversations is home view.
         $recent_views_rows.addClass("selected-home-view");
-        $recent_views_rows.find("a").attr("tabindex", 0);
+        reorder_left_sidebar_navigation_list(
+            $recent,
+            $inbox,
+            $feed,
+            $recent_condensed,
+            $inbox_condensed,
+            $feed_condensed,
+        );
     } else {
         // Inbox is home view.
         $inbox_rows.addClass("selected-home-view");
-        $inbox_rows.find("a").attr("tabindex", 0);
+        reorder_left_sidebar_navigation_list(
+            $inbox,
+            $recent,
+            $feed,
+            $inbox_condensed,
+            $recent_condensed,
+            $feed_condensed,
+        );
     }
     update_dom_with_unread_counts(res, true);
 }

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -23,6 +23,19 @@ function save_sidebar_toggle_status(): void {
     ls.set("right-sidebar", $("body").hasClass("hide-right-sidebar"));
 }
 
+// In which order should (Inbox, Recent conversations and Combined feed) appear.
+function get_navigation_list_order(): string[] {
+    if (user_settings.web_home_view === settings_config.web_home_view_values.all_messages.code) {
+        return ["feed", "inbox", "recent"];
+    } else if (
+        user_settings.web_home_view === settings_config.web_home_view_values.recent_topics.code
+    ) {
+        return ["recent", "inbox", "feed"];
+    }
+    // default home view
+    return ["inbox", "recent", "feed"];
+}
+
 export function restore_sidebar_toggle_status(): void {
     const ls = localstorage();
     if (ls.get("left-sidebar")) {
@@ -212,6 +225,7 @@ export function initialize_left_sidebar(): void {
     const rendered_sidebar = render_left_sidebar({
         is_guest: current_user.is_guest,
         development_environment: page_params.development_environment,
+        navigation_list_order: get_navigation_list_order(),
         is_inbox_home_view:
             user_settings.web_home_view === settings_config.web_home_view_values.inbox.code,
         is_all_messages_home_view:

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -657,19 +657,6 @@ li.active-sub-filter {
     }
 }
 
-.selected-home-view {
-    /* This bumps the selected view to the
-       top of the grid (expanded list).
-       Others items will auto place in the
-       remaining auto-generated grid rows. */
-    grid-area: selected-home-view;
-    /* The condensed view is a flexbox, so
-       here we'll use a negative order to
-       bump the selected home view to the
-       start of the flexbox (lefthand side). */
-    order: -1;
-}
-
 .top_left_starred_messages .unread_count,
 .top_left_drafts .unread_count,
 .top_left_scheduled_messages .unread_count,

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,34 +1,40 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
         <div id="views-label-container" class="showing-expanded-navigation {{#if is_spectator}}remove-pointer-for-spectator{{/if}}">
-            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
+            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true" tabindex="0" role="button"></i>
             {{~!-- squash whitespace --~}}
             <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
-                <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
-                    <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
-                        <span class="filter-icon">
-                            <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
-                        </span>
-                        <span class="unread_count"></span>
-                    </a>
-                </li>
-                <li class="top_left_recent_view left-sidebar-navigation-condensed-item {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
-                    <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
-                        <span class="filter-icon">
-                            <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
-                        </span>
-                        <span class="unread_count"></span>
-                    </a>
-                </li>
-                <li class="top_left_all_messages left-sidebar-navigation-condensed-item {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                    <a href="#feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
-                        <span class="filter-icon">
-                            <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
-                        </span>
-                        <span class="unread_count"></span>
-                    </a>
-                </li>
+                {{#each (lookup this "navigation_list_order") as |curr_view|}}
+                    {{#if (eq curr_view "inbox")}}
+                    <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
+                        <a href="#inbox" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
+                            <span class="filter-icon">
+                                <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
+                            </span>
+                            <span class="unread_count"></span>
+                        </a>
+                    </li>
+                    {{else if (eq curr_view "recent")}}
+                    <li class="top_left_recent_view left-sidebar-navigation-condensed-item {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
+                        <a href="#recent" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+                            <span class="filter-icon">
+                                <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
+                            </span>
+                            <span class="unread_count"></span>
+                        </a>
+                    </li>
+                    {{else if (eq curr_view "feed")}}
+                    <li class="top_left_all_messages left-sidebar-navigation-condensed-item {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
+                        <a href="#feed" class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
+                            <span class="filter-icon">
+                                <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
+                            </span>
+                            <span class="unread_count"></span>
+                        </a>
+                    </li>
+                    {{/if}}
+                {{/each}}
                 <li class="top_left_mentions left-sidebar-navigation-condensed-item">
                     <a href="#narrow/is/mentioned" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="mentions-tooltip-template">
                         <span class="filter-icon">
@@ -51,43 +57,50 @@
             </div>
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
-            <li class="top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}">
-                <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="inbox-tooltip-template">
-                    <span class="filter-icon">
-                        <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
+            {{#each (lookup this "navigation_list_order") as |curr_view|}}
+                {{#if (eq curr_view "inbox")}}
+                <li class="top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}">
+                    <a href="#inbox" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="inbox-tooltip-template">
+
+                        <span class="filter-icon">
+                            <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
+                        </span>
+                        {{~!-- squash whitespace --~}}
+                        <span class="left-sidebar-navigation-label">{{t 'Inbox' }}</span>
+                        <span class="unread_count"></span>
+                    </a>
+                    <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+                </li>
+                {{else if (eq curr_view "recent")}}
+                <li class="top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
+                    <a href="#recent" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
+                        <span class="filter-icon">
+                            <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
+                        </span>
+                        {{~!-- squash whitespace --~}}
+                        <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
+                        <span class="unread_count"></span>
+                    </a>
+                    <span class="arrow sidebar-menu-icon recent-view-sidebar-menu-icon hidden-for-spectators {{#if is_recent_view_home_view}}hide{{/if}}">
+                        <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                     </span>
-                    {{~!-- squash whitespace --~}}
-                    <span class="left-sidebar-navigation-label">{{t 'Inbox' }}</span>
-                    <span class="unread_count"></span>
-                </a>
-                <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
-            </li>
-            <li class="top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
-                <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
-                    <span class="filter-icon">
-                        <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
+                </li>
+                {{else if (eq curr_view "feed")}}
+                <li class="top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
+                    <a href="#feed" class="home-link left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="all-message-tooltip-template">
+                        <span class="filter-icon">
+                            <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
+                        </span>
+                        {{~!-- squash whitespace --~}}
+                        <span class="left-sidebar-navigation-label">{{t 'Combined feed' }}</span>
+                        <span class="unread_count"></span>
+                    </a>
+                    <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators {{#if is_all_messages_home_view}}hide{{/if}}">
+                        <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                     </span>
-                    {{~!-- squash whitespace --~}}
-                    <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
-                    <span class="unread_count"></span>
-                </a>
-                <span class="arrow sidebar-menu-icon recent-view-sidebar-menu-icon hidden-for-spectators {{#if is_recent_view_home_view}}hide{{/if}}">
-                    <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
-                </span>
-            </li>
-            <li class="top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                <a href="#feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="all-message-tooltip-template">
-                    <span class="filter-icon">
-                        <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
-                    </span>
-                    {{~!-- squash whitespace --~}}
-                    <span class="left-sidebar-navigation-label">{{t 'Combined feed' }}</span>
-                    <span class="unread_count"></span>
-                </a>
-                <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators {{#if is_all_messages_home_view}}hide{{/if}}">
-                    <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
-                </span>
-            </li>
+                </li>
+                {{/if}}
+            {{/each}}
             <li class="top_left_mentions top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/mentioned">
                     <span class="filter-icon">


### PR DESCRIPTION
Fixes #31823

## Problem

When home view changes, CSS just puts the selected home view at the top of the navigation list (expanded) or to the left (collapsed), but the rendered `<li>` elements stay in the same order in DOM.

With that said, Regardless of current home view, keyboard navigation follows the order in which the `<li>` elements appear in DOM which is always the following : 

1. Inbox
2. Recent Conversatios
3. Combined feed

## Solution

- Reorder `<li>` navigation list elements in DOM, based on current home view, and to match the order in which they should appear.

- The `<li>` elements are ordered correctly on initial state (page load) and when user changes their home view.

- Remove `tabindex="0"`, Because `<a>` already has a default tabindex value of 0, and now the `<a>` elements can follow the normal navigation flow based on their position in DOM.

- Add `tabindex="0"` to Expand/Collapse `VIEWS`, to be keyboard accessible like Expand/Collapse `Direct Messages`     

- Remove CSS code responsible for putting the home view button to the top or to the left. 
 
 
## Screen Record
https://github.com/user-attachments/assets/0a8a13b6-8201-4b5a-863f-2ac6d8a2f984
