### PR TITLE
realm_export: Add 'Export permissions' table.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -411,6 +411,13 @@ export function dispatch_normal_event(event) {
             settings_exports.populate_exports_table(event.exports);
             break;
 
+        case "realm_export_consent":
+            settings_exports.update_export_consent_data_and_redraw({
+                user_id: event.user_id,
+                consented: event.consented,
+            });
+            break;
+
         case "realm_linkifiers":
             realm.realm_linkifiers = event.realm_linkifiers;
             linkifiers.update_linkifier_rules(realm.realm_linkifiers);
@@ -490,6 +497,13 @@ export function dispatch_normal_event(event) {
 
                     if (should_redraw) {
                         activity_ui.redraw_user(event.person.user_id);
+                    }
+
+                    if (!event.person.is_bot) {
+                        settings_exports.update_export_consent_data_and_redraw({
+                            user_id: event.person.user_id,
+                            consented: false,
+                        });
                     }
                     break;
                 }

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -420,6 +420,22 @@ function maybe_store_export_consent_data_and_return(export_consent: ExportConsen
     return false;
 }
 
+function update_start_export_modal_stats(): void {
+    total_users_count = export_consents.size;
+    users_consented_for_export_count = get_export_consents_having_consent_value(true).length;
+    if ($("#allow_private_data_export_stats").length) {
+        $("#allow_private_data_export_stats").text(
+            $t(
+                {
+                    defaultMessage:
+                        "Exporting private data for {users_consented_for_export_count} users ({total_users_count} users total).",
+                },
+                {users_consented_for_export_count, total_users_count},
+            ),
+        );
+    }
+}
+
 export function remove_export_consent_data_and_redraw(user_id: number): void {
     if (!meta.loaded) {
         return;
@@ -432,6 +448,7 @@ export function remove_export_consent_data_and_redraw(user_id: number): void {
 
     export_consents.delete(user_id);
     redraw_export_consents_list();
+    update_start_export_modal_stats();
 }
 
 export function update_export_consent_data_and_redraw(export_consent: ExportConsent): void {
@@ -445,4 +462,5 @@ export function update_export_consent_data_and_redraw(export_consent: ExportCons
 
     export_consents.set(export_consent.user_id, export_consent.consented);
     redraw_export_consents_list();
+    update_start_export_modal_stats();
 }

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -1,15 +1,21 @@
 import $ from "jquery";
+import type * as tippy from "tippy.js";
 import {z} from "zod";
 
 import render_confirm_delete_data_export from "../templates/confirm_dialog/confirm_delete_data_export.hbs";
+import render_admin_export_consent_list from "../templates/settings/admin_export_consent_list.hbs";
 import render_admin_export_list from "../templates/settings/admin_export_list.hbs";
 import render_start_export_modal from "../templates/start_export_modal.hbs";
 
 import * as channel from "./channel";
+import * as components from "./components";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
+import * as dropdown_widget from "./dropdown_widget";
+import type {DropdownWidget, Option} from "./dropdown_widget";
 import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
+import type {ListWidget as ListWidgetType} from "./list_widget";
 import * as loading from "./loading";
 import * as people from "./people";
 import * as scroll_util from "./scroll_util";
@@ -22,6 +28,7 @@ const export_consent_schema = z.object({
     user_id: z.number(),
     consented: z.boolean(),
 });
+type ExportConsent = z.output<typeof export_consent_schema>;
 
 const realm_export_schema = z.object({
     id: z.number(),
@@ -115,13 +122,13 @@ export function populate_exports_table(exports: RealmExport[]): void {
                 scroll_util.reset_scrollbar($exports_table);
             },
         },
-        $parent_container: $("#data-exports").expectOne(),
+        $parent_container: $('[data-export-section="data-exports"]').expectOne(),
         init_sort: sort_user,
         sort_fields: {
             user: sort_user,
             ...ListWidget.generic_sort_functions("numeric", ["export_time"]),
         },
-        $simplebar_container: $("#data-exports .progressive-table-wrapper"),
+        $simplebar_container: $('[data-export-section="data-exports"] .progressive-table-wrapper'),
     });
 
     const $spinner = $(".export_row .export_url_spinner");
@@ -130,6 +137,124 @@ export function populate_exports_table(exports: RealmExport[]): void {
     } else {
         loading.destroy_indicator($spinner);
     }
+}
+
+function sort_user_by_name(a: ExportConsent, b: ExportConsent): number {
+    const a_name = people.get_full_name(a.user_id).toLowerCase();
+    const b_name = people.get_full_name(b.user_id).toLowerCase();
+    if (a_name > b_name) {
+        return 1;
+    } else if (a_name === b_name) {
+        return 0;
+    }
+    return -1;
+}
+
+const export_consents = new Map<number, boolean>();
+const queued_export_consents: (ExportConsent | number)[] = [];
+let export_consent_list_widget: ListWidgetType<ExportConsent>;
+let filter_by_consent_dropdown_widget: DropdownWidget;
+const filter_by_consent_options: Option[] = [
+    {
+        unique_id: 0,
+        name: $t({defaultMessage: "Granted"}),
+    },
+    {
+        unique_id: 1,
+        name: $t({defaultMessage: "Not granted"}),
+    },
+];
+
+function get_export_consents_having_consent_value(consent: boolean): ExportConsent[] {
+    const export_consent_list: ExportConsent[] = [];
+    for (const [user_id, consented] of export_consents.entries()) {
+        if (consent === consented) {
+            export_consent_list.push({user_id, consented});
+        }
+    }
+    return export_consent_list;
+}
+
+export function redraw_export_consents_list(): void {
+    let new_list_data;
+    if (filter_by_consent_dropdown_widget.value() === filter_by_consent_options[0]!.unique_id) {
+        new_list_data = get_export_consents_having_consent_value(true);
+    } else {
+        new_list_data = get_export_consents_having_consent_value(false);
+    }
+    export_consent_list_widget.replace_list_data(new_list_data);
+}
+
+export function populate_export_consents_table(): void {
+    if (!meta.loaded) {
+        return;
+    }
+
+    const $export_consents_table = $("#admin_export_consents_table").expectOne();
+    export_consent_list_widget = ListWidget.create(
+        $export_consents_table,
+        get_export_consents_having_consent_value(true),
+        {
+            name: "admin_export_consents_list",
+            get_item: ListWidget.default_get_item,
+            modifier_html(item) {
+                const person = people.get_by_user_id(item.user_id);
+                let consent = $t({defaultMessage: "Not granted"});
+                if (item.consented) {
+                    consent = $t({defaultMessage: "Granted"});
+                }
+                return render_admin_export_consent_list({
+                    export_consent: {
+                        user_id: person.user_id,
+                        full_name: person.full_name,
+                        img_src: people.small_avatar_url_for_person(person),
+                        consent,
+                    },
+                });
+            },
+            filter: {
+                $element: $export_consents_table
+                    .closest(".export_section")
+                    .find<HTMLInputElement>("input.search"),
+                predicate(item, value) {
+                    return people.get_full_name(item.user_id).toLowerCase().includes(value);
+                },
+                onupdate() {
+                    scroll_util.reset_scrollbar($export_consents_table);
+                },
+            },
+            $parent_container: $('[data-export-section="export-permissions"]').expectOne(),
+            init_sort: sort_user_by_name,
+            sort_fields: {
+                full_name: sort_user_by_name,
+            },
+            $simplebar_container: $(
+                '[data-export-section="export-permissions"] .progressive-table-wrapper',
+            ),
+        },
+    );
+
+    filter_by_consent_dropdown_widget = new dropdown_widget.DropdownWidget({
+        widget_name: "filter_by_consent",
+        unique_id_type: dropdown_widget.DataTypes.NUMBER,
+        get_options: () => filter_by_consent_options,
+        item_click_callback(
+            event: JQuery.ClickEvent,
+            dropdown: tippy.Instance,
+            widget: dropdown_widget.DropdownWidget,
+        ) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            redraw_export_consents_list();
+
+            dropdown.hide();
+            widget.render();
+        },
+        $events_container: $("#data-exports"),
+        default_id: filter_by_consent_options[0]!.unique_id,
+    });
+    filter_by_consent_dropdown_widget.setup();
 }
 
 function show_start_export_modal(): void {
@@ -203,16 +328,48 @@ function show_start_export_modal(): void {
 export function set_up(): void {
     meta.loaded = true;
 
+    const toggler = components.toggle({
+        child_wants_focus: true,
+        values: [
+            {label: $t({defaultMessage: "Data exports"}), key: "data-exports"},
+            {label: $t({defaultMessage: "Export permissions"}), key: "export-permissions"},
+        ],
+        callback(_name, key) {
+            $(".export_section").hide();
+            $(`[data-export-section="${CSS.escape(key)}"]`).show();
+        },
+    });
+
+    toggler.get().prependTo($("#data-exports .tab-container"));
+    toggler.goto("data-exports");
+
+    // Do an initial population of the 'Export permissions' table
     void channel.get({
         url: "/json/export/realm/consents",
         success(raw_data) {
             const data = z
                 .object({export_consents: z.array(export_consent_schema)})
                 .parse(raw_data);
-            total_users_count = data.export_consents.length;
-            users_consented_for_export_count = data.export_consents.filter(
-                (export_consent) => export_consent.consented,
-            ).length;
+
+            for (const export_consent of data.export_consents) {
+                export_consents.set(export_consent.user_id, export_consent.consented);
+            }
+
+            // Apply queued_export_consents on top of the received response.
+            for (const item of queued_export_consents) {
+                if (typeof item === "number") {
+                    // user deactivated; item is user_id in this case.
+                    export_consents.delete(item);
+                    continue;
+                }
+                export_consents.set(item.user_id, item.consented);
+            }
+            queued_export_consents.length = 0;
+
+            total_users_count = export_consents.size;
+            users_consented_for_export_count =
+                get_export_consents_having_consent_value(true).length;
+            populate_export_consents_table();
         },
     });
 
@@ -222,7 +379,7 @@ export function set_up(): void {
         show_start_export_modal();
     });
 
-    // Do an initial population of the table
+    // Do an initial population of the 'Data exports' table
     void channel.get({
         url: "/json/export/realm",
         success(raw_data) {
@@ -247,4 +404,45 @@ export function set_up(): void {
             loading_spinner: true,
         });
     });
+}
+
+function maybe_store_export_consent_data_and_return(export_consent: ExportConsent): boolean {
+    // Handles a race where the client has requested the server for export consents
+    // to populate 'Export permissions' table but hasn't received the response yet,
+    // but received a few updated events which should be applied on top of the received
+    // response to avoid outdated table.
+    // We store the export_consent data received via events to apply them on top of
+    // the received response.
+    if (export_consents === undefined) {
+        queued_export_consents.push(export_consent);
+        return true;
+    }
+    return false;
+}
+
+export function remove_export_consent_data_and_redraw(user_id: number): void {
+    if (!meta.loaded) {
+        return;
+    }
+
+    if (export_consents === undefined) {
+        queued_export_consents.push(user_id);
+        return;
+    }
+
+    export_consents.delete(user_id);
+    redraw_export_consents_list();
+}
+
+export function update_export_consent_data_and_redraw(export_consent: ExportConsent): void {
+    if (!meta.loaded) {
+        return;
+    }
+
+    if (maybe_store_export_consent_data_and_return(export_consent)) {
+        return;
+    }
+
+    export_consents.set(export_consent.user_id, export_consent.consented);
+    redraw_export_consents_list();
 }

--- a/web/src/user_events.js
+++ b/web/src/user_events.js
@@ -16,6 +16,7 @@ import * as pm_list from "./pm_list";
 import * as settings from "./settings";
 import * as settings_account from "./settings_account";
 import * as settings_config from "./settings_config";
+import * as settings_exports from "./settings_exports";
 import * as settings_linkifiers from "./settings_linkifiers";
 import * as settings_org from "./settings_org";
 import * as settings_profile_fields from "./settings_profile_fields";
@@ -187,6 +188,9 @@ export const update_person = function update(person) {
         settings_account.maybe_update_deactivate_account_button();
         if (people.is_valid_bot_user(person.user_id)) {
             settings_users.update_bot_data(person.user_id);
+        } else if (!person.is_active) {
+            // A human user deactivated, update 'Export permissions' table.
+            settings_exports.remove_export_consent_data_and_redraw(person.user_id);
         }
     }
 };

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2101,3 +2101,7 @@ $option_title_width: 180px;
 #admin-user-list .tab-switcher .ind-tab {
     width: 110px;
 }
+
+#data-exports .tab-switcher .ind-tab {
+    width: 160px;
+}

--- a/web/templates/settings/admin_export_consent_list.hbs
+++ b/web/templates/settings/admin_export_consent_list.hbs
@@ -1,0 +1,10 @@
+{{#with export_consent}}
+<tr>
+    <td class="user_name panel_user_list">
+        {{> ../user_display_only_pill display_value=full_name user_id=user_id img_src=img_src is_active=true}}
+    </td>
+    <td>
+        <span>{{consent}}</span>
+    </td>
+</tr>
+{{/with}}

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -25,22 +25,48 @@
     </form>
     {{/if}}
 
-    <div class="settings_panel_list_header">
-        <h3>{{t "Data exports"}}</h3>
-        <input type="hidden" class="search" placeholder="{{t 'Filter exports' }}"
-          aria-label="{{t 'Filter exports' }}"/>
+    <hr/>
+
+    <div class="tab-container"></div>
+
+    <div class="export_section" data-export-section="data-exports">
+        <div class="settings_panel_list_header">
+            <h3>{{t "Data exports"}}</h3>
+            <input type="hidden" class="search" placeholder="{{t 'Filter exports' }}"
+              aria-label="{{t 'Filter exports' }}"/>
+        </div>
+
+        <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
+            <table class="table table-striped wrapped-table admin_exports_table">
+                <thead class="table-sticky-headers">
+                    <th class="active" data-sort="user">{{t "Requesting user" }}</th>
+                    <th>{{t "Type"}}</th>
+                    <th data-sort="numeric" data-sort-prop="export_time">{{t "Time" }}</th>
+                    <th>{{t "Status" }}</th>
+                    <th class="actions">{{t "Actions" }}</th>
+                </thead>
+                <tbody id="admin_exports_table" data-empty="{{t 'There are no exports.' }}"></tbody>
+            </table>
+        </div>
     </div>
 
-    <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
-        <table class="table table-striped wrapped-table admin_exports_table">
-            <thead class="table-sticky-headers">
-                <th class="active" data-sort="user">{{t "Requesting user" }}</th>
-                <th>{{t "Type" }}</th>
-                <th data-sort="numeric" data-sort-prop="export_time">{{t "Time" }}</th>
-                <th>{{t "Status" }}</th>
-                <th class="actions">{{t "Actions" }}</th>
-            </thead>
-            <tbody id="admin_exports_table" data-empty="{{t 'There are no exports.' }}"></tbody>
-        </table>
+    <div class="export_section" data-export-section="export-permissions">
+        <div class="settings_panel_list_header">
+            <h3>{{t "Export permissions"}}</h3>
+            <div class="user_filters">
+                {{> ../dropdown_widget widget_name="filter_by_consent"}}
+                <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+            </div>
+        </div>
+
+        <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
+            <table class="table table-striped wrapped-table">
+                <thead class="table-sticky-headers">
+                    <th class="active" data-sort="full_name">{{t "Name" }}</th>
+                    <th>{{t "Export permission"}}</th>
+                </thead>
+                <tbody id="admin_export_consents_table"></tbody>
+            </table>
+        </div>
     </div>
 </div>

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -748,6 +748,7 @@ run_test("add_realm_user_redraw_logic", ({override}) => {
     presence.presence_info.set(999, {status: "active"});
 
     override(settings_account, "maybe_update_deactivate_account_button", noop);
+    override(settings_exports, "update_export_consent_data_and_redraw", noop);
 
     const check_should_redraw_new_user_stub = make_stub();
     // make_stub().f returns true by default, so it's already doing what we want.
@@ -766,6 +767,7 @@ run_test("add_realm_user_redraw_logic", ({override}) => {
 run_test("realm_user", ({override}) => {
     override(settings_account, "maybe_update_deactivate_account_button", noop);
     override(activity_ui, "check_should_redraw_new_user", noop);
+    override(settings_exports, "update_export_consent_data_and_redraw", noop);
     let event = event_fixtures.realm_user__add;
     dispatch({...event});
     const added_person = people.get_by_user_id(event.person.user_id);
@@ -1301,6 +1303,18 @@ run_test("realm_export", ({override}) => {
     assert.equal(stub.num_calls, 1);
     const args = stub.get_args("exports");
     assert.equal(args.exports, event.exports);
+});
+
+run_test("realm_export_consent", ({override}) => {
+    const event = event_fixtures.realm_export_consent;
+    const stub = make_stub();
+    override(settings_exports, "update_export_consent_data_and_redraw", stub.f);
+    dispatch(event);
+
+    assert.equal(stub.num_calls, 1);
+    const {export_consent} = stub.get_args("export_consent");
+    assert.equal(export_consent.user_id, event.user_id);
+    assert.equal(export_consent.consented, event.consented);
 });
 
 run_test("server_event_dispatch_op_errors", () => {

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -489,6 +489,12 @@ exports.fixtures = {
         ],
     },
 
+    realm_export_consent: {
+        type: "realm_export_consent",
+        user_id: test_user.user_id,
+        consented: true,
+    },
+
     realm_linkifiers: {
         type: "realm_linkifiers",
         realm_linkifiers: [


### PR DESCRIPTION
Issue: https://github.com/zulip/zulip/issues/31201

* First commit: Adds 'Export permissions' table.
* Second commit: Fixes live update issue in the `start export` modal.

**Screenshots and screen captures:**

<img width="491" alt="Screenshot 2024-10-16 at 8 31 54 PM" src="https://github.com/user-attachments/assets/eb07e603-82c5-4431-88a1-a9d6e8cf2598">

<img width="491" alt="Screenshot 2024-10-16 at 8 32 09 PM" src="https://github.com/user-attachments/assets/fbc2c9e6-2351-4946-8210-cfc87bd60e54">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
