### PR TITLE
settings: Improve handling of "message content in email notifications" setting.

### DIFF
--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -102,8 +102,8 @@ function get_realm_level_notification_settings(options) {
 
     options.general_settings = all_notifications_settings.general_settings;
     options.notification_settings = all_notifications_settings.settings;
-    options.show_push_notifications_tooltip =
-        all_notifications_settings.show_push_notifications_tooltip;
+    options.disabled_notification_settings =
+        all_notifications_settings.disabled_notification_settings;
 }
 
 export function build_page() {

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -122,8 +122,8 @@ export function build_page() {
         realm_name_in_email_notifications_policy_values:
             settings_config.realm_name_in_email_notifications_policy_values,
         desktop_icon_count_display_values: settings_config.desktop_icon_count_display_values,
-        show_push_notifications_tooltip:
-            settings_config.all_notifications(user_settings).show_push_notifications_tooltip,
+        disabled_notification_settings:
+            settings_config.all_notifications(user_settings).disabled_notification_settings,
         information_section_checkbox_group: settings_config.information_section_checkbox_group,
         information_density_settings: settings_config.get_information_density_preferences(),
         settings_render_only: settings_config.get_settings_render_only(),

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -859,7 +859,7 @@ export type AllNotifications = {
         email_message_notification_settings: string[];
         other_email_settings: string[];
     };
-    show_push_notifications_tooltip: {
+    disabled_notification_settings: {
         push_notifications: boolean;
         enable_online_push_notifications: boolean;
     };
@@ -895,7 +895,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
         email_message_notification_settings,
         other_email_settings,
     },
-    show_push_notifications_tooltip: {
+    disabled_notification_settings: {
         push_notifications: !realm.realm_push_notifications_enabled,
         enable_online_push_notifications: !realm.realm_push_notifications_enabled,
     },

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -862,6 +862,7 @@ export type AllNotifications = {
     disabled_notification_settings: {
         push_notifications: boolean;
         enable_online_push_notifications: boolean;
+        message_content_in_email_notifications: boolean;
     };
 };
 
@@ -898,6 +899,8 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
     disabled_notification_settings: {
         push_notifications: !realm.realm_push_notifications_enabled,
         enable_online_push_notifications: !realm.realm_push_notifications_enabled,
+        message_content_in_email_notifications:
+            !realm.realm_message_content_allowed_in_email_notifications,
     },
 });
 

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -56,7 +56,7 @@ function rerender_ui(): void {
                         settings_config.stream_specific_notification_settings,
                     is_disabled:
                         settings_config.all_notifications(user_settings)
-                            .show_push_notifications_tooltip,
+                            .disabled_notification_settings,
                     muted: muted_stream_ids.includes(stream.stream_id),
                 }),
             ),

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -183,7 +183,7 @@ function is_notification_setting(setting_label) {
 export function stream_settings(sub) {
     const settings_labels = settings_config.general_notifications_table_labels.stream;
     const check_realm_setting =
-        settings_config.all_notifications(user_settings).show_push_notifications_tooltip;
+        settings_config.all_notifications(user_settings).disabled_notification_settings;
 
     const settings = Object.keys(settings_labels).map((setting) => {
         const ret = {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -532,6 +532,24 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: "#user_message_content_in_email_notifications_label",
+        onShow(instance) {
+            if ($("#user_message_content_in_email_notifications").prop("disabled")) {
+                instance.setContent(
+                    $t({
+                        defaultMessage:
+                            "Including message content in message notification emails is not allowed in this organization.",
+                    }),
+                );
+                return undefined;
+            }
+            instance.destroy();
+            return false;
+        },
+        appendTo: () => document.body,
+    });
+
+    tippy.delegate("body", {
         target: ".views-tooltip-target",
         onShow(instance) {
             if ($("#toggle-top-left-navigation-area-icon").hasClass("rotate-icon-down")) {

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -212,6 +212,7 @@
               setting_name=this
               is_checked=(lookup ../settings_object this)
               label=(lookup ../settings_label this)
+              is_disabled=(lookup ../disabled_notification_settings this)
               prefix=../prefix}}
         {{/each}}
     </div>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -162,7 +162,7 @@
             {{> settings_checkbox
               setting_name=this
               is_checked=(lookup ../settings_object this)
-              is_disabled=(lookup ../show_push_notifications_tooltip this)
+              is_disabled=(lookup ../disabled_notification_settings this)
               label=(lookup ../settings_label this)
               prefix=../prefix}}
         {{/each}}


### PR DESCRIPTION
This PR addresses the issue where the "Allow message content in message notification emails" setting in user settings was not accurately reflecting the organization-level configuration. When the setting is disabled at the organization level, the corresponding checkbox should appear both disabled and greyed out in the user settings, preventing users from enabling it. Previously, users could still check the box, although the emails did not contain message content.

### Changes:
1. **Disable and Grey Out Setting:**
   - If the "message content in message notification emails" is disabled at the organization level, the user setting now appears both disabled and greyed out, accurately reflecting the organization policy.
   - Added a tooltip when hovering over the disabled checkbox: "Including message content in message notification emails is not allowed in this organization."

2. **Refactoring in `settings_config`:**
   - The object related to this setting in `settings_config` has been renamed to better reflect its purpose. This change has been made in a separate commit for clarity and easier review.

### Additional Notes:
- This PR builds upon the work in an [existing open PR #27543](https://github.com/zulip/zulip/pull/27543), which has been inactive since March. I have proceeded with the original work, resolved the comments raised in that PR, and made a new PR to complete the fix. The previous PR had addressed most of the issue.
- Implemented changes based on the discussion in [this comment](https://github.com/zulip/zulip/pull/27543/files#r1438156860), following the suggestion to have separate commits for renaming the object in `settings_config` and for the functionality to disable the setting.

Fixes: #27262.

---

This updated description provides a comprehensive overview of the PR, including the previous work, new changes, and resolution details.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<table>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>
<img width="1036" alt="Screenshot 2024-10-21 at 1 32 09 AM" src="https://github.com/user-attachments/assets/b9a24627-5e26-46a2-890c-97796bcf5732">
</td>
<td>
<img width="1028" alt="Screenshot 2024-10-21 at 1 33 12 AM" src="https://github.com/user-attachments/assets/35ba670a-63a8-4dc2-8cbb-bee1b56df02a">
</td>
</tr>
</table>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
