### PR TITLE
bundles: Remove unnecessary bootstrap_typeahead import

### DIFF
--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -1,7 +1,6 @@
 import "./common.ts";
 
 // Import third party jQuery plugins
-import "../bootstrap_typeahead.ts";
 import "jquery-caret-plugin/dist/jquery.caret";
 import "../../third/jquery-idle/jquery.idle.js";
 import "spectrum-colorpicker";


### PR DESCRIPTION
Commit db24df488c0ed81c38ee1d914ae12ac223857c78 (#29286) made this a normal function rather than a jQuery plugin, so it doesn’t need to be imported for side effects.