### PR TITLE
message_events: Refresh `is-followed` narrow on topic visibility update.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -39,6 +39,38 @@ import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 
+export function update_current_view_for_topic_visibility() {
+    // If we have rendered message list / cached data based on topic
+    // visibility policy, we need to rerender it to reflect the changes. It
+    // is easier to just load the narrow from scratch, instead of asking server
+    // for relevant messages in the updated topic.
+    const filter = message_lists.current?.data.filter;
+    if (
+        filter !== undefined &&
+        (filter.sorted_term_types().includes("is-followed") ||
+            filter.sorted_term_types().includes("not-is-followed"))
+    ) {
+        // Use `set_timeout to call after we update the topic
+        // visibility policy locally.
+        // Calling this outside `user_topics_ui` to avoid circular imports.
+        const msg_list_id = message_lists.current.id;
+        setTimeout(() => {
+            if (message_lists.current.id !== msg_list_id) {
+                // Check if the message list is still the same.
+                return;
+            }
+
+            message_view.show(filter.terms(), {
+                then_select_id: message_lists.current.selected_id(),
+                trigger: "topic visibility policy change",
+                force_rerender: true,
+            });
+        }, 0);
+        return true;
+    }
+    return false;
+}
+
 export function update_views_filtered_on_message_property(
     message_ids,
     property_term_type,
@@ -47,8 +79,11 @@ export function update_views_filtered_on_message_property(
     // NOTE: Call this function after updating the message property locally.
     assert(!property_term_type.includes("not-"));
 
-    // List of narrow terms whose msg list doesn't get updated elsewhere but
-    // can be applied locally.
+    // List of narrow terms where the message list doesn't get
+    // automatically updated elsewhere when the property changes, but
+    // we can apply locally if we have the message.
+    //
+    // is:followed is handled via update_current_view_for_topic_visibility.
     const supported_term_types = [
         "has-image",
         "has-link",
@@ -58,8 +93,6 @@ export function update_views_filtered_on_message_property(
         "is-unread",
         "is-mentioned",
         "is-alerted",
-        // TODO: Implement support for these terms.
-        // "is-followed",
     ];
 
     if (message_ids.length === 0 || !supported_term_types.includes(property_term_type)) {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -1009,7 +1009,10 @@ export function dispatch_normal_event(event) {
             break;
 
         case "user_topic":
-            user_topics_ui.handle_topic_updates(event);
+            user_topics_ui.handle_topic_updates(
+                event,
+                message_events.update_current_view_for_topic_visibility(),
+            );
             break;
     }
 }

--- a/web/src/user_topics_ui.ts
+++ b/web/src/user_topics_ui.ts
@@ -33,7 +33,10 @@ function should_add_topic_update_delay(visibility_policy: number): boolean | und
     return is_topic_muted && is_relevant_popover_open && !is_inbox_view && !is_topic_narrow;
 }
 
-export function handle_topic_updates(user_topic_event: ServerUserTopic): void {
+export function handle_topic_updates(
+    user_topic_event: ServerUserTopic,
+    refreshed_current_narrow = false,
+): void {
     // Update the UI after changes in topic visibility policies.
     user_topics.set_user_topic(user_topic_event);
 
@@ -41,11 +44,14 @@ export function handle_topic_updates(user_topic_event: ServerUserTopic): void {
         () => {
             stream_list.update_streams_sidebar();
             unread_ui.update_unread_counts();
-            message_lists.current?.update_muting_and_rerender();
             recent_view_ui.update_topic_visibility_policy(
                 user_topic_event.stream_id,
                 user_topic_event.topic_name,
             );
+
+            if (!refreshed_current_narrow) {
+                message_lists.current?.update_muting_and_rerender();
+            }
         },
         should_add_topic_update_delay(user_topic_event.visibility_policy) ? 500 : 0,
     );

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -34,6 +34,7 @@ const information_density = mock_esm("../src/information_density");
 const linkifiers = mock_esm("../src/linkifiers");
 const message_events = mock_esm("../src/message_events", {
     update_views_filtered_on_message_property: noop,
+    update_current_view_for_topic_visibility: noop,
 });
 const message_lists = mock_esm("../src/message_lists");
 const user_topics_ui = mock_esm("../src/user_topics_ui");


### PR DESCRIPTION
This adds live update support for `is-followed` narrow. We need to render the narrow again instead of just adding the relevant messages from the updated topic since it not easy to determine which message we need to add based on the selected message of the user and which messages to ask from the server.

