### PR TITLE
buddy_data: Don't filter out inactive participants.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -379,8 +379,7 @@ function get_filtered_user_id_list(
     user_filter_text: string,
     conversation_participants: Set<number>,
 ): number[] {
-    // We always want to show conversation participants even if they're inactive.
-    let base_user_id_list = [...conversation_participants];
+    let base_user_id_list = [];
 
     if (user_filter_text) {
         // If there's a filter, select from all users, not just those
@@ -418,7 +417,9 @@ function get_filtered_user_id_list(
     }
 
     const user_ids = filter_user_ids(user_filter_text, base_user_id_list);
-    return user_ids;
+    // Make sure all the participants are in the list, even if they're inactive.
+    const user_ids_set = new Set([...user_ids, ...conversation_participants]);
+    return [...user_ids_set];
 }
 
 export function get_conversation_participants(): Set<number> {


### PR DESCRIPTION
This was filtering out users that were marked as
inactive for more than a year, but we want to show all participants, including inactive ones.

More discussion on this here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/In.20this.20conversation.20and.20invisible.20mode/near/197309

I didn't know how to test this locally because all users are recently added and not inactive.