### PR TITLE
message_header: Add date on every recipient bar in search results.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -106,6 +106,7 @@ export type MessageGroup = {
           topic_url: string | undefined;
           user_can_resolve_topic: boolean;
           visibility_policy: number | false;
+          always_display_date: boolean;
       }
     | {
           is_stream: false;
@@ -114,6 +115,7 @@ export type MessageGroup = {
           is_private: true;
           pm_with_url: string;
           recipient_users: RecipientRowUser[];
+          always_display_date: boolean;
       }
 );
 
@@ -425,6 +427,14 @@ function maybe_restore_focus_to_message_edit_form(): void {
     }, 0);
 }
 
+function is_search_view(): boolean {
+    const current_filter = narrow_state.filter();
+    if (current_filter && !current_filter.supports_collapsing_recipients()) {
+        return true;
+    }
+    return false;
+}
+
 type SubscriptionMarkers = {
     bookend_top: boolean;
     stream_name: string;
@@ -443,6 +453,9 @@ function populate_group_from_message(
     const message_group_id = _.uniqueId("message_group_");
     const date = get_group_display_date(message, year_changed);
 
+    // Each searched message is a self-contained result,
+    // so we always display date in the recipient bar for those messages.
+    const always_display_date = is_search_view();
     if (is_stream) {
         assert(message.type === "stream");
         // stream messages have string display_recipient
@@ -501,6 +514,7 @@ function populate_group_from_message(
             topic_is_resolved,
             visibility_policy,
             all_visibility_policies,
+            always_display_date,
         };
     }
     // Private message group
@@ -520,6 +534,7 @@ function populate_group_from_message(
         pm_with_url: message.pm_with_url,
         recipient_users: get_users_for_recipient_row(message),
         display_reply_to_for_tooltip: message_store.get_pm_full_names(user_ids),
+        always_display_date,
     };
 }
 

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -76,7 +76,7 @@
                 </span>
             {{/if}}
         </span>
-        <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
+        <span class="recipient_row_date {{#if (and (not always_display_date) date_unchanged )}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
     </div>
 </div>
 {{else}}
@@ -96,7 +96,7 @@
             {{/tr~}}
         </span>
         </a>
-        <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
+        <span class="recipient_row_date {{#if (and (not always_display_date) date_unchanged )}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
     </div>
 </div>
 {{/if}}


### PR DESCRIPTION
Fixes #31958

[CZO Discussion ](https://chat.zulip.org/#narrow/stream/101-design/topic/Date.20indicators.20in.20search.20results)

<details>
  <summary>See Before</summary>

  ![before_adding_date](https://github.com/user-attachments/assets/90fe0ffe-ff19-4cbe-bc39-5bca4ba5acfa)
</details>

<details>
  <summary>See After</summary>

![after_adding_date](https://github.com/user-attachments/assets/3102b7e4-f315-4924-b21e-d6187cdeeee1)
</details>


