### PR TITLE
settings: Fix flaky test.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -30,6 +30,8 @@ async function open_settings(page: Page): Promise<void> {
         page_url.includes("/#settings/"),
         `Page url: ${page_url} does not contain /#settings/`,
     );
+    // Wait for settings overlay to open.
+    await page.waitForSelector("#settings_overlay_container", {visible: true});
 }
 
 async function close_settings_and_date_picker(page: Page): Promise<void> {


### PR DESCRIPTION
We wait for settings overlay to be fully visible before running rest of the tests. Without this, tests were flaky due to settings overlay not being present when running tests.

See https://github.com/zulip/zulip/actions/runs/11842922228/job/33002680462?pr=32331 for example.