### PR TITLE
Move Message: Default to "Move only this message" in search view.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -428,14 +428,6 @@ function maybe_restore_focus_to_message_edit_form(): void {
     }, 0);
 }
 
-function is_search_view(): boolean {
-    const current_filter = narrow_state.filter();
-    if (current_filter && !current_filter.supports_collapsing_recipients()) {
-        return true;
-    }
-    return false;
-}
-
 type SubscriptionMarkers = {
     bookend_top: boolean;
     stream_name: string;
@@ -456,7 +448,7 @@ function populate_group_from_message(
 
     // Each searched message is a self-contained result,
     // so we always display date in the recipient bar for those messages.
-    const always_display_date = is_search_view();
+    const always_display_date = narrow_state.is_search_view();
     if (is_stream) {
         assert(message.type === "stream");
         // stream messages have string display_recipient

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -25,6 +25,13 @@ export function search_terms(current_filter: Filter | undefined = filter()): Nar
     return current_filter.terms();
 }
 
+export function is_search_view(current_filter: Filter | undefined = filter()): boolean {
+    if (current_filter && !current_filter.supports_collapsing_recipients()) {
+        return true;
+    }
+    return false;
+}
+
 export function is_message_feed_visible(): boolean {
     // It's important that `message_lists.current` is the
     // source of truth for this since during the initial app load,

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -16,6 +16,7 @@ import {$t, $t_html} from "./i18n.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_view from "./message_view.ts";
+import * as narrow_state from "./narrow_state.ts";
 import * as popover_menus from "./popover_menus.ts";
 import {left_sidebar_tippy_options} from "./popover_menus.ts";
 import {web_channel_default_view_values} from "./settings_config.ts";
@@ -389,11 +390,20 @@ export async function build_move_topic_to_stream_popover(
         const move_limit_buffer = 5;
         args.disable_topic_input = !message_edit.is_topic_editable(message, move_limit_buffer);
         disable_stream_input = !message_edit.is_stream_editable(message, move_limit_buffer);
-        args.message_placement = await get_message_placement_in_conversation(
-            current_stream_id,
-            topic_name,
-            message.id,
-        );
+
+        // If message is in a search view, default to "move only this message" option,
+        // same as if it were the last message in any view.
+        if (narrow_state.is_search_view()) {
+            args.message_placement = "last";
+        }
+        // Else, default option is based on the message placement in the view.
+        else {
+            args.message_placement = await get_message_placement_in_conversation(
+                current_stream_id,
+                topic_name,
+                message.id,
+            );
+        }
     }
 
     function get_params_from_form() {

--- a/web/tests/narrow_state.test.cjs
+++ b/web/tests/narrow_state.test.cjs
@@ -87,6 +87,7 @@ test("narrowed", () => {
     assert.ok(!narrow_state.narrowed_by_pm_reply());
     assert.ok(!narrow_state.narrowed_by_topic_reply());
     assert.ok(narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.is_search_view());
 
     set_filter([["dm", "steve@zulip.com"]]);
     assert.ok(narrow_state.narrowed_to_pms());
@@ -94,6 +95,7 @@ test("narrowed", () => {
     assert.ok(narrow_state.narrowed_by_pm_reply());
     assert.ok(!narrow_state.narrowed_by_topic_reply());
     assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.is_search_view());
 
     set_filter([
         ["stream", foo_stream_id.toString()],
@@ -104,6 +106,7 @@ test("narrowed", () => {
     assert.ok(!narrow_state.narrowed_by_pm_reply());
     assert.ok(narrow_state.narrowed_by_topic_reply());
     assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(!narrow_state.is_search_view());
 
     set_filter([["search", "grail"]]);
     assert.ok(!narrow_state.narrowed_to_pms());
@@ -111,6 +114,7 @@ test("narrowed", () => {
     assert.ok(!narrow_state.narrowed_by_pm_reply());
     assert.ok(!narrow_state.narrowed_by_topic_reply());
     assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(narrow_state.is_search_view());
 
     set_filter([["is", "starred"]]);
     assert.ok(!narrow_state.narrowed_to_pms());
@@ -118,6 +122,7 @@ test("narrowed", () => {
     assert.ok(!narrow_state.narrowed_by_pm_reply());
     assert.ok(!narrow_state.narrowed_by_topic_reply());
     assert.ok(!narrow_state.narrowed_by_stream_reply());
+    assert.ok(narrow_state.is_search_view());
 });
 
 test("terms", () => {


### PR DESCRIPTION
Fixes #32106

Default to "Move only this message" select option if messge is in search view,
because a search view by its construction doesn't guarantee to show all/later messages in the relevant topic.

So only if the message is in a search view we default to "Move only this message", otherwise the message placment in the topic (e.g first, last) is what determines the default option.
## Example of a message that's the "first one" in its topic:


### Before
![Screenshot from 2024-11-05 13-40-36](https://github.com/user-attachments/assets/10dcb267-d093-4ade-b2f0-40edf9f010c8)

### After
![Screenshot from 2024-11-05 13-42-52](https://github.com/user-attachments/assets/33f6f08b-0b0f-4a8d-b53b-59670a271549)

