### PR TITLE
left_sidebar: Show tooltip for truncated channel names

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -92,7 +92,6 @@ async function navigation_tests(page: Page): Promise<void> {
     await common.log_in(page);
 
     await navigate_to_settings(page);
-
     await navigate_using_left_sidebar(page, "Verona");
 
     await page.click("#left-sidebar-navigation-list .home-link");

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -185,6 +185,25 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".subscription_block",
+        trigger: "mouseenter",
+        delay: LONG_HOVER_DELAY,
+        placement: "right",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const stream_name = instance.reference.querySelector(".stream-name");
+            assert(stream_name instanceof HTMLElement);
+            if (stream_name.offsetWidth < stream_name.scrollWidth) {
+                const truncated_stream_name = stream_name.textContent ?? "";
+                instance.setContent(truncated_stream_name);
+            } else {
+                return false;
+            }
+            return false;
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -193,13 +193,12 @@ export function initialize(): void {
         onShow(instance) {
             const stream_name = instance.reference.querySelector(".stream-name");
             assert(stream_name instanceof HTMLElement);
-            if (stream_name.offsetWidth < stream_name.scrollWidth) {
-                const truncated_stream_name = stream_name.textContent ?? "";
-                instance.setContent(truncated_stream_name);
-            } else {
+            if (stream_name.offsetWidth >= stream_name.scrollWidth) {
                 return false;
             }
-            return false;
+            const truncated_stream_name = stream_name.textContent ?? "";
+            instance.setContent(truncated_stream_name);
+            return undefined;
         },
     });
 


### PR DESCRIPTION
Fixes: [#31807](https://github.com/zulip/zulip/issues/31807) 

This PR is a continuation of [#31851](https://github.com/zulip/zulip/pull/31851). 
Here we're showing tooltip only for the channels with truncated channel names by replacing the default HTML tooltip with Tippy.js tooltips.

![Screenshot_20241122_225924](https://github.com/user-attachments/assets/49180411-b77b-44ed-9fab-31c7b00534c8)
![Screenshot_20241122_225911](https://github.com/user-attachments/assets/3e901721-6408-47f5-99de-701c9f0ca386)
