### PR TITLE
portico: Improve layout of the form in realm redirect page.

### DIFF
--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -19,13 +19,18 @@
                     {{ csrf_input }}
                     <div class="input-box horizontal">
                         <div class="inline-block relative">
-                            <p id="realm_redirect_description">{{ _("Enter your organization's Zulip URL:") }}</p>
+                            <label for="realm_redirect_subdomain" class="inline-block label-title">{{ _('Organization name') }}</label>
                             <input
                               type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
                               placeholder="{{ _('your-organization-url') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
                               autocomplete="off" required/>
                             <span id="realm_redirect_external_host">.{{external_host}}</span>
+                            <div class="help-text">
+                                {{ _("Don't know your organization URL?") }}
+                                <a target="_blank" rel="noopener noreferrer" href="/accounts/find/">{{ _("Find your organization.") }}</a>
+                            </div>
                         </div>
+                        
                         <div id="errors">
                             {% if form.subdomain.errors %}
                                 {% for error in form.subdomain.errors %}
@@ -34,10 +39,6 @@
                             {% endif %}
                         </div>
                         <button id="enter-realm-button" type="submit">{{ _('Next') }}</button>
-                        <p class="bottom-text">
-                            {{ _("Don't know your organization URL?") }}
-                            <a target="_blank" rel="noopener noreferrer" href="/accounts/find/">{{ _("Find your organization.") }}</a>
-                        </p>
                     </div>
                 </form>
             </div>

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -30,7 +30,6 @@
                                 <a target="_blank" rel="noopener noreferrer" href="/accounts/find/">{{ _("Find your organization.") }}</a>
                             </div>
                         </div>
-                        
                         <div id="errors">
                             {% if form.subdomain.errors %}
                                 {% for error in form.subdomain.errors %}

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -619,6 +619,22 @@ html {
             left: 1px;
         }
 
+        & .help-text {
+            width: 100%;
+            max-width: none;
+            margin: 2px 0;
+            text-align: left;
+            color: hsl(0deg 0% 47%);
+            font-size: 0.9rem;
+            font-weight: 400;
+            line-height: 1.2;
+
+            & a {
+                text-decoration: none;
+                color: hsl(164deg 100% 23%);
+            }
+        }
+
         & label.text-error {
             display: block;
 
@@ -1195,7 +1211,6 @@ button#register_auth_button_gitlab {
 
 .goto-account-page {
     #realm_redirect_subdomain {
-        text-align: right;
         position: relative;
         padding-right: 10px;
     }
@@ -1209,6 +1224,7 @@ button#register_auth_button_gitlab {
 
     #realm_redirect_description {
         top: 15px;
+        text-align: left;
         position: relative;
     }
 
@@ -1282,25 +1298,25 @@ button#register_auth_button_gitlab {
 
 /* -- media queries -- */
 
-@media (width <= 950px) {
+@media (width <=950px) {
     .split-view .left-side {
         width: 400px;
     }
 }
 
-@media (width <= 850px) {
+@media (width <=850px) {
     .split-view .left-side {
         width: 350px;
     }
 }
 
-@media (width <= 815px) {
+@media (width <=815px) {
     .flex {
         min-height: calc(100vh - 530px);
     }
 }
 
-@media (width <= 795px) {
+@media (width <=795px) {
     .register-account #registration {
         padding: 10px;
     }
@@ -1362,7 +1378,7 @@ button#register_auth_button_gitlab {
     }
 }
 
-@media (width <= 500px) {
+@media (width <=500px) {
     .new-style .get-started {
         font-size: 1.6em;
     }
@@ -1415,7 +1431,7 @@ button#register_auth_button_gitlab {
     }
 }
 
-@media (width <= 400px) {
+@media (width <=400px) {
     .flex {
         min-height: calc(100vh - 560px);
     }
@@ -1431,7 +1447,7 @@ button#register_auth_button_gitlab {
     }
 }
 
-@media (width <= 340px) {
+@media (width <=340px) {
     #create-account,
     #new-realm-creation {
         margin: -40px -60px;
@@ -1447,7 +1463,7 @@ button#register_auth_button_gitlab {
     word-break: break-all;
 }
 
-@media (width >= 800px) {
+@media (width >=800px) {
     .account-creation .white-box {
         max-width: 800px;
     }

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4712,7 +4712,7 @@ class NameRestrictionsTest(ZulipTestCase):
 class RealmRedirectTest(ZulipTestCase):
     def test_realm_redirect_without_next_param(self) -> None:
         result = self.client_get("/accounts/go/")
-        self.assert_in_success_response(["Enter your organization's Zulip URL"], result)
+        self.assert_in_success_response(["Log in to your organization"], result)
 
         result = self.client_post("/accounts/go/", {"subdomain": "zephyr"})
         self.assertEqual(result.status_code, 302)
@@ -4724,7 +4724,7 @@ class RealmRedirectTest(ZulipTestCase):
     def test_realm_redirect_with_next_param(self) -> None:
         result = self.client_get("/accounts/go/", {"next": "billing"})
         self.assert_in_success_response(
-            ["Enter your organization's Zulip URL", 'action="/accounts/go/?next=billing"'], result
+            ["Log in to your organization", 'action="/accounts/go/?next=billing"'], result
         )
 
         result = self.client_post("/accounts/go/?next=billing", {"subdomain": "lear"})


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->#32198

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/9f5eb05e-0299-475e-8e5e-f9de67bf9a0f)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>


