### PR TITLE
svgicons2svgfont: Patch to fix Node 22 punycode DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     },
     "patchedDependencies": {
       "source-sans@3.46.0": "patches/source-sans@3.46.0.patch",
+      "svgicons2svgfont": "patches/svgicons2svgfont.patch",
       "tippy.js@6.3.7": "patches/tippy.js@6.3.7.patch"
     }
   },

--- a/patches/svgicons2svgfont.patch
+++ b/patches/svgicons2svgfont.patch
@@ -1,0 +1,27 @@
+diff --git a/src/index.js b/src/index.js
+index ae8106081908e6ef98ebac640b506d8dbc34d00e..6ab77b98e9d7ab69d7addab4586512a380f464c7 100755
+--- a/src/index.js
++++ b/src/index.js
+@@ -3,7 +3,6 @@
+ 
+ 'use strict';
+ 
+-const { ucs2 } = require('punycode');
+ const { Transform } = require('stream');
+ const Sax = require('sax');
+ const { SVGPathData } = require('svg-pathdata');
+@@ -479,9 +478,11 @@ class SVGIcons2SVGFontStream extends Transform {
+       delete glyph.paths;
+       const d = glyphPath.round(this._options.round).encode();
+       glyph.unicode.forEach((unicode, i) => {
+-        const unicodeStr = ucs2
+-          .decode(unicode)
+-          .map((point) => '&#x' + point.toString(16).toUpperCase() + ';')
++        const unicodeStr = [...unicode]
++          .map(
++            (char) =>
++              '&#x' + char.codePointAt(0).toString(16).toUpperCase() + ';',
++          )
+           .join('');
+ 
+         this.push(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ patchedDependencies:
   source-sans@3.46.0:
     hash: 4n7ij66tzyhzaqnxsenbilrxr4
     path: patches/source-sans@3.46.0.patch
+  svgicons2svgfont:
+    hash: d4mkid5oxxg6zfe7zsae2cikn4
+    path: patches/svgicons2svgfont.patch
   tippy.js@6.3.7:
     hash: mlbmk5pq4q6iuwarqu6solgeeq
     path: patches/tippy.js@6.3.7.patch
@@ -11614,7 +11617,7 @@ snapshots:
       mkdirp: 1.0.4
       q: 1.5.1
       svg2ttf: 6.0.3
-      svgicons2svgfont: 10.0.6
+      svgicons2svgfont: 10.0.6(patch_hash=d4mkid5oxxg6zfe7zsae2cikn4)
       ttf2eot: 3.1.0
       ttf2woff: 3.0.0
       ttf2woff2: 4.0.5
@@ -18390,7 +18393,7 @@ snapshots:
       microbuffer: 1.0.0
       svgpath: 2.6.0
 
-  svgicons2svgfont@10.0.6:
+  svgicons2svgfont@10.0.6(patch_hash=d4mkid5oxxg6zfe7zsae2cikn4):
     dependencies:
       commander: 7.2.0
       geometry-interfaces: 1.1.4

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 319  # Last bumped for message-link class
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (299, 0)  # bumped 2024-11-08 to remove babel-plugin-rewire-ts
+PROVISION_VERSION = (299, 1)  # bumped 2024-11-08 to patch svgicons2svgfont


### PR DESCRIPTION
```
(node:13734) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

- nfroidure/svgicons2svgfont#173
