### PR TITLE
copy-and-paste: Remove not required click on all messages narrow.

### DIFF
--- a/web/e2e-tests/copy-and-paste.test.ts
+++ b/web/e2e-tests/copy-and-paste.test.ts
@@ -129,13 +129,6 @@ async function test_copying_messages_from_several_topics(page: Page): Promise<vo
 
 async function copy_paste_test(page: Page): Promise<void> {
     await common.log_in(page);
-    await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    let message_list_id = await common.get_current_msg_list_id(page, true);
-    await page.waitForSelector(
-        `.message-list[data-message-list-id='${message_list_id}'] .message_row`,
-        {visible: true},
-    );
-
     await common.send_multiple_messages(page, [
         {stream_name: "Verona", topic: "copy-paste-topic #1", content: "copy paste test A"},
 
@@ -153,7 +146,7 @@ async function copy_paste_test(page: Page): Promise<void> {
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    message_list_id = await common.get_current_msg_list_id(page, true);
+    const message_list_id = await common.get_current_msg_list_id(page, true);
     await common.check_messages_sent(page, message_list_id, [
         ["Verona > copy-paste-topic #1", ["copy paste test A", "copy paste test B"]],
         [


### PR DESCRIPTION
This change might also fix the flaky nature of this test but needs to be tested by running online on CI.
