### PR TITLE
help: Create "Configure send message keys" article.

### DIFF
--- a/help/collaborative-to-do-lists.md
+++ b/help/collaborative-to-do-lists.md
@@ -10,12 +10,13 @@
 
 1. Make sure the compose box is empty.
 
-2. Type `/todo` followed by a space, and the title of the to-do list.
+1. Type `/todo` followed by a space, and the title of the to-do list.
 
-3. _(optional)_ Type each task on a new line, with its description, if any, after a <kbd>:</kbd> and blank space.
+1. _(optional)_ Type each task on a new line, with its description, if
+   any, after a <kbd>:</kbd> and blank space.
 
-4. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
-   use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>)
+   button, or use a [keyboard shortcut](/help/configure-send-message-keys)
    to send your message.
 
 !!! tip ""
@@ -28,7 +29,8 @@
 
 {start_tabs}
 
-1. Fill out the **New task** field and optionally the **Description** field at the bottom of the to-do list.
+1. Fill out the **New task** field and optionally the **Description**
+   field at the bottom of the to-do list.
 
 1. Click **Add task** to add the new task to the to-do list.
 

--- a/help/configure-send-message-keys.md
+++ b/help/configure-send-message-keys.md
@@ -1,0 +1,41 @@
+# Configure send message keys
+
+By default, the <kbd>Enter</kbd> key adds a new line to your message,
+and <kbd>Ctrl</kbd> + <kbd>Enter</kbd> sends your message.
+
+This is convenient for typing multi-line messages, which are more common in
+Zulip than in most other chat products. However, you can also configure
+Zulip so that the <kbd>Enter</kbd> key sends your message.
+
+!!! tip ""
+
+    <kbd>Shift</kbd> + <kbd>Enter</kbd> always adds a new line, regardless
+    of whether **<kbd>Enter</kbd> to send** is enabled.
+
+## Configure send message keys
+
+{start_tabs}
+
+{tab|via-compose-box}
+
+{!start-composing.md!}
+
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
+   in the bottom right corner of the compose box, next to the **Send**
+   (<i class="zulip-icon zulip-icon-send"></i>) button.
+
+1. Toggle your preferred option for **Press ... to send**.
+
+{tab|via-personal-settings}
+
+{settings_tab|preferences}
+
+1. Under **General**, toggle **<kbd>Enter</kbd> sends when composing a message**.
+
+{end_tabs}
+
+## Related articles
+
+* [Message formatting](/help/format-your-message-using-markdown)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Mastering the compose box](/help/mastering-the-compose-box)

--- a/help/create-a-poll.md
+++ b/help/create-a-poll.md
@@ -21,9 +21,8 @@ edit the question.
    formatting.
 
 1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
-   use a [keyboard
-   shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
-   to send your message.
+   use a [keyboard shortcut](/help/configure-send-message-keys) to send your
+   message.
 
 !!! tip ""
 
@@ -43,8 +42,8 @@ edit the question.
 3. _(optional)_ Type each option on a new line.
 
 4. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
-   use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
-   to send your message.
+   use a [keyboard shortcut](/help/configure-send-message-keys) to send your
+   message.
 
 !!! tip ""
 

--- a/help/include/compose-and-send-message.md
+++ b/help/include/compose-and-send-message.md
@@ -3,5 +3,5 @@
    sending.
 
 1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
-   use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
-   to send your message.
+   use a [keyboard shortcut](/help/configure-send-message-keys) to send your
+   message.

--- a/help/include/replying-to-messages.md
+++ b/help/include/replying-to-messages.md
@@ -9,8 +9,8 @@ To reply to an existing thread:
    sending.
 
 1. Click the **Send** (<i class="zulip-icon zulip-icon-send"></i>) button, or
-   use a [keyboard shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
-   to send your message.
+   use a [keyboard shortcut](/help/configure-send-message-keys) to send your
+   message.
 
 !!! tip ""
     You can also reply by clicking on a message, or using the <kbd>R</kbd> or

--- a/help/include/set-up-your-account.md
+++ b/help/include/set-up-your-account.md
@@ -19,8 +19,8 @@
 
 - [Browse and subscribe to channels](/help/introduction-to-channels#browse-and-subscribe-to-channels).
 
-- Decide whether you want <kbd>Enter</kbd> [to send your message
-  or add a new line](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message).
+- Decide whether you want <kbd>Enter</kbd> [to send your message or add a
+  new line](/help/configure-send-message-keys).
 
 - [Configure your notifications](/#settings/notifications) to work the way
   you do. If you're joining a low traffic organization and aren't using the

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -46,6 +46,7 @@
 
 ## Preferences
 * [Dark theme](/help/dark-theme)
+* [Configure send message keys](/help/configure-send-message-keys)
 * [Font size](/help/font-size)
 * [Change your language](/help/change-your-language)
 * [Change your time zone](/help/change-your-timezone)

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -145,7 +145,7 @@ in the Zulip app to add more to your repertoire as needed.
   <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd> based on
   [your settings][toggle-enter-to-send]
 
-[toggle-enter-to-send]: /help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message
+[toggle-enter-to-send]: /help/configure-send-message-keys
 
 * **Insert italic text**: `*italic*` or <kbd>Ctrl</kbd> + <kbd>I</kbd>
 

--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -78,51 +78,10 @@ where you sent a message**, as desired.
 
 {end_tabs}
 
-## Toggle between <kbd>Ctrl</kbd> + <kbd>Enter</kbd> and <kbd>Enter</kbd> to send a message
-
-By default, the <kbd>Enter</kbd> key adds a new line to your message,
-and <kbd>Ctrl</kbd> + <kbd>Enter</kbd> sends your message.
-
-This is convenient for typing multi-line messages, which are more common in
-Zulip than in most other chat products. However, you can also configure
-Zulip so that the <kbd>Enter</kbd> key sends your message.
-
-!!! tip ""
-
-    <kbd>Shift</kbd> + <kbd>Enter</kbd> always adds a new line, regardless
-    of whether **<kbd>Enter</kbd> to send** is enabled.
-
-### Enable <kbd>Enter</kbd> to send
-
-{start_tabs}
-
-{!start-composing.md!}
-
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
-   in the bottom right corner of the compose box, next to the **Send**
-   (<i class="zulip-icon zulip-icon-send"></i>) button.
-
-1. Select **<kbd>Enter</kbd> to send**.
-
-{end_tabs}
-
-### Enable **<kbd>Ctrl</kbd> + <kbd>Enter</kbd> to send**
-
-{start_tabs}
-
-{!start-composing.md!}
-
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
-   in the bottom right corner of the compose box, next to the **Send**
-   (<i class="zulip-icon zulip-icon-send"></i>) button.
-
-1. Select **<kbd>Ctrl</kbd> + <kbd>Enter</kbd> to send**.
-
-{end_tabs}
-
 ## Related articles
 
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Message formatting](/help/format-your-message-using-markdown)
 * [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Configure send message keys](/help/configure-send-message-keys)
 * [Messaging tips and tricks](/help/messaging-tips)

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -88,6 +88,7 @@ TAB_SECTION_LABELS = {
     "via-organization-settings": "Via organization settings",
     "via-personal-settings": "Via personal settings",
     "via-channel-settings": "Via channel settings",
+    "via-compose-box": "Via compose box",
     "default-subdomain": "Default subdomain",
     "custom-subdomain": "Custom subdomain",
     "zulip-cloud-standard": "Zulip Cloud Standard",

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -36,10 +36,7 @@ HELP_DOCUMENTATION_REDIRECTS: list[URLRedirect] = [
         "/help/add-custom-profile-fields",
         "/help/custom-profile-fields",
     ),
-    URLRedirect(
-        "/help/enable-enter-to-send",
-        "/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message",
-    ),
+    URLRedirect("/help/enable-enter-to-send", "/help/configure-send-message-keys"),
     URLRedirect(
         "/help/change-the-default-language-for-your-organization",
         "/help/configure-organization-language",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15061,7 +15061,7 @@ paths:
                           enter_sends:
                             type: boolean
                             description: |
-                              Whether the user setting for [sending on pressing Enter](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+                              Whether the user setting for [sending on pressing Enter](/help/configure-send-message-keys)
                               in the compose box is enabled.
                           enable_drafts_synchronization:
                             type: boolean
@@ -16038,7 +16038,7 @@ paths:
                           `update_display_settings`.
 
                           [capabilities]: /api/register-queue#parameter-client_capabilities
-                          [set-enter-send]: /help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message
+                          [set-enter-send]: /help/configure-send-message-keys
                       emojiset_choices:
                         deprecated: true
                         description: |
@@ -17740,7 +17740,7 @@ paths:
                           enter_sends:
                             type: boolean
                             description: |
-                              Whether the user setting for [sending on pressing Enter](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+                              Whether the user setting for [sending on pressing Enter](/help/configure-send-message-keys)
                               in the compose box is enabled.
                           enable_drafts_synchronization:
                             type: boolean


### PR DESCRIPTION
Document setting the keys that will send a message or create a new line when composting a message via the compose box and via the personal settings overlay.

Updates links and redirect from former help center article about this feature. Fixes `collaborative-to-do-lists.md` for some formatting conventions we have for help center md files.

Fixes #31620.

---

**Screenshots and screen captures:**

<details>
<summary>Configure send messsage keys - for Mac users</summary>

### 1. Via compose box instructions tab
![Screenshot from 2024-10-10 12-40-10](https://github.com/user-attachments/assets/7cc498e3-14d2-42b4-8aa9-ab80a7bffd61)

### 2. Via personal settings instructions tab
![Screenshot from 2024-10-10 12-40-14](https://github.com/user-attachments/assets/e44faa56-6b79-4b4d-9582-51a8417f4c00)
</details>
<details>
<summary>Configure send messsage keys - for non-Mac users</summary>

### 1. Via compose box instructions tab
![Screenshot from 2024-10-10 12-39-41](https://github.com/user-attachments/assets/7b1bbdae-1677-4da0-9ca7-48128578f96c)

### 2. Via personal settings instructions tab
![Screenshot from 2024-10-10 12-39-49](https://github.com/user-attachments/assets/1367388e-a2f2-429c-bda8-729aed3ff805)

### 3. Via personal settings instructions tab - without relative link
![Screenshot from 2024-10-10 12-41-03](https://github.com/user-attachments/assets/28940e94-95ea-406d-93ef-ba38cdd4a517)
</details>
<details>
<summary>Preferences section of help center left sidebar</summary>

![Screenshot from 2024-10-10 12-39-14](https://github.com/user-attachments/assets/2eebfc54-2c6e-439c-a76e-45aa96f2fdce)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
