### PR TITLE
left_sidebar: Show Direct Messages controls on DM area hover.

### DIFF
--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -258,4 +258,12 @@ export function initialize(): void {
 
         clear_search();
     });
+
+    $(".direct-messages-container").on("mouseenter", () => {
+        $("#direct-messages-section-header").addClass("hover-over-dm-section");
+    });
+
+    $(".direct-messages-container").on("mouseleave", () => {
+        $("#direct-messages-section-header").removeClass("hover-over-dm-section");
+    });
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -259,6 +259,7 @@
         }
     }
 
+    &.hover-over-dm-section,
     &.zoom-in,
     &:hover {
         #compose-new-direct-message,

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -150,12 +150,12 @@
         <i id="toggle-direct-messages-section-icon" class="zulip-icon zulip-icon-heading-triangle-right sidebar-heading-icon rotate-icon-down dm-tooltip-target zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
         <h4 class="left-sidebar-title"><span class="dm-tooltip-target">{{t 'DIRECT MESSAGES' }}</span></h4>
         <div class="left-sidebar-controls">
-            <span id="compose-new-direct-message" class="tippy-left-sidebar-tooltip-no-label-delay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
-                <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'New direct message' }}"></i>
-            </span>
             <a id="show-all-direct-messages" class="tippy-left-sidebar-tooltip-no-label-delay" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                 <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
             </a>
+            <span id="compose-new-direct-message" class="tippy-left-sidebar-tooltip-no-label-delay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
+                <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'New direct message' }}"></i>
+            </span>
         </div>
         <div class="heading-markers-and-unreads">
             <span class="unread_count"></span>


### PR DESCRIPTION
DM heading-row controls are shown whenever the mouse hovers over any of the DMs area.

Additionally, the order of the DM heading-row controls are reversed in an experimental commit, putting the New DM control to the right, beside the unread count (if any).

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/.22New.20topic.22.20in.20stream.20menu/near/1965458)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![dm-area-hover](https://github.com/user-attachments/assets/38431480-2fe7-4ab0-9885-4cde68490f1c)

