### PR TITLE
narrow_history: Save narrow state after we have scrolled to the msg.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -319,7 +319,6 @@ export function initialize_kitchen_sink_stuff() {
         const $row = event.msg_list.get_row(event.id);
         $(".selected_message").removeClass("selected_message");
         $row.addClass("selected_message");
-        narrow_history.save_narrow_state();
 
         if (event.then_scroll) {
             if ($row.length === 0) {
@@ -355,6 +354,9 @@ export function initialize_kitchen_sink_stuff() {
                 });
             }
         }
+
+        // Save selected message and scroll position after we have scrolled to it.
+        narrow_history.save_narrow_state();
     });
 
     if (!realm.realm_allow_message_editing) {


### PR DESCRIPTION
Saving narrow state before we have scrolled to the message results in view scroll position being different from where the message is displayed.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/back.2Fforward.20button.20scroll.20position.20broken
