### PR TITLE
widgets: Assign zulip-button colors to edit buttons.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -260,11 +260,12 @@ input {
     flex: 0 0 30.5px;
     min-height: 30.5px;
     border-radius: 3px;
-    border: 1px solid hsl(0deg 0% 80%);
-    background-color: hsl(0deg 0% 100%);
+    border: 1px solid var(--color-border-zulip-button);
+    background-color: var(--color-background-zulip-button);
 
     &:hover {
-        border-color: hsl(0deg 0% 60%);
+        border-color: var(--color-border-zulip-button-interactive);
+        background-color: var(--color-background-zulip-button-hover);
     }
 }
 


### PR DESCRIPTION
This corrects a regression on poll and to-do widget edit buttons in dark mode.

The colors themselves will likely change once #31595 progresses.

[CZO issue](https://chat.zulip.org/#narrow/stream/9-issues/topic/Title.20edit.20checkmark.20buttons'.20background.20color.2E/near/1955900)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![widget-edit-buttons-dark-before](https://github.com/user-attachments/assets/751d9ff7-75d1-4932-8f5b-3e9e962d5a5f) | ![widget-edit-buttons-dark-after](https://github.com/user-attachments/assets/802284f6-ee9c-4561-b7bf-47a4b99fd158) |
| ![widget-edit-buttons-light-before](https://github.com/user-attachments/assets/7472ea14-5c6f-41d9-9709-6b996623ed4c) | ![widget-edit-buttons-light-after](https://github.com/user-attachments/assets/ac31e621-e2a1-487e-b995-34f990611a21) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


