### PR TITLE
templates: Remove "no-validation" class.

### DIFF
--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -41,7 +41,7 @@
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
         <div class="white-box">
             <div id="billing-page-details">
-                <div class="input-box billing-page-field no-validation">
+                <div class="input-box billing-page-field">
                     <label for="org-current-plan" class="inline-block label-title">Your plan</label>
                     <div id="org-current-plan" class="not-editable-realm-field">
                         {% if free_trial or downgrade_at_end_of_free_trial %}
@@ -61,13 +61,13 @@
                     </div>
                 </div>
                 {% if is_server_on_legacy_plan %}
-                <div class="input-box billing-page-field no-validation" id="legacy-server-push-notification-notice-wrapper">
+                <div class="input-box billing-page-field" id="legacy-server-push-notification-notice-wrapper">
                     <div id="legacy-server-push-notification-notice" class="not-editable-realm-field">
                         <i>This is a legacy plan that ends on {{ remote_server_legacy_plan_end_date }}.</i>
                     </div>
                 </div>
                 {% endif %}
-                <div class="input-box billing-page-field no-validation org-billing-frequency-wrapper"
+                <div class="input-box billing-page-field org-billing-frequency-wrapper"
                   data-current-billing-frequency="{{ billing_frequency }}"
                   {%if free_trial %}data-free-trial="true"{% endif %}
                   {%if downgrade_at_end_of_cycle %}data-downgrade-eoc="true"{% endif %}
@@ -108,7 +108,7 @@
                 </div>
                 {% if is_server_on_legacy_plan or fixed_price_plan %}
                 {% elif automanage_licenses %}
-                <div class="input-box billing-page-field no-validation">
+                <div class="input-box billing-page-field">
                     <label for="automatic-license-count" class="inline-block label-title">
                         Number of licenses
                         {% if is_self_hosted_billing %}
@@ -134,7 +134,7 @@
                 </div>
                 {% else %}
                 {% if not (free_trial or downgrade_at_end_of_free_trial) %}
-                <div class="input-box billing-page-field no-validation input-box-number">
+                <div class="input-box billing-page-field input-box-number">
                     <label for="current-manual-license-count" class="inline-block label-title">
                         Number of licenses for current billing period
                         {% if is_self_hosted_billing %}
@@ -168,7 +168,7 @@
                 </div>
                 {% endif %}
                 {% if not (downgrade_at_end_of_cycle or downgrade_at_end_of_free_trial) %}
-                <div class="input-box billing-page-field no-validation input-box-number">
+                <div class="input-box billing-page-field input-box-number">
                     <label for="next-manual-license-count" class="inline-block label-title">
                         Number of licenses for next billing period
                         {% if is_self_hosted_billing %}
@@ -199,20 +199,20 @@
                     <input name="toggle_license_management" type="hidden" value="true" />
                 </form>
                 <div id="toggle-license-management-error" class="alert alert-danger"></div>
-                <div class="input-box no-validation billing-page-field">
+                <div class="input-box billing-page-field">
                     <label for="billing-contact" class="inline-block label-title">Billing contact</label>
                     <div id="billing-contact" class="not-editable-realm-field">
                         <a href="mailto:{{ stripe_email }}">{{ stripe_email }}</a>
                     </div>
                 </div>
                 <div id="cardchange-error" class="alert alert-danger"></div>
-                <div class="input-box billing-page-field no-validation">
+                <div class="input-box billing-page-field">
                     <label for="customer-payment-method" class="inline-block label-title">Payment method</label>
                     <div id="customer-payment-method" class="not-editable-realm-field">
                         {{ payment_method }}
                     </div>
                     {% if charge_automatically %}
-                    <div class="user-stripe-card-update input-box billing-page-field no-validation">
+                    <div class="user-stripe-card-update input-box billing-page-field">
                         <button class="user-stripe-card-update-button" id="update-card-button">
                             <span class="billing-button-text">Update card</span>
                             <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
@@ -224,7 +224,7 @@
                         <a href="{{ billing_base_url }}/customer_portal/?return_to_billing_page=true">View and update</a> billing information that will be displayed on your next invoice and receipt.
                     </div>
                 </div>
-                <div class="input-box billing-page-field no-validation">
+                <div class="input-box billing-page-field">
                     <div class="next-payment-info not-editable-realm-field">
                         {% if renewal_amount %}
                             {% if downgrade_at_end_of_cycle %}
@@ -316,7 +316,7 @@
                         {% endif %}
                     </div>
                 </div>
-                <div class="input-box billing-page-field no-validation">
+                <div class="input-box billing-page-field">
                     <label class="inline-block label-title">Invoices</label>
                     <div class="not-editable-realm-field">
                         <a href="{{ billing_base_url }}/invoices/">
@@ -333,14 +333,14 @@
                 <div id="planchange-error" class="alert alert-danger"></div>
                 <div id="planchange-input-section">
                     {% if free_trial and not downgrade_at_end_of_free_trial %}
-                        <div class="end-free-trial plan-toggle-action input-box billing-page-field no-validation" id="end-free-trial">
+                        <div class="end-free-trial plan-toggle-action input-box billing-page-field" id="end-free-trial">
                             <button class="end-free-trial-button plan-toggle-action-button">
                                 <span class="billing-button-text">Cancel plan</span>
                                 <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                             </button>
                         </div>
                     {% elif downgrade_at_end_of_cycle or downgrade_at_end_of_free_trial %}
-                        <div class="reactivate-current-plan plan-toggle-action input-box billing-page-field no-validation" id="reactivate-subscription">
+                        <div class="reactivate-current-plan plan-toggle-action input-box billing-page-field" id="reactivate-subscription">
                             <button class="reactivate-current-plan-button plan-toggle-action-button">
                                 <span class="billing-button-text">
                                     {% if downgrade_at_end_of_free_trial %}
@@ -353,14 +353,14 @@
                             </button>
                         </div>
                     {% elif is_server_on_legacy_plan %}
-                        <div class="plan-toggle-action input-box billing-page-field no-validation" id="cancel-legacy-server-upgrade">
+                        <div class="plan-toggle-action input-box billing-page-field" id="cancel-legacy-server-upgrade">
                             <button class="cancel-legacy-server-upgrade-button plan-toggle-action-button">
                                 <span class="billing-button-text">Cancel upgrade</span>
                                 <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                             </button>
                         </div>
                     {% else %}
-                        <div class="cancel-current-plan plan-toggle-action input-box billing-page-field no-validation" id="cancel-subscription">
+                        <div class="cancel-current-plan plan-toggle-action input-box billing-page-field" id="cancel-subscription">
                             <button class="plan-toggle-action-button {% if is_self_hosted_billing %}cancel-current-self-hosted-plan-button{% else %}cancel-current-cloud-plan-button{% endif %}">
                                 <span class="billing-button-text">Cancel plan</span>
                                 <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>

--- a/templates/corporate/billing/legacy_server_login.html
+++ b/templates/corporate/billing/legacy_server_login.html
@@ -21,7 +21,7 @@
                         {% if next_page %}
                         <input type="hidden" name="next_page" value="{{ next_page }}" />
                         {% endif %}
-                        <div id="server-login-form-title" class="input-box server-login-form no-validation">
+                        <div id="server-login-form-title" class="input-box server-login-form">
                             <div class="not-editable-realm-field">
                                 To access plan management for a Zulip
                                 server, first enter <a href="https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#plan-management-for-an-entire-zulip-server">your server's credentials</a>.

--- a/templates/corporate/billing/remote_billing_confirm_email_form.html
+++ b/templates/corporate/billing/remote_billing_confirm_email_form.html
@@ -25,7 +25,7 @@
                 {% if next_page %}
                 <input type="hidden" name="next_page" value="{{ next_page }}" />
                 {% endif %}
-                <div class="input-box server-login-form-field no-validation" id="remote-billing-confirm-email-intro">
+                <div class="input-box server-login-form-field" id="remote-billing-confirm-email-intro">
                     <div class="not-editable-realm-field">
                         {% if remote_server_hostname %}
                             Enter the email address of the person who is logging in to manage plans and billing for this server (yourself or someone else). They will receive an email from Zulip with a log in link.

--- a/templates/corporate/billing/remote_billing_finalize_login_confirmation.html
+++ b/templates/corporate/billing/remote_billing_finalize_login_confirmation.html
@@ -35,7 +35,7 @@
                     </div>
                     {% endif %}
                 </div>
-                <div class="input-box remote-billing-confirm-login-form-field no-validation">
+                <div class="input-box remote-billing-confirm-login-form-field">
                     <label for="user-email" class="inline-block label-title">
                         Email
                     </label>

--- a/templates/corporate/billing/remote_billing_server_deactivate.html
+++ b/templates/corporate/billing/remote_billing_server_deactivate.html
@@ -24,7 +24,7 @@
                 {% endif %}
                 <form id="server-deactivate-form" method="post" action="{{ action_url }}">
                     {{ csrf_input }}
-                    <div id="server-deactivate-form-top-description" class="input-box server-deactivate-form-field no-validation">
+                    <div id="server-deactivate-form-top-description" class="input-box server-deactivate-form-field">
                         <div class="not-editable-realm-field">
                             You are about to deactivate this server's
                             registration with

--- a/templates/corporate/billing/remote_billing_server_deactivated_success.html
+++ b/templates/corporate/billing/remote_billing_server_deactivated_success.html
@@ -15,7 +15,7 @@
         </div>
         <div class="white-box">
             <div id="account-deactivated-success-page-details">
-                <div class="input-box account-deactivated-success-page-field no-validation" id="account-deactivated-success-page-top-message">
+                <div class="input-box account-deactivated-success-page-field" id="account-deactivated-success-page-top-message">
                     <div class="not-editable-realm-field">
                         Your server's registration has been deactivated.
                     </div>

--- a/templates/corporate/billing/sponsorship.html
+++ b/templates/corporate/billing/sponsorship.html
@@ -49,7 +49,7 @@
         </div>
         <div class="white-box">
             <div id="sponsorship-status-page-details">
-                <div class="input-box sponsorship-form-field no-validation">
+                <div class="input-box sponsorship-form-field">
                     <label for="sponsored-org-current-plan" class="inline-block label-title">Your plan</label>
                     <div id="sponsored-org-current-plan" class="not-editable-realm-field">
                         {% if is_sponsored %}
@@ -102,7 +102,7 @@
             <div id="sponsorship-input-section">
                 <form id="sponsorship-form" method="post" data-billing-base-url="{{ billing_base_url }}" data-is-remotely-hosted="{{ is_remotely_hosted }}">
                     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
-                    <div class="input-box sponsorship-form-field no-validation">
+                    <div class="input-box sponsorship-form-field">
                         <label for="org-name" class="inline-block label-title">Organization</label>
                         <div id="org-name" class="not-editable-realm-field">{{ org_name }}</div>
                     </div>
@@ -148,7 +148,7 @@
                         <label for="organization-requested-plan" class="inline-block label-title">Requested plan</label>
                     </div>
                     {% endif %}
-                    <div class="input-box sponsorship-form-field no-validation">
+                    <div class="input-box sponsorship-form-field">
                         <label for="org-website" class="inline-block
                           label-title">Organization website (if any)</label>
                         <input id="org-website" name="website" type="text"/>
@@ -165,7 +165,7 @@
                         <input id="expected-total-users" name="expected_total_users" type="text" />
                         <div id="sponsorship-expected-total-users-error" class="alert alert-danger sponsorship-field-error"></div>
                     </div>
-                    <div class="input-box sponsorship-form-field no-validation">
+                    <div class="input-box sponsorship-form-field">
                         <label for="paid-users-count" class="inline-block label-title">How many paid staff does your organization have?</label>
                         <input id="paid-users-count" name="paid_users_count" type="text"/>
                         <div id="sponsorship-paid-users-count-error" class="alert alert-danger sponsorship-field-error"></div>

--- a/templates/corporate/billing/upgrade.html
+++ b/templates/corporate/billing/upgrade.html
@@ -99,7 +99,7 @@
                     {% if page_params.free_trial_days and not page_params.setup_payment_by_invoice %}
                     <input type="hidden" name="schedule" value="monthly" />
                     {% else %}
-                    <div class="input-box upgrade-page-field no-validation">
+                    <div class="input-box upgrade-page-field">
                         <select name="schedule" id="payment-schedule-select">
                             {% if fixed_price_plan %}
                             <option value="monthly">Pay monthly</option>
@@ -114,7 +114,7 @@
                     {% endif %}
 
                     {% if remote_server_legacy_plan_end_date %}
-                    <div class="input-box upgrade-page-field no-validation">
+                    <div class="input-box upgrade-page-field">
                         <select name="remote_server_plan_start_date" id="remote-server-plan-start-date-select">
                             <option value="billing_cycle_end_date">{{ remote_server_legacy_plan_end_date }}</option>
                             <option value="today">Today</option>
@@ -135,7 +135,7 @@
                     {% endif %}
 
                     {% if remote_server_legacy_plan_end_date %}
-                        <div class="input-box upgrade-page-field no-validation" id="due-today-for-future-update-wrapper">
+                        <div class="input-box upgrade-page-field" id="due-today-for-future-update-wrapper">
                             <label for="due-today-for-future-update" class="inline-block label-title">
                                 Due today
                             </label>
@@ -145,7 +145,7 @@
                         </div>
                     {% endif %}
 
-                    <div class="input-box upgrade-page-field no-validation">
+                    <div class="input-box upgrade-page-field">
                         <label for="due-today" class="inline-block label-title">
                             {% if remote_server_legacy_plan_end_date %}
                             <span id="due-today-remote-server-title">
@@ -240,7 +240,7 @@
                     <div {% if page_params.setup_payment_by_invoice %} id="update-invoice-billing-info" {% elif payment_method %} id="upgrade-payment-info"{% endif %}>
                         {% if page_params.setup_payment_by_invoice %}
                         {% elif payment_method %}
-                        <div class="input-box upgrade-page-field no-validation" id="upgrade-payment-menthod-wrapper">
+                        <div class="input-box upgrade-page-field" id="upgrade-payment-menthod-wrapper">
                             <label for="customer-payment-method-for-upgrade" class="inline-block label-title">Payment method</label>
                             <div id="customer-payment-method-for-upgrade" class="not-editable-realm-field">
                                 {{ payment_method }}

--- a/templates/corporate/support/support_request.html
+++ b/templates/corporate/support/support_request.html
@@ -13,11 +13,11 @@
             {{ csrf_input }}
 
             <fieldset class="support-request">
-                <div class="input-box no-validation support-form-field">
+                <div class="input-box support-form-field">
                     <label for="support_from" class="inline-block label-title">{{ _('From') }}</label>
                     <div id="support_from">{{ email }}</div>
                 </div>
-                <div class="input-box no-validation support-form-field">
+                <div class="input-box support-form-field">
                     <label for="support_realm" class="inline-block label-title">{{ _('Organization') }}</label>
                     <div id="support_realm">{{ realm_name }}</div>
                 </div>

--- a/templates/two_factor/_wizard_forms.html
+++ b/templates/two_factor/_wizard_forms.html
@@ -16,7 +16,7 @@
 {% endif %}
 
 {% for field in wizard.form %}
-<div class="input-box no-validation">
+<div class="input-box">
     {{ field }}
     <label for="{{ field.id_for_label }}">{{ field.label }}</label>
 </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -86,9 +86,8 @@ page can be easily identified in it's respective JavaScript file. -->
                             {% endif %}
                             {{ csrf_input }}
 
-                            <!-- .no-validation is for removing the red star in CSS -->
                             {% if not two_factor_authentication_enabled or wizard.steps.current == 'auth' %}
-                            <div class="input-box no-validation">
+                            <div class="input-box">
                                 <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
                                   name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
                                   {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
@@ -104,7 +103,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                 </label>
                             </div>
 
-                            <div class="input-box no-validation password-div">
+                            <div class="input-box password-div">
                                 <input id="id_password" name="password" class="required" type="password" autocomplete="off"
                                   {% if email %} autofocus {% endif %}
                                   required />

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -77,7 +77,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 </div>
                 {% endif %}
 
-                <div class="input-box no-validation">
+                <div class="input-box">
                     <input type='hidden' name='key' value='{{ key }}' />
                     <input type='hidden' name='timezone' id='timezone'/>
                     <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>


### PR DESCRIPTION
The CSS rule for the "no-validation" class was removed in commit 388acbbfcba, but the class was not removed from the templates in those changes. Which then resulted in it being used in more templates as the billing, sponsorship and support templates grew in number and complexity.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
