### PR TITLE
Added debouncing to password input field to avoid lag.

### DIFF
--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import _ from "lodash";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
@@ -24,10 +25,18 @@ $(() => {
         // was just reloaded due to a validation failure on the backend.
         password_quality($password_field.val()!, $("#pw_strength .bar"), $password_field);
 
+        const debounced_password_quality = _.debounce((password_value: string, $field: JQuery) => {
+            password_quality(password_value, $("#pw_strength .bar"), $field);
+        }, 300);
+
         $password_field.on("input", function () {
-            // Update the password strength bar even if we aren't validating
-            // the field yet.
-            password_quality($(this).val()!, $("#pw_strength .bar"), $(this));
+            const password_value = $(this).val()!;
+
+            if (password_value.length > 30) {
+                debounced_password_quality(password_value, $(this));
+            } else {
+                password_quality(password_value, $("#pw_strength .bar"), $(this));
+            }
         });
     }
 


### PR DESCRIPTION
This pull request builds on PR #29434 and addresses the comments and feedback raised in that review. Below is a summary of the primary differences and enhancements introduced in this PR:

1. **File Change Optimization**:
   - In the previous PR, changes were included in `web/src/settings_account.js`, which were not essential to the intended functionality. 

2. **Minimum Length Validation Logic**:
   - Previously, the minimum length error would display immediately as the user began typing in the password field, which could be intrusive for users.
   - In this PR, I have introduced a new flag that tracks the initial `focusout` event on the password field. With this approach, the minimum length error is only shown after the user first blurs (focuses out of) the input field. After this initial focus out, validation occurs in real-time as the user continues typing, keeping the original behaviour as it is.

Fixes: #29429.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Video Showing the password validation:</summary>

https://github.com/user-attachments/assets/2a1267b7-6716-4e5e-a6aa-72c73197c55e


</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
