### PR TITLE
compose_box: Add background color and border to compose box when approaching/exceeding message length limit.

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -727,8 +727,8 @@ export function check_overflow_text(): number {
     const $indicator = $("#compose-limit-indicator");
 
     if (text.length > max_length) {
-        $indicator.addClass("over_limit");
-        $("textarea#compose-textarea").addClass("over_limit");
+        $indicator.addClass("over-limit");
+        $("textarea#compose-textarea").addClass("over-limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -736,8 +736,8 @@ export function check_overflow_text(): number {
         );
         set_message_too_long(true);
     } else if (remaining_characters <= 900) {
-        $indicator.removeClass("over_limit");
-        $("textarea#compose-textarea").removeClass("over_limit");
+        $indicator.removeClass("over-limit");
+        $("textarea#compose-textarea").removeClass("over-limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -746,7 +746,7 @@ export function check_overflow_text(): number {
         set_message_too_long(false);
     } else {
         $indicator.text("");
-        $("textarea#compose-textarea").removeClass("over_limit");
+        $("textarea#compose-textarea").removeClass("over-limit");
 
         set_message_too_long(false);
     }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -725,10 +725,13 @@ export function check_overflow_text(): number {
     const max_length = realm.max_message_length;
     const remaining_characters = max_length - text.length;
     const $indicator = $("#compose-limit-indicator");
+    const $textarea = $("textarea#compose-textarea");
 
     if (text.length > max_length) {
+        $indicator.removeClass("approaching-limit");
+        $textarea.removeClass("approaching-limit");
         $indicator.addClass("over-limit");
-        $("textarea#compose-textarea").addClass("over-limit");
+        $textarea.addClass("over-limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -737,7 +740,10 @@ export function check_overflow_text(): number {
         set_message_too_long(true);
     } else if (remaining_characters <= 900) {
         $indicator.removeClass("over-limit");
-        $("textarea#compose-textarea").removeClass("over-limit");
+        $textarea.removeClass("over-limit");
+        $indicator.addClass("approaching-limit");
+        $textarea.addClass("approaching-limit");
+
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -746,7 +752,8 @@ export function check_overflow_text(): number {
         set_message_too_long(false);
     } else {
         $indicator.text("");
-        $("textarea#compose-textarea").removeClass("over-limit");
+        $textarea.removeClass("over-limit");
+        $textarea.removeClass("approaching-limit");
 
         set_message_too_long(false);
     }

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -675,6 +675,8 @@
     /* Compose box colors */
     --color-compose-box-background: hsl(232deg 30% 92%);
     --color-compose-message-content-background: hsl(0deg 0% 100%);
+    --color-compose-message-content-background-warning: hsl(50deg 75% 92%);
+    --color-compose-message-content-background-error: hsl(3deg 35% 90%);
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
     --color-compose-send-button-background: hsl(240deg 96% 68%);
     --color-compose-send-button-background-interactive: hsl(240deg 41% 50%);
@@ -742,6 +744,13 @@
     --color-message-formatting-controls-container: hsl(232deg 30% 96%);
     --color-message-content-container-border: hsl(0deg 0% 0% / 10%);
     --color-message-content-container-border-focus: hsl(0deg 0% 57%);
+    --color-message-content-container-border-warning: hsl(038deg 70% 50%);
+    --color-message-content-container-border-error: hsl(0deg 76% 65%);
+    --color-message-content-container-border-invalid: hsl(3deg 57% 33%);
+    --color-message-content-container-shadow-warning: 0 0 0 1pt
+        hsl(038deg 70% 50%);
+    --color-message-content-container-shadow-error: 0 0 0 1pt hsl(0deg 76% 65%);
+    --color-message-content-container-shadow-invalid: 0 0 2px hsl(3deg 57% 33%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 0% / 5%);
     --color-compose-focus-ring: var(--color-outline-focus);
 
@@ -1230,6 +1239,8 @@
         var(--color-compose-box-background),
         hsl(0deg 0% 0%) 20%
     );
+    --color-compose-message-content-background-warning: hsl(50deg 75% 12%);
+    --color-compose-message-content-background-error: hsl(3deg 50% 12%);
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);
     --color-compose-send-control-button: hsl(240deg 30% 70%);
     --color-compose-send-control-button-background: transparent;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -327,12 +327,12 @@
         border-color: var(--color-message-content-container-border-focus);
     }
 
-    &:has(.new_message_textarea.over_limit),
-    &:has(.new_message_textarea.over_limit:focus) {
+    &:has(.new_message_textarea.over-limit),
+    &:has(.new_message_textarea.over-limit:focus) {
         box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
     }
 
-    &:has(.new_message_textarea.over_limit.flash) {
+    &:has(.new_message_textarea.over-limit.flash) {
         animation: message-limit-flash 0.5s ease-in-out 3;
     }
 
@@ -472,7 +472,7 @@
     margin-top: auto;
     padding: 3px 3px 3px 0;
 
-    &.over_limit {
+    &.over-limit {
         color: var(--color-limit-indicator-over-limit);
         font-weight: bold;
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -329,7 +329,14 @@
 
     &:has(.new_message_textarea.over-limit),
     &:has(.new_message_textarea.over-limit:focus) {
-        box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
+        border-color: var(--color-message-content-container-border-error);
+        box-shadow: var(--color-message-content-container-shadow-error);
+    }
+
+    &:has(.new_message_textarea.approaching-limit),
+    &:has(.new_message_textarea.approaching-limit:focus) {
+        border-color: var(--color-message-content-container-border-warning);
+        box-shadow: var(--color-message-content-container-shadow-warning);
     }
 
     &:has(.new_message_textarea.over-limit.flash) {
@@ -338,8 +345,8 @@
 
     &:has(.new_message_textarea.invalid),
     &:has(.new_message_textarea.invalid:focus) {
-        border-color: hsl(3deg 57% 33%);
-        box-shadow: 0 0 2px hsl(3deg 57% 33%);
+        border-color: var(--color-message-content-container-border-invalid);
+        box-shadow: var(--color-message-content-container-shadow-invalid);
     }
 }
 
@@ -400,6 +407,16 @@
     padding-right: var(--composebox-buttons-width);
     background-color: var(--color-compose-message-content-background);
     color: var(--color-text-default);
+
+    &.over-limit {
+        background-color: var(--color-compose-message-content-background-error);
+    }
+
+    &.approaching-limit {
+        background-color: var(
+            --color-compose-message-content-background-warning
+        );
+    }
 }
 
 .surround-formatting-buttons-row {

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -597,25 +597,25 @@ test_ui("test_check_overflow_text", ({mock_template, override}) => {
     });
     $textarea.val("a".repeat(10000 + 1));
     compose_validate.check_overflow_text();
-    assert.ok($indicator.hasClass("over_limit"));
+    assert.ok($indicator.hasClass("over-limit"));
     assert.equal(limit_indicator_html, "-1\n");
-    assert.ok($textarea.hasClass("over_limit"));
+    assert.ok($textarea.hasClass("over-limit"));
     assert.ok($(".message-send-controls").hasClass("disabled-message-send-controls"));
 
     // Indicator should show orange colored text
     $textarea.val("a".repeat(9100));
     compose_validate.check_overflow_text();
-    assert.ok(!$indicator.hasClass("over_limit"));
+    assert.ok(!$indicator.hasClass("over-limit"));
     assert.equal(limit_indicator_html, "900\n");
-    assert.ok(!$textarea.hasClass("over_limit"));
+    assert.ok(!$textarea.hasClass("over-limit"));
     assert.ok(!$(".message-send-controls").hasClass("disabled-message-send-controls"));
 
     // Indicator must be empty
     $textarea.val("a".repeat(9100 - 1));
     compose_validate.check_overflow_text();
-    assert.ok(!$indicator.hasClass("over_limit"));
+    assert.ok(!$indicator.hasClass("over-limit"));
     assert.equal($indicator.text(), "");
-    assert.ok(!$textarea.hasClass("over_limit"));
+    assert.ok(!$textarea.hasClass("over-limit"));
 });
 
 test_ui("needs_subscribe_warning", () => {


### PR DESCRIPTION
Fixes: #32171.

Added background color and border to compose box when approaching/exceeding message length limit. Watch the video below to see the changes made.

**Screenshots and screen captures:**

### Approaching Limit :
**Before**
![image](https://github.com/user-attachments/assets/5158faa4-4f6b-4742-9236-b8b251e4a146)
![image](https://github.com/user-attachments/assets/f9b9e273-943e-44ca-8b18-134fb78756c6)

**After**
![image](https://github.com/user-attachments/assets/fbb240f8-eb87-4e85-bfa0-1cf0c53205b7)
![image](https://github.com/user-attachments/assets/a5eb2015-17b1-4e15-9841-82e0586f5e05)

### Limit Exceeded :
**Before**
![image](https://github.com/user-attachments/assets/9d102b68-09d7-49d8-82e3-b38e5d33f304)
![image](https://github.com/user-attachments/assets/c82c6d26-b4ac-4fba-b447-9717dd38002e)

**After**
![image](https://github.com/user-attachments/assets/62256fb8-6b62-4b37-af08-dcc878412468)
![image](https://github.com/user-attachments/assets/e27aa245-2e83-4ca3-9c30-0879726d01ad)

### Final working preview : 
https://github.com/user-attachments/assets/c95059f4-99e8-4c19-b046-9320e619866b

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
