### PR TITLE
message_feed: Add support to navigate to general or personal settings.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -628,6 +628,28 @@ export function initialize() {
         });
     });
 
+    $("body").on("click", ".subscription-link.unsubscribe", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const hash = window.location.hash;
+        const channel_part = hash.split("/channel/")[1].split("/topic/")[0];
+        if (channel_part) {
+            const [stream_id, stream_name] = channel_part.split("-");
+            window.location.hash = `#channels/${stream_id}/${stream_name}/personal`;
+        }
+    });
+
+    $("body").on("click", ".subscription-link.subscribe", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const hash = window.location.hash;
+        const channel_part = hash.split("/channel/")[1].split("/topic/")[0];
+        if (channel_part) {
+            const [stream_id, stream_name] = channel_part.split("-");
+            window.location.hash = `#channels/${stream_id}/${stream_name}/general`;
+        }
+    });
+
     // Recent conversations direct messages (Not displayed on small widths)
     $("body").on("mouseenter", ".recent_topic_stream .pm_status_icon", (e) => {
         e.stopPropagation();

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -25,16 +25,16 @@
                 {{/tr}}
             {{/if}}
         </span>
-    {{/if}}
+{{/if}}
     {{#if can_toggle_subscription}}
     <div class="sub_button_row">
-        <button class="button white rounded stream_sub_unsub_button {{#unless subscribed}}sea-green{{/unless}}" type="button" name="subscription">
+        <a href="javascript:void(0)" class="subscription-link {{#if subscribed}}unsubscribe{{else}}subscribe{{/if}}">
             {{#if subscribed}}
-            {{t 'Unsubscribe' }}
+                View in channel settings
             {{else}}
-            {{t 'Subscribe' }}
+                Manage channel settings
             {{/if}}
-        </button>
+        </a>
     </div>
-    {{/if}}
+{{/if}}
 </div>


### PR DESCRIPTION
This commit handles the case, that when the user subscribe/unsubscribe from a channel they can manage their status for the channel that is subscribing or unsubscribing the channel again from the general or personal settings.

Fixes #32125 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

|Before(Unsubscribe)|After(Unsubscribe)|
|----|----|
|<img width="1440" alt="Screenshot 2024-11-07 at 4 35 43 AM" src="https://github.com/user-attachments/assets/874b20fc-8484-4d6f-b4eb-cc7df98465d0">|<img width="1440" alt="Screenshot 2024-11-07 at 4 32 06 AM" src="https://github.com/user-attachments/assets/eee19b10-707b-465d-8ff3-d35b164ef802">|

|Before(Subscribe)|After(Subscribe)|
|----|----|
|<img width="1440" alt="Screenshot 2024-11-07 at 4 36 19 AM" src="https://github.com/user-attachments/assets/97ae7abe-b42f-41b1-88f6-80db9fef7b2a">|<img width="1440" alt="Screenshot 2024-11-07 at 4 33 15 AM" src="https://github.com/user-attachments/assets/9d118781-ea3b-4c78-9261-b42dde7ec1d1">|

## Changes 
https://github.com/user-attachments/assets/6058579f-5717-4c36-a2fa-139f6fd52714

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
