### PR TITLE
transaction: Add savepoint=False or durable=True to transaction.atomic decorators.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -4506,7 +4506,7 @@ class RemoteRealmBillingSession(BillingSession):
     def process_downgrade(
         self, plan: CustomerPlan, background_update: bool = False
     ) -> None:  # nocoverage
-        with transaction.atomic():
+        with transaction.atomic(savepoint=False):
             old_plan_type = self.remote_realm.plan_type
             new_plan_type = RemoteRealm.PLAN_TYPE_SELF_MANAGED
             self.remote_realm.plan_type = new_plan_type
@@ -4933,7 +4933,7 @@ class RemoteServerBillingSession(BillingSession):
     def process_downgrade(
         self, plan: CustomerPlan, background_update: bool = False
     ) -> None:  # nocoverage
-        with transaction.atomic():
+        with transaction.atomic(savepoint=False):
             old_plan_type = self.remote_server.plan_type
             new_plan_type = RemoteZulipServer.PLAN_TYPE_SELF_MANAGED
             self.remote_server.plan_type = new_plan_type

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1093,7 +1093,7 @@ class BillingSession(ABC):
             metadata=stripe_customer_data.metadata,
         )
         event_time = timestamp_to_datetime(stripe_customer.created)
-        with transaction.atomic():
+        with transaction.atomic(durable=True):
             self.write_to_audit_log(BillingSessionEventType.STRIPE_CUSTOMER_CREATED, event_time)
             customer = self.update_or_create_customer(stripe_customer.id)
         return customer
@@ -1792,7 +1792,7 @@ class BillingSession(ABC):
 
         # TODO: The correctness of this relies on user creation, deactivation, etc being
         # in a transaction.atomic() with the relevant RealmAuditLog entries
-        with transaction.atomic():
+        with transaction.atomic(durable=True):
             # We get the current license count here in case the number of billable
             # licenses has changed since the upgrade process began.
             current_licenses_count = self.get_billable_licenses_for_customer(
@@ -2911,7 +2911,7 @@ class BillingSession(ABC):
         if status is not None:
             if status == CustomerPlan.ACTIVE:
                 assert plan.status < CustomerPlan.LIVE_STATUS_THRESHOLD
-                with transaction.atomic():
+                with transaction.atomic(durable=True):
                     # Switch to a different plan was cancelled. We end the next plan
                     # and set the current one as active.
                     if plan.status == CustomerPlan.SWITCH_PLAN_TIER_AT_PLAN_END:
@@ -3411,7 +3411,7 @@ class BillingSession(ABC):
             raise BillingError("Form validation error", message=message)
 
         request_context = self.get_sponsorship_request_session_specific_context()
-        with transaction.atomic():
+        with transaction.atomic(durable=True):
             # Ensures customer is created first before updating sponsorship status.
             self.update_customer_sponsorship_status(True)
             sponsorship_request = ZulipSponsorshipRequest(

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -69,7 +69,7 @@ def do_change_realm_subdomain(
     # deleting, clear that state.
     realm.demo_organization_scheduled_deletion_date = None
     realm.string_id = new_subdomain
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         realm.save(update_fields=["string_id", "demo_organization_scheduled_deletion_date"])
         RealmAuditLog.objects.create(
             realm=realm,
@@ -240,7 +240,7 @@ def do_create_realm(
     # is required to do so correctly.
     kwargs["push_notifications_enabled"] = sends_notifications_directly()
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         realm = Realm(string_id=string_id, name=name, **kwargs)
         if is_demo_organization:
             realm.demo_organization_scheduled_deletion_date = realm.date_created + timedelta(

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -659,7 +659,7 @@ def do_activate_mirror_dummy_user(
     if settings.BILLING_ENABLED:
         from corporate.lib.stripe import RealmBillingSession
 
-    with transaction.atomic():
+    with transaction.atomic(savepoint=False):
         change_user_is_active(user_profile, True)
         user_profile.is_mirror_dummy = False
         user_profile.set_unusable_password()

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -516,7 +516,7 @@ def do_deactivate_realm(
     if settings.BILLING_ENABLED:
         from corporate.lib.stripe import RealmBillingSession
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         realm.deactivated = True
         realm.save(update_fields=["deactivated"])
 
@@ -575,7 +575,7 @@ def do_reactivate_realm(realm: Realm) -> None:
         return
 
     realm.deactivated = False
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         realm.save(update_fields=["deactivated"])
 
         event_time = timezone_now()

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -979,7 +979,7 @@ def bulk_remove_subscriptions(
     streams_to_unsubscribe = [sub_info.stream for sub_info in subs_to_deactivate]
     # We do all the database changes in a transaction to ensure
     # RealmAuditLog entries are atomically created when making changes.
-    with transaction.atomic():
+    with transaction.atomic(savepoint=False):
         Subscription.objects.filter(
             id__in=sub_ids_to_deactivate,
         ).update(active=False)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -80,7 +80,7 @@ def do_delete_user(user_profile: UserProfile, *, acting_user: UserProfile | None
     date_joined = user_profile.date_joined
     personal_recipient = user_profile.recipient
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         user_profile.delete()
         # Recipient objects don't get deleted through CASCADE, so we need to handle
         # the user's personal recipient manually. This will also delete all Messages pointing
@@ -180,7 +180,7 @@ def do_delete_user_preserving_messages(user_profile: UserProfile) -> None:
     realm = user_profile.realm
     date_joined = user_profile.date_joined
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         # The strategy is that before calling user_profile.delete(), we need to
         # reassign Messages  sent by the user to a dummy user, so that they don't
         # get affected by CASCADE. We cannot yet create a dummy user with .id

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -486,7 +486,7 @@ def do_deactivate_user(
         for profile in bot_profiles:
             do_deactivate_user(profile, _cascade=False, acting_user=acting_user)
 
-    with transaction.atomic():
+    with transaction.atomic(savepoint=False):
         if user_profile.realm.is_zephyr_mirror_realm:  # nocoverage
             # For zephyr mirror users, we need to make them a mirror dummy
             # again; otherwise, other users won't get the correct behavior

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -596,7 +596,7 @@ def restore_data_from_archive(archive_transaction: ArchiveTransaction) -> int:
     # so that when we log "Finished", the process has indeed finished - and that happens only after
     # leaving the atomic block - Django does work committing the changes to the database when
     # the block ends.
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         msg_ids = restore_messages_from_archive(archive_transaction.id)
         restore_models_with_message_key_from_archive(archive_transaction.id)
         restore_attachments_from_archive(archive_transaction.id)

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -277,7 +277,7 @@ def do_soft_deactivate_users(
         (user_batch, users) = (users[0:BATCH_SIZE], users[BATCH_SIZE:])
         if len(user_batch) == 0:
             break
-        with transaction.atomic():
+        with transaction.atomic(durable=True):
             realm_logs = []
             for user in user_batch:
                 do_soft_deactivate_user(user)

--- a/zerver/lib/upload/__init__.py
+++ b/zerver/lib/upload/__init__.py
@@ -158,7 +158,7 @@ def upload_message_attachment(
         str(target_realm.id), sanitize_name(uploaded_file_name)
     )
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         upload_backend.upload_message_attachment(
             path_id,
             uploaded_file_name,

--- a/zerver/management/commands/deliver_scheduled_emails.py
+++ b/zerver/management/commands/deliver_scheduled_emails.py
@@ -37,7 +37,7 @@ Usage: ./manage.py deliver_scheduled_emails
     def handle(self, *args: Any, **options: Any) -> None:
         try:
             while True:
-                with transaction.atomic():
+                with transaction.atomic(durable=True):
                     job = (
                         ScheduledEmail.objects.filter(scheduled_timestamp__lte=timezone_now())
                         .prefetch_related("users")

--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -165,7 +165,7 @@ def get_or_create_direct_message_group(id_list: list[int]) -> DirectMessageGroup
     from zerver.models import Subscription, UserProfile
 
     direct_message_group_hash = get_direct_message_group_hash(id_list)
-    with transaction.atomic():
+    with transaction.atomic(savepoint=False):
         (direct_message_group, created) = DirectMessageGroup.objects.get_or_create(
             huddle_hash=direct_message_group_hash,
             group_size=len(id_list),

--- a/zerver/transaction_tests/test_user_groups.py
+++ b/zerver/transaction_tests/test_user_groups.py
@@ -28,7 +28,6 @@ def dev_update_subgroups(
     assert BARRIER is not None
     try:
         with (
-            transaction.atomic(),
             mock.patch("zerver.lib.user_groups.access_user_group_for_update") as m,
         ):
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -468,7 +468,7 @@ def compose_views(thunks: list[Callable[[], HttpResponse]]) -> dict[str, Any]:
     """
 
     json_dict: dict[str, Any] = {}
-    with transaction.atomic():
+    with transaction.atomic(savepoint=False):
         for thunk in thunks:
             response = thunk()
             json_dict.update(orjson.loads(response.content))

--- a/zerver/views/tusd.py
+++ b/zerver/views/tusd.py
@@ -194,7 +194,7 @@ def handle_upload_pre_finish_hook(
                 StorageClass=settings.S3_UPLOADS_STORAGE_CLASS,
             )
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         create_attachment(
             filename,
             path_id,

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -468,6 +468,7 @@ def remove_subgroups_from_group_backend(
 
 @require_member_or_admin
 @typed_endpoint
+@transaction.atomic(durable=True)
 def update_subgroups_of_user_group(
     request: HttpRequest,
     user_profile: UserProfile,

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -100,7 +100,7 @@ def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpRes
     assert isinstance(email_change_object, EmailChangeStatus)
     new_email = email_change_object.new_email
     old_email = email_change_object.old_email
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         user_profile = UserProfile.objects.select_for_update().get(
             id=email_change_object.user_profile_id
         )

--- a/zerver/worker/missedmessage_emails.py
+++ b/zerver/worker/missedmessage_emails.py
@@ -216,7 +216,7 @@ class MissedMessageWorker(QueueProcessingWorker):
     def maybe_send_batched_emails(self) -> None:
         current_time = timezone_now()
 
-        with transaction.atomic():
+        with transaction.atomic(durable=True):
             events_to_process = ScheduledMessageNotificationEmail.objects.filter(
                 scheduled_timestamp__lte=current_time
             ).select_for_update()

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -211,7 +211,7 @@ def register_remote_server(
             _("A server with hostname {hostname} already exists").format(hostname=hostname)
         )
 
-    with transaction.atomic():
+    with transaction.atomic(durable=True):
         if remote_server is None:
             created = True
             remote_server = RemoteZulipServer.objects.create(


### PR DESCRIPTION
This PR is follow-up of #32205

Let me know if you'd like to squash the last 5 commits. I kept them separate as the commit messages explicitly explain the reasons which led to savepoint creation, so it'd be easier to review & revisit later.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
