### PR TITLE
zulip updates: Add update about sidebars and file size limit.

### DIFF
--- a/help/user-list.md
+++ b/help/user-list.md
@@ -1,17 +1,20 @@
 # User list
 
 In the Zulip web and desktop app, the right sidebar shows a list of users in
-your organization. It shows
-[non-deactivated](/help/deactivate-or-reactivate-a-user) users, and does not
-include [bots](/help/bots-overview).
+your organization. The user list has up to three section:
 
-In organizations with up to 600 users, everyone is shown. In larger organizations,
-only users who have been active in the last two weeks are listed. All users are
-included when you search for people.
+- **In this conversation**: Recent participants in the conversation you're viewing.
+- **In this channel** or **Others in this channel**: Subscribers to the channel you're viewing.
+- **Others**: Everyone else.
 
-When you view a channel or a topic within a channel, subscribers to that channel
-are shown separately from other members of your organization. To avoid
-distraction, you can hide the user list any time.
+In organizations with up to 600 users, everyone is shown. In larger
+organizations, only users who have been active in the last two weeks are shown,
+but everyone is included when you [search](#filter-users).
+[Deactivated users](/help/deactivate-or-reactivate-a-user) and
+[bots](/help/bots-overview) are not listed.
+
+To avoid distraction, you can [hide](#show-or-hide-the-user-list) the user list
+any time.
 
 ## Filter users
 
@@ -19,11 +22,11 @@ distraction, you can hide the user list any time.
 
 {tab|desktop-web}
 
-1. If the user list in the right sidebar is hidden, click the **user list** (<i
-class="zulip-icon zulip-icon-triple-users"></i> ) icon in the upper right to
-show it.
+1. If the user list is hidden, click the **user list** (<i class="zulip-icon
+   zulip-icon-triple-users"></i> ) icon in the upper right to show it.
 
-1. Type the name of the user you are looking for in the search box.
+1. Type the name of the user you are looking for in the **Filter users** box at
+   the top of the right sidebar.
 
 !!! keyboard_tip ""
 

--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -187,6 +187,40 @@ feature highlights in Zulip Server 9.0, and other Zulip project updates.
             blog_post_9_0_url="https://blog.zulip.com/zulip-server-9-0",
         ),
     ),
+    ZulipUpdateAnnouncement(
+        level=9,
+        message=(
+            (
+                """
+- You can now [upload large files]({file_upload_limits_help_url}) up to
+  1 GB in organizations on Zulip Cloud
+  Standard or Zulip Cloud Plus [plans]({cloud_plans_url}).
+"""
+                if settings.CORPORATE_ENABLED
+                else """
+- You can now [upload large files]({file_upload_limits_help_url}), up to
+  the limit configured by your server's administrator (currently {max_file_upload_size} MB).
+"""
+            )
+            + """
+
+**Web and desktop updates**
+- You can now start a new conversation from the left sidebar. Click the `+`
+button next to the name of a channel to [start a new
+topic]({how_to_start_a_new_topic_help_url}) in that channel, or the `+` next to
+DIRECT MESSAGES to [start a DM]({starting_a_new_direct_message_help_url}).
+- The [user list]({user_list_help_url}) now shows recent participants in the
+  conversation you're viewing.
+"""
+        ).format(
+            how_to_start_a_new_topic_help_url="/help/introduction-to-topics#how-to-start-a-new-topic",
+            starting_a_new_direct_message_help_url="/help/starting-a-new-direct-message",
+            user_list_help_url="/help/user-list",
+            cloud_plans_url="/plans/",
+            file_upload_limits_help_url="/help/share-and-upload-files#file-upload-limits",
+            max_file_upload_size=settings.MAX_FILE_UPLOAD_SIZE,
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
The first commit updates the right sidebar help center page.

Current: https://zulip.com/help/user-list
<details>
<summary>
Updated
</summary>

![Screenshot 2024-11-04 at 15 48 08@2x](https://github.com/user-attachments/assets/5801b222-d05e-483e-871c-50163f9454a2)

</details>

----

The Zulip update needs to be tested!
