### PR TITLE
ui_update: Match the pencil icon color.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -271,10 +271,11 @@ input {
 
 .poll-edit-question,
 .todo-edit-task-list-title {
-    opacity: 0.4;
+    color: var(--color-message-action-visible);
 
-    &:hover {
-        opacity: 1;
+    &:hover,
+    &:focus-visible {
+        color: var(--color-message-action-interactive);
     }
 }
 


### PR DESCRIPTION
The color of pencil icon for both todo and poll is now has same color onhover/unhover in dark and light mode.

Fixes: #30339


<!-- Describe your pull request here.-->

# Unhovered
## Poll

| Before  | After |
|:-------:|:-----:|
| ![Before Image 1](https://github.com/user-attachments/assets/3018f0c2-2172-4fd9-a49c-2eb52a10ff88) ![Before Image 2](https://github.com/user-attachments/assets/45325c47-295d-4666-a2fe-4c3f7b1816f9) | ![After Image 1](https://github.com/user-attachments/assets/b13ea6bf-0ad9-4a05-9bce-51aa061e7834) ![After Image 2](https://github.com/user-attachments/assets/d4314acb-70d1-407d-b841-64cbb2c5ba40) |


## Todo

| Before  | After |
|:-------:|:-----:|
| ![Before Image 1](https://github.com/user-attachments/assets/524fa8e2-76e0-4ddb-a50b-d4ecdb8a93b8)) ![Before Image 2](https://github.com/user-attachments/assets/d4abce4c-4a3c-4895-a6f5-290dc2e38bf9)) | ![After Image 1](https://github.com/user-attachments/assets/022c5363-9c5f-438d-815e-63f2c22ca5f4)) ![After Image 2](https://github.com/user-attachments/assets/14198965-0cc0-46b6-a769-07857a808a79) |

# Hovered
## Todo

| ![Before Image 1](https://github.com/user-attachments/assets/703a6e33-aac4-415f-b6c8-170723bc53d7) | ![Before Image 2](https://github.com/user-attachments/assets/5a0ad555-bc5b-4c0d-ae6e-f38ff11fcd54) | ![After Image 1](https://github.com/user-attachments/assets/4f64f9df-b421-4f43-b8bd-f6e8f3537705) | ![After Image 2](https://github.com/user-attachments/assets/4c5f411f-9c35-4ef6-bd1f-45b0518004ac) |
|:-------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|

## Poll

| ![Before Image 1](https://github.com/user-attachments/assets/703a6e33-aac4-415f-b6c8-170723bc53d7) | ![Before Image 2](https://github.com/user-attachments/assets/d448289f-b7b1-4be5-89da-ba40721ca10b)| ![After Image 1](https://github.com/user-attachments/assets/7e05ee58-b8b0-4f1e-9414-972ebbf4ba32) | ![After Image 2](https://github.com/user-attachments/assets/98888e95-1dce-42a4-ba9c-cdddafe891a4) |
|:-------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------:|


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
