### PR TITLE
help: Improve documentation about starting a new conversation.

### DIFF
--- a/help/include/how-to-start-a-new-topic.md
+++ b/help/include/how-to-start-a-new-topic.md
@@ -1,30 +1,36 @@
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
-1. Click the **Start new conversation** button at the bottom of the app, or
-   use the <kbd>C</kbd> keyboard shortcut.
+1. Click the **plus** (<i class="zulip-icon zulip-icon-square-plus"></i>) button next
+   to the name of the channel where you'd like to start a conversation.
 
-1. _(optional)_ You can change the destination channel for your message using
-   the dropdown in the top left of the compose box. You can start typing to
-   filter channels.
-
-1. Enter a topic name. Auto-complete will provide suggestions for previously
-   used topics.
+1. Enter a topic name. Think about finishing the sentence: “Hey, can we chat about… ?”
 
 {!compose-and-send-message.md!}
 
-!!! tip ""
+!!! keyboard_tip ""
 
-    You can click on the
-    **Clear topic** (<i class="zulip-icon zulip-icon-close"></i>) icon
-    near the upper right of the compose box to erase the topic name.
+    You can also use the <kbd>C</kbd> keyboard shortcut to start a new topic in
+    the channel you're viewing.
 
-!!! warn ""
+{tab|via-compose-box}
 
-    In Zulip, you can compose a message to a different place than the one you
-    are viewing. In this situation, the message feed will fade to indicate
-    what's going on.
+1. Click the **Start new conversation** button at the bottom of the app.
+
+1. _(optional)_ You can change the destination channel for your message using
+   the dropdown in the top left of the compose box. Start typing to filter
+   channels.
+
+1. Enter a topic name. Think about finishing the sentence: “Hey, can we chat
+   about… ?”
+
+{!compose-and-send-message.md!}
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>C</kbd> keyboard shortcut to start a new topic in
+    the channel you're viewing.
 
 {tab|mobile}
 

--- a/help/include/send-dm.md
+++ b/help/include/send-dm.md
@@ -2,8 +2,9 @@
 
 {tab|desktop-web}
 
-1. Click the **New direct message** button at the bottom of the app, or the
-   **Start new conversation** button if you are in a direct message view.
+1. Click the **plus** (<i class="zulip-icon zulip-icon-square-plus"></i>) button next
+   to **DIRECT MESSAGES** in the left sidebar, or the **New direct message**
+   button at the bottom of the app.
 
 1. Start typing the name of the person or [group](/help/user-groups) you want to
    message, and select their name from the list of suggestions. You can continue

--- a/help/include/when-to-start-a-new-topic.md
+++ b/help/include/when-to-start-a-new-topic.md
@@ -8,6 +8,7 @@ Topic names should be brief but specific, for example:
 * **Not so good topic names:** "question", "hi", "help", "this topic is about
 a question I have about topics"
 
-!!! tip ""
-    Don't overthink naming your topic. The first 2-3 words that come to mind
-    are probably fine!
+
+Don't stress about making it perfect! The first 2-3 words that
+come to mind are probably fine, and you can always [change it
+later](/help/rename-a-topic).

--- a/help/introduction-to-topics.md
+++ b/help/introduction-to-topics.md
@@ -8,6 +8,8 @@
 
 ## How to start a new topic
 
+Zulip lets you start a new conversation in any channel, no matter where you are.
+
 {!how-to-start-a-new-topic.md!}
 
 ## Further reading


### PR DESCRIPTION
Document new ways to do it from the left sidebar.

The conditional instruction for new DMs was out of date.

I also removed some extra info that didn't seem relevant:
- You won't have a topic to clear if you started a conversation with the ways recommended here.
- I don't think the fading info belongs here (and we have a first-time banner for it now).
- I don't think it's worth mentioning auto-complete when talking about new conversations.

Current: https://zulip.com/help/starting-a-new-direct-message
<details>
<summary>
Updated
</summary>

![Screenshot 2024-10-25 at 15 49 15@2x](https://github.com/user-attachments/assets/6137ab34-7d36-4946-807b-850d99f99357)

</details>

Current: https://zulip.com/help/introduction-to-topics#when-to-start-a-new-topic
<details>
<summary>
Updated
</summary>

![Screenshot 2024-10-25 at 16 04 31@2x](https://github.com/user-attachments/assets/089997be-115b-4d96-9d51-28d5215049b4)
![Screenshot 2024-10-25 at 16 04 40@2x](https://github.com/user-attachments/assets/7689b0f0-13ad-4a1b-871e-f3315088bdbe)


</details>