### PR TITLE
ui: Add text line to change email model.

### DIFF
--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,5 @@
 <form id="change_email_form">
+    <p>{{t "You will receive a confirmation email at the new address you enter."}}</p>
     <label for="email" class="modal-field-label">{{t "New email" }}</label>
     <input type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>


### PR DESCRIPTION
Fixes part of #31975

This PR is made to fix the part of #31975.
To make it easy for the user, it was required to add a line explaining the flow at the top of the change_email_model.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**
Before changes - 
![Screenshot from 2024-11-08 14-55-12](https://github.com/user-attachments/assets/c53e4e0f-f2ef-4f0f-92cb-e4e6780efe96)


After Changes - 
![Screenshot from 2024-11-08 14-25-30](https://github.com/user-attachments/assets/a259167e-1e98-462f-8228-cce4eda1c8e3)

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
Completed manual review and testing of the following:
- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
