### PR TITLE
user_group: Show display_name instead of name for direct subgroups.

### DIFF
--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -93,13 +93,16 @@ export function toggle_user_group_info_popover(
                     message_lists.current.select_id(message_id);
                 }
                 user_group_popover_instance = instance;
+                const subgroups = user_groups.convert_name_to_display_name_for_groups(
+                    user_groups
+                        .get_direct_subgroups_of_group(group)
+                        .sort(user_group_components.sort_group_member_name),
+                );
                 const args = {
                     group_name: user_groups.get_display_group_name(group.name),
                     group_description: group.description,
                     members: sort_group_members(fetch_group_members([...group.members])),
-                    subgroups: user_groups
-                        .get_direct_subgroups_of_group(group)
-                        .sort(user_group_components.sort_group_member_name),
+                    subgroups,
                     group_edit_url: hash_util.group_edit_url(group, "general"),
                     is_guest: current_user.is_guest,
                     is_system_group: group.is_system_group,

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -375,6 +375,13 @@ export function get_direct_subgroups_of_group(target_user_group: UserGroup): Use
     return direct_subgroups;
 }
 
+export function convert_name_to_display_name_for_groups(user_groups: UserGroup[]): UserGroup[] {
+    return user_groups.map((user_group) => ({
+        ...user_group,
+        name: get_display_group_name(user_group.name),
+    }));
+}
+
 export function is_user_in_group(
     user_group_id: number,
     user_id: number,


### PR DESCRIPTION
For a system group, we were showing it's name, e.g. `role:members` when we want to show it's display_name instead i.e `Members` in the user group popover.

Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/system.20group.20subgroup.20display.20in.20group.20popovers/near/1986632


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="470" alt="Screenshot 2024-11-25 at 10 45 00 AM" src="https://github.com/user-attachments/assets/2420540a-6c95-4a7a-a0f0-4f3a4937a31c">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
