### PR TITLE
Refine tools/generate-integration-docs-screenshot

### DIFF
--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -172,7 +172,8 @@ def send_bot_payload_message(
     data, json_fixture, fixture_name = get_fixture_info(fixture_path)
 
     headers = get_requests_headers(integration.name, fixture_name)
-    headers.update(config.custom_headers)
+    if config.custom_headers:
+        headers.update(config.custom_headers)
     if config.use_basic_auth:
         credentials = base64.b64encode(f"{bot.email}:{bot.api_key}".encode()).decode()
         auth = f"basic {credentials}"

--- a/tools/screenshots/generate-integration-docs-screenshot
+++ b/tools/screenshots/generate-integration-docs-screenshot
@@ -61,7 +61,7 @@ def create_integration_bot(integration: Integration, bot_name: str | None = None
     owner = get_user_by_delivery_email("iago@zulip.com", realm)
     bot_email = f"{integration.name}-bot@example.com"
     if bot_name is None:
-        bot_name = f"{integration.name.capitalize()} Bot"
+        bot_name = f"{integration.display_name} Bot"
     try:
         bot = UserProfile.objects.get(email=bot_email)
     except UserProfile.DoesNotExist:


### PR DESCRIPTION
After #32413
See [comment](https://github.com/zulip/zulip/pull/32413#:~:text=We%20could%20do%20this%20round%20as%20part%20of%20%2332414%20too%2C%20after%20the%20bot%20names%20are%20updated.)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
