### PR TITLE
ui: Fixes email ui and the notification position #31975

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -544,6 +544,31 @@ input[type="checkbox"] {
     word-break: break-word;
 }
 
+.alert-notification-email {
+    display: inline-block;
+    vertical-align: top;
+    height: auto !important;
+    width: auto !important;
+    white-space: break-spaces !important;
+
+    overflow-wrap: anywhere;
+    background-color: transparent;
+    border-radius: 4px;
+    margin-top: 14px;
+    margin-left: 10px;
+    color: hsl(0deg 0% 100%);
+    padding: 3px 10px;
+
+    &.account-alert-notification-email {
+        margin: 0 0 10px;
+        vertical-align: middle;
+    }
+
+    &:not(:empty) {
+        border: none;
+    }
+}
+
 .alert-notification {
     display: inline-block;
     vertical-align: top;
@@ -581,7 +606,7 @@ input[type="checkbox"] {
 
     /* make the spinner green like the text and box. */
     .loading_indicator_spinner svg path {
-        fill: hsl(178deg 100% 40%);
+        fill: hsl(0deg 0% 100%);
     }
 
     .loading_indicator_text {

--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,5 @@
 <form id="change_email_form">
+    <p>{{t "You will receive a confirmation email at the new address you enter."}}</p>
     <label for="email" class="modal-field-label">{{t "New email" }}</label>
     <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -3,16 +3,23 @@
     <div class="account-settings-form">
         <div id="user_details_section">
             <h3 class="inline-block account-settings-heading">{{t "Account" }}</h3>
-            <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
                     <label class="settings-field-label">{{t "Email" }}</label>
                     <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
-                        <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
-                            {{current_user.delivery_email}}
-                        </button>
+                        <input type="email" value="{{current_user.delivery_email}}" disabled class="button rounded" />
+                        {{#if user_can_change_email}}
+                            <button id="change_email_button" type="button" class="button rounded" data-toggle="modal" data-target="#emailEditModal">
+                                <i class="fa fa-pencil"></i>
+                            </button>
+                        {{else}}
+                            <span class="email-disabled-tooltip" data-toggle="tooltip" data-placement="top" title="{{t 'Email address changes are disabled in this organization.'}}">
+                                <i class="fa fa-info-circle"></i>
+                            </span>
+                        {{/if}}
                     </div>
+                    <div class="alert-notification-email account-alert-notification-email" id="account-settings-status"></div>
                 </div>
                 {{else}}
                 {{! Demo organizations before the owner has configured an email address. }}


### PR DESCRIPTION
So this PR is made to solve #31975, the following changes are solved - 
1. The email edit option now has an icon that is only used which user can change or update their email.
2. The email confirmation message will disappear after 10 seconds(Proposed not implemented).
3. Added a line explaining the flow at the top of the modal:
`You will receive a confirmation email at the new address you enter.`
![Screenshot from 2024-10-17 21-58-15](https://github.com/user-attachments/assets/82fd99d1-7b86-4c00-82be-eb4f699e1fef)



- Confirmation of UI is fixed, and the notification signs' position matches the requirement.
![Screenshot from 2024-10-18 06-29-41](https://github.com/user-attachments/assets/0e1f7d6f-cb91-41a3-8d69-a7075cd53b8e)

Fixes: #31975 

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
