### PR TITLE
left_sidebar: Fix keyboard accessibility out of order.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -6,6 +6,7 @@ import render_right_sidebar from "../templates/right_sidebar.hbs";
 
 import {buddy_list} from "./buddy_list";
 import {media_breakpoints_num} from "./css_variables";
+import {reorder_left_sidebar_navigation_list} from "./left_sidebar_navigation_area";
 import {localstorage} from "./localstorage";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
@@ -228,6 +229,8 @@ export function initialize_left_sidebar(): void {
     });
 
     $("#left-sidebar-container").html(rendered_sidebar);
+    // make sure home-view and left_sidebar order persists
+    reorder_left_sidebar_navigation_list(user_settings.web_home_view);
 }
 
 export function initialize_right_sidebar(): void {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -673,11 +673,7 @@ li.active-sub-filter {
 
 #left-sidebar-navigation-list {
     margin-bottom: var(--left-sidebar-sections-vertical-gutter);
-    /* We display this as a grid only to control
-       the order of home views, using a single
-       named grid area. */
     display: grid;
-    grid-template-areas: "selected-home-view";
     line-height: var(--line-height-sidebar-row);
     /* Explicitly ensure parity with the line-height
        for the sake of low-resolution screens, whose
@@ -697,19 +693,6 @@ li.active-sub-filter {
             white-space: nowrap;
         }
     }
-}
-
-.selected-home-view {
-    /* This bumps the selected view to the
-       top of the grid (expanded list).
-       Others items will auto place in the
-       remaining auto-generated grid rows. */
-    grid-area: selected-home-view;
-    /* The condensed view is a flexbox, so
-       here we'll use a negative order to
-       bump the selected home view to the
-       start of the flexbox (lefthand side). */
-    order: -1;
 }
 
 .top_left_starred_messages .unread_count,

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,12 +1,12 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
         <div id="views-label-container" class="showing-expanded-navigation {{#if is_spectator}}remove-pointer-for-spectator{{/if}}">
-            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true"></i>
+            <i id="toggle-top-left-navigation-area-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down views-tooltip-target hidden-for-spectators" aria-hidden="true" tabindex="0" role="button"></i>
             {{~!-- squash whitespace --~}}
             <h4 class="left-sidebar-title"><span class="views-tooltip-target">{{t 'VIEWS' }}</span></h4>
             <ul id="left-sidebar-navigation-list-condensed" class="filters">
                 <li class="top_left_inbox left-sidebar-navigation-condensed-item {{#if is_inbox_home_view}}selected-home-view{{/if}}">
-                    <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
+                    <a href="#inbox" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="inbox-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                         </span>
@@ -14,7 +14,7 @@
                     </a>
                 </li>
                 <li class="top_left_recent_view left-sidebar-navigation-condensed-item {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
-                    <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+                    <a href="#recent" class="tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="recent-conversations-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
                         </span>
@@ -22,7 +22,7 @@
                     </a>
                 </li>
                 <li class="top_left_all_messages left-sidebar-navigation-condensed-item {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                    <a href="#feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
+                    <a href="#feed" class="home-link tippy-views-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="all-message-tooltip-template">
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                         </span>
@@ -52,7 +52,7 @@
         </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
             <li class="top_left_inbox top_left_row hidden-for-spectators {{#if is_inbox_home_view}}selected-home-view{{/if}}">
-                <a href="#inbox" {{#if is_inbox_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="inbox-tooltip-template">
+                <a href="#inbox" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="inbox-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
@@ -63,7 +63,7 @@
                 <span class="arrow sidebar-menu-icon inbox-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_recent_view top_left_row {{#if is_recent_view_home_view}}selected-home-view{{/if}}">
-                <a href="#recent" {{#if is_recent_view_home_view}}tabindex="0"{{/if}} class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <a href="#recent" class="left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-recent" aria-hidden="true"></i>
                     </span>
@@ -71,12 +71,12 @@
                     <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow sidebar-menu-icon recent-view-sidebar-menu-icon hidden-for-spectators {{#if is_recent_view_home_view}}hide{{/if}}">
+                <span class="arrow sidebar-menu-icon recent-view-sidebar-menu-icon hidden-for-spectators">
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </li>
             <li class="top_left_all_messages top_left_row {{#if is_all_messages_home_view}}selected-home-view{{/if}}">
-                <a href="#feed" {{#if is_all_messages_home_view}}tabindex="0"{{/if}} class="home-link left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="all-message-tooltip-template">
+                <a href="#feed" class="home-link left-sidebar-navigation-label-container tippy-views-tooltip" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-all-messages" aria-hidden="true"></i>
                     </span>
@@ -84,7 +84,7 @@
                     <span class="left-sidebar-navigation-label">{{t 'Combined feed' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators {{#if is_all_messages_home_view}}hide{{/if}}">
+                <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators">
                     <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                 </span>
             </li>


### PR DESCRIPTION
Fixes #31823

[Previous Closed PR](https://github.com/zulip/zulip/pull/31873)

Relevant [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/left_sidebar.3A.20Fix.20keyboard.20accessibility)

## Problem

When home view changes, CSS just puts the selected home view at the top of the navigation list (expanded) or to the left (collapsed), but the rendered `<li>` elements stay in the same order in DOM.

With that said, Regardless of current home view, keyboard navigation follows the order in which the `<li>` elements appear in DOM which is always the following : 

1. Inbox
2. Recent Conversatios
3. Combined feed

## Changes

- Reorder `<li>` navigation list elements in DOM, based on current home view  to match the order in which they should appear. The `<li>` elements are now ordered correctly on initial state (page load) and when home_view changes.

- Remove `tabindex=0` from `<a>` elements, because they are now ordered correctly in DOM.

- Add `tabindex="0" role="button"` to  collapsable VIEWS `<i>`, to be keyboard accessibile.

