### PR TITLE
tests: Fix order of mock.patch in use_s3_backend.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -603,8 +603,8 @@ def use_s3_backend(method: Callable[P, None]) -> Callable[P, None]:
     def new_method(*args: P.args, **kwargs: P.kwargs) -> None:
         backend = S3UploadBackend()
         with (
-            mock.patch("zerver.lib.upload.upload_backend", backend),
             mock.patch("zerver.worker.thumbnail.upload_backend", backend),
+            mock.patch("zerver.lib.upload.upload_backend", backend),
             mock.patch("zerver.views.tusd.upload_backend", backend),
         ):
             return method(*args, **kwargs)


### PR DESCRIPTION
This is a somewhat hacky and fragile fix. Due to the order in which imports seem to happen, the original ordering breaks RealmImportExportTest: if one of the `use_s3_backend` tests runs before test_import_realm, the latter will fail while processing thumbnailing, as S3UploadBackend ends up leaking and
zerver.worker.thumbnail.upload_backend is still set to S3.

By making that mock.patch the first one that gets entered, and thus the last one to get cleaned up, we fix the leak and upload_backend is set back to LocalUploadBackend as it should.

This fixes the failure that I get via `test-backend RealmImportExportTest`, and sometimes in `test-backend` running all the tests; I'm guessing that's when one of the `s3` tests ends up run in the same process with `test_import_realm`.

```spoiler
p$ test-backend RealmImportExportTest -x
-- Running tests in serial mode.
Found 18 test(s).
Destroying test database for alias 'default'...
Using existing clone for alias 'default'...
Running zerver.tests.test_import_export.RealmImportExportTest.test_export_files_from_local
Running zerver.tests.test_import_export.RealmImportExportTest.test_export_files_from_s3
Running zerver.tests.test_import_export.RealmImportExportTest.test_export_realm_with_exportable_user_ids
Running zerver.tests.test_import_export.RealmImportExportTest.test_export_realm_with_member_consent
Running zerver.tests.test_import_export.RealmImportExportTest.test_get_incoming_message_ids
Running zerver.tests.test_import_export.RealmImportExportTest.test_import_emoji_error
Running zerver.tests.test_import_export.RealmImportExportTest.test_import_files_from_local
Running zerver.tests.test_import_export.RealmImportExportTest.test_import_files_from_s3
Running zerver.tests.test_import_export.RealmImportExportTest.test_import_message_edit_history
Running zerver.tests.test_import_export.RealmImportExportTest.test_import_of_authentication_methods
Running zerver.tests.test_import_export.RealmImportExportTest.test_import_realm
2024-10-27 01:59:08.426 ERR  [] Problem handling data on queue thumbnail
Traceback (most recent call last):
  File "/home/vagrant/zulip/zerver/worker/base.py", line 206, in do_consume
    consume_func(events)
  File "/home/vagrant/zulip/zerver/worker/base.py", line 241, in <lambda>
    consume_func = lambda events: self.consume(events[0])
  File "/home/vagrant/zulip/zerver/worker/thumbnail.py", line 44, in consume
    uploaded_thumbnails = ensure_thumbnails(row)
  File "/home/vagrant/zulip/zerver/worker/thumbnail.py", line 101, in ensure_thumbnails
    upload_backend.upload_message_attachment(
  File "/home/vagrant/zulip/zerver/lib/upload/s3.py", line 255, in upload_message_attachment
    upload_content_to_s3(
  File "/home/vagrant/zulip/zerver/lib/upload/s3.py", line 113, in upload_content_to_s3
    key.put(
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/boto3/resources/factory.py", line 581, in do_action
    response = action(self, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/botocore/client.py", line 1023, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the PutObject operation: The AWS Access Key Id you provided does not exist in our records.
Stack (most recent call last):
  File "/home/vagrant/zulip/tools/test-backend", line 543, in <module>
    main()
  File "/home/vagrant/zulip/tools/test-backend", line 447, in main
    failures = test_runner.run_tests(
  File "/home/vagrant/zulip/zerver/lib/test_runner.py", line 394, in run_tests
    result = self.run_suite(suite)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/test/runner.py", line 995, in run_suite
    return runner.run(suite)
  File "/usr/lib/python3.10/unittest/runner.py", line 184, in run
    test(result)
  File "/usr/lib/python3.10/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.10/unittest/suite.py", line 122, in run
    test(result)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/test/testcases.py", line 258, in __call__
    self._setup_and_call(result)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/test/testcases.py", line 293, in _setup_and_call
    super().__call__(result)
  File "/usr/lib/python3.10/unittest/case.py", line 650, in __call__
    return self.run(*args, **kwds)
  File "/home/vagrant/zulip/zerver/lib/test_classes.py", line 232, in run
    return super().run(result)
  File "/usr/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/home/vagrant/zulip/zerver/tests/test_import_export.py", line 831, in test_import_realm
    image_path_id = self.upload_and_thumbnail_image("img.png")
  File "/home/vagrant/zulip/zerver/lib/test_classes.py", line 2211, in upload_and_thumbnail_image
    with self.captureOnCommitCallbacks(execute=True):
  File "/usr/lib/python3.10/contextlib.py", line 142, in __exit__
    next(self.gen)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/test/testcases.py", line 1371, in captureOnCommitCallbacks
    callback()
  File "/home/vagrant/zulip/zerver/lib/queue.py", line 455, in <lambda>
    transaction.on_commit(lambda: queue_json_publish(queue_name, event))
  File "/home/vagrant/zulip/zerver/lib/queue.py", line 451, in queue_json_publish
    get_worker(queue_name, disable_timeout=True).consume_single_event(event)
  File "/home/vagrant/zulip/zerver/worker/base.py", line 242, in consume_single_event
    self.do_consume(consume_func, [event])
  File "/home/vagrant/zulip/zerver/worker/base.py", line 210, in do_consume
    self._handle_consume_exception(events, e)
  File "/home/vagrant/zulip/zerver/worker/base.py", line 267, in _handle_consume_exception
    logging.exception(
....
----------------------------------------------------------------------
Ran 11 tests in 6.440s
```