### PR TITLE
left_sidebar: Add New DM hover button to DM header row.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -425,6 +425,17 @@ export function initialize() {
     });
 
     // SIDEBARS
+    $("body").on("click", "#compose-new-direct-message", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        compose_actions.start({
+            message_type: "private",
+            trigger: "new direct message",
+            keep_composebox_empty: true,
+        });
+    });
+
     $(".buddy-list-section").on("click", ".selectable_sidebar_block", (e) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey) {
             return;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -236,6 +236,7 @@
         }
     }
 
+    #compose-new-direct-message,
     #show-all-direct-messages {
         color: var(--color-left-sidebar-heads-up-icon);
         display: none;
@@ -244,6 +245,7 @@
         text-decoration: none;
         margin: 2px 0;
         border-radius: 3px;
+        grid-row: 1 / 1;
 
         &:hover {
             color: var(--color-left-sidebar-heads-up-icon-hover);
@@ -257,8 +259,11 @@
         }
     }
 
-    &:hover #show-all-direct-messages {
-        display: flex;
+    &:hover {
+        #compose-new-direct-message,
+        #show-all-direct-messages {
+            display: flex;
+        }
     }
 }
 

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -150,6 +150,9 @@
         <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
         <div class="left-sidebar-controls">
+            <span id="compose-new-direct-message" class="tippy-left-sidebar-tooltip" data-tooltip-template-id="new_direct_message_button_tooltip_template">
+                <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'New direct message' }}"></i>
+            </span>
             <a id="show-all-direct-messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                 <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
             </a>


### PR DESCRIPTION
As specified and often requested by @terpimost :) This adds a button to the DM header row that opens the compose box to compose a fresh direct message.

CZO discussion

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| On row hover | On icon hover (extra long delay) |
| --- | --- |
| ![dm-row-hover](https://github.com/user-attachments/assets/2cb4d699-da7f-4534-993c-26dfac670b90) | ![dm-icon-hover-extra-long-delay](https://github.com/user-attachments/assets/1f658e45-da4c-4a35-a1ba-a6672d66fef1) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>