### PR TITLE
create_user: Fix integrity error when importing settings.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -229,7 +229,7 @@ def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
     )
 
 
-@transaction.atomic
+@transaction.atomic(savepoint=False)
 def send_initial_realm_messages(realm: Realm) -> None:
     # Sends the initial messages for a new organization.
     #

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -67,6 +67,7 @@ from zerver.models import (
     CustomProfileFieldValue,
     DefaultStream,
     Message,
+    OnboardingStep,
     OnboardingUserMessage,
     PreregistrationRealm,
     PreregistrationUser,
@@ -2826,6 +2827,9 @@ class UserSignUpTest(ZulipTestCase):
         hamlet_in_zulip.email_address_visibility = UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE
         hamlet_in_zulip.save()
 
+        OnboardingStep.objects.filter(user=hamlet_in_zulip).delete()
+        OnboardingStep.objects.create(user=hamlet_in_zulip, onboarding_step="intro_resolve_topic")
+
         result = self.client_post("/accounts/home/", {"email": email}, subdomain=subdomain)
         self.assertEqual(result.status_code, 302)
         result = self.client_get(result["Location"], subdomain=subdomain)
@@ -2844,6 +2848,12 @@ class UserSignUpTest(ZulipTestCase):
         self.assertEqual(hamlet.high_contrast_mode, False)
         self.assertEqual(hamlet.enable_stream_audible_notifications, False)
         self.assertEqual(hamlet.enter_sends, False)
+        # 'visibility_policy_banner' is marked as read in 'process_new_human_user'.
+        # 'copy_default_settings' is not executed as the user decided to NOT import
+        # settings from another realm, hence 'intro_resolve_topic' not marked as seen.
+        onboarding_steps = OnboardingStep.objects.filter(user=hamlet)
+        self.assertEqual(onboarding_steps.count(), 1)
+        self.assertEqual(onboarding_steps[0].onboarding_step, "visibility_policy_banner")
 
     def test_signup_with_user_settings_from_another_realm(self) -> None:
         hamlet_in_zulip = self.example_user("hamlet")
@@ -2863,6 +2873,12 @@ class UserSignUpTest(ZulipTestCase):
         hamlet_in_zulip.enter_sends = True
         hamlet_in_zulip.email_address_visibility = UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE
         hamlet_in_zulip.save()
+
+        OnboardingStep.objects.filter(user=hamlet_in_zulip).delete()
+        OnboardingStep.objects.create(user=hamlet_in_zulip, onboarding_step="intro_resolve_topic")
+        OnboardingStep.objects.create(
+            user=hamlet_in_zulip, onboarding_step="visibility_policy_banner"
+        )
 
         # Now we'll be making requests to another subdomain, so we need to logout
         # to avoid polluting the session in the test environment by still being
@@ -2908,6 +2924,13 @@ class UserSignUpTest(ZulipTestCase):
         self.assertEqual(hamlet_in_lear.enable_stream_audible_notifications, False)
         self.assertEqual(
             hamlet_in_lear.email_address_visibility, UserProfile.EMAIL_ADDRESS_VISIBILITY_NOBODY
+        )
+        # Verify that 'copy_default_settings' copies the onboarding steps.
+        onboarding_steps = OnboardingStep.objects.filter(user=hamlet_in_lear)
+        self.assertEqual(onboarding_steps.count(), 2)
+        self.assertEqual(
+            set(onboarding_steps.values_list("onboarding_step", flat=True)),
+            {"intro_resolve_topic", "visibility_policy_banner"},
         )
 
         zulip_path_id = avatar_disk_path(hamlet_in_zulip)


### PR DESCRIPTION
During account creation when a user selected to import settings from an existing account, the "Mark visibility_policy_banner as read" step was raising integrity error.

It is because `copy_onboarding_steps` is already executed earlier in the `do_create_user` codeflow. If the source profile had already marked `visibility_policy_banner` as read, we were facing integrity error.

This PR fixes the bug.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
