### PR TITLE
Fix notification key structure for private and group messages

### DIFF
--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -16,6 +16,7 @@ import {user_settings} from "./user_settings";
 import * as user_topics from "./user_topics";
 import * as util from "./util";
 
+
 type TestNotificationMessage = {
     id: number;
     type: "test-notification";
@@ -88,18 +89,44 @@ function debug_notification_source_value(message: Message | TestNotificationMess
     blueslip.debug("Desktop notification from source " + notification_source);
 }
 
+// function get_notification_key(message: Message | TestNotificationMessage): string {
+//     let key;
+
+//     if (message.type === "private" || message.type === "test-notification") {
+//         key = message.display_reply_to;
+//     } else {
+//         const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
+//         key = message.sender_full_name + " to " + stream_name + " > " + message.topic;
+//     }
+
+//     return key;
+// }
 function get_notification_key(message: Message | TestNotificationMessage): string {
-    let key;
+    const notificationKey: {
+        type: string;
+        sender: string;
+        display_reply_to: string | null;
+        stream: string | null;
+        topic: string | null;
+    } = {
+        type: message.type,
+        sender: message.sender_full_name,
+        display_reply_to: message.display_reply_to || null, // Use null if not available
+        stream: null,
+        topic: null,
+    };
 
     if (message.type === "private" || message.type === "test-notification") {
-        key = message.display_reply_to;
+        return JSON.stringify(notificationKey); // Returns without stream and topic info
     } else {
         const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
-        key = message.sender_full_name + " to " + stream_name + " > " + message.topic;
-    }
+        notificationKey.stream = stream_name;
+        notificationKey.topic = message.topic;
 
-    return key;
+        return JSON.stringify(notificationKey);
+    }
 }
+
 
 function remove_sender_from_list_of_recipients(message: Message): string {
     return `, ${message.display_reply_to}, `


### PR DESCRIPTION
<!-- Describe your pull request here. -->
This pull request refines the notification key structure to properly handle both private and group messages in the Zulip messaging application. The changes improve how notification data is organized and enhance the readability of the code.

Fixes: #26729

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well. -->
No UI changes were made.

**Screenshots and screen captures:**
N/A

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
      
Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

