### PR TITLE
Remove extraneous pointer cursors on text in settings.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1451,9 +1451,9 @@ export function enable_opening_typeahead_on_clicking_label($container: JQuery): 
     const $group_setting_labels = $container.find(".group-setting-label");
     $group_setting_labels.on("click", (e) => {
         // Click opens the typeahead.
-        $(e.target).siblings(".pill-container").find(".input").expectOne().trigger("click");
+        const $pillContainer = $(e.target).closest(".input-group").find(".pill-container .input");
         // Focus puts the cursor into the input.
-        $(e.target).siblings(".pill-container").find(".input").expectOne().trigger("focus");
+        $pillContainer.trigger("click").trigger("focus");
     });
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -7,6 +7,11 @@ label {
     margin: 0;
 }
 
+.group-setting-label-text,
+.modal-field-label-text {
+    cursor: text;
+}
+
 label,
 h4,
 h3,
@@ -294,6 +299,10 @@ h3,
 
     .account-settings-heading {
         margin-right: 10px;
+    }
+
+    .group-setting-label {
+        cursor: text;
     }
 }
 
@@ -1634,6 +1643,10 @@ $option_title_width: 180px;
 
 .settings-field-label {
     margin-bottom: var(--margin-bottom-field-description);
+
+    .settings-field-label-text {
+        cursor: text;
+    }
 }
 
 .settings-profile-user-field-hint {

--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,6 @@
 <form id="change_email_form">
-    <label for="email" class="modal-field-label">{{t "New email" }}</label>
+    <label for="email" class="modal-field-label">
+        <span class="modal-field-label-text">{{t "New email" }}</span>
+    </label>
     <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -2,5 +2,5 @@
     <label for="email" class="modal-field-label">
         <span class="modal-field-label-text">{{t "New email" }}</span>
     </label>
-    <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+    <input id="email" type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -1,6 +1,8 @@
 <form id="change_password_container">
     <div class="settings-password-div">
-        <label for="old_password" class="modal-field-label">{{t "Old password" }}</label>
+        <label for="old_password" class="modal-field-label">
+            <span class="modal-field-label-text">{{t "Old password" }}</span>
+        </label>
         <div class="password-input-row">
             <input type="password" autocomplete="off" name="old_password" id="old_password" class="inline-block modal_password_input" value="" />
             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
@@ -8,7 +10,9 @@
         </div>
     </div>
     <div class="settings-password-div">
-        <label for="new_password" class="modal-field-label">{{t "New password" }}</label>
+        <label for="new_password" class="modal-field-label">
+            <span class="modal-field-label-text">{{t "New password" }}</span>
+        </label>
         <div class="password-input-row">
             <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="inline-block modal_password_input" value=""
               data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />

--- a/web/templates/dropdown_widget_with_label.hbs
+++ b/web/templates/dropdown_widget_with_label.hbs
@@ -1,5 +1,6 @@
 <div class="input-group" id="{{widget_name}}_widget_container">
-    <label class="settings-field-label" for="{{widget_name}}_widget">{{label}}
+    <label class="settings-field-label" for="{{widget_name}}_widget">
+        <span class="settings-field-label-text">{{label}}</span>
         {{#if help_link}}{{> help_link_widget link=help_link }}{{/if}}
     </label>
     <span class="prop-element hide" id="id_{{widget_name}}" data-setting-widget-type="dropdown-list-widget" {{#if value_type}}data-setting-value-type="{{value_type}}"{{/if}}></span>

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -20,7 +20,9 @@
     <div class="input-group">
         <div id="invite_users_option_tabs_container"></div>
         <div id="invitee_emails_container">
-            <label for="invitee_emails" class="modal-field-label">{{t "Emails (one on each line or comma-separated)" }}</label>
+            <label for="invitee_emails" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Emails (one on each line or comma-separated)" }}</span>
+            </label>
             <div class="pill-container">
                 <div class="input" contenteditable="true"></div>
             </div>
@@ -34,8 +36,10 @@
         </label>
     </div>
     <div class="input-group">
-        <label for="expires_in" class="modal-field-label">{{t "Invitation expires after" }}</label>
-        <select id="expires_in" name="expires_in" class="invite-user-select modal_select bootstrap-focus-style">
+        <label for="expires_in" class="modal-field-label">
+            <span class="modal-field-label-text">{{t "Invitation expires after" }}</span>
+        </label>
+        <select id="expires_in" class="invite-user-select modal_select bootstrap-focus-style">
             {{#each expires_in_options}}
                 <option {{#if this.default }}selected{{/if}} value="{{this.value}}">{{this.description}}</option>
             {{/each}}
@@ -53,7 +57,8 @@
         </div>
     </div>
     <div class="input-group">
-        <label for="invite_as" class="modal-field-label">{{t "Users join as" }}
+        <label for="invite_as" class="modal-field-label">
+            <span class="modal-field-label-text">{{t "Users join as" }}</span>
             {{> help_link_widget link="/help/roles-and-permissions" }}
         </label>
         <select id="invite_as" name="invite_as" class="invite-user-select modal_select bootstrap-focus-style">
@@ -70,7 +75,9 @@
     </div>
     {{#if can_subscribe_other_users}}
     <div>
-        <label>{{t "Channels they should join" }}</label>
+        <label class="modal-field-label">
+            <span class="modal-field-label-text">{{t "Channels they should join" }}</span>
+        </label>
         <div id="streams_to_add">
             {{#if show_select_default_streams_option}}
             <div class="select_default_streams">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -7,7 +7,9 @@
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
-                    <label class="settings-field-label">{{t "Email" }}</label>
+                    <label class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Email" }}</span>
+                    </label>
                     <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                         <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
                             {{current_user.delivery_email}}
@@ -42,7 +44,9 @@
             <form class="password-change-form grid">
                 {{#if user_can_change_password}}
                 <div>
-                    <label class="settings-field-label">{{t "Password" }}</label>
+                    <label class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Password" }}</span>
+                    </label>
                     <div class="input-group">
                         <button id="change_password" type="button" class="button rounded" data-dismiss="modal">{{t "Change your password" }}</button>
                     </div>
@@ -102,7 +106,8 @@
                   }}
             </div>
             <div class="input-group">
-                <label for="email_address_visibility" class="settings-field-label">{{t "Who can access your email address" }}
+                <label for="email_address_visibility" class="settings-field-label">
+                    <span class="settings-field-label-text">{{t "Who can access your email address" }}</span>
                     {{> ../help_link_widget link="/help/configure-email-visibility" }}
                 </label>
                 <div id="user_email_address_dropdown_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -7,7 +7,7 @@
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
-                    <label class="settings-field-label">
+                    <label class="settings-field-label" for="change_email_button">
                         <span class="settings-field-label-text">{{t "Email" }}</span>
                     </label>
                     <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
@@ -44,7 +44,7 @@
             <form class="password-change-form grid">
                 {{#if user_can_change_password}}
                 <div>
-                    <label class="settings-field-label">
+                    <label class="settings-field-label" for="change_password">
                         <span class="settings-field-label-text">{{t "Password" }}</span>
                     </label>
                     <div class="input-group">
@@ -106,14 +106,12 @@
                   }}
             </div>
             <div class="input-group">
-                <label for="email_address_visibility" class="settings-field-label">
+                <label for="user_email_address_visibility" class="settings-field-label">
                     <span class="settings-field-label-text">{{t "Who can access your email address" }}</span>
                     {{> ../help_link_widget link="/help/configure-email-visibility" }}
                 </label>
                 <div id="user_email_address_dropdown_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
-                    <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"
-                      id="user_email_address_visibility" {{#unless user_has_email_set}}disabled="disabled"{{/unless}}>
-                        {{> dropdown_options_widget option_values=email_address_visibility_values}}
+                    <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number" id="user_email_address_visibility" {{#unless user_has_email_set}}disabled="disabled"{{/unless}}>{{> dropdown_options_widget option_values=email_address_visibility_values}}
                     </select>
                 </div>
             </div>

--- a/web/templates/settings/add_alert_word.hbs
+++ b/web/templates/settings/add_alert_word.hbs
@@ -1,4 +1,6 @@
 <form id="add-alert-word-form">
-    <label for="add-alert-word-name" class="modal-field-label">{{t "Alert word" }}</label>
+    <label for="add-alert-word-name" class="modal-field-label">
+        <span class="modal-field-label-text">{{t "Alert word" }}</span>
+    </label>
     <input type="text" name="alert-word-name" id="add-alert-word-name" class="required modal_text_input" maxlength=100 placeholder="{{t 'Alert word' }}" value="" />
 </form>

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -11,7 +11,9 @@
     </div>
     <div id="emoji_file_input_error" class="text-error"></div>
     <div class="emoji_name_input">
-        <label for="emoji_name" class="modal-field-label">{{t "Emoji name" }}</label>
+        <label for="emoji_name" class="modal-field-label">
+            <span class="modal-field-label-text">{{t "Emoji name" }}</span>
+        </label>
         <input type="text" name="name" id="emoji_name" class="modal_text_input" placeholder="{{t 'leafy green vegetable' }}" />
     </div>
 </form>

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -1,7 +1,7 @@
 <form id="create_bot_form">
     <div class="new-bot-form">
         <div class="input-group">
-            <label for="bot_type" class="modal-field-label">
+            <label for="create_bot_type" class="modal-field-label">
                 <span class="modal-field-label-text">{{t "Bot type" }}</span>
                 {{> ../help_link_widget link="/help/bots-overview#bot-type" }}
             </label>
@@ -32,7 +32,7 @@
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
         <div class="input-group">
-            <label for="bot_short_name" class="modal-field-label">
+            <label for="create_bot_short_name" class="modal-field-label">
                 <span class="modal-field-label-text">{{t "Bot email (a-z, 0-9, and dashes only)" }}</span>
             </label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -2,7 +2,7 @@
     <div class="new-bot-form">
         <div class="input-group">
             <label for="bot_type" class="modal-field-label">
-                {{t "Bot type" }}
+                <span class="modal-field-label-text">{{t "Bot type" }}</span>
                 {{> ../help_link_widget link="/help/bots-overview#bot-type" }}
             </label>
             <select name="bot_type" id="create_bot_type" class="modal_select bootstrap-focus-style">
@@ -14,7 +14,9 @@
             </select>
         </div>
         <div class="input-group" id="service_name_list">
-            <label for="select_service_name" class="modal-field-label">{{t "Bot"}}</label>
+            <label for="select_service_name" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Bot"}}</span>
+            </label>
             <select name="service_name" id="select_service_name" class="modal_select bootstrap-focus-style">
                 {{#each realm_embedded_bots}}
                     <option value="{{this.name}}">{{this.name}}</option>
@@ -22,13 +24,17 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="create_bot_name" class="modal-field-label">{{t "Name" }}</label>
+            <label for="create_bot_name" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Name" }}</span>
+            </label>
             <input type="text" name="bot_name" id="create_bot_name" class="required modal_text_input"
               maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
         <div class="input-group">
-            <label for="bot_short_name" class="modal-field-label">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
+            <label for="bot_short_name" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Bot email (a-z, 0-9, and dashes only)" }}</span>
+            </label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"
               placeholder="{{t 'cookie' }}" value="" />
             -bot@{{ realm_bot_domain }}
@@ -38,13 +44,17 @@
         </div>
         <div id="payload_url_inputbox">
             <div class="input-group">
-                <label for="create_payload_url" class="modal-field-label">{{t "Endpoint URL" }}</label>
+                <label for="create_payload_url" class="modal-field-label">
+                    <span class="modal-field-label-text">{{t "Endpoint URL" }}</span>
+                </label>
                 <input type="text" name="payload_url" id="create_payload_url" class="modal_text_input"
                   maxlength=2083 placeholder="https://hostname.example.com" value="" />
                 <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
             </div>
             <div class="input-group">
-                <label for="interface_type" class="modal-field-label">{{t "Outgoing webhook message format" }}</label>
+                <label for="interface_type" class="modal-field-label">
+                    <span class="modal-field-label-text">{{t "Outgoing webhook message format" }}</span>
+                </label>
                 <select name="interface_type" id="create_interface_type" class="modal_select bootstrap-focus-style">
                     <option value="1">Zulip</option>
                     <option value="2">{{t "Slack compatible" }}</option>
@@ -60,7 +70,9 @@
             {{/each}}
         </div>
         <div class="input-group">
-            <label for="bot_avatar_file_input" class="modal-field-label">{{t "Avatar" }}</label>
+            <label for="bot_avatar_file_input" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Avatar" }}</span>
+            </label>
             <div id="bot_avatar_file"></div>
             <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
             <div id="add_bot_preview_text">

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -1,7 +1,9 @@
 <form class="admin-profile-field-form" id="add-new-custom-profile-field-form">
     <div class="new-profile-field-form wrapper">
         <div class="input-group">
-            <label for="profile_field_type" class="modal-field-label">{{t "Type" }}</label>
+            <label for="profile_field_type" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Type" }}</span>
+            </label>
             <select id="profile_field_type" name="field_type" class="modal_select bootstrap-focus-style">
                 {{#each custom_profile_field_types}}
                     <option value='{{this.id}}'>{{this.name}}</option>
@@ -18,11 +20,15 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="profile_field_name" class="modal-field-label">{{t "Label" }}</label>
+            <label for="profile_field_name" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Label" }}</span>
+            </label>
             <input type="text" id="profile_field_name" class="modal_text_input" name="name" autocomplete="off" maxlength="40" />
         </div>
         <div class="input-group">
-            <label for="profile_field_hint" class="modal-field-label">{{t "Hint (up to 80 characters)" }}</label>
+            <label for="profile_field_hint" class="modal-field-label">
+                <span class="modal-field-label-text">{{t "Hint (up to 80 characters)" }}</span>
+            </label>
             <input type="text" id="profile_field_hint" class="modal_text_input" name="hint" autocomplete="off" maxlength="80" />
             <div class="alert" id="admin-profile-field-hint-status"></div>
         </div>

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -13,7 +13,9 @@
                     <div id="api_key_form">
                         <p>{{t "Please re-enter your password to confirm your identity." }}</p>
                         <div class="settings-password-div">
-                            <label for="password" class="modal-field-label">{{t "Your password" }}</label>
+                            <label for="password" class="modal-field-label">
+                                <span class="modal-field-label-text">{{t "Your password" }}</span>
+                            </label>
                             <div class="password-input-row">
                                 <input type="password" autocomplete="off" name="password" id="get_api_key_password" class=" modal_password_input" value="" />
                                 <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -9,9 +9,9 @@
     <div class="settings-profile-user-field-hint">{{ field.hint }}</div>
     <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}} {{#unless editable_by_user}}not-editable-by-user-input-wrapper{{/unless}}">
         {{#if is_long_text_field}}
-        <textarea maxlength="500" class="custom_user_field_value settings_textarea" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
+        <textarea id="{{ field.name }}" maxlength="500" class="custom_user_field_value settings_textarea" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
         {{else if is_select_field}}
-        <select class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>
+        <select id="{{ field.name }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>
             <option value=""></option>
             {{#each field_choices}}
                 <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
@@ -26,11 +26,11 @@
           value="{{ field_value.value }}" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{#if editable_by_user}}<span class="remove_date"><i class="fa fa-close"></i></span>{{/if}}
         {{else if is_url_field }}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" {{#unless editable_by_user}}disabled{{/unless}}/>
+        <input id="{{ field.name }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else if is_pronouns_field}}
-        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
+        <input id="{{ field.name }}" class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else}}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
+        <input id="{{ field.name }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{/if}}
     </div>
 </div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -1,6 +1,8 @@
 <div class="custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
     <span class="custom-user-field-label-wrapper {{#if field.required}}required-field-wrapper{{/if}}">
-        <label class="settings-field-label inline-block" for="{{ field.name }}" class="title">{{ field.name }}</label>
+        <label class="settings-field-label inline-block" for="{{ field.name }}" class="title">
+            <span class="settings-field-label-text">{{ field.name }}</span>
+        </label>
         <span class="required-symbol {{#unless is_empty_required_field}}hidden{{/unless}}"> *</span>
     </span>
     <div class="alert-notification custom-field-status"></div>

--- a/web/templates/settings/group_setting_value_pill_input.hbs
+++ b/web/templates/settings/group_setting_value_pill_input.hbs
@@ -1,5 +1,7 @@
 <div class="input-group">
-    <label class="group-setting-label">{{label}}</label>
+    <label class="group-setting-label">
+        <span class="group-setting-label-text">{{label}}</span>
+    </label>
     <div class="pill-container person_picker prop-element" id="id_{{setting_name}}" data-setting-widget-type="group-setting-type">
         <div class="input" contenteditable="true" data-placeholder="{{t 'Add roles, groups or users' }}">
             {{~! Squash whitespace so that placeholder is displayed when empty. ~}}

--- a/web/templates/settings/language_selection_widget.hbs
+++ b/web/templates/settings/language_selection_widget.hbs
@@ -1,6 +1,6 @@
 <div class="language_selection_widget input-group prop-element" id="id_{{section_name}}" data-setting-widget-type="language-setting">
     <label class="settings-field-label">
-        {{section_title}}
+        <span class="settings-field-label-text">{{section_title}}</span>
         {{#if help_link_widget_link}}
         {{> ../help_link_widget link=help_link_widget_link }}
         {{/if}}

--- a/web/templates/settings/language_selection_widget.hbs
+++ b/web/templates/settings/language_selection_widget.hbs
@@ -1,11 +1,11 @@
 <div class="language_selection_widget input-group prop-element" id="id_{{section_name}}" data-setting-widget-type="language-setting">
-    <label class="settings-field-label">
+    <label class="settings-field-label" for="select_language">
         <span class="settings-field-label-text">{{section_title}}</span>
         {{#if help_link_widget_link}}
         {{> ../help_link_widget link=help_link_widget_link }}
         {{/if}}
     </label>
-    <button type="button" class="language_selection_button button rounded tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
+    <button id="select_language" type="button" class="language_selection_button button rounded tippy-zulip-delayed-tooltip" data-section="{{section_name}}" data-tippy-content="{{t 'Change language' }}">
         <span class="{{section_name}}" data-language-code="{{language_code}}">{{setting_value}}</span>
     </button>
 </div>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -65,7 +65,7 @@
         </div>
 
         <div class="input-group">
-            <label for="automatically_follow_topics_policy" class="settings-field-label">
+            <label for="{{prefix}}automatically_follow_topics_policy" class="settings-field-label">
                 <span class="settings-field-label-text">{{ settings_label.automatically_follow_topics_policy }}</span>
                 {{> ../help_link_widget link="/help/follow-a-topic" }}
             </label>
@@ -76,7 +76,7 @@
         </div>
 
         <div class="input-group">
-            <label for="automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">
+            <label for="{{prefix}}automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">
                 <span class="settings-field-label-text">{{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}</span>
                 {{> ../help_link_widget link="/help/mute-a-topic" }}
             </label>
@@ -134,7 +134,7 @@
         </div>
 
         <div class="input-group">
-            <label for="desktop_icon_count_display" class="settings-field-label">
+            <label for="{{prefix}}desktop_icon_count_display" class="settings-field-label">
                 <span class="settings-field-label-text">{{ settings_label.desktop_icon_count_display }}</span>
             </label>
             <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element settings_select bootstrap-focus-style" id="{{prefix}}desktop_icon_count_display" data-setting-widget-type="number">
@@ -180,8 +180,7 @@
         </div>
 
         <div class="input-group time-limit-setting">
-
-            <label for="email_notifications_batching_period" class="settings-field-label">
+            <label for="{{prefix}}email_notifications_batching_period_seconds" class="settings-field-label">
                 <span class="settings-field-label-text">{{t "Delay before sending message notification emails" }}</span>
             </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element settings_select bootstrap-focus-style" id="{{prefix}}email_notifications_batching_period_seconds" data-setting-widget-type="time-limit">

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -66,7 +66,7 @@
 
         <div class="input-group">
             <label for="automatically_follow_topics_policy" class="settings-field-label">
-                {{ settings_label.automatically_follow_topics_policy }}
+                <span class="settings-field-label-text">{{ settings_label.automatically_follow_topics_policy }}</span>
                 {{> ../help_link_widget link="/help/follow-a-topic" }}
             </label>
             <select name="automatically_follow_topics_policy" class="setting_automatically_follow_topics_policy prop-element settings_select bootstrap-focus-style"
@@ -77,7 +77,7 @@
 
         <div class="input-group">
             <label for="automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">
-                {{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}
+                <span class="settings-field-label-text">{{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}</span>
                 {{> ../help_link_widget link="/help/mute-a-topic" }}
             </label>
             <select name="automatically_unmute_topics_in_muted_streams_policy" class="setting_automatically_unmute_topics_in_muted_streams_policy prop-element settings_select bootstrap-focus-style"
@@ -114,8 +114,8 @@
               prefix=../prefix}}
         {{/each}}
 
-        <label for="{{prefix}}notification_sound">
-            {{t "Notification sound" }}
+        <label for="{{prefix}}notification_sound" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Notification sound" }}</span>
         </label>
 
         <div class="input-group input-element-with-control {{#unless enable_sound_select}}control-label-disabled{{/unless}}">
@@ -134,7 +134,9 @@
         </div>
 
         <div class="input-group">
-            <label for="desktop_icon_count_display" class="settings-field-label">{{ settings_label.desktop_icon_count_display }}</label>
+            <label for="desktop_icon_count_display" class="settings-field-label">
+                <span class="settings-field-label-text">{{ settings_label.desktop_icon_count_display }}</span>
+            </label>
             <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element settings_select bootstrap-focus-style" id="{{prefix}}desktop_icon_count_display" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=desktop_icon_count_display_values}}
             </select>
@@ -180,7 +182,7 @@
         <div class="input-group time-limit-setting">
 
             <label for="email_notifications_batching_period" class="settings-field-label">
-                {{t "Delay before sending message notification emails" }}
+                <span class="settings-field-label-text">{{t "Delay before sending message notification emails" }}</span>
             </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element settings_select bootstrap-focus-style" id="{{prefix}}email_notifications_batching_period_seconds" data-setting-widget-type="time-limit">
                 {{#each email_notifications_batching_period_values}}
@@ -201,7 +203,9 @@
         </div>
 
         <div class="input-group">
-            <label for="realm_name_in_email_notifications_policy" class="settings-field-label">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
+            <label for="{{prefix}}realm_name_in_email_notifications_policy" class="settings-field-label">
+                <span class="settings-field-label-text">{{ settings_label.realm_name_in_email_notifications_policy }}</span>
+            </label>
             <select name="realm_name_in_email_notifications_policy" class="setting_realm_name_in_email_notifications_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}realm_name_in_email_notifications_policy" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=realm_name_in_email_notifications_policy_values}}
             </select>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -16,7 +16,8 @@
                       prefix="id_"
                       is_checked=realm_invite_required
                       label=admin_settings_label.realm_invite_required}}
-                    <label for="realm_invite_to_realm_policy" class="settings-field-label">{{t "Who can send email invitations to new users" }}
+                    <label for="realm_invite_to_realm_policy" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Who can send email invitations to new users" }}</span>
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
@@ -28,7 +29,9 @@
                   label=(t 'Who can create reusable invitation links')}}
 
                 <div class="input-group">
-                    <label for="realm_org_join_restrictions" class="settings-field-label">{{t "Restrict email domains of new users" }}</label>
+                    <label for="realm_org_join_restrictions" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Restrict email domains of new users" }}</span>
+                    </label>
                     <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
                         <option value="no_restriction">{{t "No restrictions" }}</option>
                         <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
@@ -43,7 +46,7 @@
                 </div>
                 <div class="input-group time-limit-setting">
                     <label for="realm_waiting_period_threshold" class="settings-field-label">
-                        {{t "Waiting period before new members turn into full members" }}
+                        <span class="settings-field-label-text">{{t "Waiting period before new members turn into full members" }}</span>
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
                     <select name="realm_waiting_period_threshold" id="id_realm_waiting_period_threshold" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="time-limit">
@@ -51,7 +54,9 @@
                     </select>
                     {{!-- This setting is hidden unless `custom_period` --}}
                     <div class="dependent-settings-block">
-                        <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">{{t "Waiting period (days)" }}:</label>
+                        <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">
+                            <span class="settings-field-label-text">{{t "Waiting period (days)" }}:</span>
+                        </label>
                         <input type="text" id="id_realm_waiting_period_threshold_custom_input"
                           name="realm_waiting_period_threshold_custom_input"
                           class="time-limit-custom-input"
@@ -90,13 +95,16 @@
                   label=(t 'Who can create private channels')}}
 
                 <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="settings-field-label">{{t "Who can add users to channels" }}</label>
+                    <label for="realm_invite_to_stream_policy" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Who can add users to channels" }}</span>
+                    </label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_wildcard_mention_policy" class="settings-field-label">{{t "Who can notify a large number of users with a wildcard mention" }}
+                    <label for="realm_wildcard_mention_policy" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Who can notify a large number of users with a wildcard mention" }}</span>
                         {{> ../help_link_widget link="/help/restrict-wildcard-mentions" }}
                     </label>
                     <select name="realm_wildcard_mention_policy" id="id_realm_wildcard_mention_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
@@ -162,15 +170,17 @@
                   label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_edit_limit_seconds" class="settings-field-label">{{t "Time limit for editing messages" }}</label>
+                    <label for="realm_message_content_edit_limit_seconds" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Time limit for editing messages" }}</span>
+                    </label>
                     <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
                         {{#each msg_edit_limit_dropdown_values}}
                             <option value="{{value}}">{{text}}</option>
                         {{/each}}
                     </select>
                     <div class="dependent-settings-block">
-                        <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                        <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label settings-field-label">
+                            <span class="settings-field-label-text">{{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;</span>
                         </label>
                         <input type="text" id="id_realm_message_content_edit_limit_minutes"
                           name="realm_message_content_edit_limit_minutes"
@@ -196,15 +206,18 @@
               label=(t 'Who can move messages to another topic')}}
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_within_stream_limit_seconds" class="settings-field-label">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="realm_move_messages_within_stream_limit_seconds" class="settings-field-label">
+                    <span class="settings-field-label-text">{{t "Time limit for editing topics" }}
+                        <i>({{t "does not apply to moderators and administrators" }})</i></span>
+                </label>
                 <select name="realm_move_messages_within_stream_limit_seconds" id="id_realm_move_messages_within_stream_limit_seconds" class="prop-element settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
                     {{/each}}
                 </select>
                 <div class="dependent-settings-block">
-                    <label for="id_realm_move_messages_within_stream_limit_minutes" class="inline-block realm-time-limit-label">
-                        {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                    <label for="id_realm_move_messages_within_stream_limit_minutes" class="inline-block realm-time-limit-label settings-field-label">
+                        <span class="settings-field-label-text">{{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;</span>
                     </label>
                     <input type="text" id="id_realm_move_messages_within_stream_limit_minutes"
                       name="realm_move_messages_within_stream_limit_minutes"
@@ -218,15 +231,18 @@
               label=(t 'Who can move messages to another channel')}}
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_between_streams_limit_seconds" class="settings-field-label">{{t "Time limit for moving messages between channels" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="realm_move_messages_between_streams_limit_seconds" class="settings-field-label">
+                    <span class="settings-field-label-text">{{t "Time limit for moving messages between channels" }}
+                        <i>({{t "does not apply to moderators and administrators" }})</i></span>
+                </label>
                 <select name="realm_move_messages_between_streams_limit_seconds" id="id_realm_move_messages_between_streams_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
                     {{/each}}
                 </select>
                 <div class="dependent-settings-block">
-                    <label for="id_realm_move_messages_between_streams_limit_minutes" class="inline-block realm-time-limit-label">
-                        {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                    <label for="id_realm_move_messages_between_streams_limit_minutes" class="inline-block realm-time-limit-label settings-field-label">
+                        <span class="settings-field-label-text">{{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;</span>
                     </label>
                     <input type="text" id="id_realm_move_messages_between_streams_limit_minutes"
                       name="realm_move_messages_between_streams_limit_minutes"
@@ -254,7 +270,8 @@
 
                 <div class="input-group time-limit-setting">
                     <label for="realm_message_content_delete_limit_seconds" class="settings-field-label">
-                        {{t "Time limit for deleting messages" }} <i>({{t "does not apply to users who can delete any message" }})</i>
+                        <span class="settings-field-label-text">{{t "Time limit for deleting messages" }}
+                            <i>({{t "does not apply to users who can delete any message" }})</i></span>
                     </label>
                     <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                         {{#each msg_delete_limit_dropdown_values}}
@@ -262,8 +279,8 @@
                         {{/each}}
                     </select>
                     <div class="dependent-settings-block">
-                        <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
-                            {{t "Duration deletion is allowed after posting (minutes)" }}:
+                        <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label settings-field-label">
+                            <span class="settings-field-label-text">{{t "Duration deletion is allowed after posting (minutes)" }}:</span>
                         </label>
                         <input type="text" id="id_realm_message_content_delete_limit_minutes"
                           name="realm_message_content_delete_limit_minutes"
@@ -338,7 +355,9 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_bot_creation_policy" class="settings-field-label">{{t "Who can add bots" }}</label>
+                    <label for="realm_bot_creation_policy" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Who can add bots" }}</span>
+                    </label>
                     <select name="realm_bot_creation_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_bot_creation_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=bot_creation_policy_values}}
                     </select>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -16,7 +16,7 @@
                       prefix="id_"
                       is_checked=realm_invite_required
                       label=admin_settings_label.realm_invite_required}}
-                    <label for="realm_invite_to_realm_policy" class="settings-field-label">
+                    <label for="id_realm_invite_to_realm_policy" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Who can send email invitations to new users" }}</span>
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
@@ -29,7 +29,7 @@
                   label=(t 'Who can create reusable invitation links')}}
 
                 <div class="input-group">
-                    <label for="realm_org_join_restrictions" class="settings-field-label">
+                    <label for="id_realm_org_join_restrictions" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Restrict email domains of new users" }}</span>
                     </label>
                     <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="string">
@@ -45,7 +45,7 @@
                     </div>
                 </div>
                 <div class="input-group time-limit-setting">
-                    <label for="realm_waiting_period_threshold" class="settings-field-label">
+                    <label for="id_realm_waiting_period_threshold" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Waiting period before new members turn into full members" }}</span>
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
@@ -95,7 +95,7 @@
                   label=(t 'Who can create private channels')}}
 
                 <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="settings-field-label">
+                    <label for="id_realm_invite_to_stream_policy" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Who can add users to channels" }}</span>
                     </label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
@@ -103,7 +103,7 @@
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_wildcard_mention_policy" class="settings-field-label">
+                    <label for="id_realm_wildcard_mention_policy" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Who can notify a large number of users with a wildcard mention" }}</span>
                         {{> ../help_link_widget link="/help/restrict-wildcard-mentions" }}
                     </label>
@@ -170,7 +170,7 @@
                   label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_edit_limit_seconds" class="settings-field-label">
+                    <label for="id_realm_message_content_edit_limit_seconds" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Time limit for editing messages" }}</span>
                     </label>
                     <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
@@ -206,7 +206,7 @@
               label=(t 'Who can move messages to another topic')}}
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_within_stream_limit_seconds" class="settings-field-label">
+                <label for="id_realm_invite_to_realm_policyrealm_move_messages_within_stream_limit_seconds" class="settings-field-label">
                     <span class="settings-field-label-text">{{t "Time limit for editing topics" }}
                         <i>({{t "does not apply to moderators and administrators" }})</i></span>
                 </label>
@@ -231,7 +231,7 @@
               label=(t 'Who can move messages to another channel')}}
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_between_streams_limit_seconds" class="settings-field-label">
+                <label for="id_realm_move_messages_between_streams_limit_seconds" class="settings-field-label">
                     <span class="settings-field-label-text">{{t "Time limit for moving messages between channels" }}
                         <i>({{t "does not apply to moderators and administrators" }})</i></span>
                 </label>
@@ -269,7 +269,7 @@
                   label=(t 'Who can delete their own messages')}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_delete_limit_seconds" class="settings-field-label">
+                    <label for="id_realm_message_content_delete_limit_seconds" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Time limit for deleting messages" }}
                             <i>({{t "does not apply to users who can delete any message" }})</i></span>
                     </label>
@@ -355,7 +355,7 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_bot_creation_policy" class="settings-field-label">
+                    <label for="id_realm_bot_creation_policy" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Who can add bots" }}</span>
                     </label>
                     <select name="realm_bot_creation_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_bot_creation_policy" data-setting-widget-type="number">

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -20,7 +20,7 @@
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
-                    <label for="realm_org_type" class="settings-field-label">
+                    <label for="id_realm_org_type" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Organization type" }}</span>
                         {{> ../help_link_widget link="/help/organization-type" }}
                     </label>
@@ -36,7 +36,7 @@
                   label=admin_settings_label.realm_want_advertise_in_communities_directory
                   help_link="/help/communities-directory"}}
                 <div class="input-group admin-realm">
-                    <label for="realm_description" class="settings-field-label">
+                    <label for="id_realm_description" class="settings-field-label">
                         <span class="settings-field-label-text">{{t "Organization description" }}</span>
                     </label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element settings_textarea"

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -12,13 +12,16 @@
 
             <div class="organization-settings-parent">
                 <div class="input-group admin-realm">
-                    <label for="id_realm_name" class="settings-field-label">{{t "Organization name" }}</label>
+                    <label for="id_realm_name" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Organization name" }}</span>
+                    </label>
                     <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name setting-widget prop-element settings_text_input"
                       autocomplete="off" data-setting-widget-type="string"
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
-                    <label for="realm_org_type" class="settings-field-label">{{t "Organization type" }}
+                    <label for="realm_org_type" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Organization type" }}</span>
                         {{> ../help_link_widget link="/help/organization-type" }}
                     </label>
                     <select name="realm_org_type" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_org_type" data-setting-widget-type="number">
@@ -33,7 +36,9 @@
                   label=admin_settings_label.realm_want_advertise_in_communities_directory
                   help_link="/help/communities-directory"}}
                 <div class="input-group admin-realm">
-                    <label for="realm_description" class="settings-field-label">{{t "Organization description" }}</label>
+                    <label for="realm_description" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Organization description" }}</span>
+                    </label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element settings_textarea"
                       maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>
                 </div>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -113,7 +113,7 @@
             </div>
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
-                    <label for="realm_video_chat_provider" class="settings-field-label">
+                    <label for="id_realm_video_chat_provider" class="settings-field-label">
                         <span class="settings-field-label-text">{{t 'Call provider' }}</span>
                         {{> ../help_link_widget link="/help/start-a-call" }}
                     </label>
@@ -151,7 +151,7 @@
                     </div>
                 </div>
                 <div class="input-group">
-                    <label for="realm_giphy_rating" class="settings-field-label">
+                    <label for="id_realm_giphy_rating" class="settings-field-label">
                         <span class="settings-field-label-text">{{t 'GIPHY integration' }}</span>
                         {{> ../help_link_widget link=giphy_help_link }}
                     </label>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -50,7 +50,9 @@
                   label=admin_settings_label.realm_digest_emails_enabled}}
                 {{/if}}
                 <div class="input-group">
-                    <label for="realm_digest_weekday" class="settings-field-label">{{t "Day of the week to send digests" }}</label>
+                    <label for="realm_digest_weekday" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Day of the week to send digests" }}</span>
+                    </label>
                     <select name="realm_digest_weekday"
                       id="id_realm_digest_weekday"
                       class="setting-widget prop-element settings_select bootstrap-focus-style"
@@ -79,7 +81,8 @@
 
             <div class="inline-block organization-settings-parent">
                 <div class="input-group time-limit-setting">
-                    <label for="id_realm_message_retention_days" class="settings-field-label">{{t "Message retention period" }}
+                    <label for="id_realm_message_retention_days" class="settings-field-label">
+                        <span class="settings-field-label-text">{{t "Message retention period" }}</span>
                     </label>
                     <select name="realm_message_retention_days"
                       id="id_realm_message_retention_days" class="prop-element settings_select bootstrap-focus-style"
@@ -91,7 +94,7 @@
 
                     <div class="dependent-settings-block">
                         <label for="id_realm_message_retention_custom_input" class="inline-block realm-time-limit-label">
-                            {{t 'Retention period (days)' }}:
+                            <span class="settings-field-label-text">{{t 'Retention period (days)' }}</span>:
                         </label>
                         <input type="text" id="id_realm_message_retention_custom_input" autocomplete="off"
                           name="realm_message_retention_custom_input"
@@ -111,7 +114,7 @@
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
                     <label for="realm_video_chat_provider" class="settings-field-label">
-                        {{t 'Call provider' }}
+                        <span class="settings-field-label-text">{{t 'Call provider' }}</span>
                         {{> ../help_link_widget link="/help/start-a-call" }}
                     </label>
                     <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
@@ -123,7 +126,7 @@
                     <div class="dependent-settings-block" id="realm_jitsi_server_url_setting">
                         <div>
                             <label for="id_realm_jitsi_server_url" class="settings-field-label">
-                                {{t "Jitsi server URL" }}
+                                <span class="settings-field-label-text">{{t "Jitsi server URL" }}</span>
                                 {{> ../help_link_widget link="/help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet" }}
                             </label>
                             <select name="realm_jitsi_server_url" id="id_realm_jitsi_server_url" class="setting-widget prop-element settings_select bootstrap-focus-style" data-setting-widget-type="jitsi-server-url-setting">
@@ -149,7 +152,7 @@
                 </div>
                 <div class="input-group">
                     <label for="realm_giphy_rating" class="settings-field-label">
-                        {{t 'GIPHY integration' }}
+                        <span class="settings-field-label-text">{{t 'GIPHY integration' }}</span>
                         {{> ../help_link_widget link=giphy_help_link }}
                     </label>
                     <select name="realm_giphy_rating" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_giphy_rating" data-setting-widget-type="number" {{#if giphy_api_key_empty}}disabled{{/if}}>

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -44,7 +44,7 @@
                 <span class="settings-field-label-text">{{t "Who can access user's email address" }}</span>
                 {{> ../help_link_widget link="/help/configure-email-visibility" }}
             </label>
-            <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"
+            <select id="email_address_visibility" name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"
               id="realm_email_address_visibility">
                 {{> dropdown_options_widget option_values=email_address_visibility_values}}
             </select>

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -40,7 +40,8 @@
           help_link="/help/read-receipts"}}
 
         <div class="input-group">
-            <label for="email_address_visibility" class="settings-field-label">{{t "Who can access user's email address" }}
+            <label for="email_address_visibility" class="settings-field-label">
+                <span class="settings-field-label-text">{{t "Who can access user's email address" }}</span>
                 {{> ../help_link_widget link="/help/configure-email-visibility" }}
             </label>
             <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"

--- a/web/templates/settings/preferences_emoji.hbs
+++ b/web/templates/settings/preferences_emoji.hbs
@@ -5,7 +5,9 @@
     </div>
 
     <div class="input-group">
-        <label class="settings-field-label">{{t "Emoji theme" }}</label>
+        <label class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Emoji theme" }}</span>
+        </label>
         <div class="emojiset_choices grey-box prop-element" id="{{prefix}}emojiset" data-setting-widget-type="radio-group" data-setting-choice-type="string">
             {{#each settings_object.emojiset_choices}}
                 <label class="preferences-radio-choice-label">

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -14,7 +14,7 @@
     {{/unless}}
 
     <div class="input-group">
-        <label for="twenty_four_hour_time" class="settings-field-label">
+        <label for="{{prefix}}twenty_four_hour_time" class="settings-field-label">
             <span class="settings-field-label-text">{{ settings_label.twenty_four_hour_time }}</span>
         </label>
         <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style" id="{{prefix}}twenty_four_hour_time" data-setting-widget-type="string">
@@ -24,7 +24,7 @@
         </select>
     </div>
     <div class="input-group">
-        <label for="color_scheme" class="settings-field-label">
+        <label for="{{prefix}}color_scheme" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Theme" }}</span>
         </label>
         <select name="color_scheme" class="setting_color_scheme prop-element settings_select bootstrap-focus-style" id="{{prefix}}color_scheme" data-setting-widget-type="number">

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -14,7 +14,9 @@
     {{/unless}}
 
     <div class="input-group">
-        <label for="twenty_four_hour_time" class="settings-field-label">{{ settings_label.twenty_four_hour_time }}</label>
+        <label for="twenty_four_hour_time" class="settings-field-label">
+            <span class="settings-field-label-text">{{ settings_label.twenty_four_hour_time }}</span>
+        </label>
         <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style" id="{{prefix}}twenty_four_hour_time" data-setting-widget-type="string">
             {{#each twenty_four_hour_time_values}}
                 <option value='{{ this.value }}'>{{ this.description }}</option>
@@ -22,7 +24,9 @@
         </select>
     </div>
     <div class="input-group">
-        <label for="color_scheme" class="settings-field-label">{{t "Theme" }}</label>
+        <label for="color_scheme" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Theme" }}</span>
+        </label>
         <select name="color_scheme" class="setting_color_scheme prop-element settings_select bootstrap-focus-style" id="{{prefix}}color_scheme" data-setting-widget-type="number">
             {{> dropdown_options_widget option_values=color_scheme_values}}
         </select>

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -5,7 +5,9 @@
     </div>
 
     <div class="input-group">
-        <label class="settings-field-label">{{t "User list style" }}</label>
+        <label class="settings-field-label">
+            <span class="settings-field-label-text">{{t "User list style" }}</span>
+        </label>
         <div class="user_list_style_values grey-box prop-element" id="{{prefix}}user_list_style" data-setting-widget-type="radio-group" data-setting-choice-type="number">
             {{#each user_list_style_values}}
                 <label class="preferences-radio-choice-label">
@@ -50,14 +52,18 @@
     </div>
 
     <div class="input-group thinner setting-next-is-related">
-        <label for="web_animate_image_previews" class="settings-field-label">{{t "Play animated images" }}</label>
+        <label for="web_animate_image_previews" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Play animated images" }}</span>
+        </label>
         <select name="web_animate_image_previews" class="setting_web_animate_image_previews prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_animate_image_previews" data-setting-widget-type="string">
             {{> dropdown_options_widget option_values=web_animate_image_previews_values}}
         </select>
     </div>
 
     <div class="input-group">
-        <label for="web_stream_unreads_count_display_policy" class="settings-field-label">{{t "Show unread counts for" }}</label>
+        <label for="web_stream_unreads_count_display_policy" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Show unread counts for" }}</span>
+        </label>
         <select name="web_stream_unreads_count_display_policy" class="setting_web_stream_unreads_count_display_policy prop-element bootstrap-focus-style settings_select" id="{{prefix}}web_stream_unreads_count_display_policy"  data-setting-widget-type="number">
             {{> dropdown_options_widget option_values=web_stream_unreads_count_display_policy_values}}
         </select>
@@ -73,7 +79,8 @@
     {{/each}}
 
     <div class="input-group">
-        <label for="demote_inactive_streams" class="settings-field-label">{{t "Demote inactive channels" }}
+        <label for="demote_inactive_streams" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Demote inactive channels" }}</span>
             {{> ../help_link_widget link="/help/manage-inactive-channels" }}
         </label>
         <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element settings_select bootstrap-focus-style" id="{{prefix}}demote_inactive_streams"  data-setting-widget-type="number">

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -52,7 +52,7 @@
     </div>
 
     <div class="input-group thinner setting-next-is-related">
-        <label for="web_animate_image_previews" class="settings-field-label">
+        <label for="{{prefix}}web_animate_image_previews" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Play animated images" }}</span>
         </label>
         <select name="web_animate_image_previews" class="setting_web_animate_image_previews prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_animate_image_previews" data-setting-widget-type="string">
@@ -61,7 +61,7 @@
     </div>
 
     <div class="input-group">
-        <label for="web_stream_unreads_count_display_policy" class="settings-field-label">
+        <label for="{{prefix}}web_stream_unreads_count_display_policy" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Show unread counts for" }}</span>
         </label>
         <select name="web_stream_unreads_count_display_policy" class="setting_web_stream_unreads_count_display_policy prop-element bootstrap-focus-style settings_select" id="{{prefix}}web_stream_unreads_count_display_policy"  data-setting-widget-type="number">
@@ -79,7 +79,7 @@
     {{/each}}
 
     <div class="input-group">
-        <label for="demote_inactive_streams" class="settings-field-label">
+        <label for="{{prefix}}demote_inactive_streams" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Demote inactive channels" }}</span>
             {{> ../help_link_widget link="/help/manage-inactive-channels" }}
         </label>

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -5,7 +5,8 @@
     </div>
 
     <div class="input-group thinner setting-next-is-related">
-        <label for="web_home_view" class="settings-field-label">{{t "Home view" }}
+        <label for="web_home_view" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Home view" }}</span>
             {{> ../help_link_widget link="/help/configure-home-view" }}
         </label>
         <select name="web_home_view" class="setting_web_home_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_home_view" data-setting-widget-type="string">
@@ -26,7 +27,8 @@
       prefix=prefix}}
 
     <div class="input-group">
-        <label for="web_mark_read_on_scroll_policy" class="settings-field-label">{{t "Automatically mark messages as read" }}
+        <label for="web_mark_read_on_scroll_policy" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Automatically mark messages as read" }}</span>
             {{> ../help_link_widget link="/help/marking-messages-as-read" }}
         </label>
         <select name="web_mark_read_on_scroll_policy" class="setting_web_mark_read_on_scroll_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_mark_read_on_scroll_policy"  data-setting-widget-type="number">
@@ -35,7 +37,9 @@
     </div>
 
     <div class="input-group">
-        <label for="web_channel_default_view" class="settings-field-label">{{t "Channel links in the left sidebar go to" }}</label>
+        <label for="web_channel_default_view" class="settings-field-label">
+            <span class="settings-field-label-text">{{t "Channel links in the left sidebar go to" }}</span>
+        </label>
         <select name="web_channel_default_view" class="setting_web_channel_default_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_channel_default_view"  data-setting-widget-type="number">
             {{> dropdown_options_widget option_values=web_channel_default_view_values}}
         </select>

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -5,7 +5,7 @@
     </div>
 
     <div class="input-group thinner setting-next-is-related">
-        <label for="web_home_view" class="settings-field-label">
+        <label for="{{prefix}}web_home_view" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Home view" }}</span>
             {{> ../help_link_widget link="/help/configure-home-view" }}
         </label>
@@ -27,7 +27,7 @@
       prefix=prefix}}
 
     <div class="input-group">
-        <label for="web_mark_read_on_scroll_policy" class="settings-field-label">
+        <label for="{{prefix}}web_mark_read_on_scroll_policy" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Automatically mark messages as read" }}</span>
             {{> ../help_link_widget link="/help/marking-messages-as-read" }}
         </label>
@@ -37,7 +37,7 @@
     </div>
 
     <div class="input-group">
-        <label for="web_channel_default_view" class="settings-field-label">
+        <label for="{{prefix}}web_channel_default_view" class="settings-field-label">
             <span class="settings-field-label-text">{{t "Channel links in the left sidebar go to" }}</span>
         </label>
         <select name="web_channel_default_view" class="setting_web_channel_default_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_channel_default_view"  data-setting-widget-type="number">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -6,7 +6,9 @@
                 <div class="full-name-change-container">
                     <div class="input-group inline-block grid user-name-parent">
                         <div class="user-name-section inline-block">
-                            <label for="full_name" class="settings-field-label inline-block">{{t "Name" }}</label>
+                            <label for="full_name" class="settings-field-label inline-block">
+                                <span class="settings-field-label-text">{{t "Name" }}</span>
+                            </label>
                             <div class="alert-notification full-name-status"></div>
                             <div class="settings-profile-user-field-hint">{{t "How your account is displayed in Zulip." }}</div>
                             <div id="full_name_input_container" {{#unless user_can_change_name}}class="disabled_setting_tooltip"{{/unless}}>
@@ -18,7 +20,9 @@
 
                 <form class="timezone-setting-form">
                     <div class="input-group grid">
-                        <label for="timezone" class="settings-field-label inline-block">{{t "Time zone" }}</label>
+                        <label for="timezone" class="settings-field-label inline-block">
+                            <span class="settings-field-label-text">{{t "Time zone" }}</span>
+                        </label>
                         <div class="alert-notification timezone-setting-status"></div>
                         <div class="timezone-input">
                             <select name="timezone" id="user_timezone" class="bootstrap-focus-style settings_select">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -20,7 +20,7 @@
 
                 <form class="timezone-setting-form">
                     <div class="input-group grid">
-                        <label for="timezone" class="settings-field-label inline-block">
+                        <label for="user_timezone" class="settings-field-label inline-block">
                             <span class="settings-field-label-text">{{t "Time zone" }}</span>
                         </label>
                         <div class="alert-notification timezone-setting-status"></div>

--- a/web/templates/start_export_modal.hbs
+++ b/web/templates/start_export_modal.hbs
@@ -12,7 +12,9 @@
 </p>
 <form id="start-export-form">
     <div class="input-group">
-        <label for="export_type" class="modal-field-label">{{t "Export type" }}</label>
+        <label for="export_type" class="modal-field-label">
+            <span class="modal-field-label-text">{{t "Export type" }}</span>
+        </label>
         <select id="export_type" class="modal_select bootstrap-focus-style">
             {{#each export_type_values}}
                 <option {{#if this.default }}selected{{/if}} value="{{this.value}}">{{this.description}}</option>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -7,8 +7,8 @@
             <div class="stream-creation-body">
                 <div class="configure_channel_settings stream_creation_container">
                     <section id="create_stream_title_container">
-                        <label for="create_stream_name">
-                            {{t "Channel name" }}
+                        <label for="create_stream_name" class="settings-field-label">
+                            <span class="settings-field-label-text">{{t "Channel name" }}</span>
                         </label>
                         <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
                           placeholder="{{t 'Channel name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
@@ -17,7 +17,7 @@
                     </section>
                     <section id="create_stream_description_container">
                         <label for="create_stream_description" class="settings-field-label">
-                            {{t "Channel description" }}
+                            <span class="settings-field-label-text">{{t "Channel description" }}</span>
                             {{> ../help_link_widget link="/help/change-the-channel-description" }}
                         </label>
                         <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -54,7 +54,8 @@
     <div class="advanced-configurations-collapase-view hide">
 
         <div class="input-group">
-            <label class="dropdown-title">{{t 'Who can post to this channel'}}
+            <label class="dropdown-title settings-field-label" for="id_stream_post_policy">
+                <span class="settings-field-label-text">{{t 'Who can post to this channel'}}</span>
                 {{> ../help_link_widget link="/help/stream-sending-policy" }}
             </label>
             <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="id_stream_post_policy" data-setting-widget-type="number">
@@ -74,7 +75,8 @@
         {{#if (or is_owner is_stream_edit)}}
             <div>
                 <div class="input-group inline-block message-retention-setting-group time-limit-setting">
-                    <label class="dropdown-title">{{t "Message retention period" }}
+                    <label class="dropdown-title settings-field-label" for="id_message_retention_days">
+                        <span class="settings-field-label-text">{{t "Message retention period" }}</span>
                         {{> ../help_link_widget link="/help/message-retention-policy" }}
                     </label>
 

--- a/web/templates/user_group_settings/group_permissions.hbs
+++ b/web/templates/user_group_settings/group_permissions.hbs
@@ -1,5 +1,7 @@
 <div class="input-group can-manage-group-container">
-    <label class="group-setting-label">{{t "Who can administer this group" }}</label>
+    <label class="group-setting-label">
+        <span class="group-setting-label-text">{{t "Who can manage this group" }}</span>
+    </label>
     <div class="pill-container person_picker prop-element" id="id_{{can_manage_group_widget_name}}" data-setting-widget-type="group-setting-type">
         <div class="input" contenteditable="true"
           data-placeholder="{{t 'Add roles, groups or users' }}">
@@ -9,7 +11,9 @@
 </div>
 
 <div class="input-group can-mention-group-container">
-    <label class="group-setting-label">{{t "Who can mention this group" }}</label>
+    <label class="group-setting-label">
+        <span class="group-setting-label-text">{{t "Who can mention this group" }}</span>
+    </label>
     <div class="pill-container person_picker prop-element" id="id_{{can_mention_group_widget_name}}" data-setting-widget-type="group-setting-type">
         <div class="input" contenteditable="true"
           data-placeholder="{{t 'Add roles, groups or users' }}">
@@ -19,7 +23,9 @@
 </div>
 
 <div class="input-group can-add-members-group-container">
-    <label class="group-setting-label">{{t "Who can add members to this group" }}</label>
+    <label class="group-setting-label">
+        <span class="group-setting-label-text">{{t "Who can add members to this group" }}</span>
+    </label>
     <div class="pill-container person_picker prop-element" id="id_{{can_add_members_group_widget_name}}" data-setting-widget-type="group-setting-type">
         <div class="input" contenteditable="true"
           data-placeholder="{{t 'Add roles, groups or users' }}">
@@ -29,7 +35,9 @@
 </div>
 
 <div class="input-group can-join-group-container">
-    <label class="group-setting-label">{{t "Who can join this group" }}</label>
+    <label class="group-setting-label">
+        <span class="group-setting-label-text">{{t "Who can join this group" }}</span>
+    </label>
     <div class="pill-container person_picker prop-element" id="id_{{can_join_group_widget_name}}" data-setting-widget-type="group-setting-type">
         <div class="input" contenteditable="true"
           data-placeholder="{{t 'Add roles, groups or users' }}">
@@ -39,7 +47,9 @@
 </div>
 
 <div class="input-group can-leave-group-container">
-    <label class="group-setting-label">{{t "Who can leave this group" }}</label>
+    <label class="group-setting-label">
+        <span class="group-setting-label-text">{{t "Who can leave this group" }}</span>
+    </label>
     <div class="pill-container person_picker prop-element" id="id_{{can_leave_group_widget_name}}" data-setting-widget-type="group-setting-type">
         <div class="input" contenteditable="true"
           data-placeholder="{{t 'Add roles, groups or users' }}">

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -8,7 +8,7 @@
                 <div class="configure_user_group_settings user_group_creation">
                     <section id="user-group-name-container">
                         <label for="create_user_group_name" class="settings-field-label">
-                            {{t "User group name" }}
+                            <span class="settings-field-label-text">{{t "User group name" }}</span>
                         </label>
                         <input type="text" name="user_group_name" id="create_user_group_name" class="settings_text_input"
                           placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="{{ max_user_group_name_length }}"/>
@@ -16,7 +16,7 @@
                     </section>
                     <section id="user-group-description-container">
                         <label for="create_user_group_description" class="settings-field-label">
-                            {{t "User group description" }}
+                            <span class="settings-field-label-text">{{t "User group description" }}</span>
                         </label>
                         <input type="text" name="user_group_description" id="create_user_group_description" class="settings_text_input"
                           placeholder="{{t 'User group description' }}" value="" autocomplete="off" />


### PR DESCRIPTION
This PR addresses an issue in the settings menu where several labels and headings display a pointer cursor, suggesting they are clickable, even though they do not have any click interactions. As noted by @alya , this can be misleading for users.

## **Areas Updated:**

1. Channel Settings:

   - Create Channel > General Configurations
   - Create Channel > Advanced Configurations
   
2. Organization Settings:

   - Organization Profile
   - Organization Settings
   - Organization Permissions
   - Custom Emoji
   - Bots
   - Custom Profile Fields
   - Default User Settings
   - Data Exports
   
3. Group Settings:

   - Create User Group > General Settings
   - Create User Group > Group Permissions
   
4. Personal Settings:

    - Profile
    - Account & Privacy
    - Preferences
    - Notifications
    - Bots
    - Alert Words


## **Screen Captures and Screenshots**

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<th>
Cursor: Pointer and no focus
</th>
<th>
Cursor: Text and focus on click
</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/57e0fa90-0dd2-41d5-8194-f37be796c1ee">
</td>
<td>
<img src="https://github.com/user-attachments/assets/b860dd19-eaa9-4a8a-9bf2-a8b7ca644002">
</td>
</tr>
</table>

Fixes: #21769 

[Old CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/disabled.20checkbox.20label.20cursor)
[Recent CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/muted.20channel.20-.20personal.20settings.20notification.20checkboxes)

> **Note:**
In the Personal Settings > Profile section, we have multiple input and select elements with a single label for all of them. With the new approach of fixing the for and id attributes, everything works fine and as expected, except for the birthday and mentor inputs. These inputs have a div element that doesn't show any interaction with the label.

<img src="https://github.com/user-attachments/assets/2e22d16f-1e9a-4f3d-9657-1cb160a97a9a" width="400px">

Unlike PR #31306, this PR updates cursor: pointer to cursor: text. 
There are some labels which were not included in #31306. Now, all the places where the corresponding input or select elements did not get focused when clicking on the label are correctly focused upon clicking the label.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ x [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
