### PR TITLE
custom_check: Add rule to avoid creating savepoints. 

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1792,7 +1792,7 @@ class BillingSession(ABC):
         )
 
         # TODO: The correctness of this relies on user creation, deactivation, etc being
-        # in a transaction.atomic() with the relevant RealmAuditLog entries
+        # in a transaction.atomic block with the relevant RealmAuditLog entries
         with transaction.atomic(durable=True):
             # We get the current license count here in case the number of billable
             # licenses has changed since the upgrade process began.

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -462,8 +462,23 @@ python_rules = RuleList(
             "description": 'A mock function is missing a leading "assert_"',
         },
         {
-            "pattern": "@transaction.atomic\\(\\)",
-            "description": "Use @transaction.atomic as function decorator for consistency.",
+            "pattern": r"transaction\.atomic$|transaction\.atomic\(\)|savepoint=True",
+            "description": "Use 'durable=True' or 'savepoint=False' argument explicitly to avoid the possibility of creating savepoints.",
+            "exclude": {"confirmation/migrations/", "zerver/migrations/", "zilencer/migrations/"},
+            "exclude_line": {
+                (
+                    "zerver/actions/create_user.py",
+                    "with suppress(IntegrityError), transaction.atomic(savepoint=True):",
+                ),
+                (
+                    "zerver/lib/test_classes.py",
+                    "with transaction.atomic(savepoint=True):",
+                ),
+                (
+                    "zerver/tests/test_subs.py",
+                    "with transaction.atomic(savepoint=True), self.assertRaises(JsonableError):",
+                ),
+            },
         },
         *whitespace_rules,
         *shebang_rules,

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -132,7 +132,7 @@ def run_archiving(
     # archived-and-deleted or not transactionally.
     #
     # We implement this design by executing queries that archive messages and their related objects
-    # (such as UserMessage, Reaction, and Attachment) inside the same transaction.atomic() block.
+    # (such as UserMessage, Reaction, and Attachment) inside the same transaction.atomic block.
     assert type in (ArchiveTransaction.MANUAL, ArchiveTransaction.RETENTION_POLICY_BASED)
 
     if chunk_size is not None:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1462,10 +1462,10 @@ Output:
             "invite_only": orjson.dumps(invite_only).decode(),
         }
         post_data.update(extra_post_data)
-        # We wrap the API call with a 'transaction.atomic()' context
+        # We wrap the API call with a 'transaction.atomic' context
         # manager as it helps us with NOT rolling back the entire
         # test transaction due to error responses.
-        with transaction.atomic():
+        with transaction.atomic(savepoint=True):
             result = self.api_post(
                 user,
                 "/api/v1/users/me/subscriptions",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4111,7 +4111,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         def thunk2() -> HttpResponse:
             raise JsonableError("random failure")
 
-        with transaction.atomic(), self.assertRaises(JsonableError):
+        with transaction.atomic(savepoint=True), self.assertRaises(JsonableError):
             # The atomic() wrapper helps to avoid JsonableError breaking
             # the test's transaction.
             compose_views([thunk1, thunk2])

--- a/zerver/transaction_tests/test_user_groups.py
+++ b/zerver/transaction_tests/test_user_groups.py
@@ -70,7 +70,7 @@ class UserGroupRaceConditionTestCase(ZulipTransactionTestCase):
     @override
     def tearDown(self) -> None:
         # Clean up the user groups created to minimize leakage
-        with transaction.atomic():
+        with transaction.atomic(durable=True):
             for group in self.created_user_groups:
                 # can_manage_group can be deleted as long as it's the
                 # default group_creator. If we start using non-default


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/channel/3-backend/topic/make.20add_subscription_backend.20atomic/near/1978928)

* First 2 commits are to handle the remaining `transaction.atomic` calls without `durable=True` or `savepoint=False`.
* We can drop the 3rd commit if it's not required. I felt the code should be explicit when using `savepoint=True`.
* The last commit adds a custom lint rule to avoid creating unintended savepoints. 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
