### PR TITLE
Fix flashing banners while creating channels.

### DIFF
--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -22,6 +22,9 @@ import * as ui_report from "./ui_report";
 import * as util from "./util";
 
 let created_stream: string | undefined;
+// Default is true since the current user is added to
+// the subscribers list initially.
+let current_user_subscribed_to_created_stream = true;
 
 export function reset_created_stream(): void {
     created_stream = undefined;
@@ -33,6 +36,18 @@ export function set_name(stream: string): void {
 
 export function get_name(): string | undefined {
     return created_stream;
+}
+
+export function reset_current_user_subscribed_to_created_stream(): void {
+    current_user_subscribed_to_created_stream = true;
+}
+
+export function set_current_user_subscribed_to_created_stream(is_subscribed: boolean): void {
+    current_user_subscribed_to_created_stream = is_subscribed;
+}
+
+export function get_current_user_subscribed_to_created_stream(): boolean {
+    return current_user_subscribed_to_created_stream;
 }
 
 export function set_first_stream_created_modal_shown(): void {
@@ -317,6 +332,7 @@ function create_stream(): void {
     //       once we upgrade the backend to accept user_ids.
     const user_ids = stream_create_subscribers.get_principals();
     const principals = JSON.stringify(user_ids);
+    set_current_user_subscribed_to_created_stream(user_ids.includes(current_user.user_id));
 
     assert(stream_settings_components.new_stream_can_remove_subscribers_group_widget !== null);
     const widget_value =

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -348,10 +348,6 @@ function create_stream(): void {
         success(): void {
             $("#create_stream_name").val("");
             $("#create_stream_description").val("");
-            ui_report.success(
-                $t_html({defaultMessage: "Channel successfully created!"}),
-                $(".stream_create_info"),
-            );
             loading.destroy_indicator($("#stream_creating_indicator"));
             // The rest of the work is done via the subscribe event we will get
         },

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -239,18 +239,25 @@ export function add_sub_to_table(sub) {
         // top of the list, so they are more visible.
         stream_ui_updates.row_for_stream_id(sub.stream_id).trigger("click");
 
-        // This banner is for administrators creating a channel that
-        // they are themselves not initial subscribers to; other users
-        // will be immediately navigated to the channel view.
-        const context = {
-            banner_type: compose_banner.SUCCESS,
-            classname: "stream_creation_confirmation",
-            stream_name: sub.name,
-            stream_url: hash_util.by_stream_url(sub.stream_id),
-        };
-        $("#stream_settings .stream-creation-confirmation-banner").html(
-            render_stream_creation_confirmation_banner(context),
-        );
+        if (!stream_create.get_current_user_subscribed_to_created_stream()) {
+            // This banner is for administrators creating a channel that
+            // they are themselves not initial subscribers to; other users
+            // will be immediately navigated to the channel view.
+            //
+            // stream_create.get_current_user_subscribed_to_created_stream
+            // is just a work around because we do not have the subscribers
+            // info yet.
+            const context = {
+                banner_type: compose_banner.SUCCESS,
+                classname: "stream_creation_confirmation",
+                stream_name: sub.name,
+                stream_url: hash_util.by_stream_url(sub.stream_id),
+            };
+            $("#stream_settings .stream-creation-confirmation-banner").html(
+                render_stream_creation_confirmation_banner(context),
+            );
+        }
+        stream_create.reset_current_user_subscribed_to_created_stream();
     }
     update_empty_left_panel_message();
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to not show any banner on channel creation form.
- Second commit is to not show the channel creation banner when user is subscribed to the channel.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/channel/9-issues/topic/confirmation.20banner.20flashes.20when.20creating.20channel

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
User creating the stream is subscribed
![creator-subscribed](https://github.com/user-attachments/assets/f43fcab6-e67d-47d6-8cb0-dc3714006443)

User creating the stream is not subscribed 
![creator-unsubscribed](https://github.com/user-attachments/assets/7da3827b-f0ea-4ff8-a0a9-cdef21822519)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
