### PR TITLE
stream_popover: Handle no messages condition for a topic being moved.

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -491,6 +491,16 @@ export async function build_move_topic_to_stream_popover(
             current_stream_id,
             old_topic_name,
             (message_id) => {
+                if (message_id === undefined) {
+                    // There are no messages in the given topic, so we show an error banner
+                    // and return, preventing any attempts to move a non-existent topic.
+                    dialog_widget.hide_dialog_spinner();
+                    ui_report.client_error(
+                        $t_html({defaultMessage: "There are no messages to move."}),
+                        $("#move_topic_modal #dialog_error"),
+                    );
+                    return;
+                }
                 message_edit.move_topic_containing_message_to_stream(
                     message_id,
                     select_stream_id,


### PR DESCRIPTION
Previously, when there were no messages in the topic being moved, the banner in the move topic modal only showed a "Failed" error banner which did not convey the actual error to the user. Also, a server call was being made even when there were no messages in the topic being moved.

This PR explicitly handles the non-existent topic, prevents a call to the server when the message_id is undefined, and displays a more informative error banner to the user.

Fixes: [CZO Discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/Error.20moving.20topic.20with.20no.20messages/near/1966728)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2024-11-04 at 3 19 01 PM](https://github.com/user-attachments/assets/02b238bd-926c-4d16-b15c-b3b207922a60)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
