### PR TITLE
buddy_list: Add style-change options to buddy list popover.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -562,3 +562,31 @@ $user_status_emoji_width: 24px;
         }
     }
 }
+
+#buddy-list-actions-menu-popover {
+    .display-style-selector + .invite-user-link-item {
+        border-top: 1px solid var(--color-border-sidebar-subheader);
+    }
+
+    /* No hover effect on the label */
+    .display-style-selector-header:hover {
+        background: inherit;
+        cursor: default;
+    }
+
+    .popover-menu-link:not(.display-style-selector-header) {
+        display: grid;
+        grid-template: "left-icon row-content" auto / 18px 1fr;
+        align-items: center;
+
+        .popover-menu-icon,
+        .user_list_style_choice {
+            grid-area: left-icon;
+            justify-self: baseline;
+        }
+
+        .popover-menu-label {
+            grid-area: row-content;
+        }
+    }
+}

--- a/web/templates/popovers/buddy_list_popover.hbs
+++ b/web/templates/popovers/buddy_list_popover.hbs
@@ -1,12 +1,29 @@
 <div class="popover-menu" id="buddy-list-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="link-item">
+            <label class="display-style-selector-header popover-menu-link" role="menuitem">
+                <span class="popover-menu-label">
+                    {{t 'User list style' }}
+                </span>
+            </label>
+        </li>
+        {{#each display_style_options}}
+            <li role="none" class="display-style-selector link-item" value="{{this.code}}">
+                <label class="popover-menu-link" role="menuitem" tabindex="0">
+                    <input type="radio" class="user_list_style_choice" name="user_list_style" value="{{this.code}}"/>
+                    <span class="popover-menu-label">{{this.description}}</span>
+                </label>
+            </li>
+        {{/each}}
+        {{#if can_invite_users}}
+        <li role="none" class="invite-user-link-item link-item">
             <a class="invite-user-link popover-menu-link" role="menuitem" tabindex="0">
-            <i class="popover-menu-icon zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
-            <span class="popover-menu-label">
-                {{t 'Invite users to organization' }}
-            </span>
+                <i class="popover-menu-icon zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
+                <span class="popover-menu-label">
+                    {{t 'Invite users to organization' }}
+                </span>
             </a>
         </li>
+        {{/if}}
     </ul>
 </div>


### PR DESCRIPTION
As discussed here: https://chat.zulip.org/#narrow/channel/101-design/topic/buddy.20list.20style.20switcher/near/1984867

<img width="342" alt="image" src="https://github.com/user-attachments/assets/10f0e36d-aa62-4aba-a1ab-1f21f82431f0">

Manually tested:

* With and without the "invite users" option present (depends on user permissions)
* Toggling to each of the three options, including keeping it the same