### PR TITLE
left_sidebar: Solidify grid placement of filter-clearing button.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -81,11 +81,10 @@
         margin: 3px 0;
 
         .clear_search_button {
-            grid-area: row-content;
-            justify-self: self-end;
+            grid-area: clear-button;
             /* Override app-component positioning. */
             position: static;
-            padding-right: 4px;
+            padding: 0;
         }
     }
 
@@ -1098,12 +1097,11 @@ li.top_left_scheduled_messages {
 
 .topic_search_section {
     grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0 [filter-box-start] minmax(
-            0,
-            1fr
-        )
+        var(--left-sidebar-toggle-width-offset) 0 0
+        [filter-box-start] minmax(0, 1fr)
         minmax(0, max-content)
-        30px [filter-box-end] 0;
+        [clear-button-start] var(--left-sidebar-vdots-width)
+        [clear-button-end filter-box-end] 0;
 }
 
 .topic-box .zero_count {


### PR DESCRIPTION
This fixes a layout-breaking regression I introduced in #32188, but also better hardens this bit of grid definition to prevent similar issues in the future.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/topic.20filter.20layout/near/1974040)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![clear-button-before](https://github.com/user-attachments/assets/ca0cf1cc-ee94-4421-bc20-dd334ccbbe77) | ![clear-button-after](https://github.com/user-attachments/assets/1ef84773-9309-41e5-afc6-abc986c3b53b) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details> 

