### PR TITLE
Refactor: Provide better URL encoding primitives

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -273,8 +273,10 @@ def send_message_moved_breadcrumbs(
     user_mention = silent_mention_syntax_for_user(user_profile)
     old_topic_link = f"#**{old_stream.name}>{old_topic_name}**"
     new_topic_link = f"#**{new_stream.name}>{new_topic_name}**"
-    
-    moved_message_link = near_stream_message_url(target_message.realm, target_message.id, new_stream.name, new_stream.id, new_topic_name)
+
+    moved_message_link = near_stream_message_url(
+        target_message.realm, target_message.id, new_stream.name, new_stream.id, new_topic_name
+    )
 
     if new_thread_notification_string is not None:
         with override_language(new_stream.realm.default_language):

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -273,13 +273,8 @@ def send_message_moved_breadcrumbs(
     user_mention = silent_mention_syntax_for_user(user_profile)
     old_topic_link = f"#**{old_stream.name}>{old_topic_name}**"
     new_topic_link = f"#**{new_stream.name}>{new_topic_name}**"
-    message = {
-        "id": target_message.id,
-        "stream_id": new_stream.id,
-        "display_recipient": new_stream.name,
-        "topic": new_topic_name,
-    }
-    moved_message_link = near_stream_message_url(target_message.realm, message)
+    
+    moved_message_link = near_stream_message_url(target_message.realm, target_message.id, new_stream.name, new_stream.id, new_topic_name)
 
     if new_thread_notification_string is not None:
         with override_language(new_stream.realm.default_language):

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -236,7 +236,7 @@ def get_message_url(event: dict[str, Any]) -> str:
     bot_user = get_user_profile_by_id(event["user_profile_id"])
     message = event["message"]
     realm = bot_user.realm
-    
+
     stream_id, topic_name = None, None
     if message["type"] == "stream":
         stream_id, topic_name = message["stream_id"], get_topic_from_message_info(message)

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -236,10 +236,17 @@ def get_message_url(event: dict[str, Any]) -> str:
     bot_user = get_user_profile_by_id(event["user_profile_id"])
     message = event["message"]
     realm = bot_user.realm
+    
+    stream_id, topic_name = None, None
+    if message["type"] == "stream":
+        stream_id, topic_name = message["stream_id"], get_topic_from_message_info(message)
 
     return near_message_url(
         realm=realm,
-        message=message,
+        message_id=message["id"],
+        display_recipient=message["display_recipient"],
+        stream_id=stream_id,
+        topic_name=topic_name,
     )
 
 

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,10 +1,10 @@
-from typing import Any
+from typing import List, Optional
 from urllib.parse import quote, urlsplit
 
 import re2
 
 from zerver.lib.topic import get_topic_from_message_info
-from zerver.lib.types import UserDisplayRecipient
+from zerver.lib.types import UserDisplayRecipient, DisplayRecipientT
 from zerver.models import Realm, Stream, UserProfile
 
 
@@ -48,28 +48,41 @@ def topic_narrow_url(*, realm: Realm, stream: Stream, topic_name: str) -> str:
     return f"{base_url}{encode_stream(stream.id, stream.name)}/topic/{hash_util_encode(topic_name)}"
 
 
-def near_message_url(realm: Realm, message: dict[str, Any]) -> str:
-    if message["type"] == "stream":
+def near_message_url(realm: Realm,
+    message_id: int,
+    display_recipient: DisplayRecipientT,
+    stream_id: Optional[int] = None,
+    topic_name: Optional[str] = None,
+) -> str:
+    if stream_id:
+        assert isinstance(display_recipient, str)
         url = near_stream_message_url(
             realm=realm,
-            message=message,
+             message_id=message_id,
+            display_recipient=display_recipient,
+            stream_id=stream_id,
+            topic_name=topic_name,
         )
         return url
-
+    assert not isinstance(display_recipient, str)
     url = near_pm_message_url(
-        realm=realm,
-        message=message,
+        realm=realm, message_id=message_id, display_recipient=display_recipient
     )
     return url
 
 
-def near_stream_message_url(realm: Realm, message: dict[str, Any]) -> str:
-    message_id = str(message["id"])
-    stream_id = message["stream_id"]
-    stream_name = message["display_recipient"]
-    topic_name = get_topic_from_message_info(message)
-    encoded_topic_name = hash_util_encode(topic_name)
-    encoded_stream = encode_stream(stream_id=stream_id, stream_name=stream_name)
+def near_stream_message_url(
+    realm: Realm,
+    message_id: int,
+    display_recipient: DisplayRecipientT,
+    stream_id: Optional[int] = None,
+    topic_name: Optional[str] = None,
+) -> str:
+    message_id_ = str(message_id)
+    stream_id_ = int(str(stream_id))
+    stream_name = str(display_recipient)
+    encoded_topic_name = hash_util_encode(str(topic_name))
+    encoded_stream = encode_stream(stream_id=stream_id_, stream_name=stream_name)
 
     parts = [
         realm.url,
@@ -79,19 +92,21 @@ def near_stream_message_url(realm: Realm, message: dict[str, Any]) -> str:
         "topic",
         encoded_topic_name,
         "near",
-        message_id,
+        message_id_,
     ]
     full_url = "/".join(parts)
     return full_url
 
 
-def near_pm_message_url(realm: Realm, message: dict[str, Any]) -> str:
-    message_id = str(message["id"])
-    str_user_ids = [str(recipient["id"]) for recipient in message["display_recipient"]]
+def near_pm_message_url(
+    realm: Realm, message_id: int, display_recipient: List[UserDisplayRecipient]
+) -> str:
+    message_id_string = str(message_id)
+    user_id_strings = [str(recipient["id"]) for recipient in display_recipient]
 
     # Use the "perma-link" format here that includes the sender's
     # user_id, so they're easier to share between people.
-    pm_str = ",".join(str_user_ids) + "-pm"
+    pm_str = ",".join(user_id_strings) + "-pm"
 
     parts = [
         realm.url,
@@ -99,7 +114,7 @@ def near_pm_message_url(realm: Realm, message: dict[str, Any]) -> str:
         "dm",
         pm_str,
         "near",
-        message_id,
+        message_id_string,
     ]
     full_url = "/".join(parts)
     return full_url

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -78,7 +78,7 @@ def near_stream_message_url(
     stream_id: Optional[int] = None,
     topic_name: Optional[str] = None,
 ) -> str:
-    message_id_ = str(message_id)
+    
     stream_id_ = int(str(stream_id))
     stream_name = str(display_recipient)
     encoded_topic_name = hash_util_encode(str(topic_name))
@@ -92,7 +92,7 @@ def near_stream_message_url(
         "topic",
         encoded_topic_name,
         "near",
-        message_id_,
+        str(message_id),
     ]
     full_url = "/".join(parts)
     return full_url
@@ -101,7 +101,7 @@ def near_stream_message_url(
 def near_pm_message_url(
     realm: Realm, message_id: int, display_recipient: List[UserDisplayRecipient]
 ) -> str:
-    message_id_string = str(message_id)
+    
     user_id_strings = [str(recipient["id"]) for recipient in display_recipient]
 
     # Use the "perma-link" format here that includes the sender's
@@ -114,7 +114,7 @@ def near_pm_message_url(
         "dm",
         pm_str,
         "near",
-        message_id_string,
+        str(message_id),
     ]
     full_url = "/".join(parts)
     return full_url

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,10 +1,8 @@
-from typing import List, Optional
 from urllib.parse import quote, urlsplit
 
 import re2
 
-from zerver.lib.topic import get_topic_from_message_info
-from zerver.lib.types import UserDisplayRecipient, DisplayRecipientT
+from zerver.lib.types import DisplayRecipientT, UserDisplayRecipient
 from zerver.models import Realm, Stream, UserProfile
 
 
@@ -48,17 +46,18 @@ def topic_narrow_url(*, realm: Realm, stream: Stream, topic_name: str) -> str:
     return f"{base_url}{encode_stream(stream.id, stream.name)}/topic/{hash_util_encode(topic_name)}"
 
 
-def near_message_url(realm: Realm,
+def near_message_url(
+    realm: Realm,
     message_id: int,
     display_recipient: DisplayRecipientT,
-    stream_id: Optional[int] = None,
-    topic_name: Optional[str] = None,
+    stream_id: int | None = None,
+    topic_name: str | None = None,
 ) -> str:
     if stream_id:
         assert isinstance(display_recipient, str)
         url = near_stream_message_url(
             realm=realm,
-             message_id=message_id,
+            message_id=message_id,
             display_recipient=display_recipient,
             stream_id=stream_id,
             topic_name=topic_name,
@@ -75,10 +74,9 @@ def near_stream_message_url(
     realm: Realm,
     message_id: int,
     display_recipient: DisplayRecipientT,
-    stream_id: Optional[int] = None,
-    topic_name: Optional[str] = None,
+    stream_id: int | None = None,
+    topic_name: str | None = None,
 ) -> str:
-    
     stream_id_ = int(str(stream_id))
     stream_name = str(display_recipient)
     encoded_topic_name = hash_util_encode(str(topic_name))
@@ -99,9 +97,8 @@ def near_stream_message_url(
 
 
 def near_pm_message_url(
-    realm: Realm, message_id: int, display_recipient: List[UserDisplayRecipient]
+    realm: Realm, message_id: int, display_recipient: list[UserDisplayRecipient]
 ) -> str:
-    
     user_id_strings = [str(recipient["id"]) for recipient in display_recipient]
 
     # Use the "perma-link" format here that includes the sender's

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -5142,16 +5142,19 @@ class MessageVisibilityTest(ZulipTestCase):
 class PersonalMessagesNearTest(ZulipTestCase):
     def test_near_pm_message_url(self) -> None:
         realm = get_realm("zulip")
-        message = dict(
-            type="personal",
-            id=555,
-            display_recipient=[
-                dict(id=77),
-                dict(id=80),
-            ],
-        )
+        recipient_77: UserDisplayRecipient = {
+            "id": 77,
+            "email": "",
+            "full_name": "",
+            "is_mirror_dummy": False,
+        }
+        recipient_80: UserDisplayRecipient = {
+            "id": 80,
+            "email": "",
+            "full_name": "",
+            "is_mirror_dummy": False,
+        }
         url = near_message_url(
-            realm=realm,
-            message=message,
+            realm=realm, message_id=555, display_recipient=[recipient_77, recipient_80]
         )
         self.assertEqual(url, "http://zulip.testserver/#narrow/dm/77,80-pm/near/555")

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -674,8 +674,14 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, new_stream, "test")
-        
-        moved_message_link = near_stream_message_url(messages[1].realm, messages[1].realm, msg_id_later, new_stream.name, new_stream.id, "test")
+
+        moved_message_link = near_stream_message_url(
+            messages[1].realm,
+            msg_id_later,
+            new_stream.name,
+            new_stream.id,
+            "test",
+        )
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].id, msg_id_later)
         self.assertEqual(
@@ -714,8 +720,10 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, new_stream, "test")
-        
-        moved_message_link = near_stream_message_url(messages[2].realm, msg_id_later, new_stream.name, new_stream.id, "test")
+
+        moved_message_link = near_stream_message_url(
+            messages[2].realm, msg_id_later, new_stream.name, new_stream.id, "test"
+        )
         self.assert_length(messages, 3)
         self.assertEqual(messages[0].id, msg_id_later)
         self.assertEqual(
@@ -1417,8 +1425,10 @@ class MessageMoveStreamTest(ZulipTestCase):
         self.assertEqual(messages[1].content, "Third")
 
         messages = get_topic_messages(user_profile, stream, "edited")
-        
-        moved_message_link = near_stream_message_url(messages[1].realm, msg_id, stream.name, stream.id, "edited")
+
+        moved_message_link = near_stream_message_url(
+            messages[1].realm, msg_id, stream.name, stream.id, "edited"
+        )
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")
         self.assertEqual(
@@ -1459,8 +1469,10 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, stream, "edited")
-        
-        moved_message_link = near_stream_message_url(messages[0].realm, msg_id, stream.name, stream.id, "edited")
+
+        moved_message_link = near_stream_message_url(
+            messages[0].realm, msg_id, stream.name, stream.id, "edited"
+        )
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")
         self.assertEqual(

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -674,13 +674,8 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, new_stream, "test")
-        message = {
-            "id": msg_id_later,
-            "stream_id": new_stream.id,
-            "display_recipient": new_stream.name,
-            "topic": "test",
-        }
-        moved_message_link = near_stream_message_url(messages[1].realm, message)
+        
+        moved_message_link = near_stream_message_url(messages[1].realm, messages[1].realm, msg_id_later, new_stream.name, new_stream.id, "test")
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].id, msg_id_later)
         self.assertEqual(
@@ -719,13 +714,8 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, new_stream, "test")
-        message = {
-            "id": msg_id_later,
-            "stream_id": new_stream.id,
-            "display_recipient": new_stream.name,
-            "topic": "test",
-        }
-        moved_message_link = near_stream_message_url(messages[2].realm, message)
+        
+        moved_message_link = near_stream_message_url(messages[2].realm, msg_id_later, new_stream.name, new_stream.id, "test")
         self.assert_length(messages, 3)
         self.assertEqual(messages[0].id, msg_id_later)
         self.assertEqual(
@@ -1427,13 +1417,8 @@ class MessageMoveStreamTest(ZulipTestCase):
         self.assertEqual(messages[1].content, "Third")
 
         messages = get_topic_messages(user_profile, stream, "edited")
-        message = {
-            "id": msg_id,
-            "stream_id": stream.id,
-            "display_recipient": stream.name,
-            "topic": "edited",
-        }
-        moved_message_link = near_stream_message_url(messages[1].realm, message)
+        
+        moved_message_link = near_stream_message_url(messages[1].realm, msg_id, stream.name, stream.id, "edited")
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")
         self.assertEqual(
@@ -1474,13 +1459,8 @@ class MessageMoveStreamTest(ZulipTestCase):
         )
 
         messages = get_topic_messages(user_profile, stream, "edited")
-        message = {
-            "id": msg_id,
-            "stream_id": stream.id,
-            "display_recipient": stream.name,
-            "topic": "edited",
-        }
-        moved_message_link = near_stream_message_url(messages[0].realm, message)
+        
+        moved_message_link = near_stream_message_url(messages[0].realm, msg_id, stream.name, stream.id, "edited")
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")
         self.assertEqual(

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -17,6 +17,7 @@ from zerver.lib.outgoing_webhook import (
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.topic import TOPIC_NAME
+from zerver.lib.types import UserDisplayRecipient
 from zerver.lib.url_encoding import near_message_url
 from zerver.lib.users import add_service
 from zerver.models import Recipient, Service, UserProfile
@@ -508,15 +509,19 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
 
             self.assert_length(responses.calls, 1)
 
-            # create message dict to get the message url
-            message = {
-                "display_recipient": [{"id": bot.id}, {"id": sender.id}],
-                "stream_id": 999,
-                TOPIC_NAME: "Foo",
-                "id": message_id,
-                "type": "",
+            recipient_bot: UserDisplayRecipient = {
+                "id": bot.id,
+                "email": "",
+                "full_name": "",
+                "is_mirror_dummy": False,
             }
-            message_url = near_message_url(realm, message)
+            recipient_sender: UserDisplayRecipient = {
+                "id": sender.id,
+                "email": "",
+                "full_name": "",
+                "is_mirror_dummy": False,
+            }
+            message_url = near_message_url(realm, message_id, [recipient_bot, recipient_sender])
 
             last_message = self.get_last_message()
             self.assertEqual(
@@ -593,14 +598,10 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         )
 
         last_message = self.get_last_message()
-        message_dict = {
-            "stream_id": get_stream("Denmark", realm).id,
-            "display_recipient": "Denmark",
-            TOPIC_NAME: "bar",
-            "id": sent_message_id,
-            "type": "stream",
-        }
-        message_url = near_message_url(realm, message_dict)
+        
+        message_url = near_message_url(
+            realm, sent_message_id, "Denmark", get_stream("Denmark", realm).id, "bar"
+        )
         self.assertEqual(
             last_message.content,
             f"[A message]({message_url}) to your bot @_**{bot.full_name}** triggered an outgoing webhook.\n"

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -598,7 +598,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         )
 
         last_message = self.get_last_message()
-        
+
         message_url = near_message_url(
             realm, sent_message_id, "Denmark", get_stream("Denmark", realm).id, "bar"
         )


### PR DESCRIPTION
As the issue description mentioned, in the zerver/lib/url_encoding the near_stream_message_url bundle of functions accepted a dictionary of unspecified type. To solve for this, the commits refactor the functions so they receive specific attributes of a Message object and adapt all the callers of this functions to match the changes made.
- The solve is strongly based on an previous pull request, #25821 and avoid it´s conflits
- The functions now receive each information separately to create the URL (realm: Realm, message_id: int, display_recipient: DisplayRecipientT, stream_id: Optional[int], topic_name: Optional[str]).
- This approach keep the decision of not accepting a Message object on the refactor functions, as the event-handling functions don´t work with Message objects. However, if the use of a Message object is necessary, please let me know.

Fixes: #25021 

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
