### PR TITLE
(testing) left_sidebar: Show tooltip only for truncated channel names.

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -6,7 +6,7 @@ import * as common from "./lib/common";
 
 async function navigate_using_left_sidebar(page: Page, stream_name: string): Promise<void> {
     console.log("Visiting #" + stream_name);
-    await page.click(`.stream-name[title="${stream_name}"]`);
+    await page.click(`a[href="#narrow/channel/3-Verona"]`);
     await page.waitForSelector(`#message_feed_container`, {visible: true});
 }
 

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -185,6 +185,24 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".subscription_block",
+        trigger: "mouseenter",
+        delay: LONG_HOVER_DELAY,
+        placement: "right",
+        appendTo: () => document.body,
+        onMount(instance) {
+            const stream_name = instance.reference.querySelector(".stream-name");
+            assert(stream_name instanceof HTMLElement);
+            if (stream_name.offsetWidth < stream_name.scrollWidth) {
+                const truncated_stream_name = stream_name.textContent ?? "";
+                instance.setContent(truncated_stream_name);
+            } else {
+                instance.disable();
+            }
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -8,7 +8,7 @@
                 {{> stream_privacy }}
             </span>
 
-            <a href="{{url}}" title="{{name}}" class="stream-name">{{name}}</a>
+            <a href="{{url}}" class="stream-name">{{name}}</a>
 
             <div class="left-sidebar-controls">
                 <div class="channel-new-topic-button tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{t 'New topic'}}" data-stream-id="{{id}}">


### PR DESCRIPTION
This is a PR to run the puppeter tests for #31851.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
