### PR TITLE
notification_settings: Added help link for followed topics

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -852,7 +852,7 @@ export function get_notifications_table_row_data(
 }
 
 export type AllNotifications = {
-    general_settings: {label: string; notification_settings: NotificationSettingCheckbox[]}[];
+    general_settings: {label: string; help_link?: string; notification_settings: NotificationSettingCheckbox[]}[];
     settings: {
         desktop_notification_settings: string[];
         mobile_notification_settings: string[];
@@ -884,6 +884,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
         },
         {
             label: $t({defaultMessage: "Followed topics"}),
+            help_link: "/help/follow-a-topic",
             notification_settings: get_notifications_table_row_data(
                 followed_topic_notification_settings,
                 settings_object,

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -29,7 +29,11 @@
             <tbody>
                 {{#each general_settings}}
                     <tr>
-                        <td>{{ this.label }}</td>
+                        <td>{{ this.label }}
+                        {{#if this.help_link}}
+                            {{> ../help_link_widget link= this.help_link }}
+                        {{/if}}
+                        </td>
                         {{#each this.notification_settings}}
                             {{> notification_settings_checkboxes
                               setting_name=this.setting_name

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -119,6 +119,7 @@ run_test("all_notifications", ({override}) => {
         },
         {
             label: "translated: Followed topics",
+            help_link: "/help/follow-a-topics",
             notification_settings: [
                 {
                     is_checked: false,


### PR DESCRIPTION
Added help link for "Followed topics" in Settings/Notifications

Fixes: #32033 

**Before**
![image](https://github.com/user-attachments/assets/623343dc-333b-4908-81fd-264f978db37d)

**After**
![image](https://github.com/user-attachments/assets/13834574-ede5-40b1-9cb4-3aca73534842)


Added optional `help_link` support to the `AllNotifications` section in `settings_config.ts`. If a `help_link` is provided, a help icon (`[?]`) will be conditionally rendered in front of the `general_settings` label. Clicking the icon directs the user to the specified URL in a new page, allowing easy access to relevant documentation or resources.

<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
