### PR TITLE
#32301 - Configure tusd to not print so much during run-dev startup

### DIFF
--- a/zerver/management/commands/runtusd.py
+++ b/zerver/management/commands/runtusd.py
@@ -49,7 +49,9 @@ class Command(BaseCommand):
             "-hooks-http-forward-headers=Cookie,Authorization",
             "--hooks-enabled-events=pre-create,pre-finish",
             "-disable-download",
+            "--log-level=error" 
         ]
+        
         env_vars = os.environ.copy()
         if settings.LOCAL_UPLOADS_DIR is not None:
             assert settings.LOCAL_FILES_DIR is not None

--- a/zerver/management/commands/runtusd.py
+++ b/zerver/management/commands/runtusd.py
@@ -51,7 +51,6 @@ class Command(BaseCommand):
             "-disable-download",
             "--log-level=warn",
         ]
-        
         env_vars = os.environ.copy()
         if settings.LOCAL_UPLOADS_DIR is not None:
             assert settings.LOCAL_FILES_DIR is not None

--- a/zerver/management/commands/runtusd.py
+++ b/zerver/management/commands/runtusd.py
@@ -49,9 +49,8 @@ class Command(BaseCommand):
             "-hooks-http-forward-headers=Cookie,Authorization",
             "--hooks-enabled-events=pre-create,pre-finish",
             "-disable-download",
-            "--log-level=error" 
+            "--log-level=warn",
         ]
-        
         env_vars = os.environ.copy()
         if settings.LOCAL_UPLOADS_DIR is not None:
             assert settings.LOCAL_FILES_DIR is not None

--- a/zerver/management/commands/runtusd.py
+++ b/zerver/management/commands/runtusd.py
@@ -51,6 +51,7 @@ class Command(BaseCommand):
             "-disable-download",
             "--log-level=warn",
         ]
+        
         env_vars = os.environ.copy()
         if settings.LOCAL_UPLOADS_DIR is not None:
             assert settings.LOCAL_FILES_DIR is not None


### PR DESCRIPTION
Hey there, I've addressed the issue with excessive tusd logging in the run-dev script.

I made the following changes in the `zerver/management/commands/runtusd.py` file:

BEFORE --
![1 zulip bfore](https://github.com/user-attachments/assets/1cf8e8f3-a65d-47ed-bfe3-6ed81636f18e)

AFTER --
![1 zulip after](https://github.com/user-attachments/assets/f1b392ae-68a7-4217-9ac6-178be38d610b)


This change adjusts the logging level to error so that only error messages will be printed during the startup of run-dev, which solves the issue of excessive logs during development.