### PR TITLE
popovers: Refactor resend and revoke invitation confirmation modals.

### DIFF
--- a/web/src/settings_invites.ts
+++ b/web/src/settings_invites.ts
@@ -155,7 +155,6 @@ function do_revoke_invite({
 }): void {
     const modal_invite_id = $(".dialog_submit_button").attr("data-invite-id");
     const modal_is_multiuse = $(".dialog_submit_button").attr("data-is-multiuse");
-    const $revoke_button = $row.find("button.revoke");
 
     if (modal_invite_id !== invite_id || modal_is_multiuse !== is_multiuse) {
         blueslip.error("Invite revoking canceled due to non-matching fields.");
@@ -165,10 +164,10 @@ function do_revoke_invite({
             }),
             $("#revoke_invite_modal #dialog_error"),
         );
+        dialog_widget.hide_dialog_spinner();
         return;
     }
 
-    $revoke_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
     let url = "/json/invites/" + invite_id;
 
     if (modal_is_multiuse === "true") {
@@ -177,10 +176,17 @@ function do_revoke_invite({
     void channel.del({
         url,
         error(xhr) {
-            dialog_widget.close();
-            ui_report.generic_row_button_error(xhr, $revoke_button);
+            dialog_widget.hide_dialog_spinner();
+            ui_report.error(
+                $t_html({
+                    defaultMessage: "Failed",
+                }),
+                xhr,
+                $("#dialog_error"),
+            );
         },
         success() {
+            dialog_widget.hide_dialog_spinner();
             dialog_widget.close();
             $row.remove();
         },
@@ -199,18 +205,26 @@ function do_resend_invite({$row, invite_id}: {$row: JQuery; invite_id: string}):
             }),
             $("#resend_invite_modal #dialog_error"),
         );
+        dialog_widget.hide_dialog_spinner();
         return;
     }
 
-    $resend_button.prop("disabled", true).text($t({defaultMessage: "Working…"}));
     void channel.post({
         url: "/json/invites/" + invite_id + "/resend",
         error(xhr) {
-            dialog_widget.close();
-            ui_report.generic_row_button_error(xhr, $resend_button);
+            dialog_widget.hide_dialog_spinner();
+            ui_report.error(
+                $t_html({
+                    defaultMessage: "Failed",
+                }),
+                xhr,
+                $("#dialog_error"),
+            );
         },
         success() {
+            dialog_widget.hide_dialog_spinner();
             dialog_widget.close();
+            $resend_button.prop("disabled", true);
             $resend_button.text($t({defaultMessage: "Sent!"}));
             $resend_button.removeClass("resend btn-warning").addClass("sea-green");
         },
@@ -268,6 +282,7 @@ export function on_load_success(
             html_body,
             id: "revoke_invite_modal",
             close_on_submit: false,
+            loading_spinner: true,
             on_click() {
                 do_revoke_invite({$row, invite_id, is_multiuse});
             },
@@ -293,6 +308,7 @@ export function on_load_success(
             html_body,
             id: "resend_invite_modal",
             close_on_submit: false,
+            loading_spinner: true,
             on_click() {
                 do_resend_invite({$row, invite_id});
             },


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR refactors the confirmation modals for resending and revoking invitations.

It includes the following changes:
- Use `dialog_widget` instead of `confirm_dialog` to launch confirmation modals for resending and revoking invitations. 
- Change the error text as stated in #31395.
- Associate each modal with a specific ID.
    - `resend_invite_modal`: for the resend invitation confirmation modal.
    - `revoke_invite_modal`: for the revoke invitation confirmation modal.
- Display errors encountered during resending or revoking invitations within the confirmation modal, keeping the modal open.
- <details>
    <summary>Stop the process of revoking or resending invitations if an error occurs.</summary>
    
    For example, earlier, in the case of revoking an invitation, the invitation was revoked disregarding the error if `modal_invite_id !== invite_id || modal_is_multiuse !== is_multiuse` from the `settings_invites.ts` file.  
    Now, if an error occurs during the process of resending or revoking an invitation, it will be displayed inside the confirmation modal, and the process will be discontinued to prevent further actions.
</details>

  
Fixes: #31395.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
 **Before Changes:**

<details>
  <summary>1. Resend Invitation Modal</summary>
  
  ![Resend Before](https://github.com/user-attachments/assets/556de01e-6d84-4f06-8614-e2b8e8e7cf11)
  
</details>

<details>
  <summary>2. Revoke Invitation Modal</summary>

  ![Revoke Invitation Before](https://github.com/user-attachments/assets/7b411d51-2eb3-4b2a-b6fb-1366d2c6edf4)

</details>

<details>
  <summary>3. Revoke Invitation Modal (for Invitation Link)</summary>

  ![Revoke Link Before](https://github.com/user-attachments/assets/266fb4f0-a9f3-453e-a7d9-89899e694be0)

</details>

 **After Changes:**

<details>
  <summary>1. Resend Invitation Modal</summary>

  ![Resend After](https://github.com/user-attachments/assets/7038a338-3fe2-49a9-b55a-8447a2b24084)

</details>

<details>
  <summary>2. Revoke Invitation Modal</summary>

  ![Revoke Invitation After](https://github.com/user-attachments/assets/ff6fd697-ea0a-4722-84da-261c9c5a63fc)

</details>

<details>
  <summary>3. Revoke Invitation Modal (for Invitation Link)</summary>

  ![Revoke Link After](https://github.com/user-attachments/assets/dde9d23d-f645-4847-aa1f-29b586e85bed)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
