### PR TITLE
Disable compose reply button if posting is not allowed in a stream.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -328,9 +328,20 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     if (opts.message_type === "private") {
         compose_state.set_compose_recipient_id(compose_state.DIRECT_MESSAGE_ID);
         compose_recipient.on_compose_select_recipient_update();
-    } else if (opts.stream_id) {
+    } else if (opts.stream_id && opts.topic) {
         compose_state.set_stream_id(opts.stream_id);
         compose_recipient.on_compose_select_recipient_update();
+    } else if (opts.stream_id) {
+        const stream = stream_data.get_sub_by_id(opts.stream_id);
+        if (stream && stream_data.can_post_messages_in_stream(stream)) {
+            compose_state.set_stream_id(opts.stream_id);
+            compose_recipient.on_compose_select_recipient_update();
+        } else {
+            opts.stream_id = undefined;
+            compose_state.set_stream_id("");
+            opts.topic = "";
+            compose_recipient.toggle_compose_recipient_dropdown();
+        }
     } else {
         // Open stream selection dropdown if no stream is selected.
         compose_state.set_stream_id("");

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -52,6 +52,14 @@ export function initialize(): void {
                     instance.setContent(pick_empty_narrow_banner().title);
                     return;
                 }
+                case "stream_disabled": {
+                    instance.setContent(
+                        parse_html(
+                            $("#compose_disable_stream_reply_button_tooltip_template").html(),
+                        ),
+                    );
+                    return;
+                }
                 case "selected_message": {
                     instance.setContent(
                         parse_html($("#compose_reply_message_button_tooltip_template").html()),
@@ -74,13 +82,19 @@ export function initialize(): void {
                 }
             }
         },
+        onTrigger(instance, event) {
+            assert(event.currentTarget instanceof HTMLElement);
+            if ($(event.currentTarget).attr("data-reply-button-type") === "stream_disabled") {
+                instance.setProps({delay: INSTANT_HOVER_DELAY});
+            }
+        },
         onHidden(instance) {
             instance.destroy();
         },
     });
 
     tippy.delegate("body", {
-        target: "#new_conversation_button",
+        target: "#compose_buttons .compose_new_conversation_button",
         delay: EXTRA_LONG_HOVER_DELAY,
         // Only show on mouseenter since for spectators, clicking on these
         // buttons opens login modal, and Micromodal returns focus to the
@@ -88,12 +102,20 @@ export function initialize(): void {
         trigger: "mouseenter",
         appendTo: () => document.body,
         onShow(instance) {
-            const $elem = $(instance.reference);
-            const conversation_type = $elem.attr("data-conversation-type");
+            const $new_conversation_button = $("#new_conversation_button");
+            const conversation_type = $new_conversation_button.attr("data-conversation-type");
             if (conversation_type === "stream") {
-                instance.setContent(
-                    parse_html($("#new_topic_message_button_tooltip_template").html()),
-                );
+                if ($new_conversation_button.prop("disabled")) {
+                    instance.setContent(
+                        parse_html(
+                            $("#compose_disable_stream_reply_button_tooltip_template").html(),
+                        ),
+                    );
+                } else {
+                    instance.setContent(
+                        parse_html($("#new_topic_message_button_tooltip_template").html()),
+                    );
+                }
                 return undefined;
             }
             // Use new_stream_message_button_tooltip_template when the

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -600,7 +600,7 @@ export function can_unsubscribe_others(sub: StreamSubscription): boolean {
     );
 }
 
-export function can_post_messages_in_stream(stream: StreamSubscription): boolean {
+export let can_post_messages_in_stream = function (stream: StreamSubscription): boolean {
     if (stream.is_archived) {
         return false;
     }
@@ -644,6 +644,12 @@ export function can_post_messages_in_stream(stream: StreamSubscription): boolean
         return false;
     }
     return true;
+};
+
+export function rewire_can_post_messages_in_stream(
+    value: typeof can_post_messages_in_stream,
+): void {
+    can_post_messages_in_stream = value;
 }
 
 export function is_subscribed(stream_id: number): boolean {

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -10,6 +10,9 @@
     {{t 'Scroll to bottom' }}
     {{tooltip_hotkey_hints "End"}}
 </template>
+<template id="compose_disable_stream_reply_button_tooltip_template">
+    {{t 'You do not have permission to post in this channel.' }}
+</template>
 <template id="compose_reply_message_button_tooltip_template">
     {{t 'Reply to selected message' }}
     {{tooltip_hotkey_hints "R"}}

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -158,6 +158,7 @@ test("start", ({override, override_rewire, mock_template}) => {
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
     let compose_defaults;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This pull request includes several changes to improve the handling of stream permissions in the compose actions and UI components. The main changes ensure that users can only post messages in streams they have permission to, and provide appropriate feedback when they cannot.

### Enhancements to Stream Permissions Handling:

* **Compose Actions**: Added checks to ensure users can only post messages in streams they have permission to. If not, the stream ID and topic are reset, and the stream selection dropdown is opened. (`web/src/compose_actions.ts`)
* **Compose Closed UI**: Introduced functions to determine if the reply button should be disabled based on stream permissions, and updated button states and labels accordingly. (`web/src/compose_closed_ui.ts`)

### Tooltip Updates:

* **Compose Tooltips**: Added a new tooltip template for disabled stream reply buttons and updated the tooltip initialization to handle the new state. (`web/src/compose_tooltips.ts`, `web/templates/tooltip_templates.hbs`) 

### Test Adjustments:

* **Tests**: Updated tests to mock the `can_post_messages_in_stream` function to ensure consistent test behavior. (`web/tests/compose_actions.test.js`) 

### Previous PR Reference:

This PR is build over the original work done in PR #31053 by addressing the feedbacks and fixing the bug reported [here](https://github.com/zulip/zulip/pull/31053#issuecomment-2320142252).

Co-Author: @Vector73.

Fixes: #28410.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Compose Reply:</summary>
<table>
 <tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>
<img width="865" alt="Screenshot 2024-11-03 at 7 43 21 PM" src="https://github.com/user-attachments/assets/d258cbb8-865a-4e69-8c5f-60a70a4ff39a">



</td>
<td>
<img width="874" alt="Screenshot 2024-11-03 at 7 41 22 PM" src="https://github.com/user-attachments/assets/ca23fa51-1729-4304-ad31-77bdd193fce6">



</td>
</tr>
</table>
</details>

<details>
<summary>Start New Conversation:</summary>
<table>
 <tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>
<img width="859" alt="Screenshot 2024-11-03 at 7 43 30 PM" src="https://github.com/user-attachments/assets/2242f746-179a-41d8-87ce-1726229ffb8e">



</td>
<td>

<img width="871" alt="Screenshot 2024-11-03 at 7 41 39 PM" src="https://github.com/user-attachments/assets/7003e9a9-382a-466a-90be-a291bddecfcc">



</td>
</tr>
</table>
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
