### PR TITLE
desktop_notifications: refactor emoji handling in notifications

### DIFF
--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -40,7 +40,7 @@ function get_notification_content(message: Message | TestNotificationMessage): s
     let content;
     // Convert the content to plain text, replacing emoji with their alt text
     const $content = $("<div>").html(message.content);
-    ui_util.replace_emoji_with_text($content);
+    ui_util.replace_emoji_name_with_unicode_hex($content);
     ui_util.change_katex_to_raw_latex($content);
     ui_util.potentially_collapse_quotes($content);
     spoilers.hide_spoilers_in_notification($content);

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -23,25 +23,38 @@ export function place_caret_at_end(el: HTMLElement): void {
 }
 
 export function replace_emoji_name_with_unicode_hex($element: JQuery): void {
+    // Find the emoji class in the passed JQuery element
     $element.find("span.emoji").each(function () {
         const emoji_class: string | undefined = $(this).attr("class");
-
+        // If no emoji class is found do nothing to the element
         if (emoji_class === undefined) {
-            return; // Skip this iteration if class is undefined
+            return;
         }
 
+        // Emojis have a class with the emoji code next to them i.e. emoji-1f951
+        // The code 1f951 represents an avocado 🥑
         const regex = /emoji-(\w+)/;
         const match = regex.exec(emoji_class);
         const emoji_code = match?.[1] ?? "";
 
-        if (!emoji_code) {
-            return; // Skip this iteration if no emoji code is found
+        // Convert the emoji code to its hex code representation
+        // Then use String.fromCodePoint to get the standard unicode representation of the hex code
+        try {
+            const hex_code = Number.parseInt(emoji_code, 16);
+            if (Number.isNaN(hex_code)) {
+                throw new Error(`Invalid emoji code: ${emoji_code}`);
+            }
+            const emoji_char = String.fromCodePoint(hex_code);
+            $(this).text(emoji_char);
+        } catch (error: unknown) {
+            if (error instanceof Error) {
+                console.error(`Failed to convert emoji code to character: ${error.message}`);
+            } else {
+                console.error('Failed to convert emoji code to character: Unknown error');
+            }
+            // Fallback behavior: leave the original content unchanged
+            return;
         }
-
-        const hex_code = Number.parseInt(emoji_code, 16);
-
-        const emoji_char = String.fromCodePoint(hex_code);
-        $(this).text(emoji_char);
     });
 }
 

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -24,22 +24,24 @@ export function place_caret_at_end(el: HTMLElement): void {
 
 export function replace_emoji_name_with_unicode_hex($element: JQuery): void {
     $element.find("span.emoji").each(function () {
-        const emoji_class = $(this).attr("class");
+        const emoji_class: string | undefined = $(this).attr("class");
 
         if (emoji_class === undefined) {
             return; // Skip this iteration if class is undefined
         }
 
-        const emoji_code = emoji_class.match(/emoji-(\w+)/)?.[1] ?? "";
+        const regex = /emoji-(\w+)/;
+        const match = regex.exec(emoji_class);
+        const emoji_code = match?.[1] ?? "";
+
         if (!emoji_code) {
             return; // Skip this iteration if no emoji code is found
         }
 
-        const hex_code = parseInt(emoji_code, 16);
-        const unicode_escape = `\\u{${hex_code.toString(16)}}`;
+        const hex_code = Number.parseInt(emoji_code, 16);
 
-        const emoji_hex = eval(`"${unicode_escape}"`);
-        $(this).replaceWith(emoji_hex);
+        const emoji_char = String.fromCodePoint(hex_code);
+        $(this).text(emoji_char);
     });
 }
 

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -22,19 +22,6 @@ export function place_caret_at_end(el: HTMLElement): void {
     }
 }
 
-export function replace_emoji_with_text($element: JQuery): void {
-    $element
-        .find(".emoji")
-        .text(function () {
-            if ($(this).is("img")) {
-                return $(this).attr("alt") ?? "";
-            }
-            return $(this).text();
-        })
-        .contents()
-        .unwrap();
-}
-
 export function replace_emoji_name_with_unicode_hex($element: JQuery): void {
     $element.find("span.emoji").each(function () {
         const emoji_class = $(this).attr("class");

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -35,6 +35,27 @@ export function replace_emoji_with_text($element: JQuery): void {
         .unwrap();
 }
 
+export function replace_emoji_name_with_unicode_hex($element: JQuery): void {
+    $element.find("span.emoji").each(function () {
+        const emoji_class = $(this).attr("class");
+
+        if (emoji_class === undefined) {
+            return; // Skip this iteration if class is undefined
+        }
+
+        const emoji_code = emoji_class.match(/emoji-(\w+)/)?.[1] ?? "";
+        if (!emoji_code) {
+            return; // Skip this iteration if no emoji code is found
+        }
+
+        const hex_code = parseInt(emoji_code, 16);
+        const unicode_escape = `\\u{${hex_code.toString(16)}}`;
+
+        const emoji_hex = eval(`"${unicode_escape}"`);
+        $(this).replaceWith(emoji_hex);
+    });
+}
+
 export function change_katex_to_raw_latex($element: JQuery): void {
     // Find all the span elements with the class "katex"
     $element.find("span.katex").each(function () {

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -2,26 +2,26 @@
 
 const assert = require("node:assert/strict");
 
-const { mock_esm, zrequire } = require("./lib/namespace");
-const { run_test } = require("./lib/test");
+const {mock_esm, zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const { page_params } = require("./lib/zpage_params");
+const {page_params} = require("./lib/zpage_params");
 
 mock_esm("../src/electron_bridge");
-mock_esm("../src/spoilers", { hide_spoilers_in_notification() { } });
+mock_esm("../src/spoilers", {hide_spoilers_in_notification() {}});
 
 const user_topics = zrequire("user_topics");
 const stream_data = zrequire("stream_data");
 
 const desktop_notifications = zrequire("desktop_notifications");
 const message_notifications = zrequire("message_notifications");
-const { set_current_user } = zrequire("state_data");
-const { initialize_user_settings } = zrequire("user_settings");
+const {set_current_user} = zrequire("state_data");
+const {initialize_user_settings} = zrequire("user_settings");
 
 const current_user = {};
 set_current_user(current_user);
 const user_settings = {};
-initialize_user_settings({ user_settings });
+initialize_user_settings({user_settings});
 
 // Not muted streams
 const general = {
@@ -73,7 +73,7 @@ function test(label, f) {
     });
 }
 
-test("message_is_notifiable", ({ override }) => {
+test("message_is_notifiable", ({override}) => {
     // A notification is sent if both message_is_notifiable(message)
     // and the appropriate should_send_*_notification function return
     // true.
@@ -349,8 +349,8 @@ test("message_is_notifiable", ({ override }) => {
 });
 
 test("basic_notifications", () => {
-    $("<div>").set_find_results("span.emoji", { each() { } });
-    $("<div>").set_find_results("span.katex", { each() { } });
+    $("<div>").set_find_results("span.emoji", {each() {}});
+    $("<div>").set_find_results("span.katex", {each() {}});
     $("<div>").children = () => [];
 
     let n; // Object for storing all notification data for assertions.
@@ -359,7 +359,7 @@ test("basic_notifications", () => {
 
     // Notifications API stub
     class StubNotification {
-        constructor(_title, { icon, body, tag }) {
+        constructor(_title, {icon, body, tag}) {
             this.icon = icon;
             this.body = body;
             this.tag = tag;
@@ -370,7 +370,7 @@ test("basic_notifications", () => {
             last_shown_message_id = this.tag;
         }
 
-        addEventListener() { }
+        addEventListener() {}
 
         close() {
             last_closed_message_id = this.tag;
@@ -406,7 +406,7 @@ test("basic_notifications", () => {
     };
 
     // Send notification.
-    message_notifications.process_notification({ message: message_1, desktop_notify: true });
+    message_notifications.process_notification({message: message_1, desktop_notify: true});
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);
     assert.equal(n.size, 1);
@@ -421,7 +421,7 @@ test("basic_notifications", () => {
 
     // Send notification.
     message_1.id = 1001;
-    message_notifications.process_notification({ message: message_1, desktop_notify: true });
+    message_notifications.process_notification({message: message_1, desktop_notify: true});
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);
     assert.equal(n.size, 1);
@@ -429,14 +429,14 @@ test("basic_notifications", () => {
 
     // Process same message again. Notification count shouldn't increase.
     message_1.id = 1002;
-    message_notifications.process_notification({ message: message_1, desktop_notify: true });
+    message_notifications.process_notification({message: message_1, desktop_notify: true});
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);
     assert.equal(n.size, 1);
     assert.equal(last_shown_message_id, message_1.id.toString());
 
     // Send another message. Notification count should increase.
-    message_notifications.process_notification({ message: message_2, desktop_notify: true });
+    message_notifications.process_notification({message: message_2, desktop_notify: true});
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Gus Fring to general > lunch"), true);
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -2,26 +2,26 @@
 
 const assert = require("node:assert/strict");
 
-const {mock_esm, zrequire} = require("./lib/namespace");
-const {run_test} = require("./lib/test");
+const { mock_esm, zrequire } = require("./lib/namespace");
+const { run_test } = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {page_params} = require("./lib/zpage_params");
+const { page_params } = require("./lib/zpage_params");
 
 mock_esm("../src/electron_bridge");
-mock_esm("../src/spoilers", {hide_spoilers_in_notification() {}});
+mock_esm("../src/spoilers", { hide_spoilers_in_notification() { } });
 
 const user_topics = zrequire("user_topics");
 const stream_data = zrequire("stream_data");
 
 const desktop_notifications = zrequire("desktop_notifications");
 const message_notifications = zrequire("message_notifications");
-const {set_current_user} = zrequire("state_data");
-const {initialize_user_settings} = zrequire("user_settings");
+const { set_current_user } = zrequire("state_data");
+const { initialize_user_settings } = zrequire("user_settings");
 
 const current_user = {};
 set_current_user(current_user);
 const user_settings = {};
-initialize_user_settings({user_settings});
+initialize_user_settings({ user_settings });
 
 // Not muted streams
 const general = {
@@ -73,7 +73,7 @@ function test(label, f) {
     });
 }
 
-test("message_is_notifiable", ({override}) => {
+test("message_is_notifiable", ({ override }) => {
     // A notification is sent if both message_is_notifiable(message)
     // and the appropriate should_send_*_notification function return
     // true.
@@ -349,8 +349,8 @@ test("message_is_notifiable", ({override}) => {
 });
 
 test("basic_notifications", () => {
-    $("<div>").set_find_results(".emoji", {text: () => ({contents: () => ({unwrap() {}})})});
-    $("<div>").set_find_results("span.katex", {each() {}});
+    $("<div>").set_find_results("span.emoji", { each() { } });
+    $("<div>").set_find_results("span.katex", { each() { } });
     $("<div>").children = () => [];
 
     let n; // Object for storing all notification data for assertions.
@@ -359,7 +359,7 @@ test("basic_notifications", () => {
 
     // Notifications API stub
     class StubNotification {
-        constructor(_title, {icon, body, tag}) {
+        constructor(_title, { icon, body, tag }) {
             this.icon = icon;
             this.body = body;
             this.tag = tag;
@@ -370,7 +370,7 @@ test("basic_notifications", () => {
             last_shown_message_id = this.tag;
         }
 
-        addEventListener() {}
+        addEventListener() { }
 
         close() {
             last_closed_message_id = this.tag;
@@ -381,7 +381,7 @@ test("basic_notifications", () => {
 
     const message_1 = {
         id: 1000,
-        content: "@-mentions the user",
+        content: "@-mentions the user :smile:",
         avatar_url: "url",
         sent_by_me: false,
         sender_full_name: "Jesse Pinkman",
@@ -406,7 +406,7 @@ test("basic_notifications", () => {
     };
 
     // Send notification.
-    message_notifications.process_notification({message: message_1, desktop_notify: true});
+    message_notifications.process_notification({ message: message_1, desktop_notify: true });
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);
     assert.equal(n.size, 1);
@@ -421,7 +421,7 @@ test("basic_notifications", () => {
 
     // Send notification.
     message_1.id = 1001;
-    message_notifications.process_notification({message: message_1, desktop_notify: true});
+    message_notifications.process_notification({ message: message_1, desktop_notify: true });
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);
     assert.equal(n.size, 1);
@@ -429,14 +429,14 @@ test("basic_notifications", () => {
 
     // Process same message again. Notification count shouldn't increase.
     message_1.id = 1002;
-    message_notifications.process_notification({message: message_1, desktop_notify: true});
+    message_notifications.process_notification({ message: message_1, desktop_notify: true });
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);
     assert.equal(n.size, 1);
     assert.equal(last_shown_message_id, message_1.id.toString());
 
     // Send another message. Notification count should increase.
-    message_notifications.process_notification({message: message_2, desktop_notify: true});
+    message_notifications.process_notification({ message: message_2, desktop_notify: true });
     n = desktop_notifications.get_notifications();
     assert.equal(n.has("Gus Fring to general > lunch"), true);
     assert.equal(n.has("Jesse Pinkman to general > whatever"), true);


### PR DESCRIPTION
Fixes #30598: Emoji now render correctly in desktop notifications

This PR converts emoji from canonical names to Unicode characters in notification content, ensuring proper display in desktop notifications.

**Screenshots:**
Before: 
![Screenshot from 2024-10-09 17-32-23](https://github.com/user-attachments/assets/75850b71-357f-4283-b740-0e90b24f6f0f)

After:
![Screenshot from 2024-10-09 17-18-35](https://github.com/user-attachments/assets/d3f2c8fc-21f3-4cf5-b08b-2e80eb3f40db)


<details>
<summary>Self-review checklist</summary>

- [x] Self-reviewed for clarity and maintainability
- [x] Commit explains changes and motivation
- [x] Manually tested functionality and edge cases

</details>

## Implementation
- Created a function that gets the unicode representation of an emoji and used that to display the emoji in the notification.

## Next Steps
- Consider emojis that might have non-standard unicode representations. They won't display in notifications or will display wrongly.