### PR TITLE
compose: make it easy to select topic after selecting stream in composebox_typeahead

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -263,6 +263,8 @@ export class Typeahead<ItemType extends string | object> {
     // after selecting an option, instead of the default call to lookup().
     hideAfterSelect: () => boolean;
     hideOnEmptyAfterBackspace: boolean;
+    // Used for adding a custom classname to the typeahead link.
+    getCustomItemClassname: ((item: ItemType) => string) | undefined;
 
     constructor(input_element: TypeaheadInputElement, options: TypeaheadOptions<ItemType>) {
         this.input_element = input_element;
@@ -304,7 +306,7 @@ export class Typeahead<ItemType extends string | object> {
         this.updateElementContent = options.updateElementContent ?? true;
         this.hideAfterSelect = options.hideAfterSelect ?? (() => true);
         this.hideOnEmptyAfterBackspace = options.hideOnEmptyAfterBackspace ?? false;
-
+        this.getCustomItemClassname = options.getCustomItemClassname;
         this.listen();
     }
 
@@ -547,6 +549,9 @@ export class Typeahead<ItemType extends string | object> {
             const $item_html = $i.find("a").html(item_html);
 
             const option_label_html = this.option_label(matching_items, item);
+            if (this.getCustomItemClassname) {
+                $item_html.addClass(this.getCustomItemClassname(item));
+            }
 
             if (option_label_html) {
                 $item_html
@@ -887,4 +892,5 @@ type TypeaheadOptions<ItemType> = {
     shouldHighlightFirstResult?: () => boolean;
     updateElementContent?: boolean;
     hideAfterSelect?: () => boolean;
+    getCustomItemClassname?: (item: ItemType) => string;
 };

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -244,6 +244,8 @@ export class Typeahead<ItemType extends string | object> {
     query = "";
     mouse_moved_since_typeahead = false;
     shown = false;
+    // To trigger updater when Esc is pressed only during the stream topic typeahead in composebox.
+    escape_topic_completion = false;
     openInputFieldOnKeyUp: (() => void) | undefined;
     closeInputFieldOnHide: (() => void) | undefined;
     helpOnEmptyStrings: boolean;
@@ -294,6 +296,7 @@ export class Typeahead<ItemType extends string | object> {
         // return a string to show in typeahead items or false.
         this.option_label = options.option_label ?? (() => false);
         this.stopAdvance = options.stopAdvance ?? false;
+        this.escape_topic_completion = options.escape_topic_completion ?? false;
         this.advanceKeys = options.advanceKeys ?? [];
         this.openInputFieldOnKeyUp = options.openInputFieldOnKeyUp;
         this.closeInputFieldOnHide = options.closeInputFieldOnHide;
@@ -751,6 +754,11 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             case "Escape":
+                // TODO: escape_topic_completion should be scoped more narrowly.
+                // See https://github.com/zulip/zulip/pull/32217#discussion_r1934905517
+                if (this.escape_topic_completion) {
+                    this.select(e);
+                }
                 if (!this.shown) {
                     return;
                 }
@@ -881,6 +889,7 @@ type TypeaheadOptions<ItemType> = {
     sorter: (items: ItemType[], query: string) => ItemType[];
     stopAdvance?: boolean;
     tabIsEnter?: boolean;
+    escape_topic_completion?: boolean;
     trigger_selection?: (event: JQuery.KeyDownEvent) => boolean;
     updater?: (
         item: ItemType,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1068,6 +1068,7 @@ export function content_typeahead_selected(
     item: TypeaheadSuggestion,
     query: string,
     input_element: TypeaheadInputElement,
+    event?: JQuery.ClickEvent | JQuery.KeyUpEvent | JQuery.KeyDownEvent,
 ): string {
     const pieces = split_at_cursor(query, input_element.$element);
     let beginning = pieces[0];
@@ -1093,6 +1094,22 @@ export function content_typeahead_selected(
             message: "",
         };
     }
+
+    // We only want to consider escape key for the stream+topic typeahead completion case.
+    if (event?.key === "Escape" && item.type !== "topic_list") {
+        setTimeout(() => {
+            // Select any placeholder text configured to be highlighted.
+            if (highlight.start && highlight.end) {
+                $textbox.range(highlight.start, highlight.end);
+            } else {
+                $textbox.caret(beginning.length);
+            }
+            // Also, trigger autosize to check if compose box needs to be resized.
+            compose_ui.autosize_textarea($textbox);
+        }, 0);
+        return beginning + rest;
+    }
+
     switch (item.type) {
         case "emoji":
             // leading and trailing spaces are required for emoji,
@@ -1205,6 +1222,15 @@ export function content_typeahead_selected(
             break;
         }
         case "topic_list": {
+            // If we use "Escape" we would want `#**design>this is a design topic` to be
+            // resolved to `#**design** this is a design topic`
+            if (event?.key === "Escape") {
+                const topic_start_index = beginning.lastIndexOf(">");
+                const topic = beginning.slice(topic_start_index + 1);
+                beginning = beginning.slice(0, topic_start_index) + "** " + topic;
+                break;
+            }
+
             // Stream + topic mention typeahead; close the stream+topic mention syntax with
             // the topic and the final ** or replace it with markdown link syntax if topic name
             // will cause encoding issues.
@@ -1253,7 +1279,6 @@ export function content_typeahead_selected(
             return beginning + rest;
         }
     }
-
     // Keep the cursor after the newly inserted text / selecting the
     // placeholder text, as Bootstrap will call $textbox.change() to
     // overwrite the text in the textbox.
@@ -1361,6 +1386,7 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             },
             updater: content_typeahead_selected,
             stopAdvance: true, // Do not advance to the next field on a Tab or Enter
+            escape_topic_completion: true,
             automated: compose_automated_selection,
             option_label(_matching_items, item): string | false {
                 if (item.type === "topic_list" && item.is_channel_link) {

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -9,7 +9,11 @@ import render_typeahead_list_item from "../templates/typeahead_list_item.hbs";
 import {MAX_ITEMS} from "./bootstrap_typeahead.ts";
 import * as buddy_data from "./buddy_data.ts";
 import * as compose_state from "./compose_state.ts";
-import type {LanguageSuggestion, SlashCommandSuggestion} from "./composebox_typeahead.ts";
+import type {
+    LanguageSuggestion,
+    SlashCommandSuggestion,
+    TopicSuggestion,
+} from "./composebox_typeahead.ts";
 import type {InputPillContainer} from "./input_pill.ts";
 import * as people from "./people.ts";
 import type {PseudoMentionUser, User} from "./people.ts";
@@ -105,6 +109,8 @@ export let render_typeahead_item = (args: {
     stream?: StreamData;
     emoji_code?: string | undefined;
     is_empty_string_topic?: boolean;
+    topic_object?: TopicSuggestion;
+    is_stream_topic?: boolean;
 }): string => {
     const has_image = args.img_src !== undefined;
     const has_status = args.status_emoji_info !== undefined;
@@ -113,6 +119,7 @@ export let render_typeahead_item = (args: {
     const has_pronouns = args.pronouns !== undefined;
     return render_typeahead_list_item({
         ...args,
+        ...args.topic_object,
         has_image,
         has_status,
         has_secondary,
@@ -190,6 +197,12 @@ export let render_stream = (stream: StreamData): string =>
     render_typeahead_item({
         secondary_html: stream.rendered_description,
         stream,
+    });
+
+export const render_stream_topic = (topic_object: TopicSuggestion): string =>
+    render_typeahead_item({
+        topic_object,
+        is_stream_topic: true,
     });
 
 export function rewire_render_stream(value: typeof render_stream): void {

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -62,6 +62,10 @@
                 margin-left: -2px;
             }
 
+            &.topic-typeahead-link {
+                gap: 0;
+            }
+
             .typeahead-text-container {
                 display: flex;
                 align-self: center;
@@ -70,6 +74,17 @@
                 white-space: nowrap;
                 gap: 3px;
             }
+
+            .compose-stream-name {
+                overflow: visible;
+                gap: 0;
+            }
+        }
+
+        .stream-to-topic-arrow {
+            cursor: default;
+            color: var(--color-compose-chevron-arrow);
+            text-decoration: none;
         }
     }
 

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -16,6 +16,19 @@
 {{else if is_user_group}}
     <i class="typeahead-image zulip-icon zulip-icon-triple-users no-presence-circle" aria-hidden="true"></i>
 {{/if}}
+{{#if is_stream_topic}}
+<div class="typeahead-text-container compose-stream-name">
+    <strong class="typeahead-strong-section">
+        {{~> inline_decorated_stream_name stream=stream_data ~}}
+    </strong>
+    <span role="button" class="conversation-arrow zulip-icon zulip-icon-chevron-right stream-to-topic-arrow"></span>
+</div>
+<div class="typeahead-text-container">
+    <strong class="typeahead-strong-section">
+        {{~ topic ~}}
+    </strong>
+</div>
+{{else}}
 {{!-- Separate container to ensure overflowing text remains in this container. --}}
 <div class="typeahead-text-container{{#if has_secondary_html}} has_secondary_html{{/if}}">
     <strong class="typeahead-strong-section{{#if is_empty_string_topic}} empty-topic-display{{/if}}">
@@ -45,3 +58,4 @@
     </span>
     {{~/if}}
 </div>
+{{/if}}

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -831,19 +831,19 @@ test("content_typeahead_selected", ({override}) => {
     query = "#swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "#**Sweden** ";
+    expected_value = "#**Sweden>";
     assert.equal(actual_value, expected_value);
 
     query = "Hello #swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "Hello #**Sweden** ";
+    expected_value = "Hello #**Sweden>";
     assert.equal(actual_value, expected_value);
 
     query = "#**swed";
     ct.get_or_set_token_for_testing("swed");
     actual_value = ct.content_typeahead_selected(sweden_stream, query, input_element);
-    expected_value = "#**Sweden** ";
+    expected_value = "#**Sweden>";
     assert.equal(actual_value, expected_value);
 
     // topic_list
@@ -875,6 +875,32 @@ test("content_typeahead_selected", ({override}) => {
     expected_value = "Hello #**Sweden>testing** ";
     assert.equal(actual_value, expected_value);
 
+    query = "Hello #**Sweden>";
+    ct.get_or_set_token_for_testing("");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "Sweden",
+            type: "topic_list",
+            is_channel_link: false,
+        },
+        query,
+        input_element,
+    );
+    expected_value = "Hello #**Sweden>Sweden** ";
+    assert.equal(actual_value, expected_value);
+
+    ct.get_or_set_token_for_testing("");
+    actual_value = ct.content_typeahead_selected(
+        {
+            topic: "Sweden",
+            type: "topic_list",
+            is_channel_link: true,
+        },
+        query,
+        input_element,
+    );
+    expected_value = "Hello #**Sweden** ";
+    assert.equal(actual_value, expected_value);
     // syntax
     ct.get_or_set_completing_for_tests("syntax");
 
@@ -1898,10 +1924,16 @@ test("begins_typeahead", ({override, override_rewire}) => {
     // topic_list
     // includes "more ice"
     function typed_topics(topics) {
-        return topics.map((topic) => ({
-            type: "topic_list",
+        const matches_list = topics.map((topic) => ({
+            is_channel_link: false,
+            stream_data: {
+                ...stream_data.get_sub_by_name("Sweden"),
+                rendered_description: "",
+            },
             topic,
+            type: "topic_list",
         }));
+        return matches_list;
     }
     assert_typeahead_equals("#**Sweden>more ice", typed_topics(["more ice", "even more ice"]));
     assert_typeahead_equals("#**Sweden>totally new topic", typed_topics(["totally new topic"]));

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -956,6 +956,46 @@ test("render_stream", ({mock_template}) => {
     assert.ok(rendered);
 });
 
+test("render_stream_topic", ({mock_template}) => {
+    let rendered = false;
+    const streamData = {
+        invite_only: true,
+        is_web_public: false,
+        color: "blue",
+        name: "Design",
+        description: "Design related discussions.",
+        rendered_description: "",
+        subscribed: true,
+    };
+
+    const topic_object = {
+        topic: "Test topic title",
+        stream_data: {
+            invite_only: true,
+            is_web_public: false,
+            color: "blue",
+            name: "Design",
+            description: "Design related discussions.",
+            rendered_description: "",
+            subscribed: true,
+        },
+        type: "topic_list",
+        is_stream_only: false,
+    };
+
+    mock_template("typeahead_list_item.hbs", false, (args) => {
+        assert.equal(args.topic, "Test topic title");
+        assert.equal(args.type, "topic_list");
+        assert.equal(args.is_stream_only, false);
+        assert.equal(args.is_stream_topic, true);
+        assert.deepEqual(args.stream_data, streamData);
+        rendered = true;
+        return "typeahead-item-stub";
+    });
+    assert.equal(th.render_stream_topic(topic_object), "typeahead-item-stub");
+    assert.ok(rendered);
+});
+
 test("render_emoji", ({mock_template}) => {
     // Test render_emoji with normal emoji.
     let expected_template_data = {


### PR DESCRIPTION
Fixes #32184

<!-- Describe your pull request here.-->
This PR lets the user get a consecutive topic typeahead after selecting a particular stream via the typeahead menu. Previously they had to manually enter ">" after stream typeahead selection
Eg:
Previously #Den + "Tab" key would result in `#**Denmark**` and after this user would have to enter ">" to trigger the topic typeahead completion
This PR solves this unituitive behaviour by prompting a topic select after immediately selecting a particular stream via a typeahead menu.

#### Key changes in code : 
- I changed a part of **tokenize_compose_str**, since it returned "**topic_jump**" as the current_token in `get_candidates()` whenever some stream was selected from the typeahead menu. I made it return the token instead, basically slicing it to return `#stream_name>sometext`

- Also had to alter the condition which triggered stream typeahead on finding # at the start, to also check whether the current token ended with ">sometext", if it did, we don't trigger the stream typeahead, but instead trigger the topic list by returning the topicname items and setting completing="topic_list"

- It also increases the scanning capacity from 25 chars to 40 chars in tokenize_compose_str to pass certain tests as per disccusion with @timabbott [here](https://chat.zulip.org/#narrow/channel/49-development-help/topic/Make.20it.20easier.20to.20link.20to.20a.20topic/near/1974824)

- returning "topic_jump" as before caused the topic list to not get triggered since return value of topic_jump meant that the topic was already selected.
- This effectively returned an empty array from the get_candidates i.e. the `source` function in `lookup()` in the bootstrap_typeahead.ts file,

```javascript
if (!items.length && this.shown) {
            this.hide();
        }
        return items.length ? this.process(items) : this;
//This part of the code inside lookup() caused the next typeahead to not trigger, since items was an empty arr
```

- Added the function definition for the `hideAfterSelect()` function in the `TypeAhead` constructor inside composebox_typeahead.ts. It has a default implementation of `return true`, which closes the typeahead after a selection is made

- I changed it so that it didn't close the typeahead only when the stream is being completed.

- Added a test to check whether stream was getting selected after selecting it from topic menu
`#Sweden>` prompts a few options for topics, of which the first is the stream name `Sweden` itself.
If that is selected, the current token gets changed from `#Sweden>` to `#**Sweden**`
Demonstration for the above condition is present in the video attached for streams like `Denmark` and `design` which are the default streams for the dev server 

- Rendering the stream as the first option in the topic list required some changes in the type `TopicSuggestion`.
- The required logic has been added to conditionally render a stream typeahead suggestion containing privacy status without the description.
- The stream typeahead suggestion is rendered in the topic_list only when ">" is not followed by any character, that is when the token ends with a ">".
- Test coverage has been added for the `render_stream_topic` method in typeahead_helper.ts.




Discussion regarding the same:
https://chat.zulip.org/#narrow/channel/49-development-help/topic/Make.20it.20easier.20to.20link.20to.20a.20topic
https://chat.zulip.org/#narrow/channel/91-code-review/topic/.2332184.20compose.20typeahead.20ui
https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/puppeteer.20throwing.20assertion.20error.20for.20realm-playground

Fixes: <!-- Issue link, or clear description.-->
https://github.com/zulip/zulip/issues/32184

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
[show_topic_typeahead_after_selecting_stream.webm](https://github.com/user-attachments/assets/6fa0aa47-fd73-4f3e-b748-36d1a0e6af09)

[select_stream_from_topic_menu.webm](https://github.com/user-attachments/assets/df73e167-34a0-4971-af76-c9d97c780660)



https://github.com/user-attachments/assets/582990d0-4543-4d6f-aab6-0c52882a1363



https://github.com/user-attachments/assets/6b482c2d-2c55-442f-bd26-7c0701a0eec7



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
