### PR TITLE
groups: Clarify meaning of global admin setting.

### DIFF
--- a/help/manage-user-groups.md
+++ b/help/manage-user-groups.md
@@ -36,7 +36,7 @@
 
 !!! warn ""
 
-    Guests can never manage user groups, add anyone else to a group, or remove
+    Guests can never administer user groups, add anyone else to a group, or remove
     anyone else from a group, even if they belong to a group that has permissions
     to do so.
 
@@ -54,7 +54,7 @@
 
 1. Select the **General** tab on the right.
 
-1. Under **Group permissions**, configure **Who can manage this group**, **Who
+1. Under **Group permissions**, configure **Who can administer this group**, **Who
    can mention this group**, **Who can add members to this group**, **Who can join
    this group**, and **Who can leave this group**.
 
@@ -141,16 +141,17 @@ so.
 
 {end_tabs}
 
-## Configure who can manage user groups
+## Configure who can administer all user groups
 
 {!admin-only.md!}
 
-You can configure who can manage groups in your organization. Guests can never
-manage user groups, even if they belong to a group that has permissions to do
-so.
+You can configure who can administer all user groups in your
+organization. Guests can never administer user groups, even if they
+belong to a group that has permissions to do so.
 
-In addition, you can [give users permission](#configure-group-permissions) to
-manage a specific group.
+In addition, you can [give users
+permission](#configure-group-permissions) to administer a specific
+group.
 
 {start_tabs}
 
@@ -158,7 +159,7 @@ manage a specific group.
 
 {settings_tab|organization-permissions}
 
-1. Under **Other permissions**, configure **Who can manage user groups**.
+1. Under **Other permissions**, configure **Who can administer all user groups**.
 
 {!save-changes.md!}
 

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -332,7 +332,7 @@
 
                 {{> group_setting_value_pill_input
                   setting_name="realm_can_manage_all_groups"
-                  label=(t 'Who can manage user groups')}}
+                  label=(t 'Who can administer all user groups')}}
 
                 {{> group_setting_value_pill_input
                   setting_name="realm_can_add_custom_emoji_group"


### PR DESCRIPTION
The previous wording was ambiguous as to whether this permission means the ability to administer all groups in the organization.
