### PR TITLE
Backport several more changes to 9.x.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -541,8 +541,23 @@ export function create<Key, Item = Key>(
                     const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]!);
                     $target_row.after($(rendered_row));
                 } else {
-                    const $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]!);
-                    $target_row.before($(rendered_row));
+                    let $target_row = opts.html_selector!(meta.filtered_list[insert_index + 1]!);
+                    if ($target_row.length !== 0) {
+                        $target_row.before($(rendered_row));
+                    } else if (insert_index > 0) {
+                        // We don't have a row rendered after row we are trying to insert at.
+                        // So, try looking for the row before current row.
+                        $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]!);
+                        if ($target_row.length !== 0) {
+                            $target_row.after($(rendered_row));
+                        }
+                    }
+
+                    // If we failed at inserting the row due rows around the row
+                    // not being rendered yet, just do a clean redraw.
+                    if ($target_row.length === 0) {
+                        widget.clean_redraw();
+                    }
                 }
                 widget.increase_rendered_offset();
             }

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -922,10 +922,16 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     // we ensure the list remains sorted after insertion.
     topics_widget.replace_list_data(get_list_data_for_widget(), false);
     topics_widget.filter_and_sort();
-    for (const key of row_keys) {
-        inplace_rerender(key, true);
+    // Iterate in the order of which the rows should be present so that
+    // we are not inserting rows without any rows being present around them.
+    for (const topic_data of topics_widget.get_current_list()) {
+        const msg = message_store.get(topic_data.last_msg_id);
+        assert(msg !== undefined);
+        const topic_key = recent_view_util.get_key_from_message(msg);
+        if (row_keys.includes(topic_key)) {
+            inplace_rerender(topic_key, true);
+        }
     }
-
     setTimeout(revive_current_focus, 0);
 }
 

--- a/zerver/data_import/slack_message_conversion.py
+++ b/zerver/data_import/slack_message_conversion.py
@@ -157,13 +157,20 @@ def convert_markdown_syntax(text: str, regex: str, zulip_keyword: str) -> str:
 def convert_link_format(text: str) -> tuple[str, bool]:
     """
     1. Converts '<https://foo.com>' to 'https://foo.com'
-    2. Converts '<https://foo.com|foo>' to 'https://foo.com|foo'
+    2. Converts '<https://foo.com|foo>' to '[foo](https://foo.com)'
     """
     has_link = False
     for match in re.finditer(LINK_REGEX, text, re.VERBOSE):
-        converted_text = match.group(0).replace(">", "").replace("<", "")
+        slack_url = match.group(0)
+        url_parts = slack_url[1:-1].split("|", maxsplit=1)
+        # Check if there's a pipe with text after it
+        if len(url_parts) == 2:
+            converted_url = f"[{url_parts[1]}]({url_parts[0]})"
+        else:
+            converted_url = url_parts[0]
+
         has_link = True
-        text = text.replace(match.group(0), converted_text)
+        text = text.replace(slack_url, converted_url)
     return text, has_link
 
 

--- a/zerver/migrations/0622_backfill_imageattachment_again.py
+++ b/zerver/migrations/0622_backfill_imageattachment_again.py
@@ -1,3 +1,7 @@
+# Duplicate of database migration 0576, because the original used the
+# wrong path for servers using the local file upload backend, and
+# many servers had already upgraded to 9.2 where it was backported.
+
 import os
 from functools import reduce
 from operator import or_
@@ -117,7 +121,7 @@ class Migration(migrations.Migration):
     atomic = False
     dependencies = [
         # Because this will be backported to 9.x, we only depend on the last migration in 9.x
-        ("zerver", "0558_realmuserdefault_web_animate_image_previews_and_more"),
+        ("zerver", "0576_backfill_imageattachment"),
     ]
 
     operations = [

--- a/zerver/tests/fixtures/slack_message_conversion.json
+++ b/zerver/tests/fixtures/slack_message_conversion.json
@@ -8,7 +8,12 @@
     {
       "name": "slack_link_with_pipe",
       "input": ">Google logo today:\n><https://foo.com|foo>\n>Kinda boring",
-      "conversion_output": ">Google logo today:\n>https://foo.com|foo\n>Kinda boring"
+      "conversion_output": ">Google logo today:\n>[foo](https://foo.com)\n>Kinda boring"
+    },
+    {
+      "name": "slack_link_with_pipes",
+      "input": ">Google logo today:\n><https://foo.com|foo|oof>\n>Kinda boring",
+      "conversion_output": ">Google logo today:\n>[foo|oof](https://foo.com)\n>Kinda boring"
     },
     {
       "name": "slack_link2",

--- a/zerver/tests/test_slack_message_conversion.py
+++ b/zerver/tests/test_slack_message_conversion.py
@@ -113,6 +113,11 @@ class SlackMessageConversion(ZulipTestCase):
         self.assertEqual(text, "http://journals.plos.org/plosone/article")
         self.assertEqual(has_link, True)
 
+        message = "<http://chat.zulip.org/help/logging-in|Help logging in to CZO>"
+        text, mentioned_users, has_link = convert_to_zulip_markdown(message, [], {}, slack_user_map)
+        self.assertEqual(text, "[Help logging in to CZO](http://chat.zulip.org/help/logging-in)")
+        self.assertEqual(has_link, True)
+
         message = "<mailto:foo@foo.com>"
         text, mentioned_users, has_link = convert_to_zulip_markdown(message, [], {}, slack_user_map)
         self.assertEqual(text, "mailto:foo@foo.com")


### PR DESCRIPTION
Backports the following changes to 9.x:

- https://github.com/zulip/zulip/pull/32305
- ~~#31681~~
- ~~#32351~~
- ~~https://github.com/zulip/zulip/pull/32307~~
- https://github.com/zulip/zulip/pull/32162
- https://github.com/zulip/zulip/pull/32181

Edit: Dropped the migration status PRs; I'm not sure it is worth backporting their tests.