### PR TITLE
util: Make get_custom_time_in_minutes throw error for unknown unit.

### DIFF
--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -440,15 +440,17 @@ export function get_remaining_time(start_time: number, duration: number): number
 
 export function get_custom_time_in_minutes(time_unit: string, time_input: number): number {
     switch (time_unit) {
+        case "minutes":
+            return time_input;
         case "hours":
             return time_input * 60;
         case "days":
             return time_input * 24 * 60;
         case "weeks":
             return time_input * 7 * 24 * 60;
-        default:
-            return time_input;
     }
+    blueslip.error(`Unexpected custom time unit: ${time_unit}`);
+    return time_input;
 }
 
 export function check_time_input(input_value: string, keep_number_as_float = false): number {

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -394,14 +394,13 @@ run_test("get_custom_time_in_minutes", () => {
     assert.equal(util.get_custom_time_in_minutes("days", time_input), time_input * 24 * 60);
     assert.equal(util.get_custom_time_in_minutes("hours", time_input), time_input * 60);
     assert.equal(util.get_custom_time_in_minutes("minutes", time_input), time_input);
-    // Unknown time unit returns same time input
+    // Unknown time unit string throws an error, but we still return
+    // the time input that was passed to the function.
+    blueslip.expect("error", "Unexpected custom time unit: invalid");
     assert.equal(util.get_custom_time_in_minutes("invalid", time_input), time_input);
     /// NaN time input returns NaN
     const invalid_time_input = Number.NaN;
-    assert.equal(
-        util.get_custom_time_in_minutes("minutes", invalid_time_input),
-        invalid_time_input,
-    );
+    assert.equal(util.get_custom_time_in_minutes("hours", invalid_time_input), invalid_time_input);
 });
 
 run_test("check_and_validate_custom_time_input", () => {


### PR DESCRIPTION
Follow-up for this PR comment: https://github.com/zulip/zulip/pull/30510#discussion_r1803859377.

The helper function `get_custom_time_in_minutes` still returns the time value from the input, so that the app doesn't break when the error is thrown. Currently, this is only used in the invite users modal, but will likely be used in other modals where a user can set a custom time with different time units (minutes, days, etc.).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
