### PR TITLE
ui_update: Update the @ symbol in /#settings/notifications

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -633,6 +633,12 @@ input[type="checkbox"] {
             font-weight: bold;
             word-break: break-all;
         }
+
+        .zulip-icon {
+            font-size: calc(0.8 * var(--base-font-size-px));
+            top: 2px;
+            position: relative;
+        }
     }
 }
 

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -17,7 +17,7 @@
                         {{> ../help_link_widget link="/help/mobile-notifications#enabling-push-notifications-for-self-hosted-servers" }}
                     </th>
                     <th rowspan="2" width="14%">{{t "Email"}}</th>
-                    <th rowspan="2" width="14%">@all
+                    <th rowspan="2" width="14%"><i class="zulip-icon zulip-icon-at-sign" aria-label="{{t 'All'}}"></i>all
                         <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
                     </th>
                 </tr>


### PR DESCRIPTION
Changes `@` icon before the 'all' in the table head in `/#settings/notifications`.
Font-size of icon: 0.93em

Contains a part of #31868
Fixes a part of #22816.

## Screenshots of the change

**Before**

![image](https://github.com/user-attachments/assets/eb25d98e-8b38-4bfe-b979-17e77291a1f7)

![image](https://github.com/user-attachments/assets/183fbc0f-9505-4e17-8b2b-c56b3589bf56)


**After**

![image](https://github.com/user-attachments/assets/9200574b-71e8-4275-9db2-14907ee7c6ad)

![image](https://github.com/user-attachments/assets/5b9857ec-2205-407c-9edc-5d79f9b00e4b)

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
