### PR TITLE
Prep commit for adding scheduled realm data deletion time.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -284,18 +284,6 @@ function valid_to(): string {
     return $t({defaultMessage: "Expires on {date} at {time}"}, {date, time});
 }
 
-function set_expires_on_text(): void {
-    const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
-    const valid_to_text = valid_to();
-    if ($expires_in.val() === "custom") {
-        $("#expires_on").hide();
-        $("#custom_expires_on").text(valid_to_text);
-    } else {
-        $("#expires_on").show();
-        $("#expires_on").text(valid_to_text);
-    }
-}
-
 function set_streams_to_join_list_visibility(): void {
     const realm_has_default_streams = stream_data.get_default_stream_ids().length !== 0;
     const hide_streams_list =
@@ -380,7 +368,8 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             custom_expiration_time_unit,
             custom_expiration_time_input,
         );
-        set_expires_on_text();
+        const valid_to_text = valid_to();
+        settings_components.set_time_input_formatted_text($expires_in, valid_to_text);
 
         if (settings_data.user_can_subscribe_other_users()) {
             set_streams_to_join_list_visibility();
@@ -438,7 +427,8 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
                 custom_expiration_time_unit,
                 custom_expiration_time_input,
             );
-            set_expires_on_text();
+            const valid_to_text = valid_to();
+            settings_components.set_time_input_formatted_text($expires_in, valid_to_text);
             toggle_invite_submit_button();
         });
 
@@ -456,7 +446,8 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             custom_expiration_time_unit = $<HTMLSelectOneElement>(
                 "select:not([multiple])#custom-expiration-time-unit",
             ).val()!;
-            set_expires_on_text();
+            const valid_to_text = valid_to();
+            settings_components.set_time_input_formatted_text($expires_in, valid_to_text);
             toggle_invite_submit_button();
         });
 

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -24,6 +24,7 @@ import * as input_pill from "./input_pill";
 import * as invite_stream_picker_pill from "./invite_stream_picker_pill";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
+import * as settings_components from "./settings_components";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import {current_user, realm} from "./state_data";
@@ -293,19 +294,6 @@ function set_expires_on_text(): void {
     }
 }
 
-function set_custom_time_inputs_visibility(): void {
-    const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
-    if ($expires_in.val() === "custom") {
-        $("#custom-expiration-time-input").val(custom_expiration_time_input);
-        $<HTMLSelectOneElement>("select:not([multiple])#custom-expiration-time-unit").val(
-            custom_expiration_time_unit,
-        );
-        $("#custom-invite-expiration-time").show();
-    } else {
-        $("#custom-invite-expiration-time").hide();
-    }
-}
-
 function set_streams_to_join_list_visibility(): void {
     const realm_has_default_streams = stream_data.get_default_stream_ids().length !== 0;
     const hide_streams_list =
@@ -385,7 +373,11 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
 
         const user_has_email_set = !settings_data.user_email_not_configured();
 
-        set_custom_time_inputs_visibility();
+        settings_components.set_custom_time_inputs_visibility(
+            $expires_in,
+            custom_expiration_time_unit,
+            custom_expiration_time_input,
+        );
         set_expires_on_text();
 
         if (settings_data.user_can_subscribe_other_users()) {
@@ -439,7 +431,11 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         pills.onTextInputHook(toggle_invite_submit_button);
 
         $expires_in.on("change", () => {
-            set_custom_time_inputs_visibility();
+            settings_components.set_custom_time_inputs_visibility(
+                $expires_in,
+                custom_expiration_time_unit,
+                custom_expiration_time_input,
+            );
             set_expires_on_text();
             toggle_invite_submit_button();
         });

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -451,7 +451,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             }
         });
 
-        $(".custom-expiration-time").on("change", () => {
+        $("#custom-invite-expiration-time").on("change", () => {
             custom_expiration_time_input = util.check_time_input(
                 $<HTMLInputElement>("input#custom-expiration-time-input").val()!,
             );

--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -255,42 +255,44 @@ function generate_multiuse_invite(): void {
     });
 }
 
-function valid_to(time_valid: number): string {
-    if (!time_valid) {
+function valid_to(): string {
+    const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
+    const time_input_value = $expires_in.val()!;
+
+    if (time_input_value === "null") {
         return $t({defaultMessage: "Never expires"});
     }
 
+    let time_in_minutes: number;
+    if (time_input_value === "custom") {
+        if (!util.validate_custom_time_input(custom_expiration_time_input)) {
+            return $t({defaultMessage: "Invalid custom time"});
+        }
+        time_in_minutes = util.get_custom_time_in_minutes(
+            custom_expiration_time_unit,
+            custom_expiration_time_input,
+        );
+    } else {
+        time_in_minutes = Number.parseFloat(time_input_value);
+    }
+
     // The below is a duplicate of timerender.get_full_datetime, with a different base string.
-    const valid_to = add(new Date(), {minutes: time_valid});
+    const valid_to = add(new Date(), {minutes: time_in_minutes});
     const date = timerender.get_localized_date_or_time_for_format(valid_to, "dayofyear_year");
     const time = timerender.get_localized_date_or_time_for_format(valid_to, "time");
 
     return $t({defaultMessage: "Expires on {date} at {time}"}, {date, time});
 }
 
-function set_custom_expires_on_text(): void {
-    if (util.validate_custom_time_input(custom_expiration_time_input)) {
-        $("#custom_expires_on").text(
-            valid_to(
-                util.get_custom_time_in_minutes(
-                    custom_expiration_time_unit,
-                    custom_expiration_time_input,
-                ),
-            ),
-        );
-    } else {
-        $("#custom_expires_on").text($t({defaultMessage: "Invalid custom time"}));
-    }
-}
-
 function set_expires_on_text(): void {
     const $expires_in = $<HTMLSelectOneElement>("select:not([multiple])#expires_in");
+    const valid_to_text = valid_to();
     if ($expires_in.val() === "custom") {
         $("#expires_on").hide();
-        set_custom_expires_on_text();
+        $("#custom_expires_on").text(valid_to_text);
     } else {
         $("#expires_on").show();
-        $("#expires_on").text(valid_to(Number.parseFloat($expires_in.val()!)));
+        $("#expires_on").text(valid_to_text);
     }
 }
 
@@ -454,7 +456,7 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             custom_expiration_time_unit = $<HTMLSelectOneElement>(
                 "select:not([multiple])#custom-expiration-time-unit",
             ).val()!;
-            set_custom_expires_on_text();
+            set_expires_on_text();
             toggle_invite_submit_button();
         });
 

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1636,3 +1636,17 @@ export function create_realm_group_setting_widget({
         save_discard_realm_settings_widget_status_handler($save_discard_widget_container);
     });
 }
+
+export function set_custom_time_inputs_visibility(
+    $time_select_elem: JQuery,
+    time_unit: string,
+    time_value: number,
+): void {
+    if ($time_select_elem.val() === "custom") {
+        $time_select_elem.parent().find(".custom-time-input-value").val(time_value);
+        $time_select_elem.parent().find(".custom-time-input-unit").val(time_unit);
+        $time_select_elem.parent().find(".custom-time-input-container").show();
+    } else {
+        $time_select_elem.parent().find(".custom-time-input-container").hide();
+    }
+}

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1637,6 +1637,22 @@ export function create_realm_group_setting_widget({
     });
 }
 
+export function set_time_input_formatted_text(
+    $time_select_elem: JQuery,
+    formatted_text: string,
+): void {
+    if ($time_select_elem.val() === "custom") {
+        $time_select_elem.parent().find(".time-input-formatted-description").hide();
+        $time_select_elem
+            .parent()
+            .find(".custom-time-input-formatted-description")
+            .text(formatted_text);
+    } else {
+        $time_select_elem.parent().find(".time-input-formatted-description").show();
+        $time_select_elem.parent().find(".time-input-formatted-description").text(formatted_text);
+    }
+}
+
 export function set_custom_time_inputs_visibility(
     $time_select_elem: JQuery,
     time_unit: string,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -342,7 +342,7 @@
     select,
     .pill-container,
     .user-status-content-wrapper,
-    #custom-expiration-time-input,
+    .custom-time-input-value,
     #organization-permissions .dropdown-widget-button,
     #organization-settings .dropdown-widget-button,
     #stream-advanced-configurations .dropdown-widget-button {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1261,7 +1261,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
-#custom-expiration-time-input,
+.custom-time-input-value,
 #invite-user-form {
     margin: 0;
 }
@@ -1285,7 +1285,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     width: 100%;
 }
 
-#custom-expiration-time-input {
+.custom-time-input-value {
     width: 5ch;
     margin-right: 15px;
 
@@ -1307,7 +1307,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
-#custom-expiration-time-unit {
+.custom-time-input-unit {
     width: auto;
 }
 

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -41,7 +41,7 @@
             {{/each}}
         </select>
         <p id="expires_on"></p>
-        <div id="custom-invite-expiration-time" class="dependent-settings-block">
+        <div id="custom-invite-expiration-time" class="dependent-settings-block custom-time-input-container">
             <label for="expires_in" class="modal-field-label">{{t "Custom time" }}</label>
             <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-time-input-value inline-block" value="" maxlength="3"/>
             <select class="custom-time-input-unit invite-user-select modal_select bootstrap-focus-style" id="custom-expiration-time-unit">

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -40,7 +40,7 @@
                 <option {{#if this.default }}selected{{/if}} name="expires_in" value="{{this.value}}">{{this.description}}</option>
             {{/each}}
         </select>
-        <p id="expires_on"></p>
+        <p class="time-input-formatted-description"></p>
         <div id="custom-invite-expiration-time" class="dependent-settings-block custom-time-input-container">
             <label for="expires_in" class="modal-field-label">{{t "Custom time" }}</label>
             <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-time-input-value inline-block" value="" maxlength="3"/>
@@ -49,7 +49,7 @@
                     <option name="custom_time_choice" class="custom_time_choice" value="{{this.name}}">{{this.description}}</option>
                 {{/each}}
             </select>
-            <p id="custom_expires_on"></p>
+            <p class="custom-time-input-formatted-description"></p>
         </div>
     </div>
     <div class="input-group">

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -43,8 +43,8 @@
         <p id="expires_on"></p>
         <div id="custom-invite-expiration-time" class="dependent-settings-block">
             <label for="expires_in" class="modal-field-label">{{t "Custom time" }}</label>
-            <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="" maxlength="3"/>
-            <select class="custom-expiration-time invite-user-select modal_select bootstrap-focus-style" id="custom-expiration-time-unit">
+            <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-time-input-value inline-block" value="" maxlength="3"/>
+            <select class="custom-time-input-unit invite-user-select modal_select bootstrap-focus-style" id="custom-expiration-time-unit">
                 {{#each time_choices}}
                     <option name="custom_time_choice" class="custom_time_choice" value="{{this.name}}">{{this.description}}</option>
                 {{/each}}


### PR DESCRIPTION
Prep commit for #31957.

This refactor moves the functions set_custom_expires_on_text, set_expires_on_text, and set_custom_time_inputs_visibility from invite.ts to settings_ui.ts.
It also adds general class names to elements to improve extensibility.

This change was made so that these functions can be reused in several places in the future.

[CZO thread](https://chat.zulip.org/#narrow/channel/6-frontend/topic/realm.3A.20Schedule.20realm.20deletion.20time.20while.20deactivating.20realm/near/1963971)
<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/72057c29-3375-4b14-91a0-4bf74db3f3dc) | ![image](https://github.com/user-attachments/assets/5e8326ed-e9d8-4cfc-8ab5-673eba9075a8) |
| ![image](https://github.com/user-attachments/assets/78151e54-5fb1-4c1e-97d1-feda8702f01e) | ![image](https://github.com/user-attachments/assets/2449c5c0-bada-4a4f-bde3-f3f070e705e9) |
| ![image](https://github.com/user-attachments/assets/eac46682-c72a-4104-8067-94d992e14d19) | ![image](https://github.com/user-attachments/assets/d0ca08ab-fd8e-4736-b8b5-685821261664) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
