### PR TITLE
webpack: Remove unused landing_page dependency on event status page.

### DIFF
--- a/web/webpack.assets.json
+++ b/web/webpack.assets.json
@@ -35,7 +35,6 @@
     ],
     "billing-event-status": [
         "./src/bundles/portico",
-        "./styles/portico/landing_page.css",
         "./src/billing/event_status",
         "./src/billing/helpers",
         "./styles/portico/billing.css"


### PR DESCRIPTION
Event status page no longer uses any styles from this page.

Fixes #23629
 
![Screenshot from 2024-11-10 09-16-30](https://github.com/user-attachments/assets/be5eb0a7-a974-4aaf-a445-7704a86ed19a)
