### PR TITLE
notifications: Add help link for "Followed topics" in triggers table.

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -834,7 +834,11 @@ export function get_notifications_table_row_data(
 }
 
 export type AllNotifications = {
-    general_settings: {label: string; notification_settings: NotificationSettingCheckbox[]}[];
+    general_settings: {
+        label: string;
+        notification_settings: NotificationSettingCheckbox[];
+        help_link?: string;
+    }[];
     settings: {
         desktop_notification_settings: string[];
         mobile_notification_settings: string[];
@@ -870,6 +874,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
                 followed_topic_notification_settings,
                 settings_object,
             ),
+            help_link: "/help/follow-a-topic",
         },
     ],
     settings: {

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -29,7 +29,12 @@
             <tbody>
                 {{#each general_settings}}
                     <tr>
-                        <td>{{ this.label }}</td>
+                        <td>
+                            {{ this.label }}
+                            {{#if this.help_link}}
+                                {{> ../help_link_widget link=this.help_link }}
+                            {{/if}}
+                        </td>
                         {{#each this.notification_settings}}
                             {{> notification_settings_checkboxes
                               setting_name=this.setting_name

--- a/web/tests/settings_config.test.cjs
+++ b/web/tests/settings_config.test.cjs
@@ -119,6 +119,7 @@ run_test("all_notifications", ({override}) => {
         },
         {
             label: "translated: Followed topics",
+            help_link: "/help/follow-a-topic",
             notification_settings: [
                 {
                     is_checked: false,


### PR DESCRIPTION
This Pull Request addresses an issue in the Notification triggers table located at the top of **Settings / Notifications**. It adds a help icon link next to **Followed topics**, directing users to `/help/follow-a-topic`. This enhancement provides quick access to relevant documentation, making it easier for users to learn how to follow topics directly from the settings page.

**Fixes**: https://github.com/zulip/zulip/issues/32033

**Screenshots and screen captures:**
| Before (light) | After (light) |
| --- | --- |
| ![image-before-light](https://github.com/user-attachments/assets/dfd52e61-5a37-4b35-a932-96e43393c9ae) | ![image-after-light](https://github.com/user-attachments/assets/fb183441-22f7-489b-b3a1-27c2bb57339a)

| Before (dark) | After (dark) |
| --- | --- |
| ![image-before-dark](https://github.com/user-attachments/assets/f0cd65ca-e885-4605-977e-3eb5177678c6) | ![image-after-dark](https://github.com/user-attachments/assets/2c899b54-4383-4faf-b818-c707aff99bc1)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
