### PR TITLE
popover: Fix misleading time description in right side-bar.

### DIFF
--- a/web/tests/presence.test.cjs
+++ b/web/tests/presence.test.cjs
@@ -321,7 +321,7 @@ test("update_info_from_event", () => {
 
     assert.deepEqual(presence.presence_info.get(alice.user_id), {
         status: "active",
-        last_active: 510,
+        last_active: 500,
     });
 
     info = {


### PR DESCRIPTION
When going offline, the "time since active" is based on when you were last active or idle. This means that if you have been idle for hours, and then go offline, the popover in the right sidebar will state that you were "Active x minutes ago". This is misleading since much more time actually has passed since you last were active. Changing the code to always return the `active_timestamp` when offline fixes this issue. Now the popover will display the amount of time that has passed since the user was actually last active. 

I have manually measured the time between being active and going offline to confirm that the solution is working. 

Linked discussion in CZO thread: [CZO thread](https://chat.zulip.org/#narrow/channel/101-design/topic/.2332271.20Misleading.20time.20description.20in.20right.20side-bar)

Displaying the difference before and after the change with screenshots is difficult as there will be no visual difference. 

Before fix:

![Unknown-4](https://github.com/user-attachments/assets/20c194ea-e418-44f3-8561-9e1abbc6b2ed)

After fix:

![active](https://github.com/user-attachments/assets/373e34ee-dcfd-4144-bf2d-cd913787e22a)
![idle](https://github.com/user-attachments/assets/7424de78-c5ee-4b6d-b326-af07f6a9efb8)
![offline](https://github.com/user-attachments/assets/99803bc2-a8eb-480a-afbd-6836087b5113)



<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
