### PR TITLE
contributor docs: Add a page on taking over prior work.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,10 +280,8 @@ labels.
   codebase, you can also find another "help wanted" issue in the same area to
   work on.
 - **What if there is already a pull request for the issue I want to work on?**
-  Start by reviewing the existing work. If you agree with the approach, you can
-  use the existing pull request (PR) as a starting point for your contribution. If
-  you think a different approach is needed, you can post a new PR, with a comment that clearly
-  explains _why_ you decided to start from scratch.
+  See our [guide on continuing unfinished
+  work](https://zulip.readthedocs.io/en/latest/contributing/continuing-unfinished-work.html).
 - **What if I ask if someone is still working on an issue, and they don't
   respond?** If you don't get a reply within 2-3 days, go ahead and post a comment
   that you are working on the issue, and submit a pull request. If the original

--- a/docs/contributing/commit-discipline.md
+++ b/docs/contributing/commit-discipline.md
@@ -300,6 +300,10 @@ the end of your commit message:
 
     Co-authored-by: Greg Price <greg@zulip.com>
 
+You should always give credit where credit is due. See our [guide on continuing
+unfinished work](../contributing/continuing-unfinished-work.md) for step-by-step
+guidance on continuing work someone else has started.
+
 You can also add other notes, such as `Reported-by:`, `Debugged-by:`, or
 `Suggested-by:`, but we don't typically do so.
 


### PR DESCRIPTION
 <details>
<summary>
screenshots
</summary>

![Screenshot 2024-10-17 at 17 06 31@2x](https://github.com/user-attachments/assets/43924531-fbb7-4359-bfa9-d4d1965b769d)
![Screenshot 2024-10-17 at 17 06 47@2x](https://github.com/user-attachments/assets/02b4526b-58f4-42dd-83f7-fe8a1f166bb4)
![Screenshot 2024-10-17 at 17 06 52@2x](https://github.com/user-attachments/assets/658f9a59-158b-4475-b1fa-003233836a9c)

</details>