### PR TITLE
ui_update: Show the number of messages to be moved.

### DIFF
--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -84,6 +84,15 @@ export function add_new_messages_data(
     return msg_list_data.add_messages(messages);
 }
 
+export function get_count_of_messages_in_topic_sent_after_current_message(
+    stream_id: number,
+    topic: string,
+    message_id: number,
+): number {
+    const all_messages = get_messages_in_topic(stream_id, topic);
+    return all_messages.filter((msg) => msg.id >= message_id).length;
+}
+
 export function get_messages_in_topic(stream_id: number, topic: string): Message[] {
     return all_messages_data
         .all_messages()

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -901,6 +901,11 @@ ul.popover-group-menu-member-list {
         margin: 0;
     }
 
+    .modal_select {
+        width: auto;
+        max-width: 100%;
+    }
+
     #move_topic_to_stream_widget_wrapper {
         display: flex;
         margin-bottom: 10px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -938,7 +938,6 @@ div.focused-message-list {
 
 #move_topic_modal select {
     width: auto;
-    margin-bottom: 10px;
     max-width: 100%;
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -936,11 +936,6 @@ div.focused-message-list {
     outline: none;
 }
 
-#move_topic_modal select {
-    width: auto;
-    max-width: 100%;
-}
-
 .topic_move_breadcrumb_messages {
     margin: 0 5px 5px 0;
     align-self: center;

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -16,12 +16,13 @@
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}
-        <select name="propagate_mode" class="message_edit_topic_propagate modal_select bootstrap-focus-style">
+        <select id="message_move_select_options" class="message_edit_topic_propagate modal_select bootstrap-focus-style">
             <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
             <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
             <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
         </select>
         {{/if}}
+        <p id="move_messages_count"></p>
         <div class="topic_move_breadcrumb_messages">
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />


### PR DESCRIPTION
This PR adds a message count display in the **Move topic** and **Move messages** modals, showing the number of messages that will be affected by the move action. The information is displayed below the stream/topic or selection specification, depending on the context of the modal.

**Tasks completed**

- [x] Added message count display below the stream/topic in the "Move topic" UI.
- [x] Added message count display below the selection area in the "Move messages" UI.
- [x] The count will display in the format: "N messages will be moved."
- [x] Special handling for N = 1.
- [x] Handling special case when the message view is not topic narrowed. 

## Screenshots

### Move messages modal


<table>
<thead>
<tr>
<th>Before</th>
<th> After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/52a9205e-1dde-413a-ab12-20fd3af12b4a" alt="Before Image 1">
</td>
<td>
<img src="https://github.com/user-attachments/assets/5b442d2d-d543-48fa-bdda-2b9b6d7b8c5b" alt="After Image 1">
</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/177decf5-c9df-4b23-8eac-9280f0e413fc" alt="Before Image 2">
</td>
<td>
<img src="https://github.com/user-attachments/assets/6c800d47-357d-4702-8129-03238359687e" alt="After Image 2">
</td>
</tr>
</tbody>
</table>

### Move topic modal


<table>
<thead>
<tr>
<th>Before</th>
<th> After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/33242a5d-989e-4550-a5bd-4dfefa8ca9bb" alt="Before Image 1">
</td>
<td>
<img src="https://github.com/user-attachments/assets/baf78b21-a56c-4f24-b5fd-fedd535d4679" alt="After Image 1">
</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/8838b184-c2a1-43fa-9a5b-e1225c172d7e" alt="Before Image 2">
</td>
<td>
<img src="https://github.com/user-attachments/assets/8a56a72f-2e63-4674-bc8d-ef905c7fe3c8" alt="After Image 2">
</td>
</tr>
</tbody>
</table>

###  Corner Cases

<details>
<summary> Check for N = 1 and N > 1 </summary>
<table>
<thead>
<tr>
<th>For N = 1</th>
<th>For N > 1</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/1d7a2740-ba9c-464f-9265-52b1c73f0501" alt="Before Image 1">
</td>
<td>
<img src="https://github.com/user-attachments/assets/442936f7-b0d3-483c-a3ac-ceeab28d2e53" alt="After Image 1">
</td>
</tr>
</tbody>
</table>
</details>

<details>
<summary> Is view topic narrowed? </summary>
<table>
<thead>
<tr>
<th>True</th>
<th>False</th>
</tr>
</thead>
<tbody>
<tr>
<td>

https://github.com/user-attachments/assets/182404e7-9a2f-4cac-8ca8-fdf6c25162ce


</td>
<td>

https://github.com/user-attachments/assets/c1609203-e299-4afc-81e3-4622f7a7f47a


</td>
</tr>
</tbody>
</table>
</details>



Fixes: #23115 .

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
