### PR TITLE
slack_incoming: add ok=false to json in case of error.

### DIFF
--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -66,7 +66,8 @@ Hello, world.
     def test_message_without_payload(self) -> None:
         self.url = self.build_webhook_url()
         result = self.client_post(self.url)
-        self.assert_json_error(result, "Missing 'payload' argument")
+        self.assertEqual(result.json()["error"], "Missing 'payload' argument")
+        self.assertEqual(result.json()["ok"], False)
 
     def test_message_with_actions(self) -> None:
         expected_topic_name = "C1H9RESGL"


### PR DESCRIPTION
**Summary:**

This PR ensures that errors in the Slack incoming webhook handler return JSON responses with Slack's expected format: `{ok: false, error: "error string"}`. 

Previously, errors were returned using Zulip's default format (`{"result": "error", "msg": ""}`), which did not match Slack’s expected response structure. This update aligns error handling with Slack’s API requirements, improving compatibility for integrations.

**Fixes:**  
Fixes: [#31878](https://github.com/zulip/zulip/issues/31878)

---

**Screenshots and screen captures:**
No visual changes.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
