### PR TITLE
deactivated_tooltip: Configured the tooltip content for deactivated b…

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -142,29 +142,33 @@ function get_num_unread(user_id: number): number {
 }
 
 export function user_last_seen_time_status(user_id: number): string {
+    // Check if the user is deactivated
+    if (people.get_non_active_human_ids().includes(user_id)) {
+        // Determine if user is a bot or human
+        const user = people.get_by_user_id(user_id);
+        if (user.is_bot) {
+            return $t({defaultMessage: "This bot has been deactivated."});
+        } else {
+            return $t({defaultMessage: "This user has been deactivated."});
+        }
+    }
     const status = presence.get_status(user_id);
     if (status === "active") {
         return $t({defaultMessage: "Active now"});
     }
 
     if (status === "idle") {
-        // When we complete our presence API rewrite to have the data
-        // plumbed, we may want to change this to also mention when
-        // they were last active.
         return $t({defaultMessage: "Idle"});
     }
 
     const last_active_date = presence.last_active_date(user_id);
     if (realm.realm_is_zephyr_mirror_realm) {
-        // We don't send presence data to clients in Zephyr mirroring realms
         return $t({defaultMessage: "Activity unknown"});
     } else if (last_active_date === undefined) {
-        // There are situations where the client has incomplete presence
-        // history on a user. This can happen when users are deactivated,
-        // or when the user's last activity is older than what we fetch.
         assert(page_params.presence_history_limit_days_for_web_app === 365);
         return $t({defaultMessage: "Not active in the last year"});
     }
+
     return timerender.last_seen_status_from_date(last_active_date);
 }
 


### PR DESCRIPTION
…ot and users.

This commit configures the tooltip that if the user is deactivated then previously the tooltip used to show not active in the last year, but now it shows this user has been deactivated.

Fixes #32136 

|Before|After|
|----|----|
<img width="547" alt="Screenshot 2024-10-26 at 7 23 45 AM" src="https://github.com/user-attachments/assets/bcc6afeb-925f-4b32-ad7e-8a2803532bb3">|<img width="573" alt="Screenshot 2024-10-26 at 7 22 06 AM" src="https://github.com/user-attachments/assets/382e5223-7f66-4d33-a4d5-0f4bbc6a9fa2">|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
