### PR TITLE
right_sidebar: Correct line-height by decoupling .filters class.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -116,7 +116,7 @@ $user_status_emoji_width: 24px;
 }
 
 .buddy-list-section {
-    margin-bottom: 0;
+    margin: 0;
     overflow-x: hidden;
     list-style-position: inside; /* Draw the bullets inside our box */
     line-height: var(--line-height-sidebar-row);

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -21,15 +21,15 @@
             <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
                 <div id="buddy-list-participants-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
-                    <ul id="buddy-list-participants" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>
+                    <ul id="buddy-list-participants" class="buddy-list-section" data-search-results-empty="{{t 'None.' }}"></ul>
                 </div>
                 <div id="buddy-list-users-matching-view-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
-                    <ul id="buddy-list-users-matching-view" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>
+                    <ul id="buddy-list-users-matching-view" class="buddy-list-section" data-search-results-empty="{{t 'None.' }}"></ul>
                 </div>
                 <div id="buddy-list-other-users-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
-                    <ul id="buddy-list-other-users" class="buddy-list-section filters" data-search-results-empty="{{t 'None.' }}"></ul>
+                    <ul id="buddy-list-other-users" class="buddy-list-section" data-search-results-empty="{{t 'None.' }}"></ul>
                 </div>
                 <div id="buddy_list_wrapper_padding"></div>
                 <div class="right-sidebar-shortcuts">


### PR DESCRIPTION
This fixes a nasty little regression that torqued the centering of presence circles and hover buttons. In doing so, it actually cleans up one of the last remaining bits of left/right sidebar interdependence by removing the `.filters` class, whose prominent row-height was overriding what should've been applied to `.buddy-list-section`.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/shifted.20presence.20circles.20in.20right.20sidebar/near/1962405) (presence circles), [CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/buddy.20list.20.2E.2E.2E.20height/near/1965411) (vdots)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![right-sidebar-rows-before](https://github.com/user-attachments/assets/017299f5-c8ad-41f3-87cb-167db2f23e78) | ![right-sidebar-rows-after](https://github.com/user-attachments/assets/bed5c405-df4d-4d4e-b0a3-653bcc31a429) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>