### PR TITLE
migrations: Add progress indicator for imageattachment backfill.

### DIFF
--- a/zerver/migrations/0576_backfill_imageattachment.py
+++ b/zerver/migrations/0576_backfill_imageattachment.py
@@ -45,21 +45,24 @@ def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaE
         extension_limits,
     )
 
+    attachments_query = (
+        Attachment.objects.alias(
+            has_imageattachment=Exists(ImageAttachment.objects.filter(path_id=OuterRef("path_id")))
+        )
+        .filter(extension_limits, has_imageattachment=False)
+        .order_by("id")
+    )
+
+    already_processed = 0
+    total_to_process = attachments_query.count()
     min_id: int | None = 0
     while True:
-        attachments = (
-            Attachment.objects.alias(
-                has_imageattachment=Exists(
-                    ImageAttachment.objects.filter(path_id=OuterRef("path_id"))
-                )
-            )
-            .filter(extension_limits, has_imageattachment=False, id__gt=min_id)
-            .order_by("id")
-        )[:1000]
+        attachments = attachments_query.filter(id__gt=min_id)[:100]
 
         min_id = None
         for attachment in attachments:
             min_id = attachment.id
+            already_processed += 1
 
             if settings.LOCAL_UPLOADS_DIR is None:
                 try:
@@ -109,6 +112,7 @@ def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaE
             except pyvips.Error:
                 pass
 
+        print(f"Processed {already_processed}/{total_to_process}")
         if min_id is None:
             break
 

--- a/zerver/migrations/0622_backfill_imageattachment_again.py
+++ b/zerver/migrations/0622_backfill_imageattachment_again.py
@@ -49,21 +49,24 @@ def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaE
         extension_limits,
     )
 
+    attachments_query = (
+        Attachment.objects.alias(
+            has_imageattachment=Exists(ImageAttachment.objects.filter(path_id=OuterRef("path_id")))
+        )
+        .filter(extension_limits, has_imageattachment=False)
+        .order_by("id")
+    )
+
+    already_processed = 0
+    total_to_process = attachments_query.count()
     min_id: int | None = 0
     while True:
-        attachments = (
-            Attachment.objects.alias(
-                has_imageattachment=Exists(
-                    ImageAttachment.objects.filter(path_id=OuterRef("path_id"))
-                )
-            )
-            .filter(extension_limits, has_imageattachment=False, id__gt=min_id)
-            .order_by("id")
-        )[:1000]
+        attachments = attachments_query.filter(id__gt=min_id)[:100]
 
         min_id = None
         for attachment in attachments:
             min_id = attachment.id
+            already_processed += 1
 
             if settings.LOCAL_UPLOADS_DIR is None:
                 try:
@@ -113,6 +116,7 @@ def backfill_imageattachment(apps: StateApps, schema_editor: BaseDatabaseSchemaE
             except pyvips.Error:
                 pass
 
+        print(f"Processed {already_processed}/{total_to_process}")
         if min_id is None:
             break
 


### PR DESCRIPTION
These migrations can take a while, so it's worth having a progress indicator.

Fixes #32232.
