### PR TITLE
corporate: Fix misuse of timezone_now() as parameter default

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -366,13 +366,13 @@ def get_plan_data_by_remote_realm() -> dict[int, dict[int, RemoteActivityPlanDat
 
 
 def get_remote_realm_user_counts(
-    event_time: datetime = timezone_now(),
+    event_time: datetime | None = None,
 ) -> dict[int, RemoteCustomerUserCount]:  # nocoverage
     user_counts_by_realm: dict[int, RemoteCustomerUserCount] = {}
     for log in (
         RemoteRealmAuditLog.objects.filter(
             event_type__in=RemoteRealmAuditLog.SYNCED_BILLING_EVENTS,
-            event_time__lte=event_time,
+            event_time__lte=timezone_now() if event_time is None else event_time,
             remote_realm__isnull=False,
         )
         # Important: extra_data is empty for some pre-2020 audit logs
@@ -393,13 +393,13 @@ def get_remote_realm_user_counts(
 
 
 def get_remote_server_audit_logs(
-    event_time: datetime = timezone_now(),
+    event_time: datetime | None = None,
 ) -> dict[int, list[RemoteRealmAuditLog]]:
     logs_per_server: dict[int, list[RemoteRealmAuditLog]] = defaultdict(list)
     for log in (
         RemoteRealmAuditLog.objects.filter(
             event_type__in=RemoteRealmAuditLog.SYNCED_BILLING_EVENTS,
-            event_time__lte=event_time,
+            event_time__lte=timezone_now() if event_time is None else event_time,
         )
         # Important: extra_data is empty for some pre-2020 audit logs
         # prior to the introduction of realm_user_count_by_role

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -733,7 +733,7 @@ class BillingSession(ABC):
         pass
 
     @abstractmethod
-    def current_count_for_billed_licenses(self, event_time: datetime = timezone_now()) -> int:
+    def current_count_for_billed_licenses(self, event_time: datetime | None = None) -> int:
         pass
 
     @abstractmethod
@@ -3660,7 +3660,7 @@ class BillingSession(ABC):
         customer: Customer,
         tier: int,
         licenses: int | None = None,
-        event_time: datetime = timezone_now(),
+        event_time: datetime | None = None,
     ) -> int:
         if licenses is not None and customer.exempt_from_license_number_check:
             return licenses
@@ -3927,7 +3927,7 @@ class RealmBillingSession(BillingSession):
         return self.user.delivery_email
 
     @override
-    def current_count_for_billed_licenses(self, event_time: datetime = timezone_now()) -> int:
+    def current_count_for_billed_licenses(self, event_time: datetime | None = None) -> int:
         return get_latest_seat_count(self.realm)
 
     @override
@@ -4292,7 +4292,7 @@ class RemoteRealmBillingSession(BillingSession):
         return self.remote_billing_user.email
 
     @override
-    def current_count_for_billed_licenses(self, event_time: datetime = timezone_now()) -> int:
+    def current_count_for_billed_licenses(self, event_time: datetime | None = None) -> int:
         if has_stale_audit_log(self.remote_realm.server):
             raise MissingDataError
         remote_realm_counts = get_remote_realm_guest_and_non_guest_count(
@@ -4737,7 +4737,7 @@ class RemoteServerBillingSession(BillingSession):
         return self.remote_billing_user.email
 
     @override
-    def current_count_for_billed_licenses(self, event_time: datetime = timezone_now()) -> int:
+    def current_count_for_billed_licenses(self, event_time: datetime | None = None) -> int:
         if has_stale_audit_log(self.remote_server):
             raise MissingDataError
         remote_server_counts = get_remote_server_guest_and_non_guest_count(

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -523,7 +523,7 @@ def get_remote_customer_user_count(
 
 
 def get_remote_server_guest_and_non_guest_count(
-    server_id: int, event_time: datetime = timezone_now()
+    server_id: int, event_time: datetime | None = None
 ) -> RemoteCustomerUserCount:
     # For each realm hosted on the server, find the latest audit log
     # entry indicating the number of active users in that realm.
@@ -531,7 +531,7 @@ def get_remote_server_guest_and_non_guest_count(
         RemoteRealmAuditLog.objects.filter(
             server_id=server_id,
             event_type__in=RemoteRealmAuditLog.SYNCED_BILLING_EVENTS,
-            event_time__lte=event_time,
+            event_time__lte=timezone_now() if event_time is None else event_time,
         )
         # Important: extra_data is empty for some pre-2020 audit logs
         # prior to the introduction of realm_user_count_by_role
@@ -553,13 +553,13 @@ def get_remote_server_guest_and_non_guest_count(
 
 
 def get_remote_realm_guest_and_non_guest_count(
-    remote_realm: RemoteRealm, event_time: datetime = timezone_now()
+    remote_realm: RemoteRealm, event_time: datetime | None = None
 ) -> RemoteCustomerUserCount:
     latest_audit_log = (
         RemoteRealmAuditLog.objects.filter(
             remote_realm=remote_realm,
             event_type__in=RemoteRealmAuditLog.SYNCED_BILLING_EVENTS,
-            event_time__lte=event_time,
+            event_time__lte=timezone_now() if event_time is None else event_time,
         )
         # Important: extra_data is empty for some pre-2020 audit logs
         # prior to the introduction of realm_user_count_by_role


### PR DESCRIPTION
Python parameter defaults are only evaluated once at the function definition site, not at each call site. So these defaults were incorrectly evaluating to the server’s startup time rather than the current time.

- Followup to #25316
- Cc @prakhar1144 (#28070, #28242)
- Cc @laurynmm (#28634)