### PR TITLE
Fix muted messages in a stream not rendered if moved to be unmuted when narrowed to the message stream.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -600,15 +600,13 @@ export function update_messages(events) {
                 }
 
                 if (list.data.filter.can_apply_locally()) {
-                    const predicate = list.data.filter.predicate();
-                    let message_ids_to_remove = event_messages.filter((msg) => !predicate(msg));
-                    message_ids_to_remove = message_ids_to_remove.map((msg) => msg.id);
-                    // We filter out messages that do not belong to the message
-                    // list and then pass these to the remove messages codepath.
-                    // While we can pass all our messages to the add messages
-                    // codepath as the filtering is done within the method.
-                    list.remove_and_rerender(message_ids_to_remove);
-                    list.add_messages(event_messages);
+                    // Remove add messages and add them back to the list to
+                    // allow event muted messages which were previously part
+                    // of the message list but hidden could be rerendered again.
+                    const event_msg_ids = event_messages.map((msg) => msg.id);
+                    list.data.remove(event_msg_ids);
+                    list.data.add_messages(event_messages);
+                    list.rerender();
                 } else {
                     // Remove existing message that were updated, since
                     // they may not be a part of the filter now. Also,

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -599,11 +599,11 @@ export function update_messages(events) {
                     continue;
                 }
 
+                const event_msg_ids = event_messages.map((msg) => msg.id);
                 if (list.data.filter.can_apply_locally()) {
                     // Remove add messages and add them back to the list to
                     // allow event muted messages which were previously part
                     // of the message list but hidden could be rerendered again.
-                    const event_msg_ids = event_messages.map((msg) => msg.id);
                     list.data.remove(event_msg_ids);
                     list.data.add_messages(event_messages);
                     list.rerender();
@@ -613,10 +613,7 @@ export function update_messages(events) {
                     // this will help us rerender them via
                     // maybe_add_narrowed_messages, if they were
                     // simply updated.
-                    const updated_messages = event_messages.filter(
-                        (msg) => list.data.get(msg.id) !== undefined,
-                    );
-                    list.remove_and_rerender(updated_messages.map((msg) => msg.id));
+                    list.remove_and_rerender(event_msg_ids);
                     // For filters that cannot be processed locally, ask server.
                     message_events_util.maybe_add_narrowed_messages(
                         event_messages,


### PR DESCRIPTION
If a muted message for the currently rendered message list is moved
to a non muted topic, it was not rendered if it is part of
`_all_items` and not `_items` due to it being previously muted.

We fix it by removing all the moved messages from the list and
added them back which allows us filter the messages for muting again.

This overall reduces the amount of rerender calls too since we
are now guaranteed to only call it once now.

Fixes https://github.com/zulip/zulip/issues/31977