### PR TITLE
dark theme: Make critical button fixes.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -216,7 +216,6 @@ input::placeholder {
         &:active {
             border-color: hsl(156deg 30% 40%);
             color: hsl(156deg 44% 43%);
-            background-color: hsl(154deg 33% 96%);
         }
     }
 
@@ -232,7 +231,6 @@ input::placeholder {
         &:active {
             color: hsl(35deg 82% 40%);
             border-color: hsl(35deg 55% 70%);
-            background-color: hsl(33deg 48% 96%);
         }
     }
 
@@ -248,7 +246,6 @@ input::placeholder {
         &:active {
             color: hsl(357deg 55% 63%);
             border-color: hsl(2deg 46% 68%);
-            background-color: hsl(7deg 82% 98%);
         }
     }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -178,6 +178,9 @@ input::placeholder {
 
     &:hover {
         background-color: var(--color-background-zulip-button-hover);
+        /* Reset styles on a.button instances. */
+        text-decoration: none;
+        color: inherit;
     }
 
     &:focus {


### PR DESCRIPTION
This PR corrects some unsightly flashes of white on `:active` button states in dark mode, and also shores up the text-decoration and color inheritance for `a.button` cases.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![deactivate-btn-active-before](https://github.com/user-attachments/assets/f90ec782-af24-4443-9701-70901f3a36ae) | ![deactivate-btn-active-after](https://github.com/user-attachments/assets/b1ea5914-8017-4906-8d09-86d61427e906) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>