### PR TITLE
compose: Avoid highlighting recipient elements when composing.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -91,6 +91,10 @@ function hide_box(): void {
     compose_fade.clear_compose();
     $(".message_comp").hide();
     $("#compose_controls").show();
+    // Assume a muted recipient row for the next time
+    // the compose box is reopened
+    $("#compose-recipient").addClass("muted-recipient-row");
+    $("#compose").removeClass("compose-box-open");
 }
 
 function show_compose_box(opts: ComposeActionsOpts): void {
@@ -110,10 +114,15 @@ function show_compose_box(opts: ComposeActionsOpts): void {
         };
     }
     compose_recipient.update_compose_for_message_type(opts_by_message_type);
-    $("#compose").css({visibility: "visible"});
     // When changing this, edit the 42px in _maybe_autoscroll
     $(".new_message_textarea").css("min-height", "3em");
     compose_ui.set_focus(opts_by_message_type);
+    // Transitions in the recipient row of the compose box are attached
+    // to this class we add a slight delay to avoid transitions firing
+    // immediately.
+    requestAnimationFrame(() => {
+        $("#compose").addClass("compose-box-open");
+    });
 }
 
 export let clear_textarea = (): void => {
@@ -197,6 +206,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     $(document).trigger(new $.Event("compose_started.zulip", opts));
     compose_recipient.update_compose_area_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
+    compose_recipient.maybe_mute_recipient_row();
     // We explicitly call this function here apart from compose_setup.js
     // as this helps to show banner when responding in an interleaved view.
     // While responding, the compose box opens before fading resulting in

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -45,6 +45,22 @@ function composing_to_current_private_message_narrow(): boolean {
     return _.isEqual(narrow_state_recipient, compose_state_recipient);
 }
 
+export let maybe_mute_recipient_row = (): void => {
+    if (composing_to_current_topic_narrow() && compose_state.has_full_recipient()) {
+        $("#compose-recipient").toggleClass("muted-recipient-row", true);
+    } else {
+        $("#compose-recipient").toggleClass("muted-recipient-row", false);
+    }
+};
+
+export function rewire_maybe_mute_recipient_row(value: typeof maybe_mute_recipient_row): void {
+    maybe_mute_recipient_row = value;
+}
+
+export function unmute_recipient_row(): void {
+    $("#compose-recipient").removeClass("muted-recipient-row");
+}
+
 export let update_narrow_to_recipient_visibility = (): void => {
     const message_type = compose_state.get_message_type();
     if (message_type === "stream") {
@@ -98,6 +114,7 @@ export function update_on_recipient_change(): void {
     update_fade();
     update_narrow_to_recipient_visibility();
     compose_validate.warn_if_guest_in_dm_recipient();
+    maybe_mute_recipient_row();
     drafts.update_compose_draft_count();
     check_posting_policy_for_compose_box();
     compose_validate.validate_and_update_send_button_status();
@@ -187,6 +204,7 @@ export function update_compose_for_message_type(opts: ComposeTriggeredOptions): 
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
     compose_banner.clear_uploads();
+    maybe_mute_recipient_row();
 }
 
 export let on_compose_select_recipient_update = (): void => {
@@ -293,6 +311,7 @@ function on_hidden_callback(): void {
 export function handle_middle_pane_transition(): void {
     if (compose_state.composing()) {
         update_narrow_to_recipient_visibility();
+        maybe_mute_recipient_row();
     }
 }
 

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -149,8 +149,9 @@ function switch_message_type(message_type: MessageType): void {
 function update_recipient_label(stream_id?: number): void {
     const stream = stream_id !== undefined ? stream_data.get_sub_by_id(stream_id) : undefined;
     if (stream === undefined) {
-        $("#compose_select_recipient_widget .dropdown_widget_value").text(
-            $t({defaultMessage: "Select a channel"}),
+        const select_channel_label = $t({defaultMessage: "Select a channel"});
+        $("#compose_select_recipient_widget .dropdown_widget_value").html(
+            `<span class="select-channel-label">${select_channel_label}</span>`,
         );
     } else {
         $("#compose_select_recipient_widget .dropdown_widget_value").html(
@@ -179,7 +180,8 @@ export function update_compose_for_message_type(opts: ComposeTriggeredOptions): 
         // it here.
         const direct_message_label = $t({defaultMessage: "DM"});
         $("#compose_select_recipient_widget .dropdown_widget_value").html(
-            `<i class="zulip-icon zulip-icon-users channel-privacy-type-icon"></i> ${direct_message_label}`,
+            `<i class="zulip-icon zulip-icon-users channel-privacy-type-icon"></i>
+            <span class="decorated-dm-label">${direct_message_label}</span>`,
         );
     }
     compose_banner.clear_errors();

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -263,8 +263,13 @@ function focus_compose_recipient(): void {
     $("#compose_select_recipient_widget_wrapper").trigger("focus");
 }
 
+function on_show_callback(): void {
+    $("#compose_select_recipient_widget").addClass("widget-open");
+}
+
 // NOTE: Since tippy triggers this on `mousedown` it is always triggered before say a `click` on `textarea`.
 function on_hidden_callback(): void {
+    $("#compose_select_recipient_widget").removeClass("widget-open");
     if (!compose_select_recipient_dropdown_widget.item_clicked) {
         // If the dropdown was NOT closed due to selecting an item,
         // don't do anything.
@@ -300,6 +305,7 @@ export function initialize(): void {
         on_exit_with_escape_callback: focus_compose_recipient,
         // We want to focus on topic box if dropdown was closed via selecting an item.
         focus_target_on_hidden: false,
+        on_show_callback,
         on_hidden_callback,
         dropdown_input_visible_selector: "#compose_select_recipient_widget_wrapper",
         prefer_top_start_placement: true,

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -20,6 +20,7 @@ import type {DropdownWidget, Option} from "./dropdown_widget.ts";
 import {$t} from "./i18n.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {realm} from "./state_data.ts";
+import * as stream_color from "./stream_color.ts";
 import * as stream_data from "./stream_data.ts";
 import * as ui_util from "./ui_util.ts";
 import * as user_groups from "./user_groups.ts";
@@ -46,6 +47,16 @@ function composing_to_current_private_message_narrow(): boolean {
 }
 
 export let maybe_mute_recipient_row = (): void => {
+    // We need to adjust the privacy-icon colors in the muted state
+    const message_type = compose_state.get_message_type();
+    if (message_type === "stream") {
+        const stream_id = compose_state.stream_id();
+        const channel_picker_icon_selector =
+            "#compose_select_recipient_widget .channel-privacy-type-icon";
+
+        stream_color.adjust_stream_privacy_icon_colors(stream_id, channel_picker_icon_selector);
+    }
+
     // We're piggy-backing here, in a roundabout way, on
     // compose_ui.set_focus(). Any time the topic or recipient
     // row is focused, that puts us outside the muted

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -46,7 +46,14 @@ function composing_to_current_private_message_narrow(): boolean {
 }
 
 export let maybe_mute_recipient_row = (): void => {
+    // We're piggy-backing here, in a roundabout way, on
+    // compose_ui.set_focus(). Any time the topic or recipient
+    // row is focused, that puts us outside the muted
+    // recipient-row state--including the `c` hotkey or the
+    // Start new conversation button being clicked.
+    const is_compose_textarea_focused = document.activeElement?.id === "compose-textarea";
     if (
+        is_compose_textarea_focused &&
         composing_to_current_topic_narrow() &&
         compose_state.has_full_recipient() &&
         !compose_state.is_recipient_edited_manually()

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -46,7 +46,11 @@ function composing_to_current_private_message_narrow(): boolean {
 }
 
 export let maybe_mute_recipient_row = (): void => {
-    if (composing_to_current_topic_narrow() && compose_state.has_full_recipient()) {
+    if (
+        composing_to_current_topic_narrow() &&
+        compose_state.has_full_recipient() &&
+        !compose_state.is_recipient_edited_manually()
+    ) {
         $("#compose-recipient").toggleClass("muted-recipient-row", true);
     } else {
         $("#compose-recipient").toggleClass("muted-recipient-row", false);
@@ -341,16 +345,12 @@ export function initialize(): void {
     });
     compose_select_recipient_dropdown_widget.setup();
 
-    // `input` isn't relevant for streams since it registers as a change only
-    // when an item in the dropdown is selected.
-    $("#stream_message_recipient_topic,#private_message_recipient").on(
-        "input",
-        update_on_recipient_change,
-    );
     // changes for the stream dropdown are handled in on_compose_select_recipient_update
-    $("#stream_message_recipient_topic,#private_message_recipient").on("change", () => {
-        update_on_recipient_change();
+    $("#stream_message_recipient_topic,#private_message_recipient").on("input change", () => {
+        // To make sure the checks in update_on_recipient_change() are correct,
+        // we update manual editing first.
         compose_state.set_recipient_edited_manually(true);
+        update_on_recipient_change();
     });
 
     $("#private_message_recipient").on("input", restore_placeholder_in_firefox_for_no_input);

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -598,6 +598,11 @@ export function initialize() {
         const $input = $("input#stream_message_recipient_topic");
         compose_recipient.update_topic_displayed_text($input.val(), true);
         compose_recipient.update_compose_area_placeholder_text();
+        // Once the topic input has been focused, we no longer treat
+        // the recipient row as muted, as we assume the user is
+        // doing something that requires keeping attention called
+        // to the recipient row
+        compose_recipient.unmute_recipient_row();
 
         $("input#stream_message_recipient_topic").one("blur", () => {
             compose_recipient.update_topic_displayed_text($input.val());

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -614,6 +614,14 @@ export function initialize() {
         compose_recipient.update_compose_area_placeholder_text();
     });
 
+    $("#private_message_recipient").on("focus", () => {
+        // Once the DM input has been focused, we no longer treat
+        // the recipient row as muted, as we assume the user is
+        // doing something that requires keeping attention called
+        // to the recipient row
+        compose_recipient.unmute_recipient_row();
+    });
+
     $("body").on("click", ".formatting_button", function (e) {
         const $compose_click_target = $(this);
         const $textarea = $compose_click_target.closest("form").find("textarea");

--- a/web/src/stream_color.ts
+++ b/web/src/stream_color.ts
@@ -2,6 +2,7 @@ import type {Colord} from "colord";
 import {colord, extend} from "colord";
 import lchPlugin from "colord/plugins/lch";
 import mixPlugin from "colord/plugins/mix";
+import assert from "minimalistic-assert";
 
 import * as settings_data from "./settings_data.ts";
 import * as stream_data from "./stream_data.ts";
@@ -42,12 +43,23 @@ export function get_corrected_color(hex_color: string): Colord {
     return colord(color);
 }
 
-export function get_stream_privacy_icon_color(hex_color: string): string {
+export function get_stream_privacy_icon_color(
+    hex_color: string,
+    return_light_and_dark = false,
+): string {
     const corrected_color = get_corrected_color(hex_color);
-    if (settings_data.using_dark_theme()) {
-        return corrected_color.toHex();
+    const corrected_color_light = corrected_color.darken(0.12).toHex();
+    const corrected_color_dark = corrected_color.toHex();
+
+    if (return_light_and_dark) {
+        return `${corrected_color_light}, ${corrected_color_dark}`;
     }
-    return corrected_color.darken(0.12).toHex();
+
+    if (settings_data.using_dark_theme()) {
+        return corrected_color_dark;
+    }
+
+    return corrected_color_light;
 }
 
 export function get_recipient_bar_color(color: string): string {
@@ -57,6 +69,35 @@ export function get_recipient_bar_color(color: string): string {
     return colord(using_dark_theme ? "#000000" : "#f9f9f9")
         .mix(color, using_dark_theme ? 0.38 : 0.22)
         .toHex();
+}
+
+export function adjust_stream_privacy_icon_colors(
+    stream_id: number | undefined,
+    icon_selector: string,
+): void {
+    if (stream_id !== undefined) {
+        const privacy_icon_color = stream_data.get_sub_by_id(stream_id)?.color;
+
+        assert(privacy_icon_color);
+        const privacy_icon_colors_modified = get_stream_privacy_icon_color(
+            privacy_icon_color,
+            true,
+        );
+
+        // We set a couple of CSS variables on the privacy icon, and let the
+        // stylesheets decide when and how to use them. This gives us the
+        // ability to present different colors based on the presence or
+        // absence of containing classes, etc. as well as handle hover states,
+        // which would be otherwise impossible by specifying `color:` directly
+        // in the `style` attribute in HTML.
+        const original_color_css_variable = `--privacy-icon-color-original: ${privacy_icon_color};`;
+        const modified_colors_css_variable = `--privacy-icon-color-modified: light-dark(${privacy_icon_colors_modified});`;
+
+        const stream_privacy_icon = document.querySelector<HTMLElement>(icon_selector);
+
+        assert(stream_privacy_icon);
+        stream_privacy_icon.style.cssText = `${original_color_css_variable}${modified_colors_css_variable}`;
+    }
 }
 
 export const stream_color_palette = [

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -487,9 +487,9 @@
     /*
     Compose-recipient box minimum height. Used in a flexbox context to
     allow elements like DM pills to stack without breaking out of their
-    flex item. 2.1786em is 30.5px at 14px/1em.
+    flex item. 2em is 32px at 16px/1em.
     */
-    --compose-recipient-box-min-height: 2.1786em;
+    --compose-recipient-box-min-height: 2em;
     /* 28px at 14px/1em */
     /* Note that this variable can only be used in contexts where
        the font-size doesn't deviate from the base font-size;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1126,6 +1126,10 @@
         color-mix(in srgb, hsl(0deg 0% 0%) 10%, hsl(232deg 20% 92%)),
         hsl(0deg 0% 0% / 80%)
     );
+    --color-compose-recipient-box-hover: light-dark(
+        hsl(0deg 0% 69%),
+        hsl(0deg 0% 100% / 12%)
+    );
     --color-compose-recipient-box-has-focus: light-dark(
         hsl(0deg 0% 57%),
         hsl(0deg 0% 100% / 27%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -522,6 +522,10 @@
         --compose-send-controls-width: 28px;
     }
 
+    /* Compose-specific transitions and delays. */
+    --compose-muted-recipient-row-transition-delay: 100ms;
+    --compose-muted-recipient-row-transition: 150ms ease;
+
     /*
     User group info popover elements and values.
     */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1821,6 +1821,10 @@
         hsl(237deg 68% 94% / 50%),
         hsl(240deg 65% 60% / 60%)
     );
+    --color-outline-muted-input-pill: light-dark(
+        hsl(237deg 68% 88%),
+        hsl(240deg 65% 60% / 22%)
+    );
     --color-focus-outline-input-pill: light-dark(
         hsl(240deg 50% 50%),
         hsl(0deg 0% 100% / 60%)

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1561,10 +1561,9 @@ textarea.new_message_textarea {
         }
     }
 
+    /* We suppress the chevron on the channel picker. */
     .zulip-icon-chevron-down {
-        padding-left: 5px;
-        color: var(--color-compose-chevron-arrow);
-        font-weight: lighter;
+        display: none;
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -216,6 +216,10 @@
 
             #compose_select_recipient_widget {
                 border-radius: 4px !important;
+                /* This height is necessary only for the
+                   DM picker, so that it does not stretch
+                   open taller with multiple rows of user
+                   pills. */
                 height: var(--compose-recipient-box-min-height);
             }
 
@@ -1103,6 +1107,12 @@ textarea.new_message_textarea {
     #stream_message_recipient_topic {
         grid-area: topic;
         color: var(--color-compose-recipient-box-text-color);
+        /* Keep the line-height matched to the font-size
+           for a more predictable box height.
+           This will have to be watched very closely for
+           possible regressions, such as when Unicode emoji
+           appear in the topic box. */
+        line-height: 1;
         /* Override grid's effective `max-content` min-width */
         overflow: hidden;
         text-overflow: ellipsis;
@@ -1110,7 +1120,7 @@ textarea.new_message_textarea {
         box-shadow: none;
         outline: none;
 
-        padding: 4px 6px;
+        padding: 0 6px;
         /* Reset height to let `align-items: stretch` on the grid parent handle this. */
         height: auto;
 
@@ -1121,6 +1131,7 @@ textarea.new_message_textarea {
 
     #topic-not-mandatory-placeholder {
         grid-area: topic-box;
+        align-self: center;
         white-space: nowrap;
         overflow-x: hidden;
         text-overflow: ellipsis;
@@ -1375,10 +1386,9 @@ textarea.new_message_textarea {
 }
 
 #compose-recipient {
-    /* Enforce a shared, 'normal' line-height on
-       the recipient elements for baseline alignment,
-       and better use of the recipient-row space. */
-    line-height: normal;
+    /* Set a line-height equal to the font-size to
+       make a compact, predictably tall recipient row. */
+    line-height: 1;
     display: flex;
     flex: 1 1 0;
     /* Use this containing flex element to

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1196,7 +1196,9 @@ textarea.new_message_textarea {
     border-color: var(--color-compose-recipient-box-border-color);
 
     &.dropdown-widget-button {
-        padding: 0 6px;
+        /* We control the surrounding space through the
+           grid on `.dropdown_widget_value`. */
+        padding: 0;
         border-radius: 4px;
     }
 
@@ -1549,23 +1551,42 @@ textarea.new_message_textarea {
 
     .dropdown_widget_value {
         flex-grow: 1;
-        display: flex;
+        display: grid;
         align-items: baseline;
-        /* This gap matches a single space character,
-           as used previously in the icon-stream name
-           layout. */
-        gap: 0.4ch;
+        /* This is a bit of eyeball work, based on balancing
+           out the size and spatial relationships between the
+           privacy icon and the channel name, and the
+           surrounding negative space. */
+        /* 7px at 20px/1em; 4px at 20px/1em. */
+        grid-template:
+            "lefthand-offset privacy-icon privacy-icon-gap channel-name righthand-offset" auto / 0.35em auto 0.2em minmax(
+                0,
+                1fr
+            )
+            0.35em;
 
         .channel-privacy-type-icon {
-            font-size: 0.9286em; /* 13px at 14px em */
+            grid-area: privacy-icon;
+            place-self: center;
+            font-size: 0.95em; /* 19px at 20px/1em */
+            margin-top: -0.0579em; /* Eyeball work; 1.1px at 19px/1em */
+            /* Eliminate inherited component styles. */
+            position: static;
+            padding: 0;
             width: 1em;
             height: 1em;
-            position: relative;
-            top: 0.1538em; /* 2px at 13px/em */
+
+            &.zulip-icon-lock {
+                /* The lock looks better centered without
+                   a negative margin-top adjustment. */
+                margin-top: 0;
+            }
         }
 
+        .select-channel-label,
+        .decorated-dm-label,
         .decorated-channel-name {
-            flex: 1 1 auto;
+            grid-area: channel-name;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1229,10 +1229,17 @@ textarea.new_message_textarea {
 #compose.compose-box-open:hover {
     .muted-recipient-row {
         #compose_select_recipient_widget,
-        #compose_recipient_box {
+        #compose_recipient_box,
+        #compose-direct-recipient .pill-container {
             transition: 250ms ease;
             transition-delay: 150ms;
             transition-property: background-color, border-color;
+        }
+
+        #compose-direct-recipient .pill {
+            transition: 250ms ease;
+            transition-delay: 150ms;
+            transition-property: outline-color;
         }
 
         &#compose-recipient {
@@ -1248,10 +1255,7 @@ textarea.new_message_textarea {
     }
 }
 
-/* For now, we're restricting muted recipient-row styles
-   to stream topics only, as restyling DM pills will
-   will take additional work. */
-.muted-recipient-row:not(.compose-recipient-direct-selected) {
+.muted-recipient-row {
     &#compose-recipient {
         .decorated-channel-name,
         .conversation-arrow,
@@ -1265,9 +1269,23 @@ textarea.new_message_textarea {
     }
 
     #compose_select_recipient_widget,
-    #compose_recipient_box {
+    #compose_recipient_box,
+    #compose-direct-recipient .pill-container {
         background-color: transparent;
         border-color: transparent;
+
+        /* Particularly in light mode, pill colors are almost identical
+           to the compose-box background. We place a higher-contrast
+           outline on them in the muted state. */
+        .pill {
+            outline: 1px solid var(--color-outline-muted-input-pill);
+        }
+
+        &:hover {
+            .pill {
+                outline-color: transparent;
+            }
+        }
 
         /* We don't want to trigger the recipient-box-wide hover
            effects when someone is just hovering the new-topic

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1221,6 +1221,88 @@ textarea.new_message_textarea {
     width: 100%;
 }
 
+/* We want transitions to run only on user interactions with
+   the mouse, once the compose box is open. Any keyboard
+   interactions (e.g., Shift-Tabbing from the compose textarea
+   to the topic box) show instant changes, so we don't need to
+   accommodate them here. */
+#compose.compose-box-open:hover {
+    .muted-recipient-row {
+        #compose_select_recipient_widget,
+        #compose_recipient_box {
+            transition: 250ms ease;
+            transition-delay: 150ms;
+            transition-property: background-color, border-color;
+        }
+
+        &#compose-recipient {
+            .decorated-channel-name,
+            .zulip-icon-chevron-down,
+            .conversation-arrow,
+            #stream_message_recipient_topic {
+                transition: 250ms ease;
+                transition-delay: 150ms;
+                transition-property: opacity;
+            }
+        }
+    }
+}
+
+/* For now, we're restricting muted recipient-row styles
+   to stream topics only, as restyling DM pills will
+   will take additional work. */
+.muted-recipient-row:not(.compose-recipient-direct-selected) {
+    &#compose-recipient {
+        .decorated-channel-name,
+        .conversation-arrow,
+        #stream_message_recipient_topic {
+            opacity: 0.9;
+        }
+
+        .zulip-icon-chevron-down {
+            opacity: 0;
+        }
+    }
+
+    #compose_select_recipient_widget,
+    #compose_recipient_box {
+        background-color: transparent;
+        border-color: transparent;
+
+        /* We don't want to trigger the recipient-box-wide hover
+           effects when someone is just hovering the new-topic
+           button. */
+        &:not(:has(#recipient_box_clear_topic_button:hover)):hover {
+            background-color: var(
+                --color-compose-recipient-box-background-color
+            );
+            border-color: var(--color-compose-recipient-box-border-color);
+            opacity: 1;
+
+            .decorated-channel-name,
+            .zulip-icon-chevron-down,
+            .conversation-arrow,
+            #stream_message_recipient_topic {
+                opacity: 1;
+            }
+        }
+
+        #recipient_box_clear_topic_button:hover {
+            opacity: 1;
+        }
+    }
+
+    #compose_select_recipient_widget.widget-open {
+        background-color: var(--color-background-dropdown-widget-button);
+        border-color: var(--color-compose-recipient-box-border-color);
+
+        .decorated-channel-name,
+        .zulip-icon-chevron-down {
+            opacity: 1;
+        }
+    }
+}
+
 .compose-send-or-save-button {
     border-radius: 4px;
     border: 0;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1238,6 +1238,14 @@ textarea.new_message_textarea {
             transition-property: background-color, border-color;
         }
 
+        #compose_select_recipient_widget .channel-privacy-type-icon {
+            transition: var(--compose-muted-recipient-row-transition);
+            transition-delay: var(
+                --compose-muted-recipient-row-transition-delay
+            );
+            transition-property: color;
+        }
+
         #recipient_box_clear_topic_button {
             transition: var(--compose-muted-recipient-row-transition);
             transition-delay: var(
@@ -1319,13 +1327,27 @@ textarea.new_message_textarea {
         }
     }
 
-    #compose_select_recipient_widget.widget-open {
-        background-color: var(--color-background-dropdown-widget-button);
-        border-color: var(--color-compose-recipient-box-border-color);
+    #compose_select_recipient_widget {
+        .channel-privacy-type-icon.zulip-icon {
+            color: var(--privacy-icon-color-modified);
+        }
 
-        .decorated-channel-name,
-        .zulip-icon-chevron-down {
-            opacity: 1;
+        &:hover .channel-privacy-type-icon.zulip-icon {
+            color: var(--privacy-icon-color-original);
+        }
+
+        &.widget-open {
+            background-color: var(--color-background-dropdown-widget-button);
+            border-color: var(--color-compose-recipient-box-border-color);
+
+            .channel-privacy-type-icon {
+                color: var(--privacy-icon-color-original);
+            }
+
+            .decorated-channel-name,
+            .zulip-icon-chevron-down {
+                opacity: 1;
+            }
         }
     }
 }
@@ -1688,6 +1710,7 @@ textarea.new_message_textarea {
             place-self: center;
             font-size: 0.95em; /* 19px at 20px/1em */
             margin-top: -0.0579em; /* Eyeball work; 1.1px at 19px/1em */
+            color: var(--privacy-icon-color-original);
             /* Eliminate inherited component styles. */
             position: static;
             padding: 0;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1238,6 +1238,14 @@ textarea.new_message_textarea {
             transition-property: background-color, border-color;
         }
 
+        #recipient_box_clear_topic_button {
+            transition: var(--compose-muted-recipient-row-transition);
+            transition-delay: var(
+                --compose-muted-recipient-row-transition-delay
+            );
+            transition-property: color, background-color, opacity;
+        }
+
         #compose-direct-recipient .pill {
             transition: var(--compose-muted-recipient-row-transition);
             transition-delay: var(
@@ -1288,15 +1296,6 @@ textarea.new_message_textarea {
         }
 
         &:hover {
-            .pill {
-                outline-color: transparent;
-            }
-        }
-
-        /* We don't want to trigger the recipient-box-wide hover
-           effects when someone is just hovering the new-topic
-           button. */
-        &:not(:has(#recipient_box_clear_topic_button:hover)):hover {
             background-color: var(
                 --color-compose-recipient-box-background-color
             );
@@ -1308,6 +1307,10 @@ textarea.new_message_textarea {
             .conversation-arrow,
             #stream_message_recipient_topic {
                 opacity: 1;
+            }
+
+            .pill {
+                outline-color: transparent;
             }
         }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1231,14 +1231,18 @@ textarea.new_message_textarea {
         #compose_select_recipient_widget,
         #compose_recipient_box,
         #compose-direct-recipient .pill-container {
-            transition: 250ms ease;
-            transition-delay: 150ms;
+            transition: var(--compose-muted-recipient-row-transition);
+            transition-delay: var(
+                --compose-muted-recipient-row-transition-delay
+            );
             transition-property: background-color, border-color;
         }
 
         #compose-direct-recipient .pill {
-            transition: 250ms ease;
-            transition-delay: 150ms;
+            transition: var(--compose-muted-recipient-row-transition);
+            transition-delay: var(
+                --compose-muted-recipient-row-transition-delay
+            );
             transition-property: outline-color;
         }
 
@@ -1247,8 +1251,10 @@ textarea.new_message_textarea {
             .zulip-icon-chevron-down,
             .conversation-arrow,
             #stream_message_recipient_topic {
-                transition: 250ms ease;
-                transition-delay: 150ms;
+                transition: var(--compose-muted-recipient-row-transition);
+                transition-delay: var(
+                    --compose-muted-recipient-row-transition-delay
+                );
                 transition-property: opacity;
             }
         }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1092,6 +1092,10 @@ textarea.new_message_textarea {
     transition: border-color 0.2s ease;
     background: var(--color-compose-recipient-box-background-color);
 
+    &:hover {
+        border-color: var(--color-compose-recipient-box-hover);
+    }
+
     /* Give the recipient box, a `<div>`, the
        correct styles when focus is in the
        #stream_message_recipient_topic `<input>` */
@@ -1194,6 +1198,11 @@ textarea.new_message_textarea {
     color: var(--color-compose-recipient-box-text-color);
     background-color: var(--color-compose-recipient-box-background-color);
     border-color: var(--color-compose-recipient-box-border-color);
+
+    &:hover,
+    &.widget-open {
+        border-color: var(--color-compose-recipient-box-hover);
+    }
 
     &.dropdown-widget-button {
         /* We control the surrounding space through the

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -172,7 +172,7 @@
 /* Main geometry for this element is in zulip.css */
 #compose-content {
     background-color: var(--color-compose-box-background);
-    padding: 7px 7px 8px;
+    padding: 4px 4px 6px;
     border: 1px solid var(--color-border-compose-content);
     border-radius: 9px 9px 0 0;
     box-shadow: 0 0 0 hsl(236deg 11% 28%);
@@ -196,8 +196,8 @@
         max-height: min(25vh, 240px);
         overflow-y: auto;
         /* Align to compose controls; that's 112px width,
-           plus 6px of grid gap for 118px here. */
-        margin-right: calc(var(--compose-send-controls-width) + 6px);
+           plus 4px of grid gap for 116px here. */
+        margin-right: calc(var(--compose-send-controls-width) + 4px);
     }
 }
 
@@ -320,7 +320,7 @@
         grid-template-areas:
             "message-content-container message-send-controls-container"
             "message-formatting-controls-container message-send-controls-container";
-        gap: 0 6px;
+        gap: 0 4px;
     }
 
     .message_content {
@@ -644,11 +644,11 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    /* Matched to 6px grid-gap on .messagebox grid. */
-    padding-bottom: 6px;
+    /* Matched to 4px grid-gap on .messagebox grid. */
+    padding-bottom: 4px;
     /* Align to compose controls; that's 112px width,
-       plus 6px of grid gap for 118px here. */
-    margin-right: calc(var(--compose-send-controls-width) + 6px);
+       plus 4px of grid gap for 116px here. */
+    margin-right: calc(var(--compose-send-controls-width) + 4px);
 }
 
 #compose_close {
@@ -692,7 +692,9 @@
 }
 
 .main-view-banner {
-    margin-bottom: 20px;
+    /* This is same spatial value as the 4px of padding around
+       the edge of the compose box. */
+    margin-bottom: 4px;
     border-radius: 5px;
     border: 1px solid;
     display: flex;

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -233,11 +233,6 @@
         opacity: 0.5;
     }
 
-    .pill + .input:empty::before {
-        content: attr(data-some-recipients-text);
-        opacity: 0.5;
-    }
-
     &:has(.input:focus) {
         border-color: var(--color-compose-recipient-box-has-focus);
     }

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -49,7 +49,14 @@
             <form id="send_message_form" action="/json/messages" method="post">
                 <div class="compose_table">
                     <div id="compose_top">
-                        <div id="compose-recipient">
+                        {{!-- We start with the muted-recipient-row class
+                        on the template to avoid showing the transition
+                        when the compose box first opens. Note that this
+                        class is immediately removed when it's not used,
+                        so, for example, opening the compose box from
+                        Inbox view does not cause any flash of unwanted
+                        styling. --}}
+                        <div id="compose-recipient" class="muted-recipient-row">
                             {{> dropdown_widget_wrapper
                               widget_name="compose_select_recipient"}}
                             <div class="topic-marker-container">

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -67,8 +67,8 @@
                                 <span id="topic-not-mandatory-placeholder" class="placeholder">
                                     {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
                                 </span>
-                                <button type="button" id="recipient_box_clear_topic_button" class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Clear topic' }}" tabindex="-1">
-                                    <i class="zulip-icon zulip-icon-close"></i>
+                                <button type="button" id="recipient_box_clear_topic_button" class="tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'New topic' }}" tabindex="-1">
+                                    <i class="zulip-icon zulip-icon-square-plus"></i>
                                 </button>
                             </div>
                             <div id="compose-direct-recipient" data-before="{{t 'You and' }}">

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -637,6 +637,7 @@ test_ui("update_fade", ({override, override_rewire}) => {
     override_rewire(compose_recipient, "update_narrow_to_recipient_visibility", () => {
         update_narrow_to_recipient_visibility_called = true;
     });
+    override_rewire(compose_recipient, "maybe_mute_recipient_row", noop);
     override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     override_rewire(drafts, "update_compose_draft_count", noop);
     override(compose_pm_pill, "get_user_ids", () => []);

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -31,6 +31,8 @@ set_global("document", {
     to_$: () => $("document-stub"),
 });
 
+set_global("requestAnimationFrame", (func) => func());
+
 const autosize = noop;
 autosize.update = noop;
 mock_esm("autosize", {default: autosize});
@@ -165,6 +167,7 @@ test("start", ({override, override_rewire, mock_template}) => {
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_recipient, "maybe_mute_recipient_row", noop);
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_channel_name.hbs", false, noop);
 
@@ -319,6 +322,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(compose_recipient, "maybe_mute_recipient_row", noop);
     override_private_message_recipient_ids({override});
     mock_template("inline_decorated_channel_name.hbs", false, noop);
 
@@ -374,6 +378,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     mock_banners();
     compose_state.set_message_type("stream");
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
+    override_rewire(compose_recipient, "maybe_mute_recipient_row", noop);
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
     const $elem = $("#send_message_form");
@@ -436,6 +441,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
 
 test("quote_message", ({disallow, override, override_rewire}) => {
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
+    override_rewire(compose_recipient, "maybe_mute_recipient_row", noop);
     override_rewire(compose_reply, "selection_within_message_id", () => undefined);
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");


### PR DESCRIPTION
This draft experimental PR matches recipient buttons and inputs to the compose box's background color except when a user is a) hovering over the area, after a brief delay (we want to avoid hover effects on incidental pointer traversal through the recipient row), or b) the user has focused the topic area, suggesting that they might be working with the topic in some way, whether editing, clearing, or simply just activating the topic box. Opening the channel picker and choosing a different channel likewise cancels the muted state.

As of 2025-06-17, the below issues have been addressed, and modified privacy-icon colors are behaving as expected--without any kind of intercession by JavaScript for hover or theme-switching states:

![alternate-privacy-icon-colors-compose](https://github.com/user-attachments/assets/ca6e5120-cb81-4539-a092-d90b5a150417)

As of 2025-06-16, the PR has a delicate commit for displaying darker privacy-icon colors in the muted recipient row. There are currently a couple important missing features, pending a decision that we want to move in this direction (I might also suggest that we calculate these modified colors up front when rendering decorate channels, so that there isn't a need for all the duplicative/derivative logic now present in the `maybe_mute_recipient_row()` function--instead we could just reach into some data attributes):

- [x] The darkened version of the icon remains even when hovering or activating the channel picker
- [x] Shifting from light mode to dark mode and vice-versa while the muted compose box is open does not update the modified icon color

As of 2025-06-09, the PR implements the [design adjustments](https://chat.zulip.org/#narrow/channel/101-design/topic/tighter.20compose.20box.20recipient.20row/near/2189209) as recommended by @terpimost:
* Transition delays and lengths have been shortened to feel snappier
* Hovering the new-topic button highlights the whole topic box

As of 2025-06-05, the PR brings DMs into participation with the muted-recipient-row logic.

As of 2025-05-23, this PR includes the commits from #34572, an experimental PR that has had some reasonable burn-in time on CZO.

Discussions:
* [#design > tighter compose box recipient row @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/tighter.20compose.20box.20recipient.20row/near/2182073)
* [#design > making topic harder to edit? @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/making.20topic.20harder.20to.20edit.3F/near/2157770)


_The Before & After shots here showcase adjustments to the icon and channel alignment within the channel picker._

| Before | After |
| --- | --- |
| ![short-channel-active-before](https://github.com/user-attachments/assets/3ce08fe3-6bd1-45a6-8476-c76405362d97) | ![short-channel-active-after](https://github.com/user-attachments/assets/99a34749-a633-4fb0-ac54-32c8431c328e) |
| ![short-channel-muted-before](https://github.com/user-attachments/assets/410e48bc-6315-40cf-b389-b1ada1d37453) | ![short-channel-muted-after](https://github.com/user-attachments/assets/618829c5-f5ac-4d47-9867-21a9bc9aedef) |
| ![long-channel-active-before](https://github.com/user-attachments/assets/a010b552-7852-47a1-8c91-02e8eb07076c) | ![long-channel-active-after](https://github.com/user-attachments/assets/70440a74-bf51-423c-a724-4fccda2bcda2) |
| ![long-channel-muted-before](https://github.com/user-attachments/assets/1bfc696c-c6ca-43ef-bb73-9b182e9d97cd) | ![long-channel-muted-after](https://github.com/user-attachments/assets/9865feb5-732c-40fa-987a-a43bcdd0e3fc) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>




