### PR TITLE
blueslip: Include message for abnormal traces.

### DIFF
--- a/web/src/blueslip_stacktrace.ts
+++ b/web/src/blueslip_stacktrace.ts
@@ -123,7 +123,7 @@ export async function display_stacktrace(ex: unknown, message?: string): Promise
                     "constructor" in prototype
                         ? `thrown ${prototype.constructor.name}`
                         : "thrown",
-                message: ex === undefined ? message : String(ex),
+                message: ex === undefined ? message : `${String(ex)}: ${message}`,
                 stackframes: [],
             });
             break;


### PR DESCRIPTION
`ResizeObserver loop completed with undelivered notifications` errors have originalEvent.error=null; in that case, it's worth including the `message` in what we display.

I think we probably want `message` in every case where this code path is relevant, so I just append it unconditionally.

