### PR TITLE
buddy_list: Move user link a bit left to line up with empty message.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -51,7 +51,7 @@ $user_status_emoji_width: 24px;
     }
 
     .buddy-list-user-link {
-        margin-left: 15px;
+        margin-left: 5px;
     }
 }
 


### PR DESCRIPTION
More context here:
https://chat.zulip.org/#narrow/channel/101-design/topic/userlist.20avatar.20slow.20load/near/1974268

