### PR TITLE
empty narrow updates for invalid channel ids

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -290,7 +290,10 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
                 }
 
                 return {
-                    title: $t({defaultMessage: "This channel does not exist or is private."}),
+                    title: $t({
+                        defaultMessage:
+                            "This channel doesn't exist, or you are not allowed to view it.",
+                    }),
                 };
             }
             // else fallthrough to default case

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -192,7 +192,21 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
             return SPECTATOR_STREAM_NARROW_BANNER;
         }
 
-        // A stream > topic that doesn't exist yet.
+        if (streams.length === 1) {
+            const stream_sub = stream_data.get_sub_by_id_string(
+                util.the(current_filter.operands("channel")),
+            );
+            if (!stream_sub) {
+                return {
+                    title: $t({
+                        defaultMessage:
+                            "This channel doesn't exist, or you are not allowed to view it.",
+                    }),
+                };
+            }
+        }
+
+        // A valid stream, but a topic that doesn't exist yet.
         if (num_terms === 2 && streams.length === 1 && topics.length === 1) {
             return default_banner;
         }

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -258,6 +258,19 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
+    set_filter([
+        ["stream", "999"],
+        ["topic", "foo"],
+        ["near", "99"],
+    ]);
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: This channel doesn't exist, or you are not allowed to view it.",
+        ),
+    );
+
     // for non-subbed public stream
     const rome_id = 99;
     stream_data.add_sub({name: "ROME", stream_id: rome_id});

--- a/web/tests/message_view.test.js
+++ b/web/tests/message_view.test.js
@@ -253,7 +253,9 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: This channel does not exist or is private."),
+        empty_narrow_html(
+            "translated: This channel doesn't exist, or you are not allowed to view it.",
+        ),
     );
 
     // for non-subbed public stream
@@ -573,7 +575,9 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: This channel does not exist or is private."),
+        empty_narrow_html(
+            "translated: This channel doesn't exist, or you are not allowed to view it.",
+        ),
     );
 
     set_filter([


### PR DESCRIPTION
Reported on CZO: https://chat.zulip.org/#narrow/channel/6-frontend/topic/unknown.20channel.20ID.20-.20empty.20feed.20banner/near/1956805

Tested manually that the following views show the new "doesn't exist" message:

* link to invalid channel
* near link for inaccessible channel
* channel>topic link for invalid channel

Also tested:

* logged out, near link for inaccessible channel (says you need to log in)
* logged out, near link for invalid channel (says you need to log in)
* logged in, valid channel, unknown topic (offers the user to "start the conversation")

