### PR TITLE
pricing_model: Show `Contact sales` to already upgraded customers.

### DIFF
--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -107,6 +107,10 @@
                                 <a href="/billing/" class="button current-plan-button" type="button">
                                     Sponsorship requested
                                 </a>
+                                {% elif customer_plan and customer_plan.tier != customer_plan.TIER_CLOUD_STANDARD %}
+                                <a href="mailto:sales@zulip.com" target="_blank" rel="noopener noreferrer" class="button upgrade-button">
+                                    Contact sales
+                                </a>
                                 {% else %}
                                 <a href="/upgrade/?tier={{ tier_cloud_standard }}" class="button upgrade-button">
                                     {% if free_trial_days %}
@@ -147,6 +151,10 @@
                                 <a href='/billing' class="button current-plan-button" type="button">
                                     <i class="icon current-plan-icon"></i>
                                     Current plan
+                                </a>
+                                {% elif customer_plan and customer_plan.tier != customer_plan.TIER_CLOUD_PLUS %}
+                                <a href="mailto:sales@zulip.com" target="_blank" rel="noopener noreferrer" class="button upgrade-button">
+                                    Contact sales
                                 </a>
                                 {% else %}
                                 <a href="/upgrade/?tier={{ tier_cloud_plus }}" class="button upgrade-button">


### PR DESCRIPTION
Customers who are already on a paid / sponsored plan will see "Contact sales" on other paid plans.
![Screenshot 2024-10-17 at 4 19 53 PM](https://github.com/user-attachments/assets/ca4f57b0-ef3a-47f4-a790-e770023f0c6c)
![Screenshot 2024-10-17 at 4 20 34 PM](https://github.com/user-attachments/assets/93677661-a477-4d19-a1c1-403c5fab5b41)
