### PR TITLE
invite: Add guest visibility note with live-updating user count.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -158,3 +158,18 @@ export function is_user_subscribed(stream_id: number, user_id: number): boolean 
     const subscribers = get_user_set(stream_id);
     return subscribers.has(user_id);
 }
+
+export function get_unique_subscriber_count_for_streams(stream_ids: number[]): number {
+    const valid_subscribers = new LazySet([]);
+
+    for (const stream_id of stream_ids) {
+        const subscribers = get_user_set(stream_id);
+
+        for (const user_id of subscribers.keys()) {
+            if (!people.is_valid_bot_user(user_id)) {
+                valid_subscribers.add(user_id);
+            }
+        }
+    }
+    return valid_subscribers.size;
+}

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -351,3 +351,10 @@ export function get_request_data_for_stream_privacy(selected_val: string): {
         }
     }
 }
+
+export function guests_can_access_all_other_users(): boolean {
+    const everyone_group = user_groups.get_user_group_from_id(
+        realm.realm_can_access_all_users_group,
+    );
+    return everyone_group.name === "role:everyone";
+}

--- a/web/templates/guest_visible_users_message.hbs
+++ b/web/templates/guest_visible_users_message.hbs
@@ -1,0 +1,6 @@
+<p id="guest_visible_users_message">
+    {{t 'Guests will be able to see {user_count} users in their channels when they join.'}}
+    <a id="guest_help_link" class="help_link_widget" href="/help/guest-users#configure-whether-guests-can-see-all-other-users" target="_blank" rel="noopener noreferrer">
+        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+    </a>
+</p>

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -91,5 +91,7 @@
             </div>
         </div>
     </div>
+    <div id="guest_visible_users_container" class="input-group" style="display: none;">
+    </div>
     {{/if}}
 </form>

--- a/web/tests/peer_data.test.js
+++ b/web/tests/peer_data.test.js
@@ -43,6 +43,13 @@ const george = {
     full_name: "George",
     user_id: 103,
 };
+const bot_botson = {
+    email: "botson-bot@example.com",
+    user_id: 35,
+    full_name: "Bot Botson",
+    is_bot: true,
+    role: 300,
+};
 
 function contains_sub(subs, sub) {
     return subs.some((s) => s.name === sub.name);
@@ -290,4 +297,21 @@ test("is_subscriber_subset", () => {
     blueslip.expect("warn", "We called get_user_set for an untracked stream: undefined");
     peer_data.is_subscriber_subset(undefined, sub_a.stream_id);
     blueslip.reset();
+});
+
+test("get_unique_subscriber_count_for_streams", () => {
+    const sub = {name: "Rome", subscribed: true, stream_id: 1001};
+    stream_data.add_sub(sub);
+
+    people.add_active_user(fred);
+    people.add_active_user(gail);
+    people.add_active_user(george);
+    people.add_active_user(bot_botson);
+
+    const stream_id = sub.stream_id;
+    peer_data.set_subscribers(stream_id, [me.user_id, fred.user_id, bot_botson.user_id]);
+
+    const count = peer_data.get_unique_subscriber_count_for_streams([stream_id]);
+
+    assert.equal(count, 2);
 });

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -559,3 +559,31 @@ run_test("user_can_create_web_public_streams", () => {
     realm.server_web_public_streams_enabled = false;
     assert.equal(settings_data.user_can_create_web_public_streams(), false);
 });
+
+run_test("guests_can_access_all_other_users", () => {
+    const guest_user_id = 1;
+    const member_user_id = 2;
+
+    const members = {
+        name: "role:members",
+        id: 1,
+        members: new Set([member_user_id]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([]),
+    };
+    const everyone = {
+        name: "role:everyone",
+        id: 2,
+        members: new Set([guest_user_id]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([1]),
+    };
+
+    user_groups.initialize({realm_user_groups: [members]});
+    realm.realm_can_access_all_users_group = members.id;
+    assert.ok(!settings_data.guests_can_access_all_other_users());
+
+    user_groups.initialize({realm_user_groups: [members, everyone]});
+    realm.realm_can_access_all_users_group = everyone.id;
+    assert.ok(settings_data.guests_can_access_all_other_users());
+});


### PR DESCRIPTION
This PR adds a new note in the Invite modal informing users of how many users guests will be able to see in their channels. The message updates live as channel subscriptions or user roles change.

The note is displayed when the guest role is selected, and the setting prevents guests from viewing all users. The dynamic message shown is:

**"Guests will be able to see {N} users in their channels when they join."**

The value of `{N}` is determined using client-side cached subscription data, so it updates in real-time without needing any server-side interaction. This feature applies to both link and email invitations and includes a help link to guide users in configuring guest visibility settings.

#### Visual Changes:

| Email Invitation | Invitation Link | Non-Default Channel |
| ---------------- | --------------- | --------------- | 
| ![Email Invitation](https://github.com/user-attachments/assets/676cc2b2-e867-4130-b690-e857e94a1170) | ![Invitation Link](https://github.com/user-attachments/assets/dc3ddbd4-ac4c-4bf3-bfd2-1f9f3d9128df) | ![Non-Default Channel](https://github.com/user-attachments/assets/45ab0e1e-34a1-4c25-96e5-92b8af19193c) |

Fixes #31159.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

