### PR TITLE
webpack: Remove unused hexoid alias

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -278,12 +278,6 @@ const config = (
         output: {
             path: path.resolve(__dirname, "../static/webpack-bundles"),
         },
-        resolve: {
-            alias: {
-                // koa-body uses formidable 2.x, which suffers from https://github.com/node-formidable/formidable/issues/337
-                hexoid: "hexoid/dist/index.js",
-            },
-        },
     };
 
     return [frontendConfig, serverConfig];


### PR DESCRIPTION
`koa-body` was switched to `@koa/bodyparser` during development of #29198, so this was never used.