### PR TITLE
buddy_list: Fix bug where headers weren't being updated often enough.

### DIFF
--- a/web/tests/lib/buddy_list.js
+++ b/web/tests/lib/buddy_list.js
@@ -44,5 +44,4 @@ exports.stub_buddy_list_elements = () => {
     $("#buddy-list-other-users-container .view-all-users-link").length = 0;
     $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove = noop;
     $("#buddy-list-other-users-container .view-all-users-link").remove = noop;
-    $(".buddy-list-subsection-header").children = () => [];
 };


### PR DESCRIPTION
`$(".buddy-list-subsection-header").children()` has length more often than I had thought. Using the narrow filter is more direct way of managing this state.

Fixes bug reported here: https://chat.zulip.org/#narrow/stream/137-feedback/topic/hiding.20inactive.20users.20in.20right.20sidebar/near/1958300