### PR TITLE
thumbnail: Make thumbnailing work with data import.

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -260,6 +260,9 @@ NON_EXPORTED_TABLES = {
     "zerver_submessage",
     # Drafts don't need to be exported as they are supposed to be more ephemeral.
     "zerver_draft",
+    # The importer cannot trust ImageAttachment objects anyway and needs to check
+    # and process images for thumbnailing on its own.
+    "zerver_imageattachment",
     # For any tables listed below here, it's a bug that they are not present in the export.
 }
 

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -14,7 +14,7 @@ from typing_extensions import override
 
 from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.queue import queue_event_on_commit
-from zerver.models import AbstractAttachment, ImageAttachment
+from zerver.models import ImageAttachment
 
 DEFAULT_AVATAR_SIZE = 100
 MEDIUM_AVATAR_SIZE = 500
@@ -279,9 +279,9 @@ def missing_thumbnails(image_attachment: ImageAttachment) -> list[ThumbnailForma
 
 
 def maybe_thumbnail(
-    attachment: AbstractAttachment, content: bytes | pyvips.Source
+    content: bytes | pyvips.Source, content_type: str | None, path_id: str, realm_id: int
 ) -> ImageAttachment | None:
-    if attachment.content_type not in THUMBNAIL_ACCEPT_IMAGE_TYPES:
+    if content_type not in THUMBNAIL_ACCEPT_IMAGE_TYPES:
         # If it doesn't self-report as an image file that we might want
         # to thumbnail, don't parse the bytes at all.
         return None
@@ -301,8 +301,8 @@ def maybe_thumbnail(
                 (width, height) = (image.width, image.height)
 
             image_row = ImageAttachment.objects.create(
-                realm_id=attachment.realm_id,
-                path_id=attachment.path_id,
+                realm_id=realm_id,
+                path_id=path_id,
                 original_width_px=width,
                 original_height_px=height,
                 frames=image.get_n_pages(),

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -70,7 +70,7 @@ def create_attachment(
         size=file_size,
         content_type=content_type,
     )
-    maybe_thumbnail(attachment, file_real_data)
+    maybe_thumbnail(file_real_data, content_type, path_id, realm.id)
     from zerver.actions.uploads import notify_attachment_update
 
     notify_attachment_update(user_profile, "add", attachment.to_dict())

--- a/zerver/tests/test_markdown_thumbnail.py
+++ b/zerver/tests/test_markdown_thumbnail.py
@@ -2,6 +2,7 @@ import re
 from unittest.mock import patch
 
 import pyvips
+from typing_extensions import override
 
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_send import check_message, do_send_messages
@@ -9,7 +10,7 @@ from zerver.lib.addressee import Addressee
 from zerver.lib.camo import get_camo_url
 from zerver.lib.markdown import render_message_markdown
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import get_test_image_file, read_test_image_file
+from zerver.lib.test_helpers import read_test_image_file
 from zerver.lib.thumbnail import ThumbnailFormat
 from zerver.lib.upload import upload_message_attachment
 from zerver.models import (
@@ -25,20 +26,10 @@ from zerver.worker.thumbnail import ensure_thumbnails
 
 
 class MarkdownThumbnailTest(ZulipTestCase):
-    def upload_image(self, image_name: str) -> str:
+    @override
+    def setUp(self) -> None:
         self.login("othello")
-        with get_test_image_file(image_name) as image_file:
-            response = self.assert_json_success(
-                self.client_post("/json/user_uploads", {"file": image_file})
-            )
-            return re.sub(r"/user_uploads/", "", response["url"])
-
-    def upload_and_thumbnail_image(self, image_name: str) -> str:
-        with self.captureOnCommitCallbacks(execute=True):
-            # Running captureOnCommitCallbacks includes inserting into
-            # the Rabbitmq queue, which in testing means we
-            # immediately run the worker for it, producing the thumbnails.
-            return self.upload_image(image_name)
+        super().setUp()
 
     def assert_message_content_is(
         self, message_id: int, rendered_content: str, user_name: str = "othello"


### PR DESCRIPTION
**No tests yet**, but tested manually with both zulip=>zulip and Slack imports, so the main code is ready for normal review.

We didn't have thumbnailing for images coming from data import and this commit adds the functionality.

There are a few fundamental issues that the implementation needs to solve.

1. The images come from an untrusted source and therefore we don't want to just pass them through to thumbnailing without checking. For that reason, we cannot just import ImageAttachment rows from the export data, even for zulip=>zulip imports. The right way to process images is to pass them to maybe_thumbail(), which runs libvips_check_image() on them to verify we're okay with thumbnailing, creates ImageAttachment rows for them and sends them to the thumbnailing queue worker. This approach lets us handle both zulip=>zulip and 3rd party=>zulip imports in the same way,

2. There is a somewhat circular dependency between the Message, Attachment and ImageAttachment import process:

- ImageAttachments would ideally be created after importing Attachments, but they need to already exist at the time of Message import. Otherwise, the markdown processor doesn't know it has to add HTML for image previews to messages that reference images. This would mean that messages imported from 3rd party tools don't get image previews.
- Attachments only get created after Message import however, due to the many-to-many relationship between Message and Attachment.

This is solved by fixing up some data of Attachments pre-emptively, such as the path_ids. This gives us the necessary information for creating ImageAttachments before importing Messages.

While we generate ImageAttachment rows synchronously, the actual thumbnailing job is sent to the queue worker. Theoretically, the worker could be very backlogged and not process the thumbnails anytime soon. This is fine - if the app is loaded and tries to display a message with such a not-yet-generated thumbnail, the code in `serve_file` will generate the thumbnails synchronously on the fly and the user will see the image preview displayed normally. See:

https://github.com/zulip/zulip/blob/1b47134d0d564f8ba4961d25743f3ad0f09e6dfb/zerver/views/upload.py#L333-L342

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
