### PR TITLE
templates: Remove redundant {{#with this}} blocks

### DIFF
--- a/web/templates/message_group.hbs
+++ b/web/templates/message_group.hbs
@@ -1,18 +1,14 @@
 {{! Client-side Handlebars template for rendering messages. }}
 
 {{#each message_groups}}
-    {{#with this}}
-        {{#if bookend_top}}
-        {{> bookend .}}
-        {{/if}}
+    {{#if bookend_top}}
+    {{> bookend .}}
+    {{/if}}
 
-        <div class="recipient_row" id="{{message_group_id}}">
-            {{> recipient_row . use_match_properties=../use_match_properties}}
-            {{#each message_containers}}
-                {{#with this}}
-                {{> single_message . use_match_properties=../../use_match_properties message_list_id=../../message_list_id is_archived=../is_archived}}
-                {{/with}}
-            {{/each}}
-        </div>
-    {{/with}}
+    <div class="recipient_row" id="{{message_group_id}}">
+        {{> recipient_row . use_match_properties=../use_match_properties}}
+        {{#each message_containers}}
+            {{> single_message . use_match_properties=../../use_match_properties message_list_id=../../message_list_id is_archived=../is_archived}}
+        {{/each}}
+    </div>
 {{/each}}

--- a/web/templates/stream_settings/browse_streams_list_item.hbs
+++ b/web/templates/stream_settings/browse_streams_list_item.hbs
@@ -1,5 +1,4 @@
 {{! Client-side Handlebars template for rendering subscriptions. }}
-{{#with this}}
 <div class="stream-row" data-stream-id="{{stream_id}}" data-stream-name="{{name}}">
 
     {{#if subscribed}}
@@ -70,4 +69,3 @@
         </div>
     </div>
 </div>
-{{/with}}


### PR DESCRIPTION
By definition, `this` is already the current context.