### PR TITLE
puppeteer: Fix flaky wait for narrow change after sending a message.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -134,11 +134,15 @@ async function test_narrow_to_private_messages_with_cordelia(page: Page): Promis
 async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): Promise<void> {
     const recipients = ["cordelia@zulip.com", "othello@zulip.com"];
     const multiple_recipients_pm = "A direct message group to check spaces";
-    await common.send_message(page, "private", {
-        recipient: recipients.join(", "),
-        outside_view: true,
-        content: multiple_recipients_pm,
-    });
+    await common.send_message(
+        page,
+        "private",
+        {
+            recipient: recipients.join(", "),
+            content: multiple_recipients_pm,
+        },
+        false,
+    );
 
     // Go back to the combined feed view and make sure all messages are loaded.
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -306,7 +306,6 @@ async function drafts_test(page: Page): Promise<void> {
     await common.send_message(page, "private", {
         recipient: "cordelia@zulip.com, hamlet@zulip.com",
         content: "howdy doo",
-        outside_view: true,
     });
     await create_private_message_draft(page);
     // Close and try restoring it by opening the composebox again.

--- a/web/e2e-tests/edit.test.ts
+++ b/web/e2e-tests/edit.test.ts
@@ -38,7 +38,7 @@ async function test_stream_message_edit(page: Page): Promise<void> {
 
     await edit_stream_message(page, "test edited");
 
-    const message_list_id = await common.get_current_msg_list_id(page, true);
+    const message_list_id = await common.get_current_msg_list_id(page, false);
     await common.check_messages_sent(page, message_list_id, [["Verona > edits", ["test edited"]]]);
 }
 
@@ -47,11 +47,16 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
         "messagebox",
     )}])[last()]`;
 
-    await common.send_message(page, "stream", {
-        stream_name: "Verona",
-        topic: "edits",
-        content: "/me test editing a message with me",
-    });
+    await common.send_message(
+        page,
+        "stream",
+        {
+            stream_name: "Verona",
+            topic: "edits",
+            content: "/me test editing a message with me",
+        },
+        false,
+    );
     await page.waitForSelector(
         `xpath/${last_message_xpath}//*[${common.has_class_x(
             "status-message",
@@ -88,7 +93,7 @@ async function test_edit_private_message(page: Page): Promise<void> {
     await page.click(".message_edit_save");
     await common.wait_for_fully_processed_message(page, "test edited pm");
 
-    const message_list_id = await common.get_current_msg_list_id(page, true);
+    const message_list_id = await common.get_current_msg_list_id(page, false);
     await common.check_messages_sent(page, message_list_id, [
         ["You and Cordelia, Lear's daughter", ["test edited pm"]],
     ]);

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -517,27 +517,23 @@ async function message_basic_tests(page: Page): Promise<void> {
             stream_name: "Verona",
             topic: "other topic",
             content: "verona other topic c",
-            outside_view: true,
         },
-        {stream_name: "Denmark", topic: "test", content: "denmark message", outside_view: true},
+        {stream_name: "Denmark", topic: "test", content: "denmark message"},
         {
             recipient: "cordelia@zulip.com, hamlet@zulip.com",
             content: "group direct message a",
-            outside_view: true,
         },
         {
             recipient: "cordelia@zulip.com, hamlet@zulip.com",
             content: "group direct message b",
-            outside_view: true,
         },
-        {recipient: "cordelia@zulip.com", content: "direct message c", outside_view: true},
+        {recipient: "cordelia@zulip.com", content: "direct message c"},
         {stream_name: "Verona", topic: "test", content: "verona test d"},
         {
             recipient: "cordelia@zulip.com, hamlet@zulip.com",
             content: "group direct message d",
-            outside_view: true,
         },
-        {recipient: "cordelia@zulip.com", content: "direct message e", outside_view: true},
+        {recipient: "cordelia@zulip.com", content: "direct message e"},
     ]);
 
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");

--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -61,7 +61,7 @@ async function stars_test(page: Page): Promise<void> {
 
     await toggle_test_star_message(page);
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");
-    message_list_id = await common.get_current_msg_list_id(page, true);
+    message_list_id = await common.get_current_msg_list_id(page, false);
     await page.waitForSelector(
         `.message-list[data-message-list-id='${message_list_id}'] .zulip-icon-star-filled`,
         {visible: true},


### PR DESCRIPTION
This flake was happening since `wait_for_fully_processed_message` only checks if the `star` icon is displayed on the message but doesn't check for current narrow or waits for the narrow to change.

Since narrow is changed to the message narrow after sending a message. If we don't wait for narrow to change, this narrow change can make the `get_current_msg_list_id` call return true for the wrong narrow change. Which causes message list id of the wrong message list to be returned and hence we cannot locate this message list id.

To fix it, we check if sending this message will cause a narrow change and if true, we wait for the narrow to change before checking if the message is visible.
