### PR TITLE
sidebar links: Followup design updates

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -302,6 +302,7 @@
        space created by the padding-left on .right-sidebar,
        which separates the right sidebar from the message area. */
     --right-sidebar-padding-left: 2px;
+    --right-sidebar-heading-left-spacing: 5px;
     --right-sidebar-avatar-width: 2em;
     --right-sidebar-avatar-height: var(--right-sidebar-avatar-width);
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -298,7 +298,6 @@
     );
 
     /* Right sidebar */
-    --right-sidebar-padding-right: 8px;
     /* Vlad's design adds 2px of extra padding beyond the
        space created by the padding-left on .right-sidebar,
        which separates the right sidebar from the message area. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -438,6 +438,13 @@
         align-items: center;
         color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
+        font-size: var(--font-size-sidebar-action-heading);
+        font-weight: var(--font-weight-sidebar-action-heading);
+        font-variant: var(--font-variant-sidebar-action-heading);
+        font-feature-settings: var(
+            --font-feature-settings-sidebar-action-heading
+        );
+        text-transform: var(--text-transform-sidebar-action-heading);
     }
 }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -569,13 +569,14 @@ $user_status_emoji_width: 24px;
     padding-left: 0;
 
     .invite-user-link {
-        padding-left: var(--right-sidebar-heading-left-spacing);
-        grid-template-columns: auto minmax(0, 1fr);
+        grid-template-columns:
+            var(--right-sidebar-header-icon-toggle-width)
+            minmax(0, 1fr);
 
         .zulip-icon-user-plus {
             justify-self: center;
-            /* Some space between the icon and text */
-            margin-right: 5px;
+            /* Smaller icon size to align the link text with the other buddy list links */
+            font-size: 13px;
         }
     }
 }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -460,7 +460,7 @@ $user_status_emoji_width: 24px;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     margin-bottom: 10px;
-    margin-left: 5px;
+    margin-left: var(--right-sidebar-heading-left-spacing);
     /* The scrollbar doesn't extend this high, but we want the three-dot
        menus to line up. */
     margin-right: var(--width-simplebar-scroll-hover);

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -531,19 +531,26 @@ $user_status_emoji_width: 24px;
         color: var(--color-text-sidebar-action-heading-hover);
     }
 
-    .buddy-list-user-link-text,
-    .invite-user-link {
+    .right-sidebar-wrappable-text-container {
         display: grid;
-        grid-template-rows: var(--line-height-sidebar-row-prominent);
-        text-decoration: none;
+        grid-template-rows: minmax(
+            var(--line-height-sidebar-row-prominent),
+            auto
+        );
         align-items: center;
         color: var(--color-text-sidebar-action-heading);
-        font-size: var(--font-size-sidebar-action-heading);
-        font-weight: var(--font-weight-sidebar-action-heading);
-        font-variant: var(--font-variant-sidebar-action-heading);
-        font-feature-settings: var(
-            --font-feature-settings-sidebar-action-heading
-        );
+
+        .right-sidebar-wrappable-text-inner {
+            margin: var(--spacing-top-bottom-sidebar-topic-inner) 0;
+            line-height: 1;
+            text-decoration: none;
+            font-size: var(--font-size-sidebar-action-heading);
+            font-weight: var(--font-weight-sidebar-action-heading);
+            font-variant: var(--font-variant-sidebar-action-heading);
+            font-feature-settings: var(
+                --font-feature-settings-sidebar-action-heading
+            );
+        }
         text-transform: var(--text-transform-sidebar-action-heading);
     }
 }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -538,6 +538,13 @@ $user_status_emoji_width: 24px;
         text-decoration: none;
         align-items: center;
         color: var(--color-text-sidebar-action-heading);
+        font-size: var(--font-size-sidebar-action-heading);
+        font-weight: var(--font-weight-sidebar-action-heading);
+        font-variant: var(--font-variant-sidebar-action-heading);
+        font-feature-settings: var(
+            --font-feature-settings-sidebar-action-heading
+        );
+        text-transform: var(--text-transform-sidebar-action-heading);
     }
 }
 
@@ -555,12 +562,13 @@ $user_status_emoji_width: 24px;
     padding-left: 0;
 
     .invite-user-link {
-        grid-template-columns:
-            var(--right-sidebar-header-icon-toggle-width)
-            minmax(0, 1fr);
+        padding-left: var(--right-sidebar-heading-left-spacing);
+        grid-template-columns: auto minmax(0, 1fr);
 
         .zulip-icon-user-plus {
             justify-self: center;
+            /* Some space between the icon and text */
+            margin-right: 5px;
         }
     }
 }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -8,7 +8,6 @@ $user_status_emoji_width: 24px;
 }
 
 .right-sidebar-items {
-    padding-right: var(--right-sidebar-padding-right);
     padding-left: var(--right-sidebar-padding-left);
 }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -462,6 +462,9 @@ $user_status_emoji_width: 24px;
     align-items: center;
     margin-bottom: 10px;
     margin-left: 5px;
+    /* The scrollbar doesn't extend this high, but we want the three-dot
+       menus to line up. */
+    margin-right: var(--width-simplebar-scroll-hover);
 
     #userlist-header-search {
         display: grid;

--- a/web/templates/buddy_list/view_all_subscribers.hbs
+++ b/web/templates/buddy_list/view_all_subscribers.hbs
@@ -1,3 +1,7 @@
 <div class="buddy-list-user-link view-all-subscribers-link">
-    <a class="buddy-list-user-link-text" href="{{stream_edit_hash}}">{{t "View all subscribers" }}</a>
+    <a class="right-sidebar-wrappable-text-container" href="{{stream_edit_hash}}">
+        <span class="right-sidebar-wrappable-text-inner">
+            {{t "View all subscribers" }}
+        </span>
+    </a>
 </div>

--- a/web/templates/buddy_list/view_all_users.hbs
+++ b/web/templates/buddy_list/view_all_users.hbs
@@ -1,3 +1,7 @@
 <div class="buddy-list-user-link view-all-users-link">
-    <a class="buddy-list-user-link-text" href="#organization/users">{{t "View all users" }}</a>
+    <a class="right-sidebar-wrappable-text-container" href="#organization/users">
+        <span class="right-sidebar-wrappable-text-inner">
+            {{t "View all users" }}
+        </span>
+    </a>
 </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -27,9 +27,11 @@
                 </div>
                 <div id="buddy_list_wrapper_padding"></div>
                 <div class="invite-user-shortcut">
-                    <a class="invite-user-link" role="button">
+                    <a class="invite-user-link right-sidebar-wrappable-text-container" role="button">
                         <i class="zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
-                        {{t 'Invite to organization' }}
+                        <span class="right-sidebar-wrappable-text-inner">
+                            {{t 'Invite to organization' }}
+                        </span>
                     </a>
                 </div>
             </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -29,7 +29,7 @@
                 <div class="invite-user-shortcut">
                     <a class="invite-user-link" role="button">
                         <i class="zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
-                        {{t 'Invite users to organization' }}
+                        {{t 'Invite to organization' }}
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
As discussed [here](https://chat.zulip.org/#narrow/channel/101-design/topic/invite.20users.20link.20in.20right.20sidebar.20.20.2332332/near/1986802)

buddy list

<img width="265" alt="image" src="https://github.com/user-attachments/assets/6df22beb-6918-4b74-a6a5-ee5da5f0d2cd">

<img width="242" alt="image" src="https://github.com/user-attachments/assets/fe5e0739-b19c-440f-80a1-4eac9ee216f1">

hover

<img width="258" alt="image" src="https://github.com/user-attachments/assets/4c389ac2-81d9-4e4f-a0d9-152e76ec7c9b">
<img width="263" alt="image" src="https://github.com/user-attachments/assets/d2661398-34d5-43af-bb45-fd18a90c41ff">

create a channel

<img width="312" alt="image" src="https://github.com/user-attachments/assets/f2afb9d3-bd0a-4e0d-8a5d-3125f602fc6c">

<img width="312" alt="image" src="https://github.com/user-attachments/assets/788e6323-1fca-473a-bf25-10d05764293a">

hover

<img width="325" alt="image" src="https://github.com/user-attachments/assets/49f0418e-793c-41c5-8f9e-a0dfa3146d9a">

<img width="324" alt="image" src="https://github.com/user-attachments/assets/b05b3124-216b-4558-b17f-e659f748c9c1">

buddy list popover

<img width="300" alt="image" src="https://github.com/user-attachments/assets/fd8aacf5-8b52-4a16-b4ac-cc09861f5256">


