### PR TITLE
Fix new messages marked read on active window.

### DIFF
--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -58,8 +58,24 @@ export let client_is_active = document.hasFocus();
 // server-initiated reload as user activity.
 export let new_user_input = true;
 
+export let received_new_messages = false;
+
+type UserInputHook = () => void;
+const on_new_user_input_hooks: UserInputHook[] = [];
+
+export function register_on_new_user_input_hook(hook: UserInputHook): void {
+    on_new_user_input_hooks.push(hook);
+}
+
+export function set_received_new_messages(value: boolean): void {
+    received_new_messages = value;
+}
+
 export function set_new_user_input(value: boolean): void {
     new_user_input = value;
+    for (const hook of on_new_user_input_hooks) {
+        hook();
+    }
 }
 
 export function clear_for_testing(): void {

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -139,7 +139,7 @@ export function send_presence_to_server(redraw?: () => void): void {
                 $("#zephyr-mirror-error").removeClass("show");
             }
 
-            new_user_input = false;
+            set_new_user_input(false);
 
             if (redraw) {
                 assert(
@@ -176,7 +176,7 @@ export function mark_client_active(): void {
 
 export function initialize(): void {
     $("html").on("mousemove", () => {
-        new_user_input = true;
+        set_new_user_input(true);
     });
 
     $(window).on("focus", mark_client_active);

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
+import * as activity from "./activity";
 import * as alert_words from "./alert_words";
 import * as channel from "./channel";
 import * as compose_fade from "./compose_fade";
@@ -35,7 +36,6 @@ import * as stream_list from "./stream_list";
 import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
 import * as unread from "./unread";
-import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
@@ -274,7 +274,7 @@ export function insert_new_messages(messages, sent_by_this_client, deliver_local
         messages.map((message) => echo.track_local_message(message));
     }
 
-    unread_ops.process_visible();
+    activity.set_received_new_messages(true);
     message_notifications.received_messages(messages);
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -87,6 +87,16 @@ export function scroll_finished() {
 
     if (message_scroll_state.update_selection_on_next_scroll) {
         message_viewport.keep_pointer_in_view();
+        // If we don't want to update message selection on this scroll,
+        // we also don't want to mark any visible messages as read and
+        // are waiting on user input to do so. So, we only mark messages
+        // as read if we are updating selection on this scroll.
+        //
+        // When the window scrolls, it may cause some messages to
+        // enter the screen and become read.  Calling
+        // unread_ops.process_visible will update necessary
+        // data structures and DOM elements.
+        setTimeout(unread_ops.process_visible, 0);
     } else {
         message_scroll_state.set_update_selection_on_next_scroll(true);
     }
@@ -109,12 +119,6 @@ export function scroll_finished() {
             msg_list: message_lists.current,
         });
     }
-
-    // When the window scrolls, it may cause some messages to
-    // enter the screen and become read.  Calling
-    // unread_ops.process_visible will update necessary
-    // data structures and DOM elements.
-    setTimeout(unread_ops.process_visible, 0);
 }
 
 let scroll_timer;
@@ -140,7 +144,6 @@ export function initialize() {
                 return;
             }
 
-            unread_ops.process_visible();
             message_lists.current.view.update_sticky_recipient_headers();
             scroll_finish();
         }, 50),

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -632,6 +632,16 @@ export function initialize_everything(state_data) {
 
     initialize_unread_ui();
     activity.initialize();
+    activity.register_on_new_user_input_hook(() => {
+        // Instead of marking new messages as read immediately when bottom
+        // of feed is visible, we wait for user input to mark them as read.
+        // This is to prevent marking messages as read unintentionally,
+        // especially when user is away from screen and the window is focused.
+        if (activity.received_new_messages && activity.new_user_input) {
+            unread_ops.process_visible();
+            activity.set_received_new_messages(false);
+        }
+    });
     activity_ui.initialize({
         narrow_by_email(email) {
             message_view.show(

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -916,6 +916,10 @@ test("electron_bridge", ({override_rewire}) => {
         activity.mark_client_active();
         assert.equal(activity.compute_active_status(), "active");
     });
+
+    assert.ok(!activity.received_new_messages);
+    activity.set_received_new_messages(true);
+    assert.ok(activity.received_new_messages);
 });
 
 test("test_send_or_receive_no_presence_for_spectator", () => {

--- a/web/tests/example5.test.js
+++ b/web/tests/example5.test.js
@@ -27,8 +27,8 @@ const message_notifications = mock_esm("../src/message_notifications");
 const message_util = mock_esm("../src/message_util");
 const pm_list = mock_esm("../src/pm_list");
 const stream_list = mock_esm("../src/stream_list");
-const unread_ops = mock_esm("../src/unread_ops");
 const unread_ui = mock_esm("../src/unread_ui");
+const activity = mock_esm("../src/activity");
 
 message_lists.current = {
     data: {
@@ -105,8 +105,8 @@ run_test("insert_message", ({override}) => {
     helper.redirect(message_notifications, "received_messages");
     helper.redirect(message_util, "add_new_messages");
     helper.redirect(stream_list, "update_streams_sidebar");
-    helper.redirect(unread_ops, "process_visible");
     helper.redirect(unread_ui, "update_unread_counts");
+    helper.redirect(activity, "set_received_new_messages");
 
     message_events.insert_new_messages([new_message]);
 
@@ -118,7 +118,7 @@ run_test("insert_message", ({override}) => {
         [direct_message_group_data, "process_loaded_messages"],
         [message_util, "add_new_messages"],
         [unread_ui, "update_unread_counts"],
-        [unread_ops, "process_visible"],
+        [activity, "set_received_new_messages"],
         [message_notifications, "received_messages"],
         [stream_list, "update_streams_sidebar"],
     ]);

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -34,6 +34,7 @@ set_global("document", {
 });
 
 const activity_ui = mock_esm("../src/activity_ui");
+const activity = zrequire("../src/activity");
 const browser_history = mock_esm("../src/browser_history");
 const compose_actions = mock_esm("../src/compose_actions");
 const compose_reply = mock_esm("../src/compose_reply");
@@ -542,4 +543,14 @@ run_test("motion_keys", () => {
     assert_mapping("down_arrow", drafts_overlay_ui, "handle_keyboard_events");
     delete overlays.any_active;
     delete overlays.drafts_open;
+});
+
+run_test("test new user input hook called", () => {
+    let hook_called = false;
+    activity.register_on_new_user_input_hook(() => {
+        hook_called = true;
+    });
+
+    hotkey.process_keydown({which: "S".codePointAt(0)});
+    assert.ok(hook_called);
 });


### PR DESCRIPTION
This works to stop messages from being marked as read if a new message arrives and we don't scroll. Unfortunately, we scroll most of the time when trying the bring the new message into view which marks the message as read.  So, we need to carefully pipe that information to scroll event to avoid this bug in that case too to close --  #32024.