### PR TITLE
inbox: Use plural for Direct messages header.

### DIFF
--- a/web/templates/inbox_view/inbox_list.hbs
+++ b/web/templates/inbox_view/inbox_list.hbs
@@ -6,7 +6,7 @@
                 <div tabindex="0" class="inbox-header-name">
                     <div class="inbox-header-name-focus-border">
                         <i class="zulip-icon zulip-icon-user"></i>
-                        <a tabindex="-1" role="button" href="/#narrow/is/private">{{t 'Direct message'}}</a>
+                        <a tabindex="-1" role="button" href="/#narrow/is/private">{{t 'Direct messages'}}</a>
                     </div>
                 </div>
                 <div class="unread-count-focus-outline" tabindex="0">


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/direct.20messages.20in.20inbox/near/1960308)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![Screen Shot 2024-10-11 at 13 55 07](https://github.com/user-attachments/assets/aa463f19-4ca5-4c50-9d1d-eb359137229e) | ![Screen Shot 2024-10-11 at 13 54 56](https://github.com/user-attachments/assets/4e1ac656-a7dd-4a4d-813f-e9aa7a6a819c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
