### PR TITLE
web: Update strings from "Alert Words" to "Watched Phrases".

### DIFF
--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,10 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 11.0 (feature level ZF-657917), support was added for
+  `is:watched` filter. The `is:watched` filter replaced and deprecated
+  the `is:alerted` filter.
+
 * In Zulip 10.0 (feature level 366), support was added for a new
   `is:muted` operator combination, matching messages in topics and
   channels that the user has [muted](/help/mute-a-topic).

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -107,9 +107,9 @@
 * [Get subgroups of a user group](/api/get-user-group-subgroups)
 * [Mute a user](/api/mute-user)
 * [Unmute a user](/api/unmute-user)
-* [Get all alert words](/api/get-alert-words)
-* [Add alert words](/api/add-alert-words)
-* [Remove alert words](/api/remove-alert-words)
+* [Get all watched phrases](/api/get-alert-words)
+* [Add watched phrases](/api/add-alert-words)
+* [Remove watched phrases](/api/remove-alert-words)
 
 #### Invitations
 

--- a/api_docs/unmerged.d/ZF-657917.md
+++ b/api_docs/unmerged.d/ZF-657917.md
@@ -1,0 +1,8 @@
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  **Deprecated** `is:alerted` [search/narrow filter](/api/construct-narrow) in favor
+  of `is:watched`. The `is:alerted` filter continues to work for backwards compatibility,
+  but clients should use `is:watched` for consistency with the updated terminology
+  for watched phrases (previously called "alert words").

--- a/docs/subsystems/notifications.md
+++ b/docs/subsystems/notifications.md
@@ -29,7 +29,7 @@ as follows:
 - `do_send_messages` is the synchronous message-sending code path,
   and passing the following data in its `send_event_on_commit` call:
   - Data about the message's content (e.g., mentions, wildcard
-    mentions, and alert words) and encodes it into the `UserMessage`
+    mentions, and watched phrases) and encodes it into the `UserMessage`
     table's `flags` structure, which is in turn passed into
     `send_event_on_commit` for each user receiving the message.
   - Data about user configuration relevant to the message, such as

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -504,9 +504,9 @@ Do these tasks as Cordelia.
   - Create a bot with a generic avatar and send it a direct message
   - Create a bot with a custom avatar and send it a direct message
   - Change your API key
-- Alert words
-  - Create an alert word
-  - Have Hamlet send you a message that includes the alert word
+- Watched phrases
+  - Create a watched phrase
+  - Have Hamlet send you a message that includes the watched phrase
 - Zulip labs
   - Turn on auto-scroll to new messages (and have Hamlet send you one)
   - Turn on/off "Enable desktop notifications for new channels" and test.

--- a/help/channel-notifications.md
+++ b/help/channel-notifications.md
@@ -68,5 +68,5 @@ explicitly set a notification preference.
 * [Mobile notifications](/help/mobile-notifications)
 * [Mute or unmute a channel](/help/mute-a-channel)
 * [Mute or unmute a topic](/help/mute-a-topic)
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Do not disturb](/help/do-not-disturb)

--- a/help/delete-a-message.md
+++ b/help/delete-a-message.md
@@ -94,7 +94,7 @@ If you delete a message soon after sending it, any [pending email
 notifications](/help/email-notifications#configure-delay-for-message-notification-emails)
 for that message will be canceled, and
 [visual desktop notifications](/help/desktop-notifications) will be removed,
-including [mentions and alerts](/help/dm-mention-alert-notifications).
+including [mentions](/help/dm-mention-alert-notifications).
 
 ## Related articles
 

--- a/help/desktop-notifications.md
+++ b/help/desktop-notifications.md
@@ -10,7 +10,7 @@ trigger desktop notifications.
 
 {settings_tab|notifications}
 
-1. Toggle the checkboxes for **Channels** and **DMs, mentions, and alerts**
+1. Toggle the checkboxes for **Channels** and **DMs and mentions**
    in the **Desktop** column of the **Notification triggers** table.
 
 {end_tabs}
@@ -172,7 +172,7 @@ Alternate instructions:
 ## Related articles
 
 * [Channel notifications](/help/channel-notifications)
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Email notifications](/help/email-notifications)
 * [Mobile notifications](/help/mobile-notifications)
 * [Do not disturb](/help/do-not-disturb)

--- a/help/dm-mention-alert-notifications.md
+++ b/help/dm-mention-alert-notifications.md
@@ -1,4 +1,4 @@
-# DMs, mentions, and alerts
+# DMs and mentions
 
 You can configure desktop, mobile, and email notifications for
 [direct messages (DMs)](/help/direct-messages),
@@ -14,7 +14,7 @@ direct messages, mentions, and alert words.
 
 {settings_tab|notifications}
 
-1. In the **Notification triggers** table, toggle the settings for **DMs, mentions, and alerts**.
+1. In the **Notification triggers** table, toggle the settings for **DMs and mentions**.
 
 {end_tabs}
 

--- a/help/dm-mention-alert-notifications.md
+++ b/help/dm-mention-alert-notifications.md
@@ -2,13 +2,13 @@
 
 You can configure desktop, mobile, and email notifications for
 [direct messages (DMs)](/help/direct-messages),
-[mentions](/help/mention-a-user-or-group), and [alert
-words](#alert-words).
+[mentions](/help/mention-a-user-or-group), and [watched
+phrases](#watched-phrases).
 
 ## Configure notifications
 
 These settings will affect notifications for direct messages, group
-direct messages, mentions, and alert words.
+direct messages, mentions, and watched phrases.
 
 {start_tabs}
 
@@ -54,25 +54,25 @@ channels in your [Channel settings](/help/channel-notifications), and
 administrators can [restrict use of wildcard
 mentions](/help/restrict-wildcard-mentions) in large channels.
 
-## Alert words
+## Watched phrases
 
-Zulip lets you to specify **alert words or phrases** that send you a desktop
-notification whenever the alert word is included in a message. Alert words are
+Zulip lets you to specify **watched phrases** that send you a desktop
+notification whenever the watched phrase is included in a message. Watched phrases are
 case-insensitive.
 
 !!! tip ""
 
-    Alert words in messages you receive while the alert is enabled will be highlighted.
+    Watched phrases in messages you receive while the alert is enabled will be highlighted.
 
-### Add an alert word or phrase
+### Add a watched phrase
 
 {start_tabs}
 
-{settings_tab|alert-words}
+{settings_tab|watched-phrases}
 
 1. Add a word or phrase.
 
-1. Click **Add alert word**.
+1. Click **Add watched phrase**.
 
 {end_tabs}
 

--- a/help/do-not-disturb.md
+++ b/help/do-not-disturb.md
@@ -50,7 +50,7 @@ time to focus on your work.
 ## Related articles
 
 * [Desktop notifications](/help/desktop-notifications)
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Channel notifications](/help/channel-notifications)
 * [Email notifications](/help/email-notifications)
 * [Mobile notifications](/help/mobile-notifications)

--- a/help/edit-a-message.md
+++ b/help/edit-a-message.md
@@ -63,7 +63,7 @@ removed or changed from a regular mention to a
 
 If you [delete the content of a message](/help/delete-a-message#delete-message-content),
 any pending email notifications for that message will be canceled, including
-[mentions and alerts](/help/dm-mention-alert-notifications).
+[mentions](/help/dm-mention-alert-notifications).
 
 ## Related articles
 

--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -2,8 +2,8 @@
 
 ## Message notification emails
 
-Zulip can be configured to send message notification emails for [DMs mentions,
-and alerts](/help/dm-mention-alert-notifications), as well as [channel
+Zulip can be configured to send message notification emails for [DMs and
+mentions](/help/dm-mention-alert-notifications), as well as [channel
 messages](/help/channel-notifications) and [followed
 topics](/help/follow-a-topic#configure-notifications-for-followed-topics).
 
@@ -147,7 +147,7 @@ to Zulip Cloud users announcing major changes in Zulip.
 
 * [Using Zulip via email](/help/using-zulip-via-email)
 * [Message a channel by email](/help/message-a-channel-by-email)
-* [DMs mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Channel notifications](/help/channel-notifications)
 * [Follow a topic](/help/follow-a-topic)
 * [Hide message content in emails (for organizations)](/help/hide-message-content-in-emails)

--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -5,8 +5,8 @@ that channel. You can also manually **mute** a topic in an unmuted channel, or
 
 Muting has the following effects:
 
-- Messages in muted topics do not generate notifications (including [alert
-  word](/help/dm-mention-alert-notifications#alert-words) notifications), unless
+- Messages in muted topics do not generate notifications (including [watched
+phrases](/help/dm-mention-alert-notifications#watched-phrases) notifications), unless
   you are [mentioned](/help/mention-a-user-or-group).
 - Messages in muted topics do not appear in the [**Combined feed**
   view](/help/combined-feed) or the mobile **Inbox** view.

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -159,7 +159,7 @@
 * [Channel notifications](/help/channel-notifications)
 * [Topic notifications](/help/topic-notifications)
 * [Follow a topic](/help/follow-a-topic)
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Mute or unmute a channel](/help/mute-a-channel)
 * [Mute or unmute a topic](/help/mute-a-topic)
 * [Mute a user](/help/mute-a-user)

--- a/help/mobile-notifications.md
+++ b/help/mobile-notifications.md
@@ -12,7 +12,7 @@ apps.
 
 {settings_tab|notifications}
 
-1. Toggle the checkboxes for **Channels** and **DMs, mentions, and alerts**
+1. Toggle the checkboxes for **Channels** and **DMs and mentions**
    in the **Mobile** column of the **Notification triggers** table.
 
 {end_tabs}
@@ -93,7 +93,7 @@ notification.
 {settings_tab|notifications}
 
 1. In the **Mobile** column of the **Notification triggers** table, make sure
-   the **DMs, mentions, and alerts** checkbox is checked.
+   the **DMs and mentions** checkbox is checked.
 
 1. Under **Mobile message notifications**, make sure the **Send mobile
    notifications even if I'm online** checkbox is checked.
@@ -241,7 +241,7 @@ troubleshooting data provided by the mobile app.
 ## Related articles
 
 * [Channel notifications](/help/channel-notifications)
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Email notifications](/help/email-notifications)
 * [Desktop notifications](/help/desktop-notifications)
 * [Do not disturb](/help/do-not-disturb)

--- a/help/restrict-wildcard-mentions.md
+++ b/help/restrict-wildcard-mentions.md
@@ -25,4 +25,4 @@ This permission can be granted to any combination of [roles](/help/user-roles),
 
 ## Related articles
 
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -103,7 +103,7 @@ Zulip offers the following filters based on the location of the message.
 
 ### Search your important messages
 
-* `is:alerted`: Search messages that contain your [watched
+* `is:watched`: Search messages that contain your [watched
 phrases](/help/dm-mention-alert-notifications#watched-phrases). Messages are
   included in the search results based on the phrases you had configured when you
   received the message.

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -103,9 +103,9 @@ Zulip offers the following filters based on the location of the message.
 
 ### Search your important messages
 
-* `is:alerted`: Search messages that contain your [alert
-  words](/help/dm-mention-alert-notifications#alert-words). Messages are
-  included in the search results based on the alerts you had configured when you
+* `is:alerted`: Search messages that contain your [watched
+phrases](/help/dm-mention-alert-notifications#watched-phrases). Messages are
+  included in the search results based on the phrases you had configured when you
   received the message.
 * `is:mentioned`: Search messages where you were
   [mentioned](/help/mention-a-user-or-group).

--- a/help/view-your-mentions.md
+++ b/help/view-your-mentions.md
@@ -20,5 +20,5 @@ number of unread messages.
 ## Related articles
 
 * [Mention a user or group](/help/mention-a-user-or-group)
-* [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
+* [DMs and mentions](/help/dm-mention-alert-notifications)
 * [Reading strategies](/help/reading-strategies)

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -427,7 +427,7 @@ async function test_default_language_setting(page: Page): Promise<void> {
 
 async function test_notifications_section(page: Page): Promise<void> {
     await page.click('[data-section="notifications"]');
-    // At the beginning, "DMs, mentions, and alerts"(checkbox name=enable_sounds) audio will be on
+    // At the beginning, "DMs and mentions"(checkbox name=enable_sounds) audio will be on
     // and "Streams"(checkbox name=enable_stream_audible_notifications) audio will be off by default.
 
     const notification_sound_enabled =

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -325,7 +325,7 @@ async function test_duplicate_alert_words_cannot_be_added(
     const alert_word_status_selector = "#dialog_error";
     await page.waitForSelector(alert_word_status_selector, {visible: true});
     const status_text = await common.get_text_from_selector(page, alert_word_status_selector);
-    assert.strictEqual(status_text, "Alert word already exists!");
+    assert.strictEqual(status_text, "Watched phrase already exists!");
 
     await page.click("#add-alert-word .dialog_exit_button");
     await common.wait_for_micromodal_to_close(page);
@@ -340,7 +340,7 @@ async function delete_alert_word(page: Page, word: string): Promise<void> {
 async function test_alert_word_deletion(page: Page, word: string): Promise<void> {
     await delete_alert_word(page, word);
     const status_text = await get_alert_words_status_text(page);
-    assert.strictEqual(status_text, `Alert word ${word} removed successfully!`);
+    assert.strictEqual(status_text, `Watched phrase ${word} removed successfully!`);
     await close_alert_words_status(page);
 }
 

--- a/web/src/alert_words_ui.ts
+++ b/web/src/alert_words_ui.ts
@@ -53,7 +53,7 @@ const open_alert_word_status_banner = (alert_word: string, is_error: boolean): v
     if (is_error) {
         alert_word_status_banner.label = new Handlebars.SafeString(
             $t_html(
-                {defaultMessage: "Error removing alert word <b>{alert_word}</b>!"},
+                {defaultMessage: "Error removing watched phrase <b>{alert_word}</b>!"},
                 {alert_word},
             ),
         );
@@ -61,7 +61,7 @@ const open_alert_word_status_banner = (alert_word: string, is_error: boolean): v
     } else {
         alert_word_status_banner.label = new Handlebars.SafeString(
             $t_html(
-                {defaultMessage: "Alert word <b>{alert_word}</b> removed successfully!"},
+                {defaultMessage: "Watched phrase <b>{alert_word}</b> removed successfully!"},
                 {alert_word},
             ),
         );
@@ -75,7 +75,7 @@ function add_alert_word(): void {
 
     if (alert_words.has_alert_word(alert_word)) {
         ui_report.client_error(
-            $t({defaultMessage: "Alert word already exists!"}),
+            $t({defaultMessage: "Watched phrase already exists!"}),
             $("#dialog_error"),
         );
         dialog_widget.hide_dialog_spinner();
@@ -119,7 +119,7 @@ export function show_add_alert_word_modal(): void {
     }
 
     dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Add a new alert word"}),
+        html_heading: $t_html({defaultMessage: "Add a new watched phrase"}),
         html_body,
         html_submit_button: $t_html({defaultMessage: "Add"}),
         help_link: "/help/dm-mention-alert-notifications#alert-words",

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -161,7 +161,7 @@ function message_matches_search_term(message: Message, operator: string, operand
                     return message.starred;
                 case "mentioned":
                     return message.mentioned;
-                case "alerted":
+                case "watched":
                     return message.alerted;
                 case "unread":
                     return message.unread;
@@ -334,6 +334,10 @@ export class Filter {
                 // "is:private" was renamed to "is:dm"
                 if (operand === "private") {
                     operand = "dm";
+                }
+                // "is:alerted" is a legacy alias for "is:watched"
+                if (operand === "alerted") {
+                    operand = "watched";
                 }
                 break;
             case "has":
@@ -557,7 +561,7 @@ export class Filter {
                     "private",
                     "starred",
                     "mentioned",
-                    "alerted",
+                    "watched",
                     "unread",
                     "resolved",
                     "followed",
@@ -654,7 +658,7 @@ export class Filter {
             "sender",
             "near",
             "id",
-            "is-alerted",
+            "is-watched",
             "is-mentioned",
             "is-dm",
             "is-starred",
@@ -1482,7 +1486,7 @@ export class Filter {
                 // These cases return false for is_common_narrow, and therefore are not
                 // formatted in the message view header. They are used in narrow.js to
                 // update the browser title.
-                case "is-alerted":
+                case "is-watched":
                     return $t({defaultMessage: "Messages containing watched phrases"});
                 case "is-unread":
                     return $t({defaultMessage: "Unread messages"});

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1483,7 +1483,7 @@ export class Filter {
                 // formatted in the message view header. They are used in narrow.js to
                 // update the browser title.
                 case "is-alerted":
-                    return $t({defaultMessage: "Alerted messages"});
+                    return $t({defaultMessage: "Messages containing watched phrases"});
                 case "is-unread":
                     return $t({defaultMessage: "Unread messages"});
             }

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -131,7 +131,7 @@ export let update_views_filtered_on_message_property = (
         "is-starred",
         "is-unread",
         "is-mentioned",
-        "is-alerted",
+        "is-watched",
     ];
 
     if (message_ids.length === 0 || !supported_term_types.includes(property_term_type)) {
@@ -853,8 +853,8 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 "is-mentioned",
                 is_mentioned,
             );
-            const is_alerted = event.flags.includes("has_alert_word");
-            update_views_filtered_on_message_property([event.message_id], "is-alerted", is_alerted);
+            const is_watched = event.flags.includes("has_alert_word");
+            update_views_filtered_on_message_property([event.message_id], "is-watched", is_watched);
         }
     }
 

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -736,7 +736,7 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
             },
             {
                 search_string: "is:alerted",
-                description_html: "alerted messages",
+                description_html: "messages containing watched phrases",
                 is_people: false,
                 incompatible_patterns: [{operator: "is", operand: "alerted"}],
             },

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -735,10 +735,10 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
                 ],
             },
             {
-                search_string: "is:alerted",
+                search_string: "is:watched",
                 description_html: "messages containing watched phrases",
                 is_people: false,
-                incompatible_patterns: [{operator: "is", operand: "alerted"}],
+                incompatible_patterns: [{operator: "is", operand: "watched"}],
             },
             {
                 search_string: "is:unread",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1038,7 +1038,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
             ),
         },
         {
-            label: $t({defaultMessage: "DMs, mentions, and alerts"}),
+            label: $t({defaultMessage: "DMs and mentions"}),
             notification_settings: get_notifications_table_row_data(
                 pm_mention_notification_settings,
                 settings_object,

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -34,7 +34,7 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}@-mentions
             {{~!-- squash whitespace --~}}
-        {{else if (eq this.operand "alerted")}}
+        {{else if (eq this.operand "watched")}}
             {{~!-- squash whitespace --~}}
             {{this.verb}}messages containing watched phrases
             {{~!-- squash whitespace --~}}

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -34,7 +34,11 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}@-mentions
             {{~!-- squash whitespace --~}}
-        {{else if (or (eq this.operand "starred") (eq this.operand "alerted") (eq this.operand "unread"))}}
+        {{else if (eq this.operand "alerted")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}messages containing watched phrases
+            {{~!-- squash whitespace --~}}
+        {{else if (or (eq this.operand "starred") (eq this.operand "unread"))}}
             {{~!-- squash whitespace --~}}
             {{this.verb}}{{this.operand}} messages
             {{~!-- squash whitespace --~}}

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -112,7 +112,7 @@
                     <tr>
                         <td class="operator">is:alerted</td>
                         <td class="definition">
-                            {{t 'Narrow to messages with alert words.'}}
+                            {{t 'Narrow to messages containing watched phrases.'}}
                         </td>
                     </tr>
                     <tr>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -110,7 +110,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">is:alerted</td>
+                        <td class="operator">is:watched</td>
                         <td class="definition">
                             {{t 'Narrow to messages containing watched phrases.'}}
                         </td>

--- a/web/templates/settings/add_alert_word.hbs
+++ b/web/templates/settings/add_alert_word.hbs
@@ -1,4 +1,4 @@
 <form id="add-alert-word-form">
-    <label for="add-alert-word-name" class="modal-field-label">{{t "Alert word" }}</label>
-    <input type="text" name="alert-word-name" id="add-alert-word-name" class="required modal_text_input" maxlength=100 placeholder="{{t 'Alert word' }}" value="" />
+    <label for="add-alert-word-name" class="modal-field-label">{{t "Watched phrase" }}</label>
+    <input type="text" name="alert-word-name" id="add-alert-word-name" class="required modal_text_input" maxlength=100 placeholder="{{t 'Watched phrase' }}" value="" />
 </form>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -1,18 +1,18 @@
 <div id="alert-word-settings" class="settings-section" data-name="alert-words">
     <form id="alert_word_info_box">
         <p class="alert-word-settings-note">
-            {{t "Alert words allow you to be notified as if you were @-mentioned when certain words or phrases are used in Zulip. Alert words are not case sensitive."}}
+            {{t "Watched phrases allow you to be notified as if you were @-mentioned when certain words or phrases are used in Zulip. Watched phrases are not case sensitive."}}
         </p>
     </form>
     {{> ../components/action_button
-      label=(t "Add alert word")
+      label=(t "Add watched phrase")
       attention="quiet"
       intent="brand"
       id="open-add-alert-word-modal"
       }}
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Alert words"}}</h3>
+        <h3>{{t "Watched phrases"}}</h3>
     </div>
     <div class="banner-wrapper" id="alert_word_status"></div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
@@ -24,7 +24,7 @@
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
             <tbody id="alert-words-table" class="alert-words-table"
-              data-empty="{{t 'There are no current alert words.' }}"></tbody>
+              data-empty="{{t 'There are no current watched phrases.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/alert_word_settings_item.hbs
+++ b/web/templates/settings/alert_word_settings_item.hbs
@@ -1,4 +1,4 @@
-{{! Alert word in the settings page that can be removed }}
+{{! Watched phrase in the settings page that can be removed }}
 {{#with alert_word}}
 <tr class="alert-word-item" data-word='{{word}}'>
     <td>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -35,7 +35,7 @@
                     {{/unless}}
                     <li class="sidebar-item" tabindex="0" data-section="alert-words">
                         <i class="sidebar-item-icon fa fa-book" aria-hidden="true"></i>
-                        <div class="text">{{t "Alert words" }}</div>
+                        <div class="text">{{t "Watched phrases" }}</div>
                     </li>
                     {{#if show_uploaded_files_section}}
                     <li class="sidebar-item" tabindex="0" data-section="uploaded-files">

--- a/web/tests/alert_words_ui.test.cjs
+++ b/web/tests/alert_words_ui.test.cjs
@@ -91,7 +91,7 @@ run_test("remove_alert_word", ({override_rewire}) => {
     assert.ok($alert_word_status_banner.hasClass("banner-danger"));
     assert.equal(
         $alert_word_status_banner_label.text(),
-        `translated HTML: Error removing alert word <b>translated: zot</b>!`,
+        `translated HTML: Error removing watched phrase <b>translated: zot</b>!`,
     );
 
     // test success
@@ -99,6 +99,6 @@ run_test("remove_alert_word", ({override_rewire}) => {
     assert.ok($alert_word_status_banner.hasClass("banner-success"));
     assert.equal(
         $alert_word_status_banner_label.text(),
-        `translated HTML: Alert word <b>translated: zot</b> removed successfully!`,
+        `translated HTML: Watched phrase <b>translated: zot</b> removed successfully!`,
     );
 });

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -357,6 +357,12 @@ test("basics", () => {
     assert.ok(!filter.is_channel_view());
     assert.ok(!filter.has_exactly_channel_topic_operators());
 
+    // "is:alerted" was renamed to "is:watched"
+    terms = [{operator: "is", operand: "alerted"}];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operand("is", "watched"));
+    assert.ok(!filter.has_operand("is", "alerted"));
+
     terms = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(terms);
     assert.ok(!filter.contains_only_private_messages());
@@ -664,11 +670,11 @@ function assert_not_mark_read_with_is_operands(additional_terms_to_test) {
     filter = new Filter([...additional_terms_to_test, ...is_operator]);
     assert.ok(!filter.can_mark_messages_read());
 
-    is_operator = [{operator: "is", operand: "alerted"}];
+    is_operator = [{operator: "is", operand: "watched"}];
     filter = new Filter([...additional_terms_to_test, ...is_operator]);
     assert.ok(!filter.can_mark_messages_read());
 
-    is_operator = [{operator: "is", operand: "alerted", negated: true}];
+    is_operator = [{operator: "is", operand: "watched", negated: true}];
     filter = new Filter([...additional_terms_to_test, ...is_operator]);
     assert.ok(!filter.can_mark_messages_read());
 
@@ -1107,7 +1113,7 @@ test("predicate_basics", ({override}) => {
     assert.ok(predicate({unread: true}));
     assert.ok(!predicate({unread: false}));
 
-    predicate = get_predicate([["is", "alerted"]]);
+    predicate = get_predicate([["is", "watched"]]);
     assert.ok(predicate({alerted: true}));
     assert.ok(!predicate({alerted: false}));
     assert.ok(!predicate({}));
@@ -1710,7 +1716,7 @@ test("describe", ({mock_template, override}) => {
     string = "@-mentions";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
-    narrow = [{operator: "is", operand: "alerted"}];
+    narrow = [{operator: "is", operand: "watched"}];
     string = "messages containing watched phrases";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
@@ -1986,7 +1992,7 @@ test("term_type", () => {
 });
 
 test("first_valid_id_from", ({override}) => {
-    const terms = [{operator: "is", operand: "alerted"}];
+    const terms = [{operator: "is", operand: "watched"}];
 
     const filter = new Filter(terms);
 
@@ -2359,7 +2365,7 @@ test("navbar_helpers", ({override}) => {
         {operator: "dm", operand: "joe@example.com,STEVE@foo.com,sally@doesnotexist.com"},
     ];
     // not common narrows, but used for browser title updates
-    const is_alerted = [{operator: "is", operand: "alerted"}];
+    const is_watched = [{operator: "is", operand: "watched"}];
     const is_unread = [{operator: "is", operand: "unread"}];
     const channel_topic_near = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -2581,7 +2587,7 @@ test("navbar_helpers", ({override}) => {
             link: "/help/emoji-reactions",
         },
         {
-            terms: is_alerted,
+            terms: is_watched,
             is_common_narrow: false,
             icon: undefined,
             title: "translated: Messages containing watched phrases",

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1711,7 +1711,7 @@ test("describe", ({mock_template, override}) => {
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "alerted"}];
-    string = "alerted messages";
+    string = "messages containing watched phrases";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "resolved"}];
@@ -2584,7 +2584,7 @@ test("navbar_helpers", ({override}) => {
             terms: is_alerted,
             is_common_narrow: false,
             icon: undefined,
-            title: "translated: Alerted messages",
+            title: "translated: Messages containing watched phrases",
             redirect_url_with_search: "#",
         },
         {

--- a/web/tests/narrow_local.test.cjs
+++ b/web/tests/narrow_local.test.cjs
@@ -259,8 +259,8 @@ test_fixture("is:mentioned with no unreads and no matches", {
     expected_msg_ids: [],
 });
 
-test_fixture("is:alerted with no unreads and one match", {
-    filter_terms: [{operator: "is", operand: "alerted"}],
+test_fixture("is:watched with no unreads and one match", {
+    filter_terms: [{operator: "is", operand: "watched"}],
     unread_info: {
         flavor: "not_found",
     },

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -398,7 +398,7 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
-    assert.equal(describe("is:alerted"), "Alerted messages");
+    assert.equal(describe("is:alerted"), "Messages containing watched phrases");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
@@ -499,7 +499,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
-    assert.equal(describe("is:alerted"), "Alerted messages");
+    assert.equal(describe("is:alerted"), "Messages containing watched phrases");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
@@ -523,7 +523,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:dm"), "Exclude direct messages");
     assert.equal(describe("-is:starred"), "Exclude starred messages");
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
-    assert.equal(describe("-is:alerted"), "Exclude alerted messages");
+    assert.equal(describe("-is:alerted"), "Exclude messages containing watched phrases");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Unresolved topics");
     assert.equal(describe("-is:followed"), "Exclude followed topics");

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -166,7 +166,6 @@ test("dm_suggestions", ({override, mock_template}) => {
     suggestions = get_suggestions(query);
     expected = [
         "is:dm al",
-        "is:dm is:alerted",
         "is:dm dm:alice@zulip.com",
         "is:dm sender:alice@zulip.com",
         "is:dm dm-including:alice@zulip.com",
@@ -240,16 +239,15 @@ test("dm_suggestions", ({override, mock_template}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     // Make sure suggestions still work if preceding tokens
-    query = "is:alerted sender:ted@zulip.com";
+    query = "is:watched sender:ted@zulip.com";
     suggestions = get_suggestions(query);
-    expected = ["is:alerted sender:ted@zulip.com", "is:alerted"];
+    expected = ["is:watched sender:ted@zulip.com", "is:watched"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:starred has:link is:dm al";
     suggestions = get_suggestions(query);
     expected = [
         "is:starred has:link is:dm al",
-        "is:starred has:link is:dm is:alerted",
         "is:starred has:link is:dm dm:alice@zulip.com",
         "is:starred has:link is:dm sender:alice@zulip.com",
         "is:starred has:link is:dm dm-including:alice@zulip.com",
@@ -376,7 +374,7 @@ test("empty_query_suggestions", () => {
         "is:starred",
         "is:mentioned",
         "is:followed",
-        "is:alerted",
+        "is:watched",
         "is:unread",
         "is:muted",
         "is:resolved",
@@ -398,7 +396,7 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
-    assert.equal(describe("is:alerted"), "Messages containing watched phrases");
+    assert.equal(describe("is:watched"), "Messages containing watched phrases");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
@@ -461,9 +459,9 @@ test("has_suggestions", ({override, mock_template}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     // 66 is misc channel id.
-    query = "channel:66 is:alerted has:lin";
+    query = "channel:66 is:watched has:lin";
     suggestions = get_suggestions(query);
-    expected = ["channel:66 is:alerted has:link", "channel:66 is:alerted", "channel:66"];
+    expected = ["channel:66 is:watched has:link", "channel:66 is:watched", "channel:66"];
     assert.deepEqual(suggestions.strings, expected);
 });
 
@@ -481,7 +479,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:starred",
         "is:mentioned",
         "is:followed",
-        "is:alerted",
+        "is:watched",
         "is:unread",
         "is:muted",
         "is:resolved",
@@ -499,7 +497,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:dm"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
-    assert.equal(describe("is:alerted"), "Messages containing watched phrases");
+    assert.equal(describe("is:watched"), "Messages containing watched phrases");
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
@@ -513,7 +511,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "-is:starred",
         "-is:mentioned",
         "-is:followed",
-        "-is:alerted",
+        "-is:watched",
         "-is:unread",
         "-is:muted",
         "-is:resolved",
@@ -523,7 +521,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:dm"), "Exclude direct messages");
     assert.equal(describe("-is:starred"), "Exclude starred messages");
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
-    assert.equal(describe("-is:alerted"), "Exclude messages containing watched phrases");
+    assert.equal(describe("-is:watched"), "Exclude messages containing watched phrases");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Unresolved topics");
     assert.equal(describe("-is:followed"), "Exclude followed topics");
@@ -538,7 +536,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:starred",
         "is:mentioned",
         "is:followed",
-        "is:alerted",
+        "is:watched",
         "is:unread",
         "is:muted",
         "is:resolved",
@@ -716,13 +714,13 @@ test("topic_suggestions", ({override, mock_template}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions(`is:alerted channel:${devel_id} is:starred topic:`);
+    suggestions = get_suggestions(`is:watched channel:${devel_id} is:starred topic:`);
     expected = [
-        `is:alerted channel:${devel_id} is:starred topic:`,
-        `is:alerted channel:${devel_id} is:starred topic:REXX`,
-        `is:alerted channel:${devel_id} is:starred`,
-        `is:alerted channel:${devel_id}`,
-        "is:alerted",
+        `is:watched channel:${devel_id} is:starred topic:`,
+        `is:watched channel:${devel_id} is:starred topic:REXX`,
+        `is:watched channel:${devel_id} is:starred`,
+        `is:watched channel:${devel_id}`,
+        "is:watched",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -1017,13 +1015,13 @@ test("operator_suggestions", ({override, mock_template}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     // 66 is a misc channel id.
-    query = "channel:66 is:alerted -f";
+    query = "channel:66 is:watched -f";
     suggestions = get_suggestions(query);
     expected = [
-        "channel:66 is:alerted -f",
-        "channel:66 is:alerted -sender:myself@zulip.com",
-        "channel:66 is:alerted -sender:",
-        "channel:66 is:alerted",
+        "channel:66 is:watched -f",
+        "channel:66 is:watched -sender:myself@zulip.com",
+        "channel:66 is:watched -sender:",
+        "channel:66 is:watched",
         "channel:66",
     ];
     assert.deepEqual(suggestions.strings, expected);

--- a/web/tests/settings_config.test.cjs
+++ b/web/tests/settings_config.test.cjs
@@ -83,7 +83,7 @@ run_test("all_notifications", ({override}) => {
             ],
         },
         {
-            label: "translated: DMs, mentions, and alerts",
+            label: "translated: DMs and mentions",
             notification_settings: [
                 {
                     is_checked: false,

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -29,7 +29,7 @@ link_mapping = {
     "preferences": ["Personal settings", "Preferences", "/#settings/preferences"],
     "notifications": ["Personal settings", "Notifications", "/#settings/notifications"],
     "your-bots": ["Personal settings", "Bots", "/#settings/your-bots"],
-    "alert-words": ["Personal settings", "Alert words", "/#settings/alert-words"],
+    "watched-phrases": ["Personal settings", "Watched phrases", "/#settings/alert-words"],
     "uploaded-files": ["Personal settings", "Uploaded files", "/#settings/uploaded-files"],
     "topics": ["Personal settings", "Topics", "/#settings/topics"],
     "muted-users": ["Personal settings", "Muted users", "/#settings/muted-users"],

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -427,7 +427,8 @@ class NarrowBuilder:
             )
             cond = column("flags", Integer).op("&")(mention_flags_mask) != 0
             return query.where(maybe_negate(cond))
-        elif operand == "alerted":
+        elif operand in ["alerted", "watched"]:
+            # "is:alerted" is a legacy alias for "is:watched"
             cond = column("flags", Integer).op("&")(UserMessage.flags.has_alert_word.mask) != 0
             return query.where(maybe_negate(cond))
         elif operand == "followed":

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -63,7 +63,8 @@ def build_narrow_predicate(
             elif operator == "is" and operand == "unread":
                 if "read" in flags:
                     return False
-            elif operator == "is" and operand in ["alerted", "mentioned"]:
+            elif operator == "is" and operand in ["alerted", "mentioned", "watched"]:
+                # "is:alerted" is a legacy alias for "is:watched"
                 if "mentioned" not in flags:
                     return False
             elif operator == "is" and operand == "resolved":

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1799,7 +1799,7 @@ def delete_custom_emoji(client: Client) -> None:
 @openapi_test_function("/users/me/alert_words:get")
 def get_alert_words(client: Client) -> None:
     # {code_example|start}
-    # Get all of the user's configured alert words.
+    # Get all of the user's configured watched phrases.
     result = client.get_alert_words()
     # {code_example|end}
     assert_success_response(result)
@@ -1810,7 +1810,7 @@ def get_alert_words(client: Client) -> None:
 def add_alert_words(client: Client) -> None:
     words = ["foo", "bar"]
     # {code_example|start}
-    # Add words (or phrases) to the user's set of configured alert words.
+    # Add phrases to the user's set of configured watched phrases.
     result = client.add_alert_words(words)
     # {code_example|end}
     assert_success_response(result)
@@ -1822,7 +1822,7 @@ def remove_alert_words(client: Client) -> None:
     words = client.get_alert_words()["alert_words"]
     assert len(words) > 0
     # {code_example|start}
-    # Remove words (or phrases) from the user's set of configured alert words.
+    # Remove phrases from the user's set of configured watched phrases.
     result = client.remove_alert_words(words)
     # {code_example|end}
     assert_success_response(result)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -225,7 +225,7 @@ paths:
                             - type: object
                               description: |
                                 Event sent to a user's clients when that user's set of configured
-                                [alert words](/help/dm-mention-alert-notifications#alert-words) have changed.
+                                [watched phrases](/help/dm-mention-alert-notifications#watched-phrases) have changed.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -237,7 +237,7 @@ paths:
                                 alert_words:
                                   type: array
                                   description: |
-                                    An array of strings, where each string is an alert word (or phrase)
+                                    An array of strings, where each string is a watched phrase
                                     configured by the user.
                                   items:
                                     type: string
@@ -2499,7 +2499,7 @@ paths:
                                     message with ID `message_id` following the edit.
 
                                     A client application should compare these to the original flags
-                                    to identify cases where a mention or alert word was added by the
+                                    to identify cases where a mention or watched phrase was added by the
                                     edit.
 
                                     **Changes**: In Zulip 8.0 (feature level 224), the `wildcard_mentioned`
@@ -8416,10 +8416,10 @@ paths:
                         <td><code>has_alert_word</code></td>
                         <td>
                             Whether the message contains any of the current user's
-                            <a href="/help/dm-mention-alert-notifications#alert-words">configured alert words</a>.
+                            <a href="/help/dm-mention-alert-notifications#watched-phrases">configured watched phrases</a>.
                             Cannot be changed by the user directly, but
                             can change if the message is edited to add/remove
-                            one of the current user's alert words.
+                            one of the current user's watched phrases.
                         </td>
                     </tr>
                     <tr>
@@ -10574,12 +10574,12 @@ paths:
   /users/me/alert_words:
     get:
       operationId: get-alert-words
-      summary: Get all alert words
+      summary: Get all watched phrases
       tags: ["users"]
       description: |
-        Get all of the user's configured [alert words][alert-words].
+        Get all of the user's configured [watched phrases][watched-phrases].
 
-        [alert-words]: /help/dm-mention-alert-notifications#alert-words
+        [watched-phrases]: /help/dm-mention-alert-notifications#watched-phrases
       responses:
         "200":
           description: Success.
@@ -10596,7 +10596,7 @@ paths:
                       alert_words:
                         type: array
                         description: |
-                          An array of strings, where each string is an alert word (or phrase)
+                          An array of strings, where each string is a watched phrase
                           configured by the user.
                         items:
                           type: string
@@ -10608,12 +10608,12 @@ paths:
                       }
     post:
       operationId: add-alert-words
-      summary: Add alert words
+      summary: Add watched phrases
       tags: ["users"]
       description: |
-        Add words (or phrases) to the user's set of configured [alert words][alert-words].
+        Add phrases to the user's set of configured [watched phrases][watched-phrases].
 
-        [alert-words]: /help/dm-mention-alert-notifications#alert-words
+        [watched-phrases]: /help/dm-mention-alert-notifications#watched-phrases
       requestBody:
         required: true
         content:
@@ -10624,10 +10624,10 @@ paths:
                 alert_words:
                   description: |
                     An array of strings to be added to the user's set of configured
-                    alert words. Strings already present in the user's set of alert words
+                    watched phrases. Strings already present in the user's set of watched phrases
                     already are ignored.
 
-                    Alert words are case insensitive.
+                    Watched phrases are case insensitive.
                   type: array
                   items:
                     type: string
@@ -10653,7 +10653,7 @@ paths:
                       alert_words:
                         type: array
                         description: |
-                          An array of strings, where each string is an alert word (or phrase)
+                          An array of strings, where each string is a watched phrase
                           configured by the user.
                         items:
                           type: string
@@ -10677,18 +10677,18 @@ paths:
                         "result": "error",
                       }
                     description: |
-                      An example JSON response for when a supplied alert word (or phrase)
+                      An example JSON response for when a supplied watched phrase
                       exceeds the character limit:
     delete:
       operationId: remove-alert-words
-      summary: Remove alert words
+      summary: Remove watched phrases
       tags: ["users"]
       description: |
-        Remove words (or phrases) from the user's set of configured [alert words][alert-words].
+        Remove phrases from the user's set of configured [watched phrases][watched-phrases].
 
-        Alert words are case insensitive.
+        Watched phrases are case insensitive.
 
-        [alert-words]: /help/dm-mention-alert-notifications#alert-words
+        [watched-phrases]: /help/dm-mention-alert-notifications#watched-phrases
       requestBody:
         required: true
         content:
@@ -10699,7 +10699,7 @@ paths:
                 alert_words:
                   description: |
                     An array of strings to be removed from the user's set of configured
-                    alert words. Strings that are not in the user's set of alert words
+                    watched phrases. Strings that are not in the user's set of watched phrases
                     are ignored.
                   type: array
                   items:
@@ -10726,7 +10726,7 @@ paths:
                       alert_words:
                         type: array
                         description: |
-                          An array of strings, where each string is an alert word (or phrase)
+                          An array of strings, where each string is a watched phrase
                           configured by the user.
                         items:
                           type: string
@@ -15503,7 +15503,7 @@ paths:
                         description: |
                           Present if `alert_words` is present in `fetch_event_types`.
 
-                          An array of strings, each an [alert word](/help/dm-mention-alert-notifications#alert-words)
+                          An array of strings, each a [watched phrase](/help/dm-mention-alert-notifications#watched-phrases)
                           that the current user has configured.
                         items:
                           type: string

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -229,7 +229,7 @@ class NarrowBuilderTest(ZulipTestCase):
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) = %(param_1)s")
 
     def test_add_term_using_is_operator_and_non_dm_operand(self) -> None:
-        for operand in ["starred", "mentioned", "alerted"]:
+        for operand in ["starred", "mentioned", "alerted", "watched"]:
             term = NarrowParameter(operator="is", operand=operand)
             self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
 
@@ -251,6 +251,14 @@ class NarrowBuilderTest(ZulipTestCase):
         self._do_add_term_test(term, where_clause, params)
 
         term = NarrowParameter(operator="is", operand="alerted", negated=True)
+        where_clause = "WHERE (flags & %(flags_1)s) = %(param_1)s"
+        params = dict(
+            flags_1=UserMessage.flags.has_alert_word.mask,
+            param_1=0,
+        )
+        self._do_add_term_test(term, where_clause, params)
+
+        term = NarrowParameter(operator="is", operand="watched", negated=True)
         where_clause = "WHERE (flags & %(flags_1)s) = %(param_1)s"
         params = dict(
             flags_1=UserMessage.flags.has_alert_word.mask,
@@ -955,10 +963,37 @@ class NarrowLibraryTest(ZulipTestCase):
             )
         )
 
+        self.assertFalse(
+            narrow_predicate(
+                message={},
+                flags=["watched"],
+            )
+        )
+
         ###
 
         narrow_predicate = build_narrow_predicate(
             [NeverNegatedNarrowTerm(operator="is", operand="alerted")]
+        )
+
+        self.assertTrue(
+            narrow_predicate(
+                message={},
+                flags=["mentioned"],
+            )
+        )
+
+        self.assertFalse(
+            narrow_predicate(
+                message={},
+                flags=["starred"],
+            )
+        )
+
+        ###
+
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="watched")]
         )
 
         self.assertTrue(
@@ -1229,6 +1264,7 @@ class IncludeHistoryTest(ZulipTestCase):
         narrow = [
             NarrowParameter(operator="channels", operand="public"),
             NarrowParameter(operator="is", operand="alerted"),
+            NarrowParameter(operator="is", operand="watched"),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
         narrow = [


### PR DESCRIPTION
This PR migrates user-facing strings and relevant code references from "Alert Words" to "Watched Phrases".
Currently, it does not include documentation changes and the handling of the `is:alerted` filter.

---

**Issue Link**  
Fixes part of #28779.

---
**Visual Changes**

| Description        | Image                                               |
|--------------------|-----------------------------------------------------|
| Watched phrases    | ![Watched phrases](https://github.com/user-attachments/assets/13b3f79a-afc3-4a94-bd72-df184a0bb86d) |
| `is:watched`         | ![is:watched](https://github.com/user-attachments/assets/0a0e7fea-5770-44d0-96db-9ada6f36606f) |

---

<details>
<summary>Self-review Checklist</summary>
<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>


---