### PR TITLE
settings: Added help link for “Followed topics” in notification setting fixes #32033

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -852,7 +852,11 @@ export function get_notifications_table_row_data(
 }
 
 export type AllNotifications = {
-    general_settings: {label: string; notification_settings: NotificationSettingCheckbox[]}[];
+    general_settings: {
+        label: string;
+        notification_settings: NotificationSettingCheckbox[];
+        help_link?: string;
+    }[];
     settings: {
         desktop_notification_settings: string[];
         mobile_notification_settings: string[];
@@ -887,6 +891,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
                 followed_topic_notification_settings,
                 settings_object,
             ),
+            help_link: "/help/follow-a-topic",
         },
     ],
     settings: {

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -29,7 +29,13 @@
             <tbody>
                 {{#each general_settings}}
                     <tr>
-                        <td>{{ this.label }}</td>
+                        <td>
+
+                            {{this.label }}
+                            {{#if this.help_link}}
+                                {{> ../help_link_widget link=this.help_link }}
+                            {{/if}}
+                        </td>
                         {{#each this.notification_settings}}
                             {{> notification_settings_checkboxes
                               setting_name=this.setting_name

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -119,6 +119,7 @@ run_test("all_notifications", ({override}) => {
         },
         {
             label: "translated: Followed topics",
+            help_link: "/help/follow-a-topic",
             notification_settings: [
                 {
                     is_checked: false,


### PR DESCRIPTION
Added help icon along with link in notification setting  as stated in #32033 
<details>
<summary>Screenshots and screen captures:</summary>
Before
<img width="1021" alt="Screenshot 2024-10-18 at 7 13 13 PM" src="https://github.com/user-attachments/assets/33055868-7f02-41e2-a604-9ed6f9d6eabe">
After
<img width="1021" alt="Screenshot 2024-10-19 at 1 12 37 AM" src="https://github.com/user-attachments/assets/7caf31ab-df38-4e05-9032-e7ff14641573">
</details>


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability  
  (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.
- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>



Thankyou for letting me claim this issue!