### PR TITLE
thumbnail: Remove type: ignore

### DIFF
--- a/zerver/worker/thumbnail.py
+++ b/zerver/worker/thumbnail.py
@@ -19,7 +19,7 @@ from zerver.lib.thumbnail import (
     rewrite_thumbnailed_images,
 )
 from zerver.lib.upload import save_attachment_contents, upload_backend
-from zerver.models import AbstractMessage, ArchivedMessage, ImageAttachment, Message
+from zerver.models import ArchivedMessage, ImageAttachment, Message
 from zerver.worker.base import QueueProcessingWorker, assign_queue
 
 logger = logging.getLogger(__name__)
@@ -158,12 +158,9 @@ def ensure_thumbnails(image_attachment: ImageAttachment) -> int:
 def update_message_rendered_content(
     realm_id: int, path_id: str, image_data: MarkdownImageMetadata | None
 ) -> None:
-    message_classes: list[type[AbstractMessage]] = [Message, ArchivedMessage]
-    for message_class in message_classes:
+    for message_class in (Message, ArchivedMessage):
         messages_with_image = (
-            message_class._default_manager.filter(  # type: ignore[misc]  # Both Message and ArchivedMessage have an "attachment" many-to-many, but this is not guaranteed by the type system
-                realm_id=realm_id, attachment__path_id=path_id
-            )
+            message_class.objects.filter(realm_id=realm_id, attachment__path_id=path_id)
             .select_for_update(of=("self",))
             .order_by("id")
         )


### PR DESCRIPTION
(An alternate solution is `message_classes: list[type[Message | ArchivedMessage]]`.)

Cc @alexmv (#31877).