### PR TITLE
popovers: Copy topic links as plain URL and HTML-rich format

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -1,4 +1,3 @@
-import ClipboardJS from "clipboard";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
@@ -213,8 +212,26 @@ function build_stream_popover(opts) {
                 e.stopPropagation();
             });
 
-            new ClipboardJS($popper.find(".copy_stream_link")[0]).on("success", () => {
-                popover_menus.hide_current_popover_if_visible(instance);
+            $popper.find(".copy_stream_link").on("click", (e) => {
+                const $linkElement = $(e.currentTarget);
+                const plainText = $linkElement.data("clipboard-text");
+                const streamName = $linkElement.closest("ul").data("name");
+                const htmlText = `<a href="${plainText}">#${streamName}</a>`;
+
+                navigator.clipboard
+                    .write([
+                        new ClipboardItem({
+                            "text/plain": new Blob([plainText], {type: "text/plain"}),
+                            "text/html": new Blob([htmlText], {type: "text/html"}),
+                        }),
+                    ])
+                    .then(() => {
+                        // Hide the popover and show a success message
+                        popover_menus.hide_current_popover_if_visible(instance);
+                    });
+
+                e.preventDefault();
+                e.stopPropagation();
             });
         },
         onHidden() {

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -56,7 +56,7 @@
         </li>
         {{/if}}
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-clipboard-text="{{ url }}" tabindex="0">
+            <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-clipboard-text="{{ url }}" data-name="{{ topic_name }}" data-stream-name="{{ stream_name }}" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Copy link to topic" }}</span>
             </a>


### PR DESCRIPTION
I have added the functionality to paste the channel and topics links as plain text in places like browser address bar while it will be pasted as HTML formatted links in places like docs, emails, etc.

Fixes: [#31813](https://github.com/zulip/zulip/issues/31813) 