### PR TITLE
portico: Improve layout of the /go page

### DIFF
--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -19,10 +19,10 @@
                     {{ csrf_input }}
                     <div class="input-box horizontal">
                         <div class="inline-block relative">
-                            <p id="realm_redirect_description">{{ _("Enter your organization's Zulip URL:") }}</p>
+                            <p id="realm_redirect_description">{{ _("Organization URL") }}</p>
                             <input
                               type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
-                              placeholder="{{ _('your-organization-url') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
+                              placeholder="{{ _('your-organization') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
                               autocomplete="off" required/>
                             <span id="realm_redirect_external_host">.{{external_host}}</span>
                         </div>
@@ -33,11 +33,11 @@
                                 {% endfor %}
                             {% endif %}
                         </div>
-                        <button id="enter-realm-button" type="submit">{{ _('Next') }}</button>
-                        <p class="bottom-text">
+                        <p class="bottom-text left-text">
                             {{ _("Don't know your organization URL?") }}
                             <a target="_blank" rel="noopener noreferrer" href="/accounts/find/">{{ _("Find your organization.") }}</a>
                         </p>
+                        <button id="enter-realm-button" type="submit">{{ _('Next') }}</button>
                     </div>
                 </form>
             </div>

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -127,7 +127,7 @@ IGNORED_PHRASES = [
     # Emoji name placeholder
     r"leafy green vegetable",
     # Subdomain placeholder
-    r"your-organization-url",
+    r"your-organization",
     # Used in invite modal
     r"or",
     # Units

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -46,6 +46,11 @@ html {
     }
 }
 
+.left-text {
+    text-align: left;
+    margin-top: 0;
+}
+
 #new-realm-creation {
     .get-started {
         font-size: 2rem;
@@ -1210,6 +1215,9 @@ button#register_auth_button_gitlab {
     #realm_redirect_description {
         top: 15px;
         position: relative;
+        text-align: left;
+        font-weight: 600;
+        margin-bottom: -5px;
     }
 
     #enter-realm-button {

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4699,7 +4699,7 @@ class NameRestrictionsTest(ZulipTestCase):
 class RealmRedirectTest(ZulipTestCase):
     def test_realm_redirect_without_next_param(self) -> None:
         result = self.client_get("/accounts/go/")
-        self.assert_in_success_response(["Enter your organization's Zulip URL"], result)
+        self.assert_in_success_response(["Organization URL"], result)
 
         result = self.client_post("/accounts/go/", {"subdomain": "zephyr"})
         self.assertEqual(result.status_code, 302)
@@ -4711,7 +4711,7 @@ class RealmRedirectTest(ZulipTestCase):
     def test_realm_redirect_with_next_param(self) -> None:
         result = self.client_get("/accounts/go/", {"next": "billing"})
         self.assert_in_success_response(
-            ["Enter your organization's Zulip URL", 'action="/accounts/go/?next=billing"'], result
+            ["Organization URL", 'action="/accounts/go/?next=billing"'], result
         )
 
         result = self.client_post("/accounts/go/?next=billing", {"subdomain": "lear"})


### PR DESCRIPTION
I have made some UI changes as mentioned in [#32198](https://github.com/zulip/zulip/issues/32198):

1. Left aligned the label to make it consistent.
2. Changed the text: 'Enter your organization's Zulip URL' -> 'Organization URL'
3. Moved 'Don't know your organization URL? Find your organization.' to be just below the URL field.
4. Changed the placeholder 'your-organization-url' -> 'your-organization'

Fixes: [#32198](https://github.com/zulip/zulip/issues/32198) 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/a92022ad-9ed5-475f-9d1f-3cbbc07efa2c)

<details>
<summary>Earlier</summary>

![Screenshot_20241123_060049](https://github.com/user-attachments/assets/7827f614-1b62-4a31-b293-fef2d0223239)

![image](https://github.com/user-attachments/assets/297969df-bc58-4359-bf33-0502ea0b698f)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
