### PR TITLE
presence_data: Fetch presence data from the server

### DIFF
--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -8,7 +8,7 @@ import {page_params} from "./page_params.ts";
 import * as presence from "./presence.ts";
 import * as watchdog from "./watchdog.ts";
 
-const post_presence_response_schema = z.object({
+export const post_presence_response_schema = z.object({
     msg: z.string(),
     result: z.string(),
     // A bunch of these fields below are .optional() due to the fact

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -4,6 +4,7 @@ import type * as tippy from "tippy.js";
 
 import render_admin_user_list from "../templates/settings/admin_user_list.hbs";
 
+import {compute_active_status, post_presence_response_schema} from "./activity.ts";
 import * as blueslip from "./blueslip.ts";
 import * as browser_history from "./browser_history.ts";
 import * as channel from "./channel.ts";
@@ -13,6 +14,7 @@ import {$t} from "./i18n.ts";
 import type {ListWidget as ListWidgetType} from "./list_widget.ts";
 import * as ListWidget from "./list_widget.ts";
 import * as loading from "./loading.ts";
+import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import type {User} from "./people.ts";
 import * as presence from "./presence.ts";
@@ -33,6 +35,7 @@ export const deactivated_user_list_dropdown_widget_name = "deactivated_user_list
 
 let should_redraw_active_users_list = false;
 let should_redraw_deactivated_users_list = false;
+let presence_data_fetched = false;
 
 type UserSettingsSection = {
     dropdown_widget_name: string;
@@ -228,8 +231,23 @@ function populate_users(): void {
 
     if (active_user_ids.length === 0 && deactivated_user_ids.length === 0) {
         failed_listing_users();
+        return;
     }
 
+    if (!presence_data_fetched) {
+        fetch_presence_user_setting({
+            render_table() {
+                presence_data_fetched = true;
+                active_section.create_table(active_user_ids);
+                deactivated_section.create_table(deactivated_user_ids);
+                create_role_filter_dropdown($("#admin-user-list"), active_section);
+                create_role_filter_dropdown(
+                    $("#admin-deactivated-users-list"),
+                    deactivated_section,
+                );
+            },
+        });
+    }
     active_section.create_table(active_user_ids);
     deactivated_section.create_table(deactivated_user_ids);
     create_role_filter_dropdown($("#admin-user-list"), active_section);
@@ -325,7 +343,7 @@ function get_last_active(user: User): string {
     const last_active_date = presence.last_active_date(user.user_id);
 
     if (!last_active_date) {
-        return $t({defaultMessage: "Unknown"});
+        return $t({defaultMessage: "Loading…"});
     }
     return timerender.render_now(last_active_date).time_str;
 }
@@ -437,9 +455,8 @@ function active_create_table(active_users: number[]): void {
         },
         $simplebar_container: $("#admin-active-users-list .progressive-table-wrapper"),
     });
-
-    set_text_search_value($users_table, active_section.filters.text_search);
     loading.destroy_indicator($("#admin_page_users_loading_indicator"));
+    set_text_search_value($users_table, active_section.filters.text_search);
     $("#admin_users_table").show();
 }
 
@@ -477,9 +494,8 @@ function deactivated_create_table(deactivated_users: number[]): void {
             $simplebar_container: $("#admin-deactivated-users-list .progressive-table-wrapper"),
         },
     );
-
-    set_text_search_value($deactivated_users_table, deactivated_section.filters.text_search);
     loading.destroy_indicator($("#admin_page_deactivated_users_loading_indicator"));
+    set_text_search_value($deactivated_users_table, deactivated_section.filters.text_search);
     $("#admin_deactivated_users_table").show();
 }
 
@@ -710,5 +726,52 @@ export function set_up_bots(): void {
         e.preventDefault();
         e.stopPropagation();
         settings_bots.add_a_new_bot();
+    });
+}
+
+type FetchPresenceUserSettingParams = {
+    render_table: () => void;
+};
+
+export function fetch_presence_user_setting({render_table}: FetchPresenceUserSettingParams): void {
+    if (page_params.is_spectator) {
+        render_table();
+        return;
+    }
+
+    channel.post({
+        url: "/json/users/me/presence",
+        data: {
+            status: compute_active_status(),
+            ping_only: false,
+            last_update_id: -1,
+            history_limit_days: 365 * 1000,
+        },
+        success(response) {
+            const data = post_presence_response_schema.parse(response);
+
+            if (data.presences) {
+                assert(
+                    data.presences !== undefined,
+                    "Presences should be present if not a ping only presence request",
+                );
+                assert(
+                    data.server_timestamp !== undefined,
+                    "Server timestamp should be present if not a ping only presence request",
+                );
+                assert(
+                    data.presence_last_update_id !== undefined,
+                    "Presence last update id should be present if not a ping only presence request",
+                );
+
+                // the next regular default presence check in with the server should naturally pick up from here.
+                presence.set_info(
+                    data.presences,
+                    data.server_timestamp,
+                    data.presence_last_update_id,
+                );
+            }
+            render_table();
+        },
     });
 }


### PR DESCRIPTION
This PR addresses issue [#31039](#31039), where the app was not fetching presence data for users who had been idle for an extended period when the "Users" tab in the **Settings > Users** panel was opened. This caused outdated or missing availability data in the "Last active" column. With this update, the app now ensures that presence data is fetched for all users when the tab is opened, allowing for more accurate and up-to-date information to be displayed.

#### Key Updates:

1. **New Data Structure:**
   - Introduced a new structure, `user_setting_presence_info`, to store presence information specifically when the "Users" tab is opened in the settings panel. This structure helps track and display presence data for users, even if they have been idle for a long time.

2. **New API Call for Presence Data:**
   - Added a function `fetch_presence_user_setting`, which makes an API call to fetch presence data with the `history_limit_days` parameter set to `9999` so that it fetches all the availability data. This ensures that even long-idle users' data is retrieved and displayed accurately.


Fixes #31039.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
