### PR TITLE
slack_incoming: add ok=true to json in case of success

### DIFF
--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -78,7 +78,7 @@ def api_slack_incoming_webhook(
     if body != "":
         body = replace_formatting(replace_links(body).strip())
         check_send_webhook_message(request, user_profile, user_specified_topic, body)
-    return json_success(request)
+    return json_success(request, data={"ok": True})
 
 
 def render_block(block: WildValue) -> str:


### PR DESCRIPTION
Hi,

When using alertmanager with zulip's slack_incoming hook zulip does not receive the "resolved" messages, only the "firing" message.
This is because alertmanager expects an `{"ok: true, ...}` in json responses [see alertmanager code](https://github.com/prometheus/alertmanager/blob/e1492602209b86e0ca6d7671c7353b62a31b897b/notify/slack/slack.go#L258). Seems [specified here](https://api.slack.com/web#responses) at slack.
The current behavior of alertmanager is like this:
1. an alert triggers, alertmanager sends a "firing" message to slack_incoming, alertmanager thinks it has failed (because no "ok: true" in the json response)
2. an alert stops, alertmanager does not notify slack_incoming because the alert trigger failed.

Best,
Pierre