### PR TITLE
compose: Better error feedback via banners.

### DIFF
--- a/tools/i18n/update-for-legacy-translations
+++ b/tools/i18n/update-for-legacy-translations
@@ -97,7 +97,7 @@ LEGACY_STRINGS_MAP = {
     "Only subscribers to this channel can edit channel permissions.": "Only subscribers to this stream can edit stream permissions.",
     "Pin channel to top": "Pin stream to top",
     "Pin channel to top of left sidebar": "Pin stream to top of left sidebar",
-    "Please specify a channel.": "Please specify a stream.",
+    "Please select a channel.": "Please specify a stream.",
     "Private channels cannot be default channels for new users.": "Private streams cannot be default streams for new users.",
     "Receives new channel announcements": "Receives new stream announcements",
     "Require topics in channel messages": "Require topics in stream messages",

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -70,6 +70,14 @@ export function initialize() {
         compose_ui.handle_keyup(event, $("textarea#compose-textarea").expectOne());
     });
 
+    $("#compose-send-button").on("mouseenter", () => {
+        compose_validate.validate(false, false);
+        compose_validate.update_send_button_status();
+    });
+    $("#compose-send-button").on("mouseleave", () => {
+        $(".message-send-controls").removeClass("disabled-message-send-controls");
+    });
+
     $("textarea#compose-textarea").on("input propertychange", () => {
         compose_validate.warn_if_topic_resolved(false);
         const compose_text_length = compose_validate.check_overflow_text($("#send_message_form"));

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -215,8 +215,11 @@ export function initialize(): void {
         trigger: "mouseenter",
         appendTo: () => document.body,
         onShow(instance) {
-            // Don't show Send button tooltip if the popover is displayed.
-            if (popover_menus.is_scheduled_messages_popover_displayed()) {
+            // Don't show send-area tooltips if the popover is displayed or if the send button is disabled.
+            if (
+                popover_menus.is_scheduled_messages_popover_displayed() ||
+                $(".message-send-controls").hasClass("disabled-message-send-controls")
+            ) {
                 return false;
             }
             if (user_settings.enter_sends) {

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -275,6 +275,12 @@ export function initialize(): void {
         target: ".disabled-message-send-controls",
         // 350px at 14px/1em
         maxWidth: "25em",
+        onTrigger(instance) {
+            instance.setContent(
+                compose_recipient.get_posting_policy_error_message() ||
+                    compose_validate.get_disabled_send_tooltip(),
+            );
+        },
         content: () =>
             compose_recipient.get_posting_policy_error_message() ||
             compose_validate.get_disabled_send_tooltip(),

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -39,6 +39,7 @@ let recipient_disallowed = false;
 export const NO_PRIVATE_RECIPIENT_ERROR_MESSAGE = $t({
     defaultMessage: "Please add a valid recipient.",
 });
+export const NO_CHANNEL_SELECTED_ERROR_MESSAGE = $t({defaultMessage: "Please select a channel."});
 
 type StreamWildcardOptions = {
     stream_id: number;
@@ -653,9 +654,10 @@ export function validate_stream_message_address_info(sub: StreamSubscription): b
 function validate_stream_message(scheduling_message: boolean): boolean {
     const stream_id = compose_state.stream_id();
     const $banner_container = $("#compose_banners");
-    if (stream_id === undefined) {
+    const no_channel_selected = stream_id === undefined;
+    if (no_channel_selected) {
         compose_banner.show_error_message(
-            $t({defaultMessage: "Please specify a channel."}),
+            NO_CHANNEL_SELECTED_ERROR_MESSAGE,
             compose_banner.CLASSNAMES.missing_stream,
             $banner_container,
             $("#compose_select_recipient_widget_wrapper"),

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -890,7 +890,8 @@ export function validate_message_length($container: JQuery, trigger_flash = true
     if (message_too_long_for_compose) {
         if (trigger_flash) {
             $textarea.addClass("flash");
-            setTimeout(() => $textarea.removeClass("flash"), 1500);
+            // This must be synchronized with the `flash` CSS.
+            setTimeout(() => $textarea.removeClass("flash"), 500);
         }
         return false;
     }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -36,6 +36,10 @@ let upload_in_progress = false;
 let message_too_long = false;
 let recipient_disallowed = false;
 
+export const NO_PRIVATE_RECIPIENT_ERROR_MESSAGE = $t({
+    defaultMessage: "Please add a valid recipient.",
+});
+
 type StreamWildcardOptions = {
     stream_id: number;
     $banner_container: JQuery;
@@ -717,7 +721,7 @@ function validate_private_message(): boolean {
 
     if (compose_state.private_message_recipient().length === 0) {
         compose_banner.show_error_message(
-            $t({defaultMessage: "Please specify at least one valid recipient."}),
+            NO_PRIVATE_RECIPIENT_ERROR_MESSAGE,
             compose_banner.CLASSNAMES.missing_private_message_recipient,
             $banner_container,
             $("#private_message_recipient"),

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -860,6 +860,7 @@ export function validate(scheduling_message: boolean): boolean {
     const no_message_content = /^\s*$/.test(message_content);
     if (no_message_content) {
         $("textarea#compose-textarea").toggleClass("invalid", true);
+        $("textarea#compose-textarea").trigger("focus");
         return false;
     }
 

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -857,6 +857,20 @@ export function validate_message_length($container: JQuery): boolean {
 
 export function validate(scheduling_message: boolean): boolean {
     const message_content = compose_state.message_content();
+    // The validation checks in this function are in a specific priority order. Don't
+    // change their order unless you want to change which priority they're shown in.
+
+    if (
+        compose_state.get_message_type() !== "private" &&
+        !validate_stream_message(scheduling_message)
+    ) {
+        return false;
+    }
+
+    if (compose_state.get_message_type() === "private" && !validate_private_message()) {
+        return false;
+    }
+
     const no_message_content = /^\s*$/.test(message_content);
     if (no_message_content) {
         $("textarea#compose-textarea").toggleClass("invalid", true);
@@ -879,10 +893,7 @@ export function validate(scheduling_message: boolean): boolean {
         return false;
     }
 
-    if (compose_state.get_message_type() === "private") {
-        return validate_private_message();
-    }
-    return validate_stream_message(scheduling_message);
+    return true;
 }
 
 export function convert_mentions_to_silent_in_direct_messages(

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -33,6 +33,10 @@ import * as util from "./util.ts";
 
 let user_acknowledged_stream_wildcard = false;
 let upload_in_progress = false;
+let no_channel_selected = false;
+let missing_topic = false;
+let no_private_recipient = true;
+let no_message_content = false;
 let message_too_long = false;
 let recipient_disallowed = false;
 
@@ -63,9 +67,24 @@ export function set_upload_in_progress(status: boolean): void {
     update_send_button_status();
 }
 
+function set_no_channel_selected(status: boolean): void {
+    no_channel_selected = status;
+}
+
+function set_missing_topic(status: boolean): void {
+    missing_topic = status;
+}
+
+function set_missing_direct_message_recipient(status: boolean): void {
+    no_private_recipient = status;
+}
+
+function set_no_message_content(status: boolean): void {
+    no_message_content = status;
+}
+
 function set_message_too_long_for_compose(status: boolean): void {
     message_too_long = status;
-    update_send_button_status();
 }
 
 function set_message_too_long_for_edit(status: boolean, $container: JQuery): void {
@@ -81,18 +100,33 @@ function set_message_too_long_for_edit(status: boolean, $container: JQuery): voi
 
 export function set_recipient_disallowed(status: boolean): void {
     recipient_disallowed = status;
-    update_send_button_status();
 }
 
-function update_send_button_status(): void {
+export function update_send_button_status(): void {
+    const recipient_type = compose_state.get_message_type();
     $(".message-send-controls").toggleClass(
         "disabled-message-send-controls",
-        message_too_long || upload_in_progress || recipient_disallowed,
+        upload_in_progress ||
+            no_channel_selected ||
+            (missing_topic && recipient_type === "stream") ||
+            (no_private_recipient && recipient_type === "private") ||
+            message_too_long ||
+            recipient_disallowed ||
+            no_message_content,
     );
 }
 
 export function get_disabled_send_tooltip(): string {
-    if (message_too_long) {
+    const recipient_type = compose_state.get_message_type();
+    if (no_channel_selected && recipient_type === "stream") {
+        return NO_CHANNEL_SELECTED_ERROR_MESSAGE;
+    } else if (missing_topic && recipient_type === "stream") {
+        return TOPICS_REQUIRED_ERROR_MESSAGE;
+    } else if (no_private_recipient && recipient_type === "private") {
+        return NO_PRIVATE_RECIPIENT_ERROR_MESSAGE;
+    } else if (no_message_content) {
+        return NO_MESSAGE_CONTENT_ERROR_MESSAGE;
+    } else if (message_too_long) {
         return get_message_too_long_for_compose_error();
     } else if (upload_in_progress) {
         return $t({defaultMessage: "Cannot send message while files are being uploaded."});
@@ -649,16 +683,18 @@ export function validate_stream_message_address_info(sub: StreamSubscription): b
     return false;
 }
 
-function validate_stream_message(scheduling_message: boolean): boolean {
-    const stream_id = compose_state.stream_id();
+function validate_stream_message(scheduling_message: boolean, show_banner = true): boolean {
     const $banner_container = $("#compose_banners");
+    const stream_id = compose_state.stream_id();
     const no_channel_selected = stream_id === undefined;
+    set_no_channel_selected(no_channel_selected);
     if (no_channel_selected) {
-        compose_banner.show_error_message(
+        report_validation_error(
             NO_CHANNEL_SELECTED_ERROR_MESSAGE,
             compose_banner.CLASSNAMES.missing_stream,
             $banner_container,
             $("#compose_select_recipient_widget_wrapper"),
+            show_banner,
         );
         return false;
     }
@@ -666,12 +702,14 @@ function validate_stream_message(scheduling_message: boolean): boolean {
     if (realm.realm_mandatory_topics) {
         const topic = compose_state.topic();
         const missing_topic = topic === "";
+        set_missing_topic(missing_topic);
         if (missing_topic) {
-            compose_banner.show_error_message(
+            report_validation_error(
                 TOPICS_REQUIRED_ERROR_MESSAGE,
                 compose_banner.CLASSNAMES.topic_missing,
                 $banner_container,
                 $("input#stream_message_recipient_topic"),
+                show_banner,
             );
             return false;
         }
@@ -715,18 +753,20 @@ function validate_stream_message(scheduling_message: boolean): boolean {
 
 // The function checks whether the recipients are users of the realm or cross realm users (bots
 // for now)
-function validate_private_message(): boolean {
+function validate_private_message(show_banner = true): boolean {
     const user_ids = compose_pm_pill.get_user_ids();
     const user_ids_string = util.sorted_ids(user_ids).join(",");
     const $banner_container = $("#compose_banners");
     const missing_direct_message_recipient = compose_state.private_message_recipient().length === 0;
 
+    set_missing_direct_message_recipient(missing_direct_message_recipient);
     if (missing_direct_message_recipient) {
-        compose_banner.show_error_message(
+        report_validation_error(
             NO_PRIVATE_RECIPIENT_ERROR_MESSAGE,
             compose_banner.CLASSNAMES.missing_private_message_recipient,
             $banner_container,
             $("#private_message_recipient"),
+            show_banner,
         );
         return false;
     } else if (realm.realm_is_zephyr_mirror_realm) {
@@ -837,7 +877,7 @@ export function check_overflow_text($container: JQuery): number {
     return text.length;
 }
 
-export function validate_message_length($container: JQuery): boolean {
+export function validate_message_length($container: JQuery, trigger_flash = true): boolean {
     const $textarea = $container.find<HTMLTextAreaElement>(".message-textarea");
     // Match the behavior of compose_state.message_content of trimming trailing whitespace
     const text = $textarea.val()!.trimEnd();
@@ -848,33 +888,53 @@ export function validate_message_length($container: JQuery): boolean {
     set_message_too_long_for_compose(message_too_long_for_compose);
 
     if (message_too_long_for_compose) {
-        $textarea.addClass("flash");
-        setTimeout(() => $textarea.removeClass("flash"), 1500);
+        if (trigger_flash) {
+            $textarea.addClass("flash");
+            setTimeout(() => $textarea.removeClass("flash"), 1500);
+        }
         return false;
     }
     return true;
 }
 
-export function validate(scheduling_message: boolean): boolean {
+function report_validation_error(
+    message: string,
+    classname: string,
+    $container: JQuery,
+    $bad_input: JQuery,
+    show_banner: boolean,
+    precursor?: () => void,
+): void {
+    if (show_banner) {
+        if (precursor) {
+            precursor();
+        }
+        compose_banner.show_error_message(message, classname, $container, $bad_input);
+    }
+}
+export function validate(scheduling_message: boolean, show_banner = true): boolean {
     const message_content = compose_state.message_content();
     // The validation checks in this function are in a specific priority order. Don't
     // change their order unless you want to change which priority they're shown in.
 
     if (
         compose_state.get_message_type() !== "private" &&
-        !validate_stream_message(scheduling_message)
+        !validate_stream_message(scheduling_message, show_banner)
     ) {
         return false;
     }
 
-    if (compose_state.get_message_type() === "private" && !validate_private_message()) {
+    if (compose_state.get_message_type() === "private" && !validate_private_message(show_banner)) {
         return false;
     }
 
     const no_message_content = /^\s*$/.test(message_content);
+    set_no_message_content(no_message_content);
     if (no_message_content) {
-        $("textarea#compose-textarea").toggleClass("invalid", true);
-        $("textarea#compose-textarea").trigger("focus");
+        if (show_banner) {
+            $("textarea#compose-textarea").toggleClass("invalid", true);
+            $("textarea#compose-textarea").trigger("focus");
+        }
         return false;
     }
 
@@ -889,7 +949,9 @@ export function validate(scheduling_message: boolean): boolean {
         );
         return false;
     }
-    if (!validate_message_length($("#send_message_form"))) {
+    // TODO: This doesn't actually show a banner, it triggers a flash
+    const trigger_flash = show_banner;
+    if (!validate_message_length($("#send_message_form"), trigger_flash)) {
         return false;
     }
 

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -841,7 +841,12 @@ export function validate_message_length($container: JQuery): boolean {
     const $textarea = $container.find<HTMLTextAreaElement>(".message-textarea");
     // Match the behavior of compose_state.message_content of trimming trailing whitespace
     const text = $textarea.val()!.trimEnd();
+
     const message_too_long_for_compose = text.length > realm.max_message_length;
+    // Usually, check_overflow_text maintains this, but since we just
+    // did the check, make sure it's up to date.
+    set_message_too_long_for_compose(message_too_long_for_compose);
+
     if (message_too_long_for_compose) {
         $textarea.addClass("flash");
         setTimeout(() => $textarea.removeClass("flash"), 1500);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1410,7 +1410,7 @@ textarea.new_message_textarea {
 
     &.disabled-message-send-controls {
         & button {
-            pointer-events: none;
+            cursor: default;
             opacity: 0.5;
         }
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -358,7 +358,8 @@
 .edit-content-container:has(
         .message_edit_content.textarea-approaching-limit.flash
     ) {
-    animation: message-limit-flash 0.5s ease-in-out 3;
+    /* This should align with the timing in compose_validate.validate_message_length. */
+    animation: message-limit-flash 0.5s ease-in-out 1;
 }
 
 #message-content-container .composebox-buttons {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -486,6 +486,14 @@ test_ui("finish", ({override, override_rewire}) => {
     });
 
     (function test_when_compose_validation_fails() {
+        // To trigger the empty banner error instead of other errors
+        // set as per the priority.
+        override(current_user, "user_id", new_user.user_id);
+        compose_state.set_stream_id(social.stream_id);
+        fake_compose_box.set_topic_val("lunch");
+        fake_compose_box.set_textarea_val("burrito");
+        compose_state.set_message_type("stream");
+
         fake_compose_box.set_textarea_toggle_class_function((classname, value) => {
             assert.equal(classname, "invalid");
             assert.equal(value, true);

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -322,7 +322,7 @@ test_ui("validate", ({mock_template, override}) => {
     let empty_stream_error_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.missing_stream);
-        assert.equal(data.banner_text, $t({defaultMessage: "Please specify a channel."}));
+        assert.equal(data.banner_text, compose_validate.NO_CHANNEL_SELECTED_ERROR_MESSAGE);
         empty_stream_error_rendered = true;
         return "<banner-stub>";
     });

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -341,10 +341,7 @@ test_ui("validate", ({mock_template, override}) => {
     let missing_topic_error_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.topic_missing);
-        assert.equal(
-            data.banner_text,
-            $t({defaultMessage: "Topics are required in this organization."}),
-        );
+        assert.equal(data.banner_text, compose_validate.TOPICS_REQUIRED_ERROR_MESSAGE);
         missing_topic_error_rendered = true;
         return "<banner-stub>";
     });

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -227,10 +227,7 @@ test_ui("validate", ({mock_template, override}) => {
     override(realm, "realm_direct_message_initiator_group", everyone.id);
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.missing_private_message_recipient);
-        assert.equal(
-            data.banner_text,
-            $t({defaultMessage: "Please specify at least one valid recipient."}),
-        );
+        assert.equal(data.banner_text, compose_validate.NO_PRIVATE_RECIPIENT_ERROR_MESSAGE);
         pm_recipient_error_rendered = true;
         return "<banner-stub>";
     });

--- a/web/tests/lib/compose_helpers.cjs
+++ b/web/tests/lib/compose_helpers.cjs
@@ -146,7 +146,7 @@ class FakeComposeBox {
 
         assert.ok(this.$content_textarea.hasClass("textarea-over-limit"));
         assert.ok($(".message-limit-indicator").hasClass("textarea-over-limit"));
-        assert.ok($(".message-send-controls").hasClass("disabled-message-send-controls"));
+        assert.ok(!$(".message-send-controls").hasClass("disabled-message-send-controls"));
     }
 
     assert_message_size_is_under_the_limit(desired_html) {

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -248,6 +248,7 @@ test("upload_files", async ({mock_template, override, override_rewire}) => {
         banner_shown = true;
         return "<banner-stub>";
     });
+    override(compose_state, "get_message_type", () => "stream");
     await upload.upload_files(uppy, config, files);
     assert.ok($(".message-send-controls").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);
@@ -455,7 +456,7 @@ test("copy_paste", ({override, override_rewire}) => {
     assert.equal(upload_files_called, false);
 });
 
-test("uppy_events", ({override_rewire, mock_template}) => {
+test("uppy_events", ({override, override_rewire, mock_template}) => {
     $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
     override_rewire(compose_ui, "smart_insert_inline", noop);
@@ -517,6 +518,7 @@ test("uppy_events", ({override_rewire, mock_template}) => {
     override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
+    override(compose_state, "get_message_type", () => "stream");
     on_upload_success_callback(file, response);
 
     assert.ok(compose_ui_replace_syntax_called);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
This commit adds some new error banners and
modifies the error message of the current private
recipient error message.

The banners are shown based on the priority defined
by @alya in https://github.com/zulip/zulip/issues/32115.

Fixes https://github.com/zulip/zulip/issues/32115.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Priority 1
![priority1](https://github.com/user-attachments/assets/29e79328-2b9d-4dce-92ea-9e90271e5170)
Priority 2
![priority2](https://github.com/user-attachments/assets/6adf600b-c0f0-4cb3-8edd-c5d490040b73)

Priority 3
![priority3.1](https://github.com/user-attachments/assets/024bd496-f5c4-4f6a-ad00-0254d8d02354)
Priority 3
![priority3.2](https://github.com/user-attachments/assets/8b16dd16-0b41-4c61-9ace-e750ee47dc35)

Priority 4
![image](https://github.com/user-attachments/assets/30d6ea34-5538-4b89-89e7-06cc3440de9a)

Priority 4
![image](https://github.com/user-attachments/assets/bc3de7a1-f2b6-42ea-b0a6-02878a2427e5)

Priority 5
![image](https://github.com/user-attachments/assets/1d46040a-4568-4a6b-a830-d6352ad1f32e)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
