### PR TITLE
Fix user with 50k+ unreads narrows to incorrect first unread message.

### DIFF
--- a/web/src/fetch_status.ts
+++ b/web/src/fetch_status.ts
@@ -10,6 +10,11 @@ function max_id_for_messages(messages: (Message | RawMessage)[]): number {
 }
 
 export class FetchStatus {
+    // Add a delay before showing the spinning loading indicator
+    // so that quick calls to server don't add visible slowness to the app.
+    SHOW_LOADING_INDICATOR_DELAY = 300;
+    _show_loading_older_indicator_timer: undefined | ReturnType<typeof setTimeout> = undefined;
+    _show_loading_newer_indicator_timer: undefined | ReturnType<typeof setTimeout> = undefined;
     // The FetchStatus object tracks the state of a
     // message_list_data object, whether rendered in the DOM or not,
     // and is the source of truth for whether the message_list_data
@@ -33,7 +38,10 @@ export class FetchStatus {
     start_older_batch(opts: {update_loading_indicator: boolean}): void {
         this._loading_older = true;
         if (opts.update_loading_indicator) {
-            message_feed_loading.show_loading_older();
+            this._show_loading_older_indicator_timer = setTimeout(
+                message_feed_loading.show_loading_older,
+                this.SHOW_LOADING_INDICATOR_DELAY,
+            );
         }
     }
 
@@ -46,6 +54,7 @@ export class FetchStatus {
         this._found_oldest = opts.found_oldest;
         this._history_limited = opts.history_limited;
         if (opts.update_loading_indicator) {
+            clearTimeout(this._show_loading_older_indicator_timer);
             message_feed_loading.hide_loading_older();
         }
     }
@@ -65,7 +74,10 @@ export class FetchStatus {
     start_newer_batch(opts: {update_loading_indicator: boolean}): void {
         this._loading_newer = true;
         if (opts.update_loading_indicator) {
-            message_feed_loading.show_loading_newer();
+            this._show_loading_newer_indicator_timer = setTimeout(
+                message_feed_loading.show_loading_newer,
+                this.SHOW_LOADING_INDICATOR_DELAY,
+            );
         }
     }
 
@@ -79,6 +91,7 @@ export class FetchStatus {
         this._loading_newer = false;
         this._found_newest = opts.found_newest;
         if (opts.update_loading_indicator) {
+            clearTimeout(this._show_loading_newer_indicator_timer);
             message_feed_loading.hide_loading_newer();
         }
         if (this._found_newest && this._expected_max_message_id > found_max_message_id) {

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -216,6 +216,12 @@ export let get_first_unread_info = (
         return cannot_compute_response;
     }
 
+    if (unread.old_unreads_missing) {
+        // We don't have full unread information from server, so we can't
+        // accurately compute the first unread message.
+        return cannot_compute_response;
+    }
+
     if (!current_filter.can_apply_locally()) {
         // For things like search queries, where the server has info
         // that the client isn't privy to, we need to wait for the

--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -41,6 +41,10 @@ export function clear_old_unreads_missing(): void {
     old_unreads_missing = false;
 }
 
+export function rewire_old_unreads_missing(value: boolean): void {
+    old_unreads_missing = value;
+}
+
 export const unread_mentions_counter = new Set<number>();
 export const direct_message_with_mention_count = new Set();
 const unread_messages = new Set<number>();

--- a/web/tests/narrow_unread.test.cjs
+++ b/web/tests/narrow_unread.test.cjs
@@ -55,7 +55,7 @@ function candidate_ids() {
     return narrow_state._possible_unread_message_ids();
 }
 
-run_test("get_unread_ids", () => {
+run_test("get_unread_ids", ({override_rewire}) => {
     unread.declare_bankruptcy();
     message_lists.set_current(undefined);
 
@@ -135,6 +135,13 @@ run_test("get_unread_ids", () => {
         flavor: "found",
         msg_id: stream_msg.id,
     });
+    // Check if we have old unreads missing, we always return
+    // status as cannot compute.
+    override_rewire(unread, "old_unreads_missing", true);
+    assert_unread_info({
+        flavor: "cannot_compute",
+    });
+    override_rewire(unread, "old_unreads_missing", false);
 
     terms = [
         {operator: "stream", operand: bogus_stream_id},


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/Handling.2050K.2B.20unreads