### PR TITLE
Show a problem indicator when the password length exceeds the maxLength. 

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -143,12 +143,14 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 </div>
                 {% elif password_required %}
                 <div class="input-box password-div">
+                    <div class="password-label-container">
+                        <span><label for="id_password">{{ _('Password') }}</label></span>
+                        <span id="password-limit-indicator" class="limit-indicator" data-tippy-content="{{ _('Maximum password length: 100 characters') }}" data-tippy-placement="top"></span>
+                    </div>
                     <input id="id_password" class="required" type="password" name="password" autocomplete="new-password"
                       value="{% if form.password.value() %}{{ form.password.value() }}{% endif %}"
-                      maxlength="{{ MAX_PASSWORD_LENGTH }}"
                       data-min-length="{{password_min_length}}"
                       data-min-guesses="{{password_min_guesses}}" required />
-                    <label for="id_password" class="inline-block">{{ _('Password') }}</label>
                     <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0"></i>
                     {% if full_name %}
                     <span class="help-inline">
@@ -252,7 +254,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 </div>
                 {% endif %}
                 <div class="register-button-box">
-                    <button class="register-button" type="submit">
+                    <button class="register-button" id="signup-button" type="submit">
                         <span>{{ _('Sign up') }}</span>
                         <object class="loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                     </button>

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -28,10 +28,12 @@
                 </div>
 
                 <div class="input-box password-div">
-                    <label for="id_new_password1" class="">{{ _('Password') }}</label>
+                    <div class="password-label-container">
+                        <span><label for="id_new_password1" class="">{{ _('Password') }}</label></span>
+                        <span id="reset-password-limit-indicator" class="limit-indicator" data-tippy-content="{{ _('Maximum password length: 100 characters') }}" data-tippy-placement="top"></span>
+                    </div>
                     <input id="id_new_password1" class="required" type="password" name="new_password1" autocomplete="new-password"
                       value="{% if form.new_password1.value() %}{{ form.new_password1.value() }}{% endif %}"
-                      maxlength="100"
                       data-min-length="{{password_min_length}}"
                       data-min-guesses="{{password_min_guesses}}" autofocus required />
                     <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0"></i>
@@ -52,7 +54,7 @@
                     <label for="id_new_password2" class="">{{ _('Confirm password') }}</label>
                     <input id="id_new_password2" class="required" type="password" name="new_password2" autocomplete="off"
                       value="{% if form.new_password2.value() %}{{ form.new_password2.value() }}{% endif %}"
-                      maxlength="100" required />
+                      required />
                     <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0"></i>
                     {% if form.new_password2.errors %}
                         {% for error in form.new_password2.errors %}
@@ -63,7 +65,7 @@
 
                 <div class="input-box m-t-30">
                     <div class="centered-button">
-                        <button type="submit" class="" value="Submit">Submit</button>
+                        <button type="submit" class="" id="reset-button" value="Submit">Submit</button>
                     </div>
                 </div>
             </form>

--- a/web/src/bundles/portico.ts
+++ b/web/src/bundles/portico.ts
@@ -6,3 +6,4 @@ import "../portico/tippyjs.ts";
 import "../../third/bootstrap/css/bootstrap.portico.css";
 import "../../styles/portico/portico_styles.css";
 import "tippy.js/dist/tippy.css";
+import "../../styles/app_variables.css";

--- a/web/src/portico/signup.ts
+++ b/web/src/portico/signup.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
+import render_compose_limit_indicator from "../../templates/compose_limit_indicator.hbs";
 import * as common from "../common.ts";
 import {$t} from "../i18n.ts";
 import {password_quality, password_warning} from "../password_quality.ts";
@@ -342,3 +343,49 @@ $(() => {
         }
     });
 });
+
+const $password_elem = $<HTMLInputElement>("input#id_password");
+const $new_password1_elem = $<HTMLInputElement>("input#id_new_password1");
+
+if ($password_elem.length) {
+    $password_elem.on("input", () => {
+        check_overflow_password($password_elem);
+    });
+}
+
+if ($new_password1_elem.length) {
+    $new_password1_elem.on("input", () => {
+        check_overflow_password($new_password1_elem);
+    });
+}
+
+export function check_overflow_password($password_elem: JQuery<HTMLInputElement>): void {
+    const password = $password_elem.val()!;
+    const max_length = 100;
+    const remaining_characters = max_length - password.length;
+
+    const $indicator = $password_elem.closest(".input-box").find(".limit-indicator");
+    const $button = $password_elem.closest("form").find("button[type='submit']");
+
+    const password_too_long = password.length > max_length;
+    $button.prop("disabled", password_too_long);
+
+    // Update the limit indicator
+    if (password_too_long) {
+        $indicator.addClass("over_limit");
+        $indicator.html(
+            render_compose_limit_indicator({
+                remaining_characters,
+            }),
+        );
+    } else if (remaining_characters <= 20) {
+        $indicator.removeClass("over_limit");
+        $indicator.html(
+            render_compose_limit_indicator({
+                remaining_characters,
+            }),
+        );
+    } else {
+        $indicator.text("");
+    }
+}

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1470,3 +1470,34 @@ button#register_auth_button_gitlab {
         padding: 0;
     }
 }
+
+#signup-button,
+#reset-button {
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+#reset-password-limit-indicator,
+#password-limit-indicator {
+    &:not(:empty) {
+        font-size: 16px;
+        color: var(--color-limit-indicator);
+        cursor: pointer;
+        height: 0;
+        margin-right: 5px;
+        z-index: 10;
+    }
+
+    &.over_limit {
+        color: var(--color-limit-indicator-over-limit);
+        font-weight: bold;
+    }
+}
+
+.password-label-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}


### PR DESCRIPTION
This PR resolves the issue of displaying an error message when users try to set a password that exceeds the maximum allowed length. The implementation follows the approach suggested [here](https://github.com/zulip/zulip/pull/29408#issuecomment-2054198028).

### Summary of Changes

- **Previous Behavior**: Previously, if the password input exceeded the maximum length, it was silently truncated. This PR enhances the experience by increasing the `maxlength` of the password input field beyond the supported limit.
- **Improved User Feedback**: Now, instead of truncating input, the signup button is disabled when the password length exceeds the limit. The field continues to accept input, showing the remaining character count and enhancing user experience.
- **New Function `check_overflow_password`**: Introduced in `signup.ts`, this function monitors the password input length and displays the remaining character count when the length approaches or exceeds the maximum limit.
- **Real-Time Limit Feedback**: Uses `render_compose_limit_indicator` to provide real-time feedback on character limits.
- **Visual Indicator**: Added a new span with the ID `password-limit-indicator` to visually indicate the character limit status for the password input field.

Fixes: #27922.

Design Discussion : [CZO Link](https://chat.zulip.org/#narrow/channel/101-design/topic/problem.20indicator.20when.20the.20password.20length.20exceeds).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Register Form: </summary>



https://github.com/user-attachments/assets/4a3b8e8c-8e09-4ffa-a56c-141c5c7720c6



</details>
<details>
<summary>Password Reset Form: </summary>



https://github.com/user-attachments/assets/3f553e6f-c65b-4b54-9780-8523e2a4b196



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


