### PR TITLE
streams: Send message when a user is unsubscribed from a channel.

### DIFF
--- a/help/configure-automated-notices.md
+++ b/help/configure-automated-notices.md
@@ -55,7 +55,8 @@ automated notices to help others understand how content was moved.
 
 ## Notices about users
 
-You will be notified if someone [subscribes you to a
+You will be notified if someone [subscribes you
+to or removes you from a
 channel](/help/subscribe-users-to-a-channel), or changes your
 [group](/help/user-groups) membership.
 

--- a/help/include/automated-dm-channel-remove.md
+++ b/help/include/automated-dm-channel-remove.md
@@ -1,0 +1,6 @@
+!!! warn ""
+
+    **Note**: Removing someone else from a channel sends them an
+    automated direct message from the [Notification Bot][notification-bot].
+
+[notification-bot]: /help/configure-automated-notices

--- a/help/subscribe-users-to-a-channel.md
+++ b/help/subscribe-users-to-a-channel.md
@@ -107,6 +107,7 @@ subscribe the user.
       You do not have to send the message you are composing for
       the user to be subscribed this way.
 
+{!automated-dm-channel-remove.md!}
 ## Related articles
 
 * [Introduction to channels](/help/introduction-to-channels)

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -125,7 +125,7 @@ def add_emoji_to_message() -> dict[str, object]:
 
     # The message ID here is hardcoded based on the corresponding value
     # for the example message IDs we use in zulip.yaml.
-    message_id = 48
+    message_id = 49
     emoji_name = "octopus"
     emoji_code = "1f419"
     reaction_type = "unicode_emoji"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -25847,7 +25847,7 @@ components:
         The target message's ID.
       schema:
         type: integer
-      example: 43
+      example: 44
       required: true
     UserId:
       name: user_id

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -88,7 +88,7 @@ class OpenAPIToolsTest(ZulipTestCase):
             description="The target message's ID.\n",
             json_encoded=False,
             value_schema={"type": "integer"},
-            example=43,
+            example=44,
             required=True,
             deprecated=False,
         )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -7630,7 +7630,7 @@ class GetSubscribersTest(ZulipTestCase):
             )
 
         msg = f"""
-            @**King Hamlet|{hamlet.id}** subscribed you to the following channels:
+            @_**King Hamlet|{hamlet.id}** subscribed you to the following channels:
 
             * #**stream_0**
             * #**stream_1**
@@ -7665,7 +7665,7 @@ class GetSubscribersTest(ZulipTestCase):
         )
 
         msg = f"""
-            @**King Hamlet|{hamlet.id}** subscribed you to the channel #**stream_invite_only_1**.
+            @_**King Hamlet|{hamlet.id}** subscribed you to the channel #**stream_invite_only_1**.
             """
         for user in [cordelia, othello, polonius]:
             self.assert_user_got_subscription_notification(user, msg)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3302,6 +3302,20 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.archive_stream(priv_stream)
 
+    def assert_user_got_unsubscription_notification(
+        self, user: UserProfile, expected_msg: str
+    ) -> None:
+        # verify that the user was sent a message informing them about the subscription
+        realm = user.realm
+        msg = most_recent_message(user)
+        self.assertEqual(msg.recipient.type, msg.recipient.PERSONAL)
+        self.assertEqual(msg.sender_id, self.notification_bot(realm).id)
+
+        def non_ws(s: str) -> str:
+            return s.replace("\n", "").replace(" ", "")
+
+        self.assertEqual(non_ws(msg.content), non_ws(expected_msg))
+
     def attempt_unsubscribe_of_principal(
         self,
         target_users: list[UserProfile],
@@ -3381,16 +3395,60 @@ class StreamAdminTest(ZulipTestCase):
         those you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=29,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
             invite_only=False,
             target_users_subbed=True,
         )
+        user_profile = self.example_user("iago")
+        unsubscription_notification_message = f"""
+        @_**{user_profile.full_name}|{user_profile.id}** unsubscribed you from the channel #**hümbüǵ**.
+        """
         json = self.assert_json_success(result)
         self.assert_length(json["removed"], 1)
         self.assert_length(json["not_removed"], 0)
+        self.assert_user_got_unsubscription_notification(
+            self.example_user("cordelia"), unsubscription_notification_message
+        )
+
+    def test_realm_admin_remove_others_from_multiple_public_streams(self) -> None:
+        user_profile = self.example_user("iago")
+        self.login_user(user_profile)
+
+        target_users = [self.example_user(name) for name in ["cordelia", "prospero", "hamlet"]]
+        principals = [user.id for user in target_users]
+        public_channels_to_unsubscribe = []
+
+        for i in range(1, 5):
+            channel_name = f"channel_{i}"
+            self.make_stream(channel_name, invite_only=False)
+            public_channels_to_unsubscribe.append(channel_name)
+            self.subscribe(user_profile, channel_name)
+            for user in target_users:
+                self.subscribe(user, channel_name)
+
+        result = self.client_delete(
+            "/json/users/me/subscriptions",
+            {
+                "subscriptions": orjson.dumps(public_channels_to_unsubscribe).decode(),
+                "principals": orjson.dumps(principals).decode(),
+            },
+        )
+        self.assert_json_success(result)
+
+        unsubscription_notification_message = f"""
+        @_**{user_profile.full_name}|{user_profile.id}** unsubscribed you from the following channels:
+        """
+        unsubscription_notification_message += "\n\n"
+        for channel_name in public_channels_to_unsubscribe:
+            unsubscription_notification_message += f"* #**{channel_name}**\n"
+
+        for target_user in target_users:
+            self.assert_user_got_unsubscription_notification(
+                target_user, unsubscription_notification_message
+            )
 
     def test_realm_admin_remove_multiple_users_from_stream(self) -> None:
         """
@@ -3408,8 +3466,8 @@ class StreamAdminTest(ZulipTestCase):
             for name in ["cordelia", "prospero", "iago", "hamlet", "outgoing_webhook_bot"]
         ]
         result = self.attempt_unsubscribe_of_principal(
-            query_count=20,
-            cache_count=8,
+            query_count=52,
+            cache_count=27,
             target_users=target_users,
             is_realm_admin=True,
             is_subbed=True,
@@ -3426,7 +3484,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=16,
+            query_count=32,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3443,7 +3501,7 @@ class StreamAdminTest(ZulipTestCase):
         streams you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=16,
+            query_count=32,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -3469,7 +3527,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_admin_remove_others_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=29,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3483,7 +3541,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_admin_remove_multiple_users_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=15,
+            query_count=39,
             target_users=[self.example_user("cordelia"), self.example_user("prospero")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3497,7 +3555,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_remove_unsubbed_user_along_with_subbed(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=12,
+            query_count=13,
             target_users=[self.example_user("cordelia"), self.example_user("iago")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3514,7 +3572,7 @@ class StreamAdminTest(ZulipTestCase):
         fails gracefully.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=6,
+            query_count=7,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -3530,7 +3588,7 @@ class StreamAdminTest(ZulipTestCase):
         webhook_bot = self.example_user("webhook_bot")
         do_change_bot_owner(webhook_bot, bot_owner=user_profile, acting_user=user_profile)
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=14,
             target_users=[webhook_bot],
             is_realm_admin=False,
             is_subbed=True,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -569,13 +569,13 @@ def you_were_just_subscribed_message(
     if len(subscriptions) == 1:
         with override_language(recipient_user.default_language):
             return _("{user_full_name} subscribed you to the channel {channel_name}.").format(
-                user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
+                user_full_name=f"@_**{acting_user.full_name}|{acting_user.id}**",
                 channel_name=f"#**{subscriptions[0]}**",
             )
 
     with override_language(recipient_user.default_language):
         message = _("{user_full_name} subscribed you to the following channels:").format(
-            user_full_name=f"@**{acting_user.full_name}|{acting_user.id}**",
+            user_full_name=f"@_**{acting_user.full_name}|{acting_user.id}**",
         )
     message += "\n\n"
     for channel_name in subscriptions:


### PR DESCRIPTION
Previously, Notification Bot only sent messages to notify users when they were added to channels by others. However, there was no corresponding notification when they were removed from channels.

This commit ensures that when a user is unsubscribed from a channel by another user, Notification Bot sends a message to inform them, using a silent mention of the acting user. The message follows this format:

> @_**username** unsubscribed you from the channel #channel_name.

**Fixes:** #29272

---

<!-- Describe your pull request here. -->

### Screenshots and Screen Captures

| Scenario                         | Screenshot                                                                                                              |
|----------------------------------|--------------------------------------------------------------------------------------------------------------------------|
| **Single Stream Unsubscribe Notification**  | <img width="935" alt="Single Stream Unsubscribe Notification" src="https://github.com/user-attachments/assets/e99e251d-93fd-46a6-8b8f-bae0ab84e77d"> |
| **Multiple Streams Unsubscribe Notification** | <img width="935" alt="Multiple Streams Unsubscribe Notification" src="https://github.com/user-attachments/assets/e36eb67d-de85-43e3-8bb0-7d4a3bf4cb07"> |

| Change Type          | Image Link                                                                                                                                 |
|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| Documentation Change 1 | ![Documentation Change 1](https://github.com/user-attachments/assets/a3c9abcc-8db3-4227-975e-4b47c755f6ff)                                    |
| Documentation Change 2 | ![Documentation Change 2](https://github.com/user-attachments/assets/3b8e13b2-6ee1-46cc-8c68-ff9e83f1bb0b)                                    |


---

<details>
<summary>Self-review Checklist</summary>
<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>