### PR TITLE
unread_count: Increase prominence of quiet unreads.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -623,6 +623,25 @@ input.settings_text_input {
     color: hsl(0deg 0% 100%);
 }
 
+/* Unread-count attention levels. */
+
+.prominent-count {
+    background-color: var(--color-background-unread-counter-prominent);
+    color: var(--color-unread-counter-prominent);
+}
+
+.normal-count {
+    background-color: var(--color-background-unread-counter-normal);
+    color: var(--color-unread-counter-normal);
+    box-shadow: var(--box-shadow-unread-counter-normal);
+}
+
+.quiet-count {
+    background-color: var(--color-background-unread-counter-quiet);
+    color: var(--color-unread-counter-quiet);
+    font-weight: 475;
+}
+
 .unread_mention_info:not(:empty) {
     margin-right: 5px;
     margin-left: 2px;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1177,7 +1177,7 @@
     --color-background-unread-counter-quiet: transparent;
     --color-unread-counter-prominent: hsl(0deg 0% 100%);
     --color-unread-counter-normal: hsl(0deg 0% 100% / 85%);
-    --color-unread-counter-quiet: hsl(240deg 15% 60%);
+    --color-unread-counter-quiet: hsl(240deg 15% 65%);
     /* Legacy unread-counter color value. */
     --color-background-unread-counter: var(
         --color-background-unread-counter-prominent

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1151,8 +1151,6 @@ textarea.new_message_textarea {
 
     .unread_count {
         margin: 1px 0 0 6px;
-        background-color: var(--color-background-unread-counter-quiet);
-        color: var(--color-unread-counter-quiet);
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -694,14 +694,6 @@ li.active-sub-filter {
     }
 }
 
-.top_left_starred_messages .unread_count,
-.top_left_drafts .unread_count,
-.top_left_scheduled_messages .unread_count,
-.condensed-views-popover-menu .unread_count {
-    background-color: var(--color-background-unread-counter-quiet);
-    color: var(--color-unread-counter-quiet);
-}
-
 /* Don't show unread counts on views... */
 .top_left_my_reactions,
 .top_left_inbox,

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -42,7 +42,7 @@
                         <span class="filter-icon">
                             <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
                         </span>
-                        <span class="unread_count"></span>
+                        <span class="unread_count quiet-count"></span>
                     </a>
                 </li>
             </ul>
@@ -115,7 +115,7 @@
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>
-                    <span class="unread_count"></span>
+                    <span class="unread_count quiet-count"></span>
                     <span class="masked_unread_count">
                         <i class="zulip-icon zulip-icon-masked-unread"></i>
                     </span>
@@ -129,7 +129,7 @@
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Drafts' }}</span>
-                    <span class="unread_count"></span>
+                    <span class="unread_count quiet-count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
@@ -140,7 +140,7 @@
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Scheduled messages' }}</span>
-                    <span class="unread_count"></span>
+                    <span class="unread_count quiet-count"></span>
                 </a>
             </li>
         </ul>

--- a/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs
@@ -11,7 +11,7 @@
                 <i class="popover-menu-icon zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
                 <span class="label-and-unread-wrapper">
                     <span class="popover-menu-label">{{t 'Drafts' }}</span>
-                    <span class="unread_count"></span>
+                    <span class="unread_count quiet-count"></span>
                 </span>
             </a>
         </li>
@@ -21,7 +21,7 @@
                 <i class="popover-menu-icon zulip-icon zulip-icon-calendar-days" aria-hidden="true"></i>
                 <span class="label-and-unread-wrapper">
                     <span class="popover-menu-label">{{t 'Scheduled messages' }}</span>
-                    <span class="unread_count"></span>
+                    <span class="unread_count quiet-count"></span>
                 </span>
             </a>
         </li>

--- a/web/templates/popovers/send_later_popover.hbs
+++ b/web/templates/popovers/send_later_popover.hbs
@@ -64,7 +64,7 @@
             <a href="#drafts" role="menuitem" class="view_contextual_drafts popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-drafts" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "View drafts" }}</span>
-                <span class="compose-drafts-count-container"><span class="unread_count compose-drafts-count"></span></span>
+                <span class="compose-drafts-count-container"><span class="unread_count quiet-count compose-drafts-count"></span></span>
             </a>
         </li>
         <li role="separator" class="popover-menu-separator"></li>


### PR DESCRIPTION
In addition to upping the font weight in light and dark modes, this PR begins introducing new classes for different counter attention-levels, but only the quiet class is introduced on those elements that currently show a quiet count (Starred, Drafts, and Scheduled messages).

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/Starred.20messages.20counter.20in.20dark.20mode.20not.20very.20visible/near/1977477)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![quiet-count-light-before](https://github.com/user-attachments/assets/dffc3f50-ce54-4853-8dba-e037474fcde4) | ![quiet-count-light-after](https://github.com/user-attachments/assets/dc732a0d-58cf-4825-bde7-ae2aa8f1838b) |
| ![quiet-count-dark-before](https://github.com/user-attachments/assets/7bc0308e-3e63-4578-93ea-f8197cd84e9d) | ![quiet-count-dark-after](https://github.com/user-attachments/assets/ed898f67-3a08-4a54-bab6-5a0740946873) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>