### PR TITLE
babel: Remove transform-optional-chaining workaround

### DIFF
--- a/web/babel.config.js
+++ b/web/babel.config.js
@@ -15,7 +15,6 @@ module.exports = {
             "@babel/preset-env",
             {
                 corejs: "3.39",
-                include: ["transform-optional-chaining"],
                 shippedProposals: true,
                 useBuiltIns: "usage",
             },


### PR DESCRIPTION
This was a workaround for a bug in babel-plugin-rewire-ts (#26381), which we’ve now removed (#32296).