### PR TITLE
settings: Improve user-list style layout.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1217,6 +1217,15 @@ $option_title_width: 180px;
 .user_list_style_values {
     max-width: calc($right_sidebar_width + $option_title_width);
 
+    .preferences-radio-choice-label {
+        justify-content: space-between;
+        margin-right: 6px;
+
+        .right {
+            margin-left: unset;
+        }
+    }
+
     .preview {
         /* Match the 170px width of the right sidebar region for the name/status,
            doing something reasonable if the window shrinks. */
@@ -1226,6 +1235,13 @@ $option_title_width: 180px;
         .user-name-and-status-text {
             display: flex;
             flex-direction: column;
+        }
+
+        .user-name-and-status-emoji {
+            .user-name {
+                max-width: 100%;
+                overflow: hidden;
+            }
         }
 
         .status-text {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1218,15 +1218,10 @@ $option_title_width: 180px;
     max-width: calc($right_sidebar_width + $option_title_width);
 
     .preview {
-        background-color: inherit !important;
         /* Match the 170px width of the right sidebar region for the name/status,
            doing something reasonable if the window shrinks. */
         width: calc(100% - $option_title_width);
-        text-align: left;
         white-space: nowrap;
-        text-overflow: ellipsis;
-        overflow: hidden visible;
-        position: relative;
 
         .user-name-and-status-text {
             display: flex;


### PR DESCRIPTION
This PR cleans up the styles around user-list previews in the settings pane, and also makes better use of the available space for different previews, bringing it into better parity with the emoji-preview area.

As part of this clean-up, undesirable scrollbars and apparent scroll areas are removed.
[
CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/display.20status.20and.20profile.20picture.20in.20right.20sidebar.20.2332128/near/1975884)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![user-list-settings-light-before](https://github.com/user-attachments/assets/dd088f95-51d0-4131-afac-fd9c2f5a8cf4) | ![user-list-settings-light-after](https://github.com/user-attachments/assets/058b7761-e93c-4453-85d1-678e88e8e15c) |
| ![user-list-settings-dark-before](https://github.com/user-attachments/assets/fb3add21-3806-4400-bce2-3d1bf1672b7b) | ![user-list-settings-dark-after](https://github.com/user-attachments/assets/63f46450-14cc-46ee-9d0c-4fa9783dbdce) |

| Comparing w/ emoji, before | Comparing w/ emoji, after |
| --- | --- |
| ![emoji-comparison-before](https://github.com/user-attachments/assets/b739b64b-60ab-4f43-bff8-93428a3e6b3f) | ![emoji-comparison-after](https://github.com/user-attachments/assets/6bbff7fe-47c7-41bf-af07-ee8769ab43d5) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>