### PR TITLE
nginx: Make uwsgi timeout shorter than nginx-to-uwsgi timeout.

### DIFF
--- a/docs/production/reverse-proxies.md
+++ b/docs/production/reverse-proxies.md
@@ -255,13 +255,13 @@ things you need to be careful about when configuring it:
    browsers. This [nginx code snippet][nginx-proxy-longpolling-config]
    does this.
 
-   The key configuration options are, for the `/json/events` and
-   `/api/1/events` endpoints:
+   The key configuration options are:
 
-   - `proxy_read_timeout 1200;`. It's critical that this be
-     significantly above 60s, but the precise value isn't important.
-   - `proxy_buffering off`. If you don't do this, your `nginx` proxy may
-     return occasional 502 errors to clients using Zulip's events API.
+   - `proxy_read_timeout 1200;`. It's critical that this be significantly above
+     60s, but the precise value isn't important. This is most important for the
+     events API, but must be applied to all endpoints.
+   - `proxy_buffering off`. If you don't do this, your `nginx` proxy may return
+     occasional 502 errors to clients using Zulip's events API.
 
 1. The other tricky failure mode we've seen with `nginx` reverse
    proxies is that they can load-balance between the IPv4 and IPv6

--- a/puppet/zulip/files/nginx/uwsgi_params
+++ b/puppet/zulip/files/nginx/uwsgi_params
@@ -18,4 +18,8 @@ uwsgi_param HTTP_X_FORWARDED_PROTO $trusted_x_forwarded_proto;
 uwsgi_param HTTP_X_FORWARDED_SSL "";
 uwsgi_param HTTP_X_PROXY_MISCONFIGURATION $x_proxy_misconfiguration;
 
+# This value is the default, and is provided for explicitness; it must
+# be longer than the configured 55s "harakiri" timeout in uwsgi
+uwsgi_read_timeout 60s;
+
 uwsgi_pass django;

--- a/puppet/zulip/templates/uwsgi.ini.template.erb
+++ b/puppet/zulip/templates/uwsgi.ini.template.erb
@@ -47,7 +47,7 @@ auto-procname=true
 procname-prefix-spaced=zulip-django
 
 # Longest response allowed, in seconds, before killing the worker
-harakiri=60
+harakiri=55
 
 
 


### PR DESCRIPTION
The nginx-to-uwsig-timeout defaults to 60s, which is exactly the same
as the current "harakiri" timeout configured in uwsgi (which limits
the length a request can run before the worker is terminated).  This
causes a race, where if nginx hits its 60s before uwsgi, then we
return a 504; otherwise, we get a 502.

Make the nginx-to-uwsgi timeout explicit, and shorten the "harakiri"
timeout to be explicitly less than that.  Document the 60s timeout,
which all outer reverse proxies must be set to _longer than_ in order
to have proper "onion" timeouts.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
