### PR TITLE
change_realm_subdomain: Revoke user sessions.

### DIFF
--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -18,6 +18,7 @@ from zerver.lib.bulk_create import create_users
 from zerver.lib.push_notifications import sends_notifications_directly
 from zerver.lib.remote_server import maybe_enqueue_audit_log_upload
 from zerver.lib.server_initialization import create_internal_realm, server_initialized
+from zerver.lib.sessions import delete_realm_user_sessions
 from zerver.lib.streams import ensure_stream
 from zerver.lib.user_groups import (
     create_system_user_groups_for_realm,
@@ -93,6 +94,9 @@ def do_change_realm_subdomain(
             email_owners=False,
         )
         do_add_deactivated_redirect(placeholder_realm, realm.url)
+
+    # Sessions can't be deleted inside a transaction.
+    delete_realm_user_sessions(realm)
 
 
 def set_realm_permissions_based_on_org_type(realm: Realm) -> None:


### PR DESCRIPTION
If we don't revoke sessions, this can lead to issues when we import a realm (e.g. from Slack) into the original subdomain for the same organization. Because then, users who already had sessions before the move end up stuck:
- when they try to open Zulip on the original subdomain, which now has the imported instance, they get redirected to the moved subdomain due to their pre-existing session cookie.
- they can't even log out to get rid of the bugged cookie, because the account they're logged into in that session is now on the moved subdomain.

