### PR TITLE
Fix can_remove_subscribers_group value in never subscribed subscriptions dict.

### DIFF
--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -565,10 +565,6 @@ export function can_unsubscribe_others(sub: StreamSubscription): boolean {
         return false;
     }
 
-    if (current_user.is_admin) {
-        return true;
-    }
-
     return user_groups.is_user_in_setting_group(
         sub.can_remove_subscribers_group,
         people.my_current_user_id(),

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1187,14 +1187,13 @@ test("can_unsubscribe_others", ({override}) => {
     people.initialize_current_user(member_user_id);
     assert.equal(stream_data.can_unsubscribe_others(sub), true);
 
-    // Even with the nobody system group, admins can still unsubscribe others.
+    // With the nobody system group, admins cannot unsubscribe others.
     sub.can_remove_subscribers_group = nobody.id;
     override(current_user, "is_admin", true);
-    assert.equal(stream_data.can_unsubscribe_others(sub), true);
-    override(current_user, "is_admin", false);
     assert.equal(stream_data.can_unsubscribe_others(sub), false);
 
     // This isn't a real state, but we want coverage on !can_view_subscribers.
+    sub.can_remove_subscribers_group = all.id;
     sub.subscribed = false;
     sub.invite_only = true;
     override(current_user, "is_admin", true);

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -17,6 +17,7 @@ from zerver.lib.stream_subscription import (
 )
 from zerver.lib.stream_traffic import get_average_weekly_stream_traffic, get_streams_traffic
 from zerver.lib.streams import (
+    get_group_setting_value_dict_for_streams,
     get_setting_values_for_group_settings,
     get_web_public_streams_queryset,
     subscribed_to_stream,
@@ -31,7 +32,6 @@ from zerver.lib.types import (
     SubscriptionInfo,
     SubscriptionStreamDict,
 )
-from zerver.lib.user_groups import get_group_setting_value_for_api
 from zerver.models import Realm, Stream, Subscription, UserProfile
 from zerver.models.streams import get_all_streams
 
@@ -46,12 +46,13 @@ def get_web_public_subs(realm: Realm) -> SubscriptionInfo:
         return color
 
     subscribed = []
-    for stream in get_web_public_streams_queryset(realm):
+    streams = get_web_public_streams_queryset(realm)
+    setting_groups_dict = get_group_setting_value_dict_for_streams(list(streams))
+
+    for stream in streams:
         # Add Stream fields.
         is_archived = stream.deactivated
-        can_remove_subscribers_group = get_group_setting_value_for_api(
-            stream.can_remove_subscribers_group
-        )
+        can_remove_subscribers_group = setting_groups_dict[stream.can_remove_subscribers_group_id]
         creator_id = stream.creator_id
         date_created = datetime_to_timestamp(stream.date_created)
         description = stream.description

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -237,9 +237,9 @@ def build_stream_dict_for_sub(
 def build_stream_dict_for_never_sub(
     raw_stream_dict: RawStreamDict,
     recent_traffic: dict[int, int] | None,
+    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict],
 ) -> NeverSubscribedStreamDict:
     is_archived = raw_stream_dict["deactivated"]
-    can_remove_subscribers_group_id = raw_stream_dict["can_remove_subscribers_group_id"]
     creator_id = raw_stream_dict["creator_id"]
     date_created = datetime_to_timestamp(raw_stream_dict["date_created"])
     description = raw_stream_dict["description"]
@@ -260,13 +260,17 @@ def build_stream_dict_for_never_sub(
     else:
         stream_weekly_traffic = None
 
+    can_remove_subscribers_group_value = setting_groups_dict[
+        raw_stream_dict["can_remove_subscribers_group_id"]
+    ]
+
     # Backwards-compatibility addition of removed field.
     is_announcement_only = raw_stream_dict["stream_post_policy"] == Stream.STREAM_POST_POLICY_ADMINS
 
     # Our caller may add a subscribers field.
     return NeverSubscribedStreamDict(
         is_archived=is_archived,
-        can_remove_subscribers_group=can_remove_subscribers_group_id,
+        can_remove_subscribers_group=can_remove_subscribers_group_value,
         creator_id=creator_id,
         date_created=date_created,
         description=description,
@@ -566,7 +570,9 @@ def gather_subscriptions_helper(
         is_public = not raw_stream_dict["invite_only"]
         if is_public or user_profile.is_realm_admin:
             slim_stream_dict = build_stream_dict_for_never_sub(
-                raw_stream_dict=raw_stream_dict, recent_traffic=recent_traffic
+                raw_stream_dict=raw_stream_dict,
+                recent_traffic=recent_traffic,
+                setting_groups_dict=setting_groups_dict,
             )
 
             never_subscribed.append(slim_stream_dict)

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -220,7 +220,7 @@ class SubscriptionStreamDict(TypedDict):
 
 class NeverSubscribedStreamDict(TypedDict):
     is_archived: bool
-    can_remove_subscribers_group: int
+    can_remove_subscribers_group: int | AnonymousSettingGroupDict
     creator_id: int | None
     date_created: int
     description: str


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix the setting value in never subscribed dicts.
- Second commit is to fix the UI for admins when they are not allowed to unsubscribe others.
- Third commit is a refactor for optimization.

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
