### PR TITLE
unarchive_channel: Fix logic checking for name collision.

### DIFF
--- a/zerver/management/commands/unarchive_channel.py
+++ b/zerver/management/commands/unarchive_channel.py
@@ -90,7 +90,11 @@ class Command(ZulipBaseCommand):
             else:
                 new_name = channel_name
 
-        if Stream.objects.filter(realm=realm, name=new_name).exists():
+        if (
+            Stream.objects.filter(realm=realm, name__iexact=new_name)
+            .exclude(id=channel.id)
+            .exists()
+        ):
             raise CommandError(
                 f"Channel with name '{new_name}' already exists; pass a different --new-name"
             )


### PR DESCRIPTION
After #28478 we no longer change the name when deactivating a channel, so this is particularly needed - now there's always a "collision" on new_name.

