### PR TITLE
popovers: Fix initial focus on popover simplebar container.

### DIFF
--- a/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         {{#if is_home_view}}
         <li role="none" class="link-item popover-menu-list-item">

--- a/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list condensed-views-popover-menu">
         <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-reactions">
             <a href="#narrow/has/reaction/sender/me" role="menuitem" class="popover-menu-link tippy-left-sidebar-tooltip" data-tooltip-template-id="my-reactions-tooltip-template" tabindex="0">

--- a/web/templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="delete_all_drafts_sidebar" class="popover-menu-link" tabindex="0">

--- a/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         {{#if is_home_view}}
         <li role="none" class="link-item popover-menu-list-item">

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         {{#if is_home_view}}
         <li role="none" class="link-item popover-menu-list-item">

--- a/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         {{#if show_unstar_all_button}}
         <li role="none" class="link-item popover-menu-list-item">

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_setting_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar>
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="link-item popover-menu-list-item">
             <a href="#channels/notsubscribed" role="menuitem" class="popover-menu-link navigate_and_close_popover" tabindex="0">


### PR DESCRIPTION
This PR is a follow-up of 43eebbf9c6b6ef8f3da517bed2b2841143e27b1e, and it sets `data-simplebar-tab-index="-1"` on the remaining popovers.

This prevents the simplebar container from taking focus while trying to navigate the popovers via the keyboard, thus fixing the bug where the user had to click the down key twice before reaching the first focus-able popover menu option.

<!-- Describe your pull request here.-->

Fixes: [CZO DIscussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/extra.20.22down.22.20required.20to.20select.20top.20option/near/1957947)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/fe2a4c03-c475-417d-863d-7b170f54c460) | ![after](https://github.com/user-attachments/assets/ef3425e4-4e98-4cf8-81fa-f9814c719123) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
