### PR TITLE
streams: Move subscriber count from channel pills to channel cards.

### DIFF
--- a/web/src/stream_card_popover.ts
+++ b/web/src/stream_card_popover.ts
@@ -6,6 +6,7 @@ import render_stream_card_popover from "../templates/popovers/stream_card_popove
 import * as browser_history from "./browser_history.ts";
 import * as hash_util from "./hash_util.ts";
 import * as modals from "./modals.ts";
+import * as peer_data from "./peer_data.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
@@ -25,6 +26,7 @@ export function initialize(): void {
             const stream_id_str = $elt.attr("data-stream-id");
             assert(stream_id_str !== undefined);
             stream_id = Number.parseInt(stream_id_str, 10);
+            const subscribers_count = peer_data.get_subscriber_count(stream_id);
 
             instance.setContent(
                 ui_util.parse_html(
@@ -32,6 +34,7 @@ export function initialize(): void {
                         stream: {
                             ...sub_store.get(stream_id),
                         },
+                        subscribers_count,
                     }),
                 ),
             );

--- a/web/src/stream_pill.ts
+++ b/web/src/stream_pill.ts
@@ -2,7 +2,6 @@ import assert from "minimalistic-assert";
 
 import render_input_pill from "../templates/input_pill.hbs";
 
-import {$t} from "./i18n.ts";
 import type {InputPillContainer} from "./input_pill.ts";
 import * as peer_data from "./peer_data.ts";
 import * as stream_data from "./stream_data.ts";
@@ -18,14 +17,6 @@ export type StreamPill = {
 export type StreamPillWidget = InputPillContainer<StreamPill>;
 
 export type StreamPillData = StreamSubscription & {type: "stream"};
-
-function format_stream_name_and_subscriber_count(sub: StreamSubscription): string {
-    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
-    return $t(
-        {defaultMessage: "{stream_name}: {sub_count} users"},
-        {stream_name: sub.name, sub_count},
-    );
-}
 
 export function create_item_from_stream_name(
     stream_name: string,
@@ -83,9 +74,6 @@ export function get_user_ids(pill_widget: StreamPillWidget | CombinedPillContain
 export function get_display_value_from_item(item: StreamPill): string {
     const stream = stream_data.get_sub_by_id(item.stream_id);
     assert(stream !== undefined);
-    if (item.show_subscriber_count) {
-        return format_stream_name_and_subscriber_count(stream);
-    }
     return stream.name;
 }
 

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -12,6 +12,11 @@
             {{> ../stream_settings/stream_description
               rendered_description=stream.rendered_description}}
         </li>
+        <li role="none" class="popover-menu-list-item text-item italic">
+            {{#tr}}
+            {subscribers_count, plural, =0 {No subscribers} =1 {1 subscriber} other {# subscribers}}
+            {{/tr}}
+        </li>
         <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="open_stream_settings popover-menu-link" tabindex="0">

--- a/web/tests/stream_pill.test.cjs
+++ b/web/tests/stream_pill.test.cjs
@@ -87,14 +87,8 @@ run_test("create_item", ({override}) => {
 });
 
 run_test("display_value", () => {
-    assert.deepEqual(
-        stream_pill.get_display_value_from_item(denmark_pill),
-        "translated: Denmark: 3 users",
-    );
-    assert.deepEqual(
-        stream_pill.get_display_value_from_item(sweden_pill),
-        "translated: Sweden: 5 users",
-    );
+    assert.deepEqual(stream_pill.get_display_value_from_item(denmark_pill), "Denmark");
+    assert.deepEqual(stream_pill.get_display_value_from_item(sweden_pill), "Sweden");
     sweden_pill.show_subscriber_count = false;
     assert.deepEqual(stream_pill.get_display_value_from_item(sweden_pill), "Sweden");
 });
@@ -125,7 +119,7 @@ run_test("generate_pill_html", () => {
         "<div class='pill 'data-stream-id=\"101\" tabindex=0>\n" +
             '    <span class="pill-label">\n' +
             '        <span class="pill-value">\n' +
-            '<i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon" aria-hidden="true"></i>            translated: Denmark: 3 users\n' +
+            '<i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon" aria-hidden="true"></i>            Denmark\n' +
             "        </span></span>\n" +
             '    <div class="exit">\n' +
             '        <a role="button" class="zulip-icon zulip-icon-close pill-close-button"></a>\n' +


### PR DESCRIPTION
This Pull Request addresses an issue in the channel display UI by adjusting where the subscriber count is shown for channels. It removes the subscriber count from channel pills, and adds the count to channel cards. The subscriber count is styled to match the group member count in group cards and displays as "N subscribers" (or "1 subscriber" for singular cases). This change improves consistency in the UI and enhances readability.

**Fixes**: https://github.com/zulip/zulip/issues/32235.

**Screenshots and screen captures:**
| Area | Before | After |
| --- | --- | --- |
| Stream Pill | ![pill-image-before](https://github.com/user-attachments/assets/8cabe3af-d858-42d1-a87d-2f89a4c09565) | ![pill-image-after](https://github.com/user-attachments/assets/624657a2-395f-47ff-88a0-9cb2e3d8c967) |
| Card(1 subscriber) | ![card-sing-image-before](https://github.com/user-attachments/assets/317c6525-289a-426a-8cd2-45c37d739570) | ![card-sing-image-after](https://github.com/user-attachments/assets/2d4d57a2-2712-4f54-9158-37c4d4128389) |
| Card(N subscribers) |  ![card-plural-image-before](https://github.com/user-attachments/assets/e08fc1ba-4bf5-4c28-b2c1-dada45e32d8e) | ![card-plural-image-after](https://github.com/user-attachments/assets/448cec91-a17c-42d2-856c-9d845d2eb913) |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
