### PR TITLE
Restrict create group

### DIFF
--- a/help/include/user-groups-intro.md
+++ b/help/include/user-groups-intro.md
@@ -1,3 +1,4 @@
+{!cloud-paid-plans-only.md!}
 User groups offer a flexible way to manage permissions in your organization.
 Most permissions in Zulip can be granted to any combination of
 [roles](/help/roles-and-permissions), [groups](/help/user-groups), and

--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -812,12 +812,12 @@
                 <td class="comparison-table-feature">
                     <a href="/help/create-user-groups">Custom user groups</a>
                 </td>
-                <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>
+                <td class="comparison-value-positive cloud-cell"><i class="icon icon-x"></i></td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>
 
                 <td class="comparison-value-warning self-hosted-cell" data-title="{{ _('Self-managed') }}"><i class="icon icon-wrench"></i></td>
-                <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
+                <td class="comparison-value-warning self-hosted-cell" data-title="{{ _('Self-managed') }}"><i class="icon icon-wrench"></i></td>
                 <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
                 <td class="comparison-value-positive self-hosted-cell" data-title="{{ _('Supported') }}"><i class="icon icon-check"></i></td>
             </tr>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -68,6 +68,7 @@
                             <ul class="feature-list">
                                 <li><span>Unlimited search history</span></li>
                                 <li><span>File storage up to 5 GB per user</span></li>
+                                <li><span>Flexible permissions with <a href="/help/user-groups">custom groups</a></span></li>
                                 <li><span><a href="/help/message-retention-policy">Message retention policies</a></span></li>
                                 <li><span>Brand Zulip with your logo</span></li>
                                 <li><span>Priority commercial support</span></li>

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1489,6 +1489,12 @@ export function disable_opening_typeahead_on_clicking_label($container: JQuery):
     $group_setting_labels.off("click");
 }
 
+export function disable_group_permission_setting($container: JQuery): void {
+    $container.find(".input").prop("contenteditable", false);
+    $container.closest(".input-group").addClass("group_setting_disabled");
+    disable_opening_typeahead_on_clicking_label($container.closest(".input-group"));
+}
+
 export const group_setting_widget_map = new Map<string, GroupSettingPillContainer | null>([
     ["can_add_members_group", null],
     ["can_join_group", null],

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -144,11 +144,7 @@ export function enable_or_disable_group_permission_settings(): void {
         ];
         for (const setting_name of owner_editable_settings) {
             const $permission_pill_container = $(`#id_${CSS.escape(setting_name)}`);
-            $permission_pill_container.find(".input").prop("contenteditable", false);
-            $permission_pill_container.closest(".input-group").addClass("group_setting_disabled");
-            settings_components.disable_opening_typeahead_on_clicking_label(
-                $permission_pill_container.closest(".input-group"),
-            );
+            settings_components.disable_group_permission_setting($permission_pill_container);
         }
         return;
     }
@@ -156,9 +152,7 @@ export function enable_or_disable_group_permission_settings(): void {
     const $permission_pill_container_elements = $("#organization-permissions").find(
         ".pill-container",
     );
-    $permission_pill_container_elements.find(".input").prop("contenteditable", false);
-    $permission_pill_container_elements.closest(".input-group").addClass("group_setting_disabled");
-    settings_components.disable_opening_typeahead_on_clicking_label($("#organization-permissions"));
+    settings_components.disable_group_permission_setting($permission_pill_container_elements);
 }
 
 type OrganizationSettingsOptions = {
@@ -359,6 +353,14 @@ function set_create_web_public_stream_dropdown_visibility(): void {
     );
 }
 
+function disable_create_user_groups_if_on_limited_plan(): void {
+    if (!realm.zulip_plan_is_not_limited) {
+        settings_components.disable_group_permission_setting(
+            $("#id_realm_can_create_groups").closest(".input-group"),
+        );
+    }
+}
+
 export function check_disable_direct_message_initiator_group_widget(): void {
     const direct_message_permission_group_widget = settings_components.get_group_setting_widget(
         "realm_direct_message_permission_group",
@@ -373,12 +375,8 @@ export function check_disable_direct_message_initiator_group_widget(): void {
         direct_message_permission_group_widget,
     );
     if (user_groups.is_setting_group_empty(direct_message_permission_value)) {
-        $("#id_realm_direct_message_initiator_group").find(".input").prop("contenteditable", false);
-        $("#id_realm_direct_message_initiator_group")
-            .closest(".input-group")
-            .addClass("group_setting_disabled");
-        settings_components.disable_opening_typeahead_on_clicking_label(
-            $("#id_realm_direct_message_initiator_group").closest(".input-group"),
+        settings_components.disable_group_permission_setting(
+            $("#id_realm_direct_message_initiator_group"),
         );
     } else if (current_user.is_admin) {
         $("#id_realm_direct_message_initiator_group").find(".input").prop("contenteditable", true);
@@ -1127,6 +1125,7 @@ export function build_page(): void {
     set_message_content_in_email_notifications_visibility();
     set_digest_emails_weekday_visibility();
     set_create_web_public_stream_dropdown_visibility();
+    disable_create_user_groups_if_on_limited_plan();
 
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -129,16 +129,13 @@ function update_group_permission_settings_elements(group) {
         });
         settings_components.enable_opening_typeahead_on_clicking_label($group_permission_settings);
     } else {
-        $permission_pill_container_elements.find(".input").prop("contenteditable", false);
-
-        $permission_input_groups.addClass("group_setting_disabled");
         $permission_input_groups.each(function () {
             settings_components.initialize_disable_button_hint_popover(
                 $(this),
                 $t({defaultMessage: "You do not have permission to edit this setting."}),
             );
         });
-        settings_components.disable_opening_typeahead_on_clicking_label($group_permission_settings);
+        settings_components.disable_group_permission_setting($permission_input_groups);
     }
 }
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -23,6 +23,7 @@ import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_components from "./settings_components.ts";
+import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import * as settings_org from "./settings_org.ts";
 import {current_user, realm} from "./state_data.ts";
@@ -837,6 +838,10 @@ export function setup_page(callback) {
     function populate_and_fill() {
         const template_data = {
             can_create_user_groups: settings_data.user_can_create_user_groups(),
+            zulip_plan_is_not_limited: realm.zulip_plan_is_not_limited,
+            upgrade_text_for_wide_organization_logo: realm.upgrade_text_for_wide_organization_logo,
+            is_business_type_org:
+                realm.realm_org_type === settings_config.all_org_type_values.business.code,
             max_user_group_name_length,
         };
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -92,6 +92,12 @@
         position: relative;
         top: -5px;
     }
+
+    &:disabled {
+        /* Replicate disabled values */
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
 }
 
 #create_user_group_description,
@@ -365,8 +371,7 @@ h4.user_group_setting_subsection_title {
 
     .left .no-streams-to-show,
     .left .no-groups-to-show,
-    .right .nothing-selected .create-stream-button-container,
-    .right .nothing-selected .create-group-button-container {
+    .right .nothing-selected .create-stream-button-container {
         display: block;
         text-align: center;
         font-size: 1em;
@@ -397,6 +402,18 @@ h4.user_group_setting_subsection_title {
 
         .create-group-button-container {
             margin-top: calc(45vh - 134px);
+            text-align: center;
+
+            .settings-empty-option-text {
+                color: hsl(0deg 0% 67%);
+            }
+
+            .upgrade-or-sponsorship-tip,
+            .upgrade-tip {
+                /* Center tip in parent container */
+                margin-left: auto;
+                margin-right: auto;
+            }
         }
     }
 

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -117,7 +117,7 @@
                 {{> group_setting_value_pill_input
                   setting_name="realm_can_manage_all_groups"
                   label=(t 'Who can administer all user groups')}}
-
+                {{> upgrade_tip_widget . }}
                 {{> group_setting_value_pill_input
                   setting_name="realm_can_create_groups"
                   label=(t 'Who can create user groups')}}

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -12,7 +12,7 @@
                 <div class="list-toggler-container">
                     <div id="add_new_user_group">
                         {{#if can_create_user_groups}}
-                        <button class="create_user_group_button create_user_group_plus_button">
+                        <button class="create_user_group_button create_user_group_plus_button" {{#if (not zulip_plan_is_not_limited)}}disabled{{/if}}>
                             <span class="create_button_plus_sign">+</span>
                         </button>
                         {{/if}}
@@ -52,7 +52,8 @@
                 <div class="nothing-selected">
                     <div class="group-info-banner"></div>
                     <div class="create-group-button-container">
-                        <button type="button" class="create_user_group_button animated-purple-button" {{#unless can_create_user_groups}}disabled{{/unless}}>{{t 'Create user group' }}</button>
+                        {{> ../settings/upgrade_tip_widget . }}
+                        <button type="button" class="create_user_group_button animated-purple-button" {{#unless (and can_create_user_groups zulip_plan_is_not_limited)}}disabled{{/unless}}>{{t 'Create user group' }}</button>
                         {{#unless can_create_user_groups}}
                         <span class="settings-empty-option-text">
                             {{t 'You do not have permission to create user groups.' }}

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -634,6 +634,10 @@ test("set_up", ({override, override_rewire}) => {
         $.create("<stub-can-create-web-public-channel-group-parent>"),
     );
 
+    // Make our plan not limited so we don't have to stub all the
+    // elements involved in disabling the can_create_groups input.
+    override(realm, "zulip_plan_is_not_limited", true);
+
     override_rewire(settings_components, "get_input_element_value", (elem) => {
         if ($(elem).data() === "number") {
             return Number.parseInt($(elem).val(), 10);

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2362,6 +2362,16 @@ class RealmAPITest(ZulipTestCase):
         result = self.client_patch("/json/realm", req)
         self.assert_json_error(result, "Available on Zulip Cloud Standard. Upgrade to access.")
 
+    def test_can_create_groups_limited_plan_realms(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        do_change_realm_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
+
+        members_group = NamedUserGroup.objects.get(name="role:members", realm=realm)
+        req = {"can_create_groups": orjson.dumps({"new": members_group.id}).decode()}
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_error(result, "Available on Zulip Cloud Standard. Upgrade to access.")
+
     def test_changing_can_access_all_users_group_based_on_plan_type(self) -> None:
         realm = get_realm("zulip")
         do_change_realm_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -218,6 +218,9 @@ def update_realm(
             message_retention_days_raw, Realm.MESSAGE_RETENTION_SPECIAL_VALUES_MAP
         )
 
+    if can_create_groups is not None:
+        realm.ensure_not_on_limited_plan()
+
     if (
         invite_to_realm_policy is not None
         or invite_required is not None

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -64,6 +64,7 @@ def add_user_group(
     can_manage_group: Json[int | AnonymousSettingGroupDict] | None = None,
     can_mention_group: Json[int | AnonymousSettingGroupDict] | None = None,
 ) -> HttpResponse:
+    user_profile.realm.ensure_not_on_limited_plan()
     user_profiles = user_ids_to_users(members, user_profile.realm, allow_deactivated=False)
     name = check_user_group_name(name)
 


### PR DESCRIPTION
Users on limited plans can continue making changes to their existing groups. 

**Screenshots and screen captures:**

Group settings screen:
![Screenshot 2024-11-11 at 8 30 57 PM](https://github.com/user-attachments/assets/08994b2c-55d1-45f2-b9f9-3bccda64d4e7)

Org permissions screen:
![Screenshot 2024-11-11 at 8 30 41 PM](https://github.com/user-attachments/assets/230462d9-ff04-4dc9-95f4-60a0d621f4d3)

Help center:
![Screenshot 2024-11-11 at 8 28 27 PM](https://github.com/user-attachments/assets/24dd7583-544b-48fd-ba08-565978684540)

Standard plan feature list:
![Screenshot 2024-11-11 at 8 29 12 PM](https://github.com/user-attachments/assets/5503beca-3cc7-4ac7-88f6-7c8fdc170983)

Feature table:
![Screenshot 2024-11-11 at 8 29 51 PM](https://github.com/user-attachments/assets/dbf8fc99-affd-46db-b91e-0e976ede6de9)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
