### PR TITLE
Put channel and topic on separate lines in Move messages / Move topic modals

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1366,23 +1366,19 @@ input.settings_text_input {
 .text-error {
     color: hsl(1.06deg 44.66% 50.39%);
 }
-
 .topic_stream_edit_header {
     display: flex;
     flex-direction: column;
     gap: 12px;
 }
-
 .form-label {
     display: block;
 }
-
 .form-label-bold {
     font-weight: bold;
     margin-top: 8px;
     display: block;
 }
-
 .modal_text_input {
     width: auto;
     min-width: 200px;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1366,3 +1366,20 @@ input.settings_text_input {
 .text-error {
     color: hsl(1.06deg 44.66% 50.39%);
 }
+.topic_stream_edit_header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.form-label {
+    display: block;
+}
+.form-label-bold {
+    font-weight: bold;
+    margin-top: 8px;
+    display: block;
+}
+.modal_text_input {
+    width: auto;
+    min-width: 200px;
+}

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1366,19 +1366,23 @@ input.settings_text_input {
 .text-error {
     color: hsl(1.06deg 44.66% 50.39%);
 }
+
 .topic_stream_edit_header {
     display: flex;
     flex-direction: column;
     gap: 12px;
 }
+
 .form-label {
     display: block;
 }
+
 .form-label-bold {
     font-weight: bold;
     margin-top: 8px;
     display: block;
 }
+
 .modal_text_input {
     width: auto;
     min-width: 200px;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1366,35 +1366,19 @@ input.settings_text_input {
 .text-error {
     color: hsl(1.06deg 44.66% 50.39%);
 }
-<<<<<<< HEAD
-=======
-
->>>>>>> 2b23a2f382ec577f39ccadb2824f1ef7164efda4
 .topic_stream_edit_header {
     display: flex;
     flex-direction: column;
     gap: 12px;
 }
-<<<<<<< HEAD
 .form-label {
     display: block;
 }
-=======
-
-.form-label {
-    display: block;
-}
-
->>>>>>> 2b23a2f382ec577f39ccadb2824f1ef7164efda4
 .form-label-bold {
     font-weight: bold;
     margin-top: 8px;
     display: block;
 }
-<<<<<<< HEAD
-=======
-
->>>>>>> 2b23a2f382ec577f39ccadb2824f1ef7164efda4
 .modal_text_input {
     width: auto;
     min-width: 200px;

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -1,20 +1,34 @@
 {{#unless (or from_message_actions_popover only_topic_edit)}}
-<p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{{topic_name}}</strong>{{/tr}} to:</p>
+<p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
 {{/unless}}
 <form id="move_topic_form">
     {{#if only_topic_edit }}
-    <p>{{t "Rename topic to:"}}</p>
+    <p>{{t "Rename topic to:" }}</p>
     {{else if from_message_actions_popover}}
+    <p>{{t "Move messages to:" }}</p>
     {{/if}}
     <div class="topic_stream_edit_header">
+<<<<<<< HEAD
+        
+        <!-- Channel Label and Dropdown -->
         {{#unless only_topic_edit}}
             <label for="move-topic-stream" class="form-label">{{t "Channel"}}</label>
             {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
         {{/unless}}
+
+        <!-- Topic Label and Input with Dynamic Width -->
         <label for="new_topic_name" class="form-label">{{t "Topic"}}</label>
-        <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+        <input 
+          name="new_topic_name" 
+          type="text" 
+          class="move_messages_edit_topic modal_text_input" 
+          autocomplete="off" 
+          value="{{topic_name}}" 
+          {{#if disable_topic_input}}disabled{{/if}} />
+        
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />               
+
         {{#if from_message_actions_popover}}
           <label for="message-range" class="form-label-bold">{{t "Which messages to move?"}}</label>
           <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
@@ -22,17 +36,32 @@
               <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}>{{t "Move this and all following messages in this topic"}}</option>
               <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}>{{t "Move all messages in this topic"}}</option>
           </select>
+=======
+        {{#unless only_topic_edit}}
+        {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
+        <i class="fa fa-angle-right" aria-hidden="true"></i>
+        {{/unless}}
+        <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+        <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
+        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
+        {{#if from_message_actions_popover}}
+        <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
+            <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
+            <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
+            <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
+        </select>
+>>>>>>> parent of 710c76026a (Update move_topic_to_stream.hbs)
         {{/if}}
         <div class="topic_move_breadcrumb_messages">
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                 <span class="rendered-checkbox"></span>
-                {{t "Send automated notice to new topic"}}
+                {{t "Send automated notice to new topic" }}
             </label>
             <label class="checkbox">
                 <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                 <span class="rendered-checkbox"></span>
-                {{t "Send automated notice to old topic"}}
+                {{t "Send automated notice to old topic" }}
             </label>
         </div>
     </div>

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -14,7 +14,7 @@
         <label for="new_topic_name" class="form-label">{{t "Topic"}}</label>
         <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
-        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />               
+        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}
           <label for="message-range" class="form-label-bold">{{t "Which messages to move?"}}</label>
           <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -14,7 +14,7 @@
         <label for="new_topic_name" class="form-label">{{t "Topic"}}</label>
         <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
-        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
+        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />               
         {{#if from_message_actions_popover}}
           <label for="message-range" class="form-label-bold">{{t "Which messages to move?"}}</label>
           <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -3,8 +3,9 @@
 {{/unless}}
 <form id="move_topic_form">
     {{#if only_topic_edit }}
-    <p>{{t "Rename topic to:"}}</p>
+    <p>{{t "Rename topic to:" }}</p>
     {{else if from_message_actions_popover}}
+    <p>{{t "Move messages to:" }}</p>
     {{/if}}
     <div class="topic_stream_edit_header">
 <<<<<<< HEAD
@@ -37,40 +38,30 @@
           </select>
 =======
         {{#unless only_topic_edit}}
-            <label for="move-topic-stream" class="form-label">{{t "Channel"}}</label>
-            {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
+        {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
+        <i class="fa fa-angle-right" aria-hidden="true"></i>
         {{/unless}}
-        <label for="new_topic_name" class="form-label">{{t "Topic"}}</label>
         <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}
-<<<<<<< HEAD
         <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
             <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
             <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
             <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
         </select>
 >>>>>>> parent of 710c76026a (Update move_topic_to_stream.hbs)
-=======
-            <label for="message-range" class="form-label-bold">{{t "Which messages to move?"}}</label>
-            <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
-                <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}>{{t "Move only this message"}}</option>
-                <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}>{{t "Move this and all following messages in this topic"}}</option>
-                <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}>{{t "Move all messages in this topic"}}</option>
-            </select>
->>>>>>> 2b23a2f382ec577f39ccadb2824f1ef7164efda4
         {{/if}}
         <div class="topic_move_breadcrumb_messages">
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                 <span class="rendered-checkbox"></span>
-                {{t "Send automated notice to new topic"}}
+                {{t "Send automated notice to new topic" }}
             </label>
             <label class="checkbox">
                 <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                 <span class="rendered-checkbox"></span>
-                {{t "Send automated notice to old topic"}}
+                {{t "Send automated notice to old topic" }}
             </label>
         </div>
     </div>

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -7,26 +7,14 @@
     {{else if from_message_actions_popover}}
     {{/if}}
     <div class="topic_stream_edit_header">
-        
-        <!-- Channel Label and Dropdown -->
         {{#unless only_topic_edit}}
             <label for="move-topic-stream" class="form-label">{{t "Channel"}}</label>
             {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
         {{/unless}}
-
-        <!-- Topic Label and Input with Dynamic Width -->
         <label for="new_topic_name" class="form-label">{{t "Topic"}}</label>
-        <input 
-          name="new_topic_name" 
-          type="text" 
-          class="move_messages_edit_topic modal_text_input" 
-          autocomplete="off" 
-          value="{{topic_name}}" 
-          {{#if disable_topic_input}}disabled{{/if}} />
-        
+        <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />               
-
         {{#if from_message_actions_popover}}
           <label for="message-range" class="form-label-bold">{{t "Which messages to move?"}}</label>
           <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
@@ -35,8 +23,6 @@
               <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}>{{t "Move all messages in this topic"}}</option>
           </select>
         {{/if}}
-        
-        <!-- Notification Checkboxes -->
         <div class="topic_move_breadcrumb_messages">
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -6,29 +6,29 @@
     <p>{{t "Rename topic to:"}}</p>
     {{else if from_message_actions_popover}}
     {{/if}}
-    <div class="topic_stream_edit_header" style="display: flex; flex-direction: column; gap: 12px;">
+    <div class="topic_stream_edit_header">
         
         <!-- Channel Label and Dropdown -->
         {{#unless only_topic_edit}}
-            <label for="move-topic-stream" style="display: block;">{{t "Channel"}}</label>
+            <label for="move-topic-stream" class="form-label">{{t "Channel"}}</label>
             {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
         {{/unless}}
 
         <!-- Topic Label and Input with Dynamic Width -->
-        <label for="new_topic_name" style="display: block;">{{t "Topic"}}</label>
+        <label for="new_topic_name" class="form-label">{{t "Topic"}}</label>
         <input 
           name="new_topic_name" 
           type="text" 
           class="move_messages_edit_topic modal_text_input" 
           autocomplete="off" 
           value="{{topic_name}}" 
-          style="width: auto; min-width: 200px;" 
           {{#if disable_topic_input}}disabled{{/if}} />
         
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />               
+
         {{#if from_message_actions_popover}}
-          <label for="message-range" style="font-weight: bold; margin-top: 8px; display: block;">{{t "Which messages to move?"}}</label>
+          <label for="message-range" class="form-label-bold">{{t "Which messages to move?"}}</label>
           <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
               <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}>{{t "Move only this message"}}</option>
               <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}>{{t "Move this and all following messages in this topic"}}</option>

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -1,37 +1,52 @@
 {{#unless (or from_message_actions_popover only_topic_edit)}}
-<p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
+<p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{{topic_name}}</strong>{{/tr}} to:</p>
 {{/unless}}
 <form id="move_topic_form">
     {{#if only_topic_edit }}
-    <p>{{t "Rename topic to:" }}</p>
+    <p>{{t "Rename topic to:"}}</p>
     {{else if from_message_actions_popover}}
-    <p>{{t "Move messages to:" }}</p>
     {{/if}}
-    <div class="topic_stream_edit_header">
+    <div class="topic_stream_edit_header" style="display: flex; flex-direction: column; gap: 12px;">
+        
+        <!-- Channel Label and Dropdown -->
         {{#unless only_topic_edit}}
-        {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
-        <i class="fa fa-angle-right" aria-hidden="true"></i>
+            <label for="move-topic-stream" style="display: block;">{{t "Channel"}}</label>
+            {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
         {{/unless}}
-        <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+
+        <!-- Topic Label and Input with Dynamic Width -->
+        <label for="new_topic_name" style="display: block;">{{t "Topic"}}</label>
+        <input 
+          name="new_topic_name" 
+          type="text" 
+          class="move_messages_edit_topic modal_text_input" 
+          autocomplete="off" 
+          value="{{topic_name}}" 
+          style="width: auto; min-width: 200px;" 
+          {{#if disable_topic_input}}disabled{{/if}} />
+        
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
-        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
+        <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />               
         {{#if from_message_actions_popover}}
-        <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
-            <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
-            <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
-            <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
-        </select>
+          <label for="message-range" style="font-weight: bold; margin-top: 8px; display: block;">{{t "Which messages to move?"}}</label>
+          <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">
+              <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}>{{t "Move only this message"}}</option>
+              <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}>{{t "Move this and all following messages in this topic"}}</option>
+              <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}>{{t "Move all messages in this topic"}}</option>
+          </select>
         {{/if}}
+        
+        <!-- Notification Checkboxes -->
         <div class="topic_move_breadcrumb_messages">
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                 <span class="rendered-checkbox"></span>
-                {{t "Send automated notice to new topic" }}
+                {{t "Send automated notice to new topic"}}
             </label>
             <label class="checkbox">
                 <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                 <span class="rendered-checkbox"></span>
-                {{t "Send automated notice to old topic" }}
+                {{t "Send automated notice to old topic"}}
             </label>
         </div>
     </div>


### PR DESCRIPTION
**"Put channel and topic on separate lines in Move messages / Move topic modals"** includes the following changes:

1. **Channel Label Above Dropdown**: 
   - The "Channel" label is added above the channel selection dropdown for improved readability and alignment, so users can clearly identify the channel selection section.

2. **Topic Label Above Input Field**:
   - A "Topic" label is added above the topic input field, giving it a consistent structure similar to the channel section. This makes it easier to identify the topic field separately.

3. **Separated Lines for Channel and Topic**:
   - Both the channel and topic sections are placed on separate lines to create a clean, vertical layout, improving the visual clarity of the form.

4. **Expanded Topic Field**:
   - The width of the "Topic" input field is adjusted to expand based on its content, allowing longer topic names to be fully visible without being truncated.

5. **"Which Messages to Move?" Label**:
   - The label for selecting the message range (e.g., "Move only this message," "Move this and all following messages," etc.) is updated to "Which messages to move?" and styled in bold for prominence, clarifying the user's options for message movement.

6. **Enhanced CSS Styling**:
   - Inline CSS adjustments are applied to achieve the desired layout without affecting other parts of the codebase. This includes:
     - Setting `display: flex` and `flex-direction: column` on the main container to create a structured column layout.
     - Adding `gap` between the elements for visual spacing.
     - Adding `font-weight: bold` to the "Which messages to move?" label for emphasis.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

Fixes: #32168 
**Screenshots and screen captures:**

**Before**
![before](https://github.com/user-attachments/assets/e951b17d-dc51-4841-9255-e48012ae21bc)


**After**
![after](https://github.com/user-attachments/assets/ac62a9d9-1cbc-4efd-8800-8a27b60e23dc)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
