### PR TITLE
tooltip: Remove "last active" time from deactivated user tooltip.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -240,6 +240,7 @@ export function get_title_data(
     second_line: string | undefined;
     third_line: string;
     show_you?: boolean;
+    is_deactivated?: boolean;
 } {
     if (is_group) {
         // For groups, just return a string with recipient names.
@@ -253,6 +254,7 @@ export function get_title_data(
     // Since it's not a group, user_ids_string is a single user ID.
     const user_id = Number.parseInt(user_ids_string, 10);
     const person = people.get_by_user_id(user_id);
+    const is_deactivated = !people.is_person_active(user_id);
 
     if (person.is_bot) {
         const bot_owner = people.get_bot_owner_user(person);
@@ -266,7 +268,10 @@ export function get_title_data(
             return {
                 first_line: person.full_name,
                 second_line: bot_owner_name,
-                third_line: "",
+                third_line: is_deactivated
+                    ? $t({defaultMessage: "This bot has been deactivated."})
+                    : "",
+                is_deactivated,
             };
         }
 
@@ -282,6 +287,16 @@ export function get_title_data(
     // Since is_group=False, it's a single, human user.
     const last_seen = user_last_seen_time_status(user_id);
     const is_my_user = people.is_my_user_id(user_id);
+
+    if (is_deactivated) {
+        return {
+            first_line: person.full_name,
+            second_line: $t({defaultMessage: "This user has been deactivated."}),
+            third_line: "",
+            show_you: is_my_user,
+            is_deactivated,
+        };
+    }
 
     // Users has a status.
     if (user_status.get_status_text(user_id)) {

--- a/web/templates/buddy_list_tooltip_content.hbs
+++ b/web/templates/buddy_list_tooltip_content.hbs
@@ -6,9 +6,9 @@
         {{/if}}
     </div>
     {{#if second_line}}
-        <div class="tooltip-inner-content">{{second_line}}</div>
+        <div class="tooltip-inner-content {{#if is_deactivated}}italic{{/if}}" >{{second_line}}</div>
     {{/if}}
     {{#if third_line}}
-        <div class="tooltip-inner-content">{{third_line}}</div>
+        <div class="tooltip-inner-content {{#if is_deactivated}}italic{{/if}}">{{third_line}}</div>
     {{/if}}
 </div>

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -192,6 +192,7 @@ test("title_data", ({override}) => {
         first_line: "Blue Herring Bot",
         second_line: "translated: Owner: Human Myself",
         third_line: "",
+        is_deactivated: false,
     };
     assert.deepEqual(
         buddy_data.get_title_data(bot_with_owner.user_id, is_group),
@@ -228,6 +229,30 @@ test("title_data", ({override}) => {
         show_you: false,
     };
     assert.deepEqual(buddy_data.get_title_data(old_user.user_id, is_group), expected_data);
+
+    // Deactivated users.
+    people.deactivate(selma);
+    expected_data = {
+        first_line: "Human Selma",
+        second_line: "translated: This user has been deactivated.",
+        third_line: "",
+        show_you: false,
+        is_deactivated: true,
+    };
+    assert.deepEqual(buddy_data.get_title_data(selma.user_id, is_group), expected_data);
+
+    // Deactivated bots.
+    people.deactivate(bot_with_owner);
+    expected_group_data = {
+        first_line: "Blue Herring Bot",
+        second_line: "translated: Owner: Human Myself",
+        third_line: "translated: This bot has been deactivated.",
+        is_deactivated: true,
+    };
+    assert.deepEqual(
+        buddy_data.get_title_data(bot_with_owner.user_id, is_group),
+        expected_group_data,
+    );
 });
 
 test("filters deactivated users", () => {


### PR DESCRIPTION
Removes "last active" time from the deactivated user tooltip and instead adds "This user has been deactivated." Also, in the deactivated bot tooltip, "This bot has been deactivated." has been added.

Fixes #32136.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![WhatsApp Image 2024-10-28 at 12 26 54_eef87a0d](https://github.com/user-attachments/assets/e210e949-8d81-477c-9a9e-798badf31a31) | ![image](https://github.com/user-attachments/assets/08b7c49f-be71-4e18-b8ca-4164a4e6a37c) |
| ![image](https://github.com/user-attachments/assets/63c5edc7-7f53-4116-b1c3-248be4ad2a86) | ![image](https://github.com/user-attachments/assets/82b7d2a4-9f80-4b83-ae8e-313923e8900c) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
