### PR TITLE
topic_link_util: Add `&` as a character which can produce broken links.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -4,7 +4,7 @@ import * as internal_url from "../shared/src/internal_url";
 
 import * as stream_data from "./stream_data";
 
-const invalid_stream_topic_regex = /[*>`]|(\$\$)/g;
+const invalid_stream_topic_regex = /[`>*&]|(\$\$)/g;
 
 export function will_produce_broken_stream_topic_link(word: string): boolean {
     return invalid_stream_topic_regex.test(word);
@@ -24,6 +24,8 @@ export function escape_invalid_stream_topic_characters(text: string): string {
             return "&gt;";
         case "*":
             return "&#42;";
+        case "&":
+            return "&amp;";
         case "$$":
             return "&#36;&#36;";
         default:

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -19,7 +19,7 @@ function get_stream_name_from_topic_link_syntax(syntax: string): string {
 export function escape_invalid_stream_topic_characters(text: string): string {
     switch (text) {
         case "`":
-            return "&grave;";
+            return "&#96;";
         case ">":
             return "&gt;";
         case "*":

--- a/web/tests/topic_link_util.test.js
+++ b/web/tests/topic_link_util.test.js
@@ -83,6 +83,11 @@ run_test("stream_topic_link_syntax_test", () => {
         "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6-.24.24MONEY.24.24)",
     );
 
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("#**Sweden>&ab", "&ab"),
+        "[#Sweden>&amp;ab](#narrow/channel/1-Sweden/topic/.26ab)",
+    );
+
     // Only for full coverage of the module.
     assert.equal(topic_link_util.escape_invalid_stream_topic_characters("Sweden"), "Sweden");
 });

--- a/web/tests/topic_link_util.test.js
+++ b/web/tests/topic_link_util.test.js
@@ -47,11 +47,11 @@ run_test("stream_topic_link_syntax_test", () => {
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "test `test` test"),
-        "[#Sweden>test &grave;test&grave; test](#narrow/channel/1-Sweden/topic/test.20.60test.60.20test)",
+        "[#Sweden>test &#96;test&#96; test](#narrow/channel/1-Sweden/topic/test.20.60test.60.20test)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Denmark>t", "test `test` test`s"),
-        "[#Denmark>test &grave;test&grave; test&grave;s](#narrow/channel/2-Denmark/topic/test.20.60test.60.20test.60s)",
+        "[#Denmark>test &#96;test&#96; test&#96;s](#narrow/channel/2-Denmark/topic/test.20.60test.60.20test.60s)",
     );
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("#**Sweden>typeah", "error due to *"),


### PR DESCRIPTION
`&` in topic names like `&copy;` can result in broken stream topic links. So we generate fallback markdown links for them too. 

This is a follow up to #30071.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
