### PR TITLE
typing: Check empty topic string if realm has mandatory topics.

### DIFF
--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -130,6 +130,10 @@ export function get_recipient(): Recipient | null {
             return null;
         }
         const topic = compose_state.topic();
+        if (realm.realm_mandatory_topics && topic === "") {
+            // compose box with empty topic string.
+            return null;
+        }
         return {
             message_type: "stream",
             notification_event_type: "typing",


### PR DESCRIPTION
Before sending typing notifications to the server, if the realm requires topics for channel messages, make sure that the topic string is not an empty string in the compose box.

Follow-up to #31999.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
