### PR TITLE
buddy_list: Show all sections (uncollapse) when searching.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -285,15 +285,12 @@ export class BuddyList extends BuddyListConf {
         // in already-sorted order.
         this.all_user_ids = opts.all_user_ids;
 
-        this.fill_screen_with_content();
-
         $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove();
         $("#buddy-list-other-users-container .view-all-users-link").remove();
         if (!buddy_data.get_is_searching_users()) {
             this.render_view_user_list_links();
         }
 
-        this.render_section_headers();
         // Ensure the "other" section is visible when headers are collapsed,
         // because we're hiding its header so there's no way to collapse or
         // uncollapse the list in this view. Ensure we're showing/hiding as
@@ -302,7 +299,9 @@ export class BuddyList extends BuddyListConf {
             "#buddy-list-other-users-container",
             this.render_data.hide_headers ? false : this.other_users_is_collapsed,
         );
+
         this.update_empty_list_placeholders();
+        this.fill_screen_with_content();
     }
 
     update_empty_list_placeholders(): void {

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -452,7 +452,6 @@ export class BuddyList extends BuddyListConf {
                     id: "buddy-list-participants-section-heading",
                     header_text: $t({defaultMessage: "In this conversation"}),
                     user_count: get_formatted_sub_count(this.participant_user_ids.length),
-                    toggle_class: "toggle-participants",
                     is_collapsed: this.participants_is_collapsed,
                 }),
             ),
@@ -466,7 +465,6 @@ export class BuddyList extends BuddyListConf {
                     user_count: get_formatted_sub_count(
                         total_human_subscribers_count - this.participant_user_ids.length,
                     ),
-                    toggle_class: "toggle-users-matching-view",
                     is_collapsed: this.users_matching_view_is_collapsed,
                 }),
             ),
@@ -478,7 +476,6 @@ export class BuddyList extends BuddyListConf {
                     id: "buddy-list-other-users-section-heading",
                     header_text: $t({defaultMessage: "Others"}),
                     user_count: get_formatted_sub_count(other_users_count),
-                    toggle_class: "toggle-other-users",
                     is_collapsed: this.other_users_is_collapsed,
                 }),
             ),
@@ -491,11 +488,11 @@ export class BuddyList extends BuddyListConf {
             "collapsed",
             this.participants_is_collapsed,
         );
-        $("#buddy-list-participants-container .toggle-participants").toggleClass(
+        $("#buddy-list-participants-container .buddy-list-section-toggle").toggleClass(
             "rotate-icon-down",
             !this.participants_is_collapsed,
         );
-        $("#buddy-list-participants-container .toggle-participants").toggleClass(
+        $("#buddy-list-participants-container .buddy-list-section-toggle").toggleClass(
             "rotate-icon-right",
             this.participants_is_collapsed,
         );
@@ -511,11 +508,11 @@ export class BuddyList extends BuddyListConf {
             "collapsed",
             this.users_matching_view_is_collapsed,
         );
-        $("#buddy-list-users-matching-view-container .toggle-users-matching-view").toggleClass(
+        $("#buddy-list-users-matching-view-container .buddy-list-section-toggle").toggleClass(
             "rotate-icon-down",
             !this.users_matching_view_is_collapsed,
         );
-        $("#buddy-list-users-matching-view-container .toggle-users-matching-view").toggleClass(
+        $("#buddy-list-users-matching-view-container .buddy-list-section-toggle").toggleClass(
             "rotate-icon-right",
             this.users_matching_view_is_collapsed,
         );
@@ -531,11 +528,11 @@ export class BuddyList extends BuddyListConf {
             "collapsed",
             this.other_users_is_collapsed,
         );
-        $("#buddy-list-other-users-container .toggle-other-users").toggleClass(
+        $("#buddy-list-other-users-container .buddy-list-section-toggle").toggleClass(
             "rotate-icon-down",
             !this.other_users_is_collapsed,
         );
-        $("#buddy-list-other-users-container .toggle-other-users").toggleClass(
+        $("#buddy-list-other-users-container .buddy-list-section-toggle").toggleClass(
             "rotate-icon-right",
             this.other_users_is_collapsed,
         );

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -79,7 +79,7 @@ type BuddyListRenderData = {
     other_users_count: number;
     total_human_users: number;
     hide_headers: boolean;
-    participant_ids_set: Set<number>;
+    all_participant_ids: Set<number>;
 };
 
 function get_render_data(): BuddyListRenderData {
@@ -90,7 +90,7 @@ function get_render_data(): BuddyListRenderData {
     const total_human_users = people.get_active_human_count();
     const other_users_count = total_human_users - total_human_subscribers_count;
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
-    const participant_ids_set = buddy_data.get_conversation_participants();
+    const all_participant_ids = buddy_data.get_conversation_participants();
 
     return {
         current_sub,
@@ -99,7 +99,7 @@ function get_render_data(): BuddyListRenderData {
         other_users_count,
         total_human_users,
         hide_headers,
-        participant_ids_set,
+        all_participant_ids,
     };
 }
 
@@ -364,12 +364,12 @@ export class BuddyList extends BuddyListConf {
     }
 
     update_section_header_counts(): void {
-        const {total_human_subscribers_count, other_users_count, participant_ids_set} =
+        const {total_human_subscribers_count, other_users_count, all_participant_ids} =
             this.render_data;
         const subscriber_section_user_count =
             total_human_subscribers_count - this.participant_user_ids.length;
 
-        const formatted_participants_count = get_formatted_sub_count(participant_ids_set.size);
+        const formatted_participants_count = get_formatted_sub_count(all_participant_ids.size);
         const formatted_sub_users_count = get_formatted_sub_count(subscriber_section_user_count);
         const formatted_other_users_count = get_formatted_sub_count(other_users_count);
 
@@ -385,7 +385,7 @@ export class BuddyList extends BuddyListConf {
 
         $("#buddy-list-participants-section-heading").attr(
             "data-user-count",
-            participant_ids_set.size,
+            all_participant_ids.size,
         );
         $("#buddy-list-users-matching-view-section-heading").attr(
             "data-user-count",
@@ -398,11 +398,11 @@ export class BuddyList extends BuddyListConf {
     }
 
     render_section_headers(): void {
-        const {hide_headers, participant_ids_set} = this.render_data;
+        const {hide_headers, all_participant_ids} = this.render_data;
         // We only show the participants list if it has members, so even if we're not
         // changing filters and only updating user counts for the current filter, that
         // can affect if we show/hide this section.
-        const show_participants_list = !hide_headers && participant_ids_set.size;
+        const show_participants_list = !hide_headers && all_participant_ids.size;
         $("#buddy-list-participants-container").toggleClass("no-display", !show_participants_list);
 
         // If we're not changing filters, this just means some users were added or
@@ -444,7 +444,7 @@ export class BuddyList extends BuddyListConf {
 
         let header_text;
         if (current_sub) {
-            if (participant_ids_set.size) {
+            if (all_participant_ids.size) {
                 header_text = $t({defaultMessage: "Others in this channel"});
             } else {
                 header_text = $t({defaultMessage: "In this channel"});
@@ -558,7 +558,7 @@ export class BuddyList extends BuddyListConf {
 
         for (const item of items) {
             if (buddy_data.user_matches_narrow(item.user_id, pm_ids_set, current_sub?.stream_id)) {
-                if (this.render_data.participant_ids_set.has(item.user_id)) {
+                if (this.render_data.all_participant_ids.has(item.user_id)) {
                     participants.push(item);
                     this.participant_user_ids.push(item.user_id);
                 } else {
@@ -822,7 +822,7 @@ export class BuddyList extends BuddyListConf {
                     list_user_id,
                     current_sub,
                     pm_ids_set,
-                    this.render_data.participant_ids_set,
+                    this.render_data.all_participant_ids,
                 ) < 0,
         );
         return i === -1 ? user_id_list.length : i;
@@ -934,7 +934,7 @@ export class BuddyList extends BuddyListConf {
             current_sub?.stream_id,
         );
         let user_id_list;
-        if (this.render_data.participant_ids_set.has(user_id)) {
+        if (this.render_data.all_participant_ids.has(user_id)) {
             user_id_list = this.participant_user_ids;
         } else if (is_subscribed_user) {
             user_id_list = this.users_matching_view_ids;
@@ -959,7 +959,7 @@ export class BuddyList extends BuddyListConf {
             html,
             new_user_id,
             is_subscribed_user,
-            is_participant_user: this.render_data.participant_ids_set.has(user_id),
+            is_participant_user: this.render_data.all_participant_ids.has(user_id),
         });
     }
 

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -330,27 +330,27 @@ export class BuddyList extends BuddyListConf {
             }
         }
 
-        $("#buddy-list-users-matching-view").attr(
-            "data-search-results-empty",
-            matching_view_empty_list_message,
-        );
-        if ($("#buddy-list-users-matching-view .empty-list-message").length) {
-            const empty_list_widget_html = render_empty_list_widget_for_list({
-                empty_list_message: matching_view_empty_list_message,
-            });
-            $("#buddy-list-users-matching-view").html(empty_list_widget_html);
+        function add_or_update_empty_list_placeholder(selector: string, message: string): void {
+            if (
+                $(selector).children().length === 0 ||
+                $(`${selector} .empty-list-message`).length
+            ) {
+                const empty_list_widget_html = render_empty_list_widget_for_list({
+                    empty_list_message: message,
+                });
+                $(selector).html(empty_list_widget_html);
+            }
         }
 
-        $("#buddy-list-other-users").attr(
-            "data-search-results-empty",
+        add_or_update_empty_list_placeholder(
+            "#buddy-list-users-matching-view",
+            matching_view_empty_list_message,
+        );
+
+        add_or_update_empty_list_placeholder(
+            "#buddy-list-other-users",
             other_users_empty_list_message,
         );
-        if ($("#buddy-list-other-users .empty-list-message").length) {
-            const empty_list_widget_html = render_empty_list_widget_for_list({
-                empty_list_message: other_users_empty_list_message,
-            });
-            $("#buddy-list-other-users").html(empty_list_widget_html);
-        }
     }
 
     update_section_header_counts(): void {

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -294,17 +294,15 @@ export class BuddyList extends BuddyListConf {
         }
 
         this.render_section_headers();
-        if (this.render_data.hide_headers) {
-            // Ensure the section isn't collapsed, because we're hiding its header
-            // so there's no way to collapse or uncollapse the list in this view.
-            $("#buddy-list-other-users-container").toggleClass("collapsed", false);
-        } else {
-            $("#buddy-list-other-users-container").toggleClass(
-                "collapsed",
-                this.other_users_is_collapsed,
-            );
-            this.update_empty_list_placeholders();
-        }
+        // Ensure the "other" section is visible when headers are collapsed,
+        // because we're hiding its header so there's no way to collapse or
+        // uncollapse the list in this view. Ensure we're showing/hiding as
+        // the user specified otherwise.
+        this.set_section_collapse(
+            "#buddy-list-other-users-container",
+            this.render_data.hide_headers ? false : this.other_users_is_collapsed,
+        );
+        this.update_empty_list_placeholders();
     }
 
     update_empty_list_placeholders(): void {
@@ -482,18 +480,22 @@ export class BuddyList extends BuddyListConf {
         );
     }
 
+    set_section_collapse(container_selector: string, is_collapsed: boolean): void {
+        $(container_selector).toggleClass("collapsed", is_collapsed);
+        $(`${container_selector} .buddy-list-section-toggle`).toggleClass(
+            "rotate-icon-down",
+            !is_collapsed,
+        );
+        $(`${container_selector} .buddy-list-section-toggle`).toggleClass(
+            "rotate-icon-right",
+            is_collapsed,
+        );
+    }
+
     toggle_participants_section(): void {
         this.participants_is_collapsed = !this.participants_is_collapsed;
-        $("#buddy-list-participants-container").toggleClass(
-            "collapsed",
-            this.participants_is_collapsed,
-        );
-        $("#buddy-list-participants-container .buddy-list-section-toggle").toggleClass(
-            "rotate-icon-down",
-            !this.participants_is_collapsed,
-        );
-        $("#buddy-list-participants-container .buddy-list-section-toggle").toggleClass(
-            "rotate-icon-right",
+        this.set_section_collapse(
+            "#buddy-list-participants-container",
             this.participants_is_collapsed,
         );
 
@@ -504,16 +506,8 @@ export class BuddyList extends BuddyListConf {
 
     toggle_users_matching_view_section(): void {
         this.users_matching_view_is_collapsed = !this.users_matching_view_is_collapsed;
-        $("#buddy-list-users-matching-view-container").toggleClass(
-            "collapsed",
-            this.users_matching_view_is_collapsed,
-        );
-        $("#buddy-list-users-matching-view-container .buddy-list-section-toggle").toggleClass(
-            "rotate-icon-down",
-            !this.users_matching_view_is_collapsed,
-        );
-        $("#buddy-list-users-matching-view-container .buddy-list-section-toggle").toggleClass(
-            "rotate-icon-right",
+        this.set_section_collapse(
+            "#buddy-list-users-matching-view-container",
             this.users_matching_view_is_collapsed,
         );
 
@@ -524,16 +518,8 @@ export class BuddyList extends BuddyListConf {
 
     toggle_other_users_section(): void {
         this.other_users_is_collapsed = !this.other_users_is_collapsed;
-        $("#buddy-list-other-users-container").toggleClass(
-            "collapsed",
-            this.other_users_is_collapsed,
-        );
-        $("#buddy-list-other-users-container .buddy-list-section-toggle").toggleClass(
-            "rotate-icon-down",
-            !this.other_users_is_collapsed,
-        );
-        $("#buddy-list-other-users-container .buddy-list-section-toggle").toggleClass(
-            "rotate-icon-right",
+        this.set_section_collapse(
+            "#buddy-list-other-users-container",
             this.other_users_is_collapsed,
         );
 

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -367,7 +367,7 @@ export class BuddyList extends BuddyListConf {
         const {total_human_subscribers_count, other_users_count, all_participant_ids} =
             this.render_data;
         const subscriber_section_user_count =
-            total_human_subscribers_count - this.participant_user_ids.length;
+            total_human_subscribers_count - all_participant_ids.size;
 
         const formatted_participants_count = get_formatted_sub_count(all_participant_ids.size);
         const formatted_sub_users_count = get_formatted_sub_count(subscriber_section_user_count);
@@ -458,7 +458,7 @@ export class BuddyList extends BuddyListConf {
                 render_section_header({
                     id: "buddy-list-participants-section-heading",
                     header_text: $t({defaultMessage: "In this conversation"}),
-                    user_count: get_formatted_sub_count(this.participant_user_ids.length),
+                    user_count: get_formatted_sub_count(all_participant_ids.size),
                     is_collapsed: this.participants_is_collapsed,
                 }),
             ),
@@ -470,7 +470,7 @@ export class BuddyList extends BuddyListConf {
                     id: "buddy-list-users-matching-view-section-heading",
                     header_text,
                     user_count: get_formatted_sub_count(
-                        total_human_subscribers_count - this.participant_user_ids.length,
+                        total_human_subscribers_count - all_participant_ids.size,
                     ),
                     is_collapsed: this.users_matching_view_is_collapsed,
                 }),

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -312,10 +312,13 @@ export class BuddyList extends BuddyListConf {
 
         let matching_view_empty_list_message;
         let other_users_empty_list_message;
+        // Only visible when searching, since we usually hide an empty participants section
+        let participants_empty_list_message;
 
         if (buddy_data.get_is_searching_users()) {
             matching_view_empty_list_message = $t({defaultMessage: "No matching users."});
             other_users_empty_list_message = $t({defaultMessage: "No matching users."});
+            participants_empty_list_message = $t({defaultMessage: "No matching users."});
         } else {
             if (has_inactive_users_matching_view) {
                 matching_view_empty_list_message = $t({defaultMessage: "No active users."});
@@ -351,6 +354,13 @@ export class BuddyList extends BuddyListConf {
             "#buddy-list-other-users",
             other_users_empty_list_message,
         );
+
+        if (participants_empty_list_message) {
+            add_or_update_empty_list_placeholder(
+                "#buddy-list-participants",
+                participants_empty_list_message,
+            );
+        }
     }
 
     update_section_header_counts(): void {
@@ -563,6 +573,10 @@ export class BuddyList extends BuddyListConf {
 
         this.$participants_list = $(this.participants_list_selector);
         if (participants.length) {
+            // Remove the empty list message before adding users
+            if ($(`${this.participants_list_selector} .empty-list-message`).length > 0) {
+                this.$participants_list.empty();
+            }
             const participants_html = this.items_to_html({
                 items: participants,
             });

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -287,8 +287,23 @@ export class BuddyList extends BuddyListConf {
 
         $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove();
         $("#buddy-list-other-users-container .view-all-users-link").remove();
-        if (!buddy_data.get_is_searching_users()) {
+        if (buddy_data.get_is_searching_users()) {
+            // Show all sections when searching users
+            this.set_section_collapse(".buddy-list-section-container", false);
+        } else {
             this.render_view_user_list_links();
+            this.set_section_collapse(
+                "#buddy-list-participants-container",
+                this.participants_is_collapsed,
+            );
+            this.set_section_collapse(
+                "#buddy-list-users-matching-view-container",
+                this.users_matching_view_is_collapsed,
+            );
+            this.set_section_collapse(
+                "#buddy-list-other-users-container",
+                this.other_users_is_collapsed,
+            );
         }
 
         // Ensure the "other" section is visible when headers are collapsed,

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,4 +1,4 @@
 <h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
     {{header_text}} (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
 </h5>
-<i class="buddy-list-section-toggle {{toggle_class}} fa fa-sm fa-caret-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>
+<i class="buddy-list-section-toggle fa fa-sm fa-caret-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -21,15 +21,15 @@
             <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar data-simplebar-tab-index="-1">
                 <div id="buddy-list-participants-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
-                    <ul id="buddy-list-participants" class="buddy-list-section" data-search-results-empty="{{t 'None.' }}"></ul>
+                    <ul id="buddy-list-participants" class="buddy-list-section"></ul>
                 </div>
                 <div id="buddy-list-users-matching-view-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
-                    <ul id="buddy-list-users-matching-view" class="buddy-list-section" data-search-results-empty="{{t 'None.' }}"></ul>
+                    <ul id="buddy-list-users-matching-view" class="buddy-list-section"></ul>
                 </div>
                 <div id="buddy-list-other-users-container" class="buddy-list-section-container">
                     <div class="buddy-list-subsection-header"></div>
-                    <ul id="buddy-list-other-users" class="buddy-list-section" data-search-results-empty="{{t 'None.' }}"></ul>
+                    <ul id="buddy-list-other-users" class="buddy-list-section"></ul>
                 </div>
                 <div id="buddy_list_wrapper_padding"></div>
                 <div class="right-sidebar-shortcuts">

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -137,7 +137,6 @@ function test(label, f) {
         });
 
         stub_buddy_list_elements();
-        helpers.override(buddy_list, "render_section_headers", noop);
         helpers.override(buddy_list, "render_view_user_list_links", noop);
 
         presence.presence_info.set(alice.user_id, {status: "active"});

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -731,7 +731,6 @@ test("realm_presence_disabled", ({override}) => {
 test("redraw_muted_user", () => {
     muted_users.add_muted_user(mark.user_id);
     activity_ui.redraw_user(mark.user_id);
-    assert.equal($("#buddy-list-users-matching-view").html(), "never-been-set");
 });
 
 test("update_presence_info", ({override, override_rewire}) => {


### PR DESCRIPTION
This PR has several commits, mostly refactoring some code that could be cleaner that I noticed as I was editing this.

There are three changes:
* Adding a placeholder for the participants section, since that was overlooked last time (we actually do have a situation when we want to show a placeholder, just only when searching).
* Fixing a bug where the participant count became incorrect during search.
* (the main change) Uncollapsing all sections during search so all matching users are visible. When there is no search text in the search bar, the sections collapse state return to whatever the user last had them set to.
