### PR TITLE
Show addressee typeahead when starting a new DM with no recipient.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -19,6 +19,13 @@ async function close_compose_box(page: Page): Promise<void> {
         await page.keyboard.press("Escape");
         await page.waitForSelector(".dropdown-list-container", {hidden: true});
     }
+
+    const typeahead_visible = (await page.$("[data-tippy-root] .typeahead")) !== null;
+    if (typeahead_visible) {
+        await page.keyboard.press("Escape");
+        await page.waitForSelector("[data-tippy-root] .typeahead", {hidden: true});
+    }
+
     await page.keyboard.press("Escape");
     await page.waitForSelector("#compose-textarea", {hidden: true});
 }
@@ -54,6 +61,7 @@ async function test_stream_compose_keyboard_shortcut(page: Page): Promise<void> 
 async function test_private_message_compose_shortcut(page: Page): Promise<void> {
     await page.keyboard.press("KeyX");
     await page.waitForSelector("#private_message_recipient", {visible: true});
+    await page.waitForSelector("[data-tippy-root] .typeahead", {visible: true});
     await common.pm_recipient.expect(page, "");
     await close_compose_box(page);
 }

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -704,6 +704,8 @@ export class Typeahead<ItemType extends string | object> {
                 this.blur(e);
             });
 
+        this.$container.on("click", this.click.bind(this));
+
         $(window).on("resize", this.resizeHandler.bind(this));
     }
 
@@ -888,11 +890,6 @@ export class Typeahead<ItemType extends string | object> {
                 // or if the focus is immediately back in the input field (likely
                 // when using compose formatting buttons).
                 this.hide();
-            } else if (this.shown) {
-                // refocus the input if the user clicked on the typeahead
-                // so that clicking elsewhere registers as a blur and hides
-                // the typeahead.
-                this.input_element.$element.trigger("focus");
             }
         }, 150);
     }
@@ -923,6 +920,14 @@ export class Typeahead<ItemType extends string | object> {
     click(e: JQuery.ClickEvent): void {
         e.stopPropagation();
         e.preventDefault();
+
+        if ($(e.target).closest("li.typeahead-item").length === 0) {
+            // refocus the input if the user clicked on the typeahead
+            // so that clicking elsewhere registers as a blur and hides
+            // the typeahead.
+            this.input_element.$element.trigger("focus");
+            return;
+        }
         // The original bootstrap code expected `mouseenter` to be called
         // to set the active element before `select()`.
         // Since select() selects the element with the active class, if

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -273,6 +273,8 @@ export class Typeahead<ItemType extends string | object> {
     hideOnEmptyAfterBackspace: boolean;
     // Used for adding a custom classname to the typeahead link.
     getCustomItemClassname: ((item: ItemType) => string) | undefined;
+    // Offset applied to the typeahead placement.
+    positionOffset: [number, number];
 
     constructor(input_element: TypeaheadInputElement, options: TypeaheadOptions<ItemType>) {
         this.input_element = input_element;
@@ -318,6 +320,7 @@ export class Typeahead<ItemType extends string | object> {
         this.hideAfterSelect = options.hideAfterSelect ?? (() => true);
         this.hideOnEmptyAfterBackspace = options.hideOnEmptyAfterBackspace ?? false;
         this.getCustomItemClassname = options.getCustomItemClassname;
+        this.positionOffset = options.positionOffset ?? [0, 0];
         this.listen();
     }
 
@@ -387,6 +390,7 @@ export class Typeahead<ItemType extends string | object> {
         this.mouse_moved_since_typeahead = false;
 
         const input_element = this.input_element;
+        const positionOffset = this.positionOffset;
         if (!this.non_tippy_parent_element) {
             this.instance = tippy.default(the(input_element.$element), {
                 // Lets typeahead take the width needed to fit the content
@@ -438,7 +442,10 @@ export class Typeahead<ItemType extends string | object> {
                         const scrollTop = input_element.$element.scrollTop() ?? 0;
 
                         if (placement === "top-start") {
-                            return [caret.left, -caret.top + scrollTop + gap];
+                            return [
+                                caret.left + positionOffset[0],
+                                -caret.top + scrollTop + gap + positionOffset[1],
+                            ];
                         }
 
                         // In bottom-start, the offset is calculated from bottom of the popper reference.
@@ -446,10 +453,13 @@ export class Typeahead<ItemType extends string | object> {
                             // Height of the reference is the input_element height.
                             const field_height = reference.height;
                             const distance = field_height - caret.top + scrollTop - caret.height;
-                            return [caret.left, -distance + gap];
+                            return [
+                                caret.left + positionOffset[0],
+                                -distance + gap + positionOffset[1],
+                            ];
                         }
                     }
-                    return [0, gap];
+                    return [positionOffset[0], gap + positionOffset[1]];
                 },
                 // We have event handlers to hide the typeahead, so we
                 // don't want tippy to hide it for us.
@@ -987,4 +997,5 @@ type TypeaheadOptions<ItemType> = {
     showOnClick?: boolean;
     hideAfterSelect?: () => boolean;
     getCustomItemClassname?: (item: ItemType) => string;
+    positionOffset?: [number, number];
 };

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -267,6 +267,9 @@ export class Typeahead<ItemType extends string | object> {
     // Used to determine whether the typeahead should be shown,
     // when the user clicks anywhere on the input element.
     showOnClick: boolean;
+    // Used to determine whether the typeahead should be shown,
+    // when the input element gains focus.
+    showOnFocus: boolean;
     // Used for custom situations where we want to hide the typeahead
     // after selecting an option, instead of the default call to lookup().
     hideAfterSelect: () => boolean;
@@ -317,6 +320,7 @@ export class Typeahead<ItemType extends string | object> {
         this.shouldHighlightFirstResult = options.shouldHighlightFirstResult ?? (() => true);
         this.updateElementContent = options.updateElementContent ?? true;
         this.showOnClick = options.showOnClick ?? true;
+        this.showOnFocus = options.showOnFocus ?? false;
         this.hideAfterSelect = options.hideAfterSelect ?? (() => true);
         this.hideOnEmptyAfterBackspace = options.hideOnEmptyAfterBackspace ?? false;
         this.getCustomItemClassname = options.getCustomItemClassname;
@@ -690,6 +694,7 @@ export class Typeahead<ItemType extends string | object> {
             .on("keypress", this.keypress.bind(this))
             .on("keyup", this.keyup.bind(this))
             .on("click", this.element_click.bind(this))
+            .on("focus", this.element_focus.bind(this))
             .on("keydown", this.keydown.bind(this))
             .on("typeahead.refreshPosition", this.refreshPosition.bind(this));
 
@@ -712,7 +717,7 @@ export class Typeahead<ItemType extends string | object> {
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click"];
+        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
@@ -917,6 +922,13 @@ export class Typeahead<ItemType extends string | object> {
         this.lookup(false);
     }
 
+    element_focus(): void {
+        if (!this.showOnFocus) {
+            return;
+        }
+        this.lookup(false);
+    }
+
     click(e: JQuery.ClickEvent): void {
         e.stopPropagation();
         e.preventDefault();
@@ -1000,6 +1012,7 @@ type TypeaheadOptions<ItemType> = {
     shouldHighlightFirstResult?: () => boolean;
     updateElementContent?: boolean;
     showOnClick?: boolean;
+    showOnFocus?: boolean;
     hideAfterSelect?: () => boolean;
     getCustomItemClassname?: (item: ItemType) => string;
     positionOffset?: [number, number];

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -746,7 +746,7 @@ export class Typeahead<ItemType extends string | object> {
 
         switch (e.key) {
             case "Tab":
-                if (!this.tabIsEnter) {
+                if (!this.tabIsEnter || e.shiftKey) {
                     return;
                 }
                 e.preventDefault();
@@ -817,7 +817,7 @@ export class Typeahead<ItemType extends string | object> {
         switch (e.key) {
             case "Tab":
                 // If the typeahead is not shown or tabIsEnter option is not set, do nothing and return
-                if (!this.tabIsEnter || !this.shown) {
+                if (!this.tabIsEnter || !this.shown || e.shiftKey) {
                     return;
                 }
 

--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -99,9 +99,9 @@
  *   Since it's in the right part of the DOM, we don't need to do
  *   the manual positioning in the show() function.
  *
- * 11. Add `openInputFieldOnKeyUp` option:
+ * 11. Add `openInputFieldOnInput` option:
  *
- *   If the typeahead isn't shown yet, the `lookup` call in the keyup
+ *   If the typeahead isn't shown yet, the `lookup` call in the input
  *   handler will open it. Here we make a callback to the input field
  *   before we open the lookahead in case it needs to make UI changes first
  *   (e.g. widening the search bar).
@@ -249,7 +249,7 @@ export class Typeahead<ItemType extends string | object> {
     select_on_escape_condition: () => boolean;
     // Used to clear tooltip instances attached to typeahead container.
     clear_typeahead_tooltip: (() => void) | undefined;
-    openInputFieldOnKeyUp: (() => void) | undefined;
+    openInputFieldOnInput: (() => void) | undefined;
     closeInputFieldOnHide: (() => void) | undefined;
     helpOnEmptyStrings: boolean;
     tabIsEnter: boolean;
@@ -310,7 +310,7 @@ export class Typeahead<ItemType extends string | object> {
         this.stopAdvance = options.stopAdvance ?? false;
         this.select_on_escape_condition = options.select_on_escape_condition ?? (() => false);
         this.advanceKeys = options.advanceKeys ?? [];
-        this.openInputFieldOnKeyUp = options.openInputFieldOnKeyUp;
+        this.openInputFieldOnInput = options.openInputFieldOnInput;
         this.closeInputFieldOnHide = options.closeInputFieldOnHide;
         this.tabIsEnter = options.tabIsEnter ?? true;
         this.helpOnEmptyStrings = options.helpOnEmptyStrings ?? false;
@@ -693,6 +693,7 @@ export class Typeahead<ItemType extends string | object> {
             .on("blur", this.blur.bind(this))
             .on("keypress", this.keypress.bind(this))
             .on("keyup", this.keyup.bind(this))
+            .on("input", this.input.bind(this))
             .on("click", this.element_click.bind(this))
             .on("focus", this.element_focus.bind(this))
             .on("keydown", this.keydown.bind(this))
@@ -717,7 +718,7 @@ export class Typeahead<ItemType extends string | object> {
     unlisten(): void {
         this.hide();
         this.$container.remove();
-        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus"];
+        const events = ["blur", "keydown", "keyup", "keypress", "click", "focus", "input"];
         for (const event of events) {
             $(this.input_element.$element).off(event);
         }
@@ -780,6 +781,10 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keydown(e: JQuery.KeyDownEvent): void {
+        // Any key interaction should give keyboard priority over the
+        // mouse for selecting the currently highlighted typeahead item.
+        this.mouse_moved_since_typeahead = false;
+
         if (this.trigger_selection(e)) {
             if (!this.shown) {
                 return;
@@ -802,17 +807,14 @@ export class Typeahead<ItemType extends string | object> {
     }
 
     keyup(e: JQuery.KeyUpEvent): void {
-        this.mouse_moved_since_typeahead = false;
-        // NOTE: Ideally we can ignore meta keyup calls here but
-        // it's better to just trigger the lookup call to update the list in case
-        // it did modify the query. For example, `Command + delete` on Mac
-        // doesn't trigger a keyup event but when `Command` is released, it
-        // triggers a keyup event which correctly updates the list.
+        // This handler only deals with navigation/selection keys. Query
+        // updates from typing are driven by the `input` event handler
+        // below, which fires only when the input's value actually
+        // changes -- so it naturally ignores stray keyups from keys
+        // whose keydown fired on a different element (e.g., the Tab or
+        // Shift keyup that lands here when focus moves into a typeahead
+        // input via keyboard navigation).
         switch (e.key) {
-            case "ArrowDown":
-            case "ArrowUp":
-                break;
-
             case "Tab":
                 // If the typeahead is not shown or tabIsEnter option is not set, do nothing and return
                 if (!this.tabIsEnter || !this.shown) {
@@ -852,31 +854,26 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             default:
-                // to stop typeahead from showing up momentarily
-                // when shift + tabbing to the topic field
-                if (
-                    e.key === "Shift" &&
-                    the(this.input_element.$element).id === "stream_message_recipient_topic"
-                ) {
-                    return;
-                }
-                if (this.openInputFieldOnKeyUp !== undefined && !this.shown) {
-                    // If the typeahead isn't shown yet, the `lookup` call will open it.
-                    // Here we make a callback to the input field before we open the
-                    // lookahead in case it needs to make UI changes first (e.g. widening
-                    // the search bar).
-                    this.openInputFieldOnKeyUp();
-                }
-                if (e.key === "Backspace") {
-                    this.lookup(this.hideOnEmptyAfterBackspace);
-                    return;
-                }
-                this.lookup(false);
+                return;
         }
 
         this.maybeStopAdvance(e);
 
         e.preventDefault();
+    }
+
+    input(e: JQuery.TriggeredEvent): void {
+        if (this.openInputFieldOnInput !== undefined && !this.shown) {
+            // If the typeahead isn't shown yet, the `lookup` call will open it.
+            // Here we make a callback to the input field before we open the
+            // lookahead in case it needs to make UI changes first (e.g. widening
+            // the search bar).
+            this.openInputFieldOnInput();
+        }
+        const input_event = e.originalEvent;
+        const is_backspace =
+            input_event instanceof InputEvent && input_event.inputType === "deleteContentBackward";
+        this.lookup(is_backspace ? this.hideOnEmptyAfterBackspace : false);
     }
 
     blur(e: JQuery.BlurEvent): void {
@@ -994,7 +991,7 @@ type TypeaheadOptions<ItemType> = {
     matcher?: (query: string) => (item: ItemType) => boolean;
     on_escape?: () => void;
     clear_typeahead_tooltip?: () => void;
-    openInputFieldOnKeyUp?: () => void;
+    openInputFieldOnInput?: () => void;
     option_label?: (matching_items: ItemType[], item: ItemType) => string | false;
     non_tippy_parent_element?: string;
     sorter: (items: ItemType[], query: string) => ItemType[];

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -387,6 +387,8 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         clear_box();
     }
 
+    compose_state.set_private_message_recipient_ids(opts.private_message_recipient_ids);
+
     if (opts.message_type === "private") {
         compose_state.set_compose_recipient_id(compose_state.DIRECT_MESSAGE_ID);
         compose_recipient.on_compose_select_recipient_update();
@@ -425,8 +427,6 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         compose_recipient.toggle_compose_recipient_dropdown();
     }
     compose_recipient.update_topic_displayed_text(opts.topic);
-
-    compose_state.set_private_message_recipient_ids(opts.private_message_recipient_ids);
 
     // If we're not explicitly opening a different draft, restore the last
     // saved draft (if it exists).

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -210,21 +210,39 @@ export function update_on_recipient_change(): void {
     compose_validate.clear_topic_moved_info();
 }
 
+function current_compose_triggered_opts(
+    message_type: MessageType,
+    trigger: string,
+): ComposeTriggeredOptions {
+    if (message_type === "private") {
+        return {
+            message_type: "private",
+            trigger,
+            private_message_recipient_ids: compose_state.private_message_recipient_ids(),
+        };
+    }
+    return {
+        message_type: "stream",
+        trigger,
+        stream_id: compose_state.stream_id()!,
+        topic: compose_state.topic(),
+    };
+}
+
 function switch_message_type(message_type: MessageType): void {
     $("#compose-content .alert").hide();
 
     compose_state.set_message_type(message_type);
-
-    const opts = {
-        message_type,
-        trigger: "switch_message_type",
-        stream_id: compose_state.stream_id()!,
-        topic: compose_state.topic(),
-        private_message_recipient_ids: compose_state.private_message_recipient_ids(),
-    };
-    update_compose_for_message_type(opts);
+    update_compose_for_message_type(
+        current_compose_triggered_opts(message_type, "switch_message_type"),
+    );
     update_compose_area_placeholder_text();
-    compose_ui.set_focus(opts);
+    // Focus is intentionally not moved here. Callers that want to
+    // move focus after a message-type switch (e.g., the recipient
+    // dropdown click handler) are responsible for doing so; callers
+    // that fire on server events or during compose-box opening should
+    // not disturb focus, which is either already where it belongs or
+    // will be set by `show_compose_box`.
 }
 
 function update_recipient_label(stream_id?: number): void {
@@ -318,7 +336,15 @@ function item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance)
     compose_state.set_recipient_edited_manually(true);
     // Enable or disable topic input based on `topics_policy`.
     update_topic_displayed_text(compose_state.topic());
+    const prev_message_type = compose_state.get_message_type();
     on_compose_select_recipient_update();
+    const message_type = compose_state.get_message_type();
+    if (message_type !== undefined && prev_message_type !== message_type) {
+        // A message-type switch hides the field that was previously
+        // focused (topic for stream, DM input for private), so move
+        // focus into the first empty input of the new compose state.
+        compose_ui.set_focus(current_compose_triggered_opts(message_type, "switch_message_type"));
+    }
     compose_select_recipient_dropdown_widget.item_clicked = true;
     dropdown.hide();
     event.preventDefault();

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -639,6 +639,12 @@ export function filter_and_sort_mentions(
 }
 
 export function get_pm_people(query: string): (UserGroupPillData | UserPillData)[] {
+    // If we already have a user pill added to the recipient field then we
+    // don't want to show typeahead for empty query.
+    if (query === "" && compose_state.private_message_recipient_ids().length > 0) {
+        return [];
+    }
+
     const opts = {
         want_broadcast: false,
         filter_pills: true,
@@ -1891,6 +1897,10 @@ export function initialize({
             set_recipient_from_typeahead(item);
         },
         stopAdvance: true, // Do not advance to the next field on a Tab or Enter
+        // show suggested recipients as soon as the field is focused with no query,
+        // but not when a pill is already present
+        showOnFocus: true,
+        helpOnEmptyStrings: true,
     });
 
     initialize_compose_typeahead($("textarea#compose-textarea"));

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1876,6 +1876,7 @@ export function initialize({
         source: get_pm_people,
         items: max_num_items,
         dropup: true,
+        positionOffset: [0, 6],
         item_html(_query: string): (item: UserGroupPillData | UserPillData) => string {
             return (item: UserGroupPillData | UserPillData) =>
                 typeahead_helper.render_person_or_user_group(item);

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -269,7 +269,7 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             exit_search({keep_search_narrow_open: false});
         },
         tabIsEnter: true,
-        openInputFieldOnKeyUp(): void {
+        openInputFieldOnInput(): void {
             if ($(".navbar-search.expanded").length === 0) {
                 open_search_bar_and_close_narrow_description();
             }

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -269,11 +269,6 @@ export function initialize(opts: {on_narrow_search: OnNarrowSearch}): void {
             exit_search({keep_search_narrow_open: false});
         },
         tabIsEnter: true,
-        openInputFieldOnInput(): void {
-            if ($(".navbar-search.expanded").length === 0) {
-                open_search_bar_and_close_narrow_description();
-            }
-        },
         // This is here so that we can close the search bar
         // when a user opens it and immediately changes their
         // mind and clicks away.


### PR DESCRIPTION
This PR:
- adds offset for tippy placement to typeahead and moves DM typeahead `6px` above the input.
- Make shift+tab work as keyboard navigation when typeahead is displayed
- Whenever `#private_message_recipient` is brought to `focus` and is empty, we show the DM recipient typeahead

Fixes: zulip#31803.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2024-11-26 00-40-19](https://github.com/user-attachments/assets/477a1220-a2eb-47a9-b115-e236e1845a85)

[Screencast from 25-11-24 11:38:53 PM IST.webm](https://github.com/user-attachments/assets/ec2fbd43-ba2f-47e7-ae5d-7dc3f22dafc4)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
