### PR TITLE
billing: Remove invoice option for users with fixed-price plan offer.

### DIFF
--- a/templates/corporate/billing/upgrade.html
+++ b/templates/corporate/billing/upgrade.html
@@ -260,6 +260,7 @@
                                 </span>
                                 <object class="loader upgrade-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                             </button>
+                            {% if not fixed_price_plan %}
                             <span class="not-editable-realm-field" id="upgrade-payment-by-invoice-container">
                                 {% if page_params.setup_payment_by_invoice %}
                                 or <a href="{{ page_params.billing_base_url }}/upgrade/?tier={{ page_params.tier }}">pay by card</a>
@@ -267,6 +268,7 @@
                                 or <a href="{{ page_params.billing_base_url }}/upgrade/?manual_license_management=true&tier={{ page_params.tier }}&setup_payment_by_invoice=true" id="upgrade-payment-by-invoice-link" data-tippy-content="Requires purchasing a fixed number of licenses" data-tippy-placement="right">pay by invoice</a>
                                 {% endif %}
                             </span>
+                            {% endif %}
                         </div>
                         {% if not page_params.free_trial_days and payment_method %}
                         <div class="stripe-billing-information not-editable-realm-field">


### PR DESCRIPTION
Currently, the user selected "pay by invoice" option requires manual license management, and a fixed-price plan offer requires automatic license management.

If we're offering a fixed-price plan and the user wants to pay by invoice, then the current system in place require us to create the invoice in Stripe first and then input it manually via the support page for the customer.

Here we remove the option to "pay by invoice" in the case where there is a fixed-price plan offer that's been configured for the organization.

If an invoice was configured in Stripe and added to the fixed-price plan offer, then a page with the invoice information will be shown to the user instead of the below screenshots.

---

**Zulip Basic with fixed-price offer - removes pay by invoice link**:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-11-19 17-32-28](https://github.com/user-attachments/assets/32c4f1b2-a466-481e-a551-a43f2f22f4ec) | ![Screenshot from 2024-11-19 17-31-46](https://github.com/user-attachments/assets/ba27e5be-6be9-42a9-9498-d12e5eca8352) |

**Same org for Zulip Business (no fixed-price offer) - no change to pay by invoice link**:
| Before | After |
| --- | --- |
| ![Screenshot from 2024-11-19 17-38-51](https://github.com/user-attachments/assets/88f6f9b9-1365-4450-a805-943c60660cae) | ![Screenshot from 2024-11-19 17-38-32](https://github.com/user-attachments/assets/14bef3eb-a259-407d-9be6-109273298e94) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
