### PR TITLE
user_groups: Include group_id in success response on group creation.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 317**
+
+* [`POST /user_groups/create`](/api/create-user-group):
+  Added `group_id` to the success response of the user group creation
+  endpoint, enabling clients to easily access the unique identifier
+  of the newly created user group.
+
 **Feature level 316**
 
 * `PATCH /realm`, [`GET /events`](/api/get-events),

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 316  # Last bumped for `can_move_messages_between_topics_group`
+API_FEATURE_LEVEL = 317  # Last bumped for inclusion of `group_id` in user group creation response.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20457,7 +20457,30 @@ paths:
                 contentType: application/json
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: |
+            A success response containing the unique ID of the user group.
+            This field provides a straightforward way to reference the
+            newly created user group.
+
+            **Changes**: New in Zulip 10.0 (feature level 317).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - required:
+                      - group_id
+                    additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      group_id:
+                        type: integer
+                        description: |
+                          The unique ID of the created user group.
+                    example: {"msg": "", "result": "success", "group_id": 123}
+
         "400":
           description: Bad request.
           content:

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -101,8 +101,7 @@ def add_user_group(
             add_subgroups_to_user_group(
                 context.supergroup, context.direct_subgroups, acting_user=user_profile
             )
-
-    return json_success(request)
+    return json_success(request, data={"group_id": user_group.id})
 
 
 @require_member_or_admin


### PR DESCRIPTION
### Summary
Previously, the `group_id` was not included in the success response of the user group creation API. This omission made it challenging for clients to reference the newly created user group.

### Changes Introduced
This commit enhances the API by returning a success response that includes the unique ID of the user group with the key `group_id`. This improvement simplifies the process for clients to easily reference the newly created user group.

### Fixes
Fixes: #29686

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
