### PR TITLE
portico: Align mobile subhead colors with desktop.

### DIFF
--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -50,7 +50,6 @@ details summary::-webkit-details-marker {
     margin-right: 16px;
 }
 
-.top-menu-item,
 .top-menu-mobile a {
     &,
     &:hover,
@@ -488,7 +487,6 @@ details summary::-webkit-details-marker {
 .top-menu-mobile-submenu-section {
     letter-spacing: 0.1em;
     color: hsl(0deg 0% 100% / 40%);
-    opacity: 0.8;
     text-transform: uppercase;
     margin-top: 8px;
     font-size: 17px;


### PR DESCRIPTION
This brings navbar subsheads into alignment with each other, and cleans up an unnecessary confusing selector.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Hello.20page.20mobile.20navigation.20opacity/near/1963282)

**Screenshots and screen captures:**

| Before | After (no change on desktop) |
| --- | --- |
| ![mobile-menu-before](https://github.com/user-attachments/assets/86bad7fd-acdf-4d45-b98c-7ae56a0c1893) | ![mobile-menu-after](https://github.com/user-attachments/assets/3a64645a-a5c4-4353-b0fe-9779c5d53a2f) |
| ![wide-menu-before](https://github.com/user-attachments/assets/1c9966a2-683f-438a-b059-12233d6d786c) | ![wide-menu-after-no-change](https://github.com/user-attachments/assets/baeb182b-fbee-4042-94ff-004400d0f4ee) |


