### PR TITLE
compose: Delegate max-length tooltip to body.

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -13,6 +13,7 @@ import {$t} from "./i18n.ts";
 import {pick_empty_narrow_banner} from "./narrow_banner.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as popover_menus from "./popover_menus.ts";
+import {realm} from "./state_data.ts";
 import {EXTRA_LONG_HOVER_DELAY, INSTANT_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs.ts";
 import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
@@ -166,6 +167,21 @@ export function initialize(): void {
             return undefined;
         },
         appendTo: () => document.body,
+    });
+
+    tippy.delegate("body", {
+        target: "#compose-limit-indicator",
+        delay: INSTANT_HOVER_DELAY,
+        trigger: "mouseenter",
+        appendTo: () => document.body,
+        onShow(instance) {
+            instance.setContent(
+                $t(
+                    {defaultMessage: `Maximum message length: {max_length} characters`},
+                    {max_length: realm.max_message_length},
+                ),
+            );
+        },
     });
 
     tippy.delegate("body", {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -185,7 +185,6 @@ function initialize_compose_box() {
                 giphy_enabled: giphy_state.is_giphy_enabled(),
                 max_stream_name_length: realm.max_stream_name_length,
                 max_topic_length: realm.max_topic_length,
-                max_message_length: realm.max_message_length,
             }),
         ),
     );

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -89,7 +89,7 @@
                             <a id="compose-drafts-button" role="button" class="send-control-button hide-sm" tabindex=0 href="#drafts">
                                 <span class="compose-drafts-text">{{t 'Drafts' }}</span><span class="compose-drafts-count-container">(<span class="compose-drafts-count"></span>)</span>
                             </a>
-                            <span id="compose-limit-indicator" class="tippy-zulip-tooltip" data-tippy-content="{{t 'Maximum message length: {max_message_length} characters' }}"></span>
+                            <span id="compose-limit-indicator"></span>
                             <div class="message-send-controls">
                                 <button type="submit" id="compose-send-button" class="send_message compose-submit-button compose-send-or-save-button" aria-label="{{t 'Send' }}">
                                     <img class="loader" alt="" src="" />


### PR DESCRIPTION
This PR moves the inline tooltip off of the over-limit indicator and instead delegates it to `<body>`. The complex layout and positioning in the area of the tooltip (including where in the DOM the tooltip appears) was causing the tooltip to appear beneath rows in the right sidebar—an issue not shared with the similarly-delegated disabled compose tooltip, for example.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Presence.20dot.20above.20the.20tooltip.2E/near/1983336)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![max-length-tooltip-before](https://github.com/user-attachments/assets/fc2f22c4-5b10-4340-a15f-95333047268e) | ![max-length-tooltip-after](https://github.com/user-attachments/assets/9f15d81b-9d9d-490b-83ee-0f0b35112828) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>