### PR TITLE
compose: Hide warning banners when post permissions banner visible.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -71,11 +71,13 @@ export function get_compose_banner_container($textarea: JQuery): JQuery {
 // This function provides a convenient way to add new elements
 // to a banner container. The function accepts a container element
 // as a parameter, to which a banner should be appended.
+// Returns a boolean value indicating whether the append had succeeded.
 export function append_compose_banner_to_banner_list(
     $banner: JQuery,
     $list_container: JQuery,
-): void {
+): boolean {
     scroll_util.get_content_element($list_container).append($banner);
+    return true;
 }
 
 export function update_or_append_banner(

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -76,6 +76,9 @@ export function append_compose_banner_to_banner_list(
     $banner: JQuery,
     $list_container: JQuery,
 ): boolean {
+    if ($banner.hasClass("warning") && has_error()) {
+        return false;
+    }
     scroll_util.get_content_element($list_container).append($banner);
     return true;
 }
@@ -251,4 +254,8 @@ export function show_stream_not_subscribed_error(sub: StreamSubscription): void 
         hide_close_button: true,
     });
     append_compose_banner_to_banner_list($(new_row_html), $banner_container);
+}
+
+export function has_error(): boolean {
+    return $("#compose_banners .error:visible").length > 0;
 }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -359,8 +359,13 @@ export function warn_if_topic_resolved(topic_changed: boolean): void {
         };
 
         const new_row_html = render_compose_banner(context);
-        compose_banner.append_compose_banner_to_banner_list($(new_row_html), $("#compose_banners"));
-        compose_state.set_recipient_viewed_topic_resolved_banner(true);
+        const appended = compose_banner.append_compose_banner_to_banner_list(
+            $(new_row_html),
+            $("#compose_banners"),
+        );
+        if (appended) {
+            compose_state.set_recipient_viewed_topic_resolved_banner(true);
+        }
     } else {
         clear_topic_resolved_warning();
     }


### PR DESCRIPTION
When a user doesn't have post permissions, hide warning banners as they are irrelevant.

**Banners affected:**
`warn_if_private_stream_is_linked`
`warn_if_mentioning_unsubscribed_user`
`warn_if_topic_resolved`

Fixes https://github.com/zulip/zulip/issues/25575.


**Previous PR:**

There is a previous PR #25653 opened for the same issue having `integration review` tag and now has `merge conflicts` due to `js` files being changed to `ts`. Also, the previous made changes to various section of codebase which I dont think are necessary. So, I just utilised some lines of his code and left the other untouched.


**Screenshots and screen captures:**

<details>
<summary>No post permissions, replying to a resolved topic.</summary>
<img width="878" alt="Screenshot 2024-11-12 at 1 00 54 AM" src="https://github.com/user-attachments/assets/f997052f-70ac-4d07-ae99-65b2805707d0">
</details>

<details>
<summary>Has post permissions, replying to a resolved topic.</summary>
<img width="886" alt="Screenshot 2024-11-12 at 1 02 45 AM" src="https://github.com/user-attachments/assets/c542958d-5f6a-4f5a-ba3e-06fec19f8fde">
</details>

<details>
<summary>No post permissions, mentioning unsubscribed user.</summary>
<img width="893" alt="Screenshot 2024-11-12 at 1 01 14 AM" src="https://github.com/user-attachments/assets/9fb617d6-fe4e-4b84-8caf-c1ef228df70f">
</details>

<details>
<summary>Has post permissions, mentioning unsubscribed user.</summary>
<img width="884" alt="Screenshot 2024-11-12 at 1 03 37 AM" src="https://github.com/user-attachments/assets/d120655e-a08a-4327-860f-3713b961c429">
</details>

<details>
<summary>No post permissions, linking to a private stream.</summary>
<img width="896" alt="Screenshot 2024-11-12 at 1 01 47 AM" src="https://github.com/user-attachments/assets/9792e09d-de7c-465f-bdd1-f323ccbe9ddf">
</details>

<details>
<summary>Has post permissions, linking to a private stream.</summary>
<img width="892" alt="Screenshot 2024-11-12 at 1 03 18 AM" src="https://github.com/user-attachments/assets/e0cf3b04-82a4-4065-8e25-03f6c1a5ec7c">
</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
