### PR TITLE
custom_profile_fields: Make transaction no longer durable.

### DIFF
--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -169,7 +169,7 @@ def notify_user_update_custom_profile_data(
     send_event_on_commit(user_profile.realm, event, get_user_ids_who_can_access_user(user_profile))
 
 
-@transaction.atomic(durable=True)
+@transaction.atomic(savepoint=False)
 def do_update_user_custom_profile_data_if_changed(
     user_profile: UserProfile,
     data: list[ProfileDataElementUpdateDict],
@@ -210,7 +210,7 @@ def do_update_user_custom_profile_data_if_changed(
         )
 
 
-@transaction.atomic(durable=True)
+@transaction.atomic(savepoint=False)
 def check_remove_custom_profile_field_value(
     user_profile: UserProfile, field_id: int, acting_user: UserProfile
 ) -> None:

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, TypeAlias
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.files.uploadedfile import UploadedFile
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
@@ -197,6 +198,7 @@ class ProfileDataElement(BaseModel):
 
 
 @typed_endpoint
+@transaction.atomic(durable=True)
 def update_user_backend(
     request: HttpRequest,
     user_profile: UserProfile,


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/31935

This can't be durable as it's invoked within `sync_ldap_user_data`, which is already in transaction.atomic.

Reverts 8b3d5a945594c80201753e79935f9410101700c5

@prakhar1144 Can you check if this is fine? Btw, is there a thread where i can read up on the background for why `savepoint=False` can't be used here? Since the original commit says:
> We can't set savepoint=False before hand to the outermost action function because it leads to rollback of transaction in tests when an error is raised in action function.