### PR TITLE
compose: Bring input elements into concord.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -671,6 +671,20 @@
     --color-compose-send-control-button-focus-shadow: var(
         --color-compose-send-button-focus-shadow
     );
+    --color-compose-recipient-box-text-color: inherit;
+    --color-compose-recipient-box-background-color: hsl(0deg 0% 100%);
+    /* Because of how the background color is assigned on
+       recipient-row elements, we need here to mix down the
+       border color from the compose text area,
+       --color-message-content-container-border,
+       with the compose box's background color,
+       --color-compose-box-background. */
+    --color-compose-recipient-box-border-color: color-mix(
+        in srgb,
+        hsl(0deg 0% 0%) 10%,
+        hsl(232deg 20% 92%)
+    );
+    --color-compose-recipient-box-has-focus: hsl(0deg 0% 57%);
     --color-compose-collapsed-reply-button-area-background: hsl(0deg 0% 100%);
     --color-compose-collapsed-reply-button-area-background-interactive: var(
         --color-compose-collapsed-reply-button-area-background
@@ -1192,6 +1206,10 @@
     --color-compose-send-control-button-focus-shadow: var(
         --color-compose-send-button-focus-shadow
     );
+    --color-compose-recipient-box-text-color: inherit;
+    --color-compose-recipient-box-background-color: hsl(0deg 0% 0% / 20%);
+    --color-compose-recipient-box-border-color: hsl(0deg 0% 0% / 80%);
+    --color-compose-recipient-box-has-focus: hsl(0deg 0% 100% / 27%);
     --color-compose-collapsed-reply-button-area-background: hsl(
         0deg 0% 0% / 20%
     );

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -904,16 +904,16 @@ textarea.new_message_textarea {
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: stretch;
     flex: 1 1 0;
-    border: 1px solid hsl(0deg 0% 0% / 20%);
+    border: 1px solid var(--color-compose-recipient-box-border-color);
     border-radius: 3px;
     transition: border-color 0.2s ease;
-    background: hsl(0deg 0% 100%);
+    background: var(--color-compose-recipient-box-background-color);
 
     /* Give the recipient box, a `<div>`, the
        correct styles when focus is in the
        #stream_message_recipient_topic `<input>` */
     &:focus-within {
-        border-color: hsl(0deg 0% 67%);
+        border-color: var(--color-compose-recipient-box-has-focus);
     }
 
     #stream_message_recipient_topic,
@@ -973,6 +973,11 @@ textarea.new_message_textarea {
 #compose_select_recipient_widget {
     width: auto;
     outline: none;
+    /* We override the component-level colors to
+       ensure concord with the topic box. */
+    color: var(--color-compose-recipient-box-text-color);
+    background-color: var(--color-compose-recipient-box-background-color);
+    border-color: var(--color-compose-recipient-box-border-color);
 
     &.dropdown-widget-button {
         padding: 0 6px;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -905,7 +905,7 @@ textarea.new_message_textarea {
     align-items: stretch;
     flex: 1 1 0;
     border: 1px solid var(--color-compose-recipient-box-border-color);
-    border-radius: 3px;
+    border-radius: 4px;
     transition: border-color 0.2s ease;
     background: var(--color-compose-recipient-box-background-color);
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1432,6 +1432,14 @@ textarea.new_message_textarea {
     justify-content: flex-start;
     height: var(--compose-recipient-box-min-height);
 
+    &:focus-visible {
+        outline: 0;
+
+        #compose_select_recipient_widget {
+            border-color: var(--color-compose-recipient-box-has-focus);
+        }
+    }
+
     .dropdown_widget_value {
         flex-grow: 1;
         text-overflow: ellipsis;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -345,8 +345,7 @@
     #custom-expiration-time-input,
     #organization-permissions .dropdown-widget-button,
     #organization-settings .dropdown-widget-button,
-    #stream-advanced-configurations .dropdown-widget-button,
-    #compose_recipient_box {
+    #stream-advanced-configurations .dropdown-widget-button {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -180,7 +180,7 @@
 }
 
 #compose-direct-recipient .pill-container {
-    border: 1px solid hsl(0deg 0% 0% / 20%);
+    border: 1px solid var(--color-compose-recipient-box-border-color);
     background-color: var(
         --color-background-compose-direct-recipient-pill-container
     );
@@ -193,6 +193,10 @@
     .pill + .input:empty::before {
         content: attr(data-some-recipients-text);
         opacity: 0.5;
+    }
+
+    &:has(.input:focus) {
+        border-color: var(--color-compose-recipient-box-has-focus);
     }
 }
 


### PR DESCRIPTION
This PR corrects some subtle but maddening (once you see them) differences between input elements in the compose box (the channel/DM widget, the topic box, and the compose area).

Specific changes to note:

* Borders are now exactly the same for all three elements. Both light and dark mode had subtle differences, although light mode was more obvious, with the elements on the recipient row all bordered by a neutral gray, despite the compose area's more blue-gray.
* The topic box now shares the same 4px border radius as other elements.
* The topic box in light mode uses the same color focus outline as the compose area, which is much more obvious and prominent. The dark-mode topic box previously had no outline change, but now also takes the same outline as the compose area.
* Although the widget wrapper is a `<div>`, because it takes `tabindex`, it receives a browser-default double outline on `:focus-visible`. That is now corrected to take the same outline as the focused topic box and compose area.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/recipient.20row.20concord/near/1972812)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Kinetic shots showing focus states, etc._

| Before | After |
| --- | --- |
| ![light-mode-compose-inputs-before](https://github.com/user-attachments/assets/5f178b9c-a702-4ef2-9a52-d28d88d36ea6) | ![light-mode-compose-inputs-after](https://github.com/user-attachments/assets/9c6f7f1a-8498-42ab-95a3-c5dbf10ac672) |
| ![dark-mode-compose-inputs-before](https://github.com/user-attachments/assets/70a44651-51f6-4b69-bbbd-28054de46868) | ![dark-mode-compose-inputs-after](https://github.com/user-attachments/assets/97bee3ec-d939-4ac2-9883-3b943ee834b5) |

_Static shots for comparing unfocused colors, border radius._

| Before | After |
| --- | --- |
| ![static-light-before](https://github.com/user-attachments/assets/33043393-4929-43d4-8643-f10063659d78) | ![static-light-after](https://github.com/user-attachments/assets/bc9e5952-516d-4afd-a127-a243b2d84a96) |
| ![static-dark-before](https://github.com/user-attachments/assets/086cc495-e2f4-490d-b1f0-889708eb2f32) | ![static-dark-after](https://github.com/user-attachments/assets/8df3d64c-5b12-42e6-b16f-0ef16633fb3a) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>