### PR TITLE
stream_data: Always initialize pin_to_top

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -74,7 +74,7 @@ type StreamContext = {
     invite_only: boolean;
     is_web_public: boolean;
     stream_name: string;
-    pin_to_top: boolean | undefined;
+    pin_to_top: boolean;
     is_muted: boolean;
     stream_color: string;
     stream_header_color: string;

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -736,6 +736,7 @@ export function create_sub_from_server_data(
         render_subscribers: !realm.realm_is_zephyr_mirror_realm || attrs.invite_only,
         newly_subscribed: false,
         is_muted: false,
+        pin_to_top: false,
         desktop_notifications: null,
         audible_notifications: null,
         push_notifications: null,

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -471,7 +471,7 @@ class StreamSidebarRow {
     }
 
     update_whether_active(): void {
-        if (stream_list_sort.has_recent_activity(this.sub) || this.sub.pin_to_top === true) {
+        if (stream_list_sort.has_recent_activity(this.sub) || this.sub.pin_to_top) {
             this.$list_item.removeClass("inactive_stream");
         } else {
             this.$list_item.addClass("inactive_stream");

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -9,8 +9,6 @@ import type {
     stream_subscription_schema,
 } from "./stream_types";
 
-type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<T>;
-
 export type Stream = z.infer<typeof stream_schema>;
 export type StreamSpecificNotificationSettings = z.infer<
     typeof stream_specific_notification_settings_schema
@@ -28,11 +26,7 @@ export type ExtraStreamAttrs = {
 };
 
 // This is the actual type of subscription objects we use in the app.
-export type StreamSubscription = PartialBy<
-    Omit<ApiStreamSubscription, "subscribers">,
-    "pin_to_top" | "email_address"
-> &
-    ExtraStreamAttrs;
+export type StreamSubscription = Omit<ApiStreamSubscription, "subscribers"> & ExtraStreamAttrs;
 
 const subs_by_stream_id = new Map<number, StreamSubscription>();
 


### PR DESCRIPTION
This simplifies the `StreamSubscription` type, and parallels how we always initialize every other property that isn’t in `NeverSubscribedStream` (`audible_notifications`, `desktop_notifications`, `email_notifications`, `push_notifications`, `wildcard_mentions_notify`, `color`, `is_muted`). `email_address` was already optional.