### PR TITLE
sidebar: Fix deactivated user visibility in sidebar.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -48,8 +48,10 @@ export function get_user_circle_class(user_id: number): string {
             return "user_circle_green";
         case "idle":
             return "user_circle_idle";
-        default:
+        case "offline":
             return "user_circle_empty";
+        default:
+            return "user_circle_deactivated";
     }
 }
 
@@ -66,8 +68,10 @@ export function level(user_id: number): number {
             return 1;
         case "idle":
             return 2;
-        default:
+        case "offline":
             return 3;
+        default:
+            return 4;
     }
 }
 
@@ -189,6 +193,7 @@ export type BuddyUserInfo = {
 export function info_for(user_id: number): BuddyUserInfo {
     const user_circle_class = get_user_circle_class(user_id);
     const person = people.get_by_user_id(user_id);
+    const is_deactivated = people.is_person_active(user_id);
 
     const status_emoji_info = user_status.get_status_emoji(user_id);
     const status_text = user_status.get_status_text(user_id);
@@ -201,7 +206,7 @@ export function info_for(user_id: number): BuddyUserInfo {
 
     return {
         href: hash_util.pm_with_url(person.email),
-        name: person.full_name,
+        name: is_deactivated ? person.full_name : $t({defaultMessage: "User Deactivated"}),
         user_id,
         status_emoji_info,
         is_current_user: people.is_my_user_id(user_id),
@@ -350,11 +355,6 @@ function filter_user_ids(user_filter_text: string, user_ids: number[]): number[]
             // Bots should never appear in the right sidebar.  This
             // case should never happen, since bots cannot have
             // presence data.
-            return false;
-        }
-
-        if (!people.is_person_active(user_id)) {
-            // Deactivated users are hidden from the right sidebar entirely.
             return false;
         }
 

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -53,7 +53,7 @@ function get_total_human_subscriber_count(
 
         let human_user_count = 0;
         for (const pm_id of all_recipient_user_ids_set) {
-            if (!people.is_valid_bot_user(pm_id) && people.is_person_active(pm_id)) {
+            if (!people.is_valid_bot_user(pm_id)) {
                 human_user_count += 1;
             }
         }

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -10,7 +10,7 @@ export type RawPresence = z.infer<typeof presence_schema> & {
 };
 
 export type PresenceStatus = {
-    status: "active" | "idle" | "offline";
+    status: "active" | "idle" | "offline" | "deactivated";
     last_active?: number | undefined;
 };
 
@@ -58,9 +58,19 @@ export function get_status(user_id: number): PresenceStatus["status"] {
         // if the current user is not sharing presence, they always see themselves as offline.
         return "offline";
     }
+
     if (presence_info.has(user_id)) {
+        if (presence_info.get(user_id)!.status === undefined) {
+            return "offline";
+        }
         return presence_info.get(user_id)!.status;
     }
+
+    // Check if the user is deactivated
+    if (!people.is_person_active(user_id)) {
+        return "deactivated";
+    }
+
     return "offline";
 }
 

--- a/web/styles/user_circles.css
+++ b/web/styles/user_circles.css
@@ -25,15 +25,22 @@
     border-color: hsl(0deg 0% 50%);
 }
 
+.user_circle_deactivated {
+    text-align: center;
+    font-size: 14px;
+}
+
 .user_circle_empty_line {
     border-color: hsl(0deg 0% 50%);
 
     &::after {
         content: "";
         background: hsl(0deg 0% 50%);
-        height: 1.5px; /* 1px is too thin, 2px is too thick */
+        height: 1.5px;
+        /* 1px is too thin, 2px is too thick */
         width: 6px;
         display: block;
-        margin: 3.25px auto 0; /* (total height - line height) / 2 = 3.25px */
+        margin: 3.25px auto 0;
+        /* (total height - line height) / 2 = 3.25px */
     }
 }

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -6,7 +6,11 @@
         {{else if is_bot}}
         <span class="conversation-partners-icon zulip-icon zulip-icon-bot" aria-hidden="true"></span>
         {{else}}
-        <span class="conversation-partners-icon {{user_circle_class}} user_circle"></span>
+            {{#if (eq user_circle_class "user_circle_deactivated")}}
+                <span class="conversation-partners-icon fa fa-ban user_circle_deactivated"></span>
+            {{else}}
+                <span class="conversation-partners-icon {{user_circle_class}} user_circle"></span>
+            {{/if}}
         {{/if}}
 
         <a href="{{url}}" class="conversation-partners">

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -1,6 +1,10 @@
 <li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if is_current_user}}user_sidebar_entry_me {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
     <div class="selectable_sidebar_block">
-        <span class="{{user_circle_class}} user_circle"></span>
+        {{#if (eq user_circle_class "user_circle_deactivated")}}
+            <span class="fa fa-ban user_circle_deactivated"></span>
+        {{else}}
+            <span class="{{user_circle_class}} user_circle"></span>
+        {{/if}}
         <a class="user-presence-link"
           href="{{href}}"
           data-user-id="{{user_id}}"

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -21,7 +21,11 @@
                     {{else if is_bot}}
                     <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
                     {{else}}
-                    <span class="{{user_circle_class}} user_circle" data-presence-indicator-user-id="{{user_ids_string}}"></span>
+                        {{#if (eq user_circle_class "user_circle_deactivated")}}
+                            <span class="conversation-partners-icon fa fa-ban user_circle_deactivated"></span>
+                        {{else}}
+                            <span class="conversation-partners-icon {{user_circle_class}} user_circle"></span>
+                        {{/if}}
                     {{/if}}
                 </span>
             </div>

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -166,6 +166,10 @@ test("user_circle, level", ({override}) => {
     assert.equal(buddy_data.get_user_circle_class(fred.user_id), "user_circle_idle");
     assert.equal(buddy_data.level(fred.user_id), 2);
 
+    set_presence(fred.user_id, "deactivated");
+    assert.equal(buddy_data.get_user_circle_class(fred.user_id), "user_circle_deactivated");
+    assert.equal(buddy_data.level(fred.user_id), 4);
+
     set_presence(fred.user_id, undefined);
     assert.equal(buddy_data.get_user_circle_class(fred.user_id), "user_circle_empty");
     assert.equal(buddy_data.level(fred.user_id), 3);
@@ -248,8 +252,8 @@ test("filters deactivated users", () => {
     assert.deepEqual(user_ids, []);
 
     user_ids = buddy_data.get_filtered_and_sorted_user_ids();
-    assert.equal(user_ids.includes(selma.user_id), false);
-    assert.ok(!buddy_data.matches_filter("selm", selma.user_id));
+    assert.equal(user_ids.includes(selma.user_id), true);
+    assert.ok(buddy_data.matches_filter("selm", selma.user_id));
 });
 
 test("muted users excluded from search", () => {
@@ -534,6 +538,8 @@ test("compare_function", () => {
 
 test("user_last_seen_time_status", ({override}) => {
     page_params.presence_history_limit_days_for_web_app = 365;
+    people.add_active_user(old_user);
+
     set_presence(selma.user_id, "active");
     set_presence(me.user_id, "active");
 
@@ -544,6 +550,7 @@ test("user_last_seen_time_status", ({override}) => {
         buddy_data.user_last_seen_time_status(old_user.user_id),
         "translated: Activity unknown",
     );
+
     override(realm, "realm_is_zephyr_mirror_realm", false);
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),


### PR DESCRIPTION
<!-- Describe your pull request here.-->
### Description:
This PR introduces a deactivated status icon and a "User Deactivated" label to enhance the visibility of deactivated users in the sidebar. This improvement aims to provide users with clearer feedback by clearly indicating deactivated accounts, ensuring a more intuitive and informative user experience in the sidebar.

**Fixes:** https://github.com/zulip/zulip/issues/30797

### UI Changes:
| Right Sidebar | Left Sidebar |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/947c3fee-0db3-444f-9510-aaf58cf7874e) | ![image](https://github.com/user-attachments/assets/1122f744-af2a-415c-bd19-64cf0049ae1e)  |

| Group Message |
|----------|
|    ![image](https://github.com/user-attachments/assets/a6493e5b-8485-482b-ab4c-fdfce0459f58)  |

| Recent Conversations |
|----------|
| ![image](https://github.com/user-attachments/assets/823950e4-e63d-4c83-8b57-1d70db5dd990)  |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>