### PR TITLE
thumbnailing: Add non-image form for failed to thumbnail image with empty title.

### DIFF
--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -455,7 +455,18 @@ def rewrite_thumbnailed_images(
             # This was not a valid thumbnail target, for some reason.
             # Trim out the whole "message_inline_image" element, since
             # it's not going be renderable by clients either.
+            image_href = image_link["href"]
             inline_image_div.decompose()
+
+            if not parsed_message.text.strip():
+                # If for some reason (e.g. image has empty title []) the message renderd_content
+                # becomes empty, insert a non-image form.
+                soup = BeautifulSoup("", "html.parser")
+                a_tag = soup.new_tag("a", href=image_href)
+                p_tag = soup.new_tag("p")
+                a_tag.string = image_href
+                p_tag.append(a_tag)
+                parsed_message.append(p_tag)
             changed = True
             continue
 

--- a/zerver/tests/test_markdown_thumbnail.py
+++ b/zerver/tests/test_markdown_thumbnail.py
@@ -292,6 +292,30 @@ class MarkdownThumbnailTest(ZulipTestCase):
             message_id, f'<p><a href="/user_uploads/{path_id}">image</a></p>'
         )
 
+    def test_thumbnail_bad_image_with_empty_title(self) -> None:
+        """Test what happens a file with empty title fine, but resizing later fails"""
+        path_id = self.upload_image("img.png")
+        message_id = self.send_message_content(f"[](/user_uploads/{path_id})")
+        self.assert_length(ImageAttachment.objects.get(path_id=path_id).thumbnail_metadata, 0)
+
+        with (
+            patch.object(
+                pyvips.Image, "thumbnail_buffer", side_effect=pyvips.Error("some bad error")
+            ) as thumb_mock,
+            self.assertLogs("zerver.worker.thumbnail", "ERROR") as thumbnail_logs,
+        ):
+            ensure_thumbnails(ImageAttachment.objects.get(path_id=path_id))
+            thumb_mock.assert_called_once()
+        self.assert_length(thumbnail_logs.output, 1)
+        self.assertTrue(
+            thumbnail_logs.output[0].startswith("ERROR:zerver.worker.thumbnail:some bad error")
+        )
+        self.assertFalse(ImageAttachment.objects.filter(path_id=path_id).exists())
+        # We remove all trace of the preview (since the image was bad) and replaced it with a plain link.
+        self.assert_message_content_is(
+            message_id, f'<p><a href="/user_uploads/{path_id}">/user_uploads/{path_id}</a></p>'
+        )
+
     def test_thumbnail_multiple_messages(self) -> None:
         sender_user_profile = self.example_user("othello")
         path_id = self.upload_image("img.png")


### PR DESCRIPTION
Fixes #31007

Add  non-image form `<p><a href="/user_uploads/...">/user_uploads/...</a></p>` to the image which has a valid header and empty title, but later fails to thumbnail.

This avoids an empty message, which gives users no way to access the uploaded file.
## Before
![empty_rendered_content](https://github.com/user-attachments/assets/062f705c-6acf-4c17-9f24-d121466294b9)

## After
![non_empty_rendered_content](https://github.com/user-attachments/assets/91bacd4f-676a-464f-a737-ffb9875bf11f)
