### PR TITLE
popovers: Restructure the Move messages and Move topic modals.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -346,6 +346,7 @@ export async function build_move_topic_to_stream_popover(
     message?: Message,
 ): Promise<void> {
     const current_stream_name = sub_store.get(current_stream_id)!.name;
+    const stream = sub_store.get(current_stream_id);
     const args: {
         topic_name: string;
         current_stream_id: number;
@@ -355,9 +356,11 @@ export async function build_move_topic_to_stream_popover(
         only_topic_edit: boolean;
         disable_topic_input?: boolean;
         message_placement?: "first" | "intermediate" | "last";
+        stream: sub_store.StreamSubscription | undefined;
     } = {
         topic_name,
         current_stream_id,
+        stream,
         notify_new_thread: message_edit.notify_new_thread_default,
         notify_old_thread: message_edit.notify_old_thread_default,
         from_message_actions_popover: message !== undefined,
@@ -375,13 +378,34 @@ export async function build_move_topic_to_stream_popover(
 
     let modal_heading;
     if (only_topic_edit) {
-        modal_heading = $t_html({defaultMessage: "Rename topic"});
+        modal_heading = $t_html(
+            {defaultMessage: "Rename topic <z-stream></z-stream> &gt; {topic_name}"},
+            {
+                topic_name,
+                "z-stream": () =>
+                    render_inline_decorated_stream_name({stream, show_colored_icon: true}),
+            },
+        );
     } else {
-        modal_heading = $t_html({defaultMessage: "Move topic"});
+        modal_heading = $t_html(
+            {defaultMessage: "Move topic from <z-stream></z-stream> &gt; {topic_name}"},
+            {
+                topic_name,
+                "z-stream": () =>
+                    render_inline_decorated_stream_name({stream, show_colored_icon: true}),
+            },
+        );
     }
 
     if (message !== undefined) {
-        modal_heading = $t_html({defaultMessage: "Move messages"});
+        modal_heading = $t_html(
+            {defaultMessage: "Move messages from <z-stream></z-stream> &gt; {topic_name}"},
+            {
+                topic_name,
+                "z-stream": () =>
+                    render_inline_decorated_stream_name({stream, show_colored_icon: true}),
+            },
+        );
         // We disable topic input only for modal is opened from the message actions
         // popover and not when moving the whole topic from left sidebar. This is
         // because topic editing permission depend on message and we do not have

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -906,16 +906,24 @@ ul.popover-group-menu-member-list {
         max-width: 100%;
     }
 
+    .modal__title {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+
+        .stream-privacy-type-icon {
+            padding-left: 3px;
+            padding-right: 5px;
+        }
+    }
+
     #move_topic_to_stream_widget_wrapper {
         display: flex;
-        margin-bottom: 10px;
 
         .dropdown-widget-button {
             outline: none;
             /* 24px at 16px/1em */
             line-height: 1.5em;
-            width: auto;
-            max-width: 206px;
+            width: 50%;
         }
 
         .dropdown_widget_value {
@@ -943,12 +951,23 @@ ul.popover-group-menu-member-list {
     }
 
     .move_messages_edit_topic {
-        margin-bottom: 10px;
+        margin-bottom: unset;
+        box-sizing: border-box;
+        width: 100%;
+        height: auto;
+    }
+
+    #message_move_select_options {
+        width: 100%;
+    }
+
+    #move_messages_count {
+        margin-top: -20px;
     }
 
     .topic_stream_edit_header {
         display: flex;
-        flex-wrap: wrap;
+        flex-flow: column wrap;
         justify-content: flex-start;
 
         #select_stream_id {

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -1,26 +1,26 @@
-{{#unless (or from_message_actions_popover only_topic_edit)}}
-<p class="white-space-preserve-wrap">{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
-{{/unless}}
 <form id="move_topic_form">
-    {{#if only_topic_edit }}
-    <p>{{t "Rename topic to:" }}</p>
-    {{else if from_message_actions_popover}}
-    <p>{{t "Move messages to:" }}</p>
-    {{/if}}
     <div class="topic_stream_edit_header">
         {{#unless only_topic_edit}}
-        {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
-        <i class="fa fa-angle-right" aria-hidden="true"></i>
+        <div class="input-group">
+            <label class="modal-field-label">New channel</label>
+            {{> dropdown_widget_wrapper widget_name="move_topic_to_stream"}}
+        </div>
         {{/unless}}
-        <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+        <div class="input-group">
+            <label for="move-topic-new-topic-name" class="modal-field-label">New topic</label>
+            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+        </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}
-        <select id="message_move_select_options" class="message_edit_topic_propagate modal_select bootstrap-focus-style">
-            <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
-            <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
-            <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
-        </select>
+        <div class="input-group">
+            <label for="message_move_select_options">{{t "Which messages should be moved?"}}</label>
+            <select name="propagate_mode" id="message_move_select_options" class="message_edit_topic_propagate modal_select bootstrap-focus-style">
+                <option value="change_one" {{#if (eq message_placement "last")}}selected{{/if}}> {{t "Move only this message" }}</option>
+                <option value="change_later" {{#if (eq message_placement "intermediate")}}selected{{/if}}> {{t "Move this and all following messages in this topic" }}</option>
+                <option value="change_all" {{#if (eq message_placement "first")}}selected{{/if}}> {{t "Move all messages in this topic" }}</option>
+            </select>
+        </div>
         {{/if}}
         <p id="move_messages_count"></p>
         <div class="topic_move_breadcrumb_messages">


### PR DESCRIPTION
This PR refactors the move messages and move topic modals to follow standard patterns from other modals (e.g. the invite user modal). It includes the following changes:

- Refactored the intro text for the move messages and move topic modals.
- New Labels are introduced in the move messages and move topic modals:
  - New channel
  - New topic
  - Which messages should be moved? <- in the move messages modal
     (no changes to checkboxes)
- Some CSS adjustments as mentioned in the [CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/topic.20box.20too.20short.20in.20.22move.20messages.22/near/1962636).

<!-- Describe your pull request here.-->

Fixes: #32168.
[CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/topic.20box.20too.20short.20in.20.22move.20messages.22/near/1962636)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
  <summary>1. Move messages modal</summary>
  
  | Before                               | After                                |
  |--------------------------------------|--------------------------------------|
  | ![Screenshot 2024-11-16 151315](https://github.com/user-attachments/assets/0fed3fbf-e49d-4d6a-a066-eb1b0b65b5ca) | ![Screenshot 2024-11-16 151541](https://github.com/user-attachments/assets/15088447-6745-4555-9e57-1ba9abdb098a) |

</details>


<details>
  <summary>2. Move topic modal</summary>

  | Before                               | After                                |
  |--------------------------------------|--------------------------------------|
  | ![Screenshot 2024-11-16 151218](https://github.com/user-attachments/assets/5df24465-2e81-4301-8e1c-15d6003e2b9c) | ![Screenshot 2024-11-16 151748](https://github.com/user-attachments/assets/3dbacd33-2b4d-4f34-9c64-5675d453e890) |

</details>


<details>
 <summary>3. Rename topic modal <em>(no changes)</em></summary>

  | Before                               | After                                |
  |--------------------------------------|--------------------------------------|
  | ![Screenshot 2024-11-16 151457](https://github.com/user-attachments/assets/249c5b76-b2b3-4e98-8ee0-fbd9a2e6fe81) | ![Screenshot 2024-11-16 151902](https://github.com/user-attachments/assets/f8d696b1-caf8-4e05-9098-6daf216669ee) |

</details>



---
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
