### PR TITLE
Optimize import order for Rocketchat data import tool

### DIFF
--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -1107,6 +1107,16 @@ def do_convert_data(rocketchat_data_dir: str, output_dir: str) -> None:
         user_id_mapper=user_id_mapper,
     )
 
+    rocketchat_emoji_data = rocketchat_data_to_dict(rocketchat_data_dir, ["custom_emoji"])[
+        "custom_emoji"
+    ]
+    zerver_realmemoji = build_custom_emoji(
+        realm_id=realm_id,
+        custom_emoji_data=rocketchat_emoji_data,
+        output_dir=output_dir,
+    )
+    realm["zerver_realmemoji"] = zerver_realmemoji
+
     room_id_to_room_map: dict[str, dict[str, Any]] = {}
     team_id_to_team_map: dict[str, dict[str, Any]] = {}
     dsc_id_to_dsc_map: dict[str, dict[str, Any]] = {}
@@ -1180,16 +1190,6 @@ def do_convert_data(rocketchat_data_dir: str, output_dir: str) -> None:
         personal_subscriptions + stream_subscriptions + direct_message_group_subscriptions
     )
     realm["zerver_subscription"] = zerver_subscription
-
-    rocketchat_emoji_data = rocketchat_data_to_dict(rocketchat_data_dir, ["custom_emoji"])[
-        "custom_emoji"
-    ]
-    zerver_realmemoji = build_custom_emoji(
-        realm_id=realm_id,
-        custom_emoji_data=rocketchat_emoji_data,
-        output_dir=output_dir,
-    )
-    realm["zerver_realmemoji"] = zerver_realmemoji
 
     subscriber_map = make_subscriber_map(
         zerver_subscription=zerver_subscription,

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -36,6 +36,8 @@ from zerver.lib.upload import sanitize_name
 from zerver.lib.utils import process_list_in_batches
 from zerver.models import Reaction, RealmEmoji, Recipient, UserProfile
 
+bson_codec_options = bson.DEFAULT_CODEC_OPTIONS.with_options(tz_aware=True)
+
 
 def make_realm(
     realm_id: int, realm_subdomain: str, domain_name: str, rc_instance: dict[str, Any]
@@ -976,8 +978,6 @@ def map_user_id_to_user(user_data_list: list[dict[str, Any]]) -> dict[str, dict[
 
 
 def rocketchat_data_to_dict(rocketchat_data_dir: str) -> dict[str, Any]:
-    codec_options = bson.DEFAULT_CODEC_OPTIONS.with_options(tz_aware=True)
-
     rocketchat_data: dict[str, Any] = {}
     rocketchat_data["instance"] = []
     rocketchat_data["user"] = []
@@ -989,60 +989,66 @@ def rocketchat_data_to_dict(rocketchat_data_dir: str) -> dict[str, Any]:
 
     # Get instance
     with open(os.path.join(rocketchat_data_dir, "instances.bson"), "rb") as fcache:
-        rocketchat_data["instance"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["instance"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     # Get user
     with open(os.path.join(rocketchat_data_dir, "users.bson"), "rb") as fcache:
-        rocketchat_data["user"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["user"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     # Get avatar
     with open(os.path.join(rocketchat_data_dir, "rocketchat_avatars.bson"), "rb") as fcache:
-        rocketchat_data["avatar"]["avatar"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["avatar"]["avatar"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     if rocketchat_data["avatar"]["avatar"]:
         with open(
             os.path.join(rocketchat_data_dir, "rocketchat_avatars.files.bson"), "rb"
         ) as fcache:
-            rocketchat_data["avatar"]["file"] = bson.decode_all(fcache.read(), codec_options)
+            rocketchat_data["avatar"]["file"] = bson.decode_all(fcache.read(), bson_codec_options)
 
         with open(
             os.path.join(rocketchat_data_dir, "rocketchat_avatars.chunks.bson"), "rb"
         ) as fcache:
-            rocketchat_data["avatar"]["chunk"] = bson.decode_all(fcache.read(), codec_options)
+            rocketchat_data["avatar"]["chunk"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     # Get room
     with open(os.path.join(rocketchat_data_dir, "rocketchat_room.bson"), "rb") as fcache:
-        rocketchat_data["room"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["room"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     # Get messages
     with open(os.path.join(rocketchat_data_dir, "rocketchat_message.bson"), "rb") as fcache:
-        rocketchat_data["message"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["message"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     # Get custom emoji
     with open(os.path.join(rocketchat_data_dir, "rocketchat_custom_emoji.bson"), "rb") as fcache:
-        rocketchat_data["custom_emoji"]["emoji"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["custom_emoji"]["emoji"] = bson.decode_all(
+            fcache.read(), bson_codec_options
+        )
 
     if rocketchat_data["custom_emoji"]["emoji"]:
         with open(os.path.join(rocketchat_data_dir, "custom_emoji.files.bson"), "rb") as fcache:
-            rocketchat_data["custom_emoji"]["file"] = bson.decode_all(fcache.read(), codec_options)
+            rocketchat_data["custom_emoji"]["file"] = bson.decode_all(
+                fcache.read(), bson_codec_options
+            )
 
         with open(os.path.join(rocketchat_data_dir, "custom_emoji.chunks.bson"), "rb") as fcache:
-            rocketchat_data["custom_emoji"]["chunk"] = bson.decode_all(fcache.read(), codec_options)
+            rocketchat_data["custom_emoji"]["chunk"] = bson.decode_all(
+                fcache.read(), bson_codec_options
+            )
 
     # Get uploads
     with open(os.path.join(rocketchat_data_dir, "rocketchat_uploads.bson"), "rb") as fcache:
-        rocketchat_data["upload"]["upload"] = bson.decode_all(fcache.read(), codec_options)
+        rocketchat_data["upload"]["upload"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     if rocketchat_data["upload"]["upload"]:
         with open(
             os.path.join(rocketchat_data_dir, "rocketchat_uploads.files.bson"), "rb"
         ) as fcache:
-            rocketchat_data["upload"]["file"] = bson.decode_all(fcache.read(), codec_options)
+            rocketchat_data["upload"]["file"] = bson.decode_all(fcache.read(), bson_codec_options)
 
         with open(
             os.path.join(rocketchat_data_dir, "rocketchat_uploads.chunks.bson"), "rb"
         ) as fcache:
-            rocketchat_data["upload"]["chunk"] = bson.decode_all(fcache.read(), codec_options)
+            rocketchat_data["upload"]["chunk"] = bson.decode_all(fcache.read(), bson_codec_options)
 
     return rocketchat_data
 

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -908,9 +908,9 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(
             info_log.output,
             [
-                "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2', 'os6N2Xg2JkNMCSW9Z']",
                 "INFO:root:Starting to process custom emoji",
                 "INFO:root:Done processing emoji",
+                "INFO:root:Direct message group channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2', 'os6N2Xg2JkNMCSW9Z']",
                 "INFO:root:skipping direct messages discussion mention: Discussion with Hermione",
             ],
         )


### PR DESCRIPTION
The Rocket.Chat data importer made the mistake of loading the entire data set of messages/uploads into memory before trying to validate anything, which made for an annoying edit/refresh cycle for metadata problems.