### PR TITLE
topics: Fix topic order after moving message without automated notice.

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -513,18 +513,6 @@ export function update_messages(events) {
                 drafts.rename_stream_recipient(old_stream_id, orig_topic, new_stream_id, new_topic);
             }
 
-            // Remove the stream_topic_entry for the old topics;
-            // must be called before we call set message topic.
-            const num_messages = event_messages.length;
-            if (num_messages > 0) {
-                stream_topic_history.remove_messages({
-                    stream_id: old_stream_id,
-                    topic_name: orig_topic,
-                    num_messages,
-                    max_removed_msg_id: event_messages[num_messages - 1].id,
-                });
-            }
-
             for (const moved_message of event_messages) {
                 if (realm.realm_allow_edit_history) {
                     /* Simulate the format of server-generated edit
@@ -573,6 +561,20 @@ export function update_messages(events) {
                     stream_id: moved_message.stream_id,
                     topic_name: moved_message.topic,
                     message_id: moved_message.id,
+                });
+            }
+
+            // Remove the stream_topic_entry for the old topics;
+            // must be called after we call set message topic since
+            // it calls `get_messages_in_topic` which thinks that
+            // `topic` and `stream` of the messages are correctly set.
+            const num_messages = event_messages.length;
+            if (num_messages > 0) {
+                stream_topic_history.remove_messages({
+                    stream_id: old_stream_id,
+                    topic_name: orig_topic,
+                    num_messages,
+                    max_removed_msg_id: event_messages[num_messages - 1].id,
                 });
             }
 


### PR DESCRIPTION
Previously, when a message was moved between two topics without sending an automated notice, the ordering of these topics in the left sidebar was not updated.

This is because the updated `max_message_id` of `stream_topic_history` was always computed before the moved message object's channel/topic were updated. This caused the `max_message_id` of `stream_topic_history` which determines the ordering of topics to always be the same.

This is fixed by making sure that the channel/topics of the objects of the messages which were supposed to be moved were updated before we compute this `max_message_id`.

<!-- Describe your pull request here.-->

Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/topic.20order.20after.20moving.20messages/near/1976960

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
