### PR TITLE
storage: Rework static avatar files hashing logic.

### DIFF
--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -24,26 +24,62 @@ else:
         return os.path.join(settings.STATIC_ROOT, path)
 
 
-def reformat_medium_filename(hashed_name: str) -> str:
-    """
-    Because the protocol for getting medium-size avatar URLs
-    was never fully documented, the mobile apps use a
-    substitution of the form s/.png/-medium.png/ to get the
-    medium-size avatar URLs. Thus, we must ensure the hashed
-    filenames for system bot avatars follow this naming convention.
-    """
-
-    name_parts = hashed_name.rsplit(".", 1)
-    base_name = name_parts[0]
-
-    if len(name_parts) != 2 or "-medium" not in base_name:
-        return hashed_name
-    extension = name_parts[1].replace("png", "medium.png")
-    base_name = base_name.replace("-medium", "")
-    return f"{base_name}-{extension}"
-
-
 class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    hashed_static_avatar_file_map: dict[str, str] = {}
+
+    def process_static_avatars_name(
+        self,
+        name: str,
+        content: Optional["File[bytes]"] = None,
+        filename: str | None = None,
+    ) -> str:
+        """
+        Because the protocol for getting medium-size avatar URLs
+        was never fully documented, the mobile apps use a
+        substitution of the form s/.png/-medium.png/ to get the
+        medium-size avatar URLs.
+
+        This function hashes system bots' avatar files in a way
+        that follows the pattern used for user-uploaded avatars.
+
+        It ensures the following:
+
+            * Hashed filenames for system bot avatars follow this
+            naming convention:
+            - avatar.png -> avatar-medium.png
+
+            * The system bots' default avatar file and its medium
+            version share the same hash:
+            - bot.36f721bad3d0.png -> bot.36f721bad3d0-medium.png
+        """
+
+        def reformat_medium_filename(hashed_name: str) -> str:
+            name_parts = hashed_name.rsplit(".", 1)
+            base_name = name_parts[0]
+
+            if len(name_parts) != 2 or "-medium" not in base_name:
+                return hashed_name
+            extension = name_parts[1].replace("png", "medium.png")
+            base_name = base_name.replace("-medium", "")
+            return f"{base_name}-{extension}"
+
+        if name.endswith("-medium.png"):
+            # This logic relies on the fact that the medium files will
+            # be hashed first due to the "-medium" string, which places
+            # them earlier in the naming order. So, adhering to the
+            # medium file naming convention is crucial for this logic.
+            hashed_medium_file: str = reformat_medium_filename(
+                super().hashed_name(name, content, filename)
+            )
+
+            default_file = name.replace("-medium.png", ".png")
+            hashed_default_file = hashed_medium_file.replace("-medium.png", ".png")
+
+            self.hashed_static_avatar_file_map[default_file] = hashed_default_file
+            return hashed_medium_file
+        assert name in self.hashed_static_avatar_file_map
+        return self.hashed_static_avatar_file_map[name]
+
     @override
     def hashed_name(
         self, name: str, content: Optional["File[bytes]"] = None, filename: str | None = None
@@ -64,11 +100,8 @@ class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
             # so they can hit our Nginx caching block for static files.
             # We don't need to worry about stale caches since these are
             # only used by the system bots.
-            if not name.endswith("-medium.png"):
-                return super().hashed_name(name, content, filename)
+            return self.process_static_avatars_name(name, content, filename)
 
-            hashed_medium_file = super().hashed_name(name, content, filename)
-            return reformat_medium_filename(hashed_medium_file)
         if name == "generated/emoji/emoji_api.json":
             # Unlike most .json files, we do want to hash this file;
             # its hashed URL is returned as part of the API.  See


### PR DESCRIPTION
Previously, the hashing logic for static avatar files hashed the default and medium files separately, which didn’t match how user-uploaded avatars work—where you just add the "-medium.png" suffix to get the medium version. Since we don’t have clear documentation for avatars yet, this caused some issues for the mobile apps.

This PR makes sure the default and its medium variation share the same hash. So, the medium variants can be accessed by just adding the "-medium" suffix to the system bots default avatar file. 

**Screenshots and screen captures:**
User-uploaded avatar:
`https://chat.zulip.org/user_avatars/2/f641fe6b0cdca129f1ad583f6388672bf8ab64d8-medium.png`
`https://chat.zulip.org/user_avatars/2/f641fe6b0cdca129f1ad583f6388672bf8ab64d8.png`

vs

Static system bots avatar (after rework):
`http://localhost:9991/static/images/static_avatars/emailgateway.2f97461a9420.png`
`http://localhost:9991/static/images/static_avatars/emailgateway.2f97461a9420-medium.png`

<details>

<summary>hashed static avatar files</summary>

```bash
ls /srv/zulip/prod-static/serve/images/static_avatars/
emailgateway-medium.png               emailgateway.png                          notification-bot.36f721bad3d0.png  welcome-bot.0c86744b0caf-medium.png
emailgateway.7b3c8066a0b8-medium.png  notification-bot-medium.png               notification-bot.png               welcome-bot.0c86744b0caf.png
emailgateway.7b3c8066a0b8.png         notification-bot.36f721bad3d0-medium.png  welcome-bot-medium.png             welcome-bot.png

```
</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
