### PR TITLE
Improve error handling for version mismatches in import/export with CommandError

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -13,6 +13,7 @@ import pyvips
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.cache import cache
+from django.core.management.base import CommandError
 from django.core.validators import validate_email
 from django.db import connection, transaction
 from django.db.backends.utils import CursorWrapper
@@ -2122,10 +2123,10 @@ def check_migration_status(exported_migration_status: MigrationStatusJson) -> No
     exported_primary_version = exported_migration_status["zulip_version"].split(".")[0]
     local_primary_version = local_migration_status["zulip_version"].split(".")[0]
     if exported_primary_version != local_primary_version:
-        raise Exception(
-            "Export was generated on a different Zulip major version.\n"
-            f"Export={exported_migration_status['zulip_version']}\n"
-            f"Server={local_migration_status['zulip_version']}"
+        raise CommandError(
+            "Error: Export was generated on a different Zulip major version.\n"
+            f"Export version: {exported_migration_status['zulip_version']}\n"
+            f"Server version: {local_migration_status['zulip_version']}"
         )
     exported_migrations_by_app = exported_migration_status["migrations_by_app"]
     local_migrations_by_app = local_migration_status["migrations_by_app"]
@@ -2160,13 +2161,13 @@ def check_migration_status(exported_migration_status: MigrationStatusJson) -> No
         ]
 
         error_message = (
-            "Export was generated on a different Zulip version.\n"
-            f"Export={exported_migration_status['zulip_version']}\n"
-            f"Server={local_migration_status['zulip_version']}\n"
+            "Error: Export was generated on a different Zulip version.\n"
+            f"Export version: {exported_migration_status['zulip_version']}\n"
+            f"Server version: {local_migration_status['zulip_version']}\n"
             "\n"
             "Database formats differ between the exported realm and this server.\n"
             "Printing migrations that differ between the versions:\n"
             "--- exported realm\n"
             "+++ this server"
         ) + "\n".join(sorted_error_log)
-        raise Exception(error_message)
+        raise CommandError(error_message)

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
@@ -1,6 +1,6 @@
-Export was generated on a different Zulip version.
-Export={version_placeholder}
-Server={version_placeholder}
+Error: Export was generated on a different Zulip version.
+Export version: {version_placeholder}
+Server version: {version_placeholder}
 
 Database formats differ between the exported realm and this server.
 Printing migrations that differ between the versions:

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
@@ -1,6 +1,6 @@
-Export was generated on a different Zulip version.
-Export={version_placeholder}
-Server={version_placeholder}
+Error: Export was generated on a different Zulip version.
+Export version: {version_placeholder}
+Server version: {version_placeholder}
 
 Database formats differ between the exported realm and this server.
 Printing migrations that differ between the versions:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import orjson
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.management.base import CommandError
 from django.db.models import Q, QuerySet
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
@@ -2199,7 +2200,7 @@ class RealmImportExportTest(ExportFile):
 
         with (
             patch("zerver.lib.import_realm.ZULIP_VERSION", "8.0"),
-            self.assertRaises(Exception) as e,
+            self.assertRaises(CommandError) as e,
             self.assertLogs(level="INFO"),
         ):
             do_import_realm(
@@ -2207,9 +2208,9 @@ class RealmImportExportTest(ExportFile):
                 "test-zulip",
             )
         expected_error_message = (
-            "Export was generated on a different Zulip major version.\n"
-            f"Export={ZULIP_VERSION}\n"
-            "Server=8.0"
+            "Error: Export was generated on a different Zulip major version.\n"
+            f"Export version: {ZULIP_VERSION}\n"
+            "Server version: 8.0"
         )
         self.assertEqual(expected_error_message, str(e.exception))
 


### PR DESCRIPTION
This PR refines error handling in import/export process by using `CommandError` for version mismatch notifications. Previously, these errors were raised as general Exception types, which resulted in full tracebacks that were less user-friendly. This update aligns with Django’s best practices by providing a clear and concise error message with `CommandError`, enhancing readability and user experience.

Fixes: #32292 

## Testing Info
**how would I test**
- first export by `./manage.py export --output exported_zulip -r zulip`
- extract_all of the generated `exported_zulip.tar.gz` into `./exported_zulip`
- delete the zulip realm `./manage.py delete_realm -r zulip`
- change the version in `./version.py` from `ZULIP_VERSION = "10.0-dev+git"` to `ZULIP_VERSION = "8.0-dev+git"`

when run ` ./manage.py import zulip exported_zulip --allow-reserved-subdomain`
<details>
<summary>Output before</summary>

```bash
Processing dump: /home/jitendra/projects/zulip/exported_zulip ...
2024-11-15 08:50:38.231 INFO [] Importing realm dump /home/jitendra/projects/zulip/exported_zulip
2024-11-15 08:50:38.233 INFO [] Checking migration status of exported realm
Traceback (most recent call last):
  File "/home/jitendra/projects/zulip/./manage.py", line 150, in <module>
    execute_from_command_line(sys.argv)
  File "/home/jitendra/projects/zulip/./manage.py", line 115, in execute_from_command_line
    utility.execute()
  File "/srv/zulip-venv-cache/5c8d7e2e030f6ee22bce86ccc87c95b4b82a3949/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/zulip-venv-cache/5c8d7e2e030f6ee22bce86ccc87c95b4b82a3949/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/jitendra/projects/zulip/zerver/lib/management.py", line 97, in execute
    super().execute(*args, **options)
  File "/srv/zulip-venv-cache/5c8d7e2e030f6ee22bce86ccc87c95b4b82a3949/zulip-py3-venv/lib/python3.10/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
  File "/home/jitendra/projects/zulip/zerver/management/commands/import.py", line 107, in handle
    do_import_realm(path, subdomain, num_processes)
  File "/home/jitendra/projects/zulip/zerver/lib/import_realm.py", line 1146, in do_import_realm
    check_migration_status(migration_status)
  File "/home/jitendra/projects/zulip/zerver/lib/import_realm.py", line 2125, in check_migration_status
    raise Exception(
Exception: Export was generated on a different Zulip major version.
Export=10.0-dev+git
Server=8.0-dev+git
```
</details>

<details>
<summary>Output after</summary>

```bash
Processing dump: /home/jitendra/projects/zulip/exported_zulip ...
2024-11-15 09:00:44.826 INFO [] Importing realm dump /home/jitendra/projects/zulip/exported_zulip
2024-11-15 09:00:44.827 INFO [] Checking migration status of exported realm
Export was generated on a different Zulip major version.
Export=10.0-dev+git
Server=8.0-dev+git
```
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
