### PR TITLE
user_groups: Refactor code to check group permissions.

### DIFF
--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -306,7 +306,7 @@ def add_members_to_group_backend(
             # User can still join the group if user has permission to add
             # anyone in the group.
             user_group = access_user_group_for_update(
-                user_group_id, user_profile, permission_setting="can_manage_group"
+                user_group_id, user_profile, permission_setting="can_add_members_group"
             )
     else:
         user_group = access_user_group_for_update(

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -346,16 +346,9 @@ def remove_members_from_group_backend(
 ) -> HttpResponse:
     user_profiles = user_ids_to_users(members, user_profile.realm, allow_deactivated=False)
     if len(members) == 1 and user_profile.id == members[0]:
-        try:
-            user_group = access_user_group_for_update(
-                user_group_id, user_profile, permission_setting="can_leave_group"
-            )
-        except JsonableError:
-            # User can leave the group if user has the permission to
-            # manage the group.
-            user_group = access_user_group_for_update(
-                user_group_id, user_profile, permission_setting="can_manage_group"
-            )
+        user_group = access_user_group_for_update(
+            user_group_id, user_profile, permission_setting="can_leave_group"
+        )
     else:
         user_group = access_user_group_for_update(
             user_group_id, user_profile, permission_setting="can_manage_group"


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix the code for checking group joining permission.
- Second commit is to refactor the code for checking permissions to update group.

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
