### PR TITLE
Use modal__spinner for compose and message edit.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1284,7 +1284,7 @@ export function hide_compose_spinner(): void {
 
 export function show_compose_spinner(): void {
     compose_spinner_visible = true;
-    loading.show_spinner(
+    loading.show_button_spinner(
         $(".compose-submit-button"),
         $(".compose-submit-button .modal__spinner"),
     );

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1277,15 +1277,17 @@ export function rewire_format_text(value: typeof format_text): void {
  * nothing to do with the compose textarea. */
 export function hide_compose_spinner(): void {
     compose_spinner_visible = false;
-    $(".compose-submit-button .loader").hide();
+    $(".compose-submit-button .modal__spinner").hide();
     $(".compose-submit-button .zulip-icon-send").show();
     $(".compose-submit-button").removeClass("compose-button-disabled");
 }
 
 export function show_compose_spinner(): void {
     compose_spinner_visible = true;
-    // Always use white spinner.
-    loading.show_button_spinner($(".compose-submit-button .loader"), true);
+    loading.show_spinner(
+        $(".compose-submit-button"),
+        $(".compose-submit-button .modal__spinner"),
+    );
     $(".compose-submit-button .zulip-icon-send").hide();
     $(".compose-submit-button").addClass("compose-button-disabled");
 }

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -92,7 +92,7 @@ export function hide_dialog_spinner(): void {
     const $spinner = $(`${dialog_widget_selector} .modal__spinner`);
     $(`${dialog_widget_selector} .modal__button`).prop("disabled", false);
 
-    loading.hide_spinner($(".dialog_submit_button"), $spinner);
+    loading.hide_button_spinner($(".dialog_submit_button"), $spinner);
 }
 
 export function show_dialog_spinner(): void {
@@ -102,7 +102,7 @@ export function show_dialog_spinner(): void {
 
     const $spinner = $(`${dialog_widget_selector} .modal__spinner`);
 
-    loading.show_spinner($(".dialog_submit_button"), $spinner);
+    loading.show_button_spinner($(".dialog_submit_button"), $spinner);
 }
 
 // Supports a callback to be called once the modal finishes closing.

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -81,7 +81,7 @@ export function destroy_indicator($container: JQuery): void {
     $container.css({width: 0, height: 0});
 }
 
-export function show_spinner($button_element: JQuery, $spinner: JQuery): void {
+export function show_button_spinner($button_element: JQuery, $spinner: JQuery): void {
     const span_width = $button_element.find(".submit-button-text").width();
     const span_height = $button_element.find(".submit-button-text").height();
 
@@ -96,7 +96,7 @@ export function show_spinner($button_element: JQuery, $spinner: JQuery): void {
     });
 }
 
-export function hide_spinner($button_element: JQuery, $spinner: JQuery): void {
+export function hide_button_spinner($button_element: JQuery, $spinner: JQuery): void {
     // Show the span
     $button_element.find(".submit-button-text").show();
 

--- a/web/src/loading.ts
+++ b/web/src/loading.ts
@@ -1,7 +1,5 @@
 import $ from "jquery";
 
-import loading_black_image from "../../static/images/loading/loader-black.svg";
-import loading_white_image from "../../static/images/loading/loader-white.svg";
 import render_loader from "../templates/loader.hbs";
 
 export function make_indicator(
@@ -81,15 +79,6 @@ export function destroy_indicator($container: JQuery): void {
     $container.data("destroying", true);
     $container.empty();
     $container.css({width: 0, height: 0});
-}
-
-export function show_button_spinner($elt: JQuery, using_dark_theme: boolean): void {
-    if (!using_dark_theme) {
-        $elt.attr("src", loading_black_image);
-    } else {
-        $elt.attr("src", loading_white_image);
-    }
-    $elt.css("display", "inline-block");
 }
 
 export function show_spinner($button_element: JQuery, $spinner: JQuery): void {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -339,16 +339,14 @@ export function stream_and_topic_exist_in_edit_history(
 }
 
 export function hide_message_edit_spinner($row: JQuery): void {
-    $row.find(".loader").hide();
+    $row.find(".modal__spinner").hide();
     $row.find(".message_edit_save span").show();
     $row.find(".message_edit_save").removeClass("message-edit-button-disabled");
     $row.find(".message_edit_cancel").removeClass("message-edit-button-disabled");
 }
 
 export function show_message_edit_spinner($row: JQuery): void {
-    // Always show the white spinner like we
-    // do for send button in compose box.
-    loading.show_button_spinner($row.find(".loader"), true);
+    loading.show_spinner($row, $row.find(".modal__spinner"));
     $row.find(".message_edit_save span").hide();
     $row.find(".message_edit_save").addClass("message-edit-button-disabled");
     $row.find(".message_edit_cancel").addClass("message-edit-button-disabled");

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -346,7 +346,7 @@ export function hide_message_edit_spinner($row: JQuery): void {
 }
 
 export function show_message_edit_spinner($row: JQuery): void {
-    loading.show_spinner($row, $row.find(".modal__spinner"));
+    loading.show_button_spinner($row, $row.find(".modal__spinner"));
     $row.find(".message_edit_save span").hide();
     $row.find(".message_edit_save").addClass("message-edit-button-disabled");
     $row.find(".message_edit_cancel").addClass("message-edit-button-disabled");

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -91,13 +91,13 @@ const EMBEDDED_BOT_TYPE = "4";
 export function show_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");
     $button.prop("disabled", true);
-    loading.show_spinner($button, $spinner);
+    loading.show_button_spinner($button, $spinner);
 }
 
 export function hide_button_spinner($button: JQuery): void {
     const $spinner = $button.find(".modal__spinner");
     $button.prop("disabled", false);
-    loading.hide_spinner($button, $spinner);
+    loading.hide_button_spinner($button, $spinner);
 }
 
 function compare_by_name(

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -367,6 +367,7 @@
 
 .modal__spinner {
     display: flex;
+    align-items: center;
     justify-content: center;
 }
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -92,7 +92,7 @@
                             <span id="compose-limit-indicator" class="message-limit-indicator"></span>
                             <div class="message-send-controls">
                                 <button type="submit" id="compose-send-button" class="send_message compose-submit-button compose-send-or-save-button" aria-label="{{t 'Send' }}">
-                                    <img class="loader" alt="" src="" />
+                                    <div class="modal__spinner"></div>
                                     <i class="zulip-icon zulip-icon-send"></i>
                                 </button>
                                 <button class="send-control-button send-related-action-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send options' }}">

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -32,7 +32,7 @@
                         {{#if is_editable}}
                             <div class="message_edit_save_container">
                                 <button type="button" class="message-actions-button message_edit_save">
-                                    <img class="loader" alt="" src="" />
+                                    <div class="modal__spinner"></div>
                                     <span>{{t "Save" }}</span>
                                 </button>
                             </div>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -432,7 +432,8 @@ test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
 
     const fake_compose_box = new FakeComposeBox();
 
-    override(loading, "show_button_spinner", ($spinner) => {
+    override(loading, "show_button_spinner", ($button_element, $spinner) => {
+        assert.equal($button_element.selector, ".compose-submit-button");
         assert.equal($spinner.selector, fake_compose_box.compose_spinner_selector());
         show_button_spinner_called = true;
     });
@@ -480,7 +481,8 @@ test_ui("finish", ({override, override_rewire}) => {
     override_rewire(compose_banner, "clear_message_sent_banners", noop);
 
     let show_button_spinner_called = false;
-    override(loading, "show_button_spinner", ($spinner) => {
+    override(loading, "show_button_spinner", ($button_element, $spinner) => {
+        assert.equal($button_element.selector, ".compose-submit-button");
         assert.equal($spinner.selector, fake_compose_box.compose_spinner_selector());
         show_button_spinner_called = true;
     });

--- a/web/tests/lib/compose_helpers.cjs
+++ b/web/tests/lib/compose_helpers.cjs
@@ -41,7 +41,7 @@ class FakeComposeBox {
         this.$content_textarea.trigger("blur");
 
         this.$preview_message_area.css = noop;
-        $(".compose-submit-button .loader").show();
+        $(".compose-submit-button .modal__spinner").show();
     }
 
     show_message_preview() {
@@ -67,7 +67,7 @@ class FakeComposeBox {
     }
 
     compose_spinner_selector() {
-        return ".compose-submit-button .loader";
+        return ".compose-submit-button .modal__spinner";
     }
 
     markdown_spinner_selector() {
@@ -87,7 +87,7 @@ class FakeComposeBox {
     }
 
     show_submit_button_spinner() {
-        $(".compose-submit-button .loader").show();
+        $(".compose-submit-button .modal__spinner").show();
     }
 
     set_textarea_toggle_class_function(f) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Follow up work for  PR #31782.

Fixes: #26691.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Compose UI loader:</summary>
<table>
 <tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/d4d6038f-c6e1-4273-98e8-47b82816f997


</td>
<td>

https://github.com/user-attachments/assets/038b0302-4dcc-43e0-b2b0-6b6471dd8ecc


</td>
</tr>
</table>
</details>

<details>
<summary>Edit Message UI Loader:</summary>
<table>
 <tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/9f68f073-f985-4cf7-bf44-11c6beb3f5f5


</td>
<td>

https://github.com/user-attachments/assets/5c83f030-b1a2-450a-83a7-f174422b77f1


</td>
</tr>
</table>
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
