### PR TITLE
drafts: Remove feature for discarding drafts after 30 days.

### DIFF
--- a/help/view-and-edit-your-message-drafts.md
+++ b/help/view-and-edit-your-message-drafts.md
@@ -3,7 +3,7 @@
 Zulip automatically saves the content of your message as a draft when you close
 the compose box, ensuring that you never lose your work. When you start
 composing, the most recently edited draft for the conversation you are composing
-to automatically appears in the compose box. Drafts are saved for 30 days.
+to automatically appears in the compose box.
 
 !!! warn ""
 

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -164,7 +164,6 @@ export function launch(): void {
             narrow_drafts_header,
             narrow_drafts,
             other_drafts,
-            draft_lifetime: drafts.DRAFT_LIFETIME,
         });
         const $drafts_table = $("#drafts_table");
         $drafts_table.append($(rendered));

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -6,7 +6,7 @@
         justify-content: space-between;
         gap: 5px;
 
-        .removed-drafts-message {
+        .drafts-header-note {
             text-align: left;
             margin-left: 25px;
 

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -9,8 +9,6 @@
                 <div class="header-body">
                     <div class="removed-drafts-message">
                         {{t "Drafts are not synced to other devices and browsers." }}
-                        <br />
-                        {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
                     </div>
                     <div class="delete-drafts-group">
                         <div class="delete-selected-drafts-button-container">

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -7,7 +7,7 @@
                     <span class="exit-sign">&times;</span>
                 </div>
                 <div class="header-body">
-                    <div class="removed-drafts-message">
+                    <div class="drafts-header-note">
                         {{t "Drafts are not synced to other devices and browsers." }}
                     </div>
                     <div class="delete-drafts-group">

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -265,38 +265,6 @@ test("initialize", ({override_rewire}) => {
     drafts_overlay_ui.initialize();
 });
 
-test("remove_old_drafts", ({override_rewire}) => {
-    const draft_3 = {
-        topic: "topic",
-        type: "stream",
-        content: "Test stream message",
-        updatedAt: Date.now(),
-        is_sending_saving: false,
-        drafts_version: 1,
-    };
-    const draft_4 = {
-        private_message_recipient: "aaron@zulip.com",
-        reply_to: "aaron@zulip.com",
-        type: "private",
-        content: "Test direct message",
-        updatedAt: new Date().setDate(-30),
-        is_sending_saving: false,
-        drafts_version: 1,
-    };
-    const draft_model = drafts.draft_model;
-    const ls = localstorage();
-    const data = {id3: draft_3, id4: draft_4};
-    ls.set("drafts", data);
-    assert.deepEqual(draft_model.get(), data);
-
-    const $unread_count = $("<unread-count-stub>");
-    $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
-    override_rewire(drafts, "update_compose_draft_count", noop);
-
-    drafts.remove_old_drafts();
-    assert.deepEqual(draft_model.get(), {id3: draft_3});
-});
-
 test("update_draft", ({override, override_rewire}) => {
     compose_state.set_message_type(undefined);
     let draft_id = drafts.update_draft();


### PR DESCRIPTION
This commit eliminates the 30-day automatic removal feature for saved drafts, allowing users to retain drafts indefinitely until they choose to delete them manually. The following changes are included:

- **Code Adjustments**: Removed the `DRAFT_LIFETIME` constant and associated logic that calculated and deleted drafts older than 30 days. This prevents the auto-discard mechanism, ensuring drafts are retained without expiration.
  
- **Documentation Updates**:
  - Updated the drafts modal to remove the line informing users that drafts older than 30 days are automatically removed.
  - Modified `/help/view-and-edit-your-message-drafts` to remove mentions of the 30-day retention limit, ensuring documentation accurately reflects the indefinite storage of drafts.
  - Checked other related documentation to ensure consistency and removed any outdated references to the 30-day policy.

These changes provide a better user experience by removing limitations on draft retention, allowing users more flexibility and control over their saved drafts.


Fixes #32176 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
