### PR TITLE
scheduled_messages_overlay_ui: Convert module to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -198,7 +198,7 @@ EXEMPT_FILES = make_set(
         "web/src/saved_snippets_ui.ts",
         "web/src/scheduled_messages.ts",
         "web/src/scheduled_messages_feed_ui.ts",
-        "web/src/scheduled_messages_overlay_ui.js",
+        "web/src/scheduled_messages_overlay_ui.ts",
         "web/src/scheduled_messages_ui.ts",
         "web/src/scroll_bar.ts",
         "web/src/scroll_util.ts",

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -64,23 +64,34 @@ function format(scheduled_messages) {
     const formatted_msgs = [];
     const sorted_messages = sort_scheduled_messages(scheduled_messages);
     for (const msg of sorted_messages) {
-        const msg_render_context = {...msg};
-        if (msg.type === "stream") {
-            msg_render_context.is_stream = true;
-            msg_render_context.stream_id = msg.to;
-            msg_render_context.stream_name = sub_store.maybe_get_stream_name(
-                msg_render_context.stream_id,
-            );
-            const color = stream_data.get_color(msg_render_context.stream_id);
-            msg_render_context.recipient_bar_color = stream_color.get_recipient_bar_color(color);
-            msg_render_context.stream_privacy_icon_color =
-                stream_color.get_stream_privacy_icon_color(color);
-        } else {
-            msg_render_context.is_stream = false;
-            msg_render_context.recipients = people.get_recipients(msg.to.join(","));
-        }
+        let msg_render_context;
         const time = new Date(msg.scheduled_delivery_timestamp * 1000);
-        msg_render_context.formatted_send_at_time = timerender.get_full_datetime(time, "time");
+        const formatted_send_at_time = timerender.get_full_datetime(time, "time");
+        if (msg.type === "stream") {
+            const stream_id = msg.to;
+            const stream_name = sub_store.maybe_get_stream_name(stream_id);
+            const color = stream_data.get_color(stream_id);
+            const recipient_bar_color = stream_color.get_recipient_bar_color(color);
+            const stream_privacy_icon_color = stream_color.get_stream_privacy_icon_color(color);
+
+            msg_render_context = {
+                ...msg,
+                is_stream: true,
+                stream_id,
+                stream_name,
+                recipient_bar_color,
+                stream_privacy_icon_color,
+                formatted_send_at_time,
+            };
+        } else {
+            const recipients = people.get_recipients(msg.to.join(","));
+            msg_render_context = {
+                ...msg,
+                is_stream: false,
+                recipients,
+                formatted_send_at_time,
+            };
+        }
         formatted_msgs.push(msg_render_context);
     }
     return formatted_msgs;

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -24,11 +24,11 @@ export const keyboard_handling_context = {
         return scheduled_messages_ids;
     },
     on_enter() {
-        const focused_element_id = Number.parseInt(
-            messages_overlay_ui.get_focused_element_id(this),
-            10,
-        );
-        scheduled_messages_ui.edit_scheduled_message(focused_element_id);
+        const focused_element_id = messages_overlay_ui.get_focused_element_id(this);
+        if (focused_element_id === undefined) {
+            return;
+        }
+        scheduled_messages_ui.edit_scheduled_message(Number.parseInt(focused_element_id, 10));
         overlays.close_overlay("scheduled");
     },
     on_delete() {
@@ -114,6 +114,9 @@ export function launch() {
     $messages_list.append($(rendered_list));
 
     const first_element_id = keyboard_handling_context.get_items_ids()[0];
+    if (first_element_id === undefined) {
+        return;
+    }
     messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
 }
 


### PR DESCRIPTION
I manually tested the module by scheduling some messages (both type "stream" and "private"), testing keyboard events like `delete` to remove the scheduled msg, `enter`  to edit the msg. Also tested if the messages are sorted in correct order based on their scheduled time.