### PR TITLE
import_realm: Fix near-links when importing messages.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -642,6 +642,8 @@ export class Filter {
     }
 
     static sorted_term_types(term_types: string[]): string[] {
+        // Keep this algorithm in sync with the the static method of the same name in
+        // `url_decoding.Filter` in the server.
         const levels = [
             "in",
             "channels-public",

--- a/zerver/lib/narrow_helpers.py
+++ b/zerver/lib/narrow_helpers.py
@@ -21,14 +21,17 @@ from users:
 import os
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
+from typing import TypeAlias
 
 from django.conf import settings
+
+NarrowTermOperandT: TypeAlias = str | int | list[int]
 
 
 @dataclass
 class NarrowTerm:
     operator: str
-    operand: str | int | list[int]
+    operand: NarrowTermOperandT
     negated: bool
 
 

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -1,9 +1,15 @@
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any
 from urllib.parse import unquote, urlsplit
 
 from django.conf import settings
 
+from zerver.lib.narrow import BadNarrowOperatorError
 from zerver.lib.narrow_helpers import NarrowTerm
 from zerver.lib.topic import DB_TOPIC_NAME
+from zerver.models.messages import Message
+from zerver.models.realms import Realm
 
 
 def is_same_server_message_link(url: str) -> bool:
@@ -141,3 +147,120 @@ def parse_narrow_url(
 
         terms.append(NarrowTerm(operator, operand, negated))
     return terms
+
+
+class Filter:
+    def __init__(self, terms: Sequence[NarrowTerm], realm: Realm) -> None:
+        self._terms: list[NarrowTerm] = list(terms)
+        self._realm: Realm = realm
+        self._setup_filter(terms)
+
+    @staticmethod
+    def reformat_channel_operand(operand: str | int) -> str | int:
+        match operand:
+            case int():
+                return operand
+            case str():
+                if operand.strip() == "":
+                    raise BadNarrowOperatorError("Invalid 'channel' operand")
+                if operand.isdigit():
+                    return int(operand)
+                if result := parse_recipient_slug(operand.lower()):
+                    assert isinstance(result[0], int)
+                    return result[0]
+                # if it's not a channel ID nor encoded channel slug, it's
+                # probably a channel name.
+                return operand
+
+    @staticmethod
+    def reformat_dm_operand(operand: str | int | Iterable[Any]) -> str | list[int]:
+        match operand:
+            case int():
+                return [operand]
+            case str():
+                if operand.isdigit():
+                    return [int(operand)]
+                if operand.strip() == "":
+                    raise BadNarrowOperatorError("Invalid user ID")
+                return operand.lower()
+            case Iterable():
+                try:
+                    user_ids = [int(id) for id in operand]
+                    assert user_ids != []
+                    return user_ids
+                except (ValueError, AssertionError):
+                    raise BadNarrowOperatorError("Invalid user ID")
+
+    @staticmethod
+    def canonicalize_term(term: NarrowTerm) -> NarrowTerm:
+        operator = canonicalize_operator_synonyms(term.operator)
+        operand = term.operand
+        match operator:
+            case "channel" if isinstance(operand, str | int):
+                operand = Filter.reformat_channel_operand(operand)
+
+            case "channels" if str(operand) in {"public", "web-public"}:
+                pass
+
+            case "dm":
+                operand = Filter.reformat_dm_operand(operand)
+
+            case "dm-including" | "sender" if isinstance(operand, str | int):
+                operand = int(operand) if str(operand).isdigit() else str(operand).lower()
+                if str(operand).strip() == "":
+                    raise BadNarrowOperatorError("Invalid user ID")
+            case "has":
+                # images -> image, etc.
+                operand = re.sub(r"s$", "", str(operand))
+                if operand not in {"attachment", "image", "link", "reaction"}:
+                    raise BadNarrowOperatorError(f"unknown '{operator}' operand {operand!s}")
+
+            case "id" | "near" | "with" if isinstance(operand, int | str):
+                if not str(operand).isdigit() or int(operand) > Message.MAX_POSSIBLE_MESSAGE_ID:
+                    raise BadNarrowOperatorError("Invalid message ID")
+                operand = int(operand)
+
+            case "is" if isinstance(operand, str):
+                operand = operand.lower()
+                if operand == "private":
+                    # "is:private" was renamed to "is:dm"
+                    operand = "dm"
+                if operand not in {
+                    "dm",
+                    "starred",
+                    "unread",
+                    "mentioned",
+                    "alerted",
+                    "resolved",
+                    "followed",
+                }:
+                    raise BadNarrowOperatorError(f"unknown '{operator}' operand {operand!s}")
+
+            case "search":
+                # The mac app automatically substitutes regular quotes with curly
+                # quotes when typing in the search bar.  Curly quotes don't trigger our
+                # phrase search behavior, however.  So, we replace all instances of
+                # curly quotes with regular quotes when doing a search.  This is
+                # unlikely to cause any problems and is probably what the user wants.
+                operand = re.sub(r"[\u201C\u201D]", '"', str(operand).lower())
+
+            case "topic" if isinstance(operand, str):
+                pass
+
+            case _:
+                raise BadNarrowOperatorError(f"unknown '{operator}' operand {operand!s}")
+
+        return NarrowTerm(operator, operand, term.negated)
+
+    def _canonicalize_terms(self, terms_mixed_case: Sequence[NarrowTerm]) -> list[NarrowTerm]:
+        return [Filter.canonicalize_term(term) for term in terms_mixed_case]
+
+    def _fix_terms(self, terms: Sequence[NarrowTerm]) -> list[NarrowTerm]:
+        terms = self._canonicalize_terms(terms)
+        return terms
+
+    def _setup_filter(self, terms: Sequence[NarrowTerm]) -> None:
+        self._terms = self._fix_terms(terms)
+
+    def terms(self) -> list[NarrowTerm]:
+        return self._terms

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -10,7 +10,7 @@ from zerver.lib.narrow import BadNarrowOperatorError, InvalidOperatorCombination
 from zerver.lib.narrow_helpers import NarrowTerm, NarrowTermOperandT
 from zerver.lib.streams import get_stream_by_narrow_operand_access_unchecked
 from zerver.lib.topic import DB_TOPIC_NAME
-from zerver.lib.url_encoding import encode_stream
+from zerver.lib.url_encoding import encode_stream, hash_util_encode
 from zerver.models.messages import Message
 from zerver.models.realms import Realm
 from zerver.models.streams import Stream
@@ -393,3 +393,12 @@ class Filter:
             raise BadNarrowOperatorError("unknown channel " + str(channel_id_or_name))
 
         return NARROW_FRAGMENT_BASE + f"channel/{encode_stream(channel.id, channel.name)}"
+
+    def generate_topic_url(self) -> str:
+        channel_link = self.generate_channel_url()
+        topics = self.operands("topic")
+        if not len(topics) == 1:
+            raise InvalidOperatorCombinationError("Requires exactly one 'topic' operand")
+        topic_name = topics[0]
+        assert isinstance(topic_name, str)
+        return f"{channel_link}/topic/{hash_util_encode(topic_name)}"

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -334,3 +334,13 @@ class Filter:
 
     def get_terms(self, operator: str) -> list[NarrowTerm]:
         return [term for term in self.terms() if term.operator == operator]
+
+    def update_term(self, existing_term: NarrowTerm, new_term: NarrowTerm) -> None:
+        current_terms = self.terms()
+        try:
+            term_index = current_terms.index(existing_term)
+        except ValueError:
+            raise AssertionError("Invalid term to update")
+        new_terms = self.terms()
+        new_terms[term_index] = new_term
+        self._setup_filter(new_terms)

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -19,27 +19,33 @@ from zerver.models.realms import Realm
 from zerver.models.streams import Stream
 
 
-def is_same_server_message_link(url: str) -> bool:
+def is_same_server_narrow_link(url: str) -> bool:
     split_result = urlsplit(url)
     hostname = split_result.hostname
     fragment = split_result.fragment
 
     if hostname not in {None, settings.EXTERNAL_HOST_WITHOUT_PORT}:
         return False
+    fragment_parts = fragment.split("/")
+    category = fragment_parts[0]
 
+    return category == "narrow"
+
+
+def is_same_server_message_link(url: str) -> bool:
+    if not is_same_server_narrow_link(url):
+        return False
     # A message link always has category `narrow`, section `channel`
     # or `dm`, and ends with `/near/<message_id>`, where <message_id>
     # is a sequence of digits. The URL fragment of a message link has
     # at least 5 parts. e.g. '#narrow/dm/9,15-dm/near/43'
-    fragment_parts = fragment.split("/")
+    fragment_parts = urlsplit(url).fragment.split("/")
     if len(fragment_parts) < 5:
         return False
 
-    category = fragment_parts[0]
     section = fragment_parts[1]
     ends_with_near_message_id = fragment_parts[-2] == "near" and fragment_parts[-1].isdigit()
-
-    return category == "narrow" and section in {"channel", "dm"} and ends_with_near_message_id
+    return section in {"channel", "dm"} and ends_with_near_message_id
 
 
 CHANNEL_SYNONYMS = {"stream": "channel", "streams": "channels"}

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote, urlsplit
 from django.conf import settings
 
 from zerver.lib.narrow import BadNarrowOperatorError
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NarrowTerm, NarrowTermOperandT
 from zerver.lib.topic import DB_TOPIC_NAME
 from zerver.models.messages import Message
 from zerver.models.realms import Realm
@@ -280,3 +280,8 @@ class Filter:
 
     def terms(self) -> list[NarrowTerm]:
         return self._terms
+
+    def operands(self, operator: str) -> list[NarrowTermOperandT]:
+        return [
+            term.operand for term in self.terms() if term.operator == operator and not term.negated
+        ]

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -285,3 +285,6 @@ class Filter:
         return [
             term.operand for term in self.terms() if term.operator == operator and not term.negated
         ]
+
+    def get_terms(self, operator: str) -> list[NarrowTerm]:
+        return [term for term in self.terms() if term.operator == operator]

--- a/zerver/tests/fixtures/narrow_term_fixture.json
+++ b/zerver/tests/fixtures/narrow_term_fixture.json
@@ -191,5 +191,17 @@
         "invalid_terms": [
             { "operator": "unknown_operator", "operand": "someoperand", "negated": false }
         ]
+    },
+    "redundant_is_private": {
+        "valid_terms": [
+            { "operator": "is", "operand": "private", "negated": false },
+            { "operator": "dm", "operand": "someone@example.com", "negated": false },
+            { "operator": "near", "operand": "2", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "dm", "operand": "someone@example.com", "negated": false },
+            { "operator": "near", "operand": 2, "negated": false }
+        ],
+        "invalid_terms": []
     }
 }

--- a/zerver/tests/fixtures/narrow_term_fixture.json
+++ b/zerver/tests/fixtures/narrow_term_fixture.json
@@ -1,0 +1,195 @@
+{
+    "channel_operator_validations": {
+        "valid_terms": [
+            { "operator": "stream", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": "13", "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": "Denmark", "negated": false },
+            { "operator": "channel", "operand": "13-Denmark", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": "Denmark", "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "channel", "operand": [1, 2, 3], "negated": false },
+            { "operator": "channel", "operand": " ", "negated": false }
+        ]
+    },
+    "channels_operator_validations": {
+        "valid_terms": [
+            { "operator": "streams", "operand": "public", "negated": false },
+            { "operator": "channels", "operand": "web-public", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "channels", "operand": "public", "negated": false },
+            { "operator": "channels", "operand": "web-public", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "channels", "operand": [1, 2, 3], "negated": false },
+            { "operator": "channels", "operand": "unkown-channels-operand", "negated": false },
+            { "operator": "channels", "operand": "Denmark", "negated": false }
+        ]
+    },
+    "topic_operator_validation": {
+        "valid_terms": [
+            { "operator": "subject", "operand": "Topic Name", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "topic", "operand": "Topic Name", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "topic", "operand": [1, 2, 3], "negated": false }
+        ]
+    },
+    "dm_operator_validations": {
+        "valid_terms": [
+            { "operator": "pm-with", "operand": 1, "negated": false },
+            { "operator": "dm", "operand": "1", "negated": false },
+            { "operator": "dm", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm", "operand": ["1", "2", "3"], "negated": false },
+            { "operator": "dm", "operand": "porco@zulip.com", "negated": false },
+            { "operator": "dm", "operand": "PoRcO@ZUlIp.Com", "negated": false },
+            { "operator": "dm", "operand": "totoro@zulip.com, nausicaa@zulip.com, ponyo@zulip.com", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "dm", "operand": [1], "negated": false },
+            { "operator": "dm", "operand": [1], "negated": false },
+            { "operator": "dm", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm", "operand": "porco@zulip.com", "negated": false },
+            { "operator": "dm", "operand": "porco@zulip.com", "negated": false },
+            { "operator": "dm", "operand": "totoro@zulip.com, nausicaa@zulip.com, ponyo@zulip.com", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "dm", "operand": ["totoro@zulip.com", "2", "3"], "negated": false },
+            { "operator": "dm", "operand": [], "negated": false },
+            { "operator": "dm", "operand": " ", "negated": false },
+            { "operator": "dm", "operand": ["totoro@zulip.com", "nausicaa@zulip.com", "ponyo@zulip.com"], "negated": false }
+        ]
+    },
+    "dm_including_operator_validations": {
+        "valid_terms": [
+            { "operator": "group-pm-with", "operand": "1", "negated": false },
+            { "operator": "dm-including", "operand": 1, "negated": false },
+            { "operator": "dm-including", "operand": "sophie@zulip.com", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "dm-including", "operand": 1, "negated": false },
+            { "operator": "dm-including", "operand": 1, "negated": false },
+            { "operator": "dm-including", "operand": "sophie@zulip.com", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "dm-including", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm-including", "operand": " ", "negated": false }
+        ]
+    },
+    "sender_operator_validations": {
+        "valid_terms": [
+            { "operator": "from", "operand": "1", "negated": false },
+            { "operator": "sender", "operand": 1, "negated": false },
+            { "operator": "sender", "operand": "kiki@zulip.com", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "sender", "operand": 1, "negated": false },
+            { "operator": "sender", "operand": 1, "negated": false },
+            { "operator": "sender", "operand": "kiki@zulip.com", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "dm-including", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm-including", "operand": " ", "negated": false }
+        ]
+    },
+    "is_operator_validations": {
+        "valid_terms": [
+            { "operator": "is", "operand": "private", "negated": false },
+            { "operator": "is", "operand": "starred", "negated": false },
+            { "operator": "is", "operand": "MENTIONED", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "is", "operand": "dm", "negated": false },
+            { "operator": "is", "operand": "starred", "negated": false },
+            { "operator": "is", "operand": "mentioned", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "is", "operand": "unknown_operand", "negated": false }
+        ]
+    },
+    "has_operator_validation": {
+        "valid_terms": [
+            { "operator": "has", "operand": "images", "negated": false },
+            { "operator": "has", "operand": "links", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "has", "operand": "image", "negated": false },
+            { "operator": "has", "operand": "link", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "has", "operand": "unknown", "negated": false }
+        ]
+    },
+    "search_operator_validation": {
+        "valid_terms": [
+            { "operator": "search", "operand": "Hello \u201cWorld\u201d", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "search", "operand": "hello \"world\"", "negated": false }
+        ],
+        "invalid_terms": []
+    },
+    "near_operator_validation": {
+        "valid_terms": [
+            { "operator": "near", "operand": "1", "negated": false },
+            { "operator": "near", "operand": 1, "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "near", "operand": 1, "negated": false },
+            { "operator": "near", "operand": 1, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "near", "operand": "abc", "negated": false },
+            { "operator": "near", "operand": [1,2,3], "negated": false },
+            { "operator": "near", "operand": " ", "negated": false }
+        ]
+    },
+    "with_operator_validation": {
+        "valid_terms": [
+            { "operator": "with", "operand": "1", "negated": false },
+            { "operator": "with", "operand": 1, "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "with", "operand": 1, "negated": false },
+            { "operator": "with", "operand": 1, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "with", "operand": "abc", "negated": false },
+            { "operator": "with", "operand": [1,2,3], "negated": false },
+            { "operator": "with", "operand": " ", "negated": false }
+        ]
+    },
+    "id_operator_validation":{
+        "valid_terms": [
+            { "operator": "id", "operand": "1", "negated": false },
+            { "operator": "id", "operand": 1, "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "id", "operand": 1, "negated": false },
+            { "operator": "id", "operand": 1, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "id", "operand": "abc", "negated": false },
+            { "operator": "id", "operand": [1,2,3], "negated": false },
+            { "operator": "id", "operand": " ", "negated": false }
+        ]
+    },
+    "unknown_operator": {
+        "valid_terms": [],
+        "expected_output": [],
+        "invalid_terms": [
+            { "operator": "unknown_operator", "operand": "someoperand", "negated": false }
+        ]
+    }
+}

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -1,8 +1,15 @@
-import orjson
+from typing import Any, TypeAlias
 
+import orjson
+from typing_extensions import override
+
+from zerver.lib.narrow import BadNarrowOperatorError
 from zerver.lib.narrow_helpers import NarrowTerm
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.url_decoding import is_same_server_message_link, parse_narrow_url
+from zerver.lib.url_decoding import Filter, is_same_server_message_link, parse_narrow_url
+from zerver.models.realms import get_realm
+
+NarrowTermFixtureT: TypeAlias = dict[str, dict[str, list[dict[str, Any]]]]
 
 
 class URLDecodeTest(ZulipTestCase):
@@ -31,3 +38,27 @@ class NarrowURLDecodeTest(ZulipTestCase):
                         NarrowTerm(**term) for term in expected_output
                     ]
                     self.assertListEqual(parsed_terms, expected_narrow_terms)
+
+
+class NarrowTermFilterTest(ZulipTestCase):
+    @override
+    def setUp(self) -> None:
+        self.realm = get_realm("zulip")
+        return super().setUp()
+
+    def test_initialize_narrow_terms(self) -> None:
+        tests: NarrowTermFixtureT = orjson.loads(self.fixture_data("narrow_term_fixture.json"))
+        for test_name, test_case in tests.items():
+            narrow_terms_input = [NarrowTerm(**term) for term in test_case["valid_terms"]]
+            filter_instance = Filter(narrow_terms_input, self.realm)
+            actual_output = filter_instance.terms()
+
+            with self.subTest(name=test_name):
+                expected_output: list[NarrowTerm] = [
+                    NarrowTerm(**term) for term in test_case["expected_output"]
+                ]
+                self.assertListEqual(actual_output, expected_output)
+
+                for invalid_term in test_case["invalid_terms"]:
+                    with self.assertRaises(BadNarrowOperatorError):
+                        Filter([NarrowTerm(**invalid_term)], self.realm)

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -134,3 +134,23 @@ class NarrowTermFilterTest(ZulipTestCase):
             ["channel", "unknown_term1", "unknown_term2", "topic"]
         )
         self.assertEqual(term_types, ["channel", "topic", "unknown_term1", "unknown_term2"])
+
+    def test_update_term(self) -> None:
+        base_terms = [
+            NarrowTerm(negated=False, operator="near", operand=1),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+        ]
+
+        old_term = NarrowTerm(negated=False, operator="channel", operand=13)
+        old_terms = [*base_terms, old_term]
+        filter = Filter(old_terms, self.realm)
+
+        new_term = NarrowTerm(negated=False, operator="channel", operand=12)
+        new_terms = [*base_terms, new_term]
+        filter.update_term(old_term, new_term)
+
+        self.assertEqual(filter.terms(), new_terms)
+
+        filter = Filter(base_terms, self.realm)
+        with self.assertRaisesRegex(AssertionError, "Invalid term to update"):
+            filter.update_term(old_term, new_term)

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -79,3 +79,32 @@ class NarrowTermFilterTest(ZulipTestCase):
         self.assertEqual(filter.operands("topic"), ["testing", "testing2"])
         self.assertEqual(filter.operands("near"), [1, 2])
         self.assertEqual(filter.operands("stream"), [])
+
+    def test_get_terms(self) -> None:
+        fixture_terms = [
+            NarrowTerm(negated=False, operator="channel", operand="13"),
+            NarrowTerm(negated=False, operator="channel", operand="2"),
+            NarrowTerm(negated=True, operator="channel", operand="88"),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="topic", operand="testing2"),
+            NarrowTerm(negated=False, operator="near", operand="1"),
+            NarrowTerm(negated=False, operator="near", operand="2"),
+        ]
+        filter = Filter(fixture_terms, self.realm)
+
+        self.assertEqual(
+            filter.get_terms("channel"),
+            [
+                NarrowTerm(negated=False, operator="channel", operand=13),
+                NarrowTerm(negated=False, operator="channel", operand=2),
+                NarrowTerm(negated=True, operator="channel", operand=88),
+            ],
+        )
+        self.assertEqual(
+            filter.get_terms("topic"),
+            [
+                NarrowTerm(negated=False, operator="topic", operand="testing"),
+                NarrowTerm(negated=False, operator="topic", operand="testing2"),
+            ],
+        )
+        self.assertEqual(filter.get_terms("stream"), [])

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -226,3 +226,38 @@ class NarrowTermFilterTest(ZulipTestCase):
             InvalidOperatorCombinationError, "Requires exactly one 'channel' operand"
         ):
             channel_url = filter.generate_channel_url()
+
+    def test_generate_topic_url(self) -> None:
+        channel_terms = [
+            NarrowTerm(negated=False, operator="channel", operand=13),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+        ]
+        terms = Filter(channel_terms, self.realm)
+        channel_url = terms.generate_topic_url()
+        self.assertEqual(channel_url, "#narrow/channel/13-Venice/topic/testing")
+
+        channel_terms = [
+            NarrowTerm(negated=False, operator="channel", operand=13),
+            NarrowTerm(
+                negated=False,
+                operator="topic",
+                operand="Broken Inline giphy preview / Messed up with camo :)",
+            ),
+            NarrowTerm(negated=False, operator="near", operand=1),
+        ]
+        terms = Filter(channel_terms, self.realm)
+        channel_url = terms.generate_topic_url()
+        self.assertEqual(
+            channel_url,
+            "#narrow/channel/13-Venice/topic/Broken.20Inline.20giphy.20preview.20.2F.20Messed.20up.20with.20camo.20.3A.29",
+        )
+
+        # No topic operand
+        dm_terms = [
+            NarrowTerm(negated=False, operator="channel", operand=13),
+        ]
+        terms = Filter(dm_terms, self.realm)
+        with self.assertRaisesRegex(
+            InvalidOperatorCombinationError, "Requires exactly one 'topic' operand"
+        ):
+            channel_url = terms.generate_topic_url()

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -108,3 +108,29 @@ class NarrowTermFilterTest(ZulipTestCase):
             ],
         )
         self.assertEqual(filter.get_terms("stream"), [])
+
+    def test_build_sorted_narrow_term(self) -> None:
+        expected_order = ["channel", "topic", "near"]
+
+        inverted_order = [
+            NarrowTerm(negated=False, operator="near", operand=1),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="channel", operand=13),
+        ]
+        filter = Filter(inverted_order, self.realm)
+        filter._build_sorted_term_types()
+        self.assertEqual(filter._sorted_term_types, expected_order)
+
+        correct_order = [
+            NarrowTerm(negated=False, operator="channel", operand=13),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="near", operand=1),
+        ]
+        filter = Filter(correct_order, self.realm)
+        filter._build_sorted_term_types()
+        self.assertEqual(filter._sorted_term_types, expected_order)
+
+        term_types = Filter.sorted_term_types(
+            ["channel", "unknown_term1", "unknown_term2", "topic"]
+        )
+        self.assertEqual(term_types, ["channel", "topic", "unknown_term1", "unknown_term2"])

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -62,3 +62,20 @@ class NarrowTermFilterTest(ZulipTestCase):
                 for invalid_term in test_case["invalid_terms"]:
                     with self.assertRaises(BadNarrowOperatorError):
                         Filter([NarrowTerm(**invalid_term)], self.realm)
+
+    def test_get_operands(self) -> None:
+        fixture_terms = [
+            NarrowTerm(negated=False, operator="channel", operand="13"),
+            NarrowTerm(negated=False, operator="channel", operand="2"),
+            NarrowTerm(negated=True, operator="channel", operand="88"),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="topic", operand="testing2"),
+            NarrowTerm(negated=False, operator="near", operand="1"),
+            NarrowTerm(negated=False, operator="near", operand="2"),
+        ]
+        filter = Filter(fixture_terms, self.realm)
+
+        self.assertEqual(filter.operands("channel"), [13, 2])
+        self.assertEqual(filter.operands("topic"), ["testing", "testing2"])
+        self.assertEqual(filter.operands("near"), [1, 2])
+        self.assertEqual(filter.operands("stream"), [])

--- a/zerver/tests/test_url_encoding.py
+++ b/zerver/tests/test_url_encoding.py
@@ -1,0 +1,60 @@
+from typing import Any, TypeAlias
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.url_encoding import encode_stream, get_message_narrow_link
+from zerver.models import Message
+from zerver.models.recipients import get_direct_message_group_user_ids
+
+NarrowTermFixtureT: TypeAlias = dict[str, dict[str, list[dict[str, Any]]]]
+
+
+class URLEncodeTest(ZulipTestCase):
+    def test_get_gdm_narrow_link_from_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        iago = self.example_user("iago")
+        zoe = self.example_user("ZOE")
+        gdm_content = "hello iago, zoe"
+        group_direct_message_id = self.send_group_direct_message(
+            hamlet, [iago, zoe, hamlet], gdm_content
+        )
+        group_direct_message = Message.objects.get(id=group_direct_message_id)
+        gdm_narrow_link = get_message_narrow_link(group_direct_message, "near")
+        gdm_recipients = list(get_direct_message_group_user_ids(group_direct_message.recipient))
+
+        encoded_gdm_recipients = ",".join(map(str, gdm_recipients))
+        expected_narrow_link = (
+            f"#narrow/dm/{encoded_gdm_recipients}-group/near/{group_direct_message_id}"
+        )
+        self.assertEqual(gdm_narrow_link, expected_narrow_link)
+
+    def test_get_dm_narrow_link_from_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        zoe = self.example_user("ZOE")
+        dm_content = "hello zoe"
+        direct_message_id = self.send_personal_message(hamlet, zoe, dm_content)
+        direct_message = Message.objects.get(id=direct_message_id)
+        dm_narrow_link = get_message_narrow_link(direct_message, "near")
+
+        encoded_dm_recipient = f"{zoe.id}-{zoe.full_name}"
+        expected_narrow_link = f"#narrow/dm/{encoded_dm_recipient}/near/{direct_message_id}"
+        self.assertEqual(dm_narrow_link, expected_narrow_link)
+
+    def test_get_channel_narrow_link_from_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        public_channel = self.make_stream("public")
+        self.subscribe(hamlet, public_channel.name)
+        message_content = "hello public"
+        channel_message_id = self.send_stream_message(hamlet, public_channel.name, message_content)
+        channel_message = Message.objects.get(id=channel_message_id)
+        message_narrow_link = get_message_narrow_link(channel_message, "near")
+
+        encoded_channel = encode_stream(public_channel.id, public_channel.name)
+        expected_narrow_link = (
+            f"#narrow/channel/{encoded_channel}/topic/test/near/{channel_message_id}"
+        )
+        self.assertEqual(message_narrow_link, expected_narrow_link)
+
+        # Unknown Recipient.type
+        channel_message.recipient.type = 4
+        with self.assertRaises(AssertionError):
+            get_message_narrow_link(channel_message, "near")


### PR DESCRIPTION
This is stacked on top of #33590.

---

Because we rewrite the message ID and channel ID during the import,
messages containing near-links will be broken because they still point
to the old object IDs.

This PR fixes channel links, topic links, group links, dm links and
message links in the rendered content of imported messages by remapping
the relevant IDs.

Fixes #31100.
This is also a prep PR for #30166 



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
