### PR TITLE
typing: Check for valid user IDs when setting typing recipient.

### DIFF
--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -111,10 +111,15 @@ function notify_server_stop(to: Recipient): void {
 export function get_recipient(): Recipient | null {
     const message_type = compose_state.get_message_type();
     if (message_type === "private") {
+        const user_ids = get_user_ids_array();
+        // compose box with no valid user pills.
+        if (user_ids === null) {
+            return null;
+        }
         return {
             message_type: "direct",
             notification_event_type: "typing",
-            ids: get_user_ids_array()!,
+            ids: user_ids,
         };
     }
     if (message_type === "stream") {


### PR DESCRIPTION
Before sending typing notifications to the server, make sure that the user has set at least one valid user pill in the compose box recipient bar.

**Console in dev environment before changes**:
```
2024-10-15 14:38:28.458 INFO [zr] status=400, data=b'{"result":"error","msg":"Missing \'to\' argument","code":"BAD_REQUEST"}\n', uid=9@zulip
```

**Follow-up question**:
- Do we also want to check for `topic === ""` in realms where topics are mandatory before sending these events to the server as well?

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
