### PR TITLE
right sidebar: Redesign section headings.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -440,12 +440,12 @@ export class BuddyList extends BuddyListConf {
         const {current_sub, total_human_subscribers_count, other_users_count} = this.render_data;
         $(".buddy-list-subsection-header").empty();
 
-        // If we're in the mode of hiding headers, that means we're only showing the "other users"
+        // If we're in the mode of hiding headers, that means we're only showing the "others"
         // section, so hide the other two sections.
         $("#buddy-list-users-matching-view-container").toggleClass("no-display", hide_headers);
 
         // This is the case where every subscriber is in the participants list. In this case, we
-        // hide the "others in this channel" section.
+        // hide the "in this channel" section.
         if (
             show_participants_list &&
             total_human_subscribers_count === this.participant_user_ids.length
@@ -457,22 +457,15 @@ export class BuddyList extends BuddyListConf {
             return;
         }
 
-        let header_text;
-        if (current_sub) {
-            if (all_participant_ids.size) {
-                header_text = $t({defaultMessage: "OTHERS IN THIS CHANNEL"});
-            } else {
-                header_text = $t({defaultMessage: "IN THIS CHANNEL"});
-            }
-        } else {
-            header_text = $t({defaultMessage: "IN THIS CONVERSATION"});
-        }
+        const header_text = current_sub
+            ? $t({defaultMessage: "THIS CHANNEL"})
+            : $t({defaultMessage: "THIS CONVERSATION"});
 
         $("#buddy-list-participants-container .buddy-list-subsection-header").append(
             $(
                 render_section_header({
                     id: "buddy-list-participants-section-heading",
-                    header_text: $t({defaultMessage: "IN THIS CONVERSATION"}),
+                    header_text: $t({defaultMessage: "THIS CONVERSATION"}),
                     user_count: get_formatted_sub_count(all_participant_ids.size),
                     is_collapsed: this.participants_is_collapsed,
                 }),

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -460,19 +460,19 @@ export class BuddyList extends BuddyListConf {
         let header_text;
         if (current_sub) {
             if (all_participant_ids.size) {
-                header_text = $t({defaultMessage: "Others in this channel"});
+                header_text = $t({defaultMessage: "OTHERS IN THIS CHANNEL"});
             } else {
-                header_text = $t({defaultMessage: "In this channel"});
+                header_text = $t({defaultMessage: "IN THIS CHANNEL"});
             }
         } else {
-            header_text = $t({defaultMessage: "In this conversation"});
+            header_text = $t({defaultMessage: "IN THIS CONVERSATION"});
         }
 
         $("#buddy-list-participants-container .buddy-list-subsection-header").append(
             $(
                 render_section_header({
                     id: "buddy-list-participants-section-heading",
-                    header_text: $t({defaultMessage: "In this conversation"}),
+                    header_text: $t({defaultMessage: "IN THIS CONVERSATION"}),
                     user_count: get_formatted_sub_count(all_participant_ids.size),
                     is_collapsed: this.participants_is_collapsed,
                 }),
@@ -496,7 +496,7 @@ export class BuddyList extends BuddyListConf {
             $(
                 render_section_header({
                     id: "buddy-list-other-users-section-heading",
-                    header_text: $t({defaultMessage: "Others"}),
+                    header_text: $t({defaultMessage: "OTHERS"}),
                     user_count: get_formatted_sub_count(other_users_count),
                     is_collapsed: this.other_users_is_collapsed,
                 }),

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -26,13 +26,10 @@ $user_status_emoji_width: 24px;
     overflow: auto;
 }
 
-.buddy-list-section-toggle.fa-caret-right {
-    width: 7px;
-    transition: rotate 140ms linear;
-    /* The triangle icon has asymmetrical padding on it, so
-       when it rotates down it would be too high without
-       this padding. */
-    padding-left: 2px;
+.buddy-list-section-toggle.zulip-icon-heading-triangle-right {
+    transition:
+        opacity 140ms linear,
+        rotate 140ms linear;
 
     &.rotate-icon-down {
         rotate: 90deg;
@@ -41,6 +38,11 @@ $user_status_emoji_width: 24px;
     &.rotate-icon-right {
         rotate: 0deg;
     }
+}
+
+.buddy-list-section-toggle {
+    color: var(--color-text-sidebar-heading);
+    opacity: var(--opacity-sidebar-heading-icon);
 }
 
 .buddy-list-section-container {
@@ -230,13 +232,30 @@ $user_status_emoji_width: 24px;
     top: 0;
     z-index: 1;
     color: var(--color-text-default);
+    border-radius: 4px;
+    padding-left: 4px;
+
+    &:hover {
+        background-color: var(--color-buddy-list-highlighted-user);
+        box-shadow: inset 0 0 0 1px var(--color-shadow-sidebar-row-hover);
+
+        .buddy-list-section-toggle,
+        .buddy-list-heading {
+            opacity: var(--opacity-sidebar-heading-hover);
+        }
+    }
 }
 
 .buddy-list-heading {
     user-select: none;
-    font-weight: 600;
     margin: 0;
     padding: 5px 5px 5px 0;
+    color: var(--color-text-sidebar-heading);
+    font-size: inherit;
+    font-weight: var(--font-weight-sidebar-heading);
+    letter-spacing: var(--letter-spacing-sidebar-heading);
+    opacity: var(--opacity-sidebar-heading);
+    transition: opacity 140ms linear;
 }
 
 .buddy-list-subsection-header.no-display {

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,4 +1,4 @@
 <h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
     {{header_text}} (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
 </h5>
-<i class="buddy-list-section-toggle fa fa-sm fa-caret-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>
+<i class="buddy-list-section-toggle zulip-icon zulip-icon-heading-triangle-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #32268

CZO thread: https://chat.zulip.org/#narrow/channel/101-design/topic/right.20sidebar.20headings.20.2332268/near/1980150

<img width="264" alt="image" src="https://github.com/user-attachments/assets/e4f966f3-4133-4365-af94-5c414fb578d4">
<img width="267" alt="image" src="https://github.com/user-attachments/assets/f5c641a9-84fb-4dd3-b33b-336e9948d2aa">

## hover

<img width="269" alt="image" src="https://github.com/user-attachments/assets/2ed571a9-a380-41f0-8734-d002012634e4">

<img width="256" alt="image" src="https://github.com/user-attachments/assets/bb9223e5-14df-400f-837e-8827bb9b0832">


## DM

<img width="269" alt="image" src="https://github.com/user-attachments/assets/6787a1dd-8de5-4dc0-8788-094d6ee23ba8">

<img width="284" alt="image" src="https://github.com/user-attachments/assets/17eedad1-5014-409f-bd97-98e0673b0812">
