### PR TITLE
urls: Generate narrow links using "channel" operator in web app and server.

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -345,7 +345,7 @@ _Released 2024-07-25_
   `0544_copy_avatar_images`, which re-thumbnails every uploaded avatar
   using Zulip's new image-processing pipeline.
 
-[thumbor-remediation-topic]: https://chat.zulip.org/#narrow/stream/31-production-help/topic/THUMBNAIL_IMAGES.20remediation
+[thumbor-remediation-topic]: https://chat.zulip.org/#narrow/channel/31-production-help/topic/THUMBNAIL_IMAGES.20remediation
 
 ## Zulip Server 8.x series
 

--- a/templates/corporate/development-community.md
+++ b/templates/corporate/development-community.md
@@ -132,9 +132,9 @@ topic to a different channel](/help/move-content-to-another-channel).
 - [#development help](https://chat.zulip.org/#narrow/channel/49-development-help)
   is for asking for help with any Zulip server/web app development work
   (use the app channels
-  [#mobile-dev-help](https://chat.zulip.org/#narrow/stream/516-mobile-dev-help),
-  [#desktop](https://chat.zulip.org/#narrow/stream/16-desktop), or
-  [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal)
+  [#mobile-dev-help](https://chat.zulip.org/#narrow/channel/516-mobile-dev-help),
+  [#desktop](https://chat.zulip.org/#narrow/channel/16-desktop), or
+  [#zulip-terminal](https://chat.zulip.org/#narrow/channel/206-zulip-terminal)
   for help working on one of the apps).
 - [#provision help](https://chat.zulip.org/#narrow/channel/21-provision-help)
   is for help specifically on setting up the server/web app development
@@ -200,7 +200,7 @@ topic to a different channel](/help/move-content-to-another-channel).
   Q&A sessions with project members.
 - [#documentation](https://chat.zulip.org/#narrow/channel/19-documentation)
   and
-  [#api documentation](https://chat.zulip.org/#narrow/stream/412-api-documentation)
+  [#api documentation](https://chat.zulip.org/#narrow/channel/412-api-documentation)
   are where we discuss improving Zulip’s user, sysadmin, API, and
   developer documentation.
 - [#general](https://chat.zulip.org/#narrow/channel/2-general) is for

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -477,7 +477,7 @@ async function test_narrow_public_streams(page: Page): Promise<void> {
     );
     await page.click(".subscriptions-header .exit-sign");
     await page.waitForSelector("#subscription_overlay", {hidden: true});
-    await page.goto(`http://zulip.zulipdev.com:9981/#narrow/stream/${stream_id}-Denmark`);
+    await page.goto(`http://zulip.zulipdev.com:9981/#narrow/channel/${stream_id}-Denmark`);
     let message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(
         `.message-list[data-message-list-id='${message_list_id}'] .recipient_row ~ .recipient_row ~ .recipient_row`,
@@ -488,7 +488,7 @@ async function test_narrow_public_streams(page: Page): Promise<void> {
         )) !== null,
     );
 
-    await page.goto("http://zulip.zulipdev.com:9981/#narrow/streams/public");
+    await page.goto("http://zulip.zulipdev.com:9981/#narrow/channels/public");
     message_list_id = await common.get_current_msg_list_id(page, true);
     await page.waitForSelector(
         `.message-list[data-message-list-id='${message_list_id}'] .recipient_row ~ .recipient_row ~ .recipient_row`,

--- a/web/shared/src/internal_url.ts
+++ b/web/shared/src/internal_url.ts
@@ -54,7 +54,7 @@ export function by_stream_url(
     stream_id: number,
     maybe_get_stream_name: MaybeGetStreamName,
 ): string {
-    return `#narrow/stream/${encode_stream_id(stream_id, maybe_get_stream_name)}`;
+    return `#narrow/channel/${encode_stream_id(stream_id, maybe_get_stream_name)}`;
 }
 
 export function by_stream_topic_url(
@@ -62,7 +62,7 @@ export function by_stream_topic_url(
     topic: string,
     maybe_get_stream_name: MaybeGetStreamName,
 ): string {
-    return `#narrow/stream/${encode_stream_id(
+    return `#narrow/channel/${encode_stream_id(
         stream_id,
         maybe_get_stream_name,
     )}/topic/${encodeHashComponent(topic)}`;

--- a/web/src/hash_parser.ts
+++ b/web/src/hash_parser.ts
@@ -36,11 +36,11 @@ export function get_current_hash_section(): string {
 
 export function is_same_server_message_link(url: string): boolean {
     // A same server message link always has category `narrow`,
-    // section `stream` or `dm`, and ends with `/near/<message_id>`,
+    // section `channel` or `dm`, and ends with `/near/<message_id>`,
     // where <message_id> is a sequence of digits.
     return (
         get_hash_category(url) === "narrow" &&
-        (get_hash_section(url) === "stream" || get_hash_section(url) === "dm") &&
+        (get_hash_section(url) === "channel" || get_hash_section(url) === "dm") &&
         get_nth_hash_section(url, -2) === "near" &&
         /^\d+$/.test(get_nth_hash_section(url, -1))
     );

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -35,7 +35,7 @@ export function encode_operand(operator: string, operand: string): string {
         }
     }
 
-    if (operator === "stream") {
+    if (util.canonicalize_channel_synonyms(operator) === "channel") {
         const stream_id = Number.parseInt(operand, 10);
         return encode_stream_id(stream_id);
     }
@@ -67,7 +67,7 @@ export function decode_operand(operator: string, operand: string): string {
 
     operand = internal_url.decodeHashComponent(operand);
 
-    if (util.canonicalize_stream_synonyms(operator) === "stream") {
+    if (util.canonicalize_channel_synonyms(operator) === "channel") {
         return stream_data.slug_to_stream_id(operand)?.toString() ?? "";
     }
 
@@ -97,7 +97,7 @@ export function search_terms_to_hash(terms?: NarrowTerm[]): string {
 
         for (const term of terms) {
             // Support legacy tuples.
-            const operator = util.canonicalize_stream_synonyms(term.operator);
+            const operator = util.canonicalize_channel_synonyms(term.operator);
             const operand = term.operand;
 
             const sign = term.negated ? "-" : "";

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -903,7 +903,7 @@ export function view_stream() {
     const row_data = get_row_data(active_data.$row);
     if (row_data) {
         const stream_narrow_hash =
-            "#narrow/stream/" + hash_util.encode_stream_id(row_data.object.stream_id);
+            "#narrow/channel/" + hash_util.encode_stream_id(row_data.object.stream_id);
         browser_history.go_to_location(stream_narrow_hash);
     }
 }

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -260,25 +260,20 @@ export function is_topic_synonym(operator: string): boolean {
     return operator === "subject";
 }
 
-// TODO: When "stream" is renamed to "channel", update these stream
-// synonym helper functions for the reverse logic.
-export function is_stream_synonym(text: string): boolean {
-    return text === "channel";
+export function is_channel_synonym(text: string): boolean {
+    return text === "stream";
 }
 
-export function is_streams_synonym(text: string): boolean {
-    return text === "channels";
+export function is_channels_synonym(text: string): boolean {
+    return text === "streams";
 }
 
-// For parts of the codebase that have been converted to use
-// channel/channels internally, this is used to convert those
-// back into stream/streams for external presentation.
-export function canonicalize_stream_synonyms(text: string): string {
-    if (is_stream_synonym(text.toLowerCase())) {
-        return "stream";
+export function canonicalize_channel_synonyms(text: string): string {
+    if (is_channel_synonym(text.toLowerCase())) {
+        return "channel";
     }
-    if (is_streams_synonym(text.toLowerCase())) {
-        return "streams";
+    if (is_channels_synonym(text.toLowerCase())) {
+        return "channels";
     }
     return text;
 }

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -16,36 +16,36 @@ stream_data.add_sub({
 run_test("try_stream_topic_syntax_text", () => {
     const test_cases = [
         [
-            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/old.20FAILED.20EXPORT",
+            "http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/old.20FAILED.20EXPORT",
             "#**Rome>old FAILED EXPORT**",
         ],
         [
-            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/100.25.20profits",
+            "http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/100.25.20profits",
             "#**Rome>100% profits**",
         ],
         [
-            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/old.20API.20wasn't.20compiling.20erratically",
+            "http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/old.20API.20wasn't.20compiling.20erratically",
             "#**Rome>old API wasn't compiling erratically**",
         ],
 
-        ["http://different.origin.com/#narrow/stream/4-Rome/topic/old.20FAILED.20EXPORT"],
+        ["http://different.origin.com/#narrow/channel/4-Rome/topic/old.20FAILED.20EXPORT"],
 
         // malformed urls
-        ["http://zulip.zulipdev.com/narrow/stream/4-Rome/topic/old.20FAILED.20EXPORT"],
-        ["http://zulip.zulipdev.com/#not_narrow/stream/4-Rome/topic/old.20FAILED.20EXPORT"],
+        ["http://zulip.zulipdev.com/narrow/channel/4-Rome/topic/old.20FAILED.20EXPORT"],
+        ["http://zulip.zulipdev.com/#not_narrow/channel/4-Rome/topic/old.20FAILED.20EXPORT"],
         ["http://zulip.zulipdev.com/#narrow/not_stream/4-Rome/topic/old.20FAILED.20EXPORT"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/not_topic/old.20FAILED.20EXPORT"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/old.20FAILED.20EXPORT/near/100"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/", "#**Rome**"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/not_topic/old.20FAILED.20EXPORT"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/old.20FAILED.20EXPORT/near/100"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/", "#**Rome**"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic"],
         ["http://zulip.zulipdev.com/#narrow/topic/cheese"],
         ["http://zulip.zulipdev.com/#narrow/topic/pizza/stream/Rome"],
 
         // characters which are known to produce broken #**stream>topic** urls.
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/100.25.20profits.60"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/100.25.20*profits"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/.24.24 100.25.20profits"],
-        ["http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/>100.25.20profits"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/100.25.20profits.60"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/100.25.20*profits"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/.24.24 100.25.20profits"],
+        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/>100.25.20profits"],
     ];
 
     for (const test_case of test_cases) {

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -2214,7 +2214,7 @@ test("navbar_helpers", () => {
             is_common_narrow: true,
             zulip_icon: "hashtag",
             title: "Foo",
-            redirect_url_with_search: `/#narrow/stream/${foo_stream_id}-Foo/topic/bar`,
+            redirect_url_with_search: `/#narrow/channel/${foo_stream_id}-Foo/topic/bar`,
         },
         {
             terms: invalid_channel_with_topic,
@@ -2228,14 +2228,14 @@ test("navbar_helpers", () => {
             is_common_narrow: true,
             icon: undefined,
             title: "translated: Messages in all public channels",
-            redirect_url_with_search: "/#narrow/streams/public",
+            redirect_url_with_search: "/#narrow/channels/public",
         },
         {
             terms: channel_term,
             is_common_narrow: true,
             zulip_icon: "hashtag",
             title: "Foo",
-            redirect_url_with_search: `/#narrow/stream/${foo_stream_id}-Foo`,
+            redirect_url_with_search: `/#narrow/channel/${foo_stream_id}-Foo`,
         },
         {
             terms: invalid_channel,
@@ -2249,14 +2249,14 @@ test("navbar_helpers", () => {
             is_common_narrow: true,
             zulip_icon: "lock",
             title: "psub",
-            redirect_url_with_search: `/#narrow/stream/${public_sub_id}-psub`,
+            redirect_url_with_search: `/#narrow/channel/${public_sub_id}-psub`,
         },
         {
             terms: web_public_channel,
             is_common_narrow: true,
             zulip_icon: "globe",
             title: "webPublicSub",
-            redirect_url_with_search: `/#narrow/stream/${web_public_sub_id}-webPublicSub`,
+            redirect_url_with_search: `/#narrow/channel/${web_public_sub_id}-webPublicSub`,
         },
         {
             terms: dm,

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -213,7 +213,7 @@ run_test("test_by_conversation_and_time_url", () => {
 
     assert.equal(
         hash_util.by_conversation_and_time_url(message),
-        "http://zulip.zulipdev.com/#narrow/stream/99-frontend/topic/testing/near/42",
+        "http://zulip.zulipdev.com/#narrow/channel/99-frontend/topic/testing/near/42",
     );
 
     message = {
@@ -239,19 +239,19 @@ run_test("test_search_public_streams_notice_url", () => {
 
     assert.equal(
         hash_util.search_public_streams_notice_url(get_terms("#narrow/search/abc")),
-        "#narrow/streams/public/search/abc",
+        "#narrow/channels/public/search/abc",
     );
 
     assert.equal(
         hash_util.search_public_streams_notice_url(
             get_terms("#narrow/has/link/has/image/has/attachment"),
         ),
-        "#narrow/streams/public/has/link/has/image/has/attachment",
+        "#narrow/channels/public/has/link/has/image/has/attachment",
     );
 
     assert.equal(
         hash_util.search_public_streams_notice_url(get_terms("#narrow/sender/15")),
-        "#narrow/streams/public/sender/15-Hamlet",
+        "#narrow/channels/public/sender/15-Hamlet",
     );
 });
 

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -57,11 +57,11 @@ run_test("terms_round_trip", () => {
         {operator: "topic", operand: "algol"},
     ];
     hash = hash_util.search_terms_to_hash(terms);
-    assert.equal(hash, "#narrow/stream/100-devel/topic/algol");
+    assert.equal(hash, "#narrow/channel/100-devel/topic/algol");
 
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [
-        {operator: "stream", operand: devel_id.toString(), negated: false},
+        {operator: "channel", operand: devel_id.toString(), negated: false},
         {operator: "topic", operand: "algol", negated: false},
     ]);
 
@@ -70,11 +70,11 @@ run_test("terms_round_trip", () => {
         {operator: "topic", operand: "visual c++", negated: true},
     ];
     hash = hash_util.search_terms_to_hash(terms);
-    assert.equal(hash, "#narrow/stream/100-devel/-topic/visual.20c.2B.2B");
+    assert.equal(hash, "#narrow/channel/100-devel/-topic/visual.20c.2B.2B");
 
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [
-        {operator: "stream", operand: devel_id.toString(), negated: false},
+        {operator: "channel", operand: devel_id.toString(), negated: false},
         {operator: "topic", operand: "visual c++", negated: true},
     ]);
 
@@ -87,10 +87,10 @@ run_test("terms_round_trip", () => {
     stream_data.add_sub(florida_stream);
     terms = [{operator: "stream", operand: florida_id.toString()}];
     hash = hash_util.search_terms_to_hash(terms);
-    assert.equal(hash, "#narrow/stream/987-Florida.2C-USA");
+    assert.equal(hash, "#narrow/channel/987-Florida.2C-USA");
     narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [
-        {operator: "stream", operand: florida_id.toString(), negated: false},
+        {operator: "channel", operand: florida_id.toString(), negated: false},
     ]);
 });
 
@@ -100,23 +100,23 @@ run_test("stream_to_channel_rename", () => {
     let narrow;
     let filter;
 
-    // Confirm the URLs generated from search terms use "stream" and "streams"
-    // and that the new Filter has the new "channel" and "channels" operators.
-    terms = [{operator: "channel", operand: devel_id.toString()}];
+    // Confirm searches with "stream" and "streams" return URLs and
+    // Filter objects with the new "channel" and "channels" operators.
+    terms = [{operator: "stream", operand: devel_id.toString()}];
     hash = hash_util.search_terms_to_hash(terms);
-    assert.equal(hash, "#narrow/stream/100-devel");
+    assert.equal(hash, "#narrow/channel/100-devel");
     narrow = hash_util.parse_narrow(hash.split("/"));
-    assert.deepEqual(narrow, [{operator: "stream", operand: devel_id.toString(), negated: false}]);
+    assert.deepEqual(narrow, [{operator: "channel", operand: devel_id.toString(), negated: false}]);
     filter = new Filter(narrow);
     assert.deepEqual(filter.terms(), [
         {operator: "channel", operand: devel_id.toString(), negated: false},
     ]);
 
-    terms = [{operator: "channels", operand: "public"}];
+    terms = [{operator: "streams", operand: "public"}];
     hash = hash_util.search_terms_to_hash(terms);
-    assert.equal(hash, "#narrow/streams/public");
+    assert.equal(hash, "#narrow/channels/public");
     narrow = hash_util.parse_narrow(hash.split("/"));
-    assert.deepEqual(narrow, [{operator: "streams", operand: "public", negated: false}]);
+    assert.deepEqual(narrow, [{operator: "channels", operand: "public", negated: false}]);
     filter = new Filter(narrow);
     assert.deepEqual(filter.terms(), [{operator: "channels", operand: "public", negated: false}]);
 
@@ -140,10 +140,10 @@ run_test("stream_to_channel_rename", () => {
 });
 
 run_test("terms_trailing_slash", () => {
-    const hash = "#narrow/stream/100-devel/topic/algol/";
+    const hash = "#narrow/channel/100-devel/topic/algol/";
     const narrow = hash_util.parse_narrow(hash.split("/"));
     assert.deepEqual(narrow, [
-        {operator: "stream", operand: devel_id.toString(), negated: false},
+        {operator: "channel", operand: devel_id.toString(), negated: false},
         {operator: "topic", operand: "algol", negated: false},
     ]);
 });
@@ -295,7 +295,7 @@ run_test("hash_interactions", ({override, override_rewire}) => {
         name: "Denmark",
         stream_id: denmark_id,
     });
-    window.location.hash = "#narrow/stream/Denmark";
+    window.location.hash = "#narrow/channel/Denmark";
 
     helper.clear_events();
     $window_stub.trigger("hashchange");

--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -74,7 +74,7 @@ run_test("t_tag", ({mock_template}) => {
         editability_menu_item: true,
         should_display_hide_option: true,
         conversation_time_url:
-            "http://zulip.zulipdev.com/#narrow/stream/101-devel/topic/testing/near/99",
+            "http://zulip.zulipdev.com/#narrow/channel/101-devel/topic/testing/near/99",
     };
 
     mock_template("popovers/message_actions_popover.hbs", true, (data, html) => {

--- a/web/tests/internal_url.test.js
+++ b/web/tests/internal_url.test.js
@@ -42,11 +42,11 @@ run_test("test encode_stream_id", () => {
 run_test("test by_stream_url", () => {
     const maybe_get_stream_name = () => "a test stream";
     const result = internal_url.by_stream_url(123, maybe_get_stream_name);
-    assert.equal(result, "#narrow/stream/123-a-test-stream");
+    assert.equal(result, "#narrow/channel/123-a-test-stream");
 });
 
 run_test("test by_stream_topic_url", () => {
     const maybe_get_stream_name = () => "a test stream";
     const result = internal_url.by_stream_topic_url(123, "test topic", maybe_get_stream_name);
-    assert.equal(result, "#narrow/stream/123-a-test-stream/topic/test.20topic");
+    assert.equal(result, "#narrow/channel/123-a-test-stream/topic/test.20topic");
 });

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -388,12 +388,12 @@ test("marked", () => {
         {
             input: "This is a #**Denmark** stream link",
             expected:
-                '<p>This is a <a class="stream" data-stream-id="1" href="/#narrow/stream/1-Denmark">#Denmark</a> stream link</p>',
+                '<p>This is a <a class="stream" data-stream-id="1" href="/#narrow/channel/1-Denmark">#Denmark</a> stream link</p>',
         },
         {
             input: "This is #**Denmark** and #**social** stream links",
             expected:
-                '<p>This is <a class="stream" data-stream-id="1" href="/#narrow/stream/1-Denmark">#Denmark</a> and <a class="stream" data-stream-id="2" href="/#narrow/stream/2-social">#social</a> stream links</p>',
+                '<p>This is <a class="stream" data-stream-id="1" href="/#narrow/channel/1-Denmark">#Denmark</a> and <a class="stream" data-stream-id="2" href="/#narrow/channel/2-social">#social</a> stream links</p>',
         },
         {
             input: "And this is a #**wrong** stream link",
@@ -402,12 +402,12 @@ test("marked", () => {
         {
             input: "This is a #**Denmark>some topic** stream_topic link",
             expected:
-                '<p>This is a <a class="stream-topic" data-stream-id="1" href="/#narrow/stream/1-Denmark/topic/some.20topic">#Denmark &gt; some topic</a> stream_topic link</p>',
+                '<p>This is a <a class="stream-topic" data-stream-id="1" href="/#narrow/channel/1-Denmark/topic/some.20topic">#Denmark &gt; some topic</a> stream_topic link</p>',
         },
         {
             input: "This has two links: #**Denmark>some topic** and #**social>other topic**.",
             expected:
-                '<p>This has two links: <a class="stream-topic" data-stream-id="1" href="/#narrow/stream/1-Denmark/topic/some.20topic">#Denmark &gt; some topic</a> and <a class="stream-topic" data-stream-id="2" href="/#narrow/stream/2-social/topic/other.20topic">#social &gt; other topic</a>.</p>',
+                '<p>This has two links: <a class="stream-topic" data-stream-id="1" href="/#narrow/channel/1-Denmark/topic/some.20topic">#Denmark &gt; some topic</a> and <a class="stream-topic" data-stream-id="2" href="/#narrow/channel/2-social/topic/other.20topic">#social &gt; other topic</a>.</p>',
         },
         {
             input: "This is not a #**Denmark>** stream_topic link",
@@ -510,7 +510,7 @@ test("marked", () => {
         {
             input: "T\n#**Denmark**",
             expected:
-                '<p>T<br>\n<a class="stream" data-stream-id="1" href="/#narrow/stream/1-Denmark">#Denmark</a></p>',
+                '<p>T<br>\n<a class="stream" data-stream-id="1" href="/#narrow/channel/1-Denmark">#Denmark</a></p>',
         },
         {
             input: "T\n@**Cordelia, Lear's daughter**",
@@ -617,17 +617,17 @@ test("marked", () => {
         {
             input: "#**Bobby <h1>Tables</h1>**",
             expected:
-                '<p><a class="stream-topic" data-stream-id="4" href="/#narrow/stream/4-Bobby-.3Ch1/topic/Tables.3C.2Fh1.3E">#Bobby &lt;h1 &gt; Tables&lt;/h1&gt;</a></p>',
+                '<p><a class="stream-topic" data-stream-id="4" href="/#narrow/channel/4-Bobby-.3Ch1/topic/Tables.3C.2Fh1.3E">#Bobby &lt;h1 &gt; Tables&lt;/h1&gt;</a></p>',
         },
         {
             input: "#**& &amp; &amp;amp;**",
             expected:
-                '<p><a class="stream" data-stream-id="5" href="/#narrow/stream/5-.26-.26-.26amp.3B">#&amp; &amp; &amp;amp;</a></p>',
+                '<p><a class="stream" data-stream-id="5" href="/#narrow/channel/5-.26-.26-.26amp.3B">#&amp; &amp; &amp;amp;</a></p>',
         },
         {
             input: "#**& &amp; &amp;amp;>& &amp; &amp;amp;**",
             expected:
-                '<p><a class="stream-topic" data-stream-id="5" href="/#narrow/stream/5-.26-.26-.26amp.3B/topic/.26.20.26.20.26amp.3B">#&amp; &amp; &amp;amp; &gt; &amp; &amp; &amp;amp;</a></p>',
+                '<p><a class="stream-topic" data-stream-id="5" href="/#narrow/channel/5-.26-.26-.26amp.3B/topic/.26.20.26.20.26amp.3B">#&amp; &amp; &amp;amp; &gt; &amp; &amp; &amp;amp;</a></p>',
         },
     ];
 

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -68,7 +68,7 @@ function create_devel_sidebar_row({mock_template}) {
     $subscription_block.set_find_results(".unread_mention_info", $devel_unread_mention_info);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => {
-        assert.equal(data.url, "#narrow/stream/100-devel");
+        assert.equal(data.url, "#narrow/channel/100-devel");
         return "<devel-sidebar-row-stub>";
     });
 
@@ -91,7 +91,7 @@ function create_social_sidebar_row({mock_template}) {
     $subscription_block.set_find_results(".unread_mention_info", $social_unread_mention_info);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => {
-        assert.equal(data.url, "#narrow/stream/200-social");
+        assert.equal(data.url, "#narrow/channel/200-social");
         return "<social-sidebar-row-stub>";
     });
 
@@ -663,7 +663,7 @@ test_ui("rename_stream", ({mock_template}) => {
         assert.deepEqual(payload, {
             name: "Development",
             id: 1000,
-            url: "#narrow/stream/1000-Development",
+            url: "#narrow/channel/1000-Development",
             is_muted: undefined,
             invite_only: undefined,
             is_web_public: undefined,

--- a/web/tests/topic_link_util.test.js
+++ b/web/tests/topic_link_util.test.js
@@ -47,40 +47,40 @@ run_test("stream_topic_link_syntax_test", () => {
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "test `test` test"),
-        "[#Sweden>test &grave;test&grave; test](#narrow/stream/1-Sweden/topic/test.20.60test.60.20test)",
+        "[#Sweden>test &grave;test&grave; test](#narrow/channel/1-Sweden/topic/test.20.60test.60.20test)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Denmark>t", "test `test` test`s"),
-        "[#Denmark>test &grave;test&grave; test&grave;s](#narrow/stream/2-Denmark/topic/test.20.60test.60.20test.60s)",
+        "[#Denmark>test &grave;test&grave; test&grave;s](#narrow/channel/2-Denmark/topic/test.20.60test.60.20test.60s)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>typeah", "error due to *"),
-        "[#Sweden>error due to &#42;](#narrow/stream/1-Sweden/topic/error.20due.20to.20*)",
+        "[#Sweden>error due to &#42;](#narrow/channel/1-Sweden/topic/error.20due.20to.20*)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "*asterisk"),
-        "[#Sweden>&#42;asterisk](#narrow/stream/1-Sweden/topic/*asterisk)",
+        "[#Sweden>&#42;asterisk](#narrow/channel/1-Sweden/topic/*asterisk)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>gibberish", "greaterthan>"),
-        "[#Sweden>greaterthan&gt;](#narrow/stream/1-Sweden/topic/greaterthan.3E)",
+        "[#Sweden>greaterthan&gt;](#narrow/channel/1-Sweden/topic/greaterthan.3E)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**$$MONEY$$>t", "dollar"),
-        "[#&#36;&#36;MONEY&#36;&#36;>dollar](#narrow/stream/6-.24.24MONEY.24.24/topic/dollar)",
+        "[#&#36;&#36;MONEY&#36;&#36;>dollar](#narrow/channel/6-.24.24MONEY.24.24/topic/dollar)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "swe$$dish"),
-        "[#Sweden>swe&#36;&#36;dish](#narrow/stream/1-Sweden/topic/swe.24.24dish)",
+        "[#Sweden>swe&#36;&#36;dish](#narrow/channel/1-Sweden/topic/swe.24.24dish)",
     );
     assert.equal(
         topic_link_util.get_fallback_markdown_link("Sweden"),
-        "[#Sweden](#narrow/stream/1-Sweden)",
+        "[#Sweden](#narrow/channel/1-Sweden)",
     );
 
     assert.equal(
         topic_link_util.get_fallback_markdown_link("$$MONEY$$"),
-        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/stream/6-.24.24MONEY.24.24)",
+        "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6-.24.24MONEY.24.24)",
     );
 
     // Only for full coverage of the module.

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -106,7 +106,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         is_followed: false,
         is_unmuted_or_followed: false,
         is_active_topic: true,
-        url: "#narrow/stream/556-general/topic/topic.2011",
+        url: "#narrow/channel/556-general/topic/topic.2011",
         contains_unread_mention: false,
     });
 
@@ -130,7 +130,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         topic_name: "✔ topic 9",
         topic_resolved_prefix: "✔ ",
         unread: 0,
-        url: "#narrow/stream/556-general/topic/.E2.9C.94.20topic.209",
+        url: "#narrow/channel/556-general/topic/.E2.9C.94.20topic.209",
     });
 
     assert.deepEqual(list_info.items[1], {
@@ -145,7 +145,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         topic_name: "topic 8",
         topic_resolved_prefix: "",
         unread: 0,
-        url: "#narrow/stream/556-general/topic/topic.208",
+        url: "#narrow/channel/556-general/topic/topic.208",
     });
 
     // If we zoom in, our results are based on topic filter.

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2008,7 +2008,7 @@ class StreamPattern(CompiledInlineProcessor):
         # provide more clarity to API clients.
         # Also do the same for StreamTopicPattern.
         stream_url = encode_stream(stream_id, name)
-        el.set("href", f"/#narrow/stream/{stream_url}")
+        el.set("href", f"/#narrow/channel/{stream_url}")
         text = f"#{name}"
         el.text = markdown.util.AtomicString(text)
         return el, m.start(), m.end()
@@ -2037,7 +2037,7 @@ class StreamTopicPattern(CompiledInlineProcessor):
         el.set("data-stream-id", str(stream_id))
         stream_url = encode_stream(stream_id, stream_name)
         topic_url = hash_util_encode(topic_name)
-        link = f"/#narrow/stream/{stream_url}/topic/{topic_url}"
+        link = f"/#narrow/channel/{stream_url}/topic/{topic_url}"
         el.set("href", link)
         text = f"#{stream_name} > {topic_name}"
         el.text = markdown.util.AtomicString(text)

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -11,7 +11,7 @@ def is_same_server_message_link(url: str) -> bool:
     if hostname not in {None, settings.EXTERNAL_HOST_WITHOUT_PORT}:
         return False
 
-    # A message link always has category `narrow`, section `stream`
+    # A message link always has category `narrow`, section `channel`
     # or `dm`, and ends with `/near/<message_id>`, where <message_id>
     # is a sequence of digits. The URL fragment of a message link has
     # at least 5 parts. e.g. '#narrow/dm/9,15-dm/near/43'
@@ -23,4 +23,4 @@ def is_same_server_message_link(url: str) -> bool:
     section = fragment_parts[1]
     ends_with_near_message_id = fragment_parts[-2] == "near" and fragment_parts[-1].isdigit()
 
-    return category == "narrow" and section in {"stream", "dm"} and ends_with_near_message_id
+    return category == "narrow" and section in {"channel", "dm"} and ends_with_near_message_id

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -39,12 +39,12 @@ def direct_message_group_narrow_url(
 
 
 def stream_narrow_url(realm: Realm, stream: Stream) -> str:
-    base_url = f"{realm.url}/#narrow/stream/"
+    base_url = f"{realm.url}/#narrow/channel/"
     return base_url + encode_stream(stream.id, stream.name)
 
 
 def topic_narrow_url(*, realm: Realm, stream: Stream, topic_name: str) -> str:
-    base_url = f"{realm.url}/#narrow/stream/"
+    base_url = f"{realm.url}/#narrow/channel/"
     return f"{base_url}{encode_stream(stream.id, stream.name)}/topic/{hash_util_encode(topic_name)}"
 
 
@@ -74,7 +74,7 @@ def near_stream_message_url(realm: Realm, message: dict[str, Any]) -> str:
     parts = [
         realm.url,
         "#narrow",
-        "stream",
+        "channel",
         encoded_stream,
         "topic",
         encoded_topic_name,

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -488,9 +488,9 @@
     },
     {
       "name": "fragment_link",
-      "input": "[foo](http://zulip.testserver/#narrow/stream/1-Denmark)",
-      "expected_output": "<p><a href=\"#narrow/stream/1-Denmark\">foo</a></p>",
-      "marked_expected_output": "<p><a href=\"http://zulip.testserver/#narrow/stream/1-Denmark\">foo</a></p>"
+      "input": "[foo](http://zulip.testserver/#narrow/channel/1-Denmark)",
+      "expected_output": "<p><a href=\"#narrow/channel/1-Denmark\">foo</a></p>",
+      "marked_expected_output": "<p><a href=\"http://zulip.testserver/#narrow/channel/1-Denmark\">foo</a></p>"
     },
     {
       "name": "not_fragment_link",
@@ -1050,9 +1050,9 @@
     },
     {
       "name": "normal_quote_and_reply",
-      "input": "@_**Zoe|7** [said](http://zulip.testserver/#narrow/stream/13-social/topic/party/near/103):\n```quote\nHow are you?\n```\n\nGreat",
-      "expected_output": "<p><span class=\"user-mention silent\" data-user-id=\"7\">Zoe</span> <a href=\"#narrow/stream/13-social/topic/party/near/103\">said</a>:</p>\n<blockquote>\n<p>How are you?</p>\n</blockquote>\n<p>Great</p>",
-      "marked_expected_output": "<p><span class=\"user-mention silent\" data-user-id=\"7\">Zoe</span> <a href=\"http://zulip.testserver/#narrow/stream/13-social/topic/party/near/103\">said</a>:</p>\n<blockquote>\n<p>How are you?</p>\n</blockquote>\n<p>Great</p>",
+      "input": "@_**Zoe|7** [said](http://zulip.testserver/#narrow/channel/13-social/topic/party/near/103):\n```quote\nHow are you?\n```\n\nGreat",
+      "expected_output": "<p><span class=\"user-mention silent\" data-user-id=\"7\">Zoe</span> <a href=\"#narrow/channel/13-social/topic/party/near/103\">said</a>:</p>\n<blockquote>\n<p>How are you?</p>\n</blockquote>\n<p>Great</p>",
+      "marked_expected_output": "<p><span class=\"user-mention silent\" data-user-id=\"7\">Zoe</span> <a href=\"http://zulip.testserver/#narrow/channel/13-social/topic/party/near/103\">said</a>:</p>\n<blockquote>\n<p>How are you?</p>\n</blockquote>\n<p>Great</p>",
       "text_content": "[…]\nGreat"
     },
     {
@@ -1316,8 +1316,8 @@
       ""
     ],
     [
-      "http://zulip.testserver/#narrow/stream/1-Denmark",
-      "<p><a href=\"#narrow/stream/1-Denmark\">http://zulip.testserver/#narrow/stream/1-Denmark</a></p>",
+      "http://zulip.testserver/#narrow/channel/1-Denmark",
+      "<p><a href=\"#narrow/channel/1-Denmark\">http://zulip.testserver/#narrow/channel/1-Denmark</a></p>",
       ""
     ],
     [

--- a/zerver/tests/fixtures/message_link_test_cases.json
+++ b/zerver/tests/fixtures/message_link_test_cases.json
@@ -11,17 +11,17 @@
     },
     {
         "name": "stream_message_link",
-        "message_link": "#narrow/stream/8-design/topic/desktop/near/82",
+        "message_link": "#narrow/channel/8-design/topic/desktop/near/82",
         "expected_output": true
     },
     {
         "name": "stream_link",
-        "message_link": "#narrow/stream/8-design",
+        "message_link": "#narrow/channel/8-design",
         "expected_output": false
     },
     {
         "name": "topic_link",
-        "message_link": "#narrow/stream/8-design/topic/desktop",
+        "message_link": "#narrow/channel/8-design/topic/desktop",
         "expected_output": false
     },
     {

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4747,9 +4747,9 @@ class GoogleAuthBackendTest(SocialAuthBase):
         self.assertEqual(res.status_code, 302)
         self.assertEqual(res["Location"], "http://zulip.testserver/user_uploads/path_to_image")
 
-        res = test_redirect_to_next_url("/#narrow/stream/7-test-here")
+        res = test_redirect_to_next_url("/#narrow/channel/7-test-here")
         self.assertEqual(res.status_code, 302)
-        self.assertEqual(res["Location"], "http://zulip.testserver/#narrow/stream/7-test-here")
+        self.assertEqual(res["Location"], "http://zulip.testserver/#narrow/channel/7-test-here")
 
     def test_log_into_subdomain_when_token_is_malformed(self) -> None:
         data: ExternalAuthDataDict = {
@@ -5600,7 +5600,7 @@ class TestDevAuthBackend(ZulipTestCase):
         # to the backend. Rather we depend upon the browser's behaviour of persisting
         # hash anchors in between redirect requests. See below stackoverflow conversation
         # https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects
-        res = do_local_login("/accounts/login/local/?next=#narrow/stream/7-test-here")
+        res = do_local_login("/accounts/login/local/?next=#narrow/channel/7-test-here")
         self.assertEqual(res.status_code, 302)
         self.assertEqual(res["Location"], "http://zulip.testserver")
 

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -509,7 +509,7 @@ class TestDigestEmailMessages(ZulipTestCase):
             realm, recently_created_streams, can_access_public=True
         )
         self.assertEqual(stream_count, 1)
-        expected_html = f"<a href='http://zulip.testserver/#narrow/stream/{stream.id}-New-stream'>New stream</a>"
+        expected_html = f"<a href='http://zulip.testserver/#narrow/channel/{stream.id}-New-stream'>New stream</a>"
         self.assertEqual(stream_info["html"][0], expected_html)
 
         # guests don't see our stream

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -579,10 +579,10 @@ class MarkdownLinkTest(ZulipTestCase):
         sender_user_profile = self.example_user("othello")
         message = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
-        msg = "http://zulip.testserver/#narrow/stream/999-hello"
+        msg = "http://zulip.testserver/#narrow/channel/999-hello"
         self.assertEqual(
             markdown_convert(msg, message_realm=realm, message=message).rendered_content,
-            '<p><a href="#narrow/stream/999-hello">http://zulip.testserver/#narrow/stream/999-hello</a></p>',
+            '<p><a href="#narrow/channel/999-hello">http://zulip.testserver/#narrow/channel/999-hello</a></p>',
         )
 
         msg = f"http://zulip.testserver/user_uploads/{realm.id}/ff/file.txt"
@@ -613,10 +613,10 @@ class MarkdownLinkTest(ZulipTestCase):
         sender_user_profile = self.example_user("othello")
         message = Message(sender=sender_user_profile, sending_client=get_client("test"))
 
-        msg = "[hello](http://zulip.testserver/#narrow/stream/999-hello)"
+        msg = "[hello](http://zulip.testserver/#narrow/channel/999-hello)"
         self.assertEqual(
             markdown_convert(msg, message_realm=realm, message=message).rendered_content,
-            '<p><a href="#narrow/stream/999-hello">hello</a></p>',
+            '<p><a href="#narrow/channel/999-hello">hello</a></p>',
         )
 
         msg = f"[hello](http://zulip.testserver/user_uploads/{realm.id}/ff/file.txt)"
@@ -2975,7 +2975,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         content = "#**Denmark**"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
-            f'<p><a class="stream" data-stream-id="{denmark.id}" href="/#narrow/stream/{denmark.id}-Denmark">#{denmark.name}</a></p>',
+            f'<p><a class="stream" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark">#{denmark.name}</a></p>',
         )
 
     def test_invalid_stream_followed_by_valid_mention(self) -> None:
@@ -2989,7 +2989,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         content = "#**Invalid** and #**Denmark**"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
-            f'<p>#<strong>Invalid</strong> and <a class="stream" data-stream-id="{denmark.id}" href="/#narrow/stream/{denmark.id}-Denmark">#{denmark.name}</a></p>',
+            f'<p>#<strong>Invalid</strong> and <a class="stream" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark">#{denmark.name}</a></p>',
         )
 
     def test_stream_multiple(self) -> None:
@@ -3008,10 +3008,10 @@ class MarkdownStreamMentionTests(ZulipTestCase):
             "<p>Look to "
             '<a class="stream" '
             f'data-stream-id="{denmark.id}" '
-            f'href="/#narrow/stream/{denmark.id}-Denmark">#{denmark.name}</a> and '
+            f'href="/#narrow/channel/{denmark.id}-Denmark">#{denmark.name}</a> and '
             '<a class="stream" '
             f'data-stream-id="{scotland.id}" '
-            f'href="/#narrow/stream/{scotland.id}-Scotland">#{scotland.name}</a>, '
+            f'href="/#narrow/channel/{scotland.id}-Scotland">#{scotland.name}</a>, '
             "there something</p>",
         )
 
@@ -3023,7 +3023,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         content = "#**CaseSens**"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
-            f'<p><a class="stream" data-stream-id="{case_sens.id}" href="/#narrow/stream/{case_sens.id}-{case_sens.name}">#{case_sens.name}</a></p>',
+            f'<p><a class="stream" data-stream-id="{case_sens.id}" href="/#narrow/channel/{case_sens.id}-{case_sens.name}">#{case_sens.name}</a></p>',
         )
 
     def test_stream_case_sensitivity_nonmatching(self) -> None:
@@ -3051,7 +3051,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         content = "#**Denmark>some topic**"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
-            f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/stream/{denmark.id}-Denmark/topic/some.20topic">#{denmark.name} &gt; some topic</a></p>',
+            f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark/topic/some.20topic">#{denmark.name} &gt; some topic</a></p>',
         )
 
     def test_topic_atomic_string(self) -> None:
@@ -3073,7 +3073,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         content = "#**Denmark>#1234**"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
-            f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/stream/{denmark.id}-Denmark/topic/.231234">#{denmark.name} &gt; #1234</a></p>',
+            f'<p><a class="stream-topic" data-stream-id="{denmark.id}" href="/#narrow/channel/{denmark.id}-Denmark/topic/.231234">#{denmark.name} &gt; #1234</a></p>',
         )
 
     def test_topic_multiple(self) -> None:
@@ -3090,11 +3090,11 @@ class MarkdownStreamMentionTests(ZulipTestCase):
             render_message_markdown(msg, content).rendered_content,
             "<p>This has two links: "
             f'<a class="stream-topic" data-stream-id="{denmark.id}" '
-            f'href="/#narrow/stream/{denmark.id}-{denmark.name}/topic/some.20topic">'
+            f'href="/#narrow/channel/{denmark.id}-{denmark.name}/topic/some.20topic">'
             f"#{denmark.name} &gt; some topic</a>"
             " and "
             f'<a class="stream-topic" data-stream-id="{scotland.id}" '
-            f'href="/#narrow/stream/{scotland.id}-{scotland.name}/topic/other.20topic">'
+            f'href="/#narrow/channel/{scotland.id}-{scotland.name}/topic/other.20topic">'
             f"#{scotland.name} &gt; other topic</a>"
             ".</p>",
         )
@@ -3116,7 +3116,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"), realm=realm)
         content = "#**привет**"
         quoted_name = ".D0.BF.D1.80.D0.B8.D0.B2.D0.B5.D1.82"
-        href = f"/#narrow/stream/{uni.id}-{quoted_name}"
+        href = f"/#narrow/channel/{uni.id}-{quoted_name}"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
             f'<p><a class="stream" data-stream-id="{uni.id}" href="{href}">#{uni.name}</a></p>',
@@ -3139,7 +3139,7 @@ class MarkdownStreamMentionTests(ZulipTestCase):
         stream = self.make_stream(stream_name="Stream #1234", realm=realm)
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"), realm=realm)
         content = "#**Stream #1234**"
-        href = f"/#narrow/stream/{stream.id}-Stream-.231234"
+        href = f"/#narrow/channel/{stream.id}-Stream-.231234"
         self.assertEqual(
             render_message_markdown(msg, content).rendered_content,
             f'<p><a class="stream" data-stream-id="{stream.id}" href="{href}">#{stream.name}</a></p>',
@@ -3281,7 +3281,7 @@ class MarkdownApiTests(ZulipTestCase):
         stream_id = get_stream("Denmark", get_realm("zulip")).id
         self.assertEqual(
             response_dict["rendered"],
-            f'<p>This mentions <a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-Denmark">#Denmark</a> and <span class="user-mention" data-user-id="{user_id}">@King Hamlet</span>.</p>',
+            f'<p>This mentions <a class="stream" data-stream-id="{stream_id}" href="/#narrow/channel/{stream_id}-Denmark">#Denmark</a> and <span class="user-mention" data-user-id="{user_id}">@King Hamlet</span>.</p>',
         )
 
 

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -1220,7 +1220,7 @@ class TestMessageNotificationEmails(ZulipTestCase):
             "Come and join us in #**Verona**.",
         )
         stream_id = get_stream("Verona", get_realm("zulip")).id
-        href = f"http://zulip.testserver/#narrow/stream/{stream_id}-Verona"
+        href = f"http://zulip.testserver/#narrow/channel/{stream_id}-Verona"
         verify_body_include = [
             f'<a class="stream" href="{href}" data-stream-id="{stream_id}">#Verona</a'
         ]
@@ -1493,13 +1493,13 @@ class TestMessageNotificationEmails(ZulipTestCase):
 
         # A narrow URL which begins with a '#'.
         test_data = (
-            '<p><a href="#narrow/stream/test/topic/test.20topic/near/142"'
-            ' title="#narrow/stream/test/topic/test.20topic/near/142">Conversation</a></p>'
+            '<p><a href="#narrow/channel/test/topic/test.20topic/near/142"'
+            ' title="#narrow/channel/test/topic/test.20topic/near/142">Conversation</a></p>'
         )
         actual_output = convert(test_data)
         expected_output = (
-            '<div><p><a href="http://example.com/#narrow/stream/test/topic/test.20topic/near/142"'
-            ' title="http://example.com/#narrow/stream/test/topic/test.20topic/near/142">Conversation</a></p></div>'
+            '<div><p><a href="http://example.com/#narrow/channel/test/topic/test.20topic/near/142"'
+            ' title="http://example.com/#narrow/channel/test/topic/test.20topic/near/142">Conversation</a></p></div>'
         )
         self.assertEqual(actual_output, expected_output)
 

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -132,13 +132,13 @@ class DoRestCallTests(ZulipTestCase):
             self.assertEqual(
                 m.output,
                 [
-                    f'WARNING:root:Message http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/ triggered an outgoing webhook, returning status code 500.\n Content of response (in quotes): "{final_response.text}"'
+                    f'WARNING:root:Message http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/ triggered an outgoing webhook, returning status code 500.\n Content of response (in quotes): "{final_response.text}"'
                 ],
             )
         bot_owner_notification = self.get_last_message()
         self.assertEqual(
             bot_owner_notification.content,
-            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+            """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The webhook got a response with status code *500*.""",
         )
 
@@ -196,7 +196,7 @@ The webhook got a response with status code *500*.""",
             self.assertEqual(
                 m.output,
                 [
-                    f'WARNING:root:Message http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/ triggered an outgoing webhook, returning status code 400.\n Content of response (in quotes): "{final_response.text}"'
+                    f'WARNING:root:Message http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/ triggered an outgoing webhook, returning status code 400.\n Content of response (in quotes): "{final_response.text}"'
                 ],
             )
 
@@ -205,7 +205,7 @@ The webhook got a response with status code *500*.""",
         bot_owner_notification = self.get_last_message()
         self.assertEqual(
             bot_owner_notification.content,
-            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+            """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The webhook got a response with status code *400*.""",
         )
 
@@ -291,7 +291,7 @@ The webhook got a response with status code *400*.""",
         bot_owner_notification = self.get_last_message()
         self.assertEqual(
             bot_owner_notification.content,
-            """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+            """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 When trying to send a request to the webhook service, an exception of type RequestException occurred:
 ```
 I'm a generic exception :(
@@ -322,7 +322,7 @@ I'm a generic exception :(
             bot_owner_notification = self.get_last_message()
             self.assertEqual(
                 bot_owner_notification.content,
-                """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+                """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
 > Widgets: API programmer sent invalid JSON content\nThe response contains the following payload:\n```\n'{"content": "whatever", "widget_content": "test"}'\n```""",
             )
@@ -349,7 +349,7 @@ The outgoing webhook server attempted to send a message in Zulip, but that reque
             bot_owner_notification = self.get_last_message()
             self.assertEqual(
                 bot_owner_notification.content,
-                """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+                """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
 > Invalid response format\nThe response contains the following payload:\n```\n'true'\n```""",
             )
@@ -378,7 +378,7 @@ The outgoing webhook server attempted to send a message in Zulip, but that reque
             bot_owner_notification = self.get_last_message()
             self.assertEqual(
                 bot_owner_notification.content,
-                """[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
+                """[A message](http://zulip.testserver/#narrow/channel/999-Verona/topic/Foo/near/) to your bot @_**Outgoing Webhook** triggered an outgoing webhook.
 The outgoing webhook server attempted to send a message in Zulip, but that request resulted in the following error:
 > Invalid JSON in response\nThe response contains the following payload:\n```\n"this isn't valid json"\n```""",
             )

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -5124,7 +5124,7 @@ class TestPushNotificationsContent(ZulipTestCase):
             },
             {
                 "name": "stream_names",
-                "rendered_content": f'<p>Testing stream names <a class="stream" data-stream-id="{stream.id}" href="/#narrow/stream/Verona">#Verona</a>.</p>',
+                "rendered_content": f'<p>Testing stream names <a class="stream" data-stream-id="{stream.id}" href="/#narrow/channel/Verona">#Verona</a>.</p>',
                 "expected_output": "Testing stream names #Verona.",
             },
         ]

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4352,7 +4352,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type_id, new_stream_announcements_stream.id)
         self.assertEqual(msg.sender_id, self.notification_bot(realm).id)
         stream_id = Stream.objects.latest("id").id
-        expected_rendered_msg = f'<p><span class="user-mention silent" data-user-id="{user.id}">{user.full_name}</span> created a new channel <a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-{invite_streams[0]}">#{invite_streams[0]}</a>.</p>'
+        expected_rendered_msg = f'<p><span class="user-mention silent" data-user-id="{user.id}">{user.full_name}</span> created a new channel <a class="stream" data-stream-id="{stream_id}" href="/#narrow/channel/{stream_id}-{invite_streams[0]}">#{invite_streams[0]}</a>.</p>'
         self.assertEqual(msg.rendered_content, expected_rendered_msg)
 
     def test_successful_subscriptions_notifies_with_escaping(self) -> None:

--- a/zerver/webhooks/sentry/doc.md
+++ b/zerver/webhooks/sentry/doc.md
@@ -60,4 +60,4 @@ Get Zulip notifications for the issues in your Sentry projects!
 
 {!webhooks-url-specification.md!}
 
-[dev-community]: https://chat.zulip.org/#narrow/stream/127-integrations
+[dev-community]: https://chat.zulip.org/#narrow/channel/127-integrations


### PR DESCRIPTION
Updates the web app and server to generate links using the "channel" operator instead of the deprecated "stream" operator.

Fixes #30385.

**Notes**:
- Prep commit to update any existing links in our documentation that use the "stream" operator.
- Existing links with the "stream" operator continue to work as expected in the web app, and the URL in the browser is not updated when one navigates to those links.
- `git grep -c '#narrow/stream'` returns two results:
  - `zerver/migrations/0501_delete_dangling_usermessages.py:1`: Print logging strings of near message URLs in this migration.
  - `zerver/tests/fixtures/rocketchat_fixtures/rocketchat_message.bson:3`: Some chat.zulip.org links that were included in messages in the export data fixtures to test the import code.
- In the commit with frontend changes, updates a few comments in `web/src/filter.ts` that have been added since the channel to stream rename happened. It's useful for that file in particular to use "channel" unless referring to the message type or an imported module/function.
- ~Final commit updates message fetching to use the channel ID instead of the channel name in the narrow, if it exists.~

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
