### PR TITLE
slack: Call the correct resize_* function when importing realm icon.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -50,7 +50,7 @@ from zerver.lib.emoji import codepoint_to_name, get_emoji_file_name
 from zerver.lib.export import MESSAGE_BATCH_CHUNK_SIZE
 from zerver.lib.mime_types import guess_type
 from zerver.lib.storage import static_path
-from zerver.lib.thumbnail import resize_logo
+from zerver.lib.thumbnail import resize_realm_icon
 from zerver.lib.upload import sanitize_name
 from zerver.models import (
     CustomProfileField,
@@ -1351,7 +1351,7 @@ def fetch_team_icons(
         open(resized_icon_output_path, "wb") as output_file,
         open(original_icon_output_path, "rb") as original_file,
     ):
-        resized_data = resize_logo(original_file.read())
+        resized_data = resize_realm_icon(original_file.read())
         output_file.write(resized_data)
     records.append(
         {

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -179,6 +179,10 @@ def resize_avatar(image_data: bytes, size: int = DEFAULT_AVATAR_SIZE) -> bytes:
         ).write_to_buffer(".png")
 
 
+def resize_realm_icon(image_data: bytes) -> bytes:
+    return resize_avatar(image_data)
+
+
 def resize_logo(image_data: bytes) -> bytes:
     # This will only scale the image down, and will resize it to
     # preserve aspect ratio and be contained within 8*AVATAR by AVATAR

--- a/zerver/lib/upload/local.py
+++ b/zerver/lib/upload/local.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from typing_extensions import override
 
 from zerver.lib.mime_types import guess_type
-from zerver.lib.thumbnail import resize_avatar, resize_logo
+from zerver.lib.thumbnail import resize_logo, resize_realm_icon
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.upload.base import StreamingSourceWithSize, ZulipUploadBackend
 from zerver.lib.utils import assert_is_not_none
@@ -174,7 +174,7 @@ class LocalUploadBackend(ZulipUploadBackend):
         image_data = icon_file.read()
         write_local_file("avatars", os.path.join(upload_path, "icon.original"), image_data)
 
-        resized_data = resize_avatar(image_data)
+        resized_data = resize_realm_icon(image_data)
         write_local_file("avatars", os.path.join(upload_path, "icon.png"), resized_data)
 
     @override

--- a/zerver/lib/upload/s3.py
+++ b/zerver/lib/upload/s3.py
@@ -15,7 +15,7 @@ from django.utils.http import content_disposition_header
 from typing_extensions import override
 
 from zerver.lib.partial import partial
-from zerver.lib.thumbnail import resize_avatar, resize_logo
+from zerver.lib.thumbnail import resize_logo, resize_realm_icon
 from zerver.lib.upload.base import INLINE_MIME_TYPES, StreamingSourceWithSize, ZulipUploadBackend
 from zerver.models import Realm, RealmEmoji, UserProfile
 
@@ -366,7 +366,7 @@ class S3UploadBackend(ZulipUploadBackend):
             image_data,
         )
 
-        resized_data = resize_avatar(image_data)
+        resized_data = resize_realm_icon(image_data)
         upload_content_to_s3(
             self.avatar_bucket,
             s3_file_name + ".png",


### PR DESCRIPTION
For resizing the `icon.png` files for realm icon we use `resize_avatar`:
https://github.com/zulip/zulip/blob/cb6c60ef7ab2aadb665dc5051e5e8c2e9f70323c/zerver/lib/upload/s3.py#L355-L376

But the Slack import codepath was calling `resize_logo`, which is therefore wrong. So we fix this, while also renaming other uses of `resize_avatar` in icon contexts to `resize_realm_icon`, because this is hard to mentally keep track of otherwise and causes this kind of bugs.

Despite this, in my basic testing Slack import still ended up with a correctly displaying realm icon on the login page - I think by coincidence, so we still want to fix this.

