### PR TITLE
thumbnail: Only lock the message row, not the Attachment row.

### DIFF
--- a/zerver/worker/thumbnail.py
+++ b/zerver/worker/thumbnail.py
@@ -163,7 +163,7 @@ def update_message_rendered_content(
             message_class.objects.filter(  # type: ignore[attr-defined]  # TODO: ?
                 realm_id=realm_id, attachment__path_id=path_id
             )
-            .select_for_update()
+            .select_for_update(of=("self",))
             .order_by("id")
         )
         for message in messages_with_image:


### PR DESCRIPTION
This prevents a deadlock between the thumbnailing worker and message sending, as follows:

1. A user uploads an image, making Attachment and ImageAttachment    rows, as well as enqueuing a job in the thumbnailing queue.

2. Message sending starts a transaction, creates the Message row, and calls `do_claim_attachments`, which edits the Attachment row of the upload (implicitly locking it).

3. The thumbnailing worker starts a transaction, locks the ImageAttachment row for its image, thumbnails it, and then attempts to `select_for_update()` the message objects (joined to the Attachments table) to find the ones which link to the attachment in question. This query blocks, since "a locking clause without a table list affects all tables used in the statement"[^1] and the message-send request already has a write lock on the Attachments row in question.

4. The message-send request attempts to re-fetch the ImageAttachment row inside the transaction, which tries to pull a lock on it.

5. Deadlock, because the message-send request has the Attachment lock, and waits for the ImageAttachment lock; the thumbnailing worker has the ImageAttachment lock, and waits for the Attachment lock.

We break this deadlock by limiting the `update_message_rendered_content` `select_for_update` to only take the lock on the Message table, and not also the Attachments table -- no changes will be made to the Attachments, so no lock is necessary there. This allows the thumbnailing worker to successfully pull the empty list of messages (since the message-send request has not commits its transaction, and thus the Message row is not visible yet), and release its ImageAttachment lock so that the message-send request can proceed.

[^1]: https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
