### PR TITLE
left_sidebar: Update remaining gray left sidebar elements.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -626,7 +626,7 @@ input.settings_text_input {
 .unread_mention_info:not(:empty) {
     margin-right: 5px;
     margin-left: 2px;
-    opacity: 0.7;
+    opacity: 0.5;
 }
 
 /* Implement the web app's default-hidden convention for alert

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -823,6 +823,9 @@
     --color-left-sidebar-navigation-icon: hsl(240deg 30% 40%);
     --color-left-sidebar-heads-up-icon: hsl(240deg 30% 40%);
     --color-left-sidebar-heads-up-icon-hover: hsl(240deg 100% 15%);
+    --color-left-sidebar-dm-partners-icon: var(
+        --color-left-sidebar-navigation-icon
+    );
     --background-color-left-sidebar-heads-up-icon-hover: hsl(
         240deg 100% 50% / 7%
     );
@@ -1355,6 +1358,9 @@
     --color-left-sidebar-navigation-icon: hsl(240deg 35% 68%);
     --color-left-sidebar-heads-up-icon: hsl(240deg 35% 68%);
     --color-left-sidebar-heads-up-icon-hover: hsl(240deg 100% 90%);
+    --color-left-sidebar-dm-partners-icon: var(
+        --color-left-sidebar-navigation-icon
+    );
     --background-color-left-sidebar-heads-up-icon-hover: hsl(
         240deg 100% 75% / 20%
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -611,16 +611,30 @@
     --color-background-active-popover-menu: hsl(220deg 12% 5% / 7%);
     --color-border-popover-menu: hsl(0deg 0% 0% / 40%);
     --color-border-personal-menu-avatar: hsl(0deg 0% 0% / 10%);
-    --color-background-unread-counter: hsl(105deg 2% 50%);
+    --color-background-unread-counter-prominent: hsl(240deg 10% 50% / 70%);
+    --color-background-unread-counter-normal: hsl(240deg 10% 50% / 25%);
+    --color-background-unread-counter-quiet: transparent;
+    --color-unread-counter-prominent: hsl(0deg 0% 100%);
+    --color-unread-counter-normal: hsl(0deg 0% 0% / 90%);
+    --color-unread-counter-quiet: hsl(240deg 15% 50%);
+    /* Legacy unread-counter color value. */
+    --color-background-unread-counter: var(
+        --color-background-unread-counter-prominent
+    );
+    --color-unread-counter-muted: hsl(240deg 10% 50% / 35%);
     --color-border-add-subscription-button-focus: hsl(0deg 0% 20%);
-    /* There's no alpha channel here, but this keeps
-       the variable names in line. */
-    --color-background-unread-counter-no-alpha: var(
-        --color-background-unread-counter
+    /* When unreads are hovered on the condensed
+       views, they should not have an alpha.
+       The first color corresponds to
+       --color-background-unread-counter-prominent.
+       The second color aligns with light mode's
+       --color-background. */
+    --color-background-unread-counter-no-alpha: color-mix(
+        in srgb,
+        hsl(240deg 10% 50%) 70%,
+        hsl(0deg 0% 94%)
     );
-    --color-background-unread-counter-dot: var(
-        --color-background-unread-counter
-    );
+    --color-background-unread-counter-dot: hsl(240deg 30% 40%);
     --color-border-unread-counter: var(--color-background-unread-counter);
     --color-border-unread-counter-popover-menu: inherit;
     --color-background-tab-picker-container: hsl(0deg 0% 0% / 7%);
@@ -1142,7 +1156,6 @@
     --color-background-active-popover-menu: hsl(220deg 12% 95% / 7%);
     --color-border-popover-menu: hsl(0deg 0% 0%);
     --color-border-personal-menu-avatar: hsl(0deg 0% 100% / 20%);
-    --color-background-unread-counter: hsl(105deg 2% 50% / 50%);
     /* When unreads are hovered on the condensed
        views, they should not have an alpha.
 
@@ -1152,10 +1165,21 @@
        an rgb() value by PostCSS Preset Env. */
     --color-background-unread-counter-no-alpha: color-mix(
         in srgb,
-        hsl(105deg 2% 50%) 50%,
+        hsl(240deg 10% 50%) 35%,
         hsl(0deg 0% 11%)
     );
-    --color-background-unread-counter-dot: hsl(105deg 2% 50% / 90%);
+    --color-background-unread-counter-dot: hsl(240deg 35% 68%);
+    --color-background-unread-counter-prominent: hsl(240deg 18.37% 34.42%);
+    --color-background-unread-counter-normal: hsl(240deg 10% 50% / 35%);
+    --color-background-unread-counter-quiet: transparent;
+    --color-unread-counter-prominent: hsl(0deg 0% 100%);
+    --color-unread-counter-normal: hsl(0deg 0% 100% / 85%);
+    --color-unread-counter-quiet: hsl(240deg 15% 60%);
+    /* Legacy unread-counter color value. */
+    --color-background-unread-counter: var(
+        --color-background-unread-counter-prominent
+    );
+    --color-unread-counter-muted: hsl(240deg 10% 50% / 35%);
     --color-border-unread-counter: hsl(105deg 2% 50%);
     --color-border-unread-counter-popover-menu: var(
         --color-border-unread-counter

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1151,9 +1151,8 @@ textarea.new_message_textarea {
 
     .unread_count {
         margin: 1px 0 0 6px;
-        border: 0.5px solid var(--color-border-unread-counter);
-        background-color: unset;
-        color: inherit;
+        background-color: var(--color-background-unread-counter-quiet);
+        color: var(--color-unread-counter-quiet);
     }
 }
 

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -19,10 +19,12 @@
         }
 
         .unread_count {
-            opacity: 0.7;
+            opacity: 1;
+            outline: 0 solid var(--color-background-unread-counter);
+            transition: outline-width 0.1s ease;
 
             &:hover {
-                opacity: 1;
+                outline-width: 1.5px;
             }
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -496,7 +496,7 @@ ul.filters {
     }
 
     .zulip-icon-follow {
-        opacity: 0.6;
+        opacity: 0.5;
 
         &:hover {
             opacity: 1;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -71,7 +71,7 @@
     /* Masked unreads display as flex when revealed. */
     align-items: center;
     justify-content: center;
-    color: var(--color-masked-unread-marker);
+    color: var(--color-unread-counter-muted);
     width: var(--left-sidebar-single-digit-unread-width);
 }
 
@@ -719,9 +719,8 @@ li.active-sub-filter {
 .top_left_drafts .unread_count,
 .top_left_scheduled_messages .unread_count,
 .condensed-views-popover-menu .unread_count {
-    background-color: unset;
-    color: inherit;
-    border: 0.5px solid var(--color-border-unread-counter);
+    background-color: var(--color-background-unread-counter-quiet);
+    color: var(--color-unread-counter-quiet);
 }
 
 /* Don't show unread counts on views... */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -291,7 +291,7 @@
             }
 
             .zulip-icon {
-                opacity: 0.7;
+                color: var(--color-left-sidebar-dm-partners-icon);
             }
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -25,6 +25,10 @@
     text-overflow: ellipsis;
 }
 
+#left-sidebar .unread_count {
+    user-select: none;
+}
+
 .sidebar-topic-check,
 .topic-markers-and-unreads {
     cursor: pointer;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -45,7 +45,6 @@
         align-items: center;
 
         .recent-view-table-link,
-        .recent-view-table-unread-count,
         & > .zulip-icon {
             outline: 0;
         }
@@ -191,7 +190,13 @@
         margin-right: 1px;
         margin-left: 1px;
         align-self: center;
-        background-color: hsl(105deg 2% 50%);
+        opacity: 1;
+        outline: 0 solid var(--color-background-unread-counter);
+        transition: outline-width 0.1s ease;
+
+        &:hover {
+            outline-width: 1.5px;
+        }
     }
 
     .unread_mention_info:not(:empty) {


### PR DESCRIPTION
This PR introduces the new unread-counter colors from @terpimost (https://terpimost.github.io/zulip-sidebar/), as well as the colors for DM partner icons, with the exception of user circles (which maintain their gray in Vlad's design, albeit as dots and with a different set of colors than currently in use).

Likely points of [CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/remaining.20sidebar.20grays.20.28unreads.2C.20DM.20partner.20icons.29/near/1959505) here:

1. The three levels of unread-counter prominence, including the 'quiet' ones for Drafts, Starred messages, and Scheduled messages, which here have their border removed, in keeping completely with Vlad's work. As an experiment, summary counters (Channels, Direct Messages) are also shown in the 'quiet' style.
2. Changes to both Recent conversations and Inbox views when applying the new colors. Especially in dark theme, there's little distinction between the 'normal' and 'prominent' (DM) levels of gray.
3. The uncanny-valley of hovered unreads on the collapsed views section, which might look better taking the same purple-hover background as the collapsed views icons themselves (though that would introduce yet another background color for unreads).


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Sidebars light, before | Sidebars light, after |
| --- | --- |
| ![expanded-views-light-before](https://github.com/user-attachments/assets/9eec7d5b-a989-4d1f-8224-cf2c95f120ee) | ![expanded-views-light-after](https://github.com/user-attachments/assets/209a63d5-f894-4d2a-a895-6a23beaf38bb) |
| ![collapsed-views-light-before](https://github.com/user-attachments/assets/54059b70-564d-44ab-bd37-c07777248bb8) | ![collapsed-views-light-after](https://github.com/user-attachments/assets/e97cd049-409a-4279-946c-f6d1492b2a1f) |
| ![collapsed-views-unread-hover-light-before](https://github.com/user-attachments/assets/3494b2b8-46bd-476b-b7dc-b52aa3d50888) | ![collapsed-views-unread-hover-light-after](https://github.com/user-attachments/assets/38e43499-3a06-4ce7-8ee5-21a512af6945) |

| Sidebars dark, before | Sidebars dark, after |
| --- | --- |
| ![expanded-views-dark-before](https://github.com/user-attachments/assets/50f8a948-683a-4b14-97fe-3fa34e6162b2) | ![expanded-views-dark-after](https://github.com/user-attachments/assets/60d84d73-be34-4fb8-8dd3-d64acf205254) |
| ![collapsed-views-dark-before](https://github.com/user-attachments/assets/bed4114e-d40e-4d65-b75e-113944abaa41) | ![collapsed-views-dark-after](https://github.com/user-attachments/assets/546cfaef-ec1c-4829-a415-46959c417b2a) |
| ![collapsed-views-unread-hover-dark-before](https://github.com/user-attachments/assets/87e643c7-b536-4c28-b5d7-ebcf3a46003e) | ![collapsed-views-unread-hover-dark-after](https://github.com/user-attachments/assets/ddc21587-7f62-44e5-ace2-af466ebe1ffb) |

| Inbox, before | Inbox, after |
| --- | --- |
| ![inbox-light-before](https://github.com/user-attachments/assets/65ae59c8-9d06-4e32-acde-dbb0be51b461) | ![inbox-light-after](https://github.com/user-attachments/assets/702ed6a5-b662-4b81-989f-5ae1e4e96cde) |
| ![inbox-dark-before](https://github.com/user-attachments/assets/4d22d67f-5259-477d-8731-6a0488cc8467) | ![inbox-dark-after](https://github.com/user-attachments/assets/eda12518-f09c-4e63-b5a5-63aa479bb258) |

| Recent conversations, before | Recent conversations, after |
| --- | --- |
| ![recent-light-before](https://github.com/user-attachments/assets/aba48738-37fa-461f-ad1f-10065ef7045b) | ![recent-light-after](https://github.com/user-attachments/assets/64e144f9-01ac-4c40-b8c9-f343562907c9) |
| ![recent-dark-before](https://github.com/user-attachments/assets/87f11f87-2460-4eb1-bc8a-5b1e9d52c9f9) | ![recent-dark-after](https://github.com/user-attachments/assets/130e3010-2104-429d-bd6e-53410a74be5b) |




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
