### PR TITLE
puppeteer: Fix incorrectly passed `false` value to check narrow change.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -134,15 +134,10 @@ async function test_narrow_to_private_messages_with_cordelia(page: Page): Promis
 async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): Promise<void> {
     const recipients = ["cordelia@zulip.com", "othello@zulip.com"];
     const multiple_recipients_pm = "A direct message group to check spaces";
-    await common.send_message(
-        page,
-        "private",
-        {
-            recipient: recipients.join(", "),
-            content: multiple_recipients_pm,
-        },
-        false,
-    );
+    await common.send_message(page, "private", {
+        recipient: recipients.join(", "),
+        content: multiple_recipients_pm,
+    });
 
     // Go back to the combined feed view and make sure all messages are loaded.
     await page.click("#left-sidebar-navigation-list .top_left_all_messages");

--- a/web/e2e-tests/edit.test.ts
+++ b/web/e2e-tests/edit.test.ts
@@ -55,6 +55,7 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
             topic: "edits",
             content: "/me test editing a message with me",
         },
+        // We already narrow in test_stream_message_edit.
         false,
     );
     await page.waitForSelector(


### PR DESCRIPTION
This caused another CI flake in https://github.com/zulip/zulip/actions/runs/11217538032/job/31179325677#step:16:281

Also, added a comment to the only other place where we pass false explicitly explaining why.
