### PR TITLE
Make sender configurable when generating channel email address

### DIFF
--- a/web/src/bot_data.ts
+++ b/web/src/bot_data.ts
@@ -58,16 +58,6 @@ export function get_all_bots_for_current_user(): Bot[] {
     return ret;
 }
 
-export function get_editable(): Bot[] {
-    const ret = [];
-    for (const bot of bots.values()) {
-        if (bot.is_active && bot.owner_id !== null && people.is_my_user_id(bot.owner_id)) {
-            ret.push(bot);
-        }
-    }
-    return ret;
-}
-
 export function get_all_bots_owned_by_user(user_id: number): Bot[] {
     const ret = [];
     for (const bot of bots.values()) {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -51,6 +51,7 @@ let my_user_id: number;
 
 export let INACCESSIBLE_USER_NAME: string;
 export let WELCOME_BOT: User;
+export let EMAIL_GATEWAY_BOT: User;
 
 // We have an init() function so that our automated tests
 // can easily clear data.
@@ -1451,6 +1452,8 @@ export function add_cross_realm_user(person: User): void {
     cross_realm_dict.set(person.user_id, person);
     if (person.full_name === "Welcome Bot") {
         WELCOME_BOT = person;
+    } else if (person.full_name === "Email Gateway") {
+        EMAIL_GATEWAY_BOT = person;
     }
 }
 

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -2,9 +2,10 @@ import assert from "minimalistic-assert";
 
 import * as group_permission_settings from "./group_permission_settings.ts";
 import {page_params} from "./page_params.ts";
+import type {User} from "./people.ts";
 import * as settings_config from "./settings_config.ts";
 import {current_user, realm} from "./state_data.ts";
-import type {GroupSettingValue} from "./state_data.ts";
+import type {CurrentUser, GroupSettingValue} from "./state_data.ts";
 import * as user_groups from "./user_groups.ts";
 import {user_settings} from "./user_settings.ts";
 
@@ -56,6 +57,7 @@ export function user_has_permission_for_group_setting(
     setting_value: GroupSettingValue,
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
+    user: CurrentUser | User = current_user,
 ): boolean {
     if (page_params.is_spectator) {
         return false;
@@ -67,11 +69,11 @@ export function user_has_permission_for_group_setting(
     );
     assert(settings_config !== undefined);
 
-    if (!settings_config.allow_everyone_group && current_user.is_guest) {
+    if (!settings_config.allow_everyone_group && user.is_guest) {
         return false;
     }
 
-    return user_groups.is_user_in_setting_group(setting_value, current_user.user_id);
+    return user_groups.is_user_in_setting_group(setting_value, user.user_id);
 }
 
 export function user_can_invite_users_by_email(): boolean {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -664,4 +664,13 @@ export function initialize(): void {
             instance.destroy();
         },
     });
+
+    tippy.delegate("body", {
+        target: ".generate-channel-email-button-container.disabled_setting_tooltip",
+        content: $t({defaultMessage: "You do not have permission to post in this channel."}),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
 }

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -816,7 +816,6 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
 
     const owner_id = bot_user.owner_id;
     assert(owner_id !== null);
-    const owner_full_name = people.get_full_name(owner_id);
     const is_active = people.is_person_active(user_id);
 
     assert(bot.is_bot);
@@ -828,8 +827,6 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
         user_role_values: settings_config.user_role_values,
         disable_role_dropdown: !current_user.is_admin || (bot.is_owner && !current_user.is_owner),
         bot_avatar_url: bot.avatar_url,
-        owner_full_name,
-        current_bot_owner: bot.bot_owner_id,
         is_incoming_webhook_bot: bot.bot_type === INCOMING_WEBHOOK_BOT_TYPE,
     });
     $container.append($(html_body));

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -21,6 +21,9 @@
 }
 
 .stream-email {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     font-family: "Source Code Pro", monospace;
     padding: 10px;
     font-size: 0.85rem;
@@ -31,10 +34,14 @@
 
 .stream-email .email-address {
     display: block;
-    margin: auto;
+    flex: 0 0 90%;
     word-wrap: break-word;
     word-break: break-all;
     white-space: normal;
+}
+
+.copy-email-address {
+    font-size: 16px;
 }
 
 .sub_setting_checkbox {

--- a/web/templates/stream_settings/copy_email_address_modal.hbs
+++ b/web/templates/stream_settings/copy_email_address_modal.hbs
@@ -1,6 +1,9 @@
 <div class="copy-email-modal">
+    {{> ../dropdown_widget_with_label
+      widget_name="sender_channel_email_address"
+      label=(t 'Who should be the sender of the Zulip messages for this email address?')}}
     <p class="question-which-parts">
-        {{t "Which parts of the email should be included in the Zulip message sent to this channel?"}}
+        {{t "Which parts of the emails should be included in the Zulip messages?"}}
     </p>
     {{#each tags}}
         {{#if (eq this.name "prefer-html") }}
@@ -20,5 +23,8 @@
     </p>
     <div class="stream-email">
         <div class="email-address">{{email_address}}</div>
+        <span class="copy-button tippy-zulip-tooltip copy-email-address" data-tippy-content="{{t 'Copy email address' }}" data-clipboard-text="{{email_address}}">
+            <i class="zulip-icon zulip-icon-copy"></i>
+        </span>
     </div>
 </div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -86,18 +86,18 @@
                     {{stream_id}}
                 </div>
                 {{/with}}
-                {{#if can_access_stream_email}}
                 <div class="input-group stream-email-box">
                     <label for="copy_stream_email_button" class="title inline-block">Email address</label>
                     <p class="field-hint">
                         {{t "You can use email to send messages to Zulip channels."}}
                         {{> ../help_link_widget link="/help/message-a-channel-by-email" }}
                     </p>
-                    <button class="button small rounded copy_email_button" id="copy_stream_email_button" type="button">
-                        <span class="copy_button">{{t "Generate email address" }}</span>
-                    </button>
+                    <span class="generate-channel-email-button-container {{#unless can_access_stream_email}}disabled_setting_tooltip{{/unless}}">
+                        <button class="button small rounded copy_email_button" {{#unless can_access_stream_email}}disabled="disabled"{{/unless}} id="copy_stream_email_button" type="button">
+                            <span class="copy_button">{{t "Generate email address" }}</span>
+                        </button>
+                    </span>
                 </div>
-                {{/if}}
             </div>
         </div>
 

--- a/web/tests/bot_data.test.cjs
+++ b/web/tests/bot_data.test.cjs
@@ -201,7 +201,7 @@ test("test_basics", () => {
         assert.equal(bot, undefined);
     })();
 
-    (function test_get_editable() {
+    (function test_get_all_bots_for_current_user() {
         bot_data.add({...test_bot, user_id: 44, owner_id: me.user_id, is_active: true});
         bot_data.add({
             ...test_bot,
@@ -218,11 +218,6 @@ test("test_basics", () => {
             is_active: true,
         });
 
-        const editable_bots = bot_data.get_editable().map((bot) => bot.email);
-        assert.deepEqual(["bot1@zulip.com", "bot2@zulip.com"], editable_bots);
-    })();
-
-    (function test_get_all_bots_for_current_user() {
         const bots = bot_data.get_all_bots_for_current_user();
 
         assert.equal(bots.length, 2);

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -38,6 +38,14 @@ const welcome_bot = {
     // cross realm bots have no owner
 };
 
+const email_gateway_bot = {
+    email: "emailgateway@example.com",
+    user_id: 5,
+    full_name: "Email Gateway",
+    is_bot: true,
+    // cross realm bots have no owner
+};
+
 const me = {
     email: "me@example.com",
     user_id: 30,
@@ -378,9 +386,12 @@ test_people("basics", ({override}) => {
     // Add our cross-realm bot.  It won't add to our human
     // count, and it has no owner.
     people.add_cross_realm_user(welcome_bot);
+    people.add_cross_realm_user(email_gateway_bot);
     assert.equal(people.get_bot_owner_user(welcome_bot), undefined);
+    assert.equal(people.get_bot_owner_user(email_gateway_bot), undefined);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.get_by_email(welcome_bot.email).full_name, "Welcome Bot");
+    assert.equal(people.get_by_email(email_gateway_bot.email).full_name, "Email Gateway");
 
     override(settings_data, "user_can_access_all_other_users", () => false);
     assert.equal(
@@ -400,7 +411,11 @@ test_people("basics", ({override}) => {
 
     // get_bot_ids() includes all bot users.
     bot_user_ids = people.get_bot_ids();
-    assert.deepEqual(bot_user_ids, [bot_botson.user_id, welcome_bot.user_id]);
+    assert.deepEqual(bot_user_ids, [
+        bot_botson.user_id,
+        welcome_bot.user_id,
+        email_gateway_bot.user_id,
+    ]);
 
     // The bot doesn't add to our human count.
     assert.equal(people.get_active_human_count(), 1);


### PR DESCRIPTION
* Disable "Generate email address" button with a tooltip when neither the current user nor any of the bots they control has the post message permission.
* Updated UI to configure "Sender"


Fixes #31566

---

### When neither the user nor any of their bots has the permission.

<img width="417" alt="Screenshot 2025-01-02 at 7 38 21 PM" src="https://github.com/user-attachments/assets/18e73610-a1c5-45a2-8414-b8e84ef49d66" />

### A new selector at the top of this modal to choose the sender
<img width="418" alt="Screenshot 2025-02-10 at 4 15 11 PM" src="https://github.com/user-attachments/assets/bc3ccc2f-b8f1-4649-b982-65943be92d41" />

### Updated UX

* When the modal is opened, we show the email address for 'Email gateway' bot (default).
* The copy icon is now present alongside the address (see above image), it's a common UX so shouldn't be confusing ?
* When another sender is selected, we clear the address, disable the checkboxes, and focus on the "Generate email address" button to convey what should be done. See image below:
<img width="413" alt="Screenshot 2025-02-10 at 4 16 22 PM" src="https://github.com/user-attachments/assets/1c1a476e-f4f1-4240-979d-2acbdfb428d3" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
