### PR TITLE
spoilers: Enhance toggle handling for improved click responsiveness

### DIFF
--- a/web/src/spoilers.ts
+++ b/web/src/spoilers.ts
@@ -65,14 +65,39 @@ export function initialize(): void {
         }
 
         // Allow selecting text inside a spoiler header.
+        // Flag to prevent toggling the spoiler multiple times in quick succession
+        let spoilerToggled = false;
+
         const selection = document.getSelection();
         if (selection && selection.type === "Range") {
+            $(document).one("mouseup", () => {
+                const newSelection = document.getSelection();
+                if (!newSelection || newSelection.type !== "Range") {
+                    // If the selection is cleared after the mouseup, we toggle the spoiler
+                    toggle_spoiler($spoiler_content, $button, $arrow);
+                    spoilerToggled = true;
+                }
+            });
             return;
         }
 
         e.preventDefault();
         e.stopPropagation();
 
+        if (!spoilerToggled) {
+            // Toggle the spoiler only if it hasn't been toggled during text selection
+            toggle_spoiler($spoiler_content, $button, $arrow);
+            spoilerToggled = true;
+        }
+    });
+
+    // Toggles the visibility of the spoiler content by expanding or collapsing it.
+    // If the spoiler content is currently open, this function will collapse it,
+    // hide the content, and update the associated button's state and ARIA attributes.
+    // If the spoiler content is currently closed, this function will expand it,
+    // show the content, and update the button's state and ARIA attributes accordingly.
+
+    function toggle_spoiler($spoiler_content: JQuery, $button: JQuery, $arrow: JQuery): void {
         if ($spoiler_content.hasClass("spoiler-content-open")) {
             // Content was open, we are collapsing
             $arrow.removeClass("spoiler-button-open");
@@ -92,5 +117,5 @@ export function initialize(): void {
 
             expand_spoiler($spoiler_content);
         }
-    });
+    }
 }


### PR DESCRIPTION
This pull request improves the selection logic for spoiler headers in the Zulip app, enhancing the user experience when toggling spoilers.

Key Points Addressed:
Preventing Duplicate Toggles: The flag prevents toggle_spoiler from being called multiple times within a single interaction, ensuring that each click properly responds to the current state of the spoiler.
Early Exit for Selection: The logic to allow text selection without triggering a toggle ensures that clicks made during text selection don't inadvertently change the spoiler's state.
Improved User Experience: By managing how and when the toggle function is called, the code should provide a more consistent user experience, even during rapid interactions.

Fixes: [#30770](https://github.com/zulip/zulip/issues/30770)

[GIF of the new spoiler toggle functionality](https://ibb.co.com/54sjVGY)

<details>
<summary>Self-review checklist</summary>

- [ v ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
- [ v ] (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ v ] Explains differences from previous plans (e.g., issue description).
- [ v ] Highlights technical choices and bugs encountered.
- [ v ] Calls out remaining decisions and concerns.
- [ v ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ v ] Each commit is a coherent idea.
- [ v ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ v ] Visual appearance of the changes.
- [ v ] Responsiveness and internationalization.
- [ v ] Strings and tooltips.
- [ v ] End-to-end functionality of buttons, interactions and flows.
- [ v ] Corner cases, error conditions, and easily imagined bugs.
</details>
