### PR TITLE
modals: Set new light, dark theme background and borders.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -443,8 +443,8 @@ input.settings_text_input {
 .grey-box {
     margin: 0;
     padding: 5px 10px;
-    background-color: hsl(0deg 0% 98%);
-    border: 1px solid hsl(0deg 0% 87%);
+    background-color: var(--color-background-modal-bar);
+    border: 1px solid var(--color-border-modal-bar);
     border-radius: 4px;
 
     list-style-type: none;
@@ -1004,7 +1004,8 @@ input.settings_text_input {
         padding-top: 4px;
         padding-bottom: 8px;
         text-align: center;
-        border-bottom: 1px solid hsl(0deg 0% 87%);
+        background-color: var(--color-background-modal-bar);
+        border-bottom: 1px solid var(--color-border-modal-bar);
 
         & h1 {
             margin: 0;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -587,8 +587,8 @@
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
     --color-background-modal: #ededed;
     --color-background-modal-bar: #f5f5f5;
-    --color-border-modal: #8c8c8c;
-    --color-border-modal-bar: #c2c2c2;
+    --color-border-modal: color-mix(in srgb, #8c8c8c 25%, transparent);
+    --color-border-modal-bar: color-mix(in srgb, #c2c2c2 80%, transparent);
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 100%);
     --color-unmuted-or-followed-topic-list-item: hsl(0deg 0% 20%);
     --color-topic-indent-border: hsl(0deg 0% 0% / 19%);
@@ -1103,8 +1103,8 @@
     --color-masked-unread-marker: hsl(0deg 0% 30%);
     --color-background-modal: #242424;
     --color-background-modal-bar: #333;
-    --color-border-modal: color-mix(in srgb, #fff 15%, transparent);
-    --color-border-modal-bar: color-mix(in srgb, #fff 12%, transparent);
+    --color-border-modal: color-mix(in srgb, #fff 8%, transparent);
+    --color-border-modal-bar: color-mix(in srgb, #fff 5%, transparent);
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 0% / 20%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -585,7 +585,10 @@
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
-    --color-background-modal: hsl(0deg 0% 98%);
+    --color-background-modal: #ededed;
+    --color-background-modal-bar: #f5f5f5;
+    --color-border-modal: #8c8c8c;
+    --color-border-modal-bar: #c2c2c2;
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 100%);
     --color-unmuted-or-followed-topic-list-item: hsl(0deg 0% 20%);
     --color-topic-indent-border: hsl(0deg 0% 0% / 19%);
@@ -1098,7 +1101,10 @@
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);
-    --color-background-modal: hsl(212deg 28% 18%);
+    --color-background-modal: #242424;
+    --color-background-modal-bar: #333;
+    --color-border-modal: color-mix(in srgb, #fff 15%, transparent);
+    --color-border-modal-bar: color-mix(in srgb, #fff 12%, transparent);
     --color-background-invitee-emails-pill-container: hsl(0deg 0% 0% / 20%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
     --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -43,11 +43,6 @@
         }
     }
 
-    #subscription_overlay #stream-creation .settings-sticky-footer,
-    #groups_overlay #user-group-creation .settings-sticky-footer {
-        box-shadow: inset 0 1px 0 hsl(0deg 0% 0% / 20%);
-    }
-
     #message-formatting,
     #keyboard-shortcuts {
         & kbd {
@@ -286,11 +281,6 @@
         }
     }
 
-    .stream_name_search_section,
-    .group_name_search_section {
-        border-color: hsl(0deg 0% 0% / 20%);
-    }
-
     #stream-actions-menu-popover .sp-container {
         background-color: transparent;
 
@@ -466,7 +456,6 @@
     #message-edit-history-overlay-container {
         .flex.overlay-content > .overlay-container {
             box-shadow: 0 0 30px hsl(213deg 31% 0%);
-            background-color: var(--color-background);
         }
     }
 
@@ -561,21 +550,13 @@
         background-color: hsl(228deg 11% 17%);
     }
 
-    & .drafts-container .drafts-header,
-    .subscriptions-container .subscriptions-header,
-    .user-groups-container .user-groups-header,
-    .overlay-messages-header,
+    & .overlay-messages-header,
     .grey-box,
     .white-box,
     .stream-email,
     #generate-integration-url-modal .integration-url,
-    #settings_page .settings-header,
     #settings_page .sidebar li.active,
-    #settings_page .sidebar-wrapper .tab-container,
-    .table-striped tbody tr:nth-child(odd) th,
-    #subscription_overlay #stream-creation .settings-sticky-footer,
-    #groups_overlay #user-group-creation .settings-sticky-footer {
-        border-color: hsl(0deg 0% 0% / 20%);
+    .table-striped tbody tr:nth-child(odd) th {
         background-color: hsl(0deg 0% 0% / 20%);
     }
 
@@ -588,21 +569,11 @@
         );
     }
 
-    .user-groups-container .right .display-type,
-    .subscriptions-container .right .display-type,
-    .stream-row,
-    .group-row,
-    .subscriptions-container .left .list-toggler-container,
-    .user-groups-container .left .list-toggler-container,
-    .subscriptions-container .left,
-    .user-groups-container .left,
     .subscriber-list-box,
     .subscriber-list-box .subscriber_list_container .subscriber-list td,
     .member-list-box,
     .member-list-box .member_list_container .member-list td,
     #subscription_overlay .settings-radio-input-parent,
-    #settings_page .sidebar,
-    #settings_page .sidebar .sidebar-item,
     #recent_view_table table td {
         border-color: hsl(0deg 0% 0% / 20%);
     }
@@ -755,9 +726,7 @@
     }
 
     #feedback_container {
-        background-color: hsl(212deg 25% 15%);
         border-color: hsl(0deg 0% 0% / 50%);
-        color: inherit;
 
         & a:hover {
             color: hsl(0deg 0% 100%);

--- a/web/styles/image_upload_widget.css
+++ b/web/styles/image_upload_widget.css
@@ -139,9 +139,12 @@
 }
 
 .user-avatar-section,
-.realm-logo-section,
 .realm-icon-section {
     margin: 20px 0;
+}
+
+.realm-logo-section {
+    margin: 0 0 20px;
 }
 
 /* CSS related to settings page user avatar upload widget only */
@@ -184,25 +187,26 @@
 }
 
 #realm-day-logo-upload-widget {
-    background-color: hsl(0deg 100% 100%);
+    /* Match to light-theme --color-background-navbar. */
+    background-color: hsl(0deg 0% 97%);
+    padding: 5px;
 }
 
 #realm-night-logo-upload-widget {
-    background-color: hsl(212deg 28% 18%);
-}
-
-.realm-logo-block {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: 0 20px;
+    /* Match to dark-theme --color-background-navbar. */
+    background-color: hsl(0deg 0% 13%);
+    padding: 5px;
 }
 
 .realm-logo-group {
     display: flex;
-    justify-content: space-around;
     flex-wrap: wrap;
+    gap: 20px;
+
+    .image_upload_button {
+        top: 0;
+        left: 0;
+    }
 }
 
 /* CSS  related to upload widget's preview image */

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1274,7 +1274,7 @@ $option_title_width: 180px;
     }
 
     & h5 {
-        font-size: 1.2em;
+        font-size: 1em;
         font-weight: normal;
         line-height: 1.2;
         margin: 10px 0;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1323,7 +1323,7 @@ $option_title_width: 180px;
     .sidebar {
         height: calc(100% - $settings_header_height);
         overflow-y: auto;
-        border-right: 1px solid var(--color-border-modal-bar);
+        border-right: 1px solid var(--color-border-modal);
 
         .header {
             height: auto;
@@ -1352,7 +1352,7 @@ $option_title_width: 180px;
             transition:
                 background-color 0.2s ease,
                 border-bottom 0.2s ease;
-            border-bottom: 1px solid var(--color-border-modal-bar);
+            border-bottom: 1px solid var(--color-border-modal);
 
             &:last-of-type .text {
                 border-bottom: none;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1290,7 +1290,8 @@ $option_title_width: 180px;
             box-sizing: border-box;
             height: $settings_header_height;
             padding: 6px;
-            border-bottom: 1px solid hsl(0deg 0% 87%);
+            background-color: var(--color-background-modal-bar);
+            border-bottom: 1px solid var(--color-border-modal-bar);
 
             @media (width >= $md_min) {
                 .tab-switcher {
@@ -1322,7 +1323,7 @@ $option_title_width: 180px;
     .sidebar {
         height: calc(100% - $settings_header_height);
         overflow-y: auto;
-        border-right: 1px solid hsl(0deg 0% 93%);
+        border-right: 1px solid var(--color-border-modal-bar);
 
         .header {
             height: auto;
@@ -1332,8 +1333,8 @@ $option_title_width: 180px;
             text-align: center;
             text-transform: uppercase;
 
-            background-color: hsl(180deg 6% 93%);
-            border-bottom: 1px solid hsl(0deg 0% 87%);
+            background-color: var(--color-background-modal-bar);
+            border-bottom: 1px solid var(--color-border-modal-bar);
         }
 
         .sidebar-item {
@@ -1351,15 +1352,16 @@ $option_title_width: 180px;
             transition:
                 background-color 0.2s ease,
                 border-bottom 0.2s ease;
-            border-bottom: 1px solid hsl(0deg 0% 93%);
+            border-bottom: 1px solid var(--color-border-modal-bar);
 
             &:last-of-type .text {
                 border-bottom: none;
             }
 
             &.active {
-                background-color: hsl(0deg 0% 93%);
-                border-bottom: 1px solid transparent;
+                /* TODO: Check with Vlad about highlight
+                   colors such as this. */
+                background-color: hsl(0deg 0% 98%);
             }
 
             .sidebar-item-icon {
@@ -1462,7 +1464,8 @@ $option_title_width: 180px;
             width: 100%;
             height: $settings_header_height;
             box-sizing: border-box;
-            border-bottom: 1px solid hsl(0deg 0% 87%);
+            border-bottom: 1px solid var(--color-border-modal-bar);
+            background-color: var(--color-background-modal-bar);
 
             & h1 .section {
                 font-weight: 400;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -320,7 +320,8 @@ h4.user_group_setting_subsection_title {
         text-align: center;
         text-transform: uppercase;
         font-weight: 700;
-        border-bottom: 1px solid hsl(0deg 0% 87%);
+        background-color: var(--color-background-modal-bar);
+        border-bottom: 1px solid var(--color-border-modal-bar);
 
         .fa-chevron-left {
             display: none;
@@ -378,12 +379,12 @@ h4.user_group_setting_subsection_title {
     }
 
     .left {
-        border-right: 1px solid hsl(0deg 0% 87%);
+        border-right: 1px solid var(--color-border-modal-bar);
 
         .list-toggler-container {
             align-items: center;
             padding: 6px 8px;
-            border-bottom: 1px solid hsl(0deg 0% 87%);
+            border-bottom: 1px solid var(--color-border-modal-bar);
             display: flex;
             justify-content: space-between;
 
@@ -409,7 +410,7 @@ h4.user_group_setting_subsection_title {
             padding: 2px;
             text-align: center;
             font-weight: 600;
-            border-bottom: 1px solid hsl(0deg 0% 87%);
+            border-bottom: 1px solid var(--color-border-modal-bar);
 
             & a {
                 color: inherit;
@@ -496,7 +497,7 @@ h4.user_group_setting_subsection_title {
     justify-content: center;
     margin-bottom: 0;
     height: auto;
-    border-bottom: 1px solid hsl(0deg 0% 87%);
+    border-bottom: 1px solid var(--color-border-modal-bar);
 }
 
 .user-groups-list,
@@ -537,7 +538,7 @@ h4.user_group_setting_subsection_title {
 .stream-row,
 .group-row {
     padding: 15px 10px 11px;
-    border-bottom: 1px solid hsl(0deg 0% 93%);
+    border-bottom: 1px solid var(--color-border-modal-bar);
     cursor: pointer;
     display: flex;
 
@@ -763,9 +764,8 @@ h4.user_group_setting_subsection_title {
             width: calc(100% - 27px);
             padding: 9px 15px 15px;
             text-align: right;
-            background-color: hsl(0deg 0% 96%);
-            border-top: 1px solid hsl(0deg 0% 87%);
-            box-shadow: inset 0 1px 0 hsl(0deg 0% 100%);
+            background-color: var(--color-background-modal-bar);
+            border-top: 1px solid var(--color-border-modal-bar);
         }
 
         @media (width > $md_min) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -229,7 +229,7 @@ p.n-margin {
     top: 0;
     left: calc(50vw - 220px);
     padding: 15px;
-    background-color: hsl(0deg 0% 98%);
+    background-color: var(--color-background-modal);
     border-radius: 5px;
     box-shadow: 0 0 30px hsl(0deg 0% 0% / 25%);
     z-index: 110;


### PR DESCRIPTION
This PR removes the blue background and borders from dark theme modals and toasts, and also updates the light mode backgrounds and borders according to @terpimost's new design.

It also improves the Organization logo area by aligning elements to the left, and using the exact background colors from the navbar (the backgrounds beneath logos have been opened up, too). Various layout improvements are part of that commit as well.

Note that this PR is meant as a prerequisite for testing redesigned buttons in #31595.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/removal.20of.20sea-green.20buttons/near/1944206)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Dark mode, before | Dark mode, after |
| --- | --- |
| ![personal-profile-dark-before](https://github.com/user-attachments/assets/6f3bc0ca-42b3-4da0-8d86-52fc30b96288) | ![personal-profile-dark-after](https://github.com/user-attachments/assets/909fe022-4968-41bf-85a5-aaa756bc5cdf) |
| ![channels-overlay-dark-before](https://github.com/user-attachments/assets/84d2ce15-7a08-49c0-810f-a0d1ec4c4fe4) | ![channels-overlay-dark-after](https://github.com/user-attachments/assets/52a1c93b-ab4b-432b-a29f-2fa0cb0774a1) |
| ![alert-words-dark-before](https://github.com/user-attachments/assets/b709b51b-ddf1-4a91-b0ff-3d309b6ad6ed) | ![alert-words-dark-after](https://github.com/user-attachments/assets/86af4276-6b24-4173-819e-f328a304c5ef) |
| ![move-messages-modal-dark-before](https://github.com/user-attachments/assets/7c589f1a-9158-45ed-aa87-70a8839740e5) | ![move-messages-modal-dark-after](https://github.com/user-attachments/assets/7b70e60a-586d-4612-b02a-7db471d1e676) |
| ![no-unreads-toast-dark-before](https://github.com/user-attachments/assets/1b33a859-55ff-45b3-a856-9ee260884f20) | ![no-unreads-toast-dark-after](https://github.com/user-attachments/assets/6ced94cd-35cb-4569-9510-62ca84401404) |

| Light mode, before | Light mode, after |
| --- | --- |
| ![personal-profile-light-before](https://github.com/user-attachments/assets/aaacd0ef-d035-4bd3-a1b5-71f9a7bcd688) | ![personal-profile-light-after](https://github.com/user-attachments/assets/466f8f3a-0031-4dbf-a61b-b95278ce6e36) |
|![channels-overlay-light-before](https://github.com/user-attachments/assets/d39f0efc-ff3b-436c-ae1c-4697842c646b) | ![channels-overlay-light-after](https://github.com/user-attachments/assets/0d81c17c-7bd5-415f-8683-99911adcac8c) |
| ![alert-words-light-before](https://github.com/user-attachments/assets/9ff4bb87-aaff-4e5e-a3cd-4bcd382799bb) | ![alert-words-light-after](https://github.com/user-attachments/assets/ac1a3752-ba41-4023-9c53-5adefe2e4fe4) |
| ![move-messages-modal-light-before](https://github.com/user-attachments/assets/c688ae55-5cf3-458e-a81b-31db59e68000) | ![move-messages-modal-light-after](https://github.com/user-attachments/assets/795edf68-2f07-4152-a593-6dbd5bb3bc1e) |
| ![no-unreads-toast-light-before](https://github.com/user-attachments/assets/c3ebf6cd-0072-4f30-9437-890333216b5c) | ![no-unreads-toast-light-after](https://github.com/user-attachments/assets/b568b6be-3849-4b98-ad1f-7fbf5f3d1b62) |

| Org profile, before | Org profile, after |
| --- | --- |
| ![organization-profile-dark-before](https://github.com/user-attachments/assets/4b7083f5-b05f-4358-a9a8-df1d1d153725) | ![organization-profile-dark-after](https://github.com/user-attachments/assets/09da830e-3028-496b-a06c-e795803aaadd) |
| ![organization-profile-light-before](https://github.com/user-attachments/assets/fb92732b-fca7-4680-a7ba-a858fa65aef0) | ![organization-profile-light-after](https://github.com/user-attachments/assets/8647e0ac-4659-44a0-9c0e-607b05d01f10) |

| Set status, before | Set status, after |
| --- | --- |
| ![set-status-overlay-dark-before](https://github.com/user-attachments/assets/af6e0b5a-a84d-4998-a590-da6964455a2c) | ![set-status-overlay-dark-after](https://github.com/user-attachments/assets/ad97b08e-1d01-4436-b6e0-ef4a828993f9) |
| ![set-status-overlay-light-before](https://github.com/user-attachments/assets/ff1d0e5b-3b43-4393-9c97-8ce34a0bc4ac) | ![set-status-overlay-light-after](https://github.com/user-attachments/assets/c04f1fa6-beba-47a7-8a6b-0630725a3cd1) |
| ![narrow-status-modal-before](https://github.com/user-attachments/assets/18c5dc4e-7767-42bb-90f2-e727f31a940c) | ![narrow-status-modal-after](https://github.com/user-attachments/assets/30975f1f-e0c3-4a1c-ab79-01c49955985f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>