### PR TITLE
buddy_list: Tweak spacing of rows, line-height, and circle placement.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -276,7 +276,7 @@
        the smaller line-height. */
     --line-height-sidebar-row-prominent: 1.7142em; /* 24px / 14px em */
     --line-height-sidebar-row: 1.5714em; /* 22px / 14px em */
-    --line-height-sidebar-row-with-avatars: 1.2857em; /* 18px / 14px em */
+    --line-height-sidebar-row-with-avatars: 1.3571em; /* 19px / 14px em */
 
     /* Right sidebar */
     --right-sidebar-padding-right: 8px;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -168,10 +168,10 @@ $user_status_emoji_width: 24px;
     .user_sidebar_entry.with_avatar .user_circle {
         display: inline-block;
         position: absolute;
-        width: 0.4em;
-        height: 0.4em;
-        top: 1.6em;
-        left: 1.6em;
+        width: 0.5em;
+        height: 0.5em;
+        top: 1.7em;
+        left: 1.7em;
 
         &.user_circle_idle {
             background: linear-gradient(
@@ -273,7 +273,7 @@ $user_status_emoji_width: 24px;
         );
 
     .selectable_sidebar_block {
-        margin: 2px;
+        margin: 4px;
     }
 
     .unread_count:not(.hide) {


### PR DESCRIPTION
This commit adds more space between rows, increases the line height so that the status message doesn't touch the status emoji, and makes the status circle a little bigger.

Note this doesn't address the issue of sometimes having wonky circle spacing on non-Firefox browsers.

before:

<img width="261" alt="image" src="https://github.com/user-attachments/assets/587db936-cbd5-44a6-9604-65ff6542f502">

after:

<img width="257" alt="image" src="https://github.com/user-attachments/assets/bce84c51-fe8b-4c33-a489-26122a6d537d">