### PR TITLE
portico: Fix multiple landing pages broken.

### DIFF
--- a/templates/corporate/why-zulip.html
+++ b/templates/corporate/why-zulip.html
@@ -15,7 +15,7 @@
 
 {% include 'zerver/landing_nav.html' %}
 
-<div class="portico-landing why-page" id="why-zulip-page">
+<div class="portico-landing why-page">
     <div class="hero bg-pycon why-zulip">
         <div class="bg-dimmer"></div>
         <div class="content">

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -2402,7 +2402,7 @@ button {
     border-left: 6px solid hsl(168.1deg 49.15% 46.27%);
 }
 
-#why-zulip-page,
+.why-page,
 .case-study-page,
 .solutions-page {
     .bottom-register-buttons.extra_margin_before_footer {
@@ -2692,7 +2692,7 @@ button {
 }
 
 .self-hosting-page,
-#why-zulip-page {
+.why-page {
     .hero-buttons {
         margin-top: 30px;
     }


### PR DESCRIPTION
Since postcss tries to preserve specificity of selectors which are defined in in a group, a `:not(#does-not-exist)` selector was added to the non ID selectors (solutions-page and case-study-page).

This caused the CSS styles to override other styles due to unexpectedly increased specificity.

To fix it, we remove the ID selector `#why-zulip-page` from the group.

![Screenshot from 2024-11-18 18-30-03](https://github.com/user-attachments/assets/1a038174-cc7c-4b36-ad15-c32361f516e9)
![Screenshot from 2024-11-18 18-29-55](https://github.com/user-attachments/assets/77fb68e0-97f9-4d8c-a832-c8070af83062)

