### PR TITLE
copy_and_paste: Paste fallback md link if syntax link will be broken.

### DIFF
--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -666,18 +666,21 @@ export function try_stream_topic_syntax_text(text: string): string | null {
         return null;
     }
 
+    // Now we're sure that the URL is a valid stream topic URL.
+    // But the produced #**stream>topic** syntax could be broken.
+
     const stream = stream_data.get_sub_by_id(stream_topic.stream_id);
     assert(stream !== undefined);
     const stream_name = stream.name;
     if (topic_link_util.will_produce_broken_stream_topic_link(stream_name)) {
-        return null;
+        return topic_link_util.get_fallback_markdown_link(stream_name, stream_topic.topic_name);
     }
 
     if (
         stream_topic.topic_name !== undefined &&
         topic_link_util.will_produce_broken_stream_topic_link(stream_topic.topic_name)
     ) {
-        return null;
+        return topic_link_util.get_fallback_markdown_link(stream_name, stream_topic.topic_name);
     }
 
     let syntax_text = "#**" + stream_name;

--- a/web/tests/copy_and_paste.test.js
+++ b/web/tests/copy_and_paste.test.js
@@ -12,6 +12,10 @@ stream_data.add_sub({
     stream_id: 4,
     name: "Rome",
 });
+stream_data.add_sub({
+    stream_id: 5,
+    name: "Romeo`s lair",
+});
 
 run_test("try_stream_topic_syntax_text", () => {
     const test_cases = [
@@ -41,11 +45,28 @@ run_test("try_stream_topic_syntax_text", () => {
         ["http://zulip.zulipdev.com/#narrow/topic/cheese"],
         ["http://zulip.zulipdev.com/#narrow/topic/pizza/stream/Rome"],
 
-        // characters which are known to produce broken #**stream>topic** urls.
-        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/100.25.20profits.60"],
-        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/100.25.20*profits"],
-        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/.24.24 100.25.20profits"],
-        ["http://zulip.zulipdev.com/#narrow/channel/4-Rome/topic/>100.25.20profits"],
+        // When a url containing characters which are known to produce broken
+        // #**stream>topic** urls is pasted, a normal markdown link syntax is produced.
+        [
+            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/100.25.20profits.60",
+            "[#Rome>100% profits&#96;](#narrow/channel/4-Rome/topic/100.25.20profits.60)",
+        ],
+        [
+            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/100.25.20*profits",
+            "[#Rome>100% &#42;profits](#narrow/channel/4-Rome/topic/100.25.20*profits)",
+        ],
+        [
+            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/.24.24 100.25.20profits",
+            "[#Rome>&#36;&#36; 100% profits](#narrow/channel/4-Rome/topic/.24.24.20100.25.20profits)",
+        ],
+        [
+            "http://zulip.zulipdev.com/#narrow/stream/4-Rome/topic/>100.25.20profits",
+            "[#Rome>&gt;100% profits](#narrow/channel/4-Rome/topic/.3E100.25.20profits)",
+        ],
+        [
+            "http://zulip.zulipdev.com/#narrow/stream/5-Romeo.60s-lair/topic/normal",
+            "[#Romeo&#96;s lair>normal](#narrow/channel/5-Romeo.60s-lair/topic/normal)",
+        ],
     ];
 
     for (const test_case of test_cases) {


### PR DESCRIPTION
If we paste a stream-topic URL that can be pretty formatted (as per #29302),
we only formatted the link if the `#**stream>topic**` syntax would produce a 
valid link (as per #30071).

This PR changes this behaviour to generate a normal fallback markdown url syntax 
in case the `#**stream>topic**` syntax would produce a broken link.


Fixes #31904


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures</summary>

[Screencast from 2024-10-09 00-53-12.webm](https://github.com/user-attachments/assets/fa71b72b-8cc3-4cce-91a1-cbb1d67344c2)

The topic name here produces an invalid `#**stream>topic**` link.
- We first use the typeahead to generate the fallback syntax, as done in #30071 
- Then we paste the link to the topic, which again generates the fallback syntax, **as was needed**
- We then paste using `Ctrl+Shift+V`, which pastes the raw url.

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
