### PR TITLE
Improve email change flow UI: Added explanation, moved confirmation notice

### DIFF
--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,5 @@
 <form id="change_email_form">
+    <div class="tip"> {{t "You will receive a confirmation email at the new address you enter."}} </div>
     <label for="email" class="modal-field-label">{{t "New email" }}</label>
     <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -3,11 +3,11 @@
     <div class="account-settings-form">
         <div id="user_details_section">
             <h3 class="inline-block account-settings-heading">{{t "Account" }}</h3>
-            <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
                     <label class="settings-field-label">{{t "Email" }}</label>
+                    <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
                     <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                         <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
                             {{current_user.delivery_email}}


### PR DESCRIPTION
Changes done:
1. Email Change Modal
Added an explanatory line at the top of the modal: "You will receive a confirmation email at the new address you enter."
2. Confirmation UI
Moved the confirmation notice from the section heading to a position just below the email field, keeping the original text unchanged.

Fixes parts of: #31975 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details><summary>Screenshots and screen captures:</summary>
<p>

![Screenshot 2024-10-16 012627](https://github.com/user-attachments/assets/8d65aca2-84ea-4c48-bdf2-8e8e530180fb)

![Screenshot 2024-10-16 013701](https://github.com/user-attachments/assets/0579df89-abed-4f95-87ca-efca4d6e3cd8)

</p>
</details> 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>