### PR TITLE
compose: Show bot icon after bot name in recipient picker.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -145,6 +145,7 @@ export function render_person(person: UserPillData | UserOrMentionPillData): str
         img_src: avatar_url,
         user_circle_class,
         is_person: true,
+        is_bot: person.user.is_bot,
         status_emoji_info,
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(
             person.user.user_id,

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -179,3 +179,9 @@
         margin-left: 14px;
     }
 }
+
+.typeahead-text-container {
+    i.zulip-icon-bot {
+        align-self: center;
+    }
+}

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -25,6 +25,9 @@
             {{~ primary ~}}
         {{~/if~}}
     </strong>
+    {{~#if is_bot}}
+        <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
+    {{/if}}
     {{~#if has_pronouns}}
         <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
     {{~/if}}


### PR DESCRIPTION
Fixes partially [#26831 ](https://github.com/zulip/zulip/issues/26831)

Bot icon shown in the typeahead recipient list which pops up in the compose box while typing.
On typeahead hover, bot icon takes the color of the font for better contrast.

[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/more.20user.20indicators/near/1643075)

<!-- Describe your pull request here.-->




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Screenshots and screen captures:**
<details>
<summary>Compose recipient picker</summary>

![image](https://github.com/user-attachments/assets/f203f861-007f-4bb1-be73-f25a4e4fc39f)

<hr></hr>

![image](https://github.com/user-attachments/assets/c68f51c0-c6ef-4989-b653-c02a4f7697e5)



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
