### PR TITLE
slack: Refactor Slack text formatters.

### DIFF
--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -183,7 +183,7 @@ def convert_markdown_syntax(text: str, pattern: str, zulip_keyword: str) -> str:
             + match.group(6)
         )
 
-    return regex.sub(pattern, replace_slack_format, text, flags=re.VERBOSE)
+    return regex.sub(pattern, replace_slack_format, text, flags=re.VERBOSE | re.MULTILINE)
 
 
 def convert_slack_workspace_mentions(text: str) -> str:

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -60,7 +60,7 @@ SLACK_STRIKETHROUGH_REGEX = r"""
                                 [\p{P}\p{Zs}\p{S}]|^
                              )
                              (\~)                                  # followed by a ~
-                                 ([ -)+-}—]*)([ -}]+)              # any character except ~
+                                 ([ -}]+)                          # any character except ~
                              (\~)                                  # followed by a ~
                              (
                                 # Capture punctuation, white space, symbols or end of
@@ -80,7 +80,7 @@ SLACK_ITALIC_REGEX = r"""
                         [\p{P}\p{Zs}\p{S}]|^
                       )
                       (\_)
-                          ([ -^`~—]*)([ -^`-~]+)                  # any character except _
+                          ([ -^`-~]+)                # any character except _
                       (\_)
                       (
                         (?![_`@\\\p{Pi}\p{Ps}])
@@ -95,7 +95,7 @@ SLACK_BOLD_REGEX = r"""
                         [\p{P}\p{Zs}\p{S}]|^
                     )
                     (\*)
-                        ([ -)+-~—]*)([ -)+-~]+)                   # any character except *
+                        ([ -)+-~]+)                   # any character except *
                     (\*)
                     (
                         (?![*`@\\\p{Pi}\p{Ps}])
@@ -174,14 +174,7 @@ def convert_markdown_syntax(text: str, pattern: str, zulip_keyword: str) -> str:
     """
 
     def replace_slack_format(match: regex.Match[str]) -> str:
-        return (
-            match.group(1)
-            + zulip_keyword
-            + match.group(3)
-            + match.group(4)
-            + zulip_keyword
-            + match.group(6)
-        )
+        return match.group(1) + zulip_keyword + match.group(3) + zulip_keyword + match.group(5)
 
     return regex.sub(pattern, replace_slack_format, text, flags=re.VERBOSE | re.MULTILINE)
 

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -49,22 +49,22 @@ SLACK_USERMENTION_REGEX = r"""
 # formats the word in Zulip
 SLACK_STRIKETHROUGH_REGEX = r"""
                              (^|[ -(]|[+-/]|\*|\_|[:-?]|\{|\[|\||\^)     # Start after specified characters
-                             (\~)                                  # followed by an asterisk
-                                 ([ -)+-}—]*)([ -}]+)              # any character except asterisk
-                             (\~)                                  # followed by an asterisk
+                             (\~)                                  # followed by a ~
+                                 ([ -)+-}—]*)([ -}]+)              # any character except ~
+                             (\~)                                  # followed by a ~
                              ($|[ -']|[+-/]|[:-?]|\*|\_|\}|\)|\]|\||\^)  # ends with specified characters
                              """
 SLACK_ITALIC_REGEX = r"""
                       (^|[ -*]|[+-/]|[:-?]|\{|\[|\||\^|~)
                       (\_)
-                          ([ -^`~—]*)([ -^`-~]+)                  # any character
+                          ([ -^`~—]*)([ -^`-~]+)                  # any character except _
                       (\_)
                       ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\*|\||\^|~)
                       """
 SLACK_BOLD_REGEX = r"""
                     (^|[ -(]|[+-/]|[:-?]|\{|\[|\_|\||\^|~)
                     (\*)
-                        ([ -)+-~—]*)([ -)+-~]+)                   # any character
+                        ([ -)+-~—]*)([ -)+-~]+)                   # any character except *
                     (\*)
                     ($|[ -']|[+-/]|[:-?]|\}|\)|\]|\_|\||\^|~)
                     """

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -69,7 +69,7 @@ SLACK_STRIKETHROUGH_REGEX = r"""
                                 # Skip @ and \
                                 # Skip opening brackets & opening quote (\p{Pi}\p{Ps})
                                 (?![~`@\\\p{Pi}\p{Ps}])
-                                [\p{P}\p{Zs}\p{S}]|$
+                                (?=[\p{P}\p{Zs}\p{S}]|$)
                              )
                              """
 SLACK_ITALIC_REGEX = r"""
@@ -84,7 +84,7 @@ SLACK_ITALIC_REGEX = r"""
                       (\_)
                       (
                         (?![_`@\\\p{Pi}\p{Ps}])
-                        [\p{P}\p{Zs}\p{S}]|$
+                        (?=[\p{P}\p{Zs}\p{S}]|$)
                       )
                       """
 SLACK_BOLD_REGEX = r"""
@@ -99,7 +99,7 @@ SLACK_BOLD_REGEX = r"""
                     (\*)
                     (
                         (?![*`@\\\p{Pi}\p{Ps}])
-                        [\p{P}\p{Zs}\p{S}]|$
+                        (?=[\p{P}\p{Zs}\p{S}]|$)
                     )
                     """
 
@@ -174,7 +174,7 @@ def convert_markdown_syntax(text: str, pattern: str, zulip_keyword: str) -> str:
     """
 
     def replace_slack_format(match: regex.Match[str]) -> str:
-        return match.group(1) + zulip_keyword + match.group(3) + zulip_keyword + match.group(5)
+        return match.group(1) + zulip_keyword + match.group(3) + zulip_keyword
 
     return regex.sub(pattern, replace_slack_format, text, flags=re.VERBOSE | re.MULTILINE)
 

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -60,7 +60,7 @@ SLACK_STRIKETHROUGH_REGEX = r"""
                                 [\p{P}\p{Zs}\p{S}]|^
                              )
                              (\~)                                  # followed by a ~
-                                 ([ -}]+)                          # any character except ~
+                                 ([^~]+)                           # any character except ~
                              (\~)                                  # followed by a ~
                              (
                                 # Capture punctuation, white space, symbols or end of
@@ -80,7 +80,7 @@ SLACK_ITALIC_REGEX = r"""
                         [\p{P}\p{Zs}\p{S}]|^
                       )
                       (\_)
-                          ([ -^`-~]+)                # any character except _
+                          ([^_]+)                    # any character except _
                       (\_)
                       (
                         (?![_`@\\\p{Pi}\p{Ps}])
@@ -95,7 +95,7 @@ SLACK_BOLD_REGEX = r"""
                         [\p{P}\p{Zs}\p{S}]|^
                     )
                     (\*)
-                        ([ -)+-~]+)                   # any character except *
+                        ([^*]+)                       # any character except *
                     (\*)
                     (
                         (?![*`@\\\p{Pi}\p{Ps}])

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -172,8 +172,9 @@ def convert_markdown_syntax(text: str, pattern: str, zulip_keyword: str) -> str:
     2. For bold formatting: This maps Slack's '*bold*' to Zulip's '**bold**'
     3. For italic formatting: This maps Slack's '_italic_' to Zulip's '*italic*'
     """
-    for match in regex.finditer(pattern, text, re.VERBOSE):
-        converted_token = (
+
+    def replace_slack_format(match: regex.Match[str]) -> str:
+        return (
             match.group(1)
             + zulip_keyword
             + match.group(3)
@@ -181,8 +182,8 @@ def convert_markdown_syntax(text: str, pattern: str, zulip_keyword: str) -> str:
             + zulip_keyword
             + match.group(6)
         )
-        text = text.replace(match.group(0), converted_token)
-    return text
+
+    return regex.sub(pattern, replace_slack_format, text, flags=re.VERBOSE)
 
 
 def convert_slack_workspace_mentions(text: str) -> str:

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -383,3 +383,9 @@ def render_attachment(attachment: WildValue) -> str:
         pieces.append(f"<time:{time}>")
 
     return "\n\n".join(piece.strip() for piece in pieces if piece.strip() != "")
+
+
+def replace_links(text: str) -> str:
+    text, _ = convert_link_format(text)
+    text, _ = convert_mailto_format(text)
+    return text

--- a/zerver/tests/fixtures/slack_message_conversion.json
+++ b/zerver/tests/fixtures/slack_message_conversion.json
@@ -104,6 +104,11 @@
       "name": "format_emoji_test",
       "input": "*1️⃣ bold* some _1️⃣ italic_ word ~1️⃣ strike~",
       "conversion_output": "**1️⃣ bold** some *1️⃣ italic* word ~~1️⃣ strike~~"
+    },
+    {
+      "name": "overlapping_capture_group_test",
+      "input": "*foo* *baz* *bar*",
+      "conversion_output": "**foo** **baz** **bar**"
     }
   ]
 }

--- a/zerver/tests/fixtures/slack_message_conversion.json
+++ b/zerver/tests/fixtures/slack_message_conversion.json
@@ -99,6 +99,11 @@
       "name": "zero_width_identical_bold_matches_test",
       "input": "*foo*\n*foo*\n*foo*",
       "conversion_output": "**foo**\n**foo**\n**foo**"
+    },
+    {
+      "name": "format_emoji_test",
+      "input": "*1️⃣ bold* some _1️⃣ italic_ word ~1️⃣ strike~",
+      "conversion_output": "**1️⃣ bold** some *1️⃣ italic* word ~~1️⃣ strike~~"
     }
   ]
 }

--- a/zerver/tests/fixtures/slack_message_conversion.json
+++ b/zerver/tests/fixtures/slack_message_conversion.json
@@ -84,6 +84,11 @@
       "name": "italic_and_strike_conversion",
       "input": "_~italic~_ and ~_strike_~",
       "conversion_output": "*~~italic~~* and ~~*strike*~~"
+    },
+    {
+      "name": "unicode_quotes",
+      "input": "«~strike~» 「*bold*」 ❰_italic_❱",
+      "conversion_output": "«~~strike~~» 「**bold**」 ❰*italic*❱"
     }
   ]
 }

--- a/zerver/tests/fixtures/slack_message_conversion.json
+++ b/zerver/tests/fixtures/slack_message_conversion.json
@@ -89,6 +89,16 @@
       "name": "unicode_quotes",
       "input": "«~strike~» 「*bold*」 ❰_italic_❱",
       "conversion_output": "«~~strike~~» 「**bold**」 ❰*italic*❱"
+    },
+    {
+      "name": "new_line_test",
+      "input": "\n*abc*\n_helo_\n~stike~\n",
+      "conversion_output": "\n**abc**\n*helo*\n~~stike~~\n"
+    },
+    {
+      "name": "zero_width_identical_bold_matches_test",
+      "input": "*foo*\n*foo*\n*foo*",
+      "conversion_output": "**foo**\n**foo**\n**foo**"
     }
   ]
 }

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -281,7 +281,7 @@ class SlackWebhookTests(WebhookTestCase):
         )
 
     def test_message_with_complex_formatted_mentions(self) -> None:
-        message_body = "@**John Doe** **#general** ~~***@**all*****~"
+        message_body = "@**John Doe** **#general** ~~***@**all*****~~"
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_complex_formatted_mentions",

--- a/zerver/webhooks/slack/tests.py
+++ b/zerver/webhooks/slack/tests.py
@@ -271,7 +271,7 @@ class SlackWebhookTests(WebhookTestCase):
         )
 
     def test_message_with_complex_formatted_texts(self) -> None:
-        message_body = "this is text messages with overlapping formatting\n_**bold with italic**_\n~**bold with strike through**~\n~*italic with strike through*~\n~***all three***~"
+        message_body = "this is text messages with overlapping formatting\n***bold with italic***\n~~**bold with strike through**~~\n~~*italic with strike through*~~\n~~***all three***~~"
         expected_message = EXPECTED_MESSAGE.format(user=USER, message=message_body)
         self.check_webhook(
             "message_with_complex_formatted_texts",

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -8,7 +8,12 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.utils.translation import gettext as _
 from typing_extensions import ParamSpec
 
-from zerver.data_import.slack_message_conversion import render_attachment, render_block
+from zerver.data_import.slack_message_conversion import (
+    convert_slack_formatting,
+    render_attachment,
+    render_block,
+    replace_links,
+)
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import RequestVariableMissingError
@@ -93,19 +98,6 @@ def api_slack_incoming_webhook(
         body = body.strip()
 
     if body != "":
-        body = replace_formatting(replace_links(body).strip())
+        body = convert_slack_formatting(replace_links(body).strip())
         check_send_webhook_message(request, user_profile, user_specified_topic, body)
     return json_success(request, data={"ok": True})
-
-
-def replace_links(text: str) -> str:
-    return re.sub(r"<(\w+?:\/\/.*?)\|(.*?)>", r"[\2](\1)", text)
-
-
-def replace_formatting(text: str) -> str:
-    # Slack uses *text* for bold, whereas Zulip interprets that as italics
-    text = re.sub(r"([^\w]|^)\*(?!\s+)([^\*\n]+)(?<!\s)\*((?=[^\w])|$)", r"\1**\2**\3", text)
-
-    # Slack uses _text_ for emphasis, whereas Zulip interprets that as nothing
-    text = re.sub(r"([^\w]|^)[_](?!\s+)([^\_\n]+)(?<!\s)[_]((?=[^\w])|$)", r"\1*\2*\3", text)
-    return text


### PR DESCRIPTION
This PR aims to make `render_block` and ` render_attachments` be reusable (primarily for the Slack importer)  and clean up any duplicative functions(`replace_links` & `replace_formattings`) in `slack_incoming`. 

---
- This means, moving `render_block` and ` render_attachments` from `slack_incoming` to `slack_message_conversion`. (Done)

- Make `render_block` and ` render_attachments` compatible with `convert_slack_formatting` instead of `replace_links` & `replace_formattings` from `slack_incoming` (Commit: e919327bb1b529deb3daa5d74825d1ce5d6cd933). 

  However, if one tries to use the current regex in `convert_slack_formatting` directly in `slack_incoming`, some tests will fail:
  <details>
  
  <summary>
  Running tests in slack_incoming with previous `convert_slack_formatting` regex:
  </summary>
  
  ```bash
  ======================================================================
  FAIL: test_attachment_fields (zerver.webhooks.slack_incoming.tests.SlackIncomingHookTests)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/srv/zulip/zerver/webhooks/slack_incoming/tests.py", line 215, in test_attachment_fields
      self.check_webhook(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2448, in check_webhook
      self.assert_channel_message(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2464, in assert_channel_message
      self.assertEqual(message.content, content)
    File "/srv/zulip/zerver/lib/test_classes.py", line 290, in assertEqual
      raise AssertionError(
  AssertionError: Actual and expected outputs do not match; showing diff.
    Build bla bla succeeded
    
  - *Requested by*: Some user
  + **Requested by**: Some user
  - *Duration*: 00:02:03
  + **Duration**: 00:02:03
  - *Build pipeline*: ConsumerAddressModule
  + **Build pipeline**: ConsumerAddressModule
  - *Title with null value*
  + **Title with null value**
  - *Title without value*
  + **Title without value**
    Value with null title
    Value without title
  
  
  ======================================================================
  FAIL: test_complicated (zerver.webhooks.slack_incoming.tests.SlackIncomingHookTests)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/srv/zulip/zerver/webhooks/slack_incoming/tests.py", line 171, in test_complicated
      self.check_webhook(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2448, in check_webhook
      self.assert_channel_message(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2464, in assert_channel_message
      self.assertEqual(message.content, content)
    File "/srv/zulip/zerver/lib/test_classes.py", line 290, in assertEqual
      raise AssertionError(
  AssertionError: Actual and expected outputs do not match; showing diff.
    ## Hello from TaskBot
    
    Hey there 👋 I'm TaskBot. I'm here to help you create and manage tasks in Slack.
    There are two ways to quickly create tasks:
    
  - *1️⃣ Use the `/task` command*. Type `/task` followed by a short description of your tasks and I'll ask for a due date (if applicable). Try it out by using the `/task` command in this channel.
  + **1️⃣ Use the `/task` command**. Type `/task` followed by a short description of your tasks and I'll ask for a due date (if applicable). Try it out by using the `/task` command in this channel.
    
  - *2️⃣ Use the *Create a Task* action.* If you want to create a task from a message, select `Create a Task` in a message's context menu. Try it out by selecting the *Create a Task* action for this message (shown below).
  + **2️⃣ Use the *Create a Task* action.** If you want to create a task from a message, select `Create a Task` in a message's context menu. Try it out by selecting the *Create a Task* action for this message (shown below).
    
    [image1](https://api.slack.com/img/blocks/bkb_template_images/onboardingComplex.jpg)
    
    ➕ To start tracking your team's tasks, **add me to a channel** and I'll introduce myself. I'm usually added to a team or project channel. Type `/invite @TaskBot` from the channel or pick a channel on the right.
    
    ----
    
    [cute cat](https://pbs.twimg.com/profile_images/625633822235693056/lNGUneLX_400x400.jpg)
    
    👀 View all tasks with `/task list`
    
    ❓Get help at any time with:
    - `/task help`, or
    - type **help** in a DM with me
  
  
  ======================================================================
  FAIL: test_message_formatting (zerver.webhooks.slack_incoming.tests.SlackIncomingHookTests)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/srv/zulip/zerver/webhooks/slack_incoming/tests.py", line 40, in test_message_formatting
      self.assert_channel_message(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2464, in assert_channel_message
      self.assertEqual(message.content, content)
    File "/srv/zulip/zerver/lib/test_classes.py", line 290, in assertEqual
      raise AssertionError(
  AssertionError: Actual and expected outputs do not match; showing diff.
  - **foo** *bar*
  + **foo** **bar**
  
  
  ======================================================================
  FAIL: test_message_with_actions (zerver.webhooks.slack_incoming.tests.SlackIncomingHookTests)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/srv/zulip/zerver/webhooks/slack_incoming/tests.py", line 85, in test_message_with_actions
      self.check_webhook(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2448, in check_webhook
      self.assert_channel_message(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2464, in assert_channel_message
      self.assertEqual(message.content, content)
    File "/srv/zulip/zerver/lib/test_classes.py", line 290, in assertEqual
      raise AssertionError(
  AssertionError: Actual and expected outputs do not match; showing diff.
    Danny Torrence left the following *review* for your property:
    
    [Overlook Hotel](https://google.com) 
     :star: 
     Doors had too many axe holes, guest in room 237 was far too rowdy, whole place felt stuck in the 1920s.
    
    [Haunted hotel image](https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/d3/72/5c/d3725c8f-c642-5d69-1904-aa36e4297885/source/256x256bb.jpg)
    
  - *Average Rating*
  + **Average Rating**
    1.0
  
  
  ======================================================================
  FAIL: test_message_with_attachment (zerver.webhooks.slack_incoming.tests.SlackIncomingHookTests)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/srv/zulip/zerver/webhooks/slack_incoming/tests.py", line 135, in test_message_with_attachment
      self.check_webhook(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2448, in check_webhook
      self.assert_channel_message(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2464, in assert_channel_message
      self.assertEqual(message.content, content)
    File "/srv/zulip/zerver/lib/test_classes.py", line 290, in assertEqual
      raise AssertionError(
  AssertionError: Actual and expected outputs do not match; showing diff.
    ## [[FIRING:2] InstanceDown for api-server (env="prod", severity="critical")](https://alertmanager.local//#/alerts?receiver=default)
    
  - :chart_with_upwards_trend: **[Graph](http://generator.local/1)**   :notebook: *[Runbook](https://runbook.local/1)*
  + :chart_with_upwards_trend: **[Graph](http://generator.local/1)**   :notebook: **[Runbook](https://runbook.local/1)**
    
  - *Alert details*:
  + **Alert details**:
  - *Alert:* api-server down - `critical`
  + **Alert:** api-server down - `critical`
  - *Description:* api-server at 1.2.3.4:8080 couldn't be scraped *Details:*
  + **Description:** api-server at 1.2.3.4:8080 couldn't be scraped **Details:**
       • **alertname:** `InstanceDown`
       • **env:** `prod`
       • **instance:** `1.2.3.4:8080`
       • **job:** `api-server`
       • **severity:** `critical`
    
  - *Alert:* api-server down - `critical`
  + **Alert:** api-server down - `critical`
  - *Description:* api-server at 1.2.3.4:8081 couldn't be scraped *Details:*
  + **Description:** api-server at 1.2.3.4:8081 couldn't be scraped **Details:**
       • **alertname:** `InstanceDown`
       • **env:** `prod`
       • **instance:** `1.2.3.4:8081`
       • **job:** `api-server`
       • **severity:** `critical`
  
  
  ======================================================================
  FAIL: test_message_with_blocks (zerver.webhooks.slack_incoming.tests.SlackIncomingHookTests)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/srv/zulip/zerver/webhooks/slack_incoming/tests.py", line 104, in test_message_with_blocks
      self.check_webhook(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2448, in check_webhook
      self.assert_channel_message(
    File "/srv/zulip/zerver/lib/test_classes.py", line 2464, in assert_channel_message
      self.assertEqual(message.content, content)
    File "/srv/zulip/zerver/lib/test_classes.py", line 290, in assertEqual
      raise AssertionError(
  AssertionError: Actual and expected outputs do not match; showing diff.
    Danny Torrence left the following review for your property:
    
    [Overlook Hotel](https://example.com) 
     :star: 
     Doors had too many axe holes, guest in room 237 was far too rowdy, whole place felt stuck in the 1920s.
    
    [Haunted hotel image](https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/d3/72/5c/d3725c8f-c642-5d69-1904-aa36e4297885/source/256x256bb.jpg)
    
  - *Average Rating*
  + **Average Rating**
    1.0
  
  
  ----------------------------------------------------------------------
  Ran 20 tests in 2.234s
  
  FAILED (failures=6)
  
  ```
  </details>
  
  From those failing tests we can conclude that to make the `convert_slack_formatting` be compatible, it must:
  - Be able to capture formatted string multiline formatted strings (e.g.," \n_abc_\n*foo*"). (Commit: 682cd08b9d8dc8749ce945a1d3720041aebdf3d1)
  - Be able to capture formatted strings containing non-ASCII characters like emoji (e.g., "* :+1:  ok*"). (Commit: aaf92144a42ff97f81e922b53f867ea8e20dcf38)
  - Be able to capture formatted strings separated exactly by one character (e.g., `*abc*d*efg`). (Commit: 74da577212af88817ac3d46824feb371ba9a7d53)

Additionally, this also refactors the other regex capture groups to be more coherent

---

Next:
- #32163

Part of https://github.com/zulip/zulip/pull/31311.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
