### PR TITLE
message_feed: Add channel settings link and remove Subscribe/Unsubscribe buttons.

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -437,6 +437,7 @@ export class MessageList {
         }
 
         this.view.render_trailing_bookend(
+            stream_id,
             sub?.name,
             subscribed,
             deactivated,

--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -430,8 +430,6 @@ export class MessageList {
         const subscribed = stream_data.is_subscribed(stream_id);
         const invite_only = sub?.invite_only;
         const is_web_public = sub?.is_web_public;
-        const can_toggle_subscription =
-            sub !== undefined && stream_data.can_toggle_subscription(sub);
         if (sub === undefined || sub.is_archived) {
             deactivated = true;
         } else if (!subscribed && !this.last_message_historical) {
@@ -443,7 +441,6 @@ export class MessageList {
             subscribed,
             deactivated,
             just_unsubscribed,
-            can_toggle_subscription,
             page_params.is_spectator,
             invite_only ?? false,
             is_web_public ?? false,

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1953,7 +1953,6 @@ export class MessageListView {
         subscribed: boolean,
         deactivated: boolean,
         just_unsubscribed: boolean,
-        can_toggle_subscription: boolean,
         is_spectator: boolean,
         invite_only: boolean,
         is_web_public: boolean,
@@ -1963,7 +1962,6 @@ export class MessageListView {
         const $rendered_trailing_bookend = $(
             render_bookend({
                 stream_name,
-                can_toggle_subscription,
                 subscribed,
                 deactivated,
                 just_unsubscribed,

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1949,6 +1949,7 @@ export class MessageListView {
     }
 
     render_trailing_bookend(
+        stream_id: number,
         stream_name: string | undefined,
         subscribed: boolean,
         deactivated: boolean,
@@ -1961,6 +1962,7 @@ export class MessageListView {
         // partial in message_group.hbs, which do not set is_trailing_bookend.
         const $rendered_trailing_bookend = $(
             render_bookend({
+                stream_id,
                 stream_name,
                 subscribed,
                 deactivated,

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -10,13 +10,15 @@
                 {{t "This channel has been archived." }}
             {{else if subscribed }}
                 {{#tr}}
-                    You subscribed to <z-stream-name></z-stream-name>.
+                    You subscribed to <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
+                    {{#*inline "channel-settings-link"}} <a href="#channels/{{stream_id}}/{{stream_name}}/personal">{{t 'Manage channel settings'}}</a>{{/inline}}
                 {{/tr}}
             {{else if just_unsubscribed }}
                 {{#tr}}
-                    You unsubscribed from <z-stream-name></z-stream-name>.
+                    You unsubscribed from <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
                     {{#*inline "z-stream-name"}}{{> stream_privacy }} {{stream_name}}{{/inline}}
+                    {{#*inline "channel-settings-link"}} <a href="#channels/{{stream_id}}/{{stream_name}}/general">{{t 'View in channel settings'}}</a>{{/inline}}
                 {{/tr}}
             {{else}}
                 {{#tr}}

--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -26,15 +26,4 @@
             {{/if}}
         </span>
     {{/if}}
-    {{#if can_toggle_subscription}}
-    <div class="sub_button_row">
-        <button class="button white rounded stream_sub_unsub_button {{#unless subscribed}}sea-green{{/unless}}" type="button" name="subscription">
-            {{#if subscribed}}
-            {{t 'Unsubscribe' }}
-            {{else}}
-            {{t 'Subscribe' }}
-            {{/if}}
-        </button>
-    </div>
-    {{/if}}
 </div>

--- a/web/tests/message_list.test.cjs
+++ b/web/tests/message_list.test.cjs
@@ -359,7 +359,6 @@ run_test("bookend", ({override}) => {
 
     override(stream_data, "is_subscribed", () => is_subscribed);
     override(stream_data, "get_sub_by_id", () => ({invite_only, name: "IceCream"}));
-    override(stream_data, "can_toggle_subscription", () => true);
 
     {
         const stub = make_stub();

--- a/web/tests/message_list.test.cjs
+++ b/web/tests/message_list.test.cjs
@@ -366,11 +366,13 @@ run_test("bookend", ({override}) => {
         list.update_trailing_bookend();
         assert.equal(stub.num_calls, 1);
         const bookend = stub.get_args(
+            "stream_id",
             "stream_name",
             "subscribed",
             "deactivated",
             "just_unsubscribed",
         );
+        assert.equal(bookend.stream_id, 5);
         assert.equal(bookend.stream_name, "IceCream");
         assert.equal(bookend.subscribed, true);
         assert.equal(bookend.deactivated, false);
@@ -386,11 +388,13 @@ run_test("bookend", ({override}) => {
         list.update_trailing_bookend();
         assert.equal(stub.num_calls, 1);
         const bookend = stub.get_args(
+            "stream_id",
             "stream_name",
             "subscribed",
             "deactivated",
             "just_unsubscribed",
         );
+        assert.equal(bookend.stream_id, 5);
         assert.equal(bookend.stream_name, "IceCream");
         assert.equal(bookend.subscribed, false);
         assert.equal(bookend.deactivated, false);
@@ -406,11 +410,13 @@ run_test("bookend", ({override}) => {
         list.update_trailing_bookend();
         assert.equal(stub.num_calls, 1);
         const bookend = stub.get_args(
+            "stream_id",
             "stream_name",
             "subscribed",
             "deactivated",
             "just_unsubscribed",
         );
+        assert.equal(bookend.stream_id, 5);
         assert.equal(bookend.stream_name, "IceCream");
         assert.equal(bookend.subscribed, false);
         assert.equal(bookend.deactivated, false);
@@ -425,11 +431,13 @@ run_test("bookend", ({override}) => {
         list.update_trailing_bookend();
         assert.equal(stub.num_calls, 1);
         const bookend = stub.get_args(
+            "stream_id",
             "stream_name",
             "subscribed",
             "deactivated",
             "just_unsubscribed",
         );
+        assert.equal(bookend.stream_id, 5);
         assert.equal(bookend.stream_name, "IceCream");
         assert.equal(bookend.subscribed, false);
         assert.equal(bookend.deactivated, false);


### PR DESCRIPTION
This PR removes the Subscribe and Unsubscribe buttons from the message feed and adds links to either view channel settings (if not subscribed) or manage channel settings (if subscribed) in the bottom divider.

Fixes: #32125 

<details>
<summary>UI Changes</summary>

| Before | After |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/d2cdba99-9fd4-4def-93dc-366b3db8d9c0) | ![After Image](https://github.com/user-attachments/assets/3c62af51-115e-45ae-a3a8-26e051fad114) |
| ![Before Image](https://github.com/user-attachments/assets/b8855bfe-0b22-4c03-a2d0-34abacc44120) | ![After Image](https://github.com/user-attachments/assets/40f706cb-4adb-460d-a124-28a26b3e77e3) |
</details>

#### Demo Video

https://github.com/user-attachments/assets/208b55a4-9491-4388-9425-49a7c506232b

<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
