### PR TITLE
webhooks: Fix the message sent on unassignment of Github pull requests.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -58,10 +58,7 @@ ISSUE_LABELED_OR_UNLABELED_MESSAGE_TEMPLATE_WITH_TITLE = "[{user_name}]({user_ur
 ISSUE_MILESTONED_OR_DEMILESTONED_MESSAGE_TEMPLATE = "[{user_name}]({user_url}) {action} milestone [{milestone_name}]({milestone_url}) {preposition} [issue #{id}]({url})."
 ISSUE_MILESTONED_OR_DEMILESTONED_MESSAGE_TEMPLATE_WITH_TITLE = "[{user_name}]({user_url}) {action} milestone [{milestone_name}]({milestone_url}) {preposition} [issue #{id} {title}]({url})."
 
-PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE = "{user_name} {action} [{type}{id}]({url})"
-PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE_WITH_TITLE = (
-    "{user_name} {action} [{type}{id} {title}]({url})"
-)
+PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE = "{user_name} {action}{assignee} [{type}{id}{title}]({url})"
 PULL_REQUEST_OR_ISSUE_ASSIGNEE_INFO_TEMPLATE = "(assigned to {assignee})"
 PULL_REQUEST_REVIEWER_INFO_TEMPLATE = "(assigned reviewers: {reviewer})"
 PULL_REQUEST_BRANCH_INFO_TEMPLATE = "from `{target}` to `{base}`"
@@ -204,6 +201,7 @@ def get_pull_request_event_message(
     message: str | None = None,
     assignee: str | None = None,
     assignees: list[dict[str, Any]] | None = None,
+    assignee_updated: str | None = None,
     reviewer: str | None = None,
     type: str = "PR",
     title: str | None = None,
@@ -214,13 +212,14 @@ def get_pull_request_event_message(
         "type": type,
         "url": url,
         "id": f" #{number}" if number is not None else "",
-        "title": title,
+        "title": f" {title}" if title is not None else "",
+        "assignee": {
+            "assigned": f" {assignee_updated} to",
+            "unassigned": f" {assignee_updated} from",
+        }.get(action, ""),
     }
 
-    if title is not None:
-        main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE_WITH_TITLE.format(**kwargs)
-    else:
-        main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE.format(**kwargs)
+    main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE.format(**kwargs)
 
     if target_branch and base_branch:
         branch_info = PULL_REQUEST_BRANCH_INFO_TEMPLATE.format(
@@ -270,6 +269,7 @@ def get_issue_event_message(
     message: str | None = None,
     assignee: str | None = None,
     assignees: list[dict[str, Any]] | None = None,
+    assignee_updated: str | None = None,
     title: str | None = None,
 ) -> str:
     return get_pull_request_event_message(
@@ -280,6 +280,7 @@ def get_issue_event_message(
         message=message,
         assignee=assignee,
         assignees=assignees,
+        assignee_updated=assignee_updated,
         type="issue",
         title=title,
     )

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -53,7 +53,7 @@ class GiteaHookTests(WebhookTestCase):
 
     def test_pull_request_assigned(self) -> None:
         expected_topic_name = "test / PR #1906 test 2"
-        expected_message = """kostekIV assigned [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master` (assigned to kostekIV)."""
+        expected_message = """kostekIV assigned kostekIV to [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master` (assigned to kostekIV)."""
         self.check_webhook("pull_request__assigned", expected_topic_name, expected_message)
 
     def test_issues_opened(self) -> None:
@@ -73,7 +73,7 @@ class GiteaHookTests(WebhookTestCase):
 
     def test_issues_assigned(self) -> None:
         expected_topic_name = "test / issue #3 Test issue"
-        expected_message = """kostekIV assigned [issue #3](https://try.gitea.io/kostekIV/test/issues/3) (assigned to kostekIV):\n\n~~~ quote\nTest body\n~~~"""
+        expected_message = """kostekIV assigned kostekIV to [issue #3](https://try.gitea.io/kostekIV/test/issues/3) (assigned to kostekIV):\n\n~~~ quote\nTest body\n~~~"""
         self.check_webhook("issues__assigned", expected_topic_name, expected_message)
 
     def test_issues_reopened(self) -> None:

--- a/zerver/webhooks/gitea/view.py
+++ b/zerver/webhooks/gitea/view.py
@@ -46,6 +46,7 @@ def format_pull_request_event(payload: WildValue, include_title: bool = False) -
         base_branch=base_branch,
         title=title,
         assignee=stringified_assignee,
+        assignee_updated=stringified_assignee if action == "assigned" else None,
     )
 
 

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -386,14 +386,15 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("pull_request__assigned", expected_topic_name, expected_message)
 
     def test_pull_request_unassigned_msg(self) -> None:
-        expected_message = (
-            "eeshangarg unassigned [PR #1](https://github.com/zulip-test-org/helloworld/pull/1)."
-        )
-        self.check_webhook(
-            "pull_request__unassigned",
-            "helloworld / PR #1 Mention that Zulip rocks!",
-            expected_message,
-        )
+        expected_message = "eeshangarg unassigned eeshangarg from [PR #1](https://github.com/zulip-test-org/helloworld/pull/1)."
+        expected_topic_name = "helloworld / PR #1 Mention that Zulip rocks!"
+        self.check_webhook("pull_request__unassigned", expected_topic_name, expected_message)
+
+    def test_pull_request_unassigned_msg_with_custom_topic_in_url(self) -> None:
+        self.url = self.build_webhook_url(topic="notifications")
+        expected_topic_name = "notifications"
+        expected_message = "eeshangarg unassigned eeshangarg from [PR #1 Mention that Zulip rocks!](https://github.com/zulip-test-org/helloworld/pull/1)"
+        self.check_webhook("pull_request__unassigned", expected_topic_name, expected_message)
 
     def test_pull_request_ready_for_review_msg(self) -> None:
         expected_message = "**Hypro999** has marked [PR #2](https://github.com/Hypro999/temp-test-github-webhook/pull/2) as ready for review."

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -94,7 +94,7 @@ class GogsHookTests(WebhookTestCase):
 
     def test_pull_request_assigned(self) -> None:
         expected_topic_name = "test / PR #1349 Test"
-        expected_message = """kostekIV assigned [PR #2](https://try.gogs.io/kostekIV/test/pulls/2) from `c` to `master`."""
+        expected_message = """kostekIV assigned kostekIV to [PR #2](https://try.gogs.io/kostekIV/test/pulls/2) from `c` to `master`."""
         self.check_webhook("pull_request__assigned", expected_topic_name, expected_message)
 
     def test_pull_request_synchronized(self) -> None:
@@ -119,7 +119,7 @@ class GogsHookTests(WebhookTestCase):
 
     def test_issues_assignee(self) -> None:
         expected_topic_name = "test / issue #3 New test issue"
-        expected_message = """kostekIV assigned [issue #3](https://try.gogs.io/kostekIV/test/issues/3) (assigned to kostekIV):\n\n~~~ quote\nTest\n~~~"""
+        expected_message = """kostekIV assigned kostekIV to [issue #3](https://try.gogs.io/kostekIV/test/issues/3) (assigned to kostekIV):\n\n~~~ quote\nTest\n~~~"""
         self.check_webhook("issues__assigned", expected_topic_name, expected_message)
 
     def test_issues_closed(self) -> None:

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -86,6 +86,11 @@ def format_pull_request_event(payload: WildValue, include_title: bool = False) -
         target_branch = payload["pull_request"]["head_branch"].tame(check_string)
         base_branch = payload["pull_request"]["base_branch"].tame(check_string)
     title = payload["pull_request"]["title"].tame(check_string) if include_title else None
+    stringified_assignee = (
+        payload["pull_request"]["assignee"]["login"].tame(check_string)
+        if payload["action"] and payload["pull_request"]["assignee"]
+        else None
+    )
 
     return get_pull_request_event_message(
         user_name=user_name,
@@ -95,20 +100,24 @@ def format_pull_request_event(payload: WildValue, include_title: bool = False) -
         target_branch=target_branch,
         base_branch=base_branch,
         title=title,
+        assignee_updated=stringified_assignee,
     )
 
 
 def format_issues_event(payload: WildValue, include_title: bool = False) -> str:
     issue_nr = payload["issue"]["number"].tame(check_int)
     assignee = payload["issue"]["assignee"]
+    stringified_assignee = assignee["login"].tame(check_string) if assignee else None
+    action = payload["action"].tame(check_string)
     return get_issue_event_message(
         user_name=payload["sender"]["login"].tame(check_string),
         action=payload["action"].tame(check_string),
         url=get_issue_url(payload["repository"]["html_url"].tame(check_string), issue_nr),
         number=issue_nr,
         message=payload["issue"]["body"].tame(check_string),
-        assignee=assignee["login"].tame(check_string) if assignee else None,
+        assignee=stringified_assignee,
         title=payload["issue"]["title"].tame(check_string) if include_title else None,
+        assignee_updated=stringified_assignee if action == "assigned" else None,
     )
 
 


### PR DESCRIPTION
Fixes: https://chat.zulip.org/#narrow/channel/127-integrations/topic/GitHub.3A.20Wrong.20user.20identified.20as.20unassigned/near/1965136

On un-assigning everyone (when multiple people are assigned) with a single click, a message is generated for every single member un-assigned separately.

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/449f3cdf-a57a-4531-860c-950c46aec53c)
![image](https://github.com/user-attachments/assets/433bd0e4-3389-4bdd-b653-014e3b49dff1)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
