### PR TITLE
api-docs: Centralize history of realm message edit/move settings.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4272,8 +4272,13 @@ paths:
                                     allow_message_editing:
                                       type: boolean
                                       description: |
-                                        Whether this organizations [message edit policy](/help/restrict-message-editing-and-deletion)
+                                        Whether this organization's [message edit policy][config-message-editing]
                                         allows editing the content of messages.
+
+                                        See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                                        history of how message editing permissions work.
+
+                                        [config-message-editing]: /help/restrict-message-editing-and-deletion
                                     authentication_methods:
                                       type: object
                                       additionalProperties:
@@ -4483,10 +4488,12 @@ paths:
                                         - 5 = Everyone
                                         - 6 = Nobody
 
+                                        See [`PATCH /messages/{message_id}`](/api/update-message) for details and history
+                                        of how message editing permissions work.
+
                                         **Changes**: Nobody added as an option in Zulip 7.0 (feature level 159).
 
-                                        New in Zulip 5.0 (feature level 75), replacing the previous
-                                        `allow_community_topic_editing` boolean.
+                                        New in Zulip 5.0 (feature level 75).
 
                                         [permission-level]: /api/roles-and-permissions#permission-levels
                                         [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -4607,8 +4614,14 @@ paths:
                                         with this organization's
                                         [message edit policy](/help/restrict-message-editing-and-deletion).
 
-                                        **Changes**: No limit was represented using the
-                                        special value `0` before Zulip 6.0 (feature level 138).
+                                        Will not be `0`. A `null` value means no limit, so messages can be edited
+                                        regardless of how long ago they were sent.
+
+                                        See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                                        history of how message editing permissions work.
+
+                                        **Changes**: Before Zulip 6.0 (feature level 138), no limit was
+                                        represented using the special value `0`.
                                     move_messages_within_stream_limit_seconds:
                                       type: integer
                                       nullable: true
@@ -4618,8 +4631,11 @@ paths:
                                         organization's [topic edit policy](/help/restrict-moving-messages). This
                                         setting does not affect moderators and administrators.
 
-                                        Will not be 0. A `null` value means no limit, so message topics can be
+                                        Will not be `0`. A `null` value means no limit, so message topics can be
                                         edited regardless of how long ago they were sent.
+
+                                        See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                                        history of how message editing permissions work.
 
                                         **Changes**: New in Zulip 7.0 (feature level 162). Previously, this time
                                         limit was always 72 hours for users who were not administrators or
@@ -4633,8 +4649,11 @@ paths:
                                         [message move policy](/help/restrict-moving-messages). This setting does
                                         not affect moderators and administrators.
 
-                                        Will not be 0. A `null` value means no limit, so messages can be moved
+                                        Will not be `0`. A `null` value means no limit, so messages can be moved
                                         regardless of how long ago they were sent.
+
+                                        See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                                        history of how message editing permissions work.
 
                                         **Changes**: New in Zulip 7.0 (feature level 162). Previously, there was
                                         no time limit for moving messages between channels for users with permission
@@ -4650,6 +4669,9 @@ paths:
                                         - 3 = [Full members][calc-full-member] only
                                         - 4 = Moderators only
                                         - 6 = Nobody
+
+                                        See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                                        history of how message editing permissions work.
 
                                         **Changes**: Nobody added as an option in Zulip 7.0 (feature level 159).
 
@@ -8132,16 +8154,15 @@ paths:
       summary: Edit a message
       tags: ["messages"]
       description: |
-        Edit/update the content, topic, or channel of a message.
+        Update the content, topic, or channel of the message with the specified
+        ID.
 
-        `{msg_id}` in the above URL should be replaced with the ID of the
-        message you wish you update.
-
-        You can [resolve topics](/help/resolve-a-topic) by editing the
-        topic to `✔ {original_topic}`.
+        You can [resolve topics](/help/resolve-a-topic) by editing the topic to
+        `✔ {original_topic}` with the `propagate_mode` parameter set to
+        `"change_all"`.
 
         See [configuring message editing][config-message-editing] for detailed
-        documentation on when users are allowed to edit message content and
+        documentation on when users are allowed to edit message content, and
         [restricting moving messages][restrict-move-messages] for detailed
         documentation on when users are allowed to change a message's topic
         and/or channel.
@@ -8193,6 +8214,12 @@ paths:
 
         Before Zulip 7.0 (feature level 159), message senders were allowed to edit
         the topic of their messages indefinitely.
+
+        In Zulip 5.0 (feature level 75), the `edit_topic_policy` realm setting
+        was added, replacing the `allow_community_topic_editing` boolean.
+
+        In Zulip 4.0 (feature level 56), the `move_messages_between_streams_policy`
+        realm setting was added.
 
         [config-message-editing]: /help/restrict-message-editing-and-deletion
         [restrict-move-messages]: /help/restrict-moving-messages
@@ -16404,26 +16431,6 @@ paths:
                           `"role:internet"` and `"role:owners"`.
 
                           **Changes**: New in Zulip 8.0 (feature level 209).
-                      realm_move_messages_between_streams_policy:
-                        type: integer
-                        description: |
-                          Present if `realm` is present in `fetch_event_types`.
-
-                          The [policy][permission-level] for which users can move messages
-                          from one channel to another.
-
-                          - 1 = Members only
-                          - 2 = Administrators only
-                          - 3 = [Full members][calc-full-member] only
-                          - 4 = Moderators only
-                          - 6 = Nobody
-
-                          **Changes**: Nobody added as an option in Zulip 7.0 (feature level 159).
-
-                          New in Zulip 4.0 (feature level 56).
-
-                          [permission-level]: /api/roles-and-permissions#permission-levels
-                          [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
                       realm_inline_image_preview:
                         type: boolean
                         description: |
@@ -16687,8 +16694,13 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          Whether this organizations [message edit policy](/help/restrict-message-editing-and-deletion)
+                          Whether this organization's [message edit policy][config-message-editing]
                           allows editing the content of messages.
+
+                          See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                          history of how message editing permissions work.
+
+                          [config-message-editing]: /help/restrict-message-editing-and-deletion
                       realm_edit_topic_policy:
                         type: integer
                         description: |
@@ -16703,10 +16715,35 @@ paths:
                           - 5 = Everyone
                           - 6 = Nobody
 
+                          See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                          history of how message editing permissions work.
+
                           **Changes**: Nobody added as an option in Zulip 7.0 (feature level 159).
 
-                          New in Zulip 5.0 (feature level 75), replacing the previous
-                          `allow_community_topic_editing` boolean.
+                          New in Zulip 5.0 (feature level 75).
+
+                          [permission-level]: /api/roles-and-permissions#permission-levels
+                          [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
+                      realm_move_messages_between_streams_policy:
+                        type: integer
+                        description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
+                          The [policy][permission-level] for which users can move messages
+                          from one channel to another.
+
+                          - 1 = Members only
+                          - 2 = Administrators only
+                          - 3 = [Full members][calc-full-member] only
+                          - 4 = Moderators only
+                          - 6 = Nobody
+
+                          See [`PATCH /messages/{message_id}`](/api/update-message) for details
+                          and history of how message editing permissions work.
+
+                          **Changes**: Nobody added as an option in Zulip 7.0 (feature level 159).
+
+                          New in Zulip 4.0 (feature level 56).
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
                           [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -16720,11 +16757,14 @@ paths:
                           with this organization's
                           [message edit policy](/help/restrict-message-editing-and-deletion).
 
-                          Will not be 0. A `null` value means no limit: messages can be edited
+                          Will not be `0`. A `null` value means no limit, so messages can be edited
                           regardless of how long ago they were sent.
 
-                          **Changes**: No limit was represented using the
-                          special value `0` before Zulip 6.0 (feature level 138).
+                          See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                          history of how message editing permissions work.
+
+                          **Changes**: Before Zulip 6.0 (feature level 138), no limit was
+                          represented using the special value `0`.
                       realm_move_messages_within_stream_limit_seconds:
                         type: integer
                         nullable: true
@@ -16736,8 +16776,11 @@ paths:
                           organization's [topic edit policy](/help/restrict-moving-messages). This
                           setting does not affect moderators and administrators.
 
-                          Will not be 0. A `null` value means no limit, so message topics can be
+                          Will not be `0`. A `null` value means no limit, so message topics can be
                           edited regardless of how long ago they were sent.
+
+                          See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                          history of how message editing permissions work.
 
                           **Changes**: New in Zulip 7.0 (feature level 162). Previously, this time
                           limit was always 72 hours for users who were not administrators or
@@ -16753,8 +16796,11 @@ paths:
                           [message move policy](/help/restrict-moving-messages). This setting does
                           not affect moderators and administrators.
 
-                          Will not be 0. A `null` value means no limit, so messages can be moved
+                          Will not be `0`. A `null` value means no limit, so messages can be moved
                           regardless of how long ago they were sent.
+
+                          See [`PATCH /messages/{message_id}`](/api/update-message) for details and
+                          history of how message editing permissions work.
 
                           **Changes**: New in Zulip 7.0 (feature level 162). Previously, there was
                           no time limit for moving messages between channels for users with permission


### PR DESCRIPTION
For the six realm settings mentioned in the main description of the [/api/update-message](https://zulip.com/api/update-message) endpoint, link back to that page in the [/api/register-queue](https://zulip.com/api/register-queue) and [/api/get-events](https://zulip.com/api/get-events#realm-update_dict) endpoints. This way we can maintain a centralized point of documentation for how these settings work for message content edits and moving messages.

The descriptions in the events and register pages focuses on the specifics for each realm setting, e.g., when a value is added or changed for a particular realm setting.

See [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/realm_edit_topic_policy.20misleading/near/1956711).

**Notes**:
- Per [this CZO discussion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.20response.20field.20order/near/1954735), took the opportunity to make sure these fields are grouped together in the register response documentation.
- Changes to the "Edit a message" description:
  - Removed the sentence about the `{msg_id}`'s significance, and revised initial phrase to match current API doc conventions.
  - Expanded note about resolving topics to note the `propagate_mode` parameter for that as well.
  - Expanded history to include when the `edit_topic_policy` and `move_messages_between_streams_policy` realm settings were added.
- There are some small tweaks to the descriptions on the events and register pages for consistency.

---

**Screenshots and screen captures:**

<details>
<summary>Updated "Edit a message" endpoint main description</summary>

[Current documentation](https://zulip.com/api/update-message)
![Screenshot from 2024-10-10 17-50-52](https://github.com/user-attachments/assets/a5820487-132a-48f1-9f28-5430e82e1824)
</details>
<details>
<summary>Updated realm op: update_dict fields</summary>

[Current documentation](https://zulip.com/api/get-events#realm-update_dict) -> *note fields in alphabetical order*
![Screenshot from 2024-10-10 18-18-28](https://github.com/user-attachments/assets/a38591c2-c6d7-4f50-aea8-08dcbcf2b2eb)
![Screenshot from 2024-10-10 18-18-11](https://github.com/user-attachments/assets/5813ce13-537a-4a5a-982e-d9faade610a2)
![Screenshot from 2024-10-10 18-17-42](https://github.com/user-attachments/assets/f53e506d-99fb-4da1-8728-8b3159918ab3)
</details>
<details>
<summary>Updated fields in register reponse</summary>

[Current documentation](https://zulip.com/api/register-queue) -> *search for realm setting names*
![Screenshot from 2024-10-10 18-19-56](https://github.com/user-attachments/assets/844569c4-a6c3-4032-a1b6-2052ab6b343f)
![Screenshot from 2024-10-10 18-20-10](https://github.com/user-attachments/assets/d952e99e-d883-43ca-bb4f-011ec94fb438)
</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
