### PR TITLE
notifications: Move new organization notifications to BillingSession framework.

### DIFF
--- a/corporate/lib/support.py
+++ b/corporate/lib/support.py
@@ -1,11 +1,8 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Optional, TypedDict, Union
-from urllib.parse import urlencode, urljoin, urlunsplit
 
-from django.conf import settings
 from django.db.models import Sum
-from django.urls import reverse
 from django.utils.timezone import now as timezone_now
 
 from corporate.lib.stripe import (
@@ -30,7 +27,7 @@ from corporate.models import (
 )
 from zerver.models import Realm
 from zerver.models.realm_audit_logs import AuditLogEventType
-from zerver.models.realms import get_org_type_display_name, get_realm
+from zerver.models.realms import get_org_type_display_name
 from zilencer.lib.remote_counts import MissingDataError
 from zilencer.models import (
     RemoteCustomerUserCount,
@@ -128,15 +125,6 @@ class CloudSupportData:
 
 def get_stripe_customer_url(stripe_id: str) -> str:
     return f"https://dashboard.stripe.com/customers/{stripe_id}"  # nocoverage
-
-
-def get_realm_support_url(realm: Realm) -> str:
-    support_realm_url = get_realm(settings.STAFF_SUBDOMAIN).url
-    support_url = urljoin(
-        support_realm_url,
-        urlunsplit(("", "", reverse("support"), urlencode({"q": realm.string_id}), "")),
-    )
-    return support_url
 
 
 def get_realm_user_data(realm: Realm) -> UserData:

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -98,7 +98,7 @@ class DemoRequestForm(forms.Form):
 @zulip_login_required
 @typed_endpoint_without_parameters
 def support_request(request: HttpRequest) -> HttpResponse:
-    from corporate.lib.support import get_realm_support_url
+    from corporate.lib.stripe import build_support_url
 
     user = request.user
     assert user.is_authenticated
@@ -119,7 +119,7 @@ def support_request(request: HttpRequest) -> HttpResponse:
                 "realm_string_id": user.realm.string_id,
                 "request_subject": form.cleaned_data["request_subject"],
                 "request_message": form.cleaned_data["request_message"],
-                "support_url": get_realm_support_url(user.realm),
+                "support_url": build_support_url("support", user.realm.string_id),
                 "user_role": user.get_role_name(),
             }
             # Sent to the server's support team, so this email is not user-facing.

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -835,11 +835,6 @@ def get_stream_by_narrow_operand_access_unchecked(operand: str | int, realm: Rea
     return get_stream_by_id_in_realm(operand, realm)
 
 
-def get_signups_stream(realm: Realm) -> Stream:
-    # This one-liner helps us work around a lint rule.
-    return get_stream("signups", realm)
-
-
 def ensure_stream(
     realm: Realm,
     stream_name: str,


### PR DESCRIPTION
When new realms are created on Zulip Cloud, a notification message is sent to the admin realm. This moves the logic for generating and sending that message to the BillingSession framework in `corporate.lib.stripe.py`.

This is a preparatory change to adding more notification messages for other realm and remote server/realm changes.

**Notes**:
- Adds a channel name parameter for sending these messages since future messages may be sent to channels other than the one used for new organization signups.
- Adds a fallback of sending a direct message to admins in the admin realm when a channel with the specified name does not exist.
- Removes the `get_signups_stream` helper function as a result of the above changes.
- Removes the `get_realm_support_url` in `corporate.lib.support.py` in favor of using the more generic helper `build_support_url` for generating these URLs in `corporate.lib.stripe.py`.

---

**Screenshots and screen captures:**

<details>
<summary>New organization notification in signups channel</summary>

*No changes from the current notification messages.*
![Screenshot from 2024-11-05 17-00-08](https://github.com/user-attachments/assets/644887d2-53f5-4135-8112-930af73eaf09)
</details>
<details>
<summary>New organization notification in DM - new</summary>

*Previously, if the channel didn't exist no message was sent.*
![Screenshot from 2024-11-05 16-59-21](https://github.com/user-attachments/assets/f02e0232-b64e-4b63-b0dc-ddf80014c772)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
