### PR TITLE
Show non-sticky recipient bar action buttons on hover. 

### DIFF
--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -56,6 +56,12 @@ export function update_current_message_list(msg_list: MessageList | undefined): 
         message_list_data_cache.add(current.data);
         current.view.$list.addClass("focused-message-list");
     }
+
+    if (current?.data.filter.is_conversation_view()) {
+        $(".focused-message-list").addClass("is-conversation-view");
+    } else {
+        $(".focused-message-list").removeClass("is-conversation-view");
+    }
 }
 
 export function all_rendered_message_lists(): MessageList[] {

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -80,6 +80,11 @@
             opacity: 0;
         }
 
+        /* When any of the actions are focused, don't hide them */
+        .recipient_bar_controls:focus-within {
+            opacity: 1;
+        }
+
         /* Show the bar controls on hover and when the bar is sticky */
         &:hover {
             .recipient_bar_controls {

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -75,6 +75,23 @@
                 top: -0.5px;
             }
         }
+
+        .recipient_bar_controls {
+            opacity: 0;
+        }
+
+        /* Show the bar controls on hover and when the bar is sticky */
+        &:hover {
+            .recipient_bar_controls {
+                opacity: 1;
+            }
+        }
+
+        &.sticky_header {
+            .recipient_bar_controls {
+                opacity: 1;
+            }
+        }
     }
 }
 

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -78,23 +78,27 @@
 
         .recipient_bar_controls {
             opacity: 0;
+            transition: opacity 0.15s ease-out;
         }
 
-        /* When any of the actions are focused, don't hide them */
         .recipient_bar_controls:focus-within {
             opacity: 1;
+            transition: opacity 0.1s ease-in;
         }
 
-        /* Show the bar controls on hover and when the bar is sticky */
+        /* Show the bar controls on hover with a slight delay */
         &:hover {
             .recipient_bar_controls {
                 opacity: 1;
+                transition: opacity 0.15s ease-in 0.1s;
             }
         }
 
+        /* Always show controls when header is sticky */
         &.sticky_header {
             .recipient_bar_controls {
                 opacity: 1;
+                transition: opacity 0.15s ease-in;
             }
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -888,6 +888,13 @@ div.focused-message-list {
     display: block;
 }
 
+/* In conversation view, always show the recipient bar action buttons */
+div.focused-message-list.is-conversation-view .recipient_row {
+    & .recipient_bar_controls {
+        opacity: 1;
+    }
+}
+
 .rtl {
     direction: rtl;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -902,6 +902,7 @@ div.focused-message-list.is-conversation-view .recipient_row {
 .topic_edit {
     display: none;
     line-height: 22px;
+    visibility: visible;
 
     .alert {
         display: inline-block;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -892,6 +892,7 @@ div.focused-message-list {
 div.focused-message-list.is-conversation-view .recipient_row {
     & .recipient_bar_controls {
         opacity: 1;
+        transition: opacity 0.15s ease-in;
     }
 }
 


### PR DESCRIPTION
This PR completes the work in the PR: #27265 which was authored by @ecxtacy .

- **Recipient Bars Hover Behavior**: Action buttons are displayed on recipient bars when hovered over, except for the sticky recipient bar, which always displays the action buttons.
- **CSS Visibility Control**: The CSS rule `opacity: 0;` is toggled to `opacity: 1;` on hover. For sticky bars, `opacity: 1;` is applied by default to keep the action buttons visible.
- **Persistent Action Buttons with Active UI Elements**: To prevent the action buttons from disappearing when other UI elements (e.g., notification menu, topic editing UI) are active, the `:focus-within` CSS pseudo-class is used on `recipient_bar`, ensuring the buttons remain visible.
- **Conversation View Consistency**: In conversation views where a single message box is present, the action buttons are permanently visible using the `:only-child` CSS pseudo-selector for a consistent user experience.

As per @terpimost's comment in the CZO, I have added animation for opacity.

Fixes: #26852 

[CZO Thread](https://chat.zulip.org/#narrow/channel/101-design/topic/UI.20redesign.3A.20recipient.20bar)

<details>
<summary> Action buttons appear after a short delay on hover only </summary>

[Screencast from 2024-12-26 00-50-12.webm](https://github.com/user-attachments/assets/33245063-a781-4f42-9bcd-08bf1ba63715)


</details>

<details>
<summary> Persistent Action Buttons with Active UI Elements </summary>

[Screencast from 2024-12-26 00-50-50.webm](https://github.com/user-attachments/assets/6a77c6e3-7bef-412f-9680-38c195d3cbc1)


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
