### PR TITLE
user_group_popover: Fix misaligned icons in user group member list.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -328,7 +328,7 @@ export function initialize(): void {
             "#filter_streams_tooltip",
             ".error-icon-message-recipient .zulip-icon",
             "#personal-menu-dropdown .status-circle",
-            ".popover-group-menu-member-list .popover_user_presence",
+            ".popover-group-menu-member-list .popover-group-menu-user-presence",
             "#copy_generated_invite_link",
         ].join(","),
         appendTo: () => document.body,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -468,6 +468,12 @@
     }
 
     /*
+    User group info popover elements and values.
+    */
+    --user-group-popover-horizontal-padding: 0.6666em; /* 10px at 15px/1em */
+    --user-group-popover-icon-text-gap: 0.3125em; /* 5px at 16px/1em */
+
+    /*
     Width to be reserved for document scrollbar when scrolling is disabled.
     Using `scrollbar-gutter` would be more appropriate but doesn't has wide
     support and doesn't work for `fixed` elements.

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -308,7 +308,7 @@
     display: flex;
     flex-direction: column;
     gap: 5px;
-    padding: 3px 10px;
+    padding: 3px var(--user-group-popover-horizontal-padding);
 }
 
 .popover-group-menu-name-container {
@@ -337,23 +337,39 @@ ul.popover-group-menu-member-list {
     flex-direction: column;
 
     .simplebar-content {
+        display: grid;
+        grid-template-areas: "group-member-icon gap group-member-name";
+        grid-template-columns:
+            max-content var(--user-group-popover-icon-text-gap)
+            minmax(0, 1fr);
         width: unset;
+    }
+
+    .popover-group-menu-member {
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
+        align-items: center;
+        padding: 0 var(--user-group-popover-horizontal-padding);
+    }
+
+    .popover-group-member-icon {
+        justify-self: center;
+        grid-area: group-member-icon;
+    }
+
+    .popover-group-menu-member-name {
+        grid-area: group-member-name;
     }
 }
 
-.popover-group-menu-member,
 .popover-group-menu-placeholder {
-    display: flex;
-    align-items: center;
-    padding: 0 10px;
+    padding: 0 var(--user-group-popover-horizontal-padding);
+}
 
+.popover-group-menu-member {
     .zulip-icon-triple-users {
         color: var(--color-icon-purple);
-    }
-
-    .zulip-icon {
-        padding-left: 3px;
-        padding-right: 3px;
     }
 }
 
@@ -369,14 +385,13 @@ ul.popover-group-menu-member-list {
     color: var(--color-text-popover-menu);
 }
 
-.popover_user_presence {
-    margin: 0 2px;
-    /* 11px at 16px/1em */
-    font-size: 0.6875em;
-}
-
 .user-status-icon-wrapper {
     display: flex;
+}
+
+.popover-group-menu-user-presence {
+    /* 11px at 16px/1em */
+    font-size: 0.6875em;
 }
 
 .user_profile_presence {

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -27,16 +27,16 @@
                 <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
                     {{#each subgroups}}
                         <li class="popover-group-menu-member">
-                            <i class="popover-menu-icon zulip-icon zulip-icon-triple-users" aria-hidden="true"></i>
+                            <i class="popover-group-member-icon popover-menu-icon zulip-icon zulip-icon-triple-users" aria-hidden="true"></i>
                             <span class="popover-group-menu-member-name">{{name}}</span>
                         </li>
                     {{/each}}
                     {{#each members}}
                         <li class="popover-group-menu-member">
                             {{#if is_bot}}
-                                <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                                <i class="popover-group-member-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                             {{else}}
-                                <span class="user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} popover_user_presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
+                                <span class="user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} popover-group-menu-user-presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
                             {{/if}}
                             <span class="popover-group-menu-member-name">{{full_name}}</span>
                         </li>

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -6,7 +6,9 @@
                     <i class="popover-menu-icon zulip-icon zulip-icon-triple-users" aria-hidden="true"></i>
                     <span class="popover-group-menu-name">{{group_name}}</span>
                 </div>
-                <div class="popover-group-menu-description">{{group_description}}</div>
+                {{#if group_description}}
+                    <div class="popover-group-menu-description">{{group_description}}</div>
+                {{/if}}
             </div>
         </li>
         {{#if (or members.length subgroups.length)}}
@@ -36,7 +38,7 @@
                             {{#if is_bot}}
                                 <i class="popover-group-member-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                             {{else}}
-                                <span class="user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} popover-group-menu-user-presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
+                                <span class="popover-group-member-icon user-circle zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} popover-group-menu-user-presence hidden-for-spectators" data-tippy-content="{{user_last_seen_time_status}}"></span>
                             {{/if}}
                             <span class="popover-group-menu-member-name">{{full_name}}</span>
                         </li>


### PR DESCRIPTION
Previously, due the uneven width between the icons and the user presence indicator, the icons and presence indicator were misaligned with each other.

This PR uses the grid and subgrid layout systems to fix this misalignment issue.

> [!NOTE]  
> Also contains a follow-up commit fixing the extra gap when the group description is absent.

Fixes: [CZO Discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/bots.20misaligned.20in.20group.20modal/near/1962348)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2024-11-12 at 7 17 31 PM](https://github.com/user-attachments/assets/a88a6e5f-2d2d-41c4-9b2f-c871af588b5a) | ![Screenshot 2024-11-12 at 8 01 41 PM](https://github.com/user-attachments/assets/5ca335b5-6a33-4b04-832c-99fdde91bd4f) | 

**Updated After Screenshot**:
![Screenshot 2024-12-13 at 6 39 36 PM](https://github.com/user-attachments/assets/797f446f-be08-46e4-8d9b-8666e077b40e)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
