### PR TITLE
settings: Wait for settings overlay to close.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -42,6 +42,7 @@ async function close_settings_and_date_picker(page: Page): Promise<void> {
 
     await page.keyboard.press("Escape");
     await page.waitForSelector(".flatpickr-calendar", {hidden: true});
+    await page.waitForSelector("#settings_overlay_container", {hidden: true});
 }
 
 async function test_change_full_name(page: Page): Promise<void> {


### PR DESCRIPTION
Since pressing `escape` key closes flatpickr and settings overlay at the same time, we need to wait for the settings to be not visible.

If we don't wait for the settings overlay to close, the next test could think the settings overlay is already open and continue with its tests which can easily become flaky.
