### PR TITLE
tests: Unmock user_settings, state_data

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -289,7 +289,6 @@ EXEMPT_FILES = make_set(
         "web/src/user_groups.ts",
         "web/src/user_pill.ts",
         "web/src/user_profile.ts",
-        "web/src/user_settings.ts",
         "web/src/user_sort.ts",
         "web/src/user_status.ts",
         "web/src/user_status_ui.ts",

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -13,7 +13,7 @@ const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespac
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const $window_stub = $.create("window-stub");
 set_global("to_$", () => $window_stub);
@@ -52,8 +52,13 @@ const peer_data = zrequire("peer_data");
 const message_lists = zrequire("message_lists");
 const util = zrequire("util");
 const {Filter} = zrequire("../src/filter");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -164,7 +164,7 @@ run_test("reload_defaults", () => {
 
 test("get_status", ({override}) => {
     page_params.realm_users = [];
-    current_user.user_id = 999;
+    override(current_user, "user_id", 999);
 
     assert.equal(presence.get_status(current_user.user_id), "active");
     assert.equal(presence.get_status(alice.user_id), "active");

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -13,7 +13,7 @@ const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespac
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 const $window_stub = $.create("window-stub");
 set_global("to_$", () => $window_stub);
@@ -52,6 +52,10 @@ const peer_data = zrequire("peer_data");
 const message_lists = zrequire("message_lists");
 const util = zrequire("util");
 const {Filter} = zrequire("../src/filter");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const me = {
     email: "me@zulip.com",

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -717,8 +717,8 @@ test("insert_unfiltered_user_with_filter", () => {
     activity_ui.redraw_user(fred.user_id);
 });
 
-test("realm_presence_disabled", () => {
-    realm.realm_presence_disabled = true;
+test("realm_presence_disabled", ({override}) => {
+    override(realm, "realm_presence_disabled", true);
 
     activity_ui.redraw_user();
     activity_ui.build_user_sidebar();
@@ -734,9 +734,9 @@ test("update_presence_info", ({override, override_rewire}) => {
     override(pm_list, "update_private_messages", noop);
     override_rewire(activity_ui, "update_presence_indicators", noop);
 
-    realm.realm_presence_disabled = false;
-    realm.server_presence_ping_interval_seconds = 60;
-    realm.server_presence_offline_threshold_seconds = 200;
+    override(realm, "realm_presence_disabled", false);
+    override(realm, "server_presence_ping_interval_seconds", 60);
+    override(realm, "server_presence_offline_threshold_seconds", 200);
 
     const server_time = 500;
     const info = {
@@ -918,7 +918,7 @@ test("test_send_or_receive_no_presence_for_spectator", () => {
     activity.send_presence_to_server();
 });
 
-test("check_should_redraw_new_user", () => {
+test("check_should_redraw_new_user", ({override}) => {
     presence.presence_info.set(9999, {status: "active"});
 
     // A user that wasn't yet known, but has presence info should be redrawn
@@ -927,10 +927,10 @@ test("check_should_redraw_new_user", () => {
 
     // We don't even build the user sidebar if realm_presence_disabled is true,
     // so nothing to redraw.
-    realm.realm_presence_disabled = true;
+    override(realm, "realm_presence_disabled", true);
     assert.equal(activity_ui.check_should_redraw_new_user(9999), false);
 
-    realm.realm_presence_disabled = false;
+    override(realm, "realm_presence_disabled", false);
     // A new user that didn't have presence info should not be redrawn.
     assert.equal(activity_ui.check_should_redraw_new_user(99999), false);
 });

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -116,7 +116,7 @@ function add_sub_and_set_as_current_narrow(sub) {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        user_settings.presence_enabled = true;
+        helpers.override(user_settings, "presence_enabled", true);
         // Simulate a small window by having the
         // fill_screen_with_content render the entire
         // list in one pass.  We will do more refined
@@ -158,7 +158,7 @@ run_test("reload_defaults", () => {
     assert.equal(activity_ui.get_filter_text(), "");
 });
 
-test("get_status", () => {
+test("get_status", ({override}) => {
     page_params.realm_users = [];
     current_user.user_id = 999;
 
@@ -167,9 +167,9 @@ test("get_status", () => {
     assert.equal(presence.get_status(mark.user_id), "idle");
     assert.equal(presence.get_status(fred.user_id), "active");
 
-    user_settings.presence_enabled = false;
+    override(user_settings, "presence_enabled", false);
     assert.equal(presence.get_status(current_user.user_id), "offline");
-    user_settings.presence_enabled = true;
+    override(user_settings, "presence_enabled", true);
     assert.equal(presence.get_status(current_user.user_id), "active");
 
     presence.presence_info.delete(zoe.user_id);
@@ -505,7 +505,7 @@ test("render_empty_user_list_message", ({override, mock_template}) => {
 });
 
 test("insert_one_user_into_empty_list", ({override, mock_template}) => {
-    user_settings.user_list_style = 2;
+    override(user_settings, "user_list_style", 2);
 
     override(padded_widget, "update_padding", noop);
     mock_template("presence_row.hbs", true, (data, html) => {

--- a/web/tests/browser_history.test.js
+++ b/web/tests/browser_history.test.js
@@ -13,11 +13,11 @@ window.location.hash = "#bogus";
 const browser_history = zrequire("browser_history");
 
 function test(label, f) {
-    run_test(label, (...args) => {
-        user_settings.web_home_view = "recent";
+    run_test(label, (helpers) => {
+        helpers.override(user_settings, "web_home_view", "recent");
         window.location.hash = "#bogus";
         browser_history.clear_for_testing();
-        f(...args);
+        f(helpers);
     });
 }
 

--- a/web/tests/browser_history.test.js
+++ b/web/tests/browser_history.test.js
@@ -6,11 +6,14 @@ const {zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {user_settings} = require("./lib/zpage_params");
 
 window.location.hash = "#bogus";
 
 const browser_history = zrequire("browser_history");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 function test(label, f) {
     run_test(label, (helpers) => {

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -166,7 +166,7 @@ test("user_circle, level", ({override}) => {
     assert.equal(buddy_data.level(fred.user_id), 3);
 });
 
-test("title_data", () => {
+test("title_data", ({override}) => {
     page_params.presence_history_limit_days_for_web_app = 365;
     add_canned_users();
 
@@ -213,7 +213,7 @@ test("title_data", () => {
         third_line: "translated: Active now",
         show_you: true,
     };
-    current_user.user_id = me.user_id;
+    override(current_user, "user_id", me.user_id);
     assert.deepEqual(buddy_data.get_title_data(me.user_id, is_group), expected_data);
 
     expected_data = {

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -6,7 +6,7 @@ const _ = require("lodash");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, page_params, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -24,6 +24,10 @@ const user_status = zrequire("user_status");
 const buddy_data = zrequire("buddy_data");
 const {Filter} = zrequire("filter");
 const message_lists = zrequire("message_lists");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 // The buddy_data module is mostly tested indirectly through
 // activity.test.js, but we should feel free to add direct tests

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -6,7 +6,7 @@ const _ = require("lodash");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -24,8 +24,13 @@ const user_status = zrequire("user_status");
 const buddy_data = zrequire("buddy_data");
 const {Filter} = zrequire("filter");
 const message_lists = zrequire("message_lists");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -101,7 +101,7 @@ function add_canned_users() {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        user_settings.presence_enabled = true;
+        helpers.override(user_settings, "presence_enabled", true);
         compose_fade_helper.clear_focused_recipient();
         stream_data.clear_subscriptions();
         peer_data.clear_for_testing();
@@ -126,7 +126,7 @@ function set_presence(user_id, status) {
     });
 }
 
-test("user_circle, level", () => {
+test("user_circle, level", ({override}) => {
     add_canned_users();
 
     set_presence(selma.user_id, "active");
@@ -145,11 +145,11 @@ test("user_circle, level", () => {
     assert.equal(buddy_data.get_user_circle_class(me.user_id), "user_circle_green");
     assert.equal(buddy_data.level(me.user_id), 0);
 
-    user_settings.presence_enabled = false;
+    override(user_settings, "presence_enabled", false);
     assert.equal(buddy_data.get_user_circle_class(me.user_id), "user_circle_empty");
     assert.equal(buddy_data.level(me.user_id), 0);
 
-    user_settings.presence_enabled = true;
+    override(user_settings, "presence_enabled", true);
     assert.equal(buddy_data.get_user_circle_class(me.user_id), "user_circle_green");
     assert.equal(buddy_data.level(me.user_id), 0);
 
@@ -412,7 +412,7 @@ test("get_conversation_participants", ({override_rewire}) => {
     assert.deepEqual(buddy_data.get_conversation_participants(), new Set([selma.user_id]));
 });
 
-test("level", () => {
+test("level", ({override}) => {
     realm.server_presence_offline_threshold_seconds = 200;
 
     add_canned_users();
@@ -432,7 +432,7 @@ test("level", () => {
     assert.equal(buddy_data.level(me.user_id), 0);
     assert.equal(buddy_data.level(selma.user_id), 1);
 
-    user_settings.presence_enabled = false;
+    override(user_settings, "presence_enabled", false);
     set_presence(selma.user_id, "offline");
 
     // Selma gets demoted to level 3, but "me"
@@ -557,12 +557,12 @@ test("user_last_seen_time_status", ({override}) => {
     assert.equal(buddy_data.user_last_seen_time_status(selma.user_id), "translated: Idle");
 });
 
-test("get_items_for_users", () => {
+test("get_items_for_users", ({override}) => {
     people.add_active_user(alice);
     people.add_active_user(fred);
     set_presence(alice.user_id, "offline");
-    user_settings.emojiset = "google";
-    user_settings.user_list_style = 2;
+    override(user_settings, "emojiset", "google");
+    override(user_settings, "user_list_style", 2);
 
     const status_emoji_info = {
         emoji_alt_code: false,

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -417,7 +417,7 @@ test("get_conversation_participants", ({override_rewire}) => {
 });
 
 test("level", ({override}) => {
-    realm.server_presence_offline_threshold_seconds = 200;
+    override(realm, "server_presence_offline_threshold_seconds", 200);
 
     add_canned_users();
     assert.equal(buddy_data.level(me.user_id), 0);
@@ -534,12 +534,12 @@ test("user_last_seen_time_status", ({override}) => {
 
     assert.equal(buddy_data.user_last_seen_time_status(selma.user_id), "translated: Active now");
 
-    realm.realm_is_zephyr_mirror_realm = true;
+    override(realm, "realm_is_zephyr_mirror_realm", true);
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
         "translated: Activity unknown",
     );
-    realm.realm_is_zephyr_mirror_realm = false;
+    override(realm, "realm_is_zephyr_mirror_realm", false);
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
         "translated: Not active in the last year",

--- a/web/tests/buddy_list.test.js
+++ b/web/tests/buddy_list.test.js
@@ -22,8 +22,10 @@ const message_viewport = mock_esm("../src/message_viewport");
 const buddy_data = zrequire("buddy_data");
 const {BuddyList} = zrequire("buddy_list");
 const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
 initialize_user_settings({user_settings: {}});
 
 function init_simulated_scrolling() {

--- a/web/tests/buddy_list.test.js
+++ b/web/tests/buddy_list.test.js
@@ -22,6 +22,9 @@ const message_viewport = mock_esm("../src/message_viewport");
 const buddy_data = zrequire("buddy_data");
 const {BuddyList} = zrequire("buddy_list");
 const people = zrequire("people");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 function init_simulated_scrolling() {
     const elem = {

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -8,7 +8,7 @@ const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const user_groups = zrequire("user_groups");
 
@@ -58,9 +58,14 @@ const compose_setup = zrequire("compose_setup");
 const drafts = zrequire("drafts");
 const echo = zrequire("echo");
 const people = zrequire("people");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -408,7 +408,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     $("#compose .preview_message_area").show();
     $("#compose .markdown_preview").hide();
     $("#compose").addClass("preview_mode");
-    user_settings.enter_sends = true;
+    override(user_settings, "enter_sends", true);
     let send_message_called = false;
     override_rewire(compose, "send_message", () => {
         send_message_called = true;
@@ -421,7 +421,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     assert.ok(send_message_called);
     assert.ok(show_button_spinner_called);
 
-    user_settings.enter_sends = false;
+    override(user_settings, "enter_sends", false);
     $("textarea#compose-textarea").trigger("blur");
     compose.enter_with_preview_open();
     assert.ok($("textarea#compose-textarea").is_focused());
@@ -429,7 +429,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     // Test sending a message without content.
     $("textarea#compose-textarea").val("");
     $("#compose .preview_message_area").show();
-    user_settings.enter_sends = true;
+    override(user_settings, "enter_sends", true);
 
     compose.enter_with_preview_open();
 });

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -265,7 +265,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         stub_state = initialize_state_stub_dict();
         compose_state.topic("");
         compose_state.set_message_type("private");
-        current_user.user_id = new_user.user_id;
+        override(current_user, "user_id", new_user.user_id);
         override(compose_pm_pill, "get_emails", () => "alice@example.com");
 
         const server_message_id = 127;
@@ -401,7 +401,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
         show_button_spinner_called = true;
     });
 
-    current_user.user_id = new_user.user_id;
+    override(current_user, "user_id", new_user.user_id);
 
     // Test sending a message with content.
     compose_state.set_message_type("stream");

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -522,7 +522,7 @@ test_ui("initialize", ({override}) => {
         resize_watch_manual_resize_checked = true;
     });
 
-    realm.max_file_upload_size_mib = 512;
+    override(realm, "max_file_upload_size_mib", 512);
 
     let uppy_cancel_all_called = false;
     override(upload, "compose_upload_cancel", () => {

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -8,7 +8,7 @@ const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 const user_groups = zrequire("user_groups");
 
@@ -59,6 +59,10 @@ const drafts = zrequire("drafts");
 const echo = zrequire("echo");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 function reset_jquery() {
     // Avoid leaks.

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -569,8 +569,8 @@ test("on_narrow", ({override, override_rewire}) => {
         start_called = true;
     });
     narrowed_by_pm_reply = true;
-    realm.realm_direct_message_permission_group = nobody.id;
-    realm.realm_direct_message_initiator_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", everyone.id);
     compose_actions.on_narrow({
         force_close: false,
         trigger: "not-search",
@@ -585,7 +585,7 @@ test("on_narrow", ({override, override_rewire}) => {
     });
     assert.ok(start_called);
 
-    realm.realm_direct_message_permission_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", everyone.id);
     blueslip.expect("warn", "Unknown emails");
     compose_actions.on_narrow({
         force_close: false,

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -7,7 +7,6 @@ const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {realm} = require("./lib/zpage_params");
 
 const user_groups = zrequire("user_groups");
 
@@ -88,6 +87,10 @@ const compose_reply = zrequire("compose_reply");
 const message_lists = zrequire("message_lists");
 const stream_data = zrequire("stream_data");
 const compose_recipient = zrequire("compose_recipient");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
 
 const start = compose_actions.start;
 const cancel = compose_actions.cancel;

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -10,6 +10,9 @@ const input_pill = mock_esm("../src/input_pill");
 const people = zrequire("people");
 
 const compose_pm_pill = zrequire("compose_pm_pill");
+const {set_realm} = zrequire("state_data");
+
+set_realm({});
 
 let pills = {
     pill: {},

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -27,6 +27,9 @@ const channel = mock_esm("../src/channel");
 const compose_reply = zrequire("compose_reply");
 const message_lists = zrequire("message_lists");
 const text_field_edit = mock_esm("text-field-edit");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const alice = {
     email: "alice@zulip.com",

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -6,7 +6,6 @@ const {$t} = require("./lib/i18n");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {realm} = require("./lib/zpage_params");
 
 set_global("navigator", {});
 
@@ -27,8 +26,11 @@ const channel = mock_esm("../src/channel");
 const compose_reply = zrequire("compose_reply");
 const message_lists = zrequire("message_lists");
 const text_field_edit = mock_esm("text-field-edit");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
 initialize_user_settings({user_settings: {}});
 
 const alice = {

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -187,7 +187,7 @@ run_test("replace_syntax", ({override}) => {
     assert.equal(prev_caret + "$$\\pi$$".length - "Bca".length, $textbox.caret());
 });
 
-run_test("compute_placeholder_text", () => {
+run_test("compute_placeholder_text", ({override}) => {
     let opts = {
         message_type: "stream",
         stream_id: undefined,
@@ -253,13 +253,13 @@ run_test("compute_placeholder_text", () => {
     );
 
     alice.is_guest = true;
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
     assert.equal(
         compose_ui.compute_placeholder_text(opts),
         $t({defaultMessage: "Message translated: Alice (guest) and Bob"}),
     );
 
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     assert.equal(
         compose_ui.compute_placeholder_text(opts),
         $t({defaultMessage: "Message Alice and Bob"}),

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -8,7 +8,6 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, realm} = require("./lib/zpage_params");
 
 const compose_banner = zrequire("compose_banner");
 const compose_pm_pill = zrequire("compose_pm_pill");
@@ -19,9 +18,15 @@ const people = zrequire("people");
 const resolved_topic = zrequire("../shared/src/resolved_topic");
 const settings_config = zrequire("settings_config");
 const settings_data = mock_esm("../src/settings_data");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const compose_recipient = zrequire("/compose_recipient");
 const user_groups = zrequire("user_groups");
+
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 
 const me = {
     email: "me@example.com",

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -136,7 +136,7 @@ test_ui("validate_stream_message_address_info", ({mock_template}) => {
     assert.ok(user_not_subscribed_rendered);
 });
 
-test_ui("validate", ({mock_template}) => {
+test_ui("validate", ({mock_template, override}) => {
     function initialize_pm_pill() {
         $.clear_all_elements();
 
@@ -172,8 +172,8 @@ test_ui("validate", ({mock_template}) => {
     add_content_to_compose_box();
     compose_state.private_message_recipient("");
     let pm_recipient_error_rendered = false;
-    realm.realm_direct_message_permission_group = everyone.id;
-    realm.realm_direct_message_initiator_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", everyone.id);
+    override(realm, "realm_direct_message_initiator_group", everyone.id);
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.missing_private_message_recipient);
         assert.equal(
@@ -193,16 +193,16 @@ test_ui("validate", ({mock_template}) => {
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
 
-    realm.realm_direct_message_initiator_group = admin.id;
+    override(realm, "realm_direct_message_initiator_group", admin.id);
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
 
-    realm.realm_direct_message_permission_group = admin.id;
+    override(realm, "realm_direct_message_permission_group", admin.id);
     assert.ok(compose_validate.validate());
     assert.ok(!pm_recipient_error_rendered);
 
-    realm.realm_direct_message_initiator_group = everyone.id;
-    realm.realm_direct_message_permission_group = everyone.id;
+    override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_permission_group", everyone.id);
     people.deactivate(bob);
     let deactivated_user_error_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
@@ -217,9 +217,9 @@ test_ui("validate", ({mock_template}) => {
     assert.ok(!compose_validate.validate());
     assert.ok(deactivated_user_error_rendered);
 
-    realm.realm_is_zephyr_mirror_realm = true;
+    override(realm, "realm_is_zephyr_mirror_realm", true);
     assert.ok(compose_validate.validate());
-    realm.realm_is_zephyr_mirror_realm = false;
+    override(realm, "realm_is_zephyr_mirror_realm", false);
 
     initialize_pm_pill();
     add_content_to_compose_box();
@@ -284,7 +284,7 @@ test_ui("validate", ({mock_template}) => {
     };
     stream_data.add_sub(denmark);
     compose_state.set_stream_id(denmark.stream_id);
-    realm.realm_mandatory_topics = true;
+    override(realm, "realm_mandatory_topics", true);
     compose_state.topic("");
     let missing_topic_error_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
@@ -374,7 +374,7 @@ test_ui("test_stream_wildcard_mention_allowed", ({override, override_rewire}) =>
         settings_config.wildcard_mention_policy_values.by_full_members.code;
     const person = people.get_by_user_id(current_user.user_id);
     person.date_joined = new Date(Date.now());
-    realm.realm_waiting_period_threshold = 10;
+    override(realm, "realm_waiting_period_threshold", 10);
 
     assert.ok(compose_validate.stream_wildcard_mention_allowed());
     override(current_user, "is_admin", false);
@@ -397,7 +397,7 @@ test_ui("validate_stream_message", ({override, override_rewire, mock_template}) 
     // of execution should not be changed.
     mock_banners();
     override(current_user, "user_id", me.user_id);
-    realm.realm_mandatory_topics = false;
+    override(realm, "realm_mandatory_topics", false);
 
     const special_sub = {
         stream_id: 101,
@@ -558,8 +558,8 @@ test_ui(
     },
 );
 
-test_ui("test_check_overflow_text", ({mock_template}) => {
-    realm.max_message_length = 10000;
+test_ui("test_check_overflow_text", ({mock_template, override}) => {
+    override(realm, "max_message_length", 10000);
 
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
@@ -724,7 +724,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
         new_banner_rendered = false;
         const msg_type = is_private ? "private" : "stream";
         compose_state.set_message_type(msg_type);
-        realm.realm_is_zephyr_mirror_realm = is_zephyr_mirror;
+        override(realm, "realm_is_zephyr_mirror_realm", is_zephyr_mirror);
         mentioned_details.type = type;
         compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
         assert.ok(!new_banner_rendered);
@@ -736,7 +736,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 
     $("#compose_invite_users").hide();
     compose_state.set_message_type("stream");
-    realm.realm_is_zephyr_mirror_realm = false;
+    override(realm, "realm_is_zephyr_mirror_realm", false);
 
     // Test with empty stream name in compose box. It should return noop.
     new_banner_rendered = false;

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -61,13 +61,17 @@ const realm_available_video_chat_providers = {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        realm.realm_available_video_chat_providers = realm_available_video_chat_providers;
+        helpers.override(
+            realm,
+            "realm_available_video_chat_providers",
+            realm_available_video_chat_providers,
+        );
         f(helpers);
     });
 }
 
 test("videos", ({override}) => {
-    realm.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
+    override(realm, "realm_video_chat_provider", realm_available_video_chat_providers.disabled.id);
 
     stub_out_video_calls();
 
@@ -114,15 +118,19 @@ test("videos", ({override}) => {
         const handler = $("body").get_on_handler("click", ".video_link");
         $("textarea#compose-textarea").val("");
 
-        realm.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
+        override(
+            realm,
+            "realm_video_chat_provider",
+            realm_available_video_chat_providers.jitsi_meet.id,
+        );
 
-        realm.realm_jitsi_server_url = null;
-        realm.server_jitsi_server_url = null;
+        override(realm, "realm_jitsi_server_url", null);
+        override(realm, "server_jitsi_server_url", null);
         handler(ev);
         assert.ok(!called);
 
-        realm.realm_jitsi_server_url = null;
-        realm.server_jitsi_server_url = "https://server.example.com";
+        override(realm, "realm_jitsi_server_url", null);
+        override(realm, "server_jitsi_server_url", "https://server.example.com");
         handler(ev);
         // video link ids consist of 15 random digits
         let video_link_regex =
@@ -130,16 +138,16 @@ test("videos", ({override}) => {
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
 
-        realm.realm_jitsi_server_url = "https://realm.example.com";
-        realm.server_jitsi_server_url = null;
+        override(realm, "realm_jitsi_server_url", "https://realm.example.com");
+        override(realm, "server_jitsi_server_url", null);
         handler(ev);
         video_link_regex =
             /\[translated: Join video call\.]\(https:\/\/realm.example.com\/\d{15}#config.startWithVideoMuted=false\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
 
-        realm.realm_jitsi_server_url = "https://realm.example.com";
-        realm.server_jitsi_server_url = "https://server.example.com";
+        override(realm, "realm_jitsi_server_url", "https://realm.example.com");
+        override(realm, "server_jitsi_server_url", "https://server.example.com");
         handler(ev);
         video_link_regex =
             /\[translated: Join video call\.]\(https:\/\/realm.example.com\/\d{15}#config.startWithVideoMuted=false\)/;
@@ -167,7 +175,7 @@ test("videos", ({override}) => {
             called = true;
         });
 
-        realm.realm_video_chat_provider = realm_available_video_chat_providers.zoom.id;
+        override(realm, "realm_video_chat_provider", realm_available_video_chat_providers.zoom.id);
         override(current_user, "has_zoom_token", false);
 
         window.open = (url) => {
@@ -226,7 +234,11 @@ test("videos", ({override}) => {
         const handler = $("body").get_on_handler("click", ".video_link");
         $("textarea#compose-textarea").val("");
 
-        realm.realm_video_chat_provider = realm_available_video_chat_providers.big_blue_button.id;
+        override(
+            realm,
+            "realm_video_chat_provider",
+            realm_available_video_chat_providers.big_blue_button.id,
+        );
 
         override(compose_closed_ui, "get_recipient_label", () => "a");
 
@@ -248,22 +260,30 @@ test("videos", ({override}) => {
     })();
 });
 
-test("test_video_chat_button_toggle disabled", () => {
-    realm.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
+test("test_video_chat_button_toggle disabled", ({override}) => {
+    override(realm, "realm_video_chat_provider", realm_available_video_chat_providers.disabled.id);
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), false);
 });
 
-test("test_video_chat_button_toggle no url", () => {
-    realm.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
+test("test_video_chat_button_toggle no url", ({override}) => {
+    override(
+        realm,
+        "realm_video_chat_provider",
+        realm_available_video_chat_providers.jitsi_meet.id,
+    );
     page_params.jitsi_server_url = null;
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), false);
 });
 
-test("test_video_chat_button_toggle enabled", () => {
-    realm.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
-    realm.realm_jitsi_server_url = "https://meet.jit.si";
+test("test_video_chat_button_toggle enabled", ({override}) => {
+    override(
+        realm,
+        "realm_video_chat_provider",
+        realm_available_video_chat_providers.jitsi_meet.id,
+    );
+    override(realm, "realm_jitsi_server_url", "https://meet.jit.si");
     compose_setup.initialize();
     assert.equal($(".compose-control-buttons-container .video_link").visible(), true);
 });

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -168,7 +168,7 @@ test("videos", ({override}) => {
         });
 
         realm.realm_video_chat_provider = realm_available_video_chat_providers.zoom.id;
-        current_user.has_zoom_token = false;
+        override(current_user, "has_zoom_token", false);
 
         window.open = (url) => {
             assert.ok(url.endsWith("/calls/zoom/register"));

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -6,7 +6,7 @@ const events = require("./lib/events");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const channel = mock_esm("../src/channel");
 const compose_closed_ui = mock_esm("../src/compose_closed_ui");
@@ -27,6 +27,12 @@ set_global(
 
 const server_events_dispatch = zrequire("server_events_dispatch");
 const compose_setup = zrequire("compose_setup");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 
 function stub_out_video_calls() {
     const $elem = $(".compose-control-buttons-container .video_link");

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1969,10 +1969,10 @@ function possibly_silent_list(list, is_silent) {
     }));
 }
 
-test("filter_and_sort_mentions (normal)", () => {
+test("filter_and_sort_mentions (normal)", ({override}) => {
     compose_state.set_message_type("stream");
     const is_silent = false;
-    current_user.user_id = 101;
+    override(current_user, "user_id", 101);
     let suggestions = ct.filter_and_sort_mentions(is_silent, "al");
 
     const mention_all = broadcast_item(ct.broadcast_mentions()[0]);
@@ -1983,7 +1983,7 @@ test("filter_and_sort_mentions (normal)", () => {
 
     // call_center group is shown in typeahead even when user is member of
     // one of the subgroups of can_mention_group.
-    current_user.user_id = 104;
+    override(current_user, "user_id", 104);
     suggestions = ct.filter_and_sort_mentions(is_silent, "al");
     assert.deepEqual(
         suggestions,
@@ -1993,7 +1993,7 @@ test("filter_and_sort_mentions (normal)", () => {
     // call_center group is not shown in typeahead when user is neither
     // a direct member of can_mention_group nor a member of any of its
     // recursive subgroups.
-    current_user.user_id = 102;
+    override(current_user, "user_id", 102);
     suggestions = ct.filter_and_sort_mentions(is_silent, "al");
     assert.deepEqual(
         suggestions,
@@ -2001,7 +2001,7 @@ test("filter_and_sort_mentions (normal)", () => {
     );
 });
 
-test("filter_and_sort_mentions (silent)", () => {
+test("filter_and_sort_mentions (silent)", ({override}) => {
     const is_silent = true;
 
     let suggestions = ct.filter_and_sort_mentions(is_silent, "al");
@@ -2014,7 +2014,7 @@ test("filter_and_sort_mentions (silent)", () => {
     // call_center group is shown in typeahead irrespective of whether
     // user is member of can_mention_group or its subgroups for a
     // silent mention.
-    current_user.user_id = 102;
+    override(current_user, "user_id", 102);
     suggestions = ct.filter_and_sort_mentions(is_silent, "al");
     assert.deepEqual(
         suggestions,
@@ -2022,7 +2022,7 @@ test("filter_and_sort_mentions (silent)", () => {
     );
 });
 
-test("typeahead_results", () => {
+test("typeahead_results", ({override}) => {
     const stream_list = [
         denmark_stream,
         sweden_stream,
@@ -2136,7 +2136,7 @@ test("typeahead_results", () => {
     // Earlier user group and stream mentions were autocompleted by their
     // description too. This is now removed as it often led to unexpected
     // behaviour, and did not have any great discoverability advantage.
-    current_user.user_id = 101;
+    override(current_user, "user_id", 101);
     // Autocomplete user group mentions by group name.
     assert_mentions_matches("hamletchar", [not_silent(hamletcharacters)]);
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -6,7 +6,6 @@ const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, realm} = require("./lib/zpage_params");
 
 let autosize_called;
 
@@ -57,8 +56,13 @@ const compose_pm_pill = zrequire("compose_pm_pill");
 const compose_recipient = zrequire("compose_recipient");
 const composebox_typeahead = zrequire("composebox_typeahead");
 const settings_config = zrequire("settings_config");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -6,7 +6,7 @@ const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, realm} = require("./lib/zpage_params");
 
 let autosize_called;
 
@@ -57,6 +57,10 @@ const compose_pm_pill = zrequire("compose_pm_pill");
 const compose_recipient = zrequire("compose_recipient");
 const composebox_typeahead = zrequire("composebox_typeahead");
 const settings_config = zrequire("settings_config");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const ct = composebox_typeahead;
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1286,7 +1286,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         }
     });
 
-    user_settings.enter_sends = false;
+    override(user_settings, "enter_sends", false);
     let compose_finish_called = false;
     function finish() {
         compose_finish_called = true;
@@ -1328,7 +1328,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     $stub_target.attr("id", "stream_message_recipient_topic");
     $("form#send_message_form").trigger(event);
     $stub_target.attr("id", "compose-textarea");
-    user_settings.enter_sends = false;
+    override(user_settings, "enter_sends", false);
     event.metaKey = true;
 
     $("form#send_message_form").trigger(event);
@@ -1336,7 +1336,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     event.metaKey = false;
     event.ctrlKey = true;
     $("form#send_message_form").trigger(event);
-    user_settings.enter_sends = true;
+    override(user_settings, "enter_sends", true);
     event.ctrlKey = false;
     event.altKey = true;
     $("form#send_message_form").trigger(event);

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -893,7 +893,7 @@ run_test("stream_typing", ({override}) => {
 run_test("user_settings", ({override}) => {
     settings_preferences.set_default_language_name = () => {};
     let event = event_fixtures.user_settings__default_language;
-    user_settings.default_language = "en";
+    override(user_settings, "default_language", "en");
     override(settings_preferences, "update_page", noop);
     override(information_density, "calculate_timestamp_widths", noop);
     override(overlays, "settings_open", () => true);
@@ -901,7 +901,7 @@ run_test("user_settings", ({override}) => {
     assert_same(user_settings.default_language, "fr");
 
     event = event_fixtures.user_settings__web_escape_navigates_to_home_view;
-    user_settings.web_escape_navigates_to_home_view = false;
+    override(user_settings, "web_escape_navigates_to_home_view", false);
     let toggled = [];
     $("#go-to-home-view-hotkey-help").toggleClass = (cls) => {
         toggled.push(cls);
@@ -919,24 +919,24 @@ run_test("user_settings", ({override}) => {
         called_for_cached_msg_list = true;
     };
     event = event_fixtures.user_settings__twenty_four_hour_time;
-    user_settings.twenty_four_hour_time = false;
+    override(user_settings, "twenty_four_hour_time", false);
     dispatch(event);
     assert_same(user_settings.twenty_four_hour_time, true);
     assert_same(called, true);
     assert_same(called_for_cached_msg_list, true);
 
     event = event_fixtures.user_settings__translate_emoticons;
-    user_settings.translate_emoticons = false;
+    override(user_settings, "translate_emoticons", false);
     dispatch(event);
     assert_same(user_settings.translate_emoticons, true);
 
     event = event_fixtures.user_settings__display_emoji_reaction_users;
-    user_settings.display_emoji_reaction_users = false;
+    override(user_settings, "display_emoji_reaction_users", false);
     dispatch(event);
     assert_same(user_settings.display_emoji_reaction_users, true);
 
     event = event_fixtures.user_settings__high_contrast_mode;
-    user_settings.high_contrast_mode = false;
+    override(user_settings, "high_contrast_mode", false);
     toggled = [];
     $("body").toggleClass = (cls) => {
         toggled.push(cls);
@@ -946,18 +946,18 @@ run_test("user_settings", ({override}) => {
     assert_same(toggled, ["high-contrast"]);
 
     event = event_fixtures.user_settings__web_mark_read_on_scroll_policy;
-    user_settings.web_mark_read_on_scroll_policy = 3;
+    override(user_settings, "web_mark_read_on_scroll_policy", 3);
     override(unread_ui, "update_unread_banner", noop);
     dispatch(event);
     assert_same(user_settings.web_mark_read_on_scroll_policy, 1);
 
     event = event_fixtures.user_settings__web_channel_default_view;
-    user_settings.web_channel_default_view = 2;
+    override(user_settings, "web_channel_default_view", 2);
     dispatch(event);
     assert_same(user_settings.web_channel_default_view, 1);
 
     event = event_fixtures.user_settings__dense_mode;
-    user_settings.dense_mode = false;
+    override(user_settings, "dense_mode", false);
     settings_preferences.user_settings_panel = {
         container: "#user-preferences",
     };
@@ -968,13 +968,13 @@ run_test("user_settings", ({override}) => {
     assert_same(toggled, ["less-dense-mode", "more-dense-mode"]);
 
     event = event_fixtures.user_settings__web_font_size_px;
-    user_settings.web_font_size_px = 14;
+    override(user_settings, "web_font_size_px", 14);
     override(information_density, "set_base_typography_css_variables", noop);
     dispatch(event);
     assert_same(user_settings.web_font_size_px, 16);
 
     event = event_fixtures.user_settings__web_line_height_percent;
-    user_settings.web_font_size_px = 122;
+    override(user_settings, "web_font_size_px", 122);
     override(information_density, "set_base_typography_css_variables", noop);
     dispatch(event);
     assert_same(user_settings.web_line_height_percent, 130);
@@ -982,7 +982,7 @@ run_test("user_settings", ({override}) => {
     {
         const stub = make_stub();
         event = event_fixtures.user_settings__color_scheme_automatic;
-        user_settings.color_scheme = 2;
+        override(user_settings, "color_scheme", 2);
         override(theme, "set_theme_and_update", stub.f); // automatically checks if called
         dispatch(event);
         const args = stub.get_args("color_scheme_code");
@@ -993,7 +993,7 @@ run_test("user_settings", ({override}) => {
     {
         const stub = make_stub();
         event = event_fixtures.user_settings__color_scheme_dark;
-        user_settings.color_scheme = 1;
+        override(user_settings, "color_scheme", 1);
         override(theme, "set_theme_and_update", stub.f); // automatically checks if called
         dispatch(event);
         const args = stub.get_args("color_scheme_code");
@@ -1004,7 +1004,7 @@ run_test("user_settings", ({override}) => {
     {
         const stub = make_stub();
         event = event_fixtures.user_settings__color_scheme_light;
-        user_settings.color_scheme = 1;
+        override(user_settings, "color_scheme", 1);
         override(theme, "set_theme_and_update", stub.f); // automatically checks if called
         dispatch(event);
         const args = stub.get_args("color_scheme_code");
@@ -1014,41 +1014,41 @@ run_test("user_settings", ({override}) => {
 
     {
         event = event_fixtures.user_settings__web_home_view_recent_topics;
-        user_settings.web_home_view = "all_messages";
+        override(user_settings, "web_home_view", "all_messages");
         dispatch(event);
         assert.equal(user_settings.web_home_view, "recent_topics");
     }
 
     {
         event = event_fixtures.user_settings__web_home_view_all_messages;
-        user_settings.web_home_view = "recent_topics";
+        override(user_settings, "web_home_view", "recent_topics");
         dispatch(event);
         assert.equal(user_settings.web_home_view, "all_messages");
     }
 
     {
         event = event_fixtures.user_settings__web_home_view_inbox;
-        user_settings.web_home_view = "all_messages";
+        override(user_settings, "web_home_view", "all_messages");
         dispatch(event);
         assert.equal(user_settings.web_home_view, "inbox");
     }
     {
         event = event_fixtures.user_settings__web_animate_image_previews_always;
-        user_settings.web_animate_image_previews = "on_hover";
+        override(user_settings, "web_animate_image_previews", "on_hover");
         dispatch(event);
         assert.equal(user_settings.web_animate_image_previews, "always");
     }
 
     {
         event = event_fixtures.user_settings__web_animate_image_previews_on_hover;
-        user_settings.web_animate_image_previews = "never";
+        override(user_settings, "web_animate_image_previews", "never");
         dispatch(event);
         assert.equal(user_settings.web_animate_image_previews, "on_hover");
     }
 
     {
         event = event_fixtures.user_settings__web_animate_image_previews_never;
-        user_settings.web_animate_image_previews = "always";
+        override(user_settings, "web_animate_image_previews", "always");
         dispatch(event);
         assert.equal(user_settings.web_animate_image_previews, "never");
     }
@@ -1059,7 +1059,7 @@ run_test("user_settings", ({override}) => {
         called = false;
         override(settings_preferences, "report_emojiset_change", stub.f);
         override(activity_ui, "build_user_sidebar", noop);
-        user_settings.emojiset = "text";
+        override(user_settings, "emojiset", "text");
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         assert_same(called, true);
@@ -1067,24 +1067,24 @@ run_test("user_settings", ({override}) => {
     }
 
     event = event_fixtures.user_settings__starred_message_counts;
-    user_settings.starred_message_counts = false;
+    override(user_settings, "starred_message_counts", false);
     dispatch(event);
     assert_same(user_settings.starred_message_counts, true);
 
     event = event_fixtures.user_settings__receives_typing_notifications;
-    user_settings.receives_typing_notifications = false;
+    override(user_settings, "receives_typing_notifications", false);
     dispatch(event);
     assert_same(user_settings.receives_typing_notifications, true);
 
     event = event_fixtures.user_settings__receives_typing_notifications_disabled;
     override(typing_events, "disable_typing_notification", noop);
-    user_settings.receives_typing_notifications = true;
+    override(user_settings, "receives_typing_notifications", true);
     dispatch(event);
     assert_same(user_settings.receives_typing_notifications, false);
 
     override(scroll_bar, "set_layout_width", noop);
     event = event_fixtures.user_settings__fluid_layout_width;
-    user_settings.fluid_layout_width = false;
+    override(user_settings, "fluid_layout_width", false);
     dispatch(event);
     assert_same(user_settings.fluid_layout_width, true);
 
@@ -1093,7 +1093,7 @@ run_test("user_settings", ({override}) => {
         event = event_fixtures.user_settings__demote_inactive_streams;
         override(stream_list_sort, "set_filter_out_inactives", noop);
         override(stream_list, "update_streams_sidebar", stub.f);
-        user_settings.demote_inactive_streams = 1;
+        override(user_settings, "demote_inactive_streams", 1);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         assert_same(user_settings.demote_inactive_streams, 2);
@@ -1103,7 +1103,7 @@ run_test("user_settings", ({override}) => {
         const stub = make_stub();
         event = event_fixtures.user_settings__web_stream_unreads_count_display_policy;
         override(stream_list, "update_dom_unread_counts_visibility", stub.f);
-        user_settings.web_stream_unreads_count_display_policy = 1;
+        override(user_settings, "web_stream_unreads_count_display_policy", 1);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         assert_same(user_settings.web_stream_unreads_count_display_policy, 2);
@@ -1113,7 +1113,7 @@ run_test("user_settings", ({override}) => {
         const stub = make_stub();
         event = event_fixtures.user_settings__user_list_style;
         override(settings_preferences, "report_user_list_style_change", stub.f);
-        user_settings.user_list_style = 1;
+        override(user_settings, "user_list_style", 1);
         override(activity_ui, "build_user_sidebar", stub.f);
         dispatch(event);
         assert.equal(stub.num_calls, 2);
@@ -1121,12 +1121,12 @@ run_test("user_settings", ({override}) => {
     }
 
     event = event_fixtures.user_settings__enter_sends;
-    user_settings.enter_sends = false;
+    override(user_settings, "enter_sends", false);
     dispatch(event);
     assert_same(user_settings.enter_sends, true);
 
     event = event_fixtures.user_settings__presence_disabled;
-    user_settings.presence_enabled = true;
+    override(user_settings, "presence_enabled", true);
     override(activity_ui, "redraw_user", noop);
     override(settings_account, "update_privacy_settings_box", noop);
     dispatch(event);
@@ -1153,12 +1153,12 @@ run_test("user_settings", ({override}) => {
     dispatch(event);
 
     event = event_fixtures.user_settings__email_address_visibility;
-    user_settings.email_address_visibility = 3;
+    override(user_settings, "email_address_visibility", 3);
     dispatch(event);
     assert_same(user_settings.email_address_visibility, 5);
 
     event = event_fixtures.user_settings__web_navigate_to_sent_message;
-    user_settings.web_navigate_to_sent_message = true;
+    override(user_settings, "web_navigate_to_sent_message", true);
     dispatch(event);
     assert_same(user_settings.web_navigate_to_sent_message, false);
 });

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -127,7 +127,6 @@ message_lists.all_rendered_message_lists = () => [cached_message_list, message_l
 
 // page_params is highly coupled to dispatching now
 page_params.test_suite = false;
-realm.realm_description = "already set description";
 
 // For data-oriented modules, just use them, don't stub them.
 const alert_words = zrequire("alert_words");
@@ -453,7 +452,7 @@ run_test("scheduled_messages", ({override}) => {
 
 run_test("realm settings", ({override}) => {
     override(current_user, "is_admin", true);
-    realm.realm_date_created = new Date("2023-01-01Z");
+    override(realm, "realm_date_created", new Date("2023-01-01Z"));
 
     override(settings_org, "check_disable_direct_message_initiator_group_dropdown", noop);
     override(settings_org, "sync_realm_settings", noop);
@@ -540,17 +539,17 @@ run_test("realm settings", ({override}) => {
     event = event_fixtures.realm__update__new_stream_announcements_stream_id;
     dispatch(event);
     assert_same(realm.realm_new_stream_announcements_stream_id, 42);
-    realm.realm_new_stream_announcements_stream_id = -1; // make sure to reset for future tests
+    override(realm, "realm_new_stream_announcements_stream_id", -1); // make sure to reset for future tests
 
     event = event_fixtures.realm__update__signup_announcements_stream_id;
     dispatch(event);
     assert_same(realm.realm_signup_announcements_stream_id, 41);
-    realm.realm_signup_announcements_stream_id = -1; // make sure to reset for future tests
+    override(realm, "realm_signup_announcements_stream_id", -1); // make sure to reset for future tests
 
     event = event_fixtures.realm__update__zulip_update_announcements_stream_id;
     dispatch(event);
     assert_same(realm.realm_zulip_update_announcements_stream_id, 42);
-    realm.realm_zulip_update_announcements_stream_id = -1; // make sure to reset for future tests
+    override(realm, "realm_zulip_update_announcements_stream_id", -1); // make sure to reset for future tests
 
     event = event_fixtures.realm__update__default_code_block_language;
     dispatch(event);
@@ -573,13 +572,13 @@ run_test("realm settings", ({override}) => {
     };
 
     event = event_fixtures.realm__update_dict__default;
-    realm.realm_create_multiuse_invite_group = 1;
-    realm.realm_allow_message_editing = false;
-    realm.realm_message_content_edit_limit_seconds = 0;
-    realm.realm_edit_topic_policy = 3;
-    realm.realm_authentication_methods = {Google: {enabled: false, available: true}};
-    realm.realm_can_create_public_channel_group = 1;
-    realm.realm_direct_message_permission_group = 1;
+    override(realm, "realm_create_multiuse_invite_group", 1);
+    override(realm, "realm_allow_message_editing", false);
+    override(realm, "realm_message_content_edit_limit_seconds", 0);
+    override(realm, "realm_edit_topic_policy", 3);
+    override(realm, "realm_authentication_methods", {Google: {enabled: false, available: true}});
+    override(realm, "realm_can_create_public_channel_group", 1);
+    override(realm, "realm_direct_message_permission_group", 1);
     override(settings_org, "populate_auth_methods", noop);
     dispatch(event);
     assert_same(realm.realm_create_multiuse_invite_group, 3);
@@ -694,7 +693,7 @@ run_test("realm_emoji", ({override}) => {
 
 run_test("realm_linkifiers", ({override}) => {
     const event = event_fixtures.realm_linkifiers;
-    realm.realm_linkifiers = [];
+    override(realm, "realm_linkifiers", []);
     override(settings_linkifiers, "populate_linkifiers", noop);
     override(linkifiers, "update_linkifier_rules", noop);
     dispatch(event);
@@ -703,7 +702,7 @@ run_test("realm_linkifiers", ({override}) => {
 
 run_test("realm_playgrounds", ({override}) => {
     const event = event_fixtures.realm_playgrounds;
-    realm.realm_playgrounds = [];
+    override(realm, "realm_playgrounds", []);
     override(settings_playgrounds, "populate_playgrounds", noop);
     override(realm_playground, "update_playgrounds", noop);
     dispatch(event);
@@ -712,7 +711,7 @@ run_test("realm_playgrounds", ({override}) => {
 
 run_test("realm_domains", ({override}) => {
     let event = event_fixtures.realm_domains__add;
-    realm.realm_domains = [];
+    override(realm, "realm_domains", []);
     override(settings_org, "populate_realm_domains_label", noop);
     override(settings_realm_domains, "populate_realm_domains_table", noop);
     dispatch(event);

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -8,12 +8,7 @@ const {make_stub} = require("./lib/stub");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {
-    current_user,
-    page_params,
-    realm,
-    realm_user_settings_defaults,
-} = require("./lib/zpage_params");
+const {page_params, realm_user_settings_defaults} = require("./lib/zpage_params");
 
 const event_fixtures = events.fixtures;
 const test_message = events.test_message;
@@ -102,8 +97,13 @@ const user_group_edit = mock_esm("../src/user_group_edit");
 const overlays = mock_esm("../src/overlays");
 mock_esm("../src/giphy");
 const {Filter} = zrequire("filter");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -13,7 +13,6 @@ const {
     page_params,
     realm,
     realm_user_settings_defaults,
-    user_settings,
 } = require("./lib/zpage_params");
 
 const event_fixtures = events.fixtures;
@@ -103,6 +102,10 @@ const user_group_edit = mock_esm("../src/user_group_edit");
 const overlays = mock_esm("../src/overlays");
 mock_esm("../src/giphy");
 const {Filter} = zrequire("filter");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 message_lists.update_recipient_bar_background_color = noop;
 message_lists.current = {

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -127,7 +127,6 @@ message_lists.all_rendered_message_lists = () => [cached_message_list, message_l
 
 // page_params is highly coupled to dispatching now
 page_params.test_suite = false;
-current_user.is_admin = true;
 realm.realm_description = "already set description";
 
 // For data-oriented modules, just use them, don't stub them.
@@ -453,7 +452,7 @@ run_test("scheduled_messages", ({override}) => {
 });
 
 run_test("realm settings", ({override}) => {
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
     realm.realm_date_created = new Date("2023-01-01Z");
 
     override(settings_org, "check_disable_direct_message_initiator_group_dropdown", noop);
@@ -834,7 +833,7 @@ run_test("submessage", ({override}) => {
 
 run_test("typing", ({override}) => {
     // Simulate that we are not typing.
-    current_user.user_id = typing_person1.user_id + 1;
+    override(current_user, "user_id", typing_person1.user_id + 1);
 
     let event = event_fixtures.typing__start;
     {
@@ -857,10 +856,10 @@ run_test("typing", ({override}) => {
     }
 
     // Get line coverage--we ignore our own typing events.
-    current_user.user_id = typing_person1.user_id;
+    override(current_user, "user_id", typing_person1.user_id);
     event = event_fixtures.typing__start;
     dispatch(event);
-    current_user.user_id = undefined; // above change shouldn't effect stream_typing tests below
+    override(current_user, "user_id", undefined); // above change shouldn't effect stream_typing tests below
 });
 
 run_test("stream_typing", ({override}) => {

--- a/web/tests/dispatch_subs.test.js
+++ b/web/tests/dispatch_subs.test.js
@@ -7,7 +7,6 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {realm} = require("./lib/zpage_params");
 
 const event_fixtures = events.fixtures;
 const test_user = events.test_user;
@@ -27,8 +26,12 @@ const compose_state = zrequire("compose_state");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const server_events_dispatch = zrequire("server_events_dispatch");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const sub_store = zrequire("sub_store");
+
+const realm = {};
+set_realm(realm);
 
 people.add_active_user(test_user);
 

--- a/web/tests/dispatch_subs.test.js
+++ b/web/tests/dispatch_subs.test.js
@@ -241,9 +241,9 @@ test("stream delete (special streams)", ({override}) => {
 
     // sanity check data
     assert.equal(event.streams.length, 2);
-    realm.realm_new_stream_announcements_stream_id = event.streams[0].stream_id;
-    realm.realm_signup_announcements_stream_id = event.streams[1].stream_id;
-    realm.realm_zulip_update_announcements_stream_id = event.streams[0].stream_id;
+    override(realm, "realm_new_stream_announcements_stream_id", event.streams[0].stream_id);
+    override(realm, "realm_signup_announcements_stream_id", event.streams[1].stream_id);
+    override(realm, "realm_zulip_update_announcements_stream_id", event.streams[0].stream_id);
 
     override(stream_settings_ui, "remove_stream", noop);
     override(settings_org, "sync_realm_settings", noop);

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -16,6 +16,9 @@ const compose_state = zrequire("compose_state");
 const compose_recipient = zrequire("compose_recipient");
 const sub_store = zrequire("sub_store");
 const stream_data = zrequire("stream_data");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const aaron = {
     email: "aaron@zulip.com",

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -6,7 +6,6 @@ const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {user_settings} = require("./lib/zpage_params");
 
 const user_pill = mock_esm("../src/user_pill");
 const messages_overlay_ui = mock_esm("../src/messages_overlay_ui");
@@ -58,7 +57,6 @@ mock_esm("tippy.js", {
     },
     delegate: noop,
 });
-user_settings.twenty_four_hour_time = false;
 
 const {localstorage} = zrequire("localstorage");
 const drafts = zrequire("drafts");

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -188,8 +188,8 @@ run_test("process_from_server for messages to add to narrow", ({override}) => {
     ]);
 });
 
-run_test("build_display_recipient", () => {
-    current_user.user_id = 123;
+run_test("build_display_recipient", ({override}) => {
+    override(current_user, "user_id", 123);
 
     const params = {};
     params.realm_users = [
@@ -321,7 +321,7 @@ run_test("insert_local_message streams", ({override}) => {
 run_test("insert_local_message direct message", ({override}) => {
     const local_id_float = 102.01;
 
-    current_user.user_id = 123;
+    override(current_user, "user_id", 123);
 
     const params = {};
     params.realm_users = [

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -7,7 +7,6 @@ const MockDate = require("mockdate");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
 const {run_test, noop} = require("./lib/test");
-const {current_user} = require("./lib/zpage_params");
 
 const compose_notifications = mock_esm("../src/compose_notifications");
 const markdown = mock_esm("../src/markdown");
@@ -70,8 +69,12 @@ message_lists.non_rendered_data = () => [];
 const echo = zrequire("echo");
 const echo_state = zrequire("echo_state");
 const people = zrequire("people");
+const {set_current_user} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
+
+const current_user = {};
+set_current_user(current_user);
 
 const general_sub = {
     stream_id: 101,

--- a/web/tests/example2.test.js
+++ b/web/tests/example2.test.js
@@ -19,10 +19,13 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const unread = zrequire("unread");
+const {initialize_user_settings} = zrequire("user_settings");
 
 // It's typical to set up a little bit of data at the top of a
 // test module, but you can also do this within tests. Here we
 // will set up things at the top.
+
+initialize_user_settings({user_settings: {}});
 
 const isaac = make_user({
     email: "isaac@example.com",

--- a/web/tests/example3.test.js
+++ b/web/tests/example3.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {make_stream} = require("./lib/example_stream");
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {realm} = require("./lib/zpage_params");
 
 // In the Zulip app you can narrow your message stream by topic, by
 // sender, by direct message recipient, by search keywords, etc.
@@ -14,13 +13,6 @@ const {realm} = require("./lib/zpage_params");
 
 const {Filter} = zrequire("../src/filter");
 const stream_data = zrequire("stream_data");
-
-// This is the first time we have to deal with `realm`.
-// `realm` has a lot of important data shared by various
-// modules. Most of the data is irrelevant to our tests.
-// Use this to explicitly say we are not a special Zephyr
-// realm, since we want to test the "normal" codepath.
-realm.realm_is_zephyr_mirror_realm = false;
 
 const denmark_stream = make_stream({
     color: "blue",

--- a/web/tests/example3.test.js
+++ b/web/tests/example3.test.js
@@ -12,7 +12,10 @@ const {run_test} = require("./lib/test");
 // core piece of code that makes things work.
 
 const {Filter} = zrequire("../src/filter");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
+
+set_realm({});
 
 const denmark_stream = make_stream({
     color: "blue",

--- a/web/tests/example4.test.js
+++ b/web/tests/example4.test.js
@@ -65,6 +65,9 @@ const user_profile = mock_esm("../src/user_profile");
 // Use real versions of these modules.
 const people = zrequire("people");
 const server_events_dispatch = zrequire("server_events_dispatch");
+const {set_current_user} = zrequire("state_data");
+
+set_current_user({});
 
 const bob = make_bot({
     email: "bob@example.com",

--- a/web/tests/example5.test.js
+++ b/web/tests/example5.test.js
@@ -46,6 +46,9 @@ message_lists.non_rendered_data = () => [];
 const message_events = zrequire("message_events");
 const message_store = zrequire("message_store");
 const people = zrequire("people");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const isaac = make_user({
     email: "isaac@example.com",

--- a/web/tests/example8.test.js
+++ b/web/tests/example8.test.js
@@ -6,7 +6,6 @@ const {make_user} = require("./lib/example_user");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -30,8 +29,12 @@ mock_esm("../src/settings_data", {
 const {Filter} = zrequire("filter");
 const message_lists = zrequire("message_lists");
 const people = zrequire("people");
+const {set_current_user} = zrequire("state_data");
 const typing_data = zrequire("typing_data");
 const typing_events = zrequire("typing_events");
+
+const current_user = {};
+set_current_user(current_user);
 
 // Let us add a few users to use as typists.
 const anna = make_user({

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -17,6 +17,9 @@ const resolved_topic = zrequire("../shared/src/resolved_topic");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const {Filter} = zrequire("../src/filter");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const stream_message = "stream";
 const direct_message = "private";

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -2020,7 +2020,7 @@ function make_web_public_sub(name, stream_id) {
     stream_data.add_sub(sub);
 }
 
-test("navbar_helpers", () => {
+test("navbar_helpers", ({override}) => {
     stream_data.add_sub(foo_sub);
 
     // make sure title has names separated with correct delimiters
@@ -2355,7 +2355,7 @@ test("navbar_helpers", () => {
         },
     ];
 
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
 
     for (const test_case of test_cases) {
         test_helpers(test_case);
@@ -2410,7 +2410,7 @@ test("navbar_helpers", () => {
 
     test_get_title(channel_topic_search_term_test_case);
 
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     const guest_user_test_cases_without_indicator = [
         {
             terms: guest_sender,

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -2567,8 +2567,8 @@ run_test("equals", () => {
     );
 });
 
-run_test("adjusted_terms_if_moved", () => {
-    current_user.email = me.email;
+run_test("adjusted_terms_if_moved", ({override}) => {
+    override(current_user, "email", me.email);
     // should return null for non-stream messages containing no
     // `with` operator
     let raw_terms = [{operator: "channel", operand: foo_stream_id.toString()}];

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -8,7 +8,7 @@ const {mock_esm, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const message_store = mock_esm("../src/message_store");
 const user_topics = mock_esm("../src/user_topics");
@@ -17,8 +17,13 @@ const resolved_topic = zrequire("../shared/src/resolved_topic");
 const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const {Filter} = zrequire("../src/filter");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 initialize_user_settings({user_settings: {}});
 
 const stream_message = "stream";

--- a/web/tests/gear_menu_util.test.js
+++ b/web/tests/gear_menu_util.test.js
@@ -8,60 +8,60 @@ const {realm} = require("./lib/zpage_params");
 
 const gear_menu_util = zrequire("gear_menu_util");
 
-run_test("version_display_string", () => {
+run_test("version_display_string", ({override}) => {
     let expected_version_display_string;
 
     // An official release
-    realm.zulip_version = "5.6";
-    realm.zulip_merge_base = "5.6";
+    override(realm, "zulip_version", "5.6");
+    override(realm, "zulip_merge_base", "5.6");
     expected_version_display_string = "translated: Zulip Server 5.6";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // An official beta
-    realm.zulip_version = "6.0-beta1";
-    realm.zulip_merge_base = "6.0-beta1";
+    override(realm, "zulip_version", "6.0-beta1");
+    override(realm, "zulip_merge_base", "6.0-beta1");
     expected_version_display_string = "translated: Zulip Server 6.0-beta1";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // An official release candidate
-    realm.zulip_version = "6.0-rc1";
-    realm.zulip_merge_base = "6.0-rc1";
+    override(realm, "zulip_version", "6.0-rc1");
+    override(realm, "zulip_merge_base", "6.0-rc1");
     expected_version_display_string = "translated: Zulip Server 6.0-rc1";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // The Zulip development environment
-    realm.zulip_version = "6.0-dev+git";
-    realm.zulip_merge_base = "6.0-dev+git";
+    override(realm, "zulip_version", "6.0-dev+git");
+    override(realm, "zulip_merge_base", "6.0-dev+git");
     expected_version_display_string = "translated: Zulip Server dev environment";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // A commit on Zulip's main branch.
-    realm.zulip_version = "6.0-dev-1976-g4bb381fc80";
-    realm.zulip_merge_base = "6.0-dev-1976-g4bb381fc80";
+    override(realm, "zulip_version", "6.0-dev-1976-g4bb381fc80");
+    override(realm, "zulip_merge_base", "6.0-dev-1976-g4bb381fc80");
     expected_version_display_string = "translated: Zulip Server 6.0-dev";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // A fork with 18 commits beyond Zulip's main branch.
-    realm.zulip_version = "6.0-dev-1994-g93730766b0";
-    realm.zulip_merge_base = "6.0-dev-1976-g4bb381fc80";
+    override(realm, "zulip_version", "6.0-dev-1994-g93730766b0");
+    override(realm, "zulip_merge_base", "6.0-dev-1976-g4bb381fc80");
     expected_version_display_string = "translated: Zulip Server 6.0-dev (modified)";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // A commit from the Zulip 5.x branch
-    realm.zulip_version = "5.6+git-4-g385a408be5";
-    realm.zulip_merge_base = "5.6+git-4-g385a408be5";
+    override(realm, "zulip_version", "5.6+git-4-g385a408be5");
+    override(realm, "zulip_merge_base", "5.6+git-4-g385a408be5");
     expected_version_display_string = "translated: Zulip Server 5.6 (patched)";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // A fork with 3 commits beyond the Zulip 5.x branch.
-    realm.zulip_version = "5.6+git-4-g385a408be5";
-    realm.zulip_merge_base = "5.6+git-7-abcda4235c2";
+    override(realm, "zulip_version", "5.6+git-4-g385a408be5");
+    override(realm, "zulip_merge_base", "5.6+git-7-abcda4235c2");
     expected_version_display_string = "translated: Zulip Server 5.6 (modified)";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 
     // A fork of a Zulip release commit, not on 5.x branch.
-    realm.zulip_version = "5.3-1-g7ed896c0db";
-    realm.zulip_merge_base = "5.3";
+    override(realm, "zulip_version", "5.3-1-g7ed896c0db");
+    override(realm, "zulip_merge_base", "5.3");
     expected_version_display_string = "translated: Zulip Server 5.3 (modified)";
     assert.equal(gear_menu_util.version_display_string(), expected_version_display_string);
 });

--- a/web/tests/gear_menu_util.test.js
+++ b/web/tests/gear_menu_util.test.js
@@ -4,9 +4,12 @@ const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {realm} = require("./lib/zpage_params");
 
 const gear_menu_util = zrequire("gear_menu_util");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
 
 run_test("version_display_string", ({override}) => {
     let expected_version_display_string;

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -6,7 +6,6 @@ const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {user_settings} = require("./lib/zpage_params");
 
 let $window_stub;
 set_global("to_$", () => $window_stub);
@@ -37,6 +36,10 @@ const hashchange = zrequire("hashchange");
 const message_view = zrequire("../src/message_view");
 const stream_data = zrequire("stream_data");
 const {Filter} = zrequire("../src/filter");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const devel_id = 100;
 const devel = {

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -232,7 +232,7 @@ function test_helper({override, override_rewire, change_tab}) {
 
 run_test("hash_interactions", ({override, override_rewire}) => {
     $window_stub = $.create("window-stub");
-    user_settings.web_home_view = "recent_topics";
+    override(user_settings, "web_home_view", "recent_topics");
 
     const helper = test_helper({override, override_rewire, change_tab: true});
 

--- a/web/tests/lib/index.js
+++ b/web/tests/lib/index.js
@@ -129,8 +129,6 @@ test.set_verbose(files.length === 1);
         require("../../src/billing/page_params");
         namespace.mock_esm("../../src/page_params", zpage_params);
         require("../../src/page_params");
-        namespace.mock_esm("../../src/state_data", zpage_params);
-        require("../../src/state_data");
         namespace.mock_esm("../../src/realm_user_settings_defaults", zpage_params);
         require("../../src/realm_user_settings_defaults");
 

--- a/web/tests/lib/index.js
+++ b/web/tests/lib/index.js
@@ -131,8 +131,6 @@ test.set_verbose(files.length === 1);
         require("../../src/page_params");
         namespace.mock_esm("../../src/state_data", zpage_params);
         require("../../src/state_data");
-        namespace.mock_esm("../../src/user_settings", zpage_params);
-        require("../../src/user_settings");
         namespace.mock_esm("../../src/realm_user_settings_defaults", zpage_params);
         require("../../src/realm_user_settings_defaults");
 

--- a/web/tests/lib/zpage_params.js
+++ b/web/tests/lib/zpage_params.js
@@ -4,7 +4,6 @@ exports.current_user = {};
 exports.page_params = {};
 exports.realm = {};
 exports.realm_user_settings_defaults = {};
-exports.user_settings = {};
 
 exports.reset = () => {
     for (const field in exports.current_user) {
@@ -20,11 +19,6 @@ exports.reset = () => {
     for (const field in exports.realm) {
         if (Object.hasOwn(exports.realm, field)) {
             delete exports.realm[field];
-        }
-    }
-    for (const field in exports.user_settings) {
-        if (Object.hasOwn(exports.user_settings, field)) {
-            delete exports.user_settings[field];
         }
     }
     for (const field in exports.realm_user_settings_defaults) {

--- a/web/tests/lib/zpage_params.js
+++ b/web/tests/lib/zpage_params.js
@@ -1,24 +1,12 @@
 "use strict";
 
-exports.current_user = {};
 exports.page_params = {};
-exports.realm = {};
 exports.realm_user_settings_defaults = {};
 
 exports.reset = () => {
-    for (const field in exports.current_user) {
-        if (Object.hasOwn(exports.current_user, field)) {
-            delete exports.current_user[field];
-        }
-    }
     for (const field in exports.page_params) {
         if (Object.hasOwn(exports.page_params, field)) {
             delete exports.page_params[field];
-        }
-    }
-    for (const field in exports.realm) {
-        if (Object.hasOwn(exports.realm, field)) {
-            delete exports.realm[field];
         }
     }
     for (const field in exports.realm_user_settings_defaults) {

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -38,7 +38,6 @@ const example_realm_linkifiers = [
         id: 4,
     },
 ];
-user_settings.translate_emoticons = false;
 
 set_global("document", {compatMode: "CSS1Compat"});
 
@@ -259,7 +258,7 @@ test("markdown_detection", () => {
     }
 });
 
-test("marked_shared", () => {
+test("marked_shared", ({override}) => {
     const tests = markdown_test_cases.regular_tests;
 
     for (const test of tests) {
@@ -270,7 +269,7 @@ test("marked_shared", () => {
         }
 
         let message = {raw_content: test.input};
-        user_settings.translate_emoticons = test.translate_emoticons || false;
+        override(user_settings, "translate_emoticons", test.translate_emoticons || false);
         message = {
             ...message,
             ...markdown.render(message.raw_content),
@@ -320,7 +319,7 @@ test("message_flags", () => {
     assert.ok(message.flags.includes("topic_wildcard_mentioned"));
 });
 
-test("marked", () => {
+test("marked", ({override}) => {
     const test_cases = [
         {input: "hello", expected: "<p>hello</p>"},
         {input: "hello there", expected: "<p>hello there</p>"},
@@ -633,7 +632,7 @@ test("marked", () => {
 
     for (const test_case of test_cases) {
         // Disable emoji conversion by default.
-        user_settings.translate_emoticons = test_case.translate_emoticons || false;
+        override(user_settings, "translate_emoticons", test_case.translate_emoticons || false);
 
         const input = test_case.input;
         const expected = test_case.expected;

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -53,10 +53,12 @@ const markdown_config = zrequire("markdown_config");
 const markdown = zrequire("markdown");
 const people = zrequire("people");
 const pygments_data = zrequire("pygments_data");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/markdown.test.js
+++ b/web/tests/markdown.test.js
@@ -7,7 +7,7 @@ const markdown_test_cases = require("../../zerver/tests/fixtures/markdown_test_c
 const markdown_assert = require("./lib/markdown_assert");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {page_params, user_settings} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const example_realm_linkifiers = [
     {
@@ -55,6 +55,10 @@ const people = zrequire("people");
 const pygments_data = zrequire("pygments_data");
 const stream_data = zrequire("stream_data");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const emoji_params = {
     realm_emoji: {

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -92,7 +92,7 @@ run_test("is_topic_editable", ({override}) => {
     };
     realm.realm_allow_message_editing = true;
     override(settings_data, "user_can_move_messages_to_another_topic", () => true);
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
 
     assert.equal(message_edit.is_topic_editable(message), false);
 
@@ -109,7 +109,7 @@ run_test("is_topic_editable", ({override}) => {
     override(settings_data, "user_can_move_messages_to_another_topic", () => false);
     assert.equal(message_edit.is_topic_editable(message), false);
 
-    current_user.is_admin = false;
+    override(current_user, "is_admin", false);
     assert.equal(message_edit.is_topic_editable(message), false);
 
     message.topic = "translated: (no topic)";
@@ -128,7 +128,7 @@ run_test("is_topic_editable", ({override}) => {
     message.timestamp = current_timestamp - 600000;
     assert.equal(message_edit.is_topic_editable(message), false);
 
-    current_user.is_moderator = true;
+    override(current_user, "is_moderator", true);
     assert.equal(message_edit.is_topic_editable(message), true);
 
     realm.realm_allow_message_editing = false;
@@ -146,7 +146,7 @@ run_test("is_stream_editable", ({override}) => {
     };
     realm.realm_allow_message_editing = true;
     override(settings_data, "user_can_move_messages_between_streams", () => true);
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
 
     assert.equal(message_edit.is_stream_editable(message), false);
 
@@ -163,7 +163,7 @@ run_test("is_stream_editable", ({override}) => {
     override(settings_data, "user_can_move_messages_between_streams", () => false);
     assert.equal(message_edit.is_stream_editable(message), false);
 
-    current_user.is_admin = false;
+    override(current_user, "is_admin", false);
     assert.equal(message_edit.is_stream_editable(message), false);
 
     realm.realm_move_messages_between_streams_limit_seconds = 259200;
@@ -175,12 +175,12 @@ run_test("is_stream_editable", ({override}) => {
     message.timestamp = current_timestamp - 600000;
     assert.equal(message_edit.is_stream_editable(message), false);
 
-    current_user.is_moderator = true;
+    override(current_user, "is_moderator", true);
     assert.equal(message_edit.is_stream_editable(message), true);
 });
 
 run_test("get_deletability", ({override}) => {
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
     override(settings_data, "user_can_delete_any_message", () => true);
     override(settings_data, "user_can_delete_own_message", () => false);
     realm.realm_message_content_delete_limit_seconds = null;

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -4,14 +4,19 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, realm} = require("./lib/zpage_params");
 
 const message_edit = zrequire("message_edit");
 const people = zrequire("people");
+const {set_current_user, set_realm} = zrequire("state_data");
 
 const is_content_editable = message_edit.is_content_editable;
 
 const settings_data = mock_esm("../src/settings_data");
+
+const realm = {};
+set_realm(realm);
+const current_user = {};
+set_current_user(current_user);
 
 run_test("is_content_editable", ({override}) => {
     // You can't edit a null message

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -28,6 +28,9 @@ const message_helper = zrequire("message_helper");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const unread = zrequire("unread");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const alice = {
     email: "alice@example.com",

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -65,7 +65,7 @@ function test_helper(side_effects) {
     return self;
 }
 
-run_test("update_messages", () => {
+run_test("update_messages", ({override}) => {
     const raw_message = {
         id: 111,
         display_recipient: denmark.name,
@@ -115,7 +115,7 @@ run_test("update_messages", () => {
 
     const helper = test_helper(side_effects);
 
-    realm.realm_allow_edit_history = false;
+    override(realm, "realm_allow_edit_history", false);
 
     const $message_edit_history_modal = $.create("#message-edit-history");
     const $modal = $.create("micromodal").addClass("modal--open");

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {realm} = require("./lib/zpage_params");
 
 const message_edit = mock_esm("../src/message_edit");
 const message_lists = mock_esm("../src/message_lists");
@@ -25,10 +24,14 @@ const people = zrequire("people");
 const message_events = zrequire("message_events");
 message_events.__Rewire__("update_views_filtered_on_message_property", () => {});
 const message_helper = zrequire("message_helper");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const unread = zrequire("unread");
 const {initialize_user_settings} = zrequire("user_settings");
+
+const realm = {};
+set_realm(realm);
 
 initialize_user_settings({user_settings: {}});
 

--- a/web/tests/message_flags.test.js
+++ b/web/tests/message_flags.test.js
@@ -22,6 +22,9 @@ mock_esm("../src/left_sidebar_navigation_area", {
 
 const message_flags = zrequire("message_flags");
 const starred_messages_ui = zrequire("starred_messages_ui");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 run_test("starred", ({override}) => {
     const message = {

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -7,7 +7,6 @@ const {make_stub} = require("./lib/stub");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user} = require("./lib/zpage_params");
 
 // These unit tests for web/src/message_list.ts emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
@@ -42,6 +41,10 @@ mock_esm("../src/message_list_view", {
     MessageListView,
 });
 const {Filter} = zrequire("filter");
+const {set_current_user} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
 
 run_test("basics", ({override}) => {
     override(activity_ui, "build_user_sidebar", noop);

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -230,7 +230,7 @@ run_test("change_message_id", () => {
     assert.equal(list.change_message_id(13, 15), undefined);
 });
 
-run_test("last_sent_by_me", () => {
+run_test("last_sent_by_me", ({override}) => {
     const list = new MessageList({
         data: new MessageListData({
             excludes_muted_topics: false,
@@ -253,7 +253,7 @@ run_test("last_sent_by_me", () => {
     ];
 
     list.append(items);
-    current_user.user_id = 3;
+    override(current_user, "user_id", 3);
     // Look for the last message where user_id == 3 (our ID)
     assert.equal(list.get_last_message_sent_by_me().id, 2);
 });

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -27,8 +27,10 @@ const pm_conversations = zrequire("pm_conversations");
 const message_helper = zrequire("message_helper");
 const message_store = zrequire("message_store");
 const message_user_ids = zrequire("message_user_ids");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
 initialize_user_settings({user_settings: {}});
 
 const denmark = {

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -30,6 +30,9 @@ const pm_conversations = zrequire("pm_conversations");
 const message_helper = zrequire("message_helper");
 const message_store = zrequire("message_store");
 const message_user_ids = zrequire("message_user_ids");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const denmark = {
     subscribed: false,

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user, realm} = require("./lib/zpage_params");
+const {realm} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -22,7 +22,6 @@ mock_esm("../src/recent_senders", {
 
 set_global("document", "document-stub");
 realm.realm_allow_message_editing = true;
-current_user.is_admin = true;
 
 const util = zrequire("util");
 const people = zrequire("people");

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {realm} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -21,7 +20,6 @@ mock_esm("../src/recent_senders", {
 });
 
 set_global("document", "document-stub");
-realm.realm_allow_message_editing = true;
 
 const util = zrequire("util");
 const people = zrequire("people");

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -20,6 +20,9 @@ const recent_view_util = zrequire("recent_view_util");
 const inbox_util = zrequire("inbox_util");
 const message_lists = zrequire("message_lists");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 mock_esm("../src/compose_banner", {
     clear_errors() {},

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -229,8 +229,8 @@ run_test("urls", () => {
     assert.equal(emails, "me@example.com");
 });
 
-run_test("show_empty_narrow_message", ({mock_template}) => {
-    realm.stop_words = [];
+run_test("show_empty_narrow_message", ({mock_template, override}) => {
+    override(realm, "stop_words", []);
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
@@ -324,8 +324,8 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
-    realm.realm_direct_message_permission_group = everyone.id;
-    realm.realm_direct_message_initiator_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", everyone.id);
+    override(realm, "realm_direct_message_initiator_group", everyone.id);
     set_filter([["is", "dm"]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
@@ -358,7 +358,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // organization has disabled sending direct messages
-    realm.realm_direct_message_permission_group = nobody.id;
+    override(realm, "realm_direct_message_permission_group", nobody.id);
 
     // prioritize information about invalid user(s) in narrow/search
     set_filter([["dm", ["Yo"]]]);
@@ -412,7 +412,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // sending direct messages enabled
-    realm.realm_direct_message_permission_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", everyone.id);
     set_filter([["dm", "alice@example.com"]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
@@ -424,7 +424,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // sending direct messages to deactivated user
-    realm.realm_direct_message_permission_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", everyone.id);
     people.deactivate(alice);
     set_filter([["dm", alice.email]]);
     narrow_banner.show_empty_narrow_message();
@@ -467,7 +467,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     people.add_active_user(alice);
 
     // organization has disabled sending direct messages
-    realm.realm_direct_message_permission_group = nobody.id;
+    override(realm, "realm_direct_message_permission_group", nobody.id);
 
     // prioritize information about invalid user in narrow/search
     set_filter([["dm-including", ["Yo"]]]);
@@ -497,8 +497,8 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 
     // sending direct messages enabled
-    realm.realm_direct_message_permission_group = everyone.id;
-    realm.realm_direct_message_permission_group = everyone.id;
+    override(realm, "realm_direct_message_permission_group", everyone.id);
+    override(realm, "realm_direct_message_permission_group", everyone.id);
     set_filter([["dm-including", "alice@example.com"]]);
     narrow_banner.show_empty_narrow_message();
     assert.equal(
@@ -586,8 +586,8 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 });
 
-run_test("show_empty_narrow_message_with_search", ({mock_template}) => {
-    realm.stop_words = [];
+run_test("show_empty_narrow_message_with_search", ({mock_template, override}) => {
+    override(realm, "stop_words", []);
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
@@ -602,8 +602,8 @@ run_test("hide_empty_narrow_message", () => {
     assert.equal($(".empty_feed_notice").text(), "never-been-set");
 });
 
-run_test("show_search_stopwords", ({mock_template}) => {
-    realm.stop_words = ["what", "about"];
+run_test("show_search_stopwords", ({mock_template, override}) => {
+    override(realm, "stop_words", ["what", "about"]);
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -6,7 +6,7 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const hash_util = zrequire("hash_util");
 const compose_state = zrequire("compose_state");
@@ -19,9 +19,13 @@ const narrow_title = zrequire("narrow_title");
 const recent_view_util = zrequire("recent_view_util");
 const inbox_util = zrequire("inbox_util");
 const message_lists = zrequire("message_lists");
+const {set_current_user, set_realm} = zrequire("state_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_current_user({});
+const realm = {};
+set_realm(realm);
 initialize_user_settings({user_settings: {}});
 
 mock_esm("../src/compose_banner", {

--- a/web/tests/muted_users.test.js
+++ b/web/tests/muted_users.test.js
@@ -6,6 +6,9 @@ const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
 const muted_users = zrequire("muted_users");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 function test(label, f) {
     run_test(label, ({override}) => {

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -80,6 +80,9 @@ const narrow_state = zrequire("narrow_state");
 const stream_data = zrequire("stream_data");
 const message_view = zrequire("message_view");
 const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
+
+set_realm({});
 
 const denmark = {
     subscribed: false,

--- a/web/tests/narrow_unread.test.js
+++ b/web/tests/narrow_unread.test.js
@@ -18,6 +18,10 @@ const unread = zrequire("unread");
 // The main code we are testing lives here.
 const narrow_state = zrequire("narrow_state");
 const message_lists = zrequire("message_lists");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+set_current_user({});
+set_realm({});
 
 const alice = {
     email: "alice@example.com",

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -69,7 +69,7 @@ test("profile_incomplete_alert", ({override}) => {
 
     // Show alert.
     override(current_user, "is_admin", true);
-    realm.realm_description = "Organization imported from Slack!";
+    override(realm, "realm_description", "Organization imported from Slack!");
     assert.equal(navbar_alerts.check_profile_incomplete(), true);
 
     // Avoid showing if the user is not admin.
@@ -79,7 +79,7 @@ test("profile_incomplete_alert", ({override}) => {
     // Avoid showing if the realm description is already updated.
     override(current_user, "is_admin", true);
     assert.equal(navbar_alerts.check_profile_incomplete(), true);
-    realm.realm_description = "Organization description already set!";
+    override(realm, "realm_description", "Organization description already set!");
     assert.equal(navbar_alerts.check_profile_incomplete(), false);
 });
 
@@ -103,12 +103,20 @@ test("demo_organization_days_remaining", ({override}) => {
     const start_time = new Date(1620327447050); // Thursday 06/5/2021 07:02:27 AM (UTC+0)
 
     const high_priority_deadline = addDays(start_time, 5);
-    realm.demo_organization_scheduled_deletion_date = Math.trunc(high_priority_deadline / 1000);
+    override(
+        realm,
+        "demo_organization_scheduled_deletion_date",
+        Math.trunc(high_priority_deadline / 1000),
+    );
     override(Date, "now", () => start_time);
     assert.equal(navbar_alerts.get_demo_organization_deadline_days_remaining(), 5);
 
     const low_priority_deadline = addDays(start_time, 10);
-    realm.demo_organization_scheduled_deletion_date = Math.trunc(low_priority_deadline / 1000);
+    override(
+        realm,
+        "demo_organization_scheduled_deletion_date",
+        Math.trunc(low_priority_deadline / 1000),
+    );
     override(Date, "now", () => start_time);
     assert.equal(navbar_alerts.get_demo_organization_deadline_days_remaining(), 10);
 });

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -68,16 +68,16 @@ test("profile_incomplete_alert", ({override}) => {
     override(timerender, "should_display_profile_incomplete_alert", () => true);
 
     // Show alert.
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
     realm.realm_description = "Organization imported from Slack!";
     assert.equal(navbar_alerts.check_profile_incomplete(), true);
 
     // Avoid showing if the user is not admin.
-    current_user.is_admin = false;
+    override(current_user, "is_admin", false);
     assert.equal(navbar_alerts.check_profile_incomplete(), false);
 
     // Avoid showing if the realm description is already updated.
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
     assert.equal(navbar_alerts.check_profile_incomplete(), true);
     realm.realm_description = "Organization description already set!";
     assert.equal(navbar_alerts.check_profile_incomplete(), false);

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -6,7 +6,7 @@ const {addDays} = require("date-fns");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 page_params.is_spectator = false;
 
@@ -16,6 +16,12 @@ const timerender = mock_esm("../src/timerender");
 
 const {localstorage} = zrequire("localstorage");
 const navbar_alerts = zrequire("navbar_alerts");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 
 function test(label, f) {
     run_test(label, (helpers) => {

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -55,18 +55,18 @@ function test(label, f) {
     run_test(label, (helpers) => {
         current_user.is_admin = false;
         page_params.realm_users = [];
-        user_settings.enable_followed_topic_desktop_notifications = true;
-        user_settings.enable_followed_topic_audible_notifications = true;
-        user_settings.enable_desktop_notifications = true;
-        user_settings.enable_sounds = true;
-        user_settings.enable_followed_topic_wildcard_mentions_notify = true;
-        user_settings.wildcard_mentions_notify = true;
-        user_settings.notification_sound = "ding";
+        helpers.override(user_settings, "enable_followed_topic_desktop_notifications", true);
+        helpers.override(user_settings, "enable_followed_topic_audible_notifications", true);
+        helpers.override(user_settings, "enable_desktop_notifications", true);
+        helpers.override(user_settings, "enable_sounds", true);
+        helpers.override(user_settings, "enable_followed_topic_wildcard_mentions_notify", true);
+        helpers.override(user_settings, "wildcard_mentions_notify", true);
+        helpers.override(user_settings, "notification_sound", "ding");
         f(helpers);
     });
 }
 
-test("message_is_notifiable", () => {
+test("message_is_notifiable", ({override}) => {
     // A notification is sent if both message_is_notifiable(message)
     // and the appropriate should_send_*_notification function return
     // true.
@@ -150,14 +150,14 @@ test("message_is_notifiable", () => {
 
     // But not if 'enable_followed_topic_desktop_notifications'
     // and 'enable_followed_topic_audible_notifications' are disabled.
-    user_settings.enable_followed_topic_desktop_notifications = false;
-    user_settings.enable_followed_topic_audible_notifications = false;
+    override(user_settings, "enable_followed_topic_desktop_notifications", false);
+    override(user_settings, "enable_followed_topic_audible_notifications", false);
     assert.equal(message_notifications.should_send_desktop_notification(message), false);
     assert.equal(message_notifications.should_send_audible_notification(message), false);
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
     // Reset state
-    user_settings.enable_followed_topic_desktop_notifications = true;
+    override(user_settings, "enable_followed_topic_desktop_notifications", true);
 
     // Case 5:
     // Mentioning should trigger notification in unmuted topic
@@ -195,7 +195,7 @@ test("message_is_notifiable", () => {
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
     // But not if it's disabled
-    user_settings.wildcard_mentions_notify = false;
+    override(user_settings, "wildcard_mentions_notify", false);
     assert.equal(message_notifications.should_send_desktop_notification(message), false);
     assert.equal(message_notifications.should_send_audible_notification(message), false);
     assert.equal(message_notifications.message_is_notifiable(message), true);
@@ -207,7 +207,7 @@ test("message_is_notifiable", () => {
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
     // Reset state
-    user_settings.wildcard_mentions_notify = true;
+    override(user_settings, "wildcard_mentions_notify", true);
     general.wildcard_mentions_notify = null;
 
     // Case 7: If a message is in a muted stream
@@ -270,9 +270,9 @@ test("message_is_notifiable", () => {
     // 'enable_followed_topic_audible_notifications' disabled and
     // 'enable_followed_topic_wildcard_mentions_notify' enabled;
     // DO visually and audibly notify the user
-    user_settings.wildcard_mentions_notify = false;
-    user_settings.enable_followed_topic_desktop_notifications = false;
-    user_settings.enable_followed_topic_audible_notifications = false;
+    override(user_settings, "wildcard_mentions_notify", false);
+    override(user_settings, "enable_followed_topic_desktop_notifications", false);
+    override(user_settings, "enable_followed_topic_audible_notifications", false);
     message = {
         id: 50,
         content: "message number 5",
@@ -289,16 +289,16 @@ test("message_is_notifiable", () => {
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
     // But not if 'enable_followed_topic_wildcard_mentions_notify' is disabled
-    user_settings.enable_followed_topic_wildcard_mentions_notify = false;
+    override(user_settings, "enable_followed_topic_wildcard_mentions_notify", false);
     assert.equal(message_notifications.should_send_desktop_notification(message), false);
     assert.equal(message_notifications.should_send_audible_notification(message), false);
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
     // Reset state
-    user_settings.wildcard_mentions_notify = true;
-    user_settings.enable_followed_topic_desktop_notifications = true;
-    user_settings.enable_followed_topic_audible_notifications = true;
-    user_settings.enable_followed_topic_wildcard_mentions_notify = true;
+    override(user_settings, "wildcard_mentions_notify", true);
+    override(user_settings, "enable_followed_topic_desktop_notifications", true);
+    override(user_settings, "enable_followed_topic_audible_notifications", true);
+    override(user_settings, "enable_followed_topic_wildcard_mentions_notify", true);
 
     // Case 11: If `None` is selected as the notification sound, send no
     // audible notification, no matter what other user configurations are.
@@ -313,13 +313,13 @@ test("message_is_notifiable", () => {
         stream_id: general.stream_id,
         topic: "whatever",
     };
-    user_settings.notification_sound = "none";
+    override(user_settings, "notification_sound", "none");
     assert.equal(message_notifications.should_send_desktop_notification(message), true);
     assert.equal(message_notifications.should_send_audible_notification(message), false);
     assert.equal(message_notifications.message_is_notifiable(message), true);
 
     // Reset state
-    user_settings.notification_sound = "ding";
+    override(user_settings, "notification_sound", "ding");
 
     // If none of the above cases apply
     // (ie: topic is not muted, message does not mention user,

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params} = require("./lib/zpage_params");
 
 mock_esm("../src/electron_bridge");
 mock_esm("../src/spoilers", {hide_spoilers_in_notification() {}});
@@ -15,6 +15,10 @@ const stream_data = zrequire("stream_data");
 
 const desktop_notifications = zrequire("desktop_notifications");
 const message_notifications = zrequire("message_notifications");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 // Not muted streams
 const general = {

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 mock_esm("../src/electron_bridge");
 mock_esm("../src/spoilers", {hide_spoilers_in_notification() {}});
@@ -15,8 +15,11 @@ const stream_data = zrequire("stream_data");
 
 const desktop_notifications = zrequire("desktop_notifications");
 const message_notifications = zrequire("message_notifications");
+const {set_current_user} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -57,7 +57,7 @@ user_topics.update_user_topics(
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        current_user.is_admin = false;
+        helpers.override(current_user, "is_admin", false);
         page_params.realm_users = [];
         helpers.override(user_settings, "enable_followed_topic_desktop_notifications", true);
         helpers.override(user_settings, "enable_followed_topic_audible_notifications", true);

--- a/web/tests/peer_data.test.js
+++ b/web/tests/peer_data.test.js
@@ -15,7 +15,10 @@ const {page_params} = require("./lib/zpage_params");
 
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
+const {set_current_user} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
+
+set_current_user({});
 
 page_params.realm_users = [];
 

--- a/web/tests/peer_data.test.js
+++ b/web/tests/peer_data.test.js
@@ -11,15 +11,13 @@ const assert = require("node:assert/strict");
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user, page_params} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 
-current_user.is_admin = false;
 page_params.realm_users = [];
-current_user.is_guest = false;
 
 const me = {
     email: "me@zulip.com",

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -511,7 +511,7 @@ test_people("get_display_full_names", ({override}) => {
     people.add_active_user(bob);
     people.add_active_user(charles);
     people.add_active_user(guest);
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
 
     let user_ids = [me.user_id, steven.user_id, bob.user_id, charles.user_id, guest.user_id];
     let names = people.get_display_full_names(user_ids);
@@ -527,7 +527,7 @@ test_people("get_display_full_names", ({override}) => {
     ]);
 
     muted_users.add_muted_user(charles.user_id);
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     names = people.get_display_full_names(user_ids);
     assert.deepEqual(names, [
         "Me Myself",
@@ -547,7 +547,7 @@ test_people("get_display_full_names", ({override}) => {
         "translated: Muted user",
     ]);
 
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
     names = people.get_display_full_names(user_ids);
     assert.deepEqual(names, [
         "Me Myself",
@@ -1428,15 +1428,15 @@ test_people("get_realm_active_human_users", () => {
     assert.deepEqual(humans, [me]);
 });
 
-test_people("should_show_guest_user_indicator", () => {
+test_people("should_show_guest_user_indicator", ({override}) => {
     people.add_active_user(charles);
     people.add_active_user(guest);
 
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     assert.equal(people.should_add_guest_user_indicator(charles.user_id), false);
     assert.equal(people.should_add_guest_user_indicator(guest.user_id), false);
 
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
     assert.equal(people.should_add_guest_user_indicator(charles.user_id), false);
     assert.equal(people.should_add_guest_user_indicator(guest.user_id), true);
 });
@@ -1444,7 +1444,7 @@ test_people("should_show_guest_user_indicator", () => {
 test_people("get_user_by_id_assert_valid", ({override}) => {
     people.add_active_user(charles);
     const inaccessible_user_id = 99;
-    realm.realm_bot_domain = "zulipdev.com";
+    override(realm, "realm_bot_domain", "zulipdev.com");
     override(settings_data, "user_can_access_all_other_users", () => false);
 
     let user = people.get_user_by_id_assert_valid(inaccessible_user_id);
@@ -1476,14 +1476,14 @@ test_people("get_user_by_id_assert_valid", ({override}) => {
     assert.equal(user.email, charles.email);
 });
 
-test_people("user_can_initiate_direct_message_thread", () => {
+test_people("user_can_initiate_direct_message_thread", ({override}) => {
     people.add_active_user(welcome_bot);
-    realm.realm_direct_message_initiator_group = nobody.id;
+    override(realm, "realm_direct_message_initiator_group", nobody.id);
     assert.ok(!people.user_can_initiate_direct_message_thread("32"));
     // Can send if only bots and self are present.
     assert.ok(people.user_can_initiate_direct_message_thread("4,30"));
 
-    realm.realm_direct_message_initiator_group = everyone.id;
+    override(realm, "realm_direct_message_initiator_group", everyone.id);
     assert.ok(people.user_can_initiate_direct_message_thread("32"));
 });
 

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -10,7 +10,7 @@ const {$t} = require("./lib/i18n");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const message_user_ids = mock_esm("../src/message_user_ids");
 const settings_data = mock_esm("../src/settings_data", {
@@ -19,9 +19,14 @@ const settings_data = mock_esm("../src/settings_data", {
 
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
+const {set_current_user, set_realm} = zrequire("state_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -614,19 +614,19 @@ test_people("bot_custom_profile_data", () => {
     assert.equal(people.get_custom_profile_data(bot_botson.user_id, 3), null);
 });
 
-test_people("user_timezone", () => {
+test_people("user_timezone", ({override}) => {
     MockDate.set(parseISO("20130208T080910").getTime());
 
-    user_settings.twenty_four_hour_time = true;
+    override(user_settings, "twenty_four_hour_time", true);
     assert.equal(people.get_user_time(me.user_id), "00:09");
 
-    user_settings.twenty_four_hour_time = false;
+    override(user_settings, "twenty_four_hour_time", false);
     assert.equal(people.get_user_time(me.user_id), "12:09 AM");
 });
 
 test_people("utcToZonedTime", ({override}) => {
     MockDate.set(parseISO("20130208T080910").getTime());
-    user_settings.twenty_four_hour_time = true;
+    override(user_settings, "twenty_four_hour_time", true);
 
     assert.deepEqual(people.get_user_time(unknown_user.user_id), undefined);
     assert.equal(people.get_user_time(me.user_id), "00:09");

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -10,7 +10,7 @@ const {$t} = require("./lib/i18n");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user, page_params, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 const message_user_ids = mock_esm("../src/message_user_ids");
 const settings_data = mock_esm("../src/settings_data", {
@@ -20,6 +20,10 @@ const settings_data = mock_esm("../src/settings_data", {
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const welcome_bot = {
     email: "welcome-bot@example.com",

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -707,14 +707,14 @@ test_people("set_custom_profile_field_data", () => {
     assert.equal(person.profile_data[field.id].rendered_value, "<p>Field value</p>");
 });
 
-test_people("is_current_user_only_owner", () => {
+test_people("is_current_user_only_owner", ({override}) => {
     const person = people.get_by_email(me.email);
     person.is_owner = false;
-    current_user.is_owner = false;
+    override(current_user, "is_owner", false);
     assert.ok(!people.is_current_user_only_owner());
 
     person.is_owner = true;
-    current_user.is_owner = true;
+    override(current_user, "is_owner", true);
     assert.ok(people.is_current_user_only_owner());
 
     people.add_active_user(realm_owner);
@@ -1262,13 +1262,13 @@ test_people("initialize", () => {
     assert.equal(page_params.realm_non_active_users, undefined);
 });
 
-test_people("predicate_for_user_settings_filters", () => {
+test_people("predicate_for_user_settings_filters", ({override}) => {
     /*
         This function calls matches_user_settings_search,
         so that is where we do more thorough testing.
         This test is just a sanity check for now.
     */
-    current_user.is_admin = false;
+    override(current_user, "is_admin", false);
 
     const fred_smith = {full_name: "Fred Smith", role: 100};
 
@@ -1307,15 +1307,15 @@ test_people("predicate_for_user_settings_filters", () => {
     );
 });
 
-test_people("matches_user_settings_search", () => {
+test_people("matches_user_settings_search", ({override}) => {
     const match = people.matches_user_settings_search;
 
-    current_user.is_admin = false;
+    override(current_user, "is_admin", false);
 
     assert.equal(match({email: "fred@example.com"}, "fred"), false);
     assert.equal(match({full_name: "Fred Smith"}, "fr"), true);
 
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
 
     assert.equal(match({delivery_email: "fred@example.com"}, "fr"), true);
     assert.equal(

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -614,7 +614,7 @@ run_test("set_up_group_setting_typeahead", ({mock_template, override, override_r
     const system_group_items = [moderators_item];
 
     page_params.development_environment = true;
-    realm.realm_waiting_period_threshold = 0;
+    override(realm, "realm_waiting_period_threshold", 0);
 
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -6,7 +6,7 @@ const {zrequire, mock_esm} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const noop = function () {};
 
@@ -17,9 +17,13 @@ const input_pill = zrequire("input_pill");
 const pill_typeahead = zrequire("pill_typeahead");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const user_groups = zrequire("user_groups");
 const typeahead_helper = zrequire("typeahead_helper");
+
+const realm = {};
+set_realm(realm);
 
 // set global test variables.
 let sort_recipients_called = false;

--- a/web/tests/pm_conversations.test.js
+++ b/web/tests/pm_conversations.test.js
@@ -4,12 +4,15 @@ const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user} = require("./lib/zpage_params");
 
 const user_topics = zrequire("user_topics");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
 const pmc = zrequire("pm_conversations");
+const {set_current_user} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
 
 const alice = {
     user_id: 1,

--- a/web/tests/pm_conversations.test.js
+++ b/web/tests/pm_conversations.test.js
@@ -132,8 +132,8 @@ test("muted_users", () => {
     assert.deepEqual(pmc.recent.get_strings(), ["3", "1,2,3", "15"]);
 });
 
-test("has_conversation", () => {
-    current_user.user_id = me.user_id;
+test("has_conversation", ({override}) => {
+    override(current_user, "user_id", me.user_id);
     pmc.recent.initialize(params);
 
     // Tests if `has_conversation` returns `true` when there are previous

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -23,8 +23,10 @@ const people = zrequire("people");
 const pm_conversations = zrequire("pm_conversations");
 const pm_list_data = zrequire("pm_list_data");
 const message_lists = zrequire("message_lists");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
 initialize_user_settings({user_settings: {}});
 
 const alice = {

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -23,6 +23,9 @@ const people = zrequire("people");
 const pm_conversations = zrequire("pm_conversations");
 const pm_list_data = zrequire("pm_list_data");
 const message_lists = zrequire("message_lists");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const alice = {
     email: "alice@zulip.com",

--- a/web/tests/poll_widget.test.js
+++ b/web/tests/poll_widget.test.js
@@ -16,6 +16,9 @@ const {PollData} = zrequire("../shared/src/poll_data");
 const poll_widget = zrequire("poll_widget");
 
 const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
+
+set_realm({});
 
 const me = {
     email: "me@zulip.com",

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {page_params, realm, current_user} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const {Filter} = zrequire("filter");
 const {MessageList} = zrequire("message_list");
@@ -16,6 +16,7 @@ const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 const user_groups = zrequire("user_groups");
 const {MessageListData} = zrequire("message_list_data");
+const {set_current_user, set_realm} = zrequire("state_data");
 
 const noop = function () {};
 
@@ -53,6 +54,11 @@ mock_esm("../src/group_permission_settings", {
         };
     },
 });
+
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 
 // Define test users
 const mike = {

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -156,12 +156,12 @@ function test(label, f) {
 }
 
 // Test functions
-test("my_message_all_actions", () => {
+test("my_message_all_actions", ({override}) => {
     // Set page parameters.
     set_page_params_no_edit_restrictions();
     realm.realm_can_delete_any_message_group = everyone.id;
     realm.realm_can_delete_own_message_group = everyone.id;
-    current_user.user_id = me.user_id;
+    override(current_user, "user_id", me.user_id);
     // Get message with maximum permissions available
     // Initialize message list
     const list = init_message_list();

--- a/web/tests/popover_menus_data.test.js
+++ b/web/tests/popover_menus_data.test.js
@@ -128,15 +128,15 @@ function add_message_with_view(list, messages) {
 
 // Function sets page parameters with no time constraints on editing the message.
 // User is assumed to not be an admin.
-function set_page_params_no_edit_restrictions() {
+function set_page_params_no_edit_restrictions({override}) {
     page_params.is_spectator = false;
-    realm.realm_allow_message_editing = true;
-    realm.realm_message_content_edit_limit_seconds = null;
-    realm.realm_allow_edit_history = true;
-    realm.realm_message_content_delete_limit_seconds = null;
-    realm.realm_enable_read_receipts = true;
-    realm.realm_edit_topic_policy = 5;
-    realm.realm_move_messages_within_stream_limit_seconds = null;
+    override(realm, "realm_allow_message_editing", true);
+    override(realm, "realm_message_content_edit_limit_seconds", null);
+    override(realm, "realm_allow_edit_history", true);
+    override(realm, "realm_message_content_delete_limit_seconds", null);
+    override(realm, "realm_enable_read_receipts", true);
+    override(realm, "realm_edit_topic_policy", 5);
+    override(realm, "realm_move_messages_within_stream_limit_seconds", null);
 }
 
 // Test init function
@@ -158,9 +158,9 @@ function test(label, f) {
 // Test functions
 test("my_message_all_actions", ({override}) => {
     // Set page parameters.
-    set_page_params_no_edit_restrictions();
-    realm.realm_can_delete_any_message_group = everyone.id;
-    realm.realm_can_delete_own_message_group = everyone.id;
+    set_page_params_no_edit_restrictions({override});
+    override(realm, "realm_can_delete_any_message_group", everyone.id);
+    override(realm, "realm_can_delete_own_message_group", everyone.id);
     override(current_user, "user_id", me.user_id);
     // Get message with maximum permissions available
     // Initialize message list
@@ -210,10 +210,10 @@ test("my_message_all_actions", ({override}) => {
     assert.equal(response.should_display_quote_and_reply, true);
 });
 
-test("not_my_message_view_actions", () => {
-    set_page_params_no_edit_restrictions();
+test("not_my_message_view_actions", ({override}) => {
+    set_page_params_no_edit_restrictions({override});
     // Get message that is only viewable
-    realm.realm_can_delete_any_message_group = everyone.id;
+    override(realm, "realm_can_delete_any_message_group", everyone.id);
     const list = init_message_list();
     message_lists.set_current(list);
 
@@ -249,9 +249,9 @@ test("not_my_message_view_actions", () => {
     assert.equal(response.move_message_menu_item, undefined);
 });
 
-test("not_my_message_view_source_and_move", () => {
-    set_page_params_no_edit_restrictions();
-    realm.realm_can_delete_any_message_group = everyone.id;
+test("not_my_message_view_source_and_move", ({override}) => {
+    set_page_params_no_edit_restrictions({override});
+    override(realm, "realm_can_delete_any_message_group", everyone.id);
     // Get message that is movable with viewable source
 
     const list = init_message_list();

--- a/web/tests/postprocess_content.test.js
+++ b/web/tests/postprocess_content.test.js
@@ -4,11 +4,14 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {user_settings} = require("./lib/zpage_params");
 
 const thumbnail = mock_esm("../src/thumbnail");
 
 const {postprocess_content} = zrequire("postprocess_content");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 run_test("postprocess_content", () => {
     assert.equal(

--- a/web/tests/presence.test.js
+++ b/web/tests/presence.test.js
@@ -82,7 +82,7 @@ people.initialize_current_user(me.user_id);
 function test(label, f) {
     run_test(label, (helpers) => {
         realm.server_presence_offline_threshold_seconds = OFFLINE_THRESHOLD_SECS;
-        user_settings.presence_enabled = true;
+        helpers.override(user_settings, "presence_enabled", true);
         presence.clear_internal_data();
         f(helpers);
     });

--- a/web/tests/presence.test.js
+++ b/web/tests/presence.test.js
@@ -85,7 +85,11 @@ people.initialize_current_user(me.user_id);
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        realm.server_presence_offline_threshold_seconds = OFFLINE_THRESHOLD_SECS;
+        helpers.override(
+            realm,
+            "server_presence_offline_threshold_seconds",
+            OFFLINE_THRESHOLD_SECS,
+        );
         helpers.override(user_settings, "presence_enabled", true);
         presence.clear_internal_data();
         f(helpers);

--- a/web/tests/presence.test.js
+++ b/web/tests/presence.test.js
@@ -4,7 +4,6 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {realm} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -12,8 +11,11 @@ mock_esm("../src/settings_data", {
 
 const people = zrequire("people");
 const presence = zrequire("presence");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/presence.test.js
+++ b/web/tests/presence.test.js
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {realm, user_settings} = require("./lib/zpage_params");
+const {realm} = require("./lib/zpage_params");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
@@ -12,6 +12,10 @@ mock_esm("../src/settings_data", {
 
 const people = zrequire("people");
 const presence = zrequire("presence");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const OFFLINE_THRESHOLD_SECS = 200;
 

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -7,7 +7,7 @@ const {make_stub} = require("./lib/stub");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, page_params} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const alice_user_id = 5;
 
@@ -59,8 +59,12 @@ const emoji = zrequire("emoji");
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
 const people = zrequire("people");
 const reactions = zrequire("reactions");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+set_realm({});
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -442,32 +442,32 @@ function stub_reaction(message_id, local_id) {
     return $reaction;
 }
 
-test("get_vote_text (more than 3 reactions)", () => {
+test("get_vote_text (more than 3 reactions)", ({override}) => {
     const user_ids = [5, 6, 7];
     const message = {...sample_message};
 
-    user_settings.display_emoji_reaction_users = true;
+    override(user_settings, "display_emoji_reaction_users", true);
     assert.equal(
         "translated: You, Bob van Roberts, Cali",
         reactions.get_vote_text(user_ids, message),
     );
 });
 
-test("get_vote_text (3 reactions)", () => {
+test("get_vote_text (3 reactions)", ({override}) => {
     const user_ids = [5, 6, 7];
     const message = {...sample_message};
 
     // slicing the reactions array to only include first 3 reactions
     message.reactions = message.reactions.slice(0, 3);
 
-    user_settings.display_emoji_reaction_users = true;
+    override(user_settings, "display_emoji_reaction_users", true);
     assert.equal(
         "translated: You, Bob van Roberts, Cali",
         reactions.get_vote_text(user_ids, message),
     );
 });
 
-test("update_vote_text_on_message", ({override_rewire}) => {
+test("update_vote_text_on_message", ({override, override_rewire}) => {
     // the vote_text in this message is intentionally wrong.
     // After calling update_vote_text_on_message(), we
     // will check if the vote_text has been correctly updated.
@@ -500,7 +500,7 @@ test("update_vote_text_on_message", ({override_rewire}) => {
     };
     convert_reactions_to_clean_reactions(message);
 
-    user_settings.display_emoji_reaction_users = true;
+    override(user_settings, "display_emoji_reaction_users", true);
 
     override_rewire(reactions, "find_reaction", noop);
     override_rewire(reactions, "set_reaction_vote_text", noop);
@@ -580,7 +580,7 @@ test("add_reaction/remove_reaction", ({override, override_rewire}) => {
     };
     convert_reactions_to_clean_reactions(message);
 
-    user_settings.display_emoji_reaction_users = true;
+    override(user_settings, "display_emoji_reaction_users", true);
 
     override(message_store, "get", () => message);
 

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -7,7 +7,7 @@ const {make_stub} = require("./lib/stub");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params} = require("./lib/zpage_params");
 
 const alice_user_id = 5;
 
@@ -59,6 +59,10 @@ const emoji = zrequire("emoji");
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
 const people = zrequire("people");
 const reactions = zrequire("reactions");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const emoji_params = {
     realm_emoji: {

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -112,7 +112,7 @@ people.add_active_user(alexus);
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        current_user.user_id = alice_user_id;
+        helpers.override(current_user, "user_id", alice_user_id);
         f(helpers);
     });
 }

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -200,7 +200,10 @@ const rt = zrequire("recent_view_ui");
 const recent_view_util = zrequire("recent_view_util");
 const rt_data = zrequire("recent_view_data");
 const muted_users = zrequire("muted_users");
+const {set_realm} = zrequire("state_data");
 const sub_store = zrequire("sub_store");
+
+set_realm({});
 
 for (const stream_id of [stream1, stream2, stream3, stream4, stream6]) {
     sub_store.add_hydrated_sub(stream_id, {

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -162,7 +162,7 @@ const get_content_element = () => {
     return $content;
 };
 
-run_test("misc_helpers", () => {
+run_test("misc_helpers", ({override}) => {
     const $elem = $.create("user-mention");
     rm.set_name_in_mention_element($elem, "Aaron");
     assert.equal($elem.text(), "@Aaron");
@@ -170,11 +170,11 @@ run_test("misc_helpers", () => {
     rm.set_name_in_mention_element($elem, "Aaron, but silent");
     assert.equal($elem.text(), "Aaron, but silent");
 
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
     rm.set_name_in_mention_element($elem, "Polonius", polonius.user_id);
     assert.equal($elem.text(), "translated: Polonius (guest)");
 
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     rm.set_name_in_mention_element($elem, "Polonius", polonius.user_id);
     assert.equal($elem.text(), "Polonius");
 });
@@ -195,7 +195,7 @@ run_test("message_inline_video", () => {
     window.GestureEvent = false;
 });
 
-run_test("user-mention", () => {
+run_test("user-mention", ({override}) => {
     // Setup
     const $content = get_content_element();
     const $iago = $.create("user-mention(iago)");
@@ -208,7 +208,7 @@ run_test("user-mention", () => {
     $polonius.set_find_results(".highlight", false);
     $polonius.attr("data-user-id", polonius.user_id);
     $content.set_find_results(".user-mention", $array([$iago, $cordelia, $polonius]));
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
     // Initial asserts
     assert.ok(!$iago.hasClass("user-mention-me"));
     assert.equal($iago.text(), "never-been-set");
@@ -228,14 +228,14 @@ run_test("user-mention", () => {
     assert.ok($iago.hasClass("user-mention-me"));
 });
 
-run_test("user-mention without guest indicator", () => {
+run_test("user-mention without guest indicator", ({override}) => {
     const $content = get_content_element();
     const $polonius = $.create("user-mention(polonius-again)");
     $polonius.set_find_results(".highlight", false);
     $polonius.attr("data-user-id", polonius.user_id);
     $content.set_find_results(".user-mention", $array([$polonius]));
 
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     rm.update_elements($content);
     assert.equal($polonius.text(), `@${polonius.full_name}`);
 });

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -7,7 +7,6 @@ const {mock_cjs, mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {realm} = require("./lib/zpage_params");
 
 let clipboard_args;
 class Clipboard {
@@ -33,8 +32,11 @@ const message_store = mock_esm("../src/message_store");
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => false,
 });
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -23,7 +23,6 @@ mock_cjs("clipboard", Clipboard);
 
 const realm_playground = mock_esm("../src/realm_playground");
 const copied_tooltip = mock_esm("../src/copied_tooltip");
-user_settings.emojiset = "apple";
 
 const rm = zrequire("rendered_markdown");
 const people = zrequire("people");
@@ -475,7 +474,7 @@ run_test("timestamp-error", () => {
     assert.equal($timestamp_error.text(), "translated: Invalid time format: the-time-format");
 });
 
-run_test("emoji", () => {
+run_test("emoji", ({override}) => {
     // Setup
     const $content = get_content_element();
     const $emoji = $.create("emoji-stub");
@@ -488,14 +487,14 @@ run_test("emoji", () => {
         return {contents: () => ({unwrap() {}})};
     };
     $content.set_find_results(".emoji", $emoji);
-    user_settings.emojiset = "text";
+    override(user_settings, "emojiset", "text");
 
     rm.update_elements($content);
 
     assert.ok(called);
 
     // Set page parameters back so that test run order is independent
-    user_settings.emojiset = "apple";
+    override(user_settings, "emojiset", "apple");
 });
 
 run_test("spoiler-header", () => {

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -7,7 +7,7 @@ const {mock_cjs, mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {realm, user_settings} = require("./lib/zpage_params");
+const {realm} = require("./lib/zpage_params");
 
 let clipboard_args;
 class Clipboard {
@@ -33,6 +33,10 @@ const message_store = mock_esm("../src/message_store");
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => false,
 });
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const iago = {
     email: "iago@zulip.com",

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -7,6 +7,9 @@ const {run_test} = require("./lib/test");
 
 const scheduled_messages = zrequire("scheduled_messages");
 const compose_send_menu_popover = zrequire("compose_send_menu_popover");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const per_day_stamps = {
     "2023-04-30": {

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -937,7 +937,7 @@ test("people_suggestions", ({override, mock_template}) => {
         }
     }
 
-    realm.realm_enable_guest_user_indicator = true;
+    override(realm, "realm_enable_guest_user_indicator", true);
     suggestions = get_suggestions(query);
 
     test_guest_user_indicator("dm:bob@zulip.com", false);
@@ -951,7 +951,7 @@ test("people_suggestions", ({override, mock_template}) => {
     test_guest_user_indicator("sender:bob@zulip.com", true);
     test_guest_user_indicator("dm-including:bob@zulip.com", true);
 
-    realm.realm_enable_guest_user_indicator = false;
+    override(realm, "realm_enable_guest_user_indicator", false);
     suggestions = get_suggestions(query);
 
     test_guest_user_indicator("dm:bob@zulip.com", false);

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -56,8 +56,8 @@ function new_stream_id() {
     return _stream_id;
 }
 
-function init() {
-    current_user.is_admin = true;
+function init({override}) {
+    override(current_user, "is_admin", true);
 
     people.init();
     people.add_active_user(bob);
@@ -79,7 +79,7 @@ function get_suggestions(query, pill_query = "") {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        init();
+        init(helpers);
         f(helpers);
     });
 }

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const narrow_state = mock_esm("../src/narrow_state");
 const stream_topic_history_util = mock_esm("../src/stream_topic_history_util");
@@ -16,6 +16,12 @@ const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
 const search = zrequire("search_suggestion");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 
 const me = {
     email: "myself@zulip.com",

--- a/web/tests/settings_bots.test.js
+++ b/web/tests/settings_bots.test.js
@@ -34,7 +34,7 @@ bot_data.initialize(bot_data_params);
 
 function test(label, f) {
     run_test(label, ({override}) => {
-        realm.realm_url = "https://chat.example.com";
+        override(realm, "realm_url", "https://chat.example.com");
         realm.realm_embedded_bots = [
             {name: "converter", config: {}},
             {name: "giphy", config: {key: "12345678"}},
@@ -96,9 +96,9 @@ test("can_create_new_bots", ({override}) => {
     assert.ok(settings_bots.can_create_new_bots());
 
     override(current_user, "is_admin", false);
-    realm.realm_bot_creation_policy = 1;
+    override(realm, "realm_bot_creation_policy", 1);
     assert.ok(settings_bots.can_create_new_bots());
 
-    realm.realm_bot_creation_policy = 3;
+    override(realm, "realm_bot_creation_policy", 3);
     assert.ok(!settings_bots.can_create_new_bots());
 });

--- a/web/tests/settings_bots.test.js
+++ b/web/tests/settings_bots.test.js
@@ -4,7 +4,6 @@ const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, realm} = require("./lib/zpage_params");
 
 const bot_data_params = {
     realm_bots: [
@@ -29,6 +28,12 @@ const bot_data_params = {
 
 const bot_data = zrequire("bot_data");
 const settings_bots = zrequire("settings_bots");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 
 bot_data.initialize(bot_data_params);
 

--- a/web/tests/settings_bots.test.js
+++ b/web/tests/settings_bots.test.js
@@ -91,11 +91,11 @@ test("generate_botserverrc_content", () => {
     assert.equal(content, expected);
 });
 
-test("can_create_new_bots", () => {
-    current_user.is_admin = true;
+test("can_create_new_bots", ({override}) => {
+    override(current_user, "is_admin", true);
     assert.ok(settings_bots.can_create_new_bots());
 
-    current_user.is_admin = false;
+    override(current_user, "is_admin", false);
     realm.realm_bot_creation_policy = 1;
     assert.ok(settings_bots.can_create_new_bots());
 

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -8,20 +8,20 @@ const {user_settings} = require("./lib/zpage_params");
 
 const settings_config = zrequire("settings_config");
 
-run_test("all_notifications", () => {
-    user_settings.enable_stream_desktop_notifications = false;
-    user_settings.enable_stream_audible_notifications = true;
-    user_settings.enable_stream_push_notifications = true;
-    user_settings.enable_stream_email_notifications = false;
-    user_settings.enable_desktop_notifications = false;
-    user_settings.enable_sounds = true;
-    user_settings.enable_offline_push_notifications = false;
-    user_settings.enable_offline_email_notifications = true;
-    user_settings.enable_followed_topic_desktop_notifications = false;
-    user_settings.enable_followed_topic_audible_notifications = true;
-    user_settings.enable_followed_topic_push_notifications = false;
-    user_settings.enable_followed_topic_email_notifications = true;
-    user_settings.enable_followed_topic_wildcard_mentions_notify = false;
+run_test("all_notifications", ({override}) => {
+    override(user_settings, "enable_stream_desktop_notifications", false);
+    override(user_settings, "enable_stream_audible_notifications", true);
+    override(user_settings, "enable_stream_push_notifications", true);
+    override(user_settings, "enable_stream_email_notifications", false);
+    override(user_settings, "enable_desktop_notifications", false);
+    override(user_settings, "enable_sounds", true);
+    override(user_settings, "enable_offline_push_notifications", false);
+    override(user_settings, "enable_offline_email_notifications", true);
+    override(user_settings, "enable_followed_topic_desktop_notifications", false);
+    override(user_settings, "enable_followed_topic_audible_notifications", true);
+    override(user_settings, "enable_followed_topic_push_notifications", false);
+    override(user_settings, "enable_followed_topic_email_notifications", true);
+    override(user_settings, "enable_followed_topic_wildcard_mentions_notify", false);
 
     // Check that it throws error if incorrect settings name
     // is passed. In this case, we articulate that with
@@ -38,7 +38,7 @@ run_test("all_notifications", () => {
     assert.equal(error_name, "TypeError");
     assert.equal(error_message, "Incorrect setting_name passed: wildcard_mentions_notify");
 
-    user_settings.wildcard_mentions_notify = false;
+    override(user_settings, "wildcard_mentions_notify", false);
     const notifications = settings_config.all_notifications(user_settings);
 
     assert.deepEqual(notifications.general_settings, [

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -6,8 +6,10 @@ const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
 const settings_config = zrequire("settings_config");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -4,9 +4,12 @@ const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {user_settings} = require("./lib/zpage_params");
 
 const settings_config = zrequire("settings_config");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 run_test("all_notifications", ({override}) => {
     override(user_settings, "enable_stream_desktop_notifications", false);

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -4,13 +4,18 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");
+const {set_current_user, set_realm} = zrequire("state_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -37,10 +37,10 @@ run_test("user_can_change_email", ({override}) => {
     assert.equal(can_change_email(), true);
 
     override(current_user, "is_admin", false);
-    realm.realm_email_changes_disabled = true;
+    override(realm, "realm_email_changes_disabled", true);
     assert.equal(can_change_email(), false);
 
-    realm.realm_email_changes_disabled = false;
+    override(realm, "realm_email_changes_disabled", false);
     assert.equal(can_change_email(), true);
 });
 
@@ -51,16 +51,16 @@ run_test("user_can_change_name", ({override}) => {
     assert.equal(can_change_name(), true);
 
     override(current_user, "is_admin", false);
-    realm.realm_name_changes_disabled = true;
-    realm.server_name_changes_disabled = false;
+    override(realm, "realm_name_changes_disabled", true);
+    override(realm, "server_name_changes_disabled", false);
     assert.equal(can_change_name(), false);
 
-    realm.realm_name_changes_disabled = false;
-    realm.server_name_changes_disabled = false;
+    override(realm, "realm_name_changes_disabled", false);
+    override(realm, "server_name_changes_disabled", false);
     assert.equal(can_change_name(), true);
 
-    realm.realm_name_changes_disabled = false;
-    realm.server_name_changes_disabled = true;
+    override(realm, "realm_name_changes_disabled", false);
+    override(realm, "server_name_changes_disabled", true);
     assert.equal(can_change_name(), false);
 });
 
@@ -71,16 +71,16 @@ run_test("user_can_change_avatar", ({override}) => {
     assert.equal(can_change_avatar(), true);
 
     override(current_user, "is_admin", false);
-    realm.realm_avatar_changes_disabled = true;
-    realm.server_avatar_changes_disabled = false;
+    override(realm, "realm_avatar_changes_disabled", true);
+    override(realm, "server_avatar_changes_disabled", false);
     assert.equal(can_change_avatar(), false);
 
-    realm.realm_avatar_changes_disabled = false;
-    realm.server_avatar_changes_disabled = false;
+    override(realm, "realm_avatar_changes_disabled", false);
+    override(realm, "server_avatar_changes_disabled", false);
     assert.equal(can_change_avatar(), true);
 
-    realm.realm_avatar_changes_disabled = false;
-    realm.server_avatar_changes_disabled = true;
+    override(realm, "realm_avatar_changes_disabled", false);
+    override(realm, "server_avatar_changes_disabled", true);
     assert.equal(can_change_avatar(), false);
 });
 
@@ -88,19 +88,19 @@ run_test("user_can_change_logo", ({override}) => {
     const can_change_logo = settings_data.user_can_change_logo;
 
     override(current_user, "is_admin", true);
-    realm.zulip_plan_is_not_limited = true;
+    override(realm, "zulip_plan_is_not_limited", true);
     assert.equal(can_change_logo(), true);
 
     override(current_user, "is_admin", false);
-    realm.zulip_plan_is_not_limited = false;
+    override(realm, "zulip_plan_is_not_limited", false);
     assert.equal(can_change_logo(), false);
 
     override(current_user, "is_admin", true);
-    realm.zulip_plan_is_not_limited = false;
+    override(realm, "zulip_plan_is_not_limited", false);
     assert.equal(can_change_logo(), false);
 
     override(current_user, "is_admin", false);
-    realm.zulip_plan_is_not_limited = true;
+    override(realm, "zulip_plan_is_not_limited", true);
     assert.equal(can_change_logo(), false);
 });
 
@@ -138,7 +138,7 @@ function test_policy(label, policy, validation_func) {
         override(current_user, "user_id", 30);
         isaac.date_joined = new Date(Date.now());
         settings_data.initialize(isaac.date_joined);
-        realm.realm_waiting_period_threshold = 10;
+        override(realm, "realm_waiting_period_threshold", 10);
         assert.equal(validation_func(), false);
 
         isaac.date_joined = new Date(Date.now() - 20 * 86400000);
@@ -197,7 +197,7 @@ function test_message_policy(label, policy, validation_func) {
         realm[policy] = settings_config.common_message_policy_values.by_full_members.code;
         override(current_user, "user_id", 30);
         isaac.date_joined = new Date(Date.now());
-        realm.realm_waiting_period_threshold = 10;
+        override(realm, "realm_waiting_period_threshold", 10);
         settings_data.initialize(isaac.date_joined);
         assert.equal(validation_func(), false);
 
@@ -216,7 +216,11 @@ test_message_policy(
 run_test("user_can_move_messages_to_another_topic_nobody_case", ({override}) => {
     override(current_user, "is_admin", true);
     override(current_user, "is_guest", false);
-    realm.realm_edit_topic_policy = settings_config.edit_topic_policy_values.nobody.code;
+    override(
+        realm,
+        "realm_edit_topic_policy",
+        settings_config.edit_topic_policy_values.nobody.code,
+    );
     assert.equal(settings_data.user_can_move_messages_to_another_topic(), false);
 });
 
@@ -408,7 +412,7 @@ run_test("can_manage_user_group", ({override}) => {
     assert.ok(!settings_data.can_manage_user_group(students.id));
 
     page_params.is_spectator = false;
-    realm.realm_can_manage_all_groups = admins.id;
+    override(realm, "realm_can_manage_all_groups", admins.id);
     override(current_user, "user_id", 3);
     assert.ok(!settings_data.can_manage_user_group(students.id));
 
@@ -424,14 +428,14 @@ run_test("can_manage_user_group", ({override}) => {
     override(current_user, "user_id", 2);
     assert.ok(!settings_data.can_manage_user_group(students.id));
 
-    realm.realm_can_manage_all_groups = members.id;
+    override(realm, "realm_can_manage_all_groups", members.id);
     override(current_user, "user_id", 3);
     assert.ok(!settings_data.can_manage_user_group(students.id));
 
     override(current_user, "user_id", 2);
     assert.ok(settings_data.can_manage_user_group(students.id));
 
-    realm.realm_can_manage_all_groups = admins.id;
+    override(realm, "realm_can_manage_all_groups", admins.id);
     override(current_user, "user_id", 2);
     assert.ok(!settings_data.can_manage_user_group(students.id));
 
@@ -511,7 +515,7 @@ run_test("can_join_user_group", ({override}) => {
     user_groups.initialize({
         realm_user_groups: [admins, moderators, members, nobody, students],
     });
-    realm.realm_can_manage_all_groups = nobody.id;
+    override(realm, "realm_can_manage_all_groups", nobody.id);
 
     page_params.is_spectator = true;
     assert.ok(!settings_data.can_join_user_group(students.id));
@@ -561,7 +565,7 @@ run_test("can_join_user_group", ({override}) => {
     override(current_user, "user_id", 4);
     assert.ok(settings_data.can_join_user_group(students.id));
 
-    realm.realm_can_manage_all_groups = moderators.id;
+    override(realm, "realm_can_manage_all_groups", moderators.id);
     override(current_user, "user_id", 2);
     assert.ok(settings_data.can_join_user_group(students.id));
 });
@@ -605,7 +609,7 @@ run_test("user_can_access_all_other_users", ({override}) => {
     };
 
     user_groups.initialize({realm_user_groups: [members, everyone]});
-    realm.realm_can_access_all_users_group = members.id;
+    override(realm, "realm_can_access_all_users_group", members.id);
 
     // Test spectators case.
     page_params.is_spectator = true;
@@ -618,7 +622,7 @@ run_test("user_can_access_all_other_users", ({override}) => {
     override(current_user, "user_id", guest_user_id);
     assert.ok(!settings_data.user_can_access_all_other_users());
 
-    realm.realm_can_access_all_users_group = everyone.id;
+    override(realm, "realm_can_access_all_users_group", everyone.id);
     assert.ok(settings_data.user_can_access_all_other_users());
 });
 
@@ -648,8 +652,8 @@ run_test("user_can_create_private_streams", () => {
 });
 
 run_test("user_can_create_web_public_streams", ({override}) => {
-    realm.server_web_public_streams_enabled = true;
-    realm.realm_enable_spectator_access = true;
+    override(realm, "server_web_public_streams_enabled", true);
+    override(realm, "realm_enable_spectator_access", true);
 
     test_realm_group_settings(
         "realm_can_create_web_public_channel_group",
@@ -666,20 +670,20 @@ run_test("user_can_create_web_public_streams", ({override}) => {
     override(current_user, "user_id", owner_user_id);
     user_groups.initialize({realm_user_groups: [owners]});
 
-    realm.server_web_public_streams_enabled = true;
-    realm.realm_enable_spectator_access = true;
-    realm.realm_can_create_web_public_channel_group = owners.id;
+    override(realm, "server_web_public_streams_enabled", true);
+    override(realm, "realm_enable_spectator_access", true);
+    override(realm, "realm_can_create_web_public_channel_group", owners.id);
     assert.equal(settings_data.user_can_create_web_public_streams(), true);
 
-    realm.realm_enable_spectator_access = false;
-    realm.server_web_public_streams_enabled = true;
+    override(realm, "realm_enable_spectator_access", false);
+    override(realm, "server_web_public_streams_enabled", true);
     assert.equal(settings_data.user_can_create_web_public_streams(), false);
 
-    realm.realm_enable_spectator_access = true;
-    realm.server_web_public_streams_enabled = false;
+    override(realm, "realm_enable_spectator_access", true);
+    override(realm, "server_web_public_streams_enabled", false);
     assert.equal(settings_data.user_can_create_web_public_streams(), false);
 
-    realm.realm_enable_spectator_access = false;
-    realm.server_web_public_streams_enabled = false;
+    override(realm, "realm_enable_spectator_access", false);
+    override(realm, "server_web_public_streams_enabled", false);
     assert.equal(settings_data.user_can_create_web_public_streams(), false);
 });

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -234,11 +234,11 @@ test_realm_group_settings(
     settings_data.user_can_delete_own_message,
 );
 
-run_test("using_dark_theme", () => {
-    user_settings.color_scheme = settings_config.color_scheme_values.dark.code;
+run_test("using_dark_theme", ({override}) => {
+    override(user_settings, "color_scheme", settings_config.color_scheme_values.dark.code);
     assert.equal(settings_data.using_dark_theme(), true);
 
-    user_settings.color_scheme = settings_config.color_scheme_values.automatic.code;
+    override(user_settings, "color_scheme", settings_config.color_scheme_values.automatic.code);
 
     window.matchMedia = (query) => {
         assert.equal(query, "(prefers-color-scheme: dark)");
@@ -252,7 +252,7 @@ run_test("using_dark_theme", () => {
     };
     assert.equal(settings_data.using_dark_theme(), false);
 
-    user_settings.color_scheme = settings_config.color_scheme_values.light.code;
+    override(user_settings, "color_scheme", settings_config.color_scheme_values.light.code);
     assert.equal(settings_data.using_dark_theme(), false);
 });
 

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -4,11 +4,15 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, page_params, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 /*
     Some methods in settings_data are fairly

--- a/web/tests/settings_muted_users.test.js
+++ b/web/tests/settings_muted_users.test.js
@@ -17,8 +17,10 @@ mock_esm("../src/settings_data", {
 const settings_muted_users = zrequire("settings_muted_users");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
 initialize_user_settings({user_settings: {}});
 
 run_test("settings", ({override}) => {

--- a/web/tests/settings_muted_users.test.js
+++ b/web/tests/settings_muted_users.test.js
@@ -17,6 +17,9 @@ mock_esm("../src/settings_data", {
 const settings_muted_users = zrequire("settings_muted_users");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 run_test("settings", ({override}) => {
     people.add_active_user({user_id: 5, email: "five@zulip.com", full_name: "Feivel Fiverson"});

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -33,7 +33,7 @@ initialize_user_settings({user_settings: {}});
 function test(label, f) {
     run_test(label, (helpers) => {
         $("#realm-icon-upload-widget .upload-spinner-background").css = noop;
-        current_user.is_admin = false;
+        helpers.override(current_user, "is_admin", false);
         realm.realm_domains = [
             {domain: "example.com", allow_subdomains: true},
             {domain: "example.org", allow_subdomains: false},
@@ -788,8 +788,8 @@ test("test get_sorted_options_list", () => {
     );
 });
 
-test("misc", () => {
-    current_user.is_admin = false;
+test("misc", ({override}) => {
+    override(current_user, "is_admin", false);
     $("#user-avatar-upload-widget").length = 1;
     $("#user_details_section").length = 1;
 
@@ -843,7 +843,7 @@ test("misc", () => {
     assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
 
     // If organization admin, these UI elements are never disabled.
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
     settings_account.update_name_change_display();
     assert.ok(!$("#full_name").prop("disabled"));
     assert.ok(!$("#full_name_input_container").hasClass("disabled_setting_tooltip"));

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -7,7 +7,6 @@ const {mock_esm, zrequire, set_global} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user, realm} = require("./lib/zpage_params");
 
 const realm_icon = mock_esm("../src/realm_icon");
 
@@ -26,8 +25,13 @@ const settings_bots = zrequire("settings_bots");
 const settings_account = zrequire("settings_account");
 const settings_components = zrequire("settings_components");
 const settings_org = zrequire("settings_org");
+const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 initialize_user_settings({user_settings: {}});
 
 function test(label, f) {

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -38,7 +38,7 @@ function test(label, f) {
             {domain: "example.com", allow_subdomains: true},
             {domain: "example.org", allow_subdomains: false},
         ];
-        realm.realm_authentication_methods = {};
+        helpers.override(realm, "realm_authentication_methods", {});
         settings_org.reset();
         f(helpers);
     });
@@ -288,7 +288,7 @@ function test_extract_property_name() {
     );
 }
 
-function test_sync_realm_settings() {
+function test_sync_realm_settings({override}) {
     const $subsection_stub = $.create("org-subsection-stub");
     $subsection_stub.set_find_results(
         ".save-button-controls",
@@ -339,7 +339,7 @@ function test_sync_realm_settings() {
         $property_dropdown_elem.attr("id", "id_realm_message_content_edit_limit_seconds");
         $property_dropdown_elem.closest = () => $subsection_stub;
 
-        realm.realm_message_content_edit_limit_seconds = 120;
+        override(realm, "realm_message_content_edit_limit_seconds", 120);
 
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
         assert.equal($("#id_realm_message_content_edit_limit_minutes").val(), "2");
@@ -347,11 +347,11 @@ function test_sync_realm_settings() {
 
     {
         /* Test message content edit limit dropdown value sync */
-        realm.realm_message_content_edit_limit_seconds = 120;
+        override(realm, "realm_message_content_edit_limit_seconds", 120);
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
         assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "120");
 
-        realm.realm_message_content_edit_limit_seconds = 130;
+        override(realm, "realm_message_content_edit_limit_seconds", 130);
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
         assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "custom_period");
     }
@@ -363,18 +363,18 @@ function test_sync_realm_settings() {
         $property_elem.attr("id", "id_realm_org_join_restrictions");
         $property_elem.closest = () => $subsection_stub;
 
-        realm.realm_emails_restricted_to_domains = true;
-        realm.realm_disallow_disposable_email_addresses = false;
+        override(realm, "realm_emails_restricted_to_domains", true);
+        override(realm, "realm_disallow_disposable_email_addresses", false);
         settings_org.sync_realm_settings("emails_restricted_to_domains");
         assert.equal($("#id_realm_org_join_restrictions").val(), "only_selected_domain");
 
-        realm.realm_emails_restricted_to_domains = false;
+        override(realm, "realm_emails_restricted_to_domains", false);
 
-        realm.realm_disallow_disposable_email_addresses = true;
+        override(realm, "realm_disallow_disposable_email_addresses", true);
         settings_org.sync_realm_settings("emails_restricted_to_domains");
         assert.equal($("#id_realm_org_join_restrictions").val(), "no_disposable_email");
 
-        realm.realm_disallow_disposable_email_addresses = false;
+        override(realm, "realm_disallow_disposable_email_addresses", false);
         settings_org.sync_realm_settings("emails_restricted_to_domains");
         assert.equal($("#id_realm_org_join_restrictions").val(), "no_restriction");
     }
@@ -392,7 +392,11 @@ function test_sync_realm_settings() {
             save_button_stubs.$save_button_controls,
         );
         $property_elem.val(settings_config.common_policy_values.by_admins_only.code);
-        realm.realm_invite_to_realm_policy = settings_config.common_policy_values.by_members.code;
+        override(
+            realm,
+            "realm_invite_to_realm_policy",
+            settings_config.common_policy_values.by_members.code,
+        );
         save_button_stubs.$save_button_controls.removeClass("hide");
         $subsection_stub.set_find_results(".prop-element", [$property_elem]);
 
@@ -433,17 +437,21 @@ function test_parse_time_limit() {
     test_function("501.34", "501.3");
 }
 
-function test_discard_changes_button(discard_changes) {
+function test_discard_changes_button({override}, discard_changes) {
     const ev = {
         preventDefault: noop,
         stopPropagation: noop,
     };
 
-    realm.realm_allow_edit_history = true;
-    realm.realm_edit_topic_policy = settings_config.common_message_policy_values.by_everyone.code;
-    realm.realm_allow_message_editing = true;
-    realm.realm_message_content_edit_limit_seconds = 3600;
-    realm.realm_message_content_delete_limit_seconds = 120;
+    override(realm, "realm_allow_edit_history", true);
+    override(
+        realm,
+        "realm_edit_topic_policy",
+        settings_config.common_message_policy_values.by_everyone.code,
+    );
+    override(realm, "realm_allow_message_editing", true);
+    override(realm, "realm_message_content_edit_limit_seconds", 3600);
+    override(realm, "realm_message_content_delete_limit_seconds", 120);
 
     const $allow_edit_history = $("#id_realm_allow_edit_history").prop("checked", false);
     const $edit_topic_policy = $("#id_realm_edit_topic_policy").val(
@@ -666,9 +674,10 @@ test("set_up", ({override, override_rewire}) => {
     test_upload_realm_icon(override, upload_realm_logo_or_icon);
     test_extract_property_name();
     test_change_save_button_state();
-    test_sync_realm_settings();
+    test_sync_realm_settings({override});
     test_parse_time_limit();
     test_discard_changes_button(
+        {override},
         $(".admin-realm-form").get_on_handler(
             "click",
             ".subsection-header .subsection-changes-discard button",
@@ -793,52 +802,52 @@ test("misc", ({override}) => {
     $("#user-avatar-upload-widget").length = 1;
     $("#user_details_section").length = 1;
 
-    realm.realm_name_changes_disabled = false;
-    realm.server_name_changes_disabled = false;
+    override(realm, "realm_name_changes_disabled", false);
+    override(realm, "server_name_changes_disabled", false);
     settings_account.update_name_change_display();
     assert.ok(!$("#full_name").prop("disabled"));
     assert.ok(!$("#full_name_input_container").hasClass("disabled_setting_tooltip"));
 
-    realm.realm_name_changes_disabled = true;
-    realm.server_name_changes_disabled = false;
+    override(realm, "realm_name_changes_disabled", true);
+    override(realm, "server_name_changes_disabled", false);
     settings_account.update_name_change_display();
     assert.ok($("#full_name").prop("disabled"));
     assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
 
-    realm.realm_name_changes_disabled = true;
-    realm.server_name_changes_disabled = true;
+    override(realm, "realm_name_changes_disabled", true);
+    override(realm, "server_name_changes_disabled", true);
     settings_account.update_name_change_display();
     assert.ok($("#full_name").prop("disabled"));
     assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
 
-    realm.realm_name_changes_disabled = false;
-    realm.server_name_changes_disabled = true;
+    override(realm, "realm_name_changes_disabled", false);
+    override(realm, "server_name_changes_disabled", true);
     settings_account.update_name_change_display();
     assert.ok($("#full_name").prop("disabled"));
     assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
 
-    realm.realm_email_changes_disabled = false;
+    override(realm, "realm_email_changes_disabled", false);
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email_button").prop("disabled"));
 
-    realm.realm_email_changes_disabled = true;
+    override(realm, "realm_email_changes_disabled", true);
     settings_account.update_email_change_display();
     assert.ok($("#change_email_button").prop("disabled"));
 
-    realm.realm_avatar_changes_disabled = false;
-    realm.server_avatar_changes_disabled = false;
+    override(realm, "realm_avatar_changes_disabled", false);
+    override(realm, "server_avatar_changes_disabled", false);
     settings_account.update_avatar_change_display();
     assert.ok(!$("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
-    realm.realm_avatar_changes_disabled = true;
-    realm.server_avatar_changes_disabled = false;
+    override(realm, "realm_avatar_changes_disabled", true);
+    override(realm, "server_avatar_changes_disabled", false);
     settings_account.update_avatar_change_display();
     assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
-    realm.realm_avatar_changes_disabled = false;
-    realm.server_avatar_changes_disabled = true;
+    override(realm, "realm_avatar_changes_disabled", false);
+    override(realm, "server_avatar_changes_disabled", true);
     settings_account.update_avatar_change_display();
     assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
-    realm.realm_avatar_changes_disabled = true;
-    realm.server_avatar_changes_disabled = true;
+    override(realm, "realm_avatar_changes_disabled", true);
+    override(realm, "server_avatar_changes_disabled", true);
     settings_account.update_avatar_change_display();
     assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
 

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -26,6 +26,9 @@ const settings_bots = zrequire("settings_bots");
 const settings_account = zrequire("settings_account");
 const settings_components = zrequire("settings_components");
 const settings_org = zrequire("settings_org");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 function test(label, f) {
     run_test(label, (helpers) => {

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -55,7 +55,7 @@ function test_populate(opts, template_data) {
     with_overrides(({override}) => {
         const fields_data = opts.fields_data;
 
-        realm.custom_profile_field_types = custom_profile_field_types;
+        override(realm, "custom_profile_field_types", custom_profile_field_types);
         override(current_user, "is_admin", opts.is_admin);
         const $table = $("#admin_profile_fields_table");
         const $rows = $.create("rows");
@@ -82,9 +82,9 @@ function test_populate(opts, template_data) {
     });
 }
 
-run_test("populate_profile_fields", ({mock_template}) => {
-    realm.custom_profile_fields = {};
-    realm.realm_default_external_accounts = JSON.stringify({});
+run_test("populate_profile_fields", ({mock_template, override}) => {
+    override(realm, "custom_profile_fields", {});
+    override(realm, "realm_default_external_accounts", JSON.stringify({}));
 
     $("#admin_profile_fields_table .display_in_profile_summary_false").toggleClass = noop;
 

--- a/web/tests/settings_profile_fields.test.js
+++ b/web/tests/settings_profile_fields.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, realm} = require("./lib/zpage_params");
 
 const loading = mock_esm("../src/loading");
 
@@ -50,6 +49,12 @@ const Sortable = {create: noop};
 mock_esm("sortablejs", {default: Sortable});
 
 const settings_profile_fields = zrequire("settings_profile_fields");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 
 function test_populate(opts, template_data) {
     with_overrides(({override}) => {

--- a/web/tests/settings_user_topics.test.js
+++ b/web/tests/settings_user_topics.test.js
@@ -13,6 +13,9 @@ const list_widget = mock_esm("../src/list_widget", {
 const settings_user_topics = zrequire("settings_user_topics");
 const stream_data = zrequire("stream_data");
 const user_topics = zrequire("user_topics");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const frontend = {
     stream_id: 101,

--- a/web/tests/starred_messages.test.js
+++ b/web/tests/starred_messages.test.js
@@ -90,13 +90,13 @@ run_test("initialize", () => {
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [4, 5, 6]);
 });
 
-run_test("rerender_ui", () => {
+run_test("rerender_ui", ({override}) => {
     starred_messages.starred_ids.clear();
     for (const id of [1, 2, 3]) {
         starred_messages.starred_ids.add(id);
     }
 
-    user_settings.starred_message_counts = true;
+    override(user_settings, "starred_message_counts", true);
     with_overrides(({override}) => {
         const stub = make_stub();
         override(left_sidebar_navigation_area, "update_starred_count", stub.f);
@@ -107,7 +107,7 @@ run_test("rerender_ui", () => {
         assert.equal(args.hidden, false);
     });
 
-    user_settings.starred_message_counts = false;
+    override(user_settings, "starred_message_counts", false);
     with_overrides(({override}) => {
         const stub = make_stub();
         override(left_sidebar_navigation_area, "update_starred_count", stub.f);

--- a/web/tests/starred_messages.test.js
+++ b/web/tests/starred_messages.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, with_overrides, zrequire} = require("./lib/namespace");
 const {make_stub} = require("./lib/stub");
 const {run_test} = require("./lib/test");
-const {user_settings} = require("./lib/zpage_params");
 
 const left_sidebar_navigation_area = mock_esm("../src/left_sidebar_navigation_area", {
     update_starred_count() {},
@@ -13,6 +12,10 @@ const left_sidebar_navigation_area = mock_esm("../src/left_sidebar_navigation_ar
 const message_store = zrequire("message_store");
 const starred_messages = zrequire("starred_messages");
 const starred_messages_ui = zrequire("starred_messages_ui");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 run_test("add starred", () => {
     starred_messages.starred_ids.clear();

--- a/web/tests/stream_create_subscribers_data.test.js
+++ b/web/tests/stream_create_subscribers_data.test.js
@@ -4,10 +4,13 @@ const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user} = require("./lib/zpage_params");
 
 const people = zrequire("people");
+const {set_current_user} = zrequire("state_data");
 const stream_create_subscribers_data = zrequire("stream_create_subscribers_data");
+
+const current_user = {};
+set_current_user(current_user);
 
 const me = {
     email: "me@zulip.com",

--- a/web/tests/stream_create_subscribers_data.test.js
+++ b/web/tests/stream_create_subscribers_data.test.js
@@ -35,13 +35,13 @@ const test_user103 = {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        current_user.is_admin = false;
+        helpers.override(current_user, "is_admin", false);
         people.init();
         people.add_active_user(me);
         people.add_active_user(test_user101);
         people.add_active_user(test_user102);
         people.add_active_user(test_user103);
-        current_user.user_id = me.user_id;
+        helpers.override(current_user, "user_id", me.user_id);
         people.initialize_current_user(me.user_id);
         f(helpers);
     });
@@ -70,11 +70,11 @@ test("basics", () => {
     assert.ok(!stream_create_subscribers_data.must_be_subscribed(test_user101.user_id));
 });
 
-test("must_be_subscribed", () => {
-    current_user.is_admin = false;
+test("must_be_subscribed", ({override}) => {
+    override(current_user, "is_admin", false);
     assert.ok(stream_create_subscribers_data.must_be_subscribed(me.user_id));
     assert.ok(!stream_create_subscribers_data.must_be_subscribed(test_user101.user_id));
-    current_user.is_admin = true;
+    override(current_user, "is_admin", true);
     assert.ok(!stream_create_subscribers_data.must_be_subscribed(me.user_id));
     assert.ok(!stream_create_subscribers_data.must_be_subscribed(test_user101.user_id));
 });

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user, page_params, realm} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 // TODO: Remove after we enable support for
 // web_public_streams in production.
@@ -18,10 +18,15 @@ const settings_config = zrequire("settings_config");
 const sub_store = zrequire("sub_store");
 const stream_data = zrequire("stream_data");
 const hash_util = zrequire("hash_util");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_settings_data = zrequire("stream_settings_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -582,7 +582,7 @@ test("delete_sub", () => {
     stream_data.delete_sub(99999);
 });
 
-test("notifications", () => {
+test("notifications", ({override}) => {
     const india = {
         stream_id: 102,
         name: "India",
@@ -601,13 +601,13 @@ test("notifications", () => {
     assert.ok(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
     assert.ok(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
-    user_settings.enable_stream_desktop_notifications = true;
-    user_settings.enable_stream_audible_notifications = true;
+    override(user_settings, "enable_stream_desktop_notifications", true);
+    override(user_settings, "enable_stream_audible_notifications", true);
     assert.ok(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
     assert.ok(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
-    user_settings.enable_stream_desktop_notifications = false;
-    user_settings.enable_stream_audible_notifications = false;
+    override(user_settings, "enable_stream_desktop_notifications", false);
+    override(user_settings, "enable_stream_audible_notifications", false);
     assert.ok(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
     assert.ok(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
@@ -618,38 +618,38 @@ test("notifications", () => {
 
     india.desktop_notifications = false;
     india.audible_notifications = false;
-    user_settings.enable_stream_desktop_notifications = true;
-    user_settings.enable_stream_audible_notifications = true;
+    override(user_settings, "enable_stream_desktop_notifications", true);
+    override(user_settings, "enable_stream_audible_notifications", true);
     assert.ok(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
     assert.ok(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
-    user_settings.wildcard_mentions_notify = true;
+    override(user_settings, "wildcard_mentions_notify", true);
     assert.ok(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
-    user_settings.wildcard_mentions_notify = false;
+    override(user_settings, "wildcard_mentions_notify", false);
     assert.ok(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     india.wildcard_mentions_notify = true;
     assert.ok(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
-    user_settings.wildcard_mentions_notify = true;
+    override(user_settings, "wildcard_mentions_notify", true);
     india.wildcard_mentions_notify = false;
     assert.ok(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
 
-    user_settings.enable_stream_push_notifications = true;
+    override(user_settings, "enable_stream_push_notifications", true);
     assert.ok(stream_data.receives_notifications(india.stream_id, "push_notifications"));
-    user_settings.enable_stream_push_notifications = false;
+    override(user_settings, "enable_stream_push_notifications", false);
     assert.ok(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
     india.push_notifications = true;
     assert.ok(stream_data.receives_notifications(india.stream_id, "push_notifications"));
-    user_settings.enable_stream_push_notifications = true;
+    override(user_settings, "enable_stream_push_notifications", true);
     india.push_notifications = false;
     assert.ok(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
 
-    user_settings.enable_stream_email_notifications = true;
+    override(user_settings, "enable_stream_email_notifications", true);
     assert.ok(stream_data.receives_notifications(india.stream_id, "email_notifications"));
-    user_settings.enable_stream_email_notifications = false;
+    override(user_settings, "enable_stream_email_notifications", false);
     assert.ok(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
     india.email_notifications = true;
     assert.ok(stream_data.receives_notifications(india.stream_id, "email_notifications"));
-    user_settings.enable_stream_email_notifications = true;
+    override(user_settings, "enable_stream_email_notifications", true);
     india.email_notifications = false;
     assert.ok(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
 
@@ -680,11 +680,11 @@ test("notifications", () => {
     };
     stream_data.add_sub(antarctica);
 
-    user_settings.enable_stream_desktop_notifications = true;
-    user_settings.enable_stream_audible_notifications = true;
-    user_settings.enable_stream_email_notifications = false;
-    user_settings.enable_stream_push_notifications = false;
-    user_settings.wildcard_mentions_notify = true;
+    override(user_settings, "enable_stream_desktop_notifications", true);
+    override(user_settings, "enable_stream_audible_notifications", true);
+    override(user_settings, "enable_stream_email_notifications", false);
+    override(user_settings, "enable_stream_push_notifications", false);
+    override(user_settings, "wildcard_mentions_notify", true);
 
     india.desktop_notifications = null;
     india.audible_notifications = true;

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -324,7 +324,11 @@ test("get_streams_for_user", ({override}) => {
     peer_data.set_subscribers(test.stream_id, [test_user.user_id]);
     peer_data.set_subscribers(world.stream_id, [me.user_id]);
 
-    realm.realm_invite_to_stream_policy = settings_config.common_policy_values.by_admins_only.code;
+    override(
+        realm,
+        "realm_invite_to_stream_policy",
+        settings_config.common_policy_values.by_admins_only.code,
+    );
     assert.deepEqual(stream_data.get_streams_for_user(me.user_id).can_subscribe, [social, errors]);
 
     // test_user is subscribed to all three streams, but current user (me)
@@ -347,7 +351,11 @@ test("get_streams_for_user", ({override}) => {
     ]);
     override(current_user, "is_admin", false);
 
-    realm.realm_invite_to_stream_policy = settings_config.common_policy_values.by_members.code;
+    override(
+        realm,
+        "realm_invite_to_stream_policy",
+        settings_config.common_policy_values.by_members.code,
+    );
     assert.deepEqual(stream_data.get_streams_for_user(test_user.user_id).can_subscribe, [
         world,
         errors,
@@ -757,14 +765,14 @@ const jazy = {
     is_muted: true,
 };
 
-test("is_new_stream_announcements_stream_muted", () => {
+test("is_new_stream_announcements_stream_muted", ({override}) => {
     stream_data.add_sub(tony);
     stream_data.add_sub(jazy);
 
-    realm.realm_new_stream_announcements_stream_id = tony.stream_id;
+    override(realm, "realm_new_stream_announcements_stream_id", tony.stream_id);
     assert.ok(!stream_data.is_new_stream_announcements_stream_muted());
 
-    realm.realm_new_stream_announcements_stream_id = jazy.stream_id;
+    override(realm, "realm_new_stream_announcements_stream_id", jazy.stream_id);
     assert.ok(stream_data.is_new_stream_announcements_stream_muted());
 });
 
@@ -814,10 +822,10 @@ test("muted_stream_ids", () => {
     assert.deepEqual(stream_data.muted_stream_ids(), [1, 3]);
 });
 
-test("realm_has_new_stream_announcements_stream", () => {
-    realm.realm_new_stream_announcements_stream_id = 10;
+test("realm_has_new_stream_announcements_stream", ({override}) => {
+    override(realm, "realm_new_stream_announcements_stream_id", 10);
     assert.ok(stream_data.realm_has_new_stream_announcements_stream());
-    realm.realm_new_stream_announcements_stream_id = -1;
+    override(realm, "realm_new_stream_announcements_stream_id", -1);
     assert.ok(!stream_data.realm_has_new_stream_announcements_stream());
 });
 
@@ -879,7 +887,7 @@ test("create_sub", () => {
 
 test("creator_id", ({override}) => {
     people.add_active_user(test_user);
-    realm.realm_can_access_all_users_group = everyone_group.id;
+    override(realm, "realm_can_access_all_users_group", everyone_group.id);
     override(current_user, "user_id", me.user_id);
     // When creator id is not a valid user id
     assert.throws(() => stream_data.maybe_get_creator_details(-1), {
@@ -905,7 +913,7 @@ test("creator_id", ({override}) => {
     );
 });
 
-test("initialize", () => {
+test("initialize", ({override}) => {
     function get_params() {
         const params = {};
 
@@ -939,7 +947,7 @@ test("initialize", () => {
         stream_data.initialize(get_params());
     }
 
-    realm.realm_new_stream_announcements_stream_id = -1;
+    override(realm, "realm_new_stream_announcements_stream_id", -1);
 
     initialize();
 
@@ -950,7 +958,7 @@ test("initialize", () => {
     assert.equal(stream_data.get_new_stream_announcements_stream(), "");
 
     // Simulate a private stream the user isn't subscribed to
-    realm.realm_new_stream_announcements_stream_id = 89;
+    override(realm, "realm_new_stream_announcements_stream_id", 89);
     initialize();
     assert.equal(stream_data.get_new_stream_announcements_stream(), "");
 
@@ -1081,7 +1089,7 @@ test("can_post_messages_in_stream", ({override}) => {
     social.stream_post_policy = settings_config.stream_post_policy_values.non_new_members.code;
     override(current_user, "is_moderator", false);
     me.date_joined = new Date(Date.now());
-    realm.realm_waiting_period_threshold = 10;
+    override(realm, "realm_waiting_period_threshold", 10);
     assert.equal(stream_data.can_post_messages_in_stream(social), false);
 
     me.date_joined = new Date(Date.now() - 20 * 86400000);

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user, page_params, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params, realm} = require("./lib/zpage_params");
 
 // TODO: Remove after we enable support for
 // web_public_streams in production.
@@ -20,6 +20,10 @@ const stream_data = zrequire("stream_data");
 const hash_util = zrequire("hash_util");
 const stream_settings_data = zrequire("stream_settings_data");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 mock_esm("../src/group_permission_settings", {
     get_group_permission_setting_config() {

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -46,9 +46,13 @@ const narrow_state = zrequire("narrow_state");
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_create = zrequire("stream_create");
 const stream_data = zrequire("stream_data");
 const stream_events = zrequire("stream_events");
+
+set_current_user({});
+set_realm({});
 
 const george = {
     email: "george@zulip.com",

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -5,11 +5,10 @@ const assert = require("node:assert/strict");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params} = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 set_global("document", "document-stub");
 
-current_user.is_admin = false;
 page_params.realm_users = [];
 
 // We use this with override.

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -5,7 +5,7 @@ const assert = require("node:assert/strict");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user, page_params, user_settings} = require("./lib/zpage_params");
+const {current_user, page_params} = require("./lib/zpage_params");
 
 set_global("document", "document-stub");
 
@@ -35,6 +35,10 @@ const {Filter} = zrequire("../src/filter");
 const stream_data = zrequire("stream_data");
 const stream_list = zrequire("stream_list");
 const stream_list_sort = zrequire("stream_list_sort");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const devel = {
     name: "devel",

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -126,10 +126,10 @@ function test_ui(label, f) {
     });
 }
 
-test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
+test_ui("create_sidebar_row", ({override, override_rewire, mock_template}) => {
     // Make a couple calls to create_sidebar_row() and make sure they
     // generate the right markup as well as play nice with get_stream_li().
-    user_settings.demote_inactive_streams = 1;
+    override(user_settings, "demote_inactive_streams", 1);
 
     stream_data.add_sub(devel);
     stream_data.add_sub(social);
@@ -645,8 +645,8 @@ test_ui("separators_only_pinned", () => {
     assert.deepEqual(appended_elems, expected_elems);
 });
 
-test_ui("rename_stream", ({mock_template}) => {
-    user_settings.web_stream_unreads_count_display_policy = 3;
+test_ui("rename_stream", ({mock_template, override}) => {
+    override(user_settings, "web_stream_unreads_count_display_policy", 3);
 
     create_stream_subheader({mock_template});
     initialize_stream_data();
@@ -726,7 +726,7 @@ test_ui("refresh_pin", ({override, override_rewire, mock_template}) => {
 });
 
 test_ui("create_initial_sidebar_rows", ({override, override_rewire, mock_template}) => {
-    user_settings.web_stream_unreads_count_display_policy = 2; // Test coverage for this setting.
+    override(user_settings, "web_stream_unreads_count_display_policy", 2); // Test coverage for this setting.
     initialize_stream_data();
 
     const html_dict = new Map();

--- a/web/tests/stream_list_sort.test.js
+++ b/web/tests/stream_list_sort.test.js
@@ -196,15 +196,18 @@ test("basics", ({override_rewire}) => {
     assert.deepEqual(sorted.dormant_streams, []);
 });
 
-test("has_recent_activity", () => {
+test("has_recent_activity", ({override}) => {
     people.init();
     people.add_active_user(me);
     people.initialize_current_user(me.user_id);
 
     let sub;
 
-    user_settings.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.automatic.code;
+    override(
+        user_settings,
+        "demote_inactive_streams",
+        settings_config.demote_inactive_streams_values.automatic.code,
+    );
 
     stream_list_sort.set_filter_out_inactives();
 
@@ -235,8 +238,11 @@ test("has_recent_activity", () => {
 
     assert.ok(stream_list_sort.has_recent_activity(sub));
 
-    user_settings.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.always.code;
+    override(
+        user_settings,
+        "demote_inactive_streams",
+        settings_config.demote_inactive_streams_values.always.code,
+    );
 
     stream_list_sort.set_filter_out_inactives();
 
@@ -264,8 +270,11 @@ test("has_recent_activity", () => {
 
     assert.ok(stream_list_sort.has_recent_activity(sub));
 
-    user_settings.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.never.code;
+    override(
+        user_settings,
+        "demote_inactive_streams",
+        settings_config.demote_inactive_streams_values.never.code,
+    );
 
     stream_list_sort.set_filter_out_inactives();
 
@@ -294,9 +303,12 @@ test("has_recent_activity_but_muted", () => {
     assert.ok(stream_list_sort.has_recent_activity_but_muted(sub));
 });
 
-test("filter inactives", () => {
-    user_settings.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.automatic.code;
+test("filter inactives", ({override}) => {
+    override(
+        user_settings,
+        "demote_inactive_streams",
+        settings_config.demote_inactive_streams_values.automatic.code,
+    );
 
     assert.ok(!stream_list_sort.is_filtering_inactives());
 
@@ -317,8 +329,8 @@ test("filter inactives", () => {
     assert.ok(stream_list_sort.is_filtering_inactives());
 });
 
-test("initialize", () => {
-    user_settings.demote_inactive_streams = 1;
+test("initialize", ({override}) => {
+    override(user_settings, "demote_inactive_streams", 1);
     stream_list_sort.initialize();
 
     assert.ok(!stream_list_sort.is_filtering_inactives());

--- a/web/tests/stream_list_sort.test.js
+++ b/web/tests/stream_list_sort.test.js
@@ -6,13 +6,16 @@ const _ = require("lodash");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {user_settings} = require("./lib/zpage_params");
 
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const stream_list_sort = zrequire("stream_list_sort");
 const settings_config = zrequire("settings_config");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 function contains_sub(subs, sub) {
     return subs.some((s) => s.name === sub.name);

--- a/web/tests/stream_pill.test.js
+++ b/web/tests/stream_pill.test.js
@@ -56,9 +56,9 @@ const me = {
 people.add_active_user(me);
 people.initialize_current_user(me.user_id);
 
-run_test("create_item", () => {
-    current_user.user_id = me.user_id;
-    current_user.is_admin = true;
+run_test("create_item", ({override}) => {
+    override(current_user, "user_id", me.user_id);
+    override(current_user, "is_admin", true);
     function test_create_item(
         stream_name,
         current_items,

--- a/web/tests/stream_pill.test.js
+++ b/web/tests/stream_pill.test.js
@@ -4,12 +4,16 @@ const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user} = require("./lib/zpage_params");
 
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_pill = zrequire("stream_pill");
+
+const current_user = {};
+set_current_user(current_user);
+set_realm({});
 
 const denmark = {
     stream_id: 101,

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -28,6 +28,9 @@ set_global("page_params", {});
 const stream_data = zrequire("stream_data");
 const stream_settings_ui = zrequire("stream_settings_ui");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 run_test("redraw_left_panel", ({mock_template}) => {
     const admins_group = {

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -25,11 +25,14 @@ mock_esm("../src/hash_parser", {
 });
 set_global("page_params", {});
 
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_settings_ui = zrequire("stream_settings_ui");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+set_realm({});
+set_current_user({});
 initialize_user_settings({user_settings: {}});
 
 run_test("redraw_left_panel", ({mock_template}) => {

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -12,9 +12,12 @@ const all_messages_data = zrequire("all_messages_data");
 const echo_state = zrequire("echo_state");
 const unread = zrequire("unread");
 const message_store = zrequire("message_store");
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const stream_topic_history_util = zrequire("stream_topic_history_util");
+
+set_realm({});
 
 stream_topic_history.set_update_topic_last_message_id(noop);
 

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -9,7 +9,11 @@ const {$t} = require("./lib/i18n");
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {user_settings} = require("./lib/zpage_params");
+
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const timerender = zrequire("timerender");
 

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -11,8 +11,6 @@ const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 const {user_settings} = require("./lib/zpage_params");
 
-user_settings.twenty_four_hour_time = true;
-
 const timerender = zrequire("timerender");
 
 function get_date(time_ISO, DOW) {
@@ -35,18 +33,21 @@ const date_2021 = get_date("2021-01-27T01:53:08.000Z", "Wednesday");
 
 const date_2025 = get_date("2025-03-03T12:10:00.000Z", "Monday");
 
-run_test("get_localized_date_or_time_for_format returns default date with incorrect locale", () => {
-    const date = date_2019;
-    const expectedDate = "Friday, April 12, 2019";
+run_test(
+    "get_localized_date_or_time_for_format returns default date with incorrect locale",
+    ({override}) => {
+        const date = date_2019;
+        const expectedDate = "Friday, April 12, 2019";
 
-    user_settings.default_language = "invalid";
-    const actualDate = timerender.get_localized_date_or_time_for_format(
-        date,
-        "weekday_dayofyear_year",
-    );
+        override(user_settings, "default_language", "invalid");
+        const actualDate = timerender.get_localized_date_or_time_for_format(
+            date,
+            "weekday_dayofyear_year",
+        );
 
-    assert.equal(actualDate, expectedDate);
-});
+        assert.equal(actualDate, expectedDate);
+    },
+);
 
 run_test("get_localized_date_or_time_for_format returns correct format", () => {
     const date = date_2021;
@@ -119,7 +120,7 @@ run_test("get_localized_date_or_time_for_format returns correct format", () => {
     }
 });
 
-run_test("get_localized_date_or_time_for_format returns correct localized date", () => {
+run_test("get_localized_date_or_time_for_format returns correct localized date", ({override}) => {
     const date = add(date_2019, {years: -1});
     const languages = [
         {
@@ -161,7 +162,7 @@ run_test("get_localized_date_or_time_for_format returns correct localized date",
     ];
 
     for (const language of languages) {
-        user_settings.default_language = language.language;
+        override(user_settings, "default_language", language.language);
         const actualDate = timerender.get_localized_date_or_time_for_format(
             date,
             "weekday_dayofyear_year",
@@ -398,8 +399,8 @@ run_test("get_timestamp_for_flatpickr", () => {
     MockDate.reset();
 });
 
-run_test("absolute_time_12_hour", () => {
-    user_settings.twenty_four_hour_time = false;
+run_test("absolute_time_12_hour", ({override}) => {
+    override(user_settings, "twenty_four_hour_time", false);
 
     // timestamp with hour > 12, same year
     let timestamp = date_2019.getTime();
@@ -436,8 +437,8 @@ run_test("absolute_time_12_hour", () => {
     MockDate.reset();
 });
 
-run_test("absolute_time_24_hour", () => {
-    user_settings.twenty_four_hour_time = true;
+run_test("absolute_time_24_hour", ({override}) => {
+    override(user_settings, "twenty_four_hour_time", true);
 
     // date with hour > 12, same year
     let today = date_2019;
@@ -470,7 +471,7 @@ run_test("absolute_time_24_hour", () => {
     MockDate.reset();
 });
 
-run_test("get_full_datetime", () => {
+run_test("get_full_datetime", ({override}) => {
     const time = date_2017_PM;
 
     let expected = "translated: 5/18/2017 at 9:12:53 PM UTC";
@@ -484,13 +485,13 @@ run_test("get_full_datetime", () => {
     assert.equal(timerender.get_full_datetime(time, "time"), expected);
 
     // test 24 hour time setting.
-    user_settings.twenty_four_hour_time = true;
+    override(user_settings, "twenty_four_hour_time", true);
     expected = "translated: 5/18/2017 at 21:12:53 UTC";
     assert.equal(timerender.get_full_datetime_clarification(time), expected);
     expected = "translated: May 18, 2017 at 21:12:53";
     assert.equal(timerender.get_full_datetime(time), expected);
 
-    user_settings.twenty_four_hour_time = false;
+    override(user_settings, "twenty_four_hour_time", false);
 
     // Test the GMT[+-]x:y logic.
     timerender.set_display_time_zone("Asia/Kolkata");
@@ -615,21 +616,21 @@ run_test("relative_time_string_from_date", () => {
     MockDate.reset();
 });
 
-run_test("set_full_datetime", () => {
+run_test("set_full_datetime", ({override}) => {
     let time = date_2019;
 
-    user_settings.twenty_four_hour_time = true;
+    override(user_settings, "twenty_four_hour_time", true);
     let time_str = timerender.stringify_time(time);
     let expected = "17:52";
     assert.equal(time_str, expected);
 
-    user_settings.twenty_four_hour_time = false;
+    override(user_settings, "twenty_four_hour_time", false);
     time_str = timerender.stringify_time(time);
     expected = "5:52 PM";
     assert.equal(time_str, expected);
 
     time = add(time, {hours: -7}); // time between 1 to 12 o'clock time.
-    user_settings.twenty_four_hour_time = false;
+    override(user_settings, "twenty_four_hour_time", false);
     time_str = timerender.stringify_time(time);
     expected = "10:52 AM";
     assert.equal(time_str, expected);

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -31,10 +31,13 @@ const narrow_state = mock_esm("../src/narrow_state", {
     stream_id() {},
 });
 
+const {set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const topic_list_data = zrequire("topic_list_data");
 const unread = zrequire("unread");
+
+set_realm({});
 
 const general = {
     stream_id: 556,

--- a/web/tests/transmit.test.js
+++ b/web/tests/transmit.test.js
@@ -151,7 +151,7 @@ run_test("reply_message_stream", ({override}) => {
         send_message_args = data;
     });
 
-    current_user.user_id = 44;
+    override(current_user, "user_id", 44);
     server_events.queue_id = 66;
     sent_messages.get_new_local_id = () => "99";
 
@@ -192,7 +192,7 @@ run_test("reply_message_private", ({override}) => {
         send_message_args = data;
     });
 
-    current_user.user_id = 155;
+    override(current_user, "user_id", 155);
     server_events.queue_id = 177;
     sent_messages.get_new_local_id = () => "199";
 

--- a/web/tests/transmit.test.js
+++ b/web/tests/transmit.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {current_user} = require("./lib/zpage_params");
 
 const channel = mock_esm("../src/channel");
 const reload = mock_esm("../src/reload");
@@ -25,7 +24,11 @@ const server_events = mock_esm("../src/server_events");
 
 const people = zrequire("people");
 const transmit = zrequire("transmit");
+const {set_current_user} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
+
+const current_user = {};
+set_current_user(current_user);
 
 run_test("transmit_message_ajax", () => {
     let success_func_called;

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -178,7 +178,7 @@ function test(label, f) {
         recent_senders.clear_for_testing();
         peer_data.clear_for_testing();
         people.clear_recipient_counts_for_testing();
-        current_user.is_admin = false;
+        helpers.override(current_user, "is_admin", false);
         realm.realm_is_zephyr_mirror_realm = false;
 
         f(helpers);

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -4,7 +4,6 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, realm} = require("./lib/zpage_params");
 
 const stream_topic_history = mock_esm("../src/stream_topic_history");
 
@@ -19,12 +18,17 @@ const stream_list_sort = zrequire("stream_list_sort");
 const compose_state = zrequire("compose_state");
 const emoji = zrequire("emoji");
 const pygments_data = zrequire("pygments_data");
+const {set_current_user, set_realm} = zrequire("state_data");
 const util = zrequire("util");
 const ct = zrequire("composebox_typeahead");
 const th = zrequire("typeahead_helper");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
 
+const current_user = {};
+set_current_user(current_user);
+const realm = {};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {current_user, realm, user_settings} = require("./lib/zpage_params");
+const {current_user, realm} = require("./lib/zpage_params");
 
 const stream_topic_history = mock_esm("../src/stream_topic_history");
 
@@ -23,6 +23,10 @@ const util = zrequire("util");
 const ct = zrequire("composebox_typeahead");
 const th = zrequire("typeahead_helper");
 const user_groups = zrequire("user_groups");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 let next_id = 0;
 

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -179,7 +179,7 @@ function test(label, f) {
         peer_data.clear_for_testing();
         people.clear_recipient_counts_for_testing();
         helpers.override(current_user, "is_admin", false);
-        realm.realm_is_zephyr_mirror_realm = false;
+        helpers.override(realm, "realm_is_zephyr_mirror_realm", false);
 
         f(helpers);
     });

--- a/web/tests/typing_events.test.js
+++ b/web/tests/typing_events.test.js
@@ -5,15 +5,19 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {current_user} = require("./lib/zpage_params");
 
 const settings_data = mock_esm("../src/settings_data");
 
 const {Filter} = zrequire("filter");
 const message_lists = zrequire("message_lists");
 const people = zrequire("people");
+const {set_current_user, set_realm} = zrequire("state_data");
 const typing_data = zrequire("typing_data");
 const typing_events = zrequire("typing_events");
+
+const current_user = {};
+set_current_user(current_user);
+set_realm({});
 
 const anna = {
     email: "anna@example.com",

--- a/web/tests/typing_status.test.js
+++ b/web/tests/typing_status.test.js
@@ -11,6 +11,9 @@ const stream_data = mock_esm("../src/stream_data");
 
 const typing = zrequire("typing");
 const typing_status = zrequire("../shared/src/typing_status");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const TYPING_STARTED_WAIT_PERIOD = 10000;
 const TYPING_STOPPED_WAIT_PERIOD = 5000;

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -6,7 +6,7 @@ const _ = require("lodash");
 
 const {set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {realm, user_settings} = require("./lib/zpage_params");
+const {realm} = require("./lib/zpage_params");
 
 realm.realm_push_notifications_enabled = false;
 
@@ -18,6 +18,10 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const sub_store = zrequire("sub_store");
 const unread = zrequire("unread");
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
 
 const me = {
     email: "me@example.com",

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -6,9 +6,6 @@ const _ = require("lodash");
 
 const {set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const {realm} = require("./lib/zpage_params");
-
-realm.realm_push_notifications_enabled = false;
 
 set_global("document", "document-stub");
 const {FoldDict} = zrequire("fold_dict");

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 
 const _ = require("lodash");
 
-const {zrequire, set_global} = require("./lib/namespace");
+const {set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const {realm, user_settings} = require("./lib/zpage_params");
 
@@ -51,18 +51,20 @@ function assert_zero_counts(counts) {
 }
 
 function test_notifiable_count(home_unread_messages, expected_notifiable_count) {
-    user_settings.desktop_icon_count_display = 1;
-    let notifiable_counts = unread.get_notifiable_count();
-    assert.deepEqual(notifiable_counts, home_unread_messages);
-    user_settings.desktop_icon_count_display = 2;
-    notifiable_counts = unread.get_notifiable_count();
-    assert.deepEqual(notifiable_counts, expected_notifiable_count);
-    user_settings.desktop_icon_count_display = 3;
-    notifiable_counts = unread.get_notifiable_count();
-    assert.deepEqual(notifiable_counts, expected_notifiable_count);
-    user_settings.desktop_icon_count_display = 4;
-    notifiable_counts = unread.get_notifiable_count();
-    assert.deepEqual(notifiable_counts, 0);
+    with_overrides(({override}) => {
+        override(user_settings, "desktop_icon_count_display", 1);
+        let notifiable_counts = unread.get_notifiable_count();
+        assert.deepEqual(notifiable_counts, home_unread_messages);
+        override(user_settings, "desktop_icon_count_display", 2);
+        notifiable_counts = unread.get_notifiable_count();
+        assert.deepEqual(notifiable_counts, expected_notifiable_count);
+        override(user_settings, "desktop_icon_count_display", 3);
+        notifiable_counts = unread.get_notifiable_count();
+        assert.deepEqual(notifiable_counts, expected_notifiable_count);
+        override(user_settings, "desktop_icon_count_display", 4);
+        notifiable_counts = unread.get_notifiable_count();
+        assert.deepEqual(notifiable_counts, 0);
+    });
 }
 
 function test(label, f) {

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {realm} = require("./lib/zpage_params");
 
 class ClipboardEvent {
     constructor({clipboardData}) {
@@ -34,6 +33,11 @@ const rows = mock_esm("../src/rows");
 const compose_ui = zrequire("compose_ui");
 const upload = zrequire("upload");
 const message_lists = mock_esm("../src/message_lists");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
+
 message_lists.current = {
     id: "1",
 };

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -39,7 +39,7 @@ message_lists.current = {
 };
 function test(label, f) {
     run_test(label, (helpers) => {
-        realm.max_file_upload_size_mib = 25;
+        helpers.override(realm, "max_file_upload_size_mib", 25);
         return f(helpers);
     });
 }
@@ -162,7 +162,7 @@ test("show_error_message", ({mock_template}) => {
     upload.show_error_message(upload.compose_config);
 });
 
-test("upload_files", async ({mock_template, override_rewire}) => {
+test("upload_files", async ({mock_template, override, override_rewire}) => {
     $("#compose_banners .upload_banner").remove = noop;
     $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
@@ -208,12 +208,12 @@ test("upload_files", async ({mock_template, override_rewire}) => {
         banner_shown = true;
         return "<banner-stub>";
     });
-    realm.max_file_upload_size_mib = 0;
+    override(realm, "max_file_upload_size_mib", 0);
     $("#compose_banners .upload_banner .upload_msg").text("");
     await upload.upload_files(uppy, config, files);
     assert.ok(banner_shown);
 
-    realm.max_file_upload_size_mib = 25;
+    override(realm, "max_file_upload_size_mib", 25);
     let on_click_close_button_callback;
 
     $("#compose_banners .upload_banner.file_id_123 .upload_banner_cancel_button").one = (

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -52,8 +52,6 @@ mock_esm("../src/settings_streams", {
     maybe_disable_widgets() {},
 });
 
-current_user.is_admin = true;
-
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
 const user_events = zrequire("user_events");

--- a/web/tests/user_events.test.js
+++ b/web/tests/user_events.test.js
@@ -6,7 +6,6 @@ const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
-const {current_user} = require("./lib/zpage_params");
 
 const message_live_update = mock_esm("../src/message_live_update");
 const navbar_alerts = mock_esm("../src/navbar_alerts");
@@ -54,7 +53,12 @@ mock_esm("../src/settings_streams", {
 
 const people = zrequire("people");
 const settings_config = zrequire("settings_config");
+const {set_current_user, set_realm} = zrequire("state_data");
 const user_events = zrequire("user_events");
+
+const current_user = {};
+set_current_user(current_user);
+set_realm({});
 
 const me = {
     email: "me@example.com",

--- a/web/tests/user_groups.test.js
+++ b/web/tests/user_groups.test.js
@@ -5,9 +5,12 @@ const assert = require("node:assert/strict");
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {realm} = require("./lib/zpage_params");
 
 const user_groups = zrequire("user_groups");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
 
 run_test("user_groups", () => {
     const students = {

--- a/web/tests/user_pill.test.js
+++ b/web/tests/user_pill.test.js
@@ -5,12 +5,15 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
-const {realm} = require("./lib/zpage_params");
 
 const people = zrequire("people");
 const user_pill = zrequire("user_pill");
+const {set_realm} = zrequire("state_data");
 
 const settings_data = mock_esm("../src/settings_data");
+
+const realm = {};
+set_realm(realm);
 
 const alice = {
     email: "alice@example.com",

--- a/web/tests/user_pill.test.js
+++ b/web/tests/user_pill.test.js
@@ -67,13 +67,13 @@ function test(label, f) {
     });
 }
 
-test("create_item", () => {
+test("create_item", ({override}) => {
     function test_create_item(email, current_items, expected_item, pill_config) {
         const item = user_pill.create_item_from_email(email, current_items, pill_config);
         assert.deepEqual(item, expected_item);
     }
 
-    realm.realm_is_zephyr_mirror_realm = true;
+    override(realm, "realm_is_zephyr_mirror_realm", true);
 
     test_create_item("bogus@example.com", [], bogus_item);
     test_create_item("bogus@example.com", [bogus_item], undefined);
@@ -81,14 +81,14 @@ test("create_item", () => {
     test_create_item("isaac@example.com", [], isaac_item);
     test_create_item("isaac@example.com", [isaac_item], undefined);
 
-    realm.realm_is_zephyr_mirror_realm = false;
+    override(realm, "realm_is_zephyr_mirror_realm", false);
 
     test_create_item("bogus@example.com", [], undefined);
     test_create_item("isaac@example.com", [], isaac_item);
     test_create_item("isaac@example.com", [isaac_item], undefined);
 
     settings_data.user_can_access_all_other_users = () => false;
-    realm.realm_bot_domain = "example.com";
+    override(realm, "realm_bot_domain", "example.com");
     people.add_inaccessible_user(inaccessible_user_id);
 
     test_create_item("user103@example.com", [], undefined, {exclude_inaccessible_users: true});

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {set_global, mock_esm, zrequire} = require("./lib/namespace");
 const {run_test, noop} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {realm} = require("./lib/zpage_params");
 
 const fake_buddy_list = {
     scroll_container_selector: "#whatever",
@@ -46,6 +45,10 @@ const activity_ui = zrequire("activity_ui");
 const buddy_data = zrequire("buddy_data");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
 
 const me = {
     email: "me@zulip.com",

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -122,7 +122,7 @@ test("clear_search", ({override}) => {
 });
 
 test("escape_search", ({override}) => {
-    realm.realm_presence_disabled = true;
+    override(realm, "realm_presence_disabled", true);
 
     override(resize, "resize_sidebars", noop);
     override(popovers, "hide_all", noop);
@@ -233,7 +233,7 @@ test("click on user header to toggle display", ({override}) => {
     override(sidebar_ui, "show_userlist_sidebar", noop);
     override(resize, "resize_sidebars", noop);
 
-    realm.realm_presence_disabled = true;
+    override(realm, "realm_presence_disabled", true);
 
     assert.ok(!$("#user_search_section").hasClass("notdisplayed"));
 

--- a/web/tests/user_status.test.js
+++ b/web/tests/user_status.test.js
@@ -10,6 +10,9 @@ const channel = mock_esm("../src/channel");
 const user_status = zrequire("user_status");
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
 const emoji = zrequire("emoji");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const emoji_params = {
     realm_emoji: {

--- a/web/tests/user_topics.test.js
+++ b/web/tests/user_topics.test.js
@@ -10,6 +10,9 @@ const blueslip = require("./lib/zblueslip");
 
 const user_topics = zrequire("user_topics");
 const stream_data = zrequire("stream_data");
+const {initialize_user_settings} = zrequire("user_settings");
+
+initialize_user_settings({user_settings: {}});
 
 const design = {
     stream_id: 100,

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -9,9 +9,12 @@ const {set_global, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 
 const blueslip = zrequire("blueslip");
+const {initialize_user_settings} = zrequire("user_settings");
 
 set_global("document", {});
 const util = zrequire("util");
+
+initialize_user_settings({user_settings: {}});
 
 run_test("CachedValue", () => {
     let x = 5;


### PR DESCRIPTION
We previously auto-mocked this out of expediency, but that made it impossible to test anything that uses the Zod schemata in the same module.

Future work: we should unmock the other four modules mocked by `zpage_params`, too.