### PR TITLE
echo: Fix send messages not visible when auto narrowed to recipient.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -557,6 +557,7 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
                 // message content, but in practice, there's no harm to just
                 // doing it unconditionally.
                 msg_list.view.rerender_messages(msgs_to_rerender_or_add_to_narrow);
+                msg_list.add_messages(msgs_to_rerender_or_add_to_narrow, {});
             }
         }
     }

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -47,6 +47,7 @@ message_lists.current = {
         },
     },
     change_message_id: noop,
+    add_messages: noop,
 };
 const home_msg_list = {
     view: {
@@ -62,6 +63,7 @@ const home_msg_list = {
     },
     preserver_rendered_state: true,
     change_message_id: noop,
+    add_messages: noop,
 };
 message_lists.all_rendered_message_lists = () => [home_msg_list, message_lists.current];
 message_lists.non_rendered_data = () => [];


### PR DESCRIPTION
We simply forgot to `add_to_narrow` locally echoed messages if the current narrow changed before we received confirmation from server.

Tested by populating database with 10k messages and sending a message in different topic after applying this diff:
```diff
diff --git a/web/src/message_fetch.ts b/web/src/message_fetch.ts
index 738ce45ade..eed6ba39f1 100644
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -63,34 +63,34 @@ export const consts = {
     //
     // It's rare to have hundreds of unreads after the cursor, asking
     // for a larger number of messages after the cursor is cheap.
-    narrow_before: 60,
-    narrow_after: 150,
+    narrow_before: 10,
+    narrow_after: 10,
 
     // Number of messages that a message list restored from cached
     // message list data should have to maintain sufficient context.
-    narrow_min_num_message_for_context: 100,
+    narrow_min_num_message_for_context: 10,
 
     // Batch sizes when at the top/bottom of a narrowed view.
-    narrowed_view_backward_batch_size: 100,
-    narrowed_view_forward_batch_size: 100,
+    narrowed_view_backward_batch_size: 10,
+    narrowed_view_forward_batch_size: 10,
 
     // Initial backfill parameters to populate message history.
-    initial_backfill_fetch_size: 1000,
-    catch_up_batch_size: 2000,
+    initial_backfill_fetch_size: 10,
+    catch_up_batch_size: 20,
     // We fetch at least minimum_initial_backfill_size messages of
     // history, but after that will stop fetching at either
     // maximum_initial_backfill_size messages or
     // target_days_of_history days, whichever comes first.
-    minimum_initial_backfill_size: 9000,
-    maximum_initial_backfill_size: 25000,
-    target_days_of_history: 180,
+    minimum_initial_backfill_size: 90,
+    maximum_initial_backfill_size: 25,
+    target_days_of_history: 1,
     // Delay in milliseconds after processing a catch-up request
     // before sending the next one.
     catch_up_backfill_delay: 150,
 
     // Parameters for asking for more history in the recent view.
-    recent_view_fetch_more_batch_size: 2000,
-    recent_view_minimum_load_more_fetch_size: 50000,
+    recent_view_fetch_more_batch_size: 20,
+    recent_view_minimum_load_more_fetch_size: 50,
 };
 
diff --git a/web/src/unread.ts b/web/src/unread.ts
index 9a69f5e82b..363b28ec9e 100644
--- a/web/src/unread.ts
+++ b/web/src/unread.ts
@@ -1065,7 +1065,7 @@ type UnreadDirectMessageGroupInfo = z.infer<typeof unread_direct_message_group_i
 export function initialize(params: StateData["unread"]): void {
     const unread_msgs = params.unread_msgs;
 
-    old_unreads_missing = unread_msgs.old_unreads_missing;
+    old_unreads_missing = true;
```

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/new.20message.20not.20found