### PR TITLE
webpack: Disable CompressionPlugin for Puppeteer tests

### DIFF
--- a/tools/webpack
+++ b/tools/webpack
@@ -29,6 +29,8 @@ def build_for_prod_or_puppeteer(quiet: bool, config_name: str | None = None) -> 
         webpack_args += ["--stats=errors-only"]
     if config_name is not None:
         webpack_args += [f"--config-name={config_name}"]
+    if "PUPPETEER_TESTS" in os.environ:
+        webpack_args.append("--env=puppeteer_tests")
 
     # Silence warnings from "browserslist" about using old data; those
     # warnings are only useful for development

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -17,7 +17,7 @@ import assets from "./webpack.assets.json";
 import dev_assets from "./webpack.dev-assets.json";
 
 const config = (
-    env: {minimize?: boolean; ZULIP_VERSION?: string} = {},
+    env: {minimize?: true; puppeteer_tests?: true; ZULIP_VERSION?: string} = {},
     argv: {mode?: string},
 ): webpack.Configuration[] => {
     const production: boolean = argv.mode === "production";
@@ -55,7 +55,7 @@ const config = (
             publicPath: production ? "/static/webpack-bundles/" : "/webpack/",
         }),
     ];
-    if (production) {
+    if (production && !env.puppeteer_tests) {
         plugins.push(
             new CompressionPlugin<ZopfliOptions>({
                 // Use zopfli to write pre-compressed versions of text files


### PR DESCRIPTION
Zopfli is very slow and the development server does not use its output anyway.