### PR TITLE
stream_create: Fix puppeteer test flake from modal reopening.

### DIFF
--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -96,11 +96,19 @@ async function create_stream(page: Page): Promise<void> {
     await common.wait_for_micromodal_to_open(page);
     await page.click(".dialog_submit_button");
     await common.wait_for_micromodal_to_close(page);
+
+    // We redirect to the channel message view.
+    await page.waitForSelector("#subscription_overlay", {hidden: true});
+    await page.waitForSelector(
+        `xpath///*[${common.has_class_x("message-header-navbar-title")} and text()="Puppeteer"]`,
+    );
+
     await page.waitForSelector(".message-header-stream-settings-button");
     await page.click(".message-header-stream-settings-button");
     await page.waitForSelector(".stream_section");
     await page.waitForSelector(
-        `xpath///*[${common.has_class_x("stream-name")} and text()="Puppeteer"]`,
+        `xpath///*[${common.has_class_x("stream-name-title")} and text()="Puppeteer"]`,
+        {visible: true},
     );
     const stream_name = await common.get_text_from_selector(
         page,


### PR DESCRIPTION
In 245357c86800e5a2ceb418d1d56d2c6cd80ba791 we added a redirect after stream creation, to go to the stream feed. The puppeteer tests weren't updated, so sometimes it was able to run as before and pass before the redirect took place and sometimes it didn't. This commit updates the test to work with the new redirect.