### PR TITLE
fix: Fix cmd-[ shortcut on macOS to match ctrl-[ behavior

### DIFF
--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -30,8 +30,14 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
         return;
     }
 
-    $(kbd_elem_class).each(function () {
+    const $elements = $(kbd_elem_class);
+
+    $elements.each(function (index) {
         let key_text = $(this).text();
+
+        if (key_text === "Ctrl" && $elements.eq(index + 1).text() === "[") {
+            return;
+        }
 
         // We use data-mac-key attribute to override the default key in case
         // of exceptions. Currently, there are 2 shortcuts (for navigating back


### PR DESCRIPTION
This PR fixes the display and behavior of the `Ctrl + [`  keyboard shortcut on Mac systems. Previously, the logic automatically mapped Ctrl shortcuts to Cmd on Mac, which caused Ctrl + [ to be incorrectly displayed as Cmd + [. This PR ensures that Ctrl + [ remains consistent across platforms, as documented.

**Changes Made:**

- [x] Updated the logic in web/src/common.ts to handle Ctrl + [ as an exception, displaying it as Ctrl + [ on all platforms.
- [x] Modified adjust_mac_kbd_tags to allow selective handling of specific shortcuts to prevent automatic replacement of Ctrl with Cmd for certain keys.

**Screenshots of the changes:**

For Non-Mac users

![image](https://github.com/user-attachments/assets/c7042e80-d1e0-400b-8b17-16d02cd0a3ed)

For Mac users

![image](https://github.com/user-attachments/assets/72fa1413-e30a-4159-97a0-64d4dad9191c)


Fixes: #20107

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
