### PR TITLE
onboarding_steps: Fix blueslip error message. 

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -92,7 +92,6 @@ function delete_attachments(attachment: string, file_name: string): void {
         html_heading: $t_html({defaultMessage: "Delete file?"}),
         html_body,
         html_submit_button: $t_html({defaultMessage: "Delete"}),
-        id: "confirm_delete_file_modal",
         focus_submit_on_open: true,
         on_click() {
             dialog_widget.submit_api_request(channel.del, "/json/attachments/" + attachment, {});

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -25,9 +25,9 @@ function current_dialog_widget_selector(): string {
 }
 
 /*
- *  Look for confirm_dialog in settings_user_groups
- *  to see an example of how to use this widget.  It's
- *  pretty simple to use!
+ *  Look for dialog_widget or confirm_dialog in various
+ *  'web/src/' files to see examples of how to use this widget.
+ *  It's pretty simple to use!
  *
  *  Some things to note:
  *      1) We create DOM on the fly, and we remove

--- a/web/src/onboarding_steps.ts
+++ b/web/src/onboarding_steps.ts
@@ -15,7 +15,7 @@ export function post_onboarding_step_as_read(onboarding_step_name: string): void
         data: {onboarding_step: onboarding_step_name},
         error(err) {
             if (err.readyState !== 0) {
-                blueslip.error("Failed to fetch onboarding steps", {
+                blueslip.error(`Failed to mark ${onboarding_step_name} as read.`, {
                     readyState: err.readyState,
                     status: err.status,
                     body: err.responseText,


### PR DESCRIPTION
These are some minor independent fixes I observed in the last few days.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
