### PR TITLE
user_groups: Do not show invalid subgroups in typeahead.

### DIFF
--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -222,6 +222,7 @@ export function set_up_combined(
         user_group?: boolean;
         stream?: boolean;
         user_source?: () => User[];
+        user_group_source?: () => UserGroup[];
         exclude_bots?: boolean;
         update_func?: () => void;
     },
@@ -252,7 +253,14 @@ export function set_up_combined(
             }
 
             if (include_user_groups) {
-                source = [...source, ...user_group_pill.typeahead_source(pills)];
+                if (opts.user_group_source !== undefined) {
+                    const groups: UserGroupPillData[] = opts
+                        .user_group_source()
+                        .map((user_group) => ({type: "user_group", ...user_group}));
+                    source = [...source, ...groups];
+                } else {
+                    source = [...source, ...user_group_pill.typeahead_source(pills)];
+                }
             }
 
             if (include_users) {

--- a/web/src/user_group_edit_members.ts
+++ b/web/src/user_group_edit_members.ts
@@ -44,6 +44,10 @@ function get_potential_members(): User[] {
     return people.filter_all_users(is_potential_member);
 }
 
+function get_potential_subgroups(): UserGroup[] {
+    return user_groups.get_potential_subgroups(current_group_id);
+}
+
 function get_user_group_members(group: UserGroup): (User | UserGroup)[] {
     const member_ids = [...group.members];
     const member_users = people.get_users_from_ids(member_ids);
@@ -141,6 +145,7 @@ export function enable_member_management({
     pill_widget = add_subscribers_pill.create({
         $pill_container,
         get_potential_subscribers: get_potential_members,
+        get_potential_groups: get_potential_subgroups,
     });
 
     $pill_container.find(".input").on("input", () => {

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -311,6 +311,30 @@ export function get_recursive_group_members(target_user_group: UserGroup): Set<n
     return members;
 }
 
+export function get_potential_subgroups(target_user_group_id: number): UserGroup[] {
+    // This logic could be optimized if we maintained a reverse map
+    // from each group to the groups containing it, which might be a
+    // useful data structure for other code paths as well.
+    const target_user_group = get_user_group_from_id(target_user_group_id);
+    const already_subgroup_ids = target_user_group.direct_subgroup_ids;
+    return get_all_realm_user_groups().filter((user_group) => {
+        if (user_group.id === target_user_group.id) {
+            return false;
+        }
+
+        if (already_subgroup_ids.has(user_group.id)) {
+            return false;
+        }
+
+        const recursive_subgroup_ids = get_recursive_subgroups(user_group);
+        assert(recursive_subgroup_ids !== undefined);
+        if (recursive_subgroup_ids.has(target_user_group.id)) {
+            return false;
+        }
+        return true;
+    });
+}
+
 export function is_user_in_group(
     user_group_id: number,
     user_id: number,

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -14,9 +14,9 @@ import type {UserGroupUpdateEvent} from "./types";
 
 type UserGroupRaw = z.infer<typeof raw_user_group_schema>;
 
-// The members field is a number array which we convert
-// to a Set in the initialize function.
 export const user_group_schema = raw_user_group_schema.extend({
+    // These are delivered via the API as lists, but converted to sets
+    // during initialization for more convenient manipulation.
     members: z.set(z.number()),
     direct_subgroup_ids: z.set(z.number()),
 });

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -465,7 +465,11 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
                 })
                 .filter(Boolean);
             if (opts.user_group) {
-                expected_result = [...expected_result, ...group_items];
+                if (opts.user_group_source) {
+                    expected_result = [...expected_result, ...opts.user_group_source()];
+                } else {
+                    expected_result = [...expected_result, ...group_items];
+                }
             }
             if (opts.user) {
                 if (opts.user_source) {
@@ -530,6 +534,8 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
         {user: true, user_source: () => [fred_item, mark_item]},
         {stream: true},
         {user_group: true},
+        // user and custom user group source.
+        {user_group: true, user_group_source: () => [admins_item]},
         {user_group: true, stream: true},
         {user_group: true, user: true},
         {user: true, stream: true},


### PR DESCRIPTION
We do not show groups that will break the DAG constraint on being added to a group as subgroups in the typeahead shown in the members edit UI.

Fixes #32087.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
