### PR TITLE
settings: Remove unused realm_create_private_stream_policy.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -216,7 +216,6 @@ export function get_subsection_property_elements($subsection: JQuery): HTMLEleme
 
 type simple_dropdown_realm_settings = Pick<
     typeof realm,
-    | "realm_create_private_stream_policy"
     | "realm_invite_to_stream_policy"
     | "realm_add_custom_emoji_policy"
     | "realm_invite_to_realm_policy"

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -294,7 +294,6 @@ const realm_schema = z.object({
     realm_can_delete_own_message_group: z.number(),
     realm_can_manage_all_groups: z.number(),
     realm_create_multiuse_invite_group: z.number(),
-    realm_create_private_stream_policy: z.number(),
     realm_date_created: z.number(),
     realm_default_code_block_language: z.string(),
     realm_default_external_accounts: z.record(


### PR DESCRIPTION
This was replaced with realm_can_create_private_channel_group in e19524b and wasn't fully removed.

Note it's still present in the backend code because it's used by the mobile app.

Pulled from #31940