### PR TITLE
compose: Remove duplicate call to clear_preview_area.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -299,7 +299,6 @@ export let finish = (scheduling_message = false) => {
         return undefined;
     }
 
-    clear_preview_area();
     clear_invites();
     clear_private_stream_alert();
     compose_banner.clear_message_sent_banners();


### PR DESCRIPTION
This first call was added in this commit: 41afdc65265ef49c8c7b09e0c68faaf5d80197b1

At the time of this commit, the second call was already there. When removing this line in this commit, it seems like the earlier reported bug isn't present. So we can remove it, to avoid doing extra work when sending a message.
