### PR TITLE
stream_edit: Fix code being called for wrong subsection.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -696,7 +696,7 @@ export function initialize() {
         const sub = sub_store.get(stream_id);
         const $subsection = $(e.target).closest(".settings-subsection-parent");
         settings_components.save_discard_stream_settings_widget_status_handler($subsection, sub);
-        if (sub) {
+        if (sub && $subsection.attr("id") === "stream_permission_settings") {
             stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
         }
         return true;
@@ -755,7 +755,9 @@ export function initialize() {
 
             const $subsection = $(e.target).closest(".settings-subsection-parent");
             settings_org.discard_stream_settings_subsection_changes($subsection, sub);
-            stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
+            if ($subsection.attr("id") === "stream_permission_settings") {
+                stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
+            }
         },
     );
 }


### PR DESCRIPTION
"update_default_stream_and_stream_privacy_state" function should be called only
when changing or discarding settings in "Stream permissions" subsections and not
when changing settings in "Advanced configurations" subsection, since the behavior
of stream privacy and default stream options does not depend on settings in
"Advanced configurations".

This also fixes the bug of trying to access "checked" property on undefined value of
$default_stream.find("input"), since there is no such input in "Advanced configurations"
section.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
