### PR TITLE
ui_update: Use same @ symbol everywhere.

### DIFF
--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -1,5 +1,7 @@
 import $ from "jquery";
 
+import render_unread_mention_indicator_icon_widget from "../templates/widgets/unread_mention_indicator_icon_widget.hbs";
+
 import * as blueslip from "./blueslip.ts";
 import * as hash_parser from "./hash_parser.ts";
 import * as keydown_util from "./keydown_util.ts";
@@ -142,15 +144,13 @@ export function update_unread_mention_info_in_dom(
     $unread_mention_info_elem: JQuery,
     stream_has_any_unread_mention_messages: boolean,
 ): void {
-    const $unread_mention_info_span = $unread_mention_info_elem.find(".unread_mention_info");
+    const $unread_mention_info_div = $unread_mention_info_elem.find(".unread_mention_info");
+    const $unread_mention_indicator = render_unread_mention_indicator_icon_widget();
     if (!stream_has_any_unread_mention_messages) {
-        $unread_mention_info_span.hide();
-        $unread_mention_info_span.text("");
+        $unread_mention_info_div.empty();
         return;
     }
-
-    $unread_mention_info_span.show();
-    $unread_mention_info_span.text("@");
+    $unread_mention_info_div.append($unread_mention_indicator);
 }
 
 /**

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -16,6 +16,12 @@
             text-decoration: none;
         }
 
+        .mention-and-unread-count-container {
+            grid-area: unread_mention_info;
+            display: flex;
+            align-items: center;
+        }
+
         .unread_count {
             opacity: 1;
             outline: 0 solid var(--color-background-unread-counter);
@@ -341,7 +347,7 @@
             }
 
             .unread_mention_info {
-                grid-area: unread_mention_info;
+                display: flex;
                 margin-right: 0;
             }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1289,6 +1289,7 @@ li.top_left_scheduled_messages {
     .unread_mention_info {
         /* Unset margin in favor of flex gap. */
         margin: 0;
+        display: flex;
     }
 
     .unread_count {
@@ -1296,6 +1297,12 @@ li.top_left_scheduled_messages {
            decouples .unread_count from the app-wide
            definition. */
         height: auto;
+    }
+}
+
+.topic-markers-and-unreads {
+    .unread_mention_info {
+        display: flex;
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -641,6 +641,17 @@ input[type="checkbox"] {
             font-weight: bold;
             word-break: break-all;
         }
+
+        .notification-table-header-container {
+            display: flex;
+            justify-content: center;
+
+            .at-sign-container {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+        }
     }
 }
 

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -33,15 +33,18 @@
                         <div class="inbox-topic-name">
                             <a tabindex="-1" href="{{topic_url}}" {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</a>
                         </div>
-                        <span class="unread_mention_info tippy-zulip-tooltip
-                          {{#unless mention_in_unread}}hidden{{/unless}}"
-                          data-tippy-content="{{t 'You have unread mentions'}}">@</span>
-                        <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
-                            <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
-                              data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
-                              data-tippy-content="{{t 'Mark as read' }}" aria-label="{{t 'Mark as read' }}">
-                                {{unread_count}}
-                            </span>
+                        <div class="mention-and-unread-count-container">
+                            <div class="unread_mention_info tippy-zulip-tooltip
+                              {{#unless mention_in_unread}}hidden{{/unless}}"
+                              data-tippy-content="{{t 'You have mentions.'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                            </div>
+                            <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
+                                <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
+                                  data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
+                                  data-tippy-content="{{t 'Mark as read' }}" aria-label="{{t 'Mark as read' }}">
+                                    {{unread_count}}
+                                </span>
+                            </div>
                         </div>
                     {{/if}}
                 </div>

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -36,7 +36,7 @@
                         <div class="mention-and-unread-count-container">
                             <div class="unread_mention_info tippy-zulip-tooltip
                               {{#unless mention_in_unread}}hidden{{/unless}}"
-                              data-tippy-content="{{t 'You have mentions.'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                              data-tippy-content="{{t 'You have unread mentions in this conversation.'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                             </div>
                             <div class="unread-count-focus-outline" tabindex="0" data-col-index="{{ column_indexes.UNREAD_COUNT }}">
                                 <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -19,7 +19,7 @@
                 <div class="mention-and-unread-count-container">
                     <div class="unread_mention_info tippy-zulip-tooltip
                       {{#unless mention_in_unread}}hidden{{/unless}}"
-                      data-tippy-content="{{t 'You have mentions'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                      data-tippy-content="{{t 'You have unread mentions in this conversation.'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                     </div>
                     <div class="unread-count-focus-outline" tabindex="0">
                         <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -16,15 +16,19 @@
                         {{/if}}
                     </div>
                 </div>
-                <span class="unread_mention_info tippy-zulip-tooltip
-                  {{#unless mention_in_unread}}hidden{{/unless}}"
-                  data-tippy-content="{{t 'You have unread mentions'}}">@</span>
-                <div class="unread-count-focus-outline" tabindex="0">
-                    <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
-                      data-stream-id="{{stream_id}}" data-tippy-content="{{t 'Mark as read' }}"
-                      aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                <div class="mention-and-unread-count-container">
+                    <div class="unread_mention_info tippy-zulip-tooltip
+                      {{#unless mention_in_unread}}hidden{{/unless}}"
+                      data-tippy-content="{{t 'You have mentions'}}"><i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                    </div>
+                    <div class="unread-count-focus-outline" tabindex="0">
+                        <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
+                          data-stream-id="{{stream_id}}" data-tippy-content="{{t 'Mark as read' }}"
+                          aria-label="{{t 'Mark as read' }}">{{unread_count}}
+                        </span>
+                    </div>
+                    <div class="topic-visibility-indicator invisible" tabindex="0"></div>
                 </div>
-                <div class="topic-visibility-indicator invisible" tabindex="0"></div>
             </div>
         </div>
         <div class="inbox-right-part-wrapper">

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -5,9 +5,9 @@
         <a class="sidebar-topic-action-heading" tabindex="0">{{t "Show all topics" }}</a>
         <div class="topic-markers-and-unreads">
             {{#if more_topics_have_unread_mention_messages}}
-                <span class="unread_mention_info">
-                    @
-                </span>
+                <div class="unread_mention_info">
+                    <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                </div>
             {{/if}}
             <span class="unread_count normal-count {{#unless more_topics_unreads}}zero_count{{/unless}}">
                 {{more_topics_unreads}}

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -180,7 +180,7 @@
                         <i class="popover-menu-icon fa zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
                         <span class="popover-menu-label">{{t "Copy mention syntax" }}</span>
                         {{#if is_sender_popover}}
-                            {{popover_hotkey_hints "@"}}
+                            {{popover_hotkey_hints '<i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>'}}
                         {{/if}}
                     </a>
                 {{/if}}

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -17,8 +17,16 @@
                         {{> ../help_link_widget link="/help/mobile-notifications#enabling-push-notifications-for-self-hosted-servers" }}
                     </th>
                     <th rowspan="2" width="14%">{{t "Email"}}</th>
-                    <th rowspan="2" width="14%">@all
-                        <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
+                    <th rowspan="2" width="14%">
+                        <div class="notification-table-header-container">
+                            <div class="at-sign-container">
+                                <i class="zulip-icon zulip-icon-at-sign" aria-label="{{t 'All'}}"></i>
+                                <span>all</span>
+                            </div>
+                            <div>
+                                <i class="fa fa-question-circle settings-info-icon tippy-zulip-tooltip" data-tippy-content="{{t 'Whether wildcard mentions like @all are treated as mentions for the purpose of notifications.' }}"></i>
+                            </div>
+                        </div>
                     </th>
                 </tr>
                 <tr>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -19,8 +19,8 @@
             </div>
 
             <div class="stream-markers-and-unreads">
-                <span class="unread_mention_info"></span>
-                <span class="unread_count normal-count"></span>
+                <div class="unread_mention_info"></div>
+                <span class="unread_count"></span>
                 <span class="masked_unread_count">
                     <i class="zulip-icon zulip-icon-masked-unread"></i>
                 </span>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -8,9 +8,9 @@
         </a>
         <div class="topic-markers-and-unreads change_visibility_policy" data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}">
             {{#if contains_unread_mention}}
-                <span class="unread_mention_info">
-                    @
-                </span>
+                <div class="unread_mention_info">
+                    <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                </div>
             {{else if is_followed}}
                 <i class="zulip-icon zulip-icon-follow visibility-policy-icon" role="button" aria-hidden="true" data-tippy-content="{{t 'You follow this topic.'}}"></i>
             {{/if}}

--- a/web/templates/widgets/unread_mention_indicator_icon_widget.hbs
+++ b/web/templates/widgets/unread_mention_indicator_icon_widget.hbs
@@ -1,0 +1,1 @@
+<i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -114,7 +114,7 @@ function create_devel_sidebar_row({mock_template}) {
     stream_has_any_unread_mentions = false;
     stream_list.create_sidebar_row(devel);
     assert.equal($devel_count.text(), "42");
-    assert.equal($devel_unread_mention_info.text(), "");
+    assert.equal($devel_unread_mention_info.text(), "never-been-set");
 }
 
 function create_social_sidebar_row({mock_template}) {
@@ -137,7 +137,7 @@ function create_social_sidebar_row({mock_template}) {
     stream_has_any_unread_mentions = true;
     stream_list.create_sidebar_row(social);
     assert.equal($social_count.text(), "99");
-    assert.equal($social_unread_mention_info.text(), "@");
+    assert.equal($social_unread_mention_info.text(), "never-been-set");
 }
 
 function create_stream_subheader({mock_template}) {


### PR DESCRIPTION
This PR updates the @ icon across various locations in the app to ensure consistency.

Icon used :
```html
<i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>.
```

**Tasks completed:**

- [ ] Replace @ character in mention pills
- [x] Update @ in /#settings/notifications
- [x] Update "Copy mention syntax" icon in user popovers
- [x] Standardize unread mentions indicator icon in the left sidebar
- [x] Update @ indicator for the topics in conversation view. 

> **Note**
> - The @ before "Mention" in the sidebar did not require any changes. It already has the required updates.
> - The @ character for mention pills needs some extra work and can be fixed in a separate PR.

**Screenshots**


<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td colspan="2"> /#settings/notifications </td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/c7767d33-0b6f-4aaa-aba6-aac91a41ecea">
</td>
<td>
<img src="https://github.com/user-attachments/assets/928328b2-a2dc-4f53-a6f4-f9600755f649">
</td>
</tr>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/70502021-7598-453e-98b1-dea16001383c">
</td>
<td>
<img src="https://github.com/user-attachments/assets/b80799f8-d956-43c1-ad6d-233ef703a6b3">
</td>
</tr>
<tr>
<td colspan="2"> Copy Mention Syntax </td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/a856dca1-8b5b-4a0a-a427-e4efbd627f0c">
</td>
<td>
<img src="https://github.com/user-attachments/assets/c1207b65-5d49-42f0-b116-f7e2cec7b4dd">
</td>
</tr>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/018bddd0-2ae5-4d90-a8e9-79d2cedfbe0d">
</td>
<td>
<img src="https://github.com/user-attachments/assets/50519cca-8a45-4358-a128-4fe33b4dd652">
</td>
</tr>
<tr >
<td colspan="2"> Left Sidebar @ Indicator</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/a29c83bc-f4a0-47db-8895-c3ea6ff7e3c3">
</td>
<td>
<img src="https://github.com/user-attachments/assets/18056874-d699-46f1-8c5f-14d01fa3bc87">
</td>
</tr>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/9ef7efb0-5feb-4000-a464-249cbfa588e5">
</td>
<td>
<img src="https://github.com/user-attachments/assets/51dd3c45-be23-466c-9f92-2900387f8373">
</td>
</tr>
<td colspan="2"> @ indicator for topics in inbox view</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/ae409e8e-cbf7-40c5-8048-e520e624ca97">
</td>
<td>
<img src="https://github.com/user-attachments/assets/6edc7314-c9e3-477d-a7ff-a07665f3f6af">
</td>
</tr>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/0c6b8123-cee3-4c39-a28d-40d3382c470a">
</td>
<td>
<img src="https://github.com/user-attachments/assets/04eb3192-400a-4376-b3b7-28dff61c4688">
</td>
</tr>
</table>


Partially Fixes : #22816 .

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
