### PR TITLE
modals: Fix focus advancement in move topic modal.

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -547,6 +547,9 @@ export async function build_move_topic_to_stream_popover(
         dropdown.hide();
         event.preventDefault();
         event.stopPropagation();
+
+        // Move focus to the topic input after a new stream is selected.
+        $("#move_topic_form .move_messages_edit_topic").trigger("focus");
     }
 
     function move_topic_post_render() {


### PR DESCRIPTION
Previously, when selecting a new channel in the "move topic" modal using the keyboard, focus failed to advance to the topic input automatically. Users had to press the tab key an extra time to move focus to the topic input, which was not the intended behavior.

This PR modifies the `move_topic_on_update` function in `web/src/stream_popover.js` to explicitly set focus on the topic input field after a channel is selected.

<!-- Describe your pull request here.-->

Fixes: [CZO DIscussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/move.20topic.20modal.20keyboard.20focus/near/1954801)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![fix-move-topic-extra-tab_v2](https://github.com/user-attachments/assets/a2d06007-4d07-43f3-9bab-c6c3e603b7d3)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
