### PR TITLE
Customize /find/accounts and "No Organization Found" Pages for Self-Hosted Servers.

### DIFF
--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -38,12 +38,12 @@
             {% else %}
             <div class="find-account-form">
                 <p>
-                    {% trans %}
-                    Enter your email address to receive an email with the URLs
-                    for all the Zulip Cloud organizations in which you have
-                    active accounts. If you have also forgotten your password,
-                    you can <a href="/help/change-your-password">reset it</a>.
-                    {% endtrans %}
+                    {% if corporate_enabled %}
+                        {% trans %}Enter your email address to receive an email with the URLs for all the Zulip Cloud organizations in which you have active accounts.{% endtrans %}
+                    {% else %}
+                        {% trans %}Enter your email address to receive an email with the URLs for all the Zulip organizations on this server in which you have active accounts.{% endtrans %}
+                    {% endif %}
+                    {% trans %}If you have also forgotten your password, you can <a href="/help/change-your-password">reset it</a>.{% endtrans %}
                 </p>
                 <form class="form-inline" id="find_account" name="email_form"
                   action="{{ current_url }}" method="post">

--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -12,14 +12,15 @@
             <h1 class="get-started">{{ _('No organization found') }}</h1>
         </div>
 
-        <div class="app-main white-box">
+        <div class="app-main find-account-page-container white-box">
             <p>
                 {% trans %}There is no Zulip organization at <b>{{ current_url }}</b>.{% endtrans %}
-                <br />
+            </p>
+            <p>
                 {% if corporate_enabled %}
-                    {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact Zulip support</a>.{% endtrans %}
+                    {% trans %}Please try a different URL, <a href="{{ root_domain_url }}/accounts/find/">get a list of your Zulip Cloud accounts</a>, or <a href="mailto:{{ support_email }}">contact Zulip support</a>.{% endtrans %}
                 {% else %}
-                    {% trans %}Please try a different URL, or <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a>.{% endtrans %}
+                    {% trans %}Please try a different URL, <a href="{{ root_domain_url }}/accounts/find/">get a list of your accounts</a> on this server, or <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a>.{% endtrans %}
                 {% endif %}
             </p>
         </div>


### PR DESCRIPTION
This PR customizes the `/find/accounts` page and the "No Organization Found" page for self-hosted Zulip servers. Previously, these pages were tailored for Zulip Cloud organizations, but this update ensures that self-hosted servers display more appropriate messages.

### Changes:
1. **Customize `/find/accounts` page for self-hosted servers**:
   - The message displayed is now: 
     - For Zulip Cloud: "for all the Zulip Cloud organizations in which you have active accounts."
     - For self-hosted servers: "for all the Zulip organizations on this server."
   - This change makes the text more relevant to users on self-hosted instances.

2. **Update the "No Organization Found" page**:
   - For Zulip Cloud:
     - Message updated to: "Please try a different URL, get a list of your Zulip Cloud accounts, or contact..."
   - For self-hosted servers:
     - Message updated to: "Please try a different URL, get a list of your accounts on this server, or contact..."

Fixes: #30116 

---

### Previous PR Reference:
A previous PR #30207 addressed the same issue but has been inactive since June. This PR builds on the foundational work done in that earlier PR, which similarly focused on updating frontend text and instructions for self-hosted users.

While the earlier PR made valuable progress, there were a few gaps that this PR addresses:
- **Commit messages**: The previous PR's commit messages did not fully align with the project's contribution guidelines.
- **Incorrect link**: The link added to the "No Organization Found" page was incorrect in the earlier implementation.

This PR not only finalizes the original fixes but also ensures that all changes, including the commit history, follow the required standards. The rest of the frontend code remains consistent with the previous work, making this a continuation and completion of that effort.

---
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details> 

<summary> Current UI: </summary>
<img width="728" alt="Screenshot 2024-10-08 at 8 37 40 PM" src="https://github.com/user-attachments/assets/4bf396bf-db7b-4710-9303-2accd5f87e80">
<img width="485" alt="Screenshot 2024-10-08 at 8 41 21 PM" src="https://github.com/user-attachments/assets/bb085f53-af08-4d80-88a3-a025fae833d7">


</details>

<details> 

<summary> Updated UI for Zulip Cloud: </summary>
<img width="728" alt="Screenshot 2024-10-08 at 8 37 40 PM" src="https://github.com/user-attachments/assets/9a8abae8-c268-493f-8fbf-67075cd55252">
<img width="1440" alt="Screenshot 2024-10-22 at 10 31 05 AM" src="https://github.com/user-attachments/assets/ad4f1a88-ee5c-466d-96da-034a336a7fb8">



</details>

<details> 

<summary> Updated UI for Self-Hosted servers: </summary>
<img width="690" alt="Screenshot 2024-10-09 at 2 49 53 PM" src="https://github.com/user-attachments/assets/4be1345b-4eb2-4577-8065-49ebaa3f1cf5">
<img width="1440" alt="Screenshot 2024-10-22 at 10 32 38 AM" src="https://github.com/user-attachments/assets/53cb61b3-1c8a-4ab2-8f26-12a7cbeccd54">





</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

