### PR TITLE
templates: Avoid confusing Mustache-style conditionals

### DIFF
--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -34,7 +34,7 @@
             </div>
         </div>
         {{/if}}
-        <div class="message_row{{^is_stream}} private-message{{/is_stream}}" role="listitem">
+        <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
             <div class="messagebox">
                 <div class="messagebox-content">
                     <div class="message_top_line">

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,5 +1,5 @@
 <div class="u-{{msg/sender_id}} message-avatar sender_info_hover view_user_card_tooltip no-select" aria-hidden="true" data-is-bot="{{sender_is_bot}}">
-    <div class="inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}">
+    <div class="inline_profile_picture {{#if sender_is_guest}} guest-avatar{{/if}}">
         <img loading="lazy" src="{{small_avatar_url}}" alt="" class="no-drag"/>
     </div>
 </div>

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -24,7 +24,7 @@
                 </div>
             </div>
             {{/if}}
-            <div class="message_row{{^is_stream}} private-message{{/is_stream}}" role="listitem">
+            <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
                 <div class="messagebox">
                     <div class="messagebox-content">
                         {{#if topic_edited}}

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -31,7 +31,7 @@
                 </div>
             </div>
             {{/if}}
-            <div class="message_row{{^is_stream}} private-message{{/is_stream}}" role="listitem">
+            <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
                 <div class="messagebox">
                     <div class="messagebox-content">
                         <div class="message_top_line">

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -1,5 +1,5 @@
 <div id="message-row-{{message_list_id}}-{{msg/id}}" data-message-id="{{msg/id}}"
-  class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#include_sender}} messagebox-includes-sender{{/include_sender}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row"
+  class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#if include_sender}} messagebox-includes-sender{{/if}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#if msg.unread}} unread{{/if}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row"
   role="listitem">
     {{#if want_date_divider}}
     <div class="unread_marker date_unread_marker"><div class="unread-marker-fill"></div></div>

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -1,4 +1,4 @@
-{{#render_subscribers}}
+{{#if render_subscribers}}
 <div class="subscriber_list_settings_container" {{#unless can_access_subscribers}}style="display: none"{{/unless}}>
     <h4 class="stream_setting_subsection_title">
         {{t "Add subscribers" }}
@@ -20,4 +20,4 @@
         {{> stream_members_table .}}
     </div>
 </div>
-{{/render_subscribers}}
+{{/if}}


### PR DESCRIPTION
Extracted from #32426, but seems like a clear readability improvement regardless.