### PR TITLE
message_edit: Add message length limit indicator in edit message UI.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -132,7 +132,7 @@ export function clear_compose_box() {
     }
     $("textarea#compose-textarea").val("").trigger("focus");
     compose_ui.compose_textarea_typeahead?.hide();
-    compose_validate.check_overflow_text();
+    compose_validate.check_overflow_text($("#send_message_form"));
     compose_validate.clear_topic_resolved_warning();
     drafts.set_compose_draft_id(undefined);
     compose_ui.autosize_textarea($("textarea#compose-textarea"));

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -132,7 +132,7 @@ function clear_box(): void {
     compose_state.set_recipient_edited_manually(false);
     compose_state.set_is_content_unedited_restored_draft(false);
     clear_textarea();
-    compose_validate.check_overflow_text();
+    compose_validate.check_overflow_text($("#send_message_form"));
     drafts.set_compose_draft_id(undefined);
     $("textarea#compose-textarea").toggleClass("invalid", false);
     compose_ui.autosize_textarea($("textarea#compose-textarea"));
@@ -377,7 +377,7 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         $(".compose_control_button_container:has(.add-poll)").addClass("disabled-on-hover");
         // If we were provided with message content, we might need to
         // display that it's too long.
-        compose_validate.check_overflow_text();
+        compose_validate.check_overflow_text($("#send_message_form"));
     }
     // This has to happen after we insert the content, so that the next "input" event
     // is from user input.

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -70,7 +70,7 @@ export function initialize() {
 
     $("textarea#compose-textarea").on("input propertychange", () => {
         compose_validate.warn_if_topic_resolved(false);
-        const compose_text_length = compose_validate.check_overflow_text();
+        const compose_text_length = compose_validate.check_overflow_text($("#send_message_form"));
         if (compose_text_length !== 0 && $("textarea#compose-textarea").hasClass("invalid")) {
             $("textarea#compose-textarea").toggleClass("invalid", false);
         }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -717,15 +717,16 @@ function validate_private_message(): boolean {
     return true;
 }
 
-export function check_overflow_text(): number {
+export function check_overflow_text($container: JQuery): number {
     // This function is called when typing every character in the
     // compose box, so it's important that it not doing anything
     // expensive.
-    const $textarea = $("textarea#compose-textarea");
-    const text = compose_state.message_content();
+    const $textarea = $container.find<HTMLTextAreaElement>(".message-textarea");
+    // Match the behavior of compose_state.message_content of trimming trailing whitespace
+    const text = $textarea.val()!.trimEnd();
     const max_length = realm.max_message_length;
     const remaining_characters = max_length - text.length;
-    const $indicator = $("#compose-limit-indicator");
+    const $indicator = $container.find(".message-limit-indicator");
 
     if (text.length > max_length) {
         $indicator.addClass("over_limit");
@@ -755,9 +756,11 @@ export function check_overflow_text(): number {
     return text.length;
 }
 
-export function validate_message_length(): boolean {
-    const $textarea = $("textarea#compose-textarea");
-    if (compose_state.message_content().length > realm.max_message_length) {
+export function validate_message_length($container: JQuery): boolean {
+    const $textarea = $container.find<HTMLTextAreaElement>(".message-textarea");
+    // Match the behavior of compose_state.message_content of trimming trailing whitespace
+    const text = $textarea.val()!.trimEnd();
+    if (text.length > realm.max_message_length) {
         $textarea.addClass("flash");
         setTimeout(() => $textarea.removeClass("flash"), 1500);
         return false;
@@ -783,7 +786,7 @@ export function validate(scheduling_message: boolean): boolean {
         );
         return false;
     }
-    if (!validate_message_length()) {
+    if (!validate_message_length($("#send_message_form"))) {
         return false;
     }
 

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -721,6 +721,7 @@ export function check_overflow_text(): number {
     // This function is called when typing every character in the
     // compose box, so it's important that it not doing anything
     // expensive.
+    const $textarea = $("textarea#compose-textarea");
     const text = compose_state.message_content();
     const max_length = realm.max_message_length;
     const remaining_characters = max_length - text.length;
@@ -728,7 +729,7 @@ export function check_overflow_text(): number {
 
     if (text.length > max_length) {
         $indicator.addClass("over_limit");
-        $("textarea#compose-textarea").addClass("over_limit");
+        $textarea.addClass("over_limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -737,7 +738,7 @@ export function check_overflow_text(): number {
         set_message_too_long_for_compose(true);
     } else if (remaining_characters <= 900) {
         $indicator.removeClass("over_limit");
-        $("textarea#compose-textarea").removeClass("over_limit");
+        $textarea.removeClass("over_limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -746,7 +747,7 @@ export function check_overflow_text(): number {
         set_message_too_long_for_compose(false);
     } else {
         $indicator.text("");
-        $("textarea#compose-textarea").removeClass("over_limit");
+        $textarea.removeClass("over_limit");
 
         set_message_too_long_for_compose(false);
     }
@@ -755,9 +756,10 @@ export function check_overflow_text(): number {
 }
 
 export function validate_message_length(): boolean {
+    const $textarea = $("textarea#compose-textarea");
     if (compose_state.message_content().length > realm.max_message_length) {
-        $("textarea#compose-textarea").addClass("flash");
-        setTimeout(() => $("textarea#compose-textarea").removeClass("flash"), 1500);
+        $textarea.addClass("flash");
+        setTimeout(() => $textarea.removeClass("flash"), 1500);
         return false;
     }
     return true;

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -49,7 +49,7 @@ export function set_upload_in_progress(status: boolean): void {
     update_send_button_status();
 }
 
-function set_message_too_long(status: boolean): void {
+function set_message_too_long_for_compose(status: boolean): void {
     message_too_long = status;
     update_send_button_status();
 }
@@ -734,7 +734,7 @@ export function check_overflow_text(): number {
                 remaining_characters,
             }),
         );
-        set_message_too_long(true);
+        set_message_too_long_for_compose(true);
     } else if (remaining_characters <= 900) {
         $indicator.removeClass("over_limit");
         $("textarea#compose-textarea").removeClass("over_limit");
@@ -743,12 +743,12 @@ export function check_overflow_text(): number {
                 remaining_characters,
             }),
         );
-        set_message_too_long(false);
+        set_message_too_long_for_compose(false);
     } else {
         $indicator.text("");
         $("textarea#compose-textarea").removeClass("over_limit");
 
-        set_message_too_long(false);
+        set_message_too_long_for_compose(false);
     }
 
     return text.length;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -362,7 +362,7 @@ function handle_keydown(
                 if (should_enter_send(e)) {
                     e.preventDefault();
                     if (
-                        compose_validate.validate_message_length() &&
+                        compose_validate.validate_message_length($("#send_message_form")) &&
                         !$(".message-send-controls").hasClass("disabled-message-send-controls")
                     ) {
                         on_enter_send();

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -404,6 +404,7 @@ function handle_message_edit_enter(
             // Prevent default to avoid new-line on pressing
             // Enter inside the textarea in this case
             e.preventDefault();
+            compose_validate.validate_message_length($row);
             return;
         }
         save_message_row_edit($row);
@@ -538,6 +539,10 @@ function edit_message($row: JQuery, raw_content: string): void {
         }
     });
 
+    $form.on("input propertychange", () => {
+        compose_validate.check_overflow_text($row);
+    });
+
     $form
         .find(".message-edit-feature-group .video_link")
         .toggle(compose_call.compute_show_video_chat_button());
@@ -595,7 +600,8 @@ function edit_message($row: JQuery, raw_content: string): void {
                 // the half-finished edit around so that they can copy-paste it, but we don't want
                 // people to think "Save" will save the half-finished edit.
                 $message_edit_save.prop("disabled", true);
-                $message_edit_save_container.addClass("tippy-zulip-tooltip");
+                $message_edit_save_container.addClass("message-edit-time-limit-expired");
+                $message_edit_save_container.addClass("disabled-message-edit-save");
                 $message_edit_countdown_timer.addClass("expired");
                 $message_edit_countdown_timer.text($t({defaultMessage: "Time's up!"}));
             } else {
@@ -614,6 +620,7 @@ function edit_message($row: JQuery, raw_content: string): void {
         if (contents) {
             $message_edit_content.val(contents);
         }
+        compose_validate.check_overflow_text($row);
     }
 }
 

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -6,6 +6,7 @@ import render_message_edit_notice_tooltip from "../templates/message_edit_notice
 import render_message_inline_image_tooltip from "../templates/message_inline_image_tooltip.hbs";
 import render_narrow_tooltip from "../templates/narrow_tooltip.hbs";
 
+import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
 import type {Message} from "./message_store.ts";
@@ -275,6 +276,19 @@ export function initialize(): void {
             }
             const time = new Date(message.timestamp * 1000);
             instance.setContent(timerender.get_full_datetime_clarification(time));
+            return undefined;
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    message_list_tooltip(".disabled-message-edit-save", {
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const $row = $elem.closest(".message_row");
+            assert($row !== undefined);
+            instance.setContent(compose_validate.get_disabled_save_tooltip($row));
             return undefined;
         },
         onHidden(instance) {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1304,6 +1304,7 @@
     --color-message-formatting-controls-container: hsl(0deg 0% 0% / 8%);
     --color-message-content-container-border: hsl(0deg 0% 0% / 80%);
     --color-message-content-container-border-focus: hsl(0deg 0% 100% / 27%);
+    --color-message-content-container-border-over-limit: hsl(0deg 76% 65%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 100% / 5%);
     --color-compose-focus-ring: hsl(0deg 0% 67%);
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -327,21 +327,24 @@
         border-color: var(--color-message-content-container-border-focus);
     }
 
-    &:has(.new_message_textarea.over_limit),
-    &:has(.new_message_textarea.over_limit:focus) {
-        box-shadow: 0 0 0 1pt
-            var(--color-message-content-container-border-over-limit);
-    }
-
-    &:has(.new_message_textarea.over_limit.flash) {
-        animation: message-limit-flash 0.5s ease-in-out 3;
-    }
-
     &:has(.new_message_textarea.invalid),
     &:has(.new_message_textarea.invalid:focus) {
         border-color: hsl(3deg 57% 33%);
         box-shadow: 0 0 2px hsl(3deg 57% 33%);
     }
+}
+
+#message-content-container:has(.new_message_textarea.over_limit),
+#message-content-container:has(.new_message_textarea.over_limit:focus),
+.edit-content-container:has(.message_edit_content.over_limit),
+.edit-content-container:has(.message_edit_content.over_limit:focus) {
+    box-shadow: 0 0 0 1pt
+        var(--color-message-content-container-border-over-limit);
+}
+
+#message-content-container:has(.new_message_textarea.over_limit.flash),
+.edit-content-container:has(.message_edit_content.over_limit.flash) {
+    animation: message-limit-flash 0.5s ease-in-out 3;
 }
 
 #message-content-container .composebox-buttons {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -459,7 +459,7 @@
     margin: 0 1px;
 }
 
-#compose-limit-indicator:not(:empty) {
+.message-limit-indicator:not(:empty) {
     font-size: 12px;
     color: var(--color-limit-indicator);
     width: max-content;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -329,7 +329,8 @@
 
     &:has(.new_message_textarea.over_limit),
     &:has(.new_message_textarea.over_limit:focus) {
-        box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
+        box-shadow: 0 0 0 1pt
+            var(--color-message-content-container-border-over-limit);
     }
 
     &:has(.new_message_textarea.over_limit.flash) {
@@ -867,7 +868,8 @@
     }
 
     100% {
-        box-shadow: 0 0 0 1pt hsl(0deg 76% 65%);
+        box-shadow: 0 0 0 1pt
+            var(--color-message-content-container-border-over-limit);
     }
 }
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -89,7 +89,7 @@
                             <a id="compose-drafts-button" role="button" class="send-control-button hide-sm" tabindex=0 href="#drafts">
                                 <span class="compose-drafts-text">{{t 'Drafts' }}</span><span class="compose-drafts-count-container">(<span class="compose-drafts-count"></span>)</span>
                             </a>
-                            <span id="compose-limit-indicator"></span>
+                            <span id="compose-limit-indicator" class="message-limit-indicator"></span>
                             <div class="message-send-controls">
                                 <button type="submit" id="compose-send-button" class="send_message compose-submit-button compose-send-or-save-button" aria-label="{{t 'Send' }}">
                                     <img class="loader" alt="" src="" />

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -70,7 +70,7 @@
                     </div>
                     <div class="messagebox">
                         <div id="message-content-container" class="surround-formatting-buttons-row">
-                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
+                            <textarea class="new_message_textarea message-textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
                             <div id="preview-message-area-container">
                                 <div class="scrolling_list preview_message_area" data-simplebar data-simplebar-tab-index="-1" id="preview_message_area" style="display:none;">
                                     <div class="markdown_preview_spinner"></div>

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -8,7 +8,7 @@
                     <span class="copy_message copy-button copy-button-square tippy-zulip-tooltip" data-tippy-content="{{t 'Copy and close' }}" aria-label="{{t 'Copy and close' }}" role="button">
                         <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
                     </span>
-                    <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
+                    <textarea class="message_edit_content message-textarea">{{content}}</textarea>
                 </div>
                 <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
                     <div class="markdown_preview_spinner"></div>
@@ -24,14 +24,14 @@
                     {{/if}}
                     <div class="message-edit-buttons-and-timer">
                         {{#if is_editable}}
-                            <div class="message_edit_save_container"
-                              data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
+                            <div class="message_edit_save_container">
                                 <button type="button" class="message-actions-button message_edit_save">
                                     <img class="loader" alt="" src="" />
                                     <span>{{t "Save" }}</span>
                                 </button>
                             </div>
                             <button type="button" class="message-actions-button message_edit_cancel"><span>{{t "Cancel" }}</span></button>
+                            <span class="tippy-zulip-tooltip message-limit-indicator" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
                             <div class="message-edit-timer">
                                 <span class="message_edit_countdown_timer
                                   tippy-zulip-tooltip" data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}"></span>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -140,6 +140,15 @@ const everyone = {
 
 user_groups.initialize({realm_user_groups: [nobody, everyone]});
 
+function stub_message_row($textarea) {
+    const $stub = $.create("message_row_stub");
+    $textarea.closest = (selector) => {
+        assert.equal(selector, ".message_row");
+        $stub.length = 0;
+        return $stub;
+    };
+}
+
 function test_ui(label, f) {
     // TODO: initialize data more aggressively.
     run_test(label, f);
@@ -181,6 +190,7 @@ test_ui("send_message_success", ({override, override_rewire}) => {
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
+    stub_message_row($textarea);
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
@@ -248,6 +258,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
+    stub_message_row($textarea);
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -178,6 +178,12 @@ test_ui("send_message_success", ({override, override_rewire}) => {
         reify_message_id_checked = true;
     });
 
+    const $elem = $("#send_message_form");
+    const $textarea = $("textarea#compose-textarea");
+    const $indicator = $("#compose-limit-indicator");
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
+
     override(
         onboarding_steps,
         "ONE_TIME_NOTICES_TO_DISPLAY",
@@ -239,6 +245,11 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     mock_banners();
     MockDate.set(new Date(fake_now * 1000));
     override_rewire(drafts, "sync_count", noop);
+    const $elem = $("#send_message_form");
+    const $textarea = $("textarea#compose-textarea");
+    const $indicator = $("#compose-limit-indicator");
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
 
     // This is the common setup stuff for all of the four tests.
     let stub_state;
@@ -422,6 +433,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     override_rewire(compose, "send_message", () => {
         send_message_called = true;
     });
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     compose.enter_with_preview_open();
     assert.ok(!$("#compose .undo_markdown_preview").visible());
     assert.ok(!$("#compose .preview_message_area").visible());
@@ -448,6 +460,7 @@ test_ui("finish", ({override, override_rewire}) => {
 
     override_rewire(compose_banner, "clear_message_sent_banners", noop);
     override(document, "to_$", () => $("document-stub"));
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     let show_button_spinner_called = false;
     override(loading, "show_button_spinner", ($spinner) => {
         assert.equal($spinner.selector, ".compose-submit-button .loader");

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -126,6 +126,15 @@ function test(label, f) {
     });
 }
 
+function stub_message_row($textarea) {
+    const $stub = $.create("message_row_stub");
+    $textarea.closest = (selector) => {
+        assert.equal(selector, ".message_row");
+        $stub.length = 0;
+        return $stub;
+    };
+}
+
 test("initial_state", () => {
     assert.equal(compose_state.composing(), false);
     assert.equal(compose_state.get_message_type(), undefined);
@@ -143,6 +152,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
+    stub_message_row($textarea);
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
@@ -290,6 +300,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
+    stub_message_row($textarea);
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
@@ -351,6 +362,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
+    stub_message_row($textarea);
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 
@@ -411,6 +423,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
+    stub_message_row($textarea);
     $elem.set_find_results(".message-textarea", $textarea);
     $elem.set_find_results(".message-limit-indicator", $indicator);
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -140,6 +140,12 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "blur_compose_inputs", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    const $elem = $("#send_message_form");
+    const $textarea = $("textarea#compose-textarea");
+    const $indicator = $("#compose-limit-indicator");
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
+
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     mock_template("inline_decorated_stream_name.hbs", false, noop);
@@ -281,6 +287,12 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     mock_banners();
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    const $elem = $("#send_message_form");
+    const $textarea = $("textarea#compose-textarea");
+    const $indicator = $("#compose-limit-indicator");
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
+
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     override_private_message_recipient({override});
@@ -336,6 +348,12 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    const $elem = $("#send_message_form");
+    const $textarea = $("textarea#compose-textarea");
+    const $indicator = $("#compose-limit-indicator");
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
+
     override_private_message_recipient({override});
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     mock_template("inline_decorated_stream_name.hbs", false, noop);
@@ -390,6 +408,12 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
 test("quote_and_reply", ({disallow, override, override_rewire}) => {
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_reply, "selection_within_message_id", () => undefined);
+    const $elem = $("#send_message_form");
+    const $textarea = $("textarea#compose-textarea");
+    const $indicator = $("#compose-limit-indicator");
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
+
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
 

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -188,6 +188,7 @@ test_ui("validate", ({mock_template, override}) => {
         pm_recipient_error_rendered = true;
         return "<banner-stub>";
     });
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(!compose_validate.validate());
     assert.ok(pm_recipient_error_rendered);
 
@@ -229,6 +230,7 @@ test_ui("validate", ({mock_template, override}) => {
     initialize_pm_pill();
     add_content_to_compose_box();
     compose_state.private_message_recipient("welcome-bot@example.com");
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(compose_validate.validate());
 
     let zephyr_error_rendered = false;
@@ -263,6 +265,7 @@ test_ui("validate", ({mock_template, override}) => {
         zephyr_checked = true;
         return true;
     };
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(!compose_validate.validate());
     assert.ok(zephyr_checked);
     assert.ok(zephyr_error_rendered);
@@ -280,6 +283,7 @@ test_ui("validate", ({mock_template, override}) => {
         empty_stream_error_rendered = true;
         return "<banner-stub>";
     });
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(!compose_validate.validate());
     assert.ok(empty_stream_error_rendered);
 
@@ -433,6 +437,7 @@ test_ui("validate_stream_message", ({override, override_rewire, mock_template}) 
     stream_data.add_sub(special_sub);
 
     compose_state.set_stream_id(special_sub.stream_id);
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(compose_validate.validate());
     assert.ok(!$("#compose-all-everyone").visible());
 
@@ -496,6 +501,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", ({mock_template, 
         banner_rendered = true;
         return "<banner-stub>";
     });
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(!compose_validate.validate());
     assert.ok(banner_rendered);
 
@@ -541,6 +547,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", ({mock_templ
         banner_rendered = true;
         return "<banner-stub>";
     });
+    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
     assert.ok(!compose_validate.validate());
     assert.ok(banner_rendered);
     // Reset error message.
@@ -579,6 +586,10 @@ test_ui(
             banner_rendered = true;
             return "<banner-stub>";
         });
+        $("#send_message_form").set_find_results(
+            ".message-textarea",
+            $("textarea#compose-textarea"),
+        );
         assert.ok(!compose_validate.validate());
         assert.ok(banner_rendered);
     },
@@ -587,8 +598,12 @@ test_ui(
 test_ui("test_check_overflow_text", ({mock_template, override}) => {
     override(realm, "max_message_length", 10000);
 
-    const $textarea = $("textarea#compose-textarea");
-    const $indicator = $("#compose-limit-indicator");
+    const $elem = $("#send_message_form");
+    const $textarea = $(".message-textarea");
+    const $indicator = $(".message-limit-indicator");
+    stub_message_row($textarea);
+    $elem.set_find_results(".message-textarea", $textarea);
+    $elem.set_find_results(".message-limit-indicator", $indicator);
 
     // Indicator should show red colored text
     let limit_indicator_html;
@@ -596,7 +611,7 @@ test_ui("test_check_overflow_text", ({mock_template, override}) => {
         limit_indicator_html = html;
     });
     $textarea.val("a".repeat(10000 + 1));
-    compose_validate.check_overflow_text();
+    compose_validate.check_overflow_text($elem);
     assert.ok($indicator.hasClass("over_limit"));
     assert.equal(limit_indicator_html, "-1\n");
     assert.ok($textarea.hasClass("over_limit"));
@@ -604,7 +619,7 @@ test_ui("test_check_overflow_text", ({mock_template, override}) => {
 
     // Indicator should show orange colored text
     $textarea.val("a".repeat(9100));
-    compose_validate.check_overflow_text();
+    compose_validate.check_overflow_text($elem);
     assert.ok(!$indicator.hasClass("over_limit"));
     assert.equal(limit_indicator_html, "900\n");
     assert.ok(!$textarea.hasClass("over_limit"));
@@ -612,7 +627,7 @@ test_ui("test_check_overflow_text", ({mock_template, override}) => {
 
     // Indicator must be empty
     $textarea.val("a".repeat(9100 - 1));
-    compose_validate.check_overflow_text();
+    compose_validate.check_overflow_text($elem);
     assert.ok(!$indicator.hasClass("over_limit"));
     assert.equal($indicator.text(), "");
     assert.ok(!$textarea.hasClass("over_limit"));


### PR DESCRIPTION
Adds a message length limit indicator similar to the one in the compose box. The tooltip message for the disabled save button now appears dynamically based on whether the message exceeds the length limit or the editing time has expired.

Fixes #25271.

[CZO thread](https://chat.zulip.org/#narrow/channel/101-design/topic/UI.20redesign.3A.20message.20editing)
<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/user-attachments/assets/ec507b0c-446d-4e48-a5a1-523904738573)

![image](https://github.com/user-attachments/assets/ff5e9535-11f4-47dc-9aca-77604cd53edd)

If the editing time expires along with the message's length exceeding the max length:
![image](https://github.com/user-attachments/assets/d674818c-a007-4dea-84df-c3fb0ea691be)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
