### PR TITLE
auth: Tweak invalid credentials error message.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -52,7 +52,7 @@ MIT_VALIDATION_ERROR = Markup(
     ' <a href="mailto:support@zulip.com">contact us</a>.'
 )
 
-INVALID_ACCOUNT_CREDENTIALS_ERROR = gettext_lazy("Please enter a correct email and password.")
+INVALID_ACCOUNT_CREDENTIALS_ERROR = gettext_lazy("Incorrect email or password.")
 DEACTIVATED_ACCOUNT_ERROR = gettext_lazy(
     "Your account {username} has been deactivated."
     " Please contact your organization administrator to reactivate it."

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -856,7 +856,7 @@ class InactiveUserTest(ZulipTestCase):
         form = OurAuthenticationForm(request, payload)
         with self.settings(AUTHENTICATION_BACKENDS=("zproject.backends.EmailAuthBackend",)):
             self.assertFalse(form.is_valid())
-            self.assertIn("Please enter a correct email", str(form.errors))
+            self.assertIn("Incorrect email or password.", str(form.errors))
 
         # Test a non-mirror-dummy deactivated user.
         user_profile.is_mirror_dummy = False

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -993,7 +993,7 @@ class LoginTest(ZulipTestCase):
     def test_login_nonexistent_user(self) -> None:
         result = self.login_with_return("xxx@zulip.com", "xxx")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response("Please enter a correct email and password.", result)
+        self.assert_in_response("Incorrect email or password.", result)
         self.assert_logged_in_user_id(None)
 
     def test_login_wrong_subdomain(self) -> None:
@@ -1009,7 +1009,7 @@ class LoginTest(ZulipTestCase):
                 ],
             )
         self.assertEqual(result.status_code, 200)
-        expected_error = "Please enter a correct email and password."
+        expected_error = "Incorrect email or password."
         self.assert_in_response(expected_error, result)
         self.assert_logged_in_user_id(None)
 


### PR DESCRIPTION
Follow-up on #32104 - we decided this is the better string to use.
