### PR TITLE
realm_export: Add realm_export_consent feature to API.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 312**
+
+* [`GET /events`](/api/get-events): Added `realm_export_consent` event
+  type to allow realm administrators to view which users have
+  consented to export their private data as part of a realm export.
+
 **Feature level 311**
 
 * [`POST /user_groups/{user_group_id}/members`](/api/update-user-group-members):

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 311  # Last bumped for updating subgroups.
+API_FEATURE_LEVEL = 312  # Last bumped for adding 'realm_export_consent' event type.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -731,6 +731,18 @@ def do_reactivate_user(user_profile: UserProfile, *, acting_user: UserProfile | 
     )
     send_event_on_commit(user_profile.realm, event, get_user_ids_who_can_access_user(user_profile))
 
+    if not user_profile.is_bot:
+        realm_export_consent_event = dict(
+            type="realm_export_consent",
+            user_id=user_profile.id,
+            consented=user_profile.allow_private_data_export,
+        )
+        send_event_on_commit(
+            user_profile.realm,
+            realm_export_consent_event,
+            list(user_profile.realm.get_human_admin_users().values_list("id", flat=True)),
+        )
+
     if user_profile.is_bot:
         event = dict(
             type="realm_bot",

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -512,6 +512,18 @@ def do_change_user_setting(
 
         send_event_on_commit(user_profile.realm, legacy_event, [user_profile.id])
 
+    if setting_name == "allow_private_data_export":
+        event = {
+            "type": "realm_export_consent",
+            "user_id": user_profile.id,
+            "consented": setting_value,
+        }
+        send_event_on_commit(
+            user_profile.realm,
+            event,
+            list(user_profile.realm.get_human_admin_users().values_list("id", flat=True)),
+        )
+
     # Updates to the time zone display setting are sent to all users
     if setting_name == "timezone":
         payload = dict(

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -872,6 +872,15 @@ def check_realm_export(
     assert has_failed_timestamp == (export["failed_timestamp"] is not None)
 
 
+realm_export_consent_event = event_dict_type(
+    [
+        ("type", Equals("realm_export_consent")),
+        ("user_id", int),
+        ("consented", bool),
+    ]
+)
+check_realm_export_consent = make_checker(realm_export_consent_event)
+
 realm_linkifier_type = DictType(
     required_keys=[
         ("pattern", str),

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1564,6 +1564,10 @@ def apply_event(
         # These realm export events are only available to
         # administrators, and aren't included in page_params.
         pass
+    elif event["type"] == "realm_export_consent":
+        # These 'realm_export_consent' events are only available to
+        # administrators, and aren't included in page_params.
+        pass
     elif event["type"] == "alert_words":
         state["alert_words"] = event["alert_words"]
     elif event["type"] == "muted_topics":

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3887,6 +3887,41 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event sent to administrators when the [data export
+                                consent][help-export-consent] status for a user changes, whether due
+                                to a user changing their consent preferences or a user being created
+                                or reactivated (since user creation/activation events do not contain
+                                these data).
+
+                                [help-export-consent]: /help/export-your-organization#configure-whether-administrators-can-export-your-private-data
+
+                                **Changes**: New in Zulip 10.0 (feature level 312). Previously,
+                                there was not event available to administrators with these data.
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - realm_export_consent
+                                user_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the user whose setting was changed.
+                                consented:
+                                  type: boolean
+                                  description: |
+                                    Whether the user has consented for their private data export.
+                              example:
+                                {
+                                  "type": "realm_export_consent",
+                                  "user_id": 1,
+                                  "consented": true,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event sent to users who can administer a newly created bot
                                 user. Clients will also receive a `realm_user` event that
                                 contains basic details (but not the API key).


### PR DESCRIPTION
Fixes part of #31201.

Extracted from #31947.