### PR TITLE
auth: Fix invalid credentials message in login form.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -52,6 +52,7 @@ MIT_VALIDATION_ERROR = Markup(
     ' <a href="mailto:support@zulip.com">contact us</a>.'
 )
 
+INVALID_ACCOUNT_CREDENTIALS_ERROR = gettext_lazy("Please enter a correct email and password.")
 DEACTIVATED_ACCOUNT_ERROR = gettext_lazy(
     "Your account {username} has been deactivated."
     " Please contact your organization administrator to reactivate it."
@@ -514,9 +515,7 @@ class OurAuthenticationForm(AuthenticationForm):
 
             if self.user_cache is None:
                 raise forms.ValidationError(
-                    self.error_messages["invalid_login"],
-                    code="invalid_login",
-                    params={"username": self.username_field.verbose_name},
+                    INVALID_ACCOUNT_CREDENTIALS_ERROR,
                 )
 
             self.confirm_login_allowed(self.user_cache)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -993,7 +993,7 @@ class LoginTest(ZulipTestCase):
     def test_login_nonexistent_user(self) -> None:
         result = self.login_with_return("xxx@zulip.com", "xxx")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response("Please enter a correct email and password", result)
+        self.assert_in_response("Please enter a correct email and password.", result)
         self.assert_logged_in_user_id(None)
 
     def test_login_wrong_subdomain(self) -> None:
@@ -1009,9 +1009,7 @@ class LoginTest(ZulipTestCase):
                 ],
             )
         self.assertEqual(result.status_code, 200)
-        expected_error = (
-            "Please enter a correct email and password. Note that both fields may be case-sensitive"
-        )
+        expected_error = "Please enter a correct email and password."
         self.assert_in_response(expected_error, result)
         self.assert_logged_in_user_id(None)
 


### PR DESCRIPTION
Email is not case-sensitive. And password is obviously case-sensitive, so no point mentioning that.

Instead of:
![image](https://github.com/user-attachments/assets/41e01532-a9d4-4081-9857-7cab57075d2b)


Let's have:
![image](https://github.com/user-attachments/assets/9e98a536-d9d8-4ee3-8071-fb9ee2637e67)
