### PR TITLE
integrations: Fix jQuery .data mishandling translated category names.

### DIFF
--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -107,7 +107,7 @@
                                   class="integration-lozenge integration-{{ integration.name }} legacy"{% else %}
                                   class="integration-lozenge integration-{{ integration.name }}"
                                   {% endif %}
-                                  data-categories="{{ integration.categories }}"
+                                  data-categories='{{ integration.get_translated_categories()|tojson }}'
                                   data-name="{{ integration.name }}">
                                     <img class="integration-logo" src="{{ integration.logo_url }}"
                                       alt="{{ integration.display_name }} logo"/>

--- a/web/src/portico/integrations.js
+++ b/web/src/portico/integrations.js
@@ -15,7 +15,7 @@ const CATEGORIES = new Map();
 
 function load_data() {
     for (const integration of $(".integration-lozenge")) {
-        const name = $(integration).data("name");
+        const name = $(integration).attr("data-name");
         const display_name = $(integration).find(".integration-name").text().trim();
 
         if (display_name && name) {
@@ -24,7 +24,7 @@ function load_data() {
     }
 
     for (const category of $(".integration-category")) {
-        const name = $(category).data("category");
+        const name = $(category).attr("data-category");
         const display_name = $(category).text().trim();
 
         if (display_name && name) {
@@ -115,10 +115,10 @@ const update_integrations = _.debounce(() => {
         }
 
         if (!$integration.hasClass("integration-create-your-own")) {
-            const display_name = INTEGRATIONS.get($integration.data("name"));
+            const display_name = INTEGRATIONS.get($integration.attr("data-name"));
             const display =
                 common.phrase_match(state.query, display_name) &&
-                ($integration.data("categories").includes(CATEGORIES.get(state.category)) ||
+                ($integration.attr("data-categories").includes(CATEGORIES.get(state.category)) ||
                     state.category === "all");
 
             if (display) {
@@ -141,7 +141,7 @@ function hide_catalog_show_integration() {
     $lozenge_icon.removeClass("legacy");
 
     const categories = $(`.integration-${CSS.escape(state.integration)}`)
-        .data("categories")
+        .attr("data-categories")
         .slice(1, -1)
         .split(",")
         .map((category) => category.trim().slice(1, -1));
@@ -324,13 +324,13 @@ function integration_events() {
 
     $(".integration-instruction-block").on("click", "a .integration-category", (e) => {
         e.preventDefault();
-        const category = $(e.target).data("category");
+        const category = $(e.target).attr("data-category");
         dispatch("SHOW_CATEGORY", {category});
     });
 
     $(".integrations a .integration-category").on("click", (e) => {
         e.preventDefault();
-        const category = $(e.target).data("category");
+        const category = $(e.target).attr("data-category");
         dispatch("CHANGE_CATEGORY", {category});
         toggle_categories_dropdown();
     });
@@ -338,7 +338,7 @@ function integration_events() {
     $(".integrations a .integration-lozenge").on("click", (e) => {
         if (!$(e.target).closest(".integration-lozenge").hasClass("integration-create-your-own")) {
             e.preventDefault();
-            const integration = $(e.target).closest(".integration-lozenge").data("name");
+            const integration = $(e.target).closest(".integration-lozenge").attr("data-name");
             dispatch("SHOW_INTEGRATION", {integration});
         }
     });

--- a/web/src/portico/integrations.js
+++ b/web/src/portico/integrations.js
@@ -118,7 +118,9 @@ const update_integrations = _.debounce(() => {
             const display_name = INTEGRATIONS.get($integration.attr("data-name"));
             const display =
                 common.phrase_match(state.query, display_name) &&
-                ($integration.attr("data-categories").includes(CATEGORIES.get(state.category)) ||
+                (JSON.parse($integration.attr("data-categories")).includes(
+                    CATEGORIES.get(state.category),
+                ) ||
                     state.category === "all");
 
             if (display) {
@@ -140,11 +142,9 @@ function hide_catalog_show_integration() {
     ).clone(false);
     $lozenge_icon.removeClass("legacy");
 
-    const categories = $(`.integration-${CSS.escape(state.integration)}`)
-        .attr("data-categories")
-        .slice(1, -1)
-        .split(",")
-        .map((category) => category.trim().slice(1, -1));
+    const categories = JSON.parse(
+        $(`.integration-${CSS.escape(state.integration)}`).attr("data-categories"),
+    );
 
     function show_integration(doc) {
         $("#integration-instructions-group .name").text(INTEGRATIONS.get(state.integration));

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -139,6 +139,9 @@ class Integration:
 
         return None
 
+    def get_translated_categories(self) -> list[str]:
+        return [str(category) for category in self.categories]
+
 
 class BotIntegration(Integration):
     DEFAULT_LOGO_STATIC_PATH_PNG = "generated/bots/{name}/logo.png"


### PR DESCRIPTION
Apparently `.data("category")` would be come back as a single-element array for some French translations, rather than a string.

We fix this by using `.attr("data-category")` across this file, which is our preferred coding pattern anyway.
