### PR TITLE
buddy_list: Differentiate updating and changing to an undefined filter.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -167,7 +167,7 @@ export class BuddyList extends BuddyListConf {
     $participants_list = $(this.participants_list_selector);
     $users_matching_view_list = $(this.matching_view_list_selector);
     $other_users_list = $(this.other_user_list_selector);
-    current_filter: Filter | undefined;
+    current_filter: Filter | undefined | "unset" = "unset";
 
     initialize_tooltips(): void {
         $("#right-sidebar").on(


### PR DESCRIPTION
Followup to #31960. I forgot to consider the case of a narrow with an undefined filter. To make sure we fully run render_section_headers on narrows like Recent Conversations the first time they load, this commit initializes `current_filter` to the string "unset".

Reported on CZO here: https://chat.zulip.org/#narrow/channel/9-issues/topic/None.20in.20users.20list