### PR TITLE
popovers: Hide left sidebar actions popover for empty topics.

### DIFF
--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -12,6 +12,7 @@ import {$t} from "./i18n.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_lists from "./message_lists.ts";
 import * as muted_users from "./muted_users.ts";
+import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as settings_config from "./settings_config.ts";
@@ -52,6 +53,7 @@ type TopicPopoverContext = {
     topic_name: string;
     topic_unmuted: boolean;
     is_spectator: boolean;
+    is_topic_empty: boolean;
     can_move_topic: boolean;
     can_rename_topic: boolean;
     is_realm_admin: boolean;
@@ -248,6 +250,7 @@ export function get_topic_popover_content_context({
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
     const all_visibility_policies = user_topics.all_visibility_policies;
     const is_spectator = page_params.is_spectator;
+    const is_topic_empty = is_topic_definetly_empty(stream_id, topic_name);
     return {
         stream_name: sub.name,
         stream_id: sub.stream_id,
@@ -255,6 +258,7 @@ export function get_topic_popover_content_context({
         topic_name,
         topic_unmuted,
         is_spectator,
+        is_topic_empty,
         can_move_topic,
         can_rename_topic,
         is_realm_admin: current_user.is_admin,
@@ -356,4 +360,30 @@ export function get_gear_menu_content_context(): GearMenuContext {
         user_color_scheme: user_settings.color_scheme,
         color_scheme_values: settings_config.color_scheme_values,
     };
+}
+
+function is_topic_definetly_empty(stream_id: number, topic: string): boolean {
+    const current_narrow_stream_id = narrow_state.stream_id();
+    const current_narrow_topic = narrow_state.topic();
+
+    if (
+        current_narrow_stream_id === undefined ||
+        current_narrow_topic === undefined ||
+        current_narrow_stream_id !== stream_id ||
+        current_narrow_topic !== topic
+    ) {
+        return false;
+    }
+
+    const is_current_message_list_empty = message_lists.current?.data.empty();
+    if (!is_current_message_list_empty) {
+        return false;
+    }
+
+    const is_oldest_message_found = message_lists.current?.data.fetch_status.has_found_oldest();
+    if (!is_oldest_message_found) {
+        return false;
+    }
+
+    return true;
 }

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -63,7 +63,12 @@ export function initialize(): void {
             },
             onMount(instance) {
                 const $popper = $(instance.popper);
-                const {stream_id, topic_name} = get_conversation(instance);
+                const {stream_id, topic_name, url} = get_conversation(instance);
+                const is_topic_empty = popover_menus_data.get_topic_popover_content_context({
+                    stream_id,
+                    topic_name,
+                    url,
+                }).is_topic_empty;
 
                 if (!stream_id) {
                     popover_menus.hide_current_popover_if_visible(instance);
@@ -113,6 +118,10 @@ export function initialize(): void {
                         error_cb,
                     );
                 });
+
+                if (is_topic_empty) {
+                    return;
+                }
 
                 $popper.one("click", ".sidebar-popover-unstar-all-in-topic", () => {
                     starred_messages_ui.confirm_unstar_all_messages_in_topic(stream_id, topic_name);

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -30,76 +30,83 @@
             </div>
         </li>
         {{/unless}}
-        {{!-- Group 2 --}}
-        <li role="separator" class="popover-menu-separator"></li>
-        {{#if has_starred_messages}}
-        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="sidebar-popover-unstar-all-in-topic popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-star" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Unstar all messages in topic" }}</span>
-            </a>
-        </li>
-        {{/if}}
-        {{#if has_unread_messages}}
-        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="sidebar-popover-mark-topic-read popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
-            </a>
-        </li>
+        {{#if is_topic_empty}}
+            <li role="separator" class="popover-menu-separator"></li>
+            <li role="none" class="popover-menu-list-item text-item italic">
+                <span class="popover-menu-label">{{t "There are no messages in this topic." }}</span>
+            </li>
         {{else}}
-        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
-            <a role="menuitem" class="sidebar-popover-mark-topic-unread popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark all messages as unread" }}</span>
-            </a>
-        </li>
-        {{/if}}
-        <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-clipboard-text="{{ url }}" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Copy link to topic" }}</span>
-            </a>
-        </li>
-        {{!-- Group 3 --}}
-        {{#if (or can_move_topic can_rename_topic is_realm_admin)}}
-        <li role="separator" class="popover-menu-separator"></li>
-        {{/if}}
-        {{#if can_move_topic}}
-        <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-move-topic-messages popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Move topic" }}</span>
-            </a>
-        </li>
-        {{else if can_rename_topic}}
-        <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-rename-topic-messages popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-rename" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Rename topic" }}</span>
-            </a>
-        </li>
-        {{/if}}
-        {{#if can_rename_topic}}
-        <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-toggle-resolved popover-menu-link" tabindex="0">
-                {{# if topic_is_resolved }}
-                <i class="popover-menu-icon zulip-icon zulip-icon-check-x" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark as unresolved"}}</span>
-                {{else}}
-                <i class="popover-menu-icon zulip-icon zulip-icon-check" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Mark as resolved"}}</span>
-                {{/if}}
-            </a>
-        </li>
-        {{/if}}
-        {{#if is_realm_admin}}
-        <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-delete-topic-messages popover-menu-link" tabindex="0">
-                <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t "Delete topic"}}</span>
-            </a>
-        </li>
+            {{!-- Group 2 --}}
+            <li role="separator" class="popover-menu-separator"></li>
+            {{#if has_starred_messages}}
+            <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+                <a role="menuitem" class="sidebar-popover-unstar-all-in-topic popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-star" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Unstar all messages in topic" }}</span>
+                </a>
+            </li>
+            {{/if}}
+            {{#if has_unread_messages}}
+            <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+                <a role="menuitem" class="sidebar-popover-mark-topic-read popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Mark all messages as read" }}</span>
+                </a>
+            </li>
+            {{else}}
+            <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+                <a role="menuitem" class="sidebar-popover-mark-topic-unread popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Mark all messages as unread" }}</span>
+                </a>
+            </li>
+            {{/if}}
+            <li role="none" class="link-item popover-menu-list-item">
+                <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-clipboard-text="{{ url }}" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Copy link to topic" }}</span>
+                </a>
+            </li>
+            {{!-- Group 3 --}}
+            {{#if (or can_move_topic can_rename_topic is_realm_admin)}}
+            <li role="separator" class="popover-menu-separator"></li>
+            {{/if}}
+            {{#if can_move_topic}}
+            <li role="none" class="link-item popover-menu-list-item">
+                <a role="menuitem" class="sidebar-popover-move-topic-messages popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-move-alt" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Move topic" }}</span>
+                </a>
+            </li>
+            {{else if can_rename_topic}}
+            <li role="none" class="link-item popover-menu-list-item">
+                <a role="menuitem" class="sidebar-popover-rename-topic-messages popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-rename" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Rename topic" }}</span>
+                </a>
+            </li>
+            {{/if}}
+            {{#if can_rename_topic}}
+            <li role="none" class="link-item popover-menu-list-item">
+                <a role="menuitem" class="sidebar-popover-toggle-resolved popover-menu-link" tabindex="0">
+                    {{# if topic_is_resolved }}
+                    <i class="popover-menu-icon zulip-icon zulip-icon-check-x" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Mark as unresolved"}}</span>
+                    {{else}}
+                    <i class="popover-menu-icon zulip-icon zulip-icon-check" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Mark as resolved"}}</span>
+                    {{/if}}
+                </a>
+            </li>
+            {{/if}}
+            {{#if is_realm_admin}}
+            <li role="none" class="link-item popover-menu-list-item">
+                <a role="menuitem" class="sidebar-popover-delete-topic-messages popover-menu-link" tabindex="0">
+                    <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>
+                    <span class="popover-menu-label">{{t "Delete topic"}}</span>
+                </a>
+            </li>
+            {{/if}}
         {{/if}}
     </ul>
 </div>


### PR DESCRIPTION
This PR changes the behavior of the topic actions popover (displayed from the left sidebar via the `...` menu) to no longer appear for empty topics (topics with no messages).
Instead, in place of the popover a message is displayed: "There are no messages in this topic.", along with the name of the topic (styled like the deactivated user line).

Fixes: #32098.
[CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/Error.20moving.20topic.20with.20no.20messages/near/1966728)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before Changes**
<details>
<summary>GIF</summary>

![empty before](https://github.com/user-attachments/assets/cfd351f0-e552-4de3-a943-312c43de928b)

</details>

<details>
<summary>Image</summary>

![Screenshot 2024-11-04 223613](https://github.com/user-attachments/assets/773f6e02-3636-4961-b9ee-b192d050bce7)


</details>

**After Changes**
<details>
<summary>GIF</summary>

![empty after](https://github.com/user-attachments/assets/33381a10-cf60-4eab-af9a-30e53e221898)

</details>

<details>
<summary>Image</summary>

![Screenshot 2024-11-04 222900](https://github.com/user-attachments/assets/cd143bc0-4214-473f-89cb-60c39b4e5470)

</details>

**Please note that the left sidebar actions popover for non-empty topics remains unchanged.**

<details>
<summary>GIF: Non-empty topic actions popover.</summary>

![non empty](https://github.com/user-attachments/assets/4e097520-51f5-4c0d-9010-fd819ccc281e)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
