### PR TITLE
help and modals: Describe "edit your last message" consistently.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -164,8 +164,9 @@ in the Zulip app to add more to your repertoire as needed.
 
 ## Message actions
 
-* **Edit last message**: <kbd class="arrow-key">←</kbd> — Open the last
-  editable message in the current view (if any).
+* **Edit your last message**: <kbd class="arrow-key">←</kbd> — Scroll to the
+  most recent message you are allowed to edit in the current view, and open it
+  for editing. If there are no messages you can edit, nothing happens.
 
 ### For a selected message (outlined in blue)
 

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1255,7 +1255,7 @@ export function maybe_show_edit($row: JQuery, id: number): void {
 
 function warn_user_about_unread_msgs(last_sent_msg_id: number, num_unread: number): void {
     confirm_dialog.launch({
-        html_heading: $t({defaultMessage: "Edit last sent message"}),
+        html_heading: $t({defaultMessage: "Edit your last message?"}),
         html_body: render_confirm_edit_messages({
             num_unread,
         }),

--- a/web/templates/confirm_dialog/confirm_edit_messages.hbs
+++ b/web/templates/confirm_dialog/confirm_edit_messages.hbs
@@ -1,5 +1,5 @@
 <p>
     {{#tr}}
-    Scrolling to the last message you sent will mark <b>{num_unread}</b> unread messages as read. Would you like to scroll to that message and edit it?
+    Scrolling to your last message will mark <b>{num_unread}</b> unread messages as read. Would you like to scroll to that message and edit it?
     {{/tr}}
 </p>


### PR DESCRIPTION
<details>
<summary>
Help modal (no changes) -- other places are changed to match
</summary>

![Screenshot 2024-11-25 at 11 58 29@2x](https://github.com/user-attachments/assets/cd6ced53-fc23-4c43-b3ad-a547d9560340)

</details>

<details>
<summary>
Confirmation modal
</summary>

![Screenshot 2024-11-25 at 11 59 10@2x](https://github.com/user-attachments/assets/6fa476d1-5481-4c78-877a-8987c3a1d37f)

</details>

<details>
<summary>
https://zulip.com/help/keyboard-shortcuts#message-actions
</summary>

![Screenshot 2024-11-25 at 11 59 31@2x](https://github.com/user-attachments/assets/19dbcf92-98fe-48f0-9cbe-608a166a68fd)

</details>