### PR TITLE
right_sidebar: Match invite-user grid to others.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -556,12 +556,16 @@ $user_status_emoji_width: 24px;
        from the legacy value. */
     margin-top: calc(25px - (var(--legacy-body-line-height-unitless) * 1em));
     margin-bottom: var(--sidebar-bottom-spacing);
+    padding-left: 0;
 
     .invite-user-link {
-        grid-template-columns: auto minmax(0, 1fr);
+        grid-template-columns: var(--right-sidebar-header-icon-toggle-width) minmax(
+                0,
+                1fr
+            );
 
         .zulip-icon-user-plus {
-            padding-right: 5px;
+            justify-self: center;
         }
     }
 }


### PR DESCRIPTION
This PR provides a small tweak to the Invite users to organization link, putting its text and icon in the same gridded areas as other rows in the right sidebar.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/invite.20users.20link.20in.20right.20sidebar.20.20.2332332/near/1986017)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After, no subheads | After, with subheads | After, with avatars |
| --- | --- | --- | --- |
| ![before-no-subheads](https://github.com/user-attachments/assets/3e6997a4-91f1-4867-b154-db251ee99aab) | ![after-no-subheads](https://github.com/user-attachments/assets/89cb2705-a924-458f-bd17-2150a4787e7f) | ![after-with-subheads](https://github.com/user-attachments/assets/7db52435-d2c4-4176-8c3b-8ecc37e4b74d) | ![with-avatars-after](https://github.com/user-attachments/assets/6eede581-3705-44c4-92e6-0a7269d48bf3) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>