### PR TITLE
message_scroll: Mark message as read after blue box moves past it.

### DIFF
--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -160,12 +160,13 @@ export function initialize() {
             }
 
             const messages = event.msg_list.message_range(event.previously_selected_id, event.id);
-            // If the user just arrived at the message `event.id`, we don't mark it as read.
+            // If the user just arrived at the message `event.id`, we don't mark it as read
+            // unless it is the last message in the list.
             // We only mark messages as read when the pointer moves past the message.
             // This is likely the last message in the list. So, we loop through the messages
             // in reverse order to find the message.
             for (let i = messages.length - 1; i >= 0; i -= 1) {
-                if (messages[i].id === event.id) {
+                if (messages[i].id === event.id && event.id !== event.msg_list.last()?.id) {
                     delete messages[i];
                     break;
                 }

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -154,12 +154,23 @@ export function initialize() {
 
         if (event.mark_read && event.previously_selected_id !== -1) {
             // Mark messages between old pointer and new pointer as read
-            let messages;
             if (event.id < event.previously_selected_id) {
-                messages = event.msg_list.message_range(event.id, event.previously_selected_id);
-            } else {
-                messages = event.msg_list.message_range(event.previously_selected_id, event.id);
+                // We don't mark messages as read when the pointer moves up.
+                return;
             }
+
+            const messages = event.msg_list.message_range(event.previously_selected_id, event.id);
+            // If the user just arrived at the message `event.id`, we don't mark it as read.
+            // We only mark messages as read when the pointer moves past the message.
+            // This is likely the last message in the list. So, we loop through the messages
+            // in reverse order to find the message.
+            for (let i = messages.length - 1; i >= 0; i -= 1) {
+                if (messages[i].id === event.id) {
+                    delete messages[i];
+                    break;
+                }
+            }
+
             if (event.msg_list.can_mark_messages_read()) {
                 unread_ops.notify_server_messages_read(messages, {from: "pointer"});
             } else if (


### PR DESCRIPTION
Fixes #31833

Quoting from the issue:

Some of the reasoning behind that proposal was:

We want the first unread message to be what gets highlighted by the blue box, since that's what you should read first. It's bad to eat one unread message when entering a message feed via N or otherwise.
A consistent algorithm would be that messages get marked as read when you move the blue box past them ... except that there'd be no way to mark the last message that way.
Because the bottom being visible marks things as read, it should be fine to make this change now, even though there wouldn't currently be a way to use the location of the blue box to mark the last message in the current view as read.
