### PR TITLE
stream_delete_event: Include only stream IDs in the event.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 343**
+
+* [`GET /events`](/api/get-events): Added a new field `stream_ids` to replace
+  `streams` in stream delete event and label `streams` as deprecated.
+
 **Feature level 342**
 
 * [`GET /users/me/subscriptions`](/api/get-subscriptions),

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 342  # Last bumped for adding stream.can_add_subscribers_group
+API_FEATURE_LEVEL = 343  # Last bumped for `stream_ids` field in stream deletion events.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/message_view_header.ts
+++ b/web/src/message_view_header.ts
@@ -175,9 +175,10 @@ export function render_title_area(): void {
 // This function checks if "modified_sub" which is the stream whose values
 // have been updated is the same as the stream which is currently
 // narrowed and rerenders if necessary
-export function maybe_rerender_title_area_for_stream(modified_sub: StreamSubscription): void {
+export function maybe_rerender_title_area_for_stream(modified_stream_id: number): void {
     const current_stream_id = narrow_state.stream_id();
-    if (current_stream_id === modified_sub.stream_id) {
+
+    if (current_stream_id === modified_stream_id) {
         render_title_area();
     }
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -605,7 +605,7 @@ export function dispatch_normal_event(event) {
                         );
                         stream_data.delete_sub(stream.stream_id);
                         stream_settings_ui.remove_stream(stream.stream_id);
-                        message_view_header.maybe_rerender_title_area_for_stream(stream);
+                        message_view_header.maybe_rerender_title_area_for_stream(stream.stream_id);
                         if (was_subscribed) {
                             stream_list.remove_sidebar_row(stream.stream_id);
                             if (stream.stream_id === compose_state.selected_recipient_id) {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -598,32 +598,30 @@ export function dispatch_normal_event(event) {
                     stream_list.update_subscribe_to_more_streams_link();
                     break;
                 case "delete":
-                    for (const stream of event.streams) {
-                        const was_subscribed = sub_store.get(stream.stream_id).subscribed;
-                        const is_narrowed_to_stream = narrow_state.is_for_stream_id(
-                            stream.stream_id,
-                        );
-                        stream_data.delete_sub(stream.stream_id);
-                        stream_settings_ui.remove_stream(stream.stream_id);
-                        message_view_header.maybe_rerender_title_area_for_stream(stream.stream_id);
+                    for (const stream_id of event.stream_ids) {
+                        const was_subscribed = sub_store.get(stream_id).subscribed;
+                        const is_narrowed_to_stream = narrow_state.is_for_stream_id(stream_id);
+                        stream_data.delete_sub(stream_id);
+                        stream_settings_ui.remove_stream(stream_id);
+                        message_view_header.maybe_rerender_title_area_for_stream(stream_id);
                         if (was_subscribed) {
-                            stream_list.remove_sidebar_row(stream.stream_id);
-                            if (stream.stream_id === compose_state.selected_recipient_id) {
+                            stream_list.remove_sidebar_row(stream_id);
+                            if (stream_id === compose_state.selected_recipient_id) {
                                 compose_state.set_selected_recipient_id("");
                                 compose_recipient.on_compose_select_recipient_update();
                             }
                         }
                         settings_streams.update_default_streams_table();
-                        stream_data.remove_default_stream(stream.stream_id);
-                        if (realm.realm_new_stream_announcements_stream_id === stream.stream_id) {
+                        stream_data.remove_default_stream(stream_id);
+                        if (realm.realm_new_stream_announcements_stream_id === stream_id) {
                             realm.realm_new_stream_announcements_stream_id = -1;
                             settings_org.sync_realm_settings("new_stream_announcements_stream_id");
                         }
-                        if (realm.realm_signup_announcements_stream_id === stream.stream_id) {
+                        if (realm.realm_signup_announcements_stream_id === stream_id) {
                             realm.realm_signup_announcements_stream_id = -1;
                             settings_org.sync_realm_settings("signup_announcements_stream_id");
                         }
-                        if (realm.realm_zulip_update_announcements_stream_id === stream.stream_id) {
+                        if (realm.realm_zulip_update_announcements_stream_id === stream_id) {
                             realm.realm_zulip_update_announcements_stream_id = -1;
                             settings_org.sync_realm_settings(
                                 "zulip_update_announcements_stream_id",

--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -233,7 +233,7 @@ export function mark_subscribed(
     }
 
     // update navbar if necessary
-    message_view_header.maybe_rerender_title_area_for_stream(sub);
+    message_view_header.maybe_rerender_title_area_for_stream(sub.stream_id);
 
     if (stream_create.get_name() === sub.name) {
         // In this case, we just created this channel using this very
@@ -275,7 +275,7 @@ export function mark_unsubscribed(sub: StreamSubscription): void {
             stream_settings_ui.update_settings_for_unsubscribed(sub);
         }
         // update navbar if necessary
-        message_view_header.maybe_rerender_title_area_for_stream(sub);
+        message_view_header.maybe_rerender_title_area_for_stream(sub.stream_id);
     } else {
         // Already unsubscribed
         return;

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -135,7 +135,7 @@ export function update_stream_name(sub: StreamSubscription, new_name: string): v
     }
 
     // Update navbar if needed
-    message_view_header.maybe_rerender_title_area_for_stream(sub);
+    message_view_header.maybe_rerender_title_area_for_stream(sub.stream_id);
 
     // Update the create stream error if needed
     if (overlays.streams_open()) {
@@ -160,7 +160,7 @@ export function update_stream_description(
     stream_edit.update_stream_description(sub);
 
     // Update navbar if needed
-    message_view_header.maybe_rerender_title_area_for_stream(sub);
+    message_view_header.maybe_rerender_title_area_for_stream(sub.stream_id);
 }
 
 export function update_stream_privacy(
@@ -195,7 +195,7 @@ export function update_stream_privacy(
     }
 
     // Update navbar if needed
-    message_view_header.maybe_rerender_title_area_for_stream(sub);
+    message_view_header.maybe_rerender_title_area_for_stream(sub.stream_id);
 }
 
 export function update_message_retention_setting(
@@ -228,7 +228,7 @@ export function update_is_default_stream(): void {
 export function update_subscribers_ui(sub: StreamSubscription): void {
     update_left_panel_row(sub);
     stream_edit_subscribers.update_subscribers_list(sub);
-    message_view_header.maybe_rerender_title_area_for_stream(sub);
+    message_view_header.maybe_rerender_title_area_for_stream(sub.stream_id);
 }
 
 export function add_sub_to_table(sub: StreamSubscription): void {

--- a/web/tests/dispatch_subs.test.cjs
+++ b/web/tests/dispatch_subs.test.cjs
@@ -199,11 +199,22 @@ test("stream create", ({override}) => {
 test("stream delete (normal)", ({override}) => {
     const event = event_fixtures.stream__delete;
 
-    for (const stream of event.streams) {
-        stream_data.add_sub(stream);
-    }
+    const devel_sub = {
+        stream_id: event.stream_ids[0],
+        name: "devel",
+        is_archived: false,
+    };
 
-    stream_data.subscribe_myself(event.streams[0]);
+    const test_sub = {
+        stream_id: event.stream_ids[1],
+        name: "test",
+        is_archived: false,
+    };
+
+    stream_data.add_sub(test_sub);
+    stream_data.add_sub(devel_sub);
+
+    stream_data.subscribe_myself(devel_sub);
 
     override(settings_streams, "update_default_streams_table", noop);
 
@@ -230,7 +241,7 @@ test("stream delete (normal)", ({override}) => {
 
     dispatch(event);
 
-    assert.deepEqual(removed_stream_ids, [event.streams[0].stream_id, event.streams[1].stream_id]);
+    assert.deepEqual(removed_stream_ids, [event.stream_ids[0], event.stream_ids[1]]);
 
     // We should possibly be able to make a single call to
     // update_trailing_bookend, but we currently do it for each stream.
@@ -242,18 +253,28 @@ test("stream delete (normal)", ({override}) => {
 test("stream delete (special streams)", ({override}) => {
     const event = event_fixtures.stream__delete;
 
-    for (const stream of event.streams) {
-        stream.is_archived = false;
-        stream_data.add_sub(stream);
-    }
+    const devel_sub = {
+        stream_id: event.stream_ids[0],
+        name: "devel",
+        is_archived: false,
+    };
 
-    stream_data.subscribe_myself(event.streams[0]);
+    const test_sub = {
+        stream_id: event.stream_ids[1],
+        name: "test",
+        is_archived: false,
+    };
+
+    stream_data.add_sub(devel_sub);
+    stream_data.add_sub(test_sub);
+
+    stream_data.subscribe_myself(devel_sub);
 
     // sanity check data
-    assert.equal(event.streams.length, 2);
-    override(realm, "realm_new_stream_announcements_stream_id", event.streams[0].stream_id);
-    override(realm, "realm_signup_announcements_stream_id", event.streams[1].stream_id);
-    override(realm, "realm_zulip_update_announcements_stream_id", event.streams[0].stream_id);
+    assert.equal(event.stream_ids.length, 2);
+    override(realm, "realm_new_stream_announcements_stream_id", event.stream_ids[0]);
+    override(realm, "realm_signup_announcements_stream_id", event.stream_ids[1]);
+    override(realm, "realm_zulip_update_announcements_stream_id", event.stream_ids[0]);
 
     override(stream_settings_ui, "remove_stream", noop);
     override(settings_org, "sync_realm_settings", noop);
@@ -276,13 +297,23 @@ test("stream delete (stream is selected in compose)", ({override}) => {
 
     const event = event_fixtures.stream__delete;
 
-    for (const stream of event.streams) {
-        stream.is_archived = false;
-        stream_data.add_sub(stream);
-    }
+    const devel_sub = {
+        stream_id: event.stream_ids[0],
+        name: "devel",
+        is_archived: false,
+    };
 
-    stream_data.subscribe_myself(event.streams[0]);
-    compose_state.set_stream_id(event.streams[0].stream_id);
+    const test_sub = {
+        stream_id: event.stream_ids[1],
+        name: "test",
+        is_archived: false,
+    };
+
+    stream_data.add_sub(devel_sub);
+    stream_data.add_sub(test_sub);
+
+    stream_data.subscribe_myself(devel_sub);
+    compose_state.set_stream_id(event.stream_ids[0]);
 
     override(settings_streams, "update_default_streams_table", noop);
 
@@ -310,7 +341,7 @@ test("stream delete (stream is selected in compose)", ({override}) => {
     dispatch(event);
 
     assert.equal(compose_state.stream_name(), "");
-    assert.deepEqual(removed_stream_ids, [event.streams[0].stream_id, event.streams[1].stream_id]);
+    assert.deepEqual(removed_stream_ids, [event.stream_ids[0], event.stream_ids[1]]);
 
     // We should possibly be able to make a single call to
     // update_trailing_bookend, but we currently do it for each stream.

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -676,14 +676,13 @@ exports.fixtures = {
         op: "delete",
         streams: [
             {
-                ...streams.devel,
-                stream_weekly_traffic: null,
+                stream_id: streams.devel.stream_id,
             },
             {
-                ...streams.test,
-                stream_weekly_traffic: null,
+                stream_id: streams.test.stream_id,
             },
         ],
+        stream_ids: [streams.devel.stream_id, streams.test.stream_id],
     },
 
     stream__update: {

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -31,6 +31,7 @@ from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
     get_group_setting_value_dict_for_streams,
     get_streams_for_user,
+    send_stream_deletion_event,
     stream_to_dict,
 )
 from zerver.lib.types import AnonymousSettingGroupDict
@@ -589,12 +590,7 @@ def send_stream_events_for_role_update(
         now_inaccessible_streams = [
             stream for stream in old_accessible_streams if stream.id in now_inaccessible_stream_ids
         ]
-        event = dict(
-            type="stream",
-            op="delete",
-            streams=[stream_to_dict(stream) for stream in now_inaccessible_streams],
-        )
-        send_event_on_commit(user_profile.realm, event, [user_profile.id])
+        send_stream_deletion_event(user_profile.realm, [user_profile.id], now_inaccessible_streams)
 
 
 @transaction.atomic(savepoint=False)

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -770,7 +770,10 @@ class EventStreamCreate(BaseEvent):
 class EventStreamDelete(BaseEvent):
     type: Literal["stream"]
     op: Literal["delete"]
-    streams: list[BasicStreamFields]
+    # Streams is a legacy field for backwards-compatibility, and will
+    # be removed in the future.
+    streams: list[dict[Literal["stream_id"], int]]
+    stream_ids: list[int]
 
 
 class EventStreamUpdateCore(BaseEvent):

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -275,7 +275,7 @@ class DefaultStreamDict(TypedDict):
     message_retention_days: int | None
     name: str
     rendered_description: str
-    stream_id: int  # `stream_id`` represents `id` of the `Stream` object in `API_FIELDS`
+    stream_id: int  # `stream_id` represents `id` of the `Stream` object in `API_FIELDS`
     stream_post_policy: int
     # Computed fields not specified in `Stream.API_FIELDS`
     is_announcement_only: bool

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1386,39 +1386,39 @@ paths:
                                     - delete
                                 streams:
                                   type: array
+                                  deprecated: true
                                   description: |
-                                    Array of objects, each containing
-                                    details about a channel that was deleted.
+                                    Array of objects, each containing ID of the channel that was deleted.
+
+                                    **Changes**: **Deprecated** in Zulip 10.0 (feature level 343)
+                                    and will be removed in a future release. Previously, these
+                                    objects additionally contained all the standard fields for a
+                                    channel object.
                                   items:
-                                    $ref: "#/components/schemas/BasicChannel"
+                                    type: object
+                                    properties:
+                                      stream_id:
+                                        type: integer
+                                        description: |
+                                          ID of the deleted channel.
+                                    additionalProperties: false
+                                stream_ids:
+                                  type: array
+                                  description: |
+                                    Array containing the IDs of the channels that were deleted.
+
+                                    **Changes**: New in Zulip 10.0 (feature level 343). Previously,
+                                    these IDs were available only via the legacy `streams` array.
+                                  items:
+                                    type: integer
                               additionalProperties: false
                               example:
                                 {
                                   "type": "stream",
                                   "op": "delete",
                                   "streams":
-                                    [
-                                      {
-                                        "name": "private",
-                                        "stream_id": 12,
-                                        "is_archived": true,
-                                        "description": "",
-                                        "rendered_description": "",
-                                        "date_created": 1691057093,
-                                        "creator_id": 11,
-                                        "invite_only": true,
-                                        "is_web_public": false,
-                                        "stream_post_policy": 1,
-                                        "history_public_to_subscribers": false,
-                                        "first_message_id": null,
-                                        "is_recently_active": true,
-                                        "message_retention_days": null,
-                                        "is_announcement_only": false,
-                                        "can_add_subscribers_group": 2,
-                                        "can_remove_subscribers_group": 2,
-                                        "stream_weekly_traffic": null,
-                                      },
-                                    ],
+                                    [{"stream_id": 1}, {"stream_id": 2}],
+                                  "stream_ids": [1, 2],
                                   "id": 0,
                                 }
                             - type: object

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3414,7 +3414,6 @@ class NormalActionsTest(BaseAction):
             with self.verify_action(include_streams=include_streams) as events:
                 do_deactivate_stream(stream, acting_user=None)
             check_stream_delete("events[0]", events[0])
-            self.assertIsNone(events[0]["streams"][0]["stream_weekly_traffic"])
 
     def test_admin_deactivate_unsubscribed_stream(self) -> None:
         self.set_up_db_for_testing_user_access()

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3054,7 +3054,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=21,
+            query_count=15,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3071,7 +3071,7 @@ class StreamAdminTest(ZulipTestCase):
         streams you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=21,
+            query_count=15,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -5643,7 +5643,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Sends 3 peer-remove events, 2 unsubscribe events
         # and 2 stream delete events for private streams.
         with (
-            self.assert_database_query_count(19),
+            self.assert_database_query_count(16),
             self.assert_memcached_count(3),
             self.capture_send_event_calls(expected_num_events=7) as events,
         ):
@@ -5695,9 +5695,14 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(stream_delete_events[0]["users"], [user1.id])
         self.assertEqual(stream_delete_events[1]["users"], [user2.id])
         for event in stream_delete_events:
-            event_streams = event["event"]["streams"]
-            self.assert_length(event_streams, 1)
-            self.assertEqual(event_streams[0]["name"], "private_stream")
+            event_stream_ids = event["event"]["stream_ids"]
+            event_stream_objects = event["event"]["streams"]
+
+            self.assert_length(event_stream_ids, 1)
+            self.assertEqual(event_stream_ids[0], private.id)
+
+            self.assert_length(event_stream_objects, 1)
+            self.assertEqual(event_stream_objects[0]["stream_id"], private.id)
 
     def test_bulk_subscribe_MIT(self) -> None:
         mit_user = self.mit_user("starnine")


### PR DESCRIPTION
Fixes #32369

Migrate stream delete event to include only stream ids in the form of `"stream_ids": [1,...]` because clients only need the ids.

While also keep sending same ids in the form of `"streams": [{stream_id: 1},...]` for compatibility with all clients other than web.

