### PR TITLE
message_events: Don't update msg if we don't have it cached locally.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -381,9 +381,14 @@ export function update_messages(events) {
         const stream_archived = old_stream === undefined;
 
         if (!topic_edited && !stream_changed) {
-            // If the topic or stream of the message was changed,
+            // If the topic or stream of the anchor message was changed,
             // it will be rerendered if present in any rendered list.
-            messages_to_rerender.push(anchor_message);
+            //
+            // But for content edits, we need to schedule it to be
+            // rerendered, if we have a local copy of it.
+            if (anchor_message !== undefined) {
+                messages_to_rerender.push(anchor_message);
+            }
         } else {
             const going_forward_change = ["change_later", "change_all"].includes(
                 event.propagate_mode,


### PR DESCRIPTION
This fixes a bug where we try to rerender the anchor message even if we don't have it locally cached which results in error.

Introduced in #31942

Fixes https://zulip.sentry.io/issues/5991504658/events/recommended/?project=4504556882821120&referrer=recommended-event
