### PR TITLE
ui: Improve Uploaded files settings panel

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -70,8 +70,16 @@ function set_upload_space_stats(): void {
     }
     const args = {
         show_upgrade_message: realm.realm_plan_type === 2,
-        percent_used: percentage_used_space(upload_space_used),
-        upload_quota: bytes_to_size(mib_to_bytes(realm.realm_upload_quota_mib), true),
+        upload_quota_string: $t(
+            {
+                defaultMessage:
+                    "Your organization is using {percent_used}% of your {upload_quota} file storage quota.",
+            },
+            {
+                percent_used: percentage_used_space(upload_space_used),
+                upload_quota: bytes_to_size(mib_to_bytes(realm.realm_upload_quota_mib), true),
+            },
+        ),
     };
     const rendered_upload_stats_html = render_settings_upload_space_stats(args);
     $("#attachment-stats-holder").html(rendered_upload_stats_html);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1683,7 +1683,16 @@ $option_title_width: 180px;
 #attachment-stats-holder {
     position: relative;
     margin-top: 13px;
-    display: inline-block;
+    display: block;
+
+    .upgrade-tip {
+        width: auto;
+    }
+
+    .tip::before {
+        content: "\f135";
+        margin-right: 8px;
+    }
 }
 
 .admin_exports_table {

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -1,7 +1,7 @@
 <div id="attachments-settings" class="settings-section" data-name="uploaded-files">
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
-        <h3>{{t "Uploaded files"}}</h3>
+        <h3>{{t "Your uploads"}}</h3>
         <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
     </div>
     <div class="clear-float"></div>

--- a/web/templates/settings/upload_space_stats.hbs
+++ b/web/templates/settings/upload_space_stats.hbs
@@ -1,9 +1,11 @@
 <span>
-    {{t "Organization using {percent_used}% of {upload_quota}." }}
     {{#if show_upgrade_message}}
-        {{#tr}}
-            <z-link>Upgrade</z-link> for more space.
-            {{#*inline "z-link"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-        {{/tr}}
+    <a href="/upgrade/" class="upgrade-tip" target="_blank" rel="noopener noreferrer">
+        {{upload_quota_string}} {{t "Upgrade for more space." }}
+    </a>
+    {{else}}
+    <div class="tip">
+        {{upload_quota_string}}
+    </div>
     {{/if}}
 </span>


### PR DESCRIPTION
**Description:**

This PR addresses the requested changes to enhance the UI of the "Uploaded Files" settings panel. The following improvements have been implemented:

1. **Renaming the table**: 
   - The table header has been renamed from "Uploaded files" to "Your uploads" to clarify that the listed files are specific to the user, not everyone’s uploads.
   - Other strings in the panel continue to use "Uploaded files" as needed.

2. **Quota notice text update**:
   - The text of the storage quota notice has been updated to:
     > "Your organization is using x% of your 5 GB file storage quota. Upgrade for more space."
   
3. **Clickable banner for upgrade**:
   - Instead of having "Upgrade" as a link, the entire quota notice is now a clickable banner with a rocket icon, similar to the style used elsewhere in the settings.
   
Fixes: #29077 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details> 
<summary> Current Ui:</summary>
<img width="1091" alt="Screenshot 2024-10-04 at 11 46 00 PM" src="https://github.com/user-attachments/assets/d6b4bdae-0595-4e5d-bc56-9fcf7e007402">
</details>

<details> 
<summary>Updated UI (for Light theme):  </summary>
<img width="1023" alt="Screenshot 2024-10-11 at 7 46 22 PM" src="https://github.com/user-attachments/assets/b6e7ae77-8a01-4d87-9a9e-d2b0a93f8b16">
<img width="1028" alt="Screenshot 2024-10-11 at 7 49 32 PM" src="https://github.com/user-attachments/assets/dda4766c-53c3-4f82-bfc0-eebeaf23d79e">
</details>
<details> 
<summary>Updated UI (for Dark theme):  </summary>
<img width="1029" alt="Screenshot 2024-10-11 at 7 35 51 PM" src="https://github.com/user-attachments/assets/609851b5-0fd7-4257-82dd-27befdbff135">
<img width="1025" alt="Screenshot 2024-10-11 at 7 46 00 PM" src="https://github.com/user-attachments/assets/bf38a242-60e9-4bd6-aaf5-f990ab469d68">

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
