### PR TITLE
left_sidebar: Unread, nav area alignment fixes.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1058,14 +1058,6 @@ li.top_left_scheduled_messages {
     }
 }
 
-.condensed-views-popover-menu {
-    .unread_count {
-        margin: 1px 0 0 6px;
-        border-color: var(--color-border-unread-counter-popover-menu);
-        width: max-content;
-    }
-}
-
 .subscription_block {
     grid-template-columns:
         var(--left-sidebar-toggle-width-offset) var(

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -791,6 +791,30 @@ li.top_left_scheduled_messages {
     }
 }
 
+/* Low-attention unreads have no bounding box,
+   so their counters should be aligned on the
+   same baseline as the navigation label. */
+.top_left_starred_messages,
+.top_left_drafts,
+.top_left_scheduled_messages {
+    .left-sidebar-navigation-label-container {
+        align-items: baseline;
+    }
+
+    .left-sidebar-navigation-label {
+        @media screen and (resolution <= 1x) {
+            /* Owing to the baseline alignment in this
+               area, we don't need the low-res line-height
+               adjustment. */
+            line-height: inherit;
+        }
+    }
+
+    .filter-icon {
+        align-self: center;
+    }
+}
+
 .top_left_starred_messages {
     &.hide_starred_message_count {
         .masked_unread_count {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -691,10 +691,6 @@ li.active-sub-filter {
 
     .left-sidebar-navigation-label-container {
         .left-sidebar-navigation-label {
-            /* Again, for the sake of low-resolution screens,
-               we'll let the actual label take 1 as a line-height
-               value, and allow grid to handle the alignment. */
-            line-height: 1;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
@@ -775,6 +771,13 @@ li.top_left_scheduled_messages {
     .left-sidebar-navigation-label {
         grid-area: row-content;
         padding-right: var(--left-sidebar-before-unread-count-padding);
+
+        @media screen and (resolution <= 1x) {
+            /* For the sake of low-resolution screens,
+               we'll let the actual label take 1 as a line-height
+               value, and allow grid to handle the alignment. */
+            line-height: 1;
+        }
     }
 
     .unread_count {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1476,3 +1476,35 @@ ul.popover-menu-list {
         border: 1px solid var(--color-border-popover-hotkey-hint);
     }
 }
+
+.condensed-views-popover-menu {
+    .popover-menu-link:has(.label-and-unread-wrapper) {
+        align-items: center;
+
+        .popover-menu-icon {
+            margin-top: 1px;
+        }
+
+        .label-and-unread-wrapper {
+            /* Occupy the maximum width of the
+               parent flex container. */
+            flex: 1 0 max-content;
+            display: flex;
+            gap: 5px;
+            align-items: baseline;
+        }
+
+        .popover-menu-label {
+            margin-top: 0;
+        }
+
+        .unread_count {
+            margin: 0 0 0 6px;
+            border-color: var(--color-border-unread-counter-popover-menu);
+            width: max-content;
+            height: auto;
+            line-height: 1.2445em;
+            align-self: baseline;
+        }
+    }
+}

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1186,12 +1186,16 @@ ul.popover-group-menu-member-list {
         flex-flow: row nowrap;
         align-items: flex-start;
         gap: 5px;
+        /* 3px at 15px/1em, 10px at 15px/1em */
         padding: 0.2em 0.6666em;
         /* 15px at 15px/1em */
         font-size: 1em;
         /* 16px at 15px/1em */
         line-height: 1.0667em;
-        min-height: 26px;
+        /* 26px at 16px/1em - this height was carried forward
+           despite the information density change in 15px > 16px,
+           so we calculate its height to the 16px em in use. */
+        min-height: 1.625em;
 
         .popover-menu-icon {
             /* 16px at 15px/1em */

--- a/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
@@ -9,16 +9,20 @@
         <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-drafts">
             <a href="#drafts" role="menuitem" class="popover-menu-link tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t 'Drafts' }}</span>
-                <span class="unread_count"></span>
+                <span class="label-and-unread-wrapper">
+                    <span class="popover-menu-label">{{t 'Drafts' }}</span>
+                    <span class="unread_count"></span>
+                </span>
             </a>
         </li>
         {{#if has_scheduled_messages }}
         <li role="none" class="link-item popover-menu-list-item condensed-views-popover-menu-scheduled-messages">
             <a href="#scheduled" role="menuitem" class="popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-calendar-days" aria-hidden="true"></i>
-                <span class="popover-menu-label">{{t 'Scheduled messages' }}</span>
-                <span class="unread_count"></span>
+                <span class="label-and-unread-wrapper">
+                    <span class="popover-menu-label">{{t 'Scheduled messages' }}</span>
+                    <span class="unread_count"></span>
+                </span>
             </a>
         </li>
         {{/if}}


### PR DESCRIPTION
This PR introduces a few improvements to alignment in the left sidebar and its condensed nav popover:

1. The `line-height: 1` fix is better scoped to low-resolution screens. Careful eyes will note that the 'g' in 'Starred messages' had the very bottom of its descender cut off. That line-height adjustment is also eliminated on rows with quiet unreads, as their baseline alignment introduced here makes an adjustment unnecessary.
2. Quiet unreads are now aligned on the same baseline as their labels.
3. Quiet unread alignment has been corrected similarly in the condensed nav popover, leading to better alignment on the Drafts and Scheduled messages popover items overall.
4. There are a few improvements to the popovers CSS for info density.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/remaining.20sidebar.20grays.20.28unreads.2C.20DM.20partner.20icons.29/near/1975266)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Low-res sidebar, before | Low-res sidebar, after |
| --- | --- |
| ![low-res-before](https://github.com/user-attachments/assets/bd0a4ba5-13f6-47aa-8e10-485258add4db) | ![low-res-after](https://github.com/user-attachments/assets/a28b2ee7-dbfd-4b5b-b791-9238cd755e42) |

| Sidebar nav, before | Sidebar nav, after |
| --- | --- |
| ![expanded-nav-before](https://github.com/user-attachments/assets/a3e9dc67-3d85-42c6-83fe-5fb74123f298) | ![expanded-nav-after](https://github.com/user-attachments/assets/6e83c54d-1a1f-4b3b-b551-fc38785e8740) |


| Collapsed nav popover, before | Collapsed nav popover, after |
| --- | --- |
| ![collapsed-nav-popver-before](https://github.com/user-attachments/assets/e7824924-681a-4a70-beed-414b6d8fb7c6) | ![collapsed-nav-popover-after](https://github.com/user-attachments/assets/d8c7eac5-007e-4a12-a3df-008d04342100) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>