### PR TITLE
recent_view: Remove bootstrap classes from recent view buttons.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -510,19 +510,11 @@
     }
 
     .recent_view_container #recent_view_table .button-recent-filters {
-        background-color: hsl(211deg 29% 14%);
-        border-color: hsl(0deg 0% 0%);
-        color: hsl(0deg 0% 100%);
-
         &:focus {
             background-color: hsl(0deg 0% 0% / 50%) !important;
-            outline: 0;
         }
 
         &.fake_disabled_button {
-            cursor: not-allowed;
-            opacity: 0.5;
-
             &:hover {
                 background-color: hsl(0deg 0% 0% / 50%);
                 border-color: hsl(0deg 0% 0%);

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -162,8 +162,21 @@
     }
 
     .button-recent-filters {
+        color: var(--color-text-default);
+        background-color: var(--color-background-zulip-button);
+        border: 1px solid var(--color-border-zulip-button);
         border-radius: 40px;
         margin: 0 5px 10px 0;
+        padding: 6px 12px;
+        line-height: 100%;
+
+        &:hover {
+            background-color: var(--color-background-zulip-button-hover);
+        }
+
+        &:active {
+            background-color: var(--color-background-zulip-button-active);
+        }
 
         &:focus {
             background-color: hsl(0deg 0% 80%);

--- a/web/templates/recent_view_filters.hbs
+++ b/web/templates/recent_view_filters.hbs
@@ -1,5 +1,5 @@
 {{> ./dropdown_widget widget_name="recent-view-filter"}}
-<button data-filter="include_private" type="button" class="bootstrap-btn bootstrap-btn-default button-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="true">
+<button data-filter="include_private" type="button" class="button-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="true">
     {{#if filter_pm}}
     <i class="fa fa-check-square-o"></i>
     {{else}}
@@ -7,7 +7,7 @@
     {{/if}}
     {{t 'Include DMs' }}
 </button>
-<button data-filter="unread" type="button" class="bootstrap-btn bootstrap-btn-default button-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
+<button data-filter="unread" type="button" class="button-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
     {{#if filter_unread}}
     <i class="fa fa-check-square-o"></i>
     {{else}}
@@ -15,7 +15,7 @@
     {{/if}}
     {{t 'Unread' }}
 </button>
-<button data-filter="participated" type="button" class="bootstrap-btn bootstrap-btn-default button-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
+<button data-filter="participated" type="button" class="button-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
     {{#if filter_participated}}
     <i class="fa fa-check-square-o"></i>
     {{else}}

--- a/web/third/bootstrap/css/bootstrap-btn.css
+++ b/web/third/bootstrap/css/bootstrap-btn.css
@@ -77,33 +77,3 @@ THE SOFTWARE.
           box-shadow: none;
   opacity: .65;
 }
-.bootstrap-btn-default {
-  color: #333;
-  background-color: #fff;
-  border-color: #ccc;
-}
-.bootstrap-btn-default:hover,
-.bootstrap-btn-default:focus,
-.bootstrap-btn-default:active,
-.bootstrap-btn-default.active {
-  color: #333;
-  background-color: #ebebeb;
-  border-color: #adadad;
-}
-.bootstrap-btn-default:active,
-.bootstrap-btn-default.active {
-  background-image: none;
-}
-.bootstrap-btn-default.disabled,
-.bootstrap-btn-default[disabled],
-.bootstrap-btn-default.disabled:hover,
-.bootstrap-btn-default[disabled]:hover,
-.bootstrap-btn-default.disabled:focus,
-.bootstrap-btn-default[disabled]:focus,
-.bootstrap-btn-default.disabled:active,
-.bootstrap-btn-default[disabled]:active,
-.bootstrap-btn-default.disabled.active,
-.bootstrap-btn-default[disabled].active {
-  background-color: #fff;
-  border-color: #ccc;
-}


### PR DESCRIPTION
This PR removes the final vestiges of `bootstrap-btn-default` class from the codebase, by moving the relevant styles from the `bootstrap-btn` and `bootstrap-btn-default` classes to the `button-recent-filters` class.

Fixes: https://github.com/zulip/zulip/pull/32357#discussion_r1842726540

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2024-11-20 at 11 59 27 PM](https://github.com/user-attachments/assets/3e4694c6-ba93-4a72-a781-47a78ce5268e) | ![Screenshot 2024-11-21 at 12 01 17 AM](https://github.com/user-attachments/assets/a5673f2b-0666-4ff2-829b-2cbfea5c6675) | 
| ![Screenshot 2024-11-21 at 12 00 27 AM](https://github.com/user-attachments/assets/5b4c7db1-3d64-4e49-865d-bb91db41ca5f) | ![Screenshot 2024-11-21 at 12 01 05 AM](https://github.com/user-attachments/assets/ff07459b-e3b9-40d4-a192-ca85b7bf2180) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
