### PR TITLE
message_header: Fix message content visible above sticky header.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -161,7 +161,7 @@
         }
 
         &.sticky_header {
-            box-shadow: var(--unread-marker-left) 0 0 0 var(--color-background);
+            box-shadow: var(--unread-marker-left) -1px 0 0 var(--color-background);
 
             .recipient_row_date {
                 display: block;


### PR DESCRIPTION
This was due to `box-shadow` used to hide the content was incorrectly overridden in `.sticky_header` from the `.message_header` just above.

The bug is highly reproducible since it happens due to minor pixel differences when rendering.

| before | after |
| --- | --- |
| ![Screenshot from 2024-11-09 20-50-53](https://github.com/user-attachments/assets/50a9d7fb-c644-4161-b77b-b4e854993a80) | ![Screenshot from 2024-11-09 20-50-38](https://github.com/user-attachments/assets/a11df56f-4dac-4a68-942f-e00166c2dd63) |

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/message.20peeks.20out.20when.20scrolling/near/1975833