### PR TITLE
keyboard-shortcuts: Display "Ctrl" for Vim "Esc" keybinding behavior.

### DIFF
--- a/help/configure-home-view.md
+++ b/help/configure-home-view.md
@@ -13,8 +13,8 @@ on how to use these views.
 
 You can configure which view is set as your home view, and whether
 the <kbd>Esc</kbd> key navigates to the home view. Also, you can
-always reach the home view by using the <kbd>Ctrl</kbd> + <kbd>[</kbd>
-shortcut.
+always reach the home view by using the
+<kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> shortcut.
 
 ## Change home view
 
@@ -44,7 +44,8 @@ organization settings:
 
 1. To see your changes in action, open a new Zulip tab, or use a keyboard
    shortcut twice to exit the settings and navigate to your home view
-   (<kbd>Ctrl</kbd> + <kbd>[</kbd> or <kbd>Esc</kbd> if enabled).
+   (<kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> or <kbd>Esc</kbd>
+   if enabled).
 
 !!! tip ""
 
@@ -62,8 +63,8 @@ designed to enhance the user experience in the app.
 By default, the <kbd>Esc</kbd> key shortcut will ultimately navigate to
 your home view. You can disable this key binding if you would prefer.
 This will not disable other <kbd>Esc</kbd> key shortcuts used in Zulip,
-and will not affect the behavior of the <kbd>Ctrl</kbd> + <kbd>[</kbd>
-shortcut.
+and will not affect the behavior of the
+<kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> shortcut.
 
 ### Toggle whether <kbd>Esc</kbd> navigates to the home view
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -32,9 +32,9 @@ in the Zulip app to add more to your repertoire as needed.
   <kbd>Ctrl</kbd> + <kbd>V</kbd>, and press <kbd>Ctrl</kbd> + <kbd>Z</kbd> to
   remove formatting.
 
-* **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
-  <kbd>[</kbd> — Close the compose box and save the unsent message as a
-  draft.
+* **Cancel compose and save draft**: <kbd>Esc</kbd> or
+  <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> — Close the compose box
+  and save the unsent message as a draft.
 
 * **View drafts**: <kbd>D</kbd> — Use the arrow keys and <kbd>Enter</kbd>
   to restore a draft. Press <kbd>D</kbd> again to close.
@@ -54,8 +54,8 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Toggle keyboard shortcuts view**: <kbd>?</kbd>
 
-* **Go to your home view**: <kbd>Ctrl</kbd> + <kbd>[</kbd> (or
-  <kbd>Esc</kbd>, [if enabled][disable-escape])
+* **Go to your home view**: <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd>
+  (or <kbd>Esc</kbd>, [if enabled][disable-escape])
   until you are in your [home view](/help/configure-home-view).
 
 [disable-escape]: /help/configure-home-view#configure-whether-esc-navigates-to-the-home-view
@@ -158,8 +158,9 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Toggle preview mode**: <kbd>Alt</kbd> + <kbd>P</kbd>
 
-* **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
-  <kbd>[</kbd> — Close the compose box and save the unsent message as a draft.
+* **Cancel compose and save draft**: <kbd>Esc</kbd> or
+  <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> — Close the compose box
+  and save the unsent message as a draft.
 
 ## Message actions
 

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -34,10 +34,14 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
         let key_text = $(this).text();
 
         // We use data-mac-key attribute to override the default key in case
-        // of exceptions. Currently, there are 2 shortcuts (for navigating back
-        // and forth in browser history) which need `Cmd` instead of the expected
-        // mapping (`Opt`) for the `Alt` key, so we use this attribute to override
-        // `Opt` with `Cmd`.
+        // of exceptions:
+        // - There are 2 shortcuts (for navigating back and forth in browser
+        //   history) which need "⌘" instead of the expected mapping ("Opt")
+        //   for the "Alt" key, so we use this attribute to override "Opt"
+        //   with "⌘".
+        // - The "Ctrl" + "[" shortcuts (which match the Vim keybinding behavior
+        //   of mapping to "Esc") need to display "Ctrl" for all users, so we
+        //   use this attribute to override "⌘" with "Ctrl".
         const replace_key = $(this).attr("data-mac-key") ?? keys_map.get(key_text);
         if (replace_key !== undefined) {
             key_text = replace_key;

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -30,7 +30,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'View drafts' }}</td>
@@ -66,7 +66,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Go to your home view' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>[</kbd><span id="go-to-home-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
+                    <td><span class="hotkey"><kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd><span id="go-to-home-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
                 </tr>
             </table>
         </div>
@@ -238,7 +238,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
For all users, we want to display "Ctrl" for the "Ctrl" "[" keyboard shortcuts that match the "Esc" Vim keybinding behavior.

We use the "data-mac-key" attribute to override the default mapping of "Ctrl" to "Cmd" for Mac users in the documentation of these keyboard shortcuts. This data attribute was already in place for another exception to our default remapping of documented keyboard shortcuts for Mac users.

Fixes #20107.

---

`git grep '\[</kbd>'` after changes:
```
help/configure-home-view.md:<kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> shortcut.
help/configure-home-view.md:   (<kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> or <kbd>Esc</kbd>
help/configure-home-view.md:<kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> shortcut.
help/keyboard-shortcuts.md:  <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> — Close the compose box
help/keyboard-shortcuts.md:* **Go to your home view**: <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd>
help/keyboard-shortcuts.md:  <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd> — Close the compose box
web/templates/keyboard_shortcuts.hbs:                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd></span></td>
web/templates/keyboard_shortcuts.hbs:                    <td><span class="hotkey"><kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd><span id="go-to-home-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
web/templates/keyboard_shortcuts.hbs:                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd data-mac-key="Ctrl">Ctrl</kbd> + <kbd>[</kbd></span></td>

```

---

**Screenshots and screen captures:**

<details>
<summary>Keyboard shortcuts - help center</summary>

[Current documentation](https://zulip.com/help/keyboard-shortcuts)

| Mac | Non-Mac |
| --- | --- |
| ![Screenshot from 2024-11-01 12-58-17](https://github.com/user-attachments/assets/362c5ef2-8fd1-4a3a-95be-b57e9848b109) | ![Screenshot from 2024-11-01 12-58-31](https://github.com/user-attachments/assets/80fc8c61-b52e-4f61-931c-fea19ec072dc) |
| ![Screenshot from 2024-11-01 12-59-20](https://github.com/user-attachments/assets/8ce5be77-256c-4793-968e-f70eabaf98f3) | ![Screenshot from 2024-11-01 12-59-05](https://github.com/user-attachments/assets/4d1bc744-d1d7-4262-916f-76079ac67ee6) |
</details>

<details>
<summary>Configure home view - help center</summary>

[Current documentation](https://zulip.com/help/configure-home-view)

| Mac | Non-Mac |
| --- | --- |
| ![Screenshot from 2024-11-01 12-57-57](https://github.com/user-attachments/assets/219489cd-dae9-480a-a3be-671ae28daaf9) | ![Screenshot from 2024-11-01 12-57-37](https://github.com/user-attachments/assets/353f06af-1a19-4226-aef7-0c92860e7e16) |
</details>
<details>
<summary>Keyboard shortcuts - web app help</summary>

| Mac | Non-Mac |
| --- | --- |
| ![Screenshot from 2024-11-01 12-56-01](https://github.com/user-attachments/assets/d7a3e094-515a-4e0a-bc4c-e1b74f582b7f) | ![Screenshot from 2024-11-01 12-55-42](https://github.com/user-attachments/assets/038d354d-9e2a-4102-81d6-91b560dfe864) |
| ![Screenshot from 2024-11-01 12-56-40](https://github.com/user-attachments/assets/5fbc4b86-7d29-4ed4-bcb5-aaed0ebde4d3) | ![Screenshot from 2024-11-01 12-57-03](https://github.com/user-attachments/assets/a8a3dc26-b4e1-4ef5-a7e7-96c65292d42b) |
</details>







---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
