### PR TITLE
puppet: Require libldap-common be installed.

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -14,8 +14,20 @@ class zulip::app_frontend_base {
     # package already includes the client.
     include zulip::postgresql_client
   }
-  # For Slack import
-  zulip::safepackage { 'unzip': ensure => installed }
+  zulip::safepackage {
+    [
+      # For Slack import.
+      'unzip',
+      # Ensures `/etc/ldap/ldap.conf` exists; the default
+      # `TLS_CACERTDIR` specified there is necessary for LDAP
+      # authentication to work. This package is "Recommended" by
+      # `libldap` where is required by postgres, so has been on most
+      # Zulip servers by default; adding it here explicitly ensures it
+      # is available on those that don't include the database server.
+      'libldap-common'
+      ]:
+        ensure => installed,
+  }
 
   file { '/etc/nginx/zulip-include/app':
     require => Package[$zulip::common::nginx],

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -24,9 +24,9 @@ class zulip::app_frontend_base {
       # `libldap` where is required by postgres, so has been on most
       # Zulip servers by default; adding it here explicitly ensures it
       # is available on those that don't include the database server.
-      'libldap-common'
-      ]:
-        ensure => installed,
+      'libldap-common',
+    ]:
+      ensure => installed,
   }
 
   file { '/etc/nginx/zulip-include/app':


### PR DESCRIPTION
Zulip instances without a database included, like the Docker image, would not fail to use TLS properly, since `TLS_REQCERT` was not set in `/etc/ldap/ldap.conf`. While there's a few other ways we could fix this, just installing libldap-common on app frontend instances seems like a good solution, and has no impact on other Zulip systems, and it was already being installed through a "Recommends" tier apt dependency indirectly from the PostgreSQL server package.

Fixes zulip/docker-zulip#454.
