### PR TITLE
channel settings: Remove extraneous channel name from modal.

### DIFF
--- a/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
@@ -1,8 +1,5 @@
 <p>
-    {{#tr}}
-        Archiving this channel <z-stream></z-stream> will:
-        {{#*inline "z-stream"}}<strong>{{{stream_name_with_privacy_symbol_html}}}</strong>{{/inline}}
-    {{/tr}}
+    {{#tr}}Archiving this channel will:{{/tr}}
 </p>
 <p>
     <ul>


### PR DESCRIPTION
Before:
![Screenshot 2024-10-25 at 16 56 00@2x](https://github.com/user-attachments/assets/33c0e1cf-2d6e-4ece-ba39-68d2ef0205c0)

After:
![Screenshot 2024-10-25 at 16 58 39@2x](https://github.com/user-attachments/assets/c81e1bb4-7e42-42c1-b2e7-f0abc7c7782f)
