### PR TITLE
messages_send: Make service bots have UserMessage rows.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -443,10 +443,7 @@ def get_recipient_info(
         lambda r: not r["enable_offline_push_notifications"]
     )
 
-    # Service bots don't get UserMessage rows.
-    um_eligible_user_ids = get_ids_for(
-        lambda r: not r["is_bot"] or r["bot_type"] not in UserProfile.SERVICE_BOT_TYPES,
-    )
+    um_eligible_user_ids = get_ids_for(lambda r: True)
 
     long_term_idle_user_ids = get_ids_for(
         lambda r: r["long_term_idle"],

--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.utils.translation import gettext as _
 from zulip_bots.lib import BotIdentity, RateLimit
 
+from zerver.actions.message_flags import do_update_message_flags
 from zerver.actions.message_send import (
     internal_send_group_direct_message,
     internal_send_private_message,
@@ -153,3 +154,10 @@ class EmbeddedBotHandler:
 
     def quit(self, message: str = "") -> None:
         raise EmbeddedBotQuitError(message)
+
+
+def do_flag_service_bots_messages_as_processed(
+    bot_profile: UserProfile, message_ids: list[int]
+) -> None:
+    assert bot_profile.is_bot is True and bot_profile.bot_type in UserProfile.SERVICE_BOT_TYPES
+    do_update_message_flags(bot_profile, "add", "read", message_ids)

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1814,6 +1814,12 @@ class MessageAccessTests(ZulipTestCase):
         )
         self.assert_length(filtered_messages, 4)
 
+        # Test private message access for service bot
+        service_bot = self.example_user("outgoing_webhook_bot")
+        self.subscribe(service_bot, stream_name)
+        filtered_messages = self.assert_bulk_access(service_bot, more_message_ids, stream, 6, 2)
+        self.assert_length(filtered_messages, 4)
+
         # Verify an exception is thrown if called where the passed
         # stream not matching the messages.
         other_stream = get_stream("Denmark", unsubscribed_user.realm)
@@ -1853,6 +1859,12 @@ class MessageAccessTests(ZulipTestCase):
 
         unsubscribed_user = self.example_user("ZOE")
         filtered_messages = self.assert_bulk_access(unsubscribed_user, message_ids, stream, 4, 1)
+        self.assert_length(filtered_messages, 2)
+
+        # Test public message access for service bot
+        service_bot = self.example_user("outgoing_webhook_bot")
+        self.subscribe(service_bot, stream_name)
+        filtered_messages = self.assert_bulk_access(service_bot, message_ids, stream, 4, 1)
         self.assert_length(filtered_messages, 2)
 
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1382,13 +1382,6 @@ class StreamMessagesTest(ZulipTestCase):
         realm = get_realm("zulip")
         subscribers = self.users_subscribed_to_stream(stream_name, realm)
 
-        # Outgoing webhook bots don't store UserMessage rows; they will be processed later.
-        subscribers = [
-            subscriber
-            for subscriber in subscribers
-            if subscriber.bot_type != UserProfile.OUTGOING_WEBHOOK_BOT
-        ]
-
         old_subscriber_messages = list(map(message_stream_count, subscribers))
 
         non_subscribers = [

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -608,13 +608,12 @@ class TestServiceBotEventTriggers(ZulipTestCase):
         self.assertFalse(mock_queue_event_on_commit.called)
 
     @responses.activate
-    def test_flag_messages_outgoing_webhook_bot_has_processed(self) -> None:
+    @for_all_bot_types
+    def test_flag_messages_service_bots_has_processed(self) -> None:
         """
-        Verifies that once an event has been processed by the outgoing webhook
-        bot's queue processor, the message is marked as processed (flagged with `read`).
+        Verifies that once an event has been processed by the service bot's
+        queue processor, the message is marked as processed (flagged with `read`).
         """
-        self.bot_profile.bot_type = UserProfile.OUTGOING_WEBHOOK_BOT
-        self.bot_profile.save()
         sender = self.user_profile
         recipients = [self.user_profile, self.bot_profile, self.second_bot_profile]
         responses.add(

--- a/zerver/worker/embedded_bots.py
+++ b/zerver/worker/embedded_bots.py
@@ -6,7 +6,12 @@ from typing import Any
 from typing_extensions import override
 from zulip_bots.lib import extract_query_without_mention
 
-from zerver.lib.bot_lib import EmbeddedBotHandler, EmbeddedBotQuitError, get_bot_handler
+from zerver.lib.bot_lib import (
+    EmbeddedBotHandler,
+    EmbeddedBotQuitError,
+    do_flag_service_bots_messages_as_processed,
+    get_bot_handler,
+)
 from zerver.models import UserProfile
 from zerver.models.bots import get_bot_services
 from zerver.models.users import get_user_profile_by_id
@@ -53,3 +58,4 @@ class EmbeddedBotWorker(QueueProcessingWorker):
                 )
             except EmbeddedBotQuitError as e:
                 logging.warning("%s", e)
+        do_flag_service_bots_messages_as_processed(user_profile, [message["id"]])

--- a/zerver/worker/outgoing_webhooks.py
+++ b/zerver/worker/outgoing_webhooks.py
@@ -4,8 +4,10 @@ from typing import Any
 
 from typing_extensions import override
 
+from zerver.lib.bot_lib import do_flag_service_bots_messages_as_processed
 from zerver.lib.outgoing_webhook import do_rest_call, get_outgoing_webhook_service_handler
 from zerver.models.bots import get_bot_services
+from zerver.models.users import get_user_profile_by_id
 from zerver.worker.base import QueueProcessingWorker, assign_queue
 
 logger = logging.getLogger(__name__)
@@ -17,9 +19,12 @@ class OutgoingWebhookWorker(QueueProcessingWorker):
     def consume(self, event: dict[str, Any]) -> None:
         message = event["message"]
         event["command"] = message["content"]
+        bot_profile = get_user_profile_by_id(event["user_profile_id"])
 
         services = get_bot_services(event["user_profile_id"])
         for service in services:
             event["service_name"] = str(service.name)
             service_handler = get_outgoing_webhook_service_handler(service)
             do_rest_call(service.base_url, event, service_handler)
+
+        do_flag_service_bots_messages_as_processed(bot_profile, [message["id"]])


### PR DESCRIPTION
Previously service bots don't get UserMessage rows for new messages for optimization reasons. This commit adds `UserMessage` row for service bots to enforce the assertion that service bots behave similarly to generic bots.

Additionally, this commit also adds the ability to track whether or not service bots have processed an event (mention / direct message) message by flagging that message as read by the sending bot.

Fixes: #28869

[CZO discussion](https://chat.zulip.org/#narrow/channel/3-backend/topic/.2328869.20UserMessage.20for.20Outgoing.20webhook.20bot.20.26.20embedded.20bots)

**Screenshots and screen captures:**
- outgoing bot reacting to message in a group chat:
  ![image](https://github.com/user-attachments/assets/92f21294-b833-49fb-b631-5e757f6d9913)
  
  _before_
  ```bash
  curl -sSX POST http://localhost:9991/api/v1/messages/101/reactions 
  -u fds-bot@zulipdev.com:NPViAuxAKYircH0KQyOeywFdy9ak5WZW
  --data-urlencode emoji_name=octopus
  
  {"result":"error","msg":"Invalid message(s)","code":"BAD_REQUEST"}
  ``` 
  _after_
  ```bash
  curl -sSX POST http://localhost:9991/api/v1/messages/102/reactions 
  -u fds-bot@zulipdev.com:NPViAuxAKYircH0KQyOeywFdy9ak5WZW
  --data-urlencode emoji_name=octopus
  
  {"result":"success","msg":""}
  ``` 
- message read by outgoing webhook bot after mentioning them:
  ![image](https://github.com/user-attachments/assets/03cf7b97-6d1e-4ce3-9a86-e0cda91f90fc)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
