### PR TITLE
desktop_notifications: refactor emoji handling in notifications

### DIFF
--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -3,20 +3,18 @@ import $ from "jquery";
 import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as desktop_notifications from "./desktop_notifications";
-import type { ElectronBridgeNotification } from "./desktop_notifications";
-import { $t } from "./i18n";
+import type {ElectronBridgeNotification} from "./desktop_notifications";
+import {$t} from "./i18n";
 import * as message_parser from "./message_parser";
-import type { Message } from "./message_store";
+import type {Message} from "./message_store";
 import * as message_view from "./message_view";
 import * as people from "./people";
 import * as spoilers from "./spoilers";
 import * as stream_data from "./stream_data";
 import * as ui_util from "./ui_util";
-import { user_settings } from "./user_settings";
+import {user_settings} from "./user_settings";
 import * as user_topics from "./user_topics";
 import * as util from "./util";
-
-import { get_emoji_codepoint } from "./emoji";
 
 type TestNotificationMessage = {
     id: number;
@@ -43,17 +41,7 @@ function get_notification_content(message: Message | TestNotificationMessage): s
     // Convert the content to plain text, replacing emoji with their Unicode representations
     const $content = $("<div>").html(message.content);
 
-    // Extract canonical emoji name and convert to Unicode
-    $content.find("span.emoji").each(function () {
-        const emoji_canonical_name = $(this).text().slice(1, -1);
-        const emoji_codepoint = get_emoji_codepoint(emoji_canonical_name);
-        if (emoji_codepoint) {
-            $(this).text(String.fromCodePoint(parseInt(emoji_codepoint, 16)));
-        } else {
-            $(this).text(emoji_canonical_name);
-        }
-    });
-
+    ui_util.change_emoji_name_to_unicode($content);
     ui_util.change_katex_to_raw_latex($content);
     ui_util.potentially_collapse_quotes($content);
     spoilers.hide_spoilers_in_notification($content);
@@ -63,7 +51,7 @@ function get_notification_content(message: Message | TestNotificationMessage): s
         (message_parser.message_has_image(message.content) ||
             message_parser.message_has_attachment(message.content))
     ) {
-        content = $t({ defaultMessage: "(attached file)" });
+        content = $t({defaultMessage: "(attached file)"});
     } else {
         content = $content.text();
     }
@@ -77,8 +65,8 @@ function get_notification_content(message: Message | TestNotificationMessage): s
         !user_settings.pm_content_in_desktop_notifications
     ) {
         content = $t(
-            { defaultMessage: "New direct message from {sender_full_name}" },
-            { sender_full_name: message.sender_full_name },
+            {defaultMessage: "New direct message from {sender_full_name}"},
+            {sender_full_name: message.sender_full_name},
         );
     }
 
@@ -131,8 +119,8 @@ function get_notification_title(
 
     if (msg_count > 1) {
         title_prefix = $t(
-            { defaultMessage: "{msg_count} messages from {sender_name}" },
-            { msg_count, sender_name: message.sender_full_name },
+            {defaultMessage: "{msg_count} messages from {sender_name}"},
+            {msg_count, sender_name: message.sender_full_name},
         );
     }
 
@@ -153,17 +141,17 @@ function get_notification_title(
                 if (title_prefix.length + other_recipients_translated.length > 50) {
                     // Then count how many people are in the conversation and summarize
                     title_suffix = $t(
-                        { defaultMessage: "(to you and {participants_count} more)" },
-                        { participants_count: message.display_recipient.length - 2 },
+                        {defaultMessage: "(to you and {participants_count} more)"},
+                        {participants_count: message.display_recipient.length - 2},
                     );
                 } else {
                     title_suffix = $t(
-                        { defaultMessage: "(to you and {other_participant_names})" },
-                        { other_participant_names: other_recipients_translated },
+                        {defaultMessage: "(to you and {other_participant_names})"},
+                        {other_participant_names: other_recipients_translated},
                     );
                 }
             } else {
-                title_suffix = $t({ defaultMessage: "(to you)" });
+                title_suffix = $t({defaultMessage: "(to you)"});
             }
 
             return title_prefix + " " + title_suffix;
@@ -222,7 +210,7 @@ export function process_notification(notification: {
             notification_object.addEventListener("click", () => {
                 notification_object.close();
                 if (message.type !== "test-notification") {
-                    message_view.narrow_by_topic(message.id, { trigger: "notification" });
+                    message_view.narrow_by_topic(message.id, {trigger: "notification"});
                 }
                 window.focus();
             });

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -22,19 +22,6 @@ export function place_caret_at_end(el: HTMLElement): void {
     }
 }
 
-export function replace_emoji_with_text($element: JQuery): void {
-    $element
-        .find(".emoji")
-        .text(function () {
-            if ($(this).is("img")) {
-                return $(this).attr("alt") ?? "";
-            }
-            return $(this).text();
-        })
-        .contents()
-        .unwrap();
-}
-
 export function change_katex_to_raw_latex($element: JQuery): void {
     // Find all the span elements with the class "katex"
     $element.find("span.katex").each(function () {

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -4,6 +4,8 @@ import * as blueslip from "./blueslip";
 import * as hash_parser from "./hash_parser";
 import * as keydown_util from "./keydown_util";
 
+import {get_emoji_codepoint} from "./emoji";
+
 // Add functions to this that have no non-trivial
 // dependencies other than jQuery.
 
@@ -20,6 +22,18 @@ export function place_caret_at_end(el: HTMLElement): void {
         sel?.removeAllRanges();
         sel?.addRange(range);
     }
+}
+
+export function change_emoji_name_to_unicode($element: JQuery): void {
+    $element.find(".emoji").each(function () {
+        const emoji_canonical_name = $(this).text().slice(1, -1);
+        const emoji_codepoint = get_emoji_codepoint(emoji_canonical_name);
+        if (emoji_codepoint) {
+            $(this).text(String.fromCodePoint(parseInt(emoji_codepoint, 16)));
+        } else {
+            $(this).text(emoji_canonical_name);
+        }
+    });
 }
 
 export function change_katex_to_raw_latex($element: JQuery): void {


### PR DESCRIPTION
Fixes #30598: Emoji now render correctly in desktop notifications

This PR converts emoji from canonical names to Unicode characters in notification content, ensuring proper display in desktop notifications.

**Screenshots:**
Before: 
![Screenshot from 2024-10-09 17-32-23](https://github.com/user-attachments/assets/75850b71-357f-4283-b740-0e90b24f6f0f)

After:
![Screenshot from 2024-10-09 17-18-35](https://github.com/user-attachments/assets/d3f2c8fc-21f3-4cf5-b08b-2e80eb3f40db)


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed for clarity and maintainability
- [x] Commit explains changes and motivation
- [x] Manually tested functionality and edge cases

</details>

## Implementation
- Modified `get_notification_content` to use `get_emoji_codepoint` for conversion
- Falls back to canonical name if Unicode conversion fails

## Next Steps
- Comprehensive cross-platform testing
- Monitor performance impact
- Consider automated tests for emoji rendering