### PR TITLE
health: Disable RabbitMQ check if not USING_RABBITMQ

### DIFF
--- a/zerver/views/health.py
+++ b/zerver/views/health.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.migrations.recorder import MigrationRecorder
 from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import get_random_string
@@ -58,7 +59,8 @@ def check_memcached() -> None:
 
 def health(request: HttpRequest) -> HttpResponse:
     check_database()
-    check_rabbitmq()
+    if settings.USING_RABBITMQ:  # nocoverage
+        check_rabbitmq()
     check_redis()
     check_memcached()
 


### PR DESCRIPTION
Fixes a spurious error that’s logged and ignored during the Puppeteer tests, introduced by commit eef65d7e304847793079c8e724f0416b464de95e (#31438, cc @alexmv).

e.g. from https://github.com/zulip/zulip/actions/runs/11301057896/job/31434895030:

```pytb
2024-10-12 00:36:59.775 ERR  [django.request] Internal Server Error: /health
Traceback (most recent call last):
  File "/__w/zulip/zulip/zerver/views/health.py", line 26, in check_rabbitmq
    conn = get_queue_client().connection
  File "/__w/zulip/zulip/zerver/lib/queue.py", line 427, in get_queue_client
    raise RuntimeError("Cannot get a queue client without USING_RABBITMQ")
RuntimeError: Cannot get a queue client without USING_RABBITMQ

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/zulip/zulip/zerver/middleware.py", line 403, in process_exception
    raise exception  # Ensure correct sys.exc_info().
  File "/srv/zulip-venv-cache/f8812bf942e86c8051a0e7592ee6ec1add467314/zulip-py3-venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/__w/zulip/zulip/zerver/views/health.py", line 61, in health
    check_rabbitmq()
  File "/__w/zulip/zulip/zerver/views/health.py", line 34, in check_rabbitmq
    raise ServerNotReadyError(_("Cannot query rabbitmq"))
zerver.lib.exceptions.ServerNotReadyError: Cannot query rabbitmq
2024-10-12 00:36:59.778 INFO [zr] 127.0.0.1       GET     500  14ms (db: 0ms/2q) /health (unauth@root via Unspecified)
```