### PR TITLE
filter: Mark messages as read for `-is:dm` search views.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1151,6 +1151,22 @@ export class Filter {
             return true;
         }
 
+        if (_.isEqual(term_types, ["not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["channel", "not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["topic", "not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["channel", "topic", "not-is-dm"])) {
+            return true;
+        }
+
         if (_.isEqual(term_types, [])) {
             // Empty filters means we are displaying all possible messages.
             return true;

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -70,6 +70,18 @@ function get_message_view_header_context(filter: Filter | undefined): MessageVie
     //
     // TODO: This ideally doesn't need a special case, we can just use
     // `filter.get_description` for it.
+
+    if (filter?.has_negated_operand("is", "dm")) {
+        return {
+            title: $t({defaultMessage: "Messages excluding DMs"}),
+            description: $t({
+                defaultMessage: "All messages except direct messages.",
+            }),
+            zulip_icon: "all-messages",
+            link: "/help/combined-feed",
+        };
+    }
+
     if (filter === undefined || filter.is_in_home()) {
         let description;
         if (page_params.is_spectator) {

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -378,6 +378,61 @@ test("basics", () => {
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
 
+    terms = [{operator: "is", operand: "dm", negated: true}];
+    filter = new Filter(terms);
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+
+    terms = [
+        {operator: "channel", operand: "channel_name"},
+        {operator: "is", operand: "dm", negated: true},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("channel"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_negated_operand("channel", "not-is-dm"));
+
+    terms = [
+        {operator: "topic", operand: "topic_name"},
+        {operator: "is", operand: "dm", negated: true},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("topic"));
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_negated_operand("topic", "topic_name"));
+
+    terms = [
+        {operator: "channel", operand: "channel_name"},
+        {operator: "topic", operand: "topic_name"},
+        {operator: "is", operand: "dm", negated: true},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("channel"));
+    assert.ok(filter.has_operator("topic"));
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_negated_operand("channel", "channel_name"));
+    assert.ok(!filter.has_negated_operand("topic", "topic_name"));
+    assert.ok(filter.can_bucket_by("channel"));
+    assert.ok(filter.can_bucket_by("channel", "topic"));
+
     // "pm-with" was renamed to "dm"
     terms = [{operator: "pm-with", operand: "joe@example.com"}];
     filter = new Filter(terms);


### PR DESCRIPTION
This PR updates the behavior of the `-is:dm` search filter, both alone and when combined with channel or topic filters, to mark messages as read, aligning it with the existing behavior of `is:dm`.


Fixes: #25113.

**Screenshots and screen captures:**
_No UI changes._ 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
