### PR TITLE
test_import_export: Don't hard-code ZULIP_VERSION in fixtures.

### DIFF
--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
@@ -1,6 +1,6 @@
 Export was generated on a different Zulip version.
-Export=10.0-dev+git
-Server=10.0-dev+git
+Export={version_placeholder}
+Server={version_placeholder}
 
 Database formats differ between the exported realm and this server.
 Printing migrations that differ between the versions:

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
@@ -1,6 +1,6 @@
 Export was generated on a different Zulip version.
-Export=10.0-dev+git
-Server=10.0-dev+git
+Export={version_placeholder}
+Server={version_placeholder}
 
 Database formats differ between the exported realm and this server.
 Printing migrations that differ between the versions:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -348,6 +348,11 @@ class ExportFile(ZulipTestCase):
         )
         return fixture
 
+    def get_applied_migrations_error_message(self, fixture_name: str) -> str:
+        fixture = self.fixture_data(fixture_name, "import_fixtures/check_migrations_errors")
+        fixture = fixture.format(version_placeholder=ZULIP_VERSION)
+        return fixture.strip()
+
     def verify_migration_status_json(self) -> None:
         # This function asserts that the generated migration_status.json
         # is structurally familiar for it to be used for assertion at
@@ -2060,9 +2065,9 @@ class RealmImportExportTest(ExportFile):
             )
             do_import_realm(get_output_dir(), "test-zulip")
 
-        expected_error_message = self.fixture_data(
-            "unapplied_migrations_error.txt", "import_fixtures/check_migrations_errors"
-        ).strip()
+        expected_error_message = self.get_applied_migrations_error_message(
+            "unapplied_migrations_error.txt"
+        )
         error_message = str(e.exception).strip()
         self.assertEqual(expected_error_message, error_message)
 
@@ -2085,9 +2090,9 @@ class RealmImportExportTest(ExportFile):
                 export_type=RealmExport.EXPORT_FULL_WITH_CONSENT,
             )
             do_import_realm(get_output_dir(), "test-zulip")
-        expected_error_message = self.fixture_data(
-            "extra_migrations_error.txt", "import_fixtures/check_migrations_errors"
-        ).strip()
+        expected_error_message = self.get_applied_migrations_error_message(
+            "extra_migrations_error.txt"
+        )
         error_message = str(e.exception).strip()
         self.assertEqual(expected_error_message, error_message)
 


### PR DESCRIPTION
Fix-up to #31681

Otherwise, these tests fail if ZULIP_VERSION is different locally from what's hard-coded. Use a placeholder instead and replace dynamically in a helper function.

