### PR TITLE
empty_titles: Set line-height to match font size.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1321,6 +1321,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 .empty-feed-notice-title {
     font-size: 1.5em;
     font-weight: 400;
+    line-height: 1;
     word-wrap: break-word;
 }
 


### PR DESCRIPTION
While working on #32122, I noticed that wrapped empty-title lines collide with each other. This is basically a Bootstrap override, but also something that likely got overlooked on the information-density project from Spring 2024.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/lines.20collide.20on.20empty.20feed.20titles/near/1968970)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![no-dms-with-before](https://github.com/user-attachments/assets/cd746cd3-424b-4ccd-8d3e-b7e20d522c44) | ![no-dms-with-after](https://github.com/user-attachments/assets/744dfe4c-f636-4d8d-9ae5-9fc52a251ec4) |
| ![empty-mentions-before](https://github.com/user-attachments/assets/8219cd6e-95ff-482e-ba79-f103ee640fce) | ![empty-mentions-after](https://github.com/user-attachments/assets/0ab707a0-c728-48ee-8957-cfa13735e4cd) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>