### PR TITLE
modal: Add options for which messages are mark as read.

### DIFF
--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -46,7 +46,7 @@ function register_mark_all_read_handler(
     >,
 ): void {
     const {instance} = event.data;
-    unread_ops.confirm_mark_all_as_read();
+    unread_ops.confirm_mark_messages_as_read();
     popover_menus.hide_current_popover_if_visible(instance);
 }
 

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -41,6 +41,10 @@ export function clear_old_unreads_missing(): void {
     old_unreads_missing = false;
 }
 
+export function set_old_unreads_missing_for_tests(value: boolean): void {
+    old_unreads_missing = value;
+}
+
 export const unread_mentions_counter = new Set<number>();
 export const direct_message_with_mention_count = new Set();
 const unread_messages = new Set<number>();
@@ -912,6 +916,7 @@ export type FullUnreadCountsData = {
     stream_unread_messages: number;
     followed_topic_unread_messages_count: number;
     followed_topic_unread_messages_with_mention_count: number;
+    unfollowed_topic_unread_messages_count: number;
     muted_topic_unread_messages_count: number;
     stream_count: Map<number, StreamCountInfo>;
     streams_with_mentions: number[];
@@ -939,6 +944,8 @@ export function get_counts(): FullUnreadCountsData {
         followed_topic_unread_messages_count: topic_res.followed_topic_unread_messages,
         followed_topic_unread_messages_with_mention_count:
             unread_topic_counter.get_followed_topic_unread_mentions(),
+        unfollowed_topic_unread_messages_count:
+            unread_messages.size - topic_res.followed_topic_unread_messages - pm_res.total_count,
         muted_topic_unread_messages_count:
             unread_messages.size - topic_res.stream_unread_messages - pm_res.total_count,
         stream_count: topic_res.stream_count,

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
-import render_confirm_mark_all_as_read from "../templates/confirm_dialog/confirm_mark_all_as_read.hbs";
+import render_confirm_mark_messages_as_read from "../templates/confirm_dialog/confirm_mark_all_as_read.hbs";
 import render_confirm_mark_as_unread_from_here from "../templates/confirm_dialog/confirm_mark_as_unread_from_here.hbs";
 import render_inline_decorated_channel_name from "../templates/inline_decorated_channel_name.hbs";
 import render_skipped_marking_unread from "../templates/skipped_marking_unread.hbs";
@@ -66,16 +66,36 @@ export function is_window_focused(): boolean {
     return window_focused;
 }
 
-export function confirm_mark_all_as_read(): void {
-    const html_body = render_confirm_mark_all_as_read();
+export function confirm_mark_messages_as_read(): void {
+    const html_body = render_confirm_mark_messages_as_read();
 
     const modal_id = confirm_dialog.launch({
-        html_heading: $t_html({defaultMessage: "Mark all messages as read?"}),
+        html_heading: $t_html({defaultMessage: "Choose messages to mark as read"}),
         html_body,
         on_click() {
-            mark_all_as_read(modal_id);
+            handle_mark_messages_as_read(modal_id);
         },
         loading_spinner: true,
+    });
+
+    // When the user clicks on "Mark messages as read," the dialog box opens with a
+    // dropdown that, by default, displays the count of unread messages in
+    // topics that the user does not follow.
+    const default_messages_count = unread.get_counts().unfollowed_topic_unread_messages_count;
+    $("#message_count").text(get_message_count_text(default_messages_count));
+
+    // When the user selects another option from the dropdown, this section is executed.
+    $("#mark_as_read_option").on("change", function () {
+        const selected_option = $(this).val();
+        let messages_count;
+        if (selected_option === "muted_topics") {
+            messages_count = unread.get_counts().muted_topic_unread_messages_count;
+        } else if (selected_option === "topics_not_followed") {
+            messages_count = unread.get_counts().unfollowed_topic_unread_messages_count;
+        } else {
+            messages_count = unread.get_unread_message_count();
+        }
+        $("#message_count").text(get_message_count_text(messages_count));
     });
 }
 
@@ -127,6 +147,24 @@ function handle_skipped_unsubscribed_streams(
             title_text,
         });
     }
+}
+
+export function get_message_count_text(count: number): string {
+    if (unread.old_unreads_missing) {
+        return $t(
+            {
+                defaultMessage: "{count}+ messages will be marked as read.",
+            },
+            {count},
+        );
+    }
+    return $t(
+        {
+            defaultMessage:
+                "{count, plural, one {# message} other {# messages}} will be marked as read.",
+        },
+        {count},
+    );
 }
 
 function bulk_update_read_flags_for_narrow(
@@ -327,6 +365,28 @@ function bulk_update_read_flags_for_narrow(
             }
         },
     });
+}
+
+function handle_mark_messages_as_read(modal_id: string): void {
+    const selected_option = $("#mark_as_read_option").val();
+
+    switch (selected_option) {
+        case "muted_topics": {
+            mark_muted_topic_messages_as_read(modal_id);
+            break;
+        }
+        case "topics_not_followed": {
+            mark_unfollowed_topic_messages_as_read(modal_id);
+            break;
+        }
+        case "all_messages": {
+            mark_all_as_read(modal_id);
+            break;
+        }
+        default: {
+            assert(false, `Invalid mark_as_read_option: ${String(selected_option)}`);
+        }
+    }
 }
 
 function process_newly_read_message(
@@ -836,6 +896,31 @@ export function mark_topic_as_unread(stream_id: number, topic: string): void {
 
 export function mark_all_as_read(modal_id?: string): void {
     bulk_update_read_flags_for_narrow(all_unread_messages_narrow, "add", {}, modal_id);
+}
+
+export function mark_muted_topic_messages_as_read(modal_id?: string): void {
+    bulk_update_read_flags_for_narrow(
+        [
+            {operator: "is", operand: "unread", negated: false},
+            {operator: "is", operand: "muted", negated: false},
+        ],
+        "add",
+        {},
+        modal_id,
+    );
+}
+
+export function mark_unfollowed_topic_messages_as_read(modal_id?: string): void {
+    bulk_update_read_flags_for_narrow(
+        [
+            {operator: "is", operand: "unread", negated: false},
+            {operator: "is", operand: "followed", negated: true},
+            {operator: "is", operand: "dm", negated: true},
+        ],
+        "add",
+        {},
+        modal_id,
+    );
 }
 
 export function mark_pm_as_read(user_ids_string: string): void {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -367,6 +367,10 @@ select.settings_select {
     & label.checkbox + label {
         cursor: pointer;
     }
+
+    .message_count {
+        margin: 10px 0 0;
+    }
 }
 
 /* Class for displaying an input with an

--- a/web/templates/confirm_dialog/confirm_mark_all_as_read.hbs
+++ b/web/templates/confirm_dialog/confirm_mark_all_as_read.hbs
@@ -1,3 +1,11 @@
 <p>
-    {{t "Are you sure you want to mark all messages as read? This action cannot be undone." }}
+    {{t "Which messages do you want to mark as read? This action cannot be undone." }}
 </p>
+<div class="input-group">
+    <select id="mark_as_read_option" class="modal_select bootstrap-style-font">
+        <option value="muted_topics">{{t "Muted topics" }}</option>
+        <option value="topics_not_followed" selected>{{t "Topics you don't follow" }}</option>
+        <option value="all_messages">{{t "All messages" }}</option>
+    </select>
+    <p id="message_count" class="message_count"></p>
+</div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
@@ -5,7 +5,7 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                <span class="popover-menu-label">{{t "Mark messages as read" }}</span>
             </a>
         </li>
         {{/if}}

--- a/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
@@ -5,7 +5,7 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                <span class="popover-menu-label">{{t "Mark messages as read" }}</span>
             </a>
         </li>
         {{/if}}

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -5,7 +5,7 @@
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" id="mark_all_messages_as_read" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                <span class="popover-menu-label">{{t "Mark messages as read" }}</span>
             </a>
         </li>
         {{/if}}

--- a/web/tests/unread_ops.test.cjs
+++ b/web/tests/unread_ops.test.cjs
@@ -1,0 +1,32 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {set_global, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+set_global("document", {hasFocus: () => true});
+const unread = zrequire("unread");
+const unread_ops = zrequire("unread_ops");
+
+run_test("get_message_count_text", () => {
+    unread.set_old_unreads_missing_for_tests(true);
+    assert.equal(
+        unread_ops.get_message_count_text(5),
+        "translated: 5+ messages will be marked as read.",
+    );
+    assert.equal(
+        unread_ops.get_message_count_text(1),
+        "translated: 1+ messages will be marked as read.",
+    );
+
+    unread.set_old_unreads_missing_for_tests(false);
+    assert.equal(
+        unread_ops.get_message_count_text(5),
+        "translated: 5 messages will be marked as read.",
+    );
+    assert.equal(
+        unread_ops.get_message_count_text(1),
+        "translated: 1 message will be marked as read.",
+    );
+});


### PR DESCRIPTION
The PR updates the read messages confirmation modal by introducting a dropdown. The dropdown offers the following options:

> - [ ]  Muted topics
> - [x] Topics you don't follow (default)
> - [ ] All messages

Below the dropdown, a line dynamically displays the count of messages that will be marked as read based on the selected option:

 > N message(s) will be marked as read.

The message count updates automatically when the selection changes.
</br>

## **Difference between the previous and the present modal**


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/77db911a-afea-46df-ac4f-b41d02a5fde9" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/cda86ea6-43c4-475b-b97a-ed1ba8028530" width="300"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6c3e7769-e1e2-4607-9fa3-670b38d8ed63" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/e6c62a98-13ae-480e-b998-41f0ea16bac4" width="300"></td>
  </tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/6c3e7769-e1e2-4607-9fa3-670b38d8ed63" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/17349642-5fc0-4c34-8c8f-bb8b187d5631" width="300"></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/3c40dc7e-9fb6-4ad3-8815-9b2d11ad8455" width="300"></td>
<td><img src="https://github.com/user-attachments/assets/efacb31e-314a-4e69-b1a4-a22bac08a0c0" width="300"></td>
</tr>
</table>

</br>

## **Demonstrating how the count changes on change of select option**


<table>
  <tr>
    <th>0 messages</th>
    <th>1 message</th>
    <th>More than 1 message</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1662aced-fc2a-4ee5-87cc-62ed38b17b27" width="250"></td>
    <td><img src="https://github.com/user-attachments/assets/2f1a5242-7106-4439-b985-7980fc7ae8bc" width="250"></td>
    <td><img src="https://github.com/user-attachments/assets/4be75d2f-0a10-4499-8d45-9ff124f0ef77" width="250"></td>
  </tr>
</table>

<br/>

## **Video demonstration** 

https://github.com/user-attachments/assets/c5e8e9a1-a550-46fd-8df7-3b0e38feca0e


## **Tasks completed**

- [x] Rename "Mark all messages as read" -> "Mark messages as read" in the menu.
- [x] Change the confirmation modal.

For more information, read [Old CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/coming.20back.20to.20lots.20of.20unreads/near/1792194), [new CZO](https://chat.zulip.org/#narrow/channel/378-api-design/topic/mark.20muted-topic.20messages.20as.20read).

Fixes : #30025 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
