### PR TITLE
UI for viewing archived channels #32255

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -185,7 +185,6 @@ def get_chart_data_for_stream(
     stream, ignored_sub = access_stream_by_id(
         user_profile,
         stream_id,
-        require_active=True,
         require_content_access=False,
     )
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,19 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 362**
+
+* [`POST /users/me/subscriptions`](/api/subscribe),
+  [`DELETE /users/me/subscriptions`](/api/unsubscribe): Subscriptions
+  in archived channels can now be edited by users with the appropriate
+  permission, just like in non-archived channels.
+* [`PATCH /streams/{stream_id}`](/api/update-stream): Archived
+  channels can now be converted between public and private channels,
+  just like non-archived channels.
+* [`POST /register`](/api/register-queue): The `never_subscribed` data
+  structure now includes archived channels for clients that declared
+  the `archived_channels` client capability.
+
 **Feature level 361**
 
 * [`POST /messages/{message_id}/typing`](/api/set-typing-status-for-message-edit):

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 361
+API_FEATURE_LEVEL = 362
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1325,6 +1325,10 @@ export class Filter {
                     icon = "question-circle-o";
                     break;
                 }
+                if (sub.is_archived) {
+                    zulip_icon = "archive";
+                    break;
+                }
                 if (sub.invite_only) {
                     zulip_icon = "lock";
                     break;

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -256,18 +256,13 @@ export function validate_channels_settings_hash(hash: string): string {
         const stream_id = Number.parseInt(section, 10);
         const sub = sub_store.get(stream_id);
         // There are a few situations where we can't display stream settings:
-        // 1. This is a stream that's been archived. (sub.is_archived=true)
-        // 2. The stream ID is invalid. (sub=undefined)
-        // 3. The current user is a guest, and was unsubscribed from the stream
+        // 1. The stream ID is invalid. (sub=undefined)
+        // 2. The current user is a guest, and was unsubscribed from the stream
         //    stream in the current session. (In future sessions, the stream will
         //    not be in sub_store).
         //
-        // In all these cases we redirect the user to 'subscribed' tab.
-        if (
-            sub === undefined ||
-            sub.is_archived ||
-            (page_params.is_guest && !stream_data.is_subscribed(stream_id))
-        ) {
+        // In both cases we redirect the user to 'subscribed' tab.
+        if (sub === undefined || (page_params.is_guest && !stream_data.is_subscribed(stream_id))) {
             return channels_settings_section_url();
         }
 

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -24,7 +24,6 @@ import {user_settings} from "./user_settings.ts";
 function common_click_handlers(): void {
     $("body").on("click", ".set-home-view", (e) => {
         e.preventDefault();
-        e.preventDefault();
 
         const web_home_view = $(e.currentTarget).attr("data-view-code");
         const data = {web_home_view};

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -187,6 +187,10 @@ export function is_content_editable(message: Message, edit_limit_seconds_buffer 
         return false;
     }
 
+    if (message.type === "stream" && stream_data.is_stream_archived(message.stream_id)) {
+        return false;
+    }
+
     if (realm.realm_message_content_edit_limit_seconds === null) {
         return true;
     }

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -51,6 +51,7 @@ type TopicPopoverContext = {
     stream_name: string;
     stream_id: number;
     stream_muted: boolean;
+    stream_archived: boolean;
     topic_display_name: string;
     is_empty_string_topic: boolean;
     topic_unmuted: boolean;
@@ -250,8 +251,10 @@ export function get_topic_popover_content_context({
     const topic_unmuted = user_topics.is_topic_unmuted(sub.stream_id, topic_name);
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
     const has_unread_messages = num_unread_for_topic(sub.stream_id, topic_name) > 0;
-    const can_move_topic = settings_data.user_can_move_messages_between_streams();
-    const can_rename_topic = settings_data.user_can_move_messages_to_another_topic();
+    const can_move_topic =
+        !sub.is_archived && settings_data.user_can_move_messages_between_streams();
+    const can_rename_topic =
+        !sub.is_archived && settings_data.user_can_move_messages_to_another_topic();
     const visibility_policy = user_topics.get_topic_visibility_policy(sub.stream_id, topic_name);
     const all_visibility_policies = user_topics.all_visibility_policies;
     const is_spectator = page_params.is_spectator;
@@ -260,6 +263,7 @@ export function get_topic_popover_content_context({
         stream_name: sub.name,
         stream_id: sub.stream_id,
         stream_muted: sub.is_muted,
+        stream_archived: sub.is_archived,
         topic_display_name: util.get_final_topic_display_name(topic_name),
         is_empty_string_topic: topic_name === "",
         topic_unmuted,

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -617,6 +617,7 @@ type ConversationContext = {
           stream_url: string;
           invite_only: boolean;
           is_web_public: boolean;
+          is_archived: boolean;
           topic: string;
           topic_display_name: string;
           is_empty_string_topic: boolean;
@@ -656,6 +657,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         const stream_url = hash_util.by_stream_url(stream_id);
         const invite_only = stream_info.invite_only;
         const is_web_public = stream_info.is_web_public;
+        const is_archived = stream_info.is_archived;
         // Topic info
         const topic = last_msg.topic;
         const topic_display_name = util.get_final_topic_display_name(topic);
@@ -685,6 +687,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
             stream_url,
             invite_only,
             is_web_public,
+            is_archived,
             topic,
             topic_display_name,
             is_empty_string_topic,

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -313,12 +313,13 @@ export function delete_sub(stream_id: number): void {
         return;
     }
     sub.is_archived = true;
-    stream_info.set_false(stream_id, sub);
 }
 
 export function get_non_default_stream_names(): {name: string; unique_id: number}[] {
     let subs = [...stream_info.values()];
-    subs = subs.filter((sub) => !is_default_stream_id(sub.stream_id) && !sub.invite_only);
+    subs = subs.filter(
+        (sub) => !is_default_stream_id(sub.stream_id) && !sub.invite_only && !sub.is_archived,
+    );
     const names = subs.map((sub) => ({
         name: sub.name,
         unique_id: sub.stream_id,

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -355,6 +355,10 @@ export function subscribed_stream_ids(): number[] {
     return subscribed_subs().map((sub) => sub.stream_id);
 }
 
+export function get_archived_subs(): StreamSubscription[] {
+    return [...stream_info.values()].filter((sub) => sub.is_archived);
+}
+
 export function muted_stream_ids(): number[] {
     return subscribed_subs()
         .filter((sub) => sub.is_muted)

--- a/web/src/stream_settings_data.ts
+++ b/web/src/stream_settings_data.ts
@@ -28,6 +28,12 @@ export type SettingsSubscription = StreamSubscription & {
     subscriber_count: number;
 };
 
+export const FILTERS = {
+    ALL_CHANNELS: "all_channels",
+    NON_ARCHIVED_CHANNELS: "non_archived_channels",
+    ARCHIVED_CHANNELS: "archived_channels",
+};
+
 export function get_sub_for_settings(sub: StreamSubscription): SettingsSubscription {
     return {
         ...sub,
@@ -66,7 +72,7 @@ function get_subs_for_settings(subs: StreamSubscription[]): SettingsSubscription
     // delegating, so that we can more efficiently compute subscriber counts
     // (in bulk).  If that plan appears to have been aborted, feel free to
     // inline this.
-    return subs.filter((sub) => !sub.is_archived).map((sub) => get_sub_for_settings(sub));
+    return subs.map((sub) => get_sub_for_settings(sub));
 }
 
 export function get_updated_unsorted_subs(): SettingsSubscription[] {

--- a/web/src/stream_settings_data.ts
+++ b/web/src/stream_settings_data.ts
@@ -89,7 +89,7 @@ export function get_unmatched_streams_for_notification_settings(): ({
     invite_only: boolean;
     is_web_public: boolean;
 })[] {
-    const subscribed_rows = stream_data.subscribed_subs();
+    const subscribed_rows = stream_data.subscribed_subs().filter((sub) => !sub.is_archived);
     subscribed_rows.sort((a, b) => util.strcmp(a.name, b.name));
 
     const notification_settings = [];

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -367,7 +367,7 @@ export function update_stream_privacy_icon_in_settings(sub: StreamSubscription):
 
     const $stream_settings = stream_settings_containers.get_edit_container(sub);
 
-    $stream_settings.find(".general_settings .large-icon").replaceWith(
+    $stream_settings.find(".stream_section[data-stream-section='general'] .large-icon").replaceWith(
         $(
             render_stream_privacy_icon({
                 invite_only: sub.invite_only,

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -968,6 +968,7 @@ input.settings_text_input {
     width: 12px;
 
     &.zulip-icon-globe,
+    &.zulip-icon-archive,
     &.zulip-icon-hashtag {
         font-size: 0.75em;
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -642,9 +642,19 @@ h4.user_group_setting_subsection_title {
     padding: 8px 10px;
     display: grid;
     grid-template:
-        "search-input clear-search more-options-button" auto / minmax(0, 1fr)
+        "search-input clear-search dropdown-widget" auto / minmax(0, 1fr)
         30px;
     border-bottom: 1px solid var(--color-border-modal-bar);
+}
+
+#stream_settings_filter_widget {
+    margin-left: 10px;
+    gap: 3px;
+    width: auto;
+}
+
+.stream_settings_filter_container.hide_filter {
+    display: none;
 }
 
 #user_group_visibility_settings_widget {

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -49,7 +49,7 @@
             {{#unless is_direct}}
             <div class="inbox-right-part-wrapper">
                 <div class="inbox-right-part">
-                    {{#if is_topic}}
+                    {{#if (and is_topic (not stream_archived))}}
                         <span class="visibility-policy-indicator change_visibility_policy hidden-for-spectators{{#if (eq visibility_policy all_visibility_policies.INHERIT)}} inbox-row-visibility-policy-inherit{{/if}}"
                           data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}" tabindex="0" data-col-index="{{ column_indexes.TOPIC_VISIBILITY }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}

--- a/web/templates/inline_decorated_stream_name.hbs
+++ b/web/templates/inline_decorated_stream_name.hbs
@@ -1,5 +1,7 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
-{{~#if stream.invite_only ~}}
+{{~#if stream.is_archived ~}}
+<i class="zulip-icon zulip-icon-archive stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
+{{~ else if stream.invite_only ~}}
 <i class="zulip-icon zulip-icon-lock stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}
 {{~ else if stream.is_web_public ~}}
 <i class="zulip-icon zulip-icon-globe stream-privacy-type-icon" {{#if show_colored_icon}}style="color: {{stream.color}}"{{/if}} aria-hidden="true"></i> {{stream.name ~}}

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -1,5 +1,4 @@
 {{#if stream_settings_link}}
-{{#unless stream.is_archived}}
 <a class="message-header-stream-settings-button tippy-zulip-tooltip" data-tooltip-template-id="stream-details-tooltip-template" data-tippy-placement="bottom" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title . }}
 </a>
@@ -13,11 +12,6 @@
         {{/unless}}
     </div>
 </template>
-{{else}}
-<span class="navbar_title">
-    {{> navbar_icon_and_title . }}
-</span>
-{{/unless}}
 <span class="narrow_description rendered_markdown single-line-rendered-markdown">
     {{#if rendered_narrow_description}}
     {{rendered_markdown rendered_narrow_description}}

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -67,6 +67,7 @@
                 {{/if}}
             </a>
         </li>
+        {{#unless stream.is_archived}}
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="popover_sub_unsub_button popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-circle-x" aria-hidden="true"></i>
@@ -80,5 +81,6 @@
                 <span class="popover-menu-label">{{t "Change color"}}</span>
             </a>
         </li>
+        {{/unless}}
     </ul>
 </div>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -5,30 +5,32 @@
         </li>
         {{!-- Group 1 --}}
         {{#unless is_spectator}}
-        <li role="separator" class="popover-menu-separator"></li>
-        <li role="none" class="popover-menu-list-item">
-            <div role="group" class="tab-picker popover-menu-tab-group" aria-label="{{t 'Topic visibility' }}">
-                <input type="radio" id="sidebar-topic-muted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
-                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-muted-policy" aria-label="{{t 'Mute' }}" data-tippy-content="{{t 'Mute' }}" tabindex="0">
-                    <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
-                </label>
-                <input type="radio" id="sidebar-topic-inherit-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
-                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-inherit-policy" aria-label="{{t 'Default' }}" data-tippy-content="{{t 'Default' }}" tabindex="0">
-                    <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
-                </label>
-                {{#if (or stream_muted topic_unmuted)}}
-                <input type="radio" id="sidebar-topic-unmuted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
-                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-unmuted-policy" aria-label="{{t 'Unmute' }}" data-tippy-content="{{t 'Unmute' }}" tabindex="0">
-                    <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
-                </label>
-                {{/if}}
-                <input type="radio" id="sidebar-topic-followed-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
-                <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-followed-policy" aria-label="{{t 'Follow' }}" data-tippy-content="{{t 'Follow' }}" tabindex="0">
-                    <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
-                </label>
-                <span class="slider"></span>
-            </div>
-        </li>
+            {{#unless stream_archived}}
+            <li role="separator" class="popover-menu-separator"></li>
+            <li role="none" class="popover-menu-list-item">
+                <div role="group" class="tab-picker popover-menu-tab-group" aria-label="{{t 'Topic visibility' }}">
+                    <input type="radio" id="sidebar-topic-muted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.MUTED}}" {{#if (eq visibility_policy all_visibility_policies.MUTED)}}checked{{/if}} />
+                    <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-muted-policy" aria-label="{{t 'Mute' }}" data-tippy-content="{{t 'Mute' }}" tabindex="0">
+                        <i class="zulip-icon zulip-icon-mute-new" aria-hidden="true"></i>
+                    </label>
+                    <input type="radio" id="sidebar-topic-inherit-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.INHERIT}}" {{#if (eq visibility_policy all_visibility_policies.INHERIT)}}checked{{/if}} />
+                    <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-inherit-policy" aria-label="{{t 'Default' }}" data-tippy-content="{{t 'Default' }}" tabindex="0">
+                        <i class="zulip-icon zulip-icon-inherit" aria-hidden="true"></i>
+                    </label>
+                    {{#if (or stream_muted topic_unmuted)}}
+                    <input type="radio" id="sidebar-topic-unmuted-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.UNMUTED}}" {{#if (eq visibility_policy all_visibility_policies.UNMUTED)}}checked{{/if}} />
+                    <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-unmuted-policy" aria-label="{{t 'Unmute' }}" data-tippy-content="{{t 'Unmute' }}" tabindex="0">
+                        <i class="zulip-icon zulip-icon-unmute-new" aria-hidden="true"></i>
+                    </label>
+                    {{/if}}
+                    <input type="radio" id="sidebar-topic-followed-policy" class="tab-option" name="sidebar-topic-visibility-select" data-visibility-policy="{{all_visibility_policies.FOLLOWED}}" {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}checked{{/if}} />
+                    <label role="menuitemradio" class="tab-option-content tippy-zulip-delayed-tooltip" for="sidebar-topic-followed-policy" aria-label="{{t 'Follow' }}" data-tippy-content="{{t 'Follow' }}" tabindex="0">
+                        <i class="zulip-icon zulip-icon-follow" aria-hidden="true"></i>
+                    </label>
+                    <span class="slider"></span>
+                </div>
+            </li>
+            {{/unless}}
         {{/unless}}
         {{#if is_topic_empty}}
             <li role="separator" class="popover-menu-separator"></li>
@@ -77,7 +79,9 @@
             </li>
             {{!-- Group 3 --}}
             {{#if (or can_move_topic can_rename_topic is_realm_admin)}}
-            <li role="separator" class="popover-menu-separator"></li>
+                {{#unless stream_archived}}
+                <li role="separator" class="popover-menu-separator"></li>
+                {{/unless}}
             {{/if}}
             {{#if can_move_topic}}
             <li role="none" class="link-item popover-menu-list-item">
@@ -107,7 +111,7 @@
                 </a>
             </li>
             {{/if}}
-            {{#if is_realm_admin}}
+            {{#if (and is_realm_admin (not stream_archived))}}
             <li role="none" class="link-item popover-menu-list-item">
                 <a role="menuitem" class="sidebar-popover-delete-topic-messages popover-menu-link" tabindex="0">
                     <i class="popover-menu-icon zulip-icon zulip-icon-trash" aria-hidden="true"></i>

--- a/web/templates/popovers/stream_card_popover.hbs
+++ b/web/templates/popovers/stream_card_popover.hbs
@@ -4,7 +4,8 @@
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
                 {{> ../stream_privacy
                   invite_only=stream.invite_only
-                  is_web_public=stream.is_web_public }}
+                  is_web_public=stream.is_web_public
+                  is_archived=stream.is_archived }}
             </span>
             <span class="popover-stream-name">{{stream.name}}</span>
         </li>

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -62,6 +62,7 @@
                 </div>
                 <div class="recent_topic_actions">
                     <div class="hidden-for-spectators">
+                        {{#unless is_archived}}
                         <span class="recent_view_focusable change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-col-index="{{ column_indexes.mute }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
                                 <i class="zulip-icon zulip-icon-follow recipient_bar_icon visibility-status-icon" tabindex="0" aria-label="{{t 'Topic actions menu' }}" aria-haspopup="true" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-topic-url="{{topic_url}}" data-tippy-content="{{t 'You follow this topic.'}}" role="button"></i>
@@ -73,6 +74,7 @@
                                 <i class="zulip-icon zulip-icon-more-vertical recent-view-row-topic-menu visibility-status-icon" tabindex="0" aria-label="{{t 'Topic actions menu' }}" aria-haspopup="true" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-topic-url="{{topic_url}}" role="button"></i>
                             {{/if}}
                         </span>
+                        {{/unless}}
                     </div>
                 </div>
                 {{/if}}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -59,7 +59,7 @@
                 <div class="toggle_resolve_topic_spinner" style="display: none"></div>
             {{/if}}
 
-            {{#if is_subscribed}}
+            {{#if (and is_subscribed (not is_archived))}}
                 <span class="change_visibility_policy recipient-bar-control hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}">
                     {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
                         <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic.'}}"

--- a/web/templates/stream_privacy.hbs
+++ b/web/templates/stream_privacy.hbs
@@ -1,5 +1,7 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
-{{#if invite_only}}
+{{#if is_archived}}
+<i class="zulip-icon zulip-icon-archive" aria-hidden="true"></i>
+{{else if invite_only}}
 <i class="zulip-icon zulip-icon-lock" aria-hidden="true"></i>
 {{else if is_web_public}}
 <i class="zulip-icon zulip-icon-globe" aria-hidden="true"></i>

--- a/web/templates/stream_settings/selected_stream_title.hbs
+++ b/web/templates/stream_settings/selected_stream_title.hbs
@@ -2,6 +2,7 @@
 {{#unless preview_url}}{{t "Add subscribers to "}}{{/unless}}
 {{> stream_privacy_icon
   invite_only=sub.invite_only
-  is_web_public=sub.is_web_public }}
+  is_web_public=sub.is_web_public
+  is_archived=sub.is_archived }}
 <span class="stream-name-title">{{sub.name}}</span>
 </a>

--- a/web/templates/stream_settings/stream_privacy_icon.hbs
+++ b/web/templates/stream_settings/stream_privacy_icon.hbs
@@ -1,5 +1,9 @@
 {{! This controls whether the swatch next to streams in the stream edit page has a lock icon. }}
-{{#if invite_only}}
+{{#if is_archived}}
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
+    <i class="zulip-icon zulip-icon-archive" aria-hidden="true"></i>
+</div>
+{{else if invite_only}}
 <div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}"{{/if}}>
     <i class="zulip-icon zulip-icon-lock" aria-hidden="true"></i>
 </div>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -25,6 +25,9 @@
                     <button type="button" class="clear_search_button" id="clear_search_stream_name">
                         <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                     </button>
+                    <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
+                        {{> ../dropdown_widget widget_name="stream_settings_filter"}}
+                    </div>
                 </div>
                 <div class="no-streams-to-show">
                     <div class="subscribed_streams_tab_empty_text">

--- a/web/templates/stream_settings/subscription_setting_icon.hbs
+++ b/web/templates/stream_settings/subscription_setting_icon.hbs
@@ -1,6 +1,8 @@
 <div class="icon" style="background-color: {{color}}">
     <div class="flex">
-        {{#if invite_only}}
+        {{#if is_archived}}
+        <i class="zulip-icon zulip-icon-archive fa-lg" aria-hidden="true"></i>
+        {{else if invite_only}}
         <i class="zulip-icon zulip-icon-lock" aria-hidden="true"></i>
         {{else if is_web_public}}
         <i class="zulip-icon zulip-icon-globe fa-lg" aria-hidden="true"></i>

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -2094,6 +2094,15 @@ function make_web_public_sub(name, stream_id) {
     stream_data.add_sub(sub);
 }
 
+function make_archived_sub(name, stream_id) {
+    const sub = {
+        name,
+        stream_id,
+        is_archived: true,
+    };
+    stream_data.add_sub(sub);
+}
+
 test("navbar_helpers", ({override}) => {
     stream_data.add_sub(foo_sub);
 
@@ -2185,6 +2194,9 @@ test("navbar_helpers", ({override}) => {
     const web_public_sub_id = new_stream_id();
     make_web_public_sub("webPublicSub", web_public_sub_id); // capitalized just to try be tricky and robust.
     const web_public_channel = [{operator: "channel", operand: web_public_sub_id.toString()}];
+    const archived_sub_id = new_stream_id();
+    make_archived_sub("archivedSub", archived_sub_id);
+    const archived_channel_term = [{operator: "channel", operand: archived_sub_id.toString()}];
     const dm = [{operator: "dm", operand: "joe@example.com"}];
     const dm_with = [
         {operator: "dm", operand: "joe@example.com"},
@@ -2342,6 +2354,13 @@ test("navbar_helpers", ({override}) => {
             zulip_icon: "globe",
             title: "webPublicSub",
             redirect_url_with_search: `/#narrow/channel/${web_public_sub_id}-webPublicSub`,
+        },
+        {
+            terms: archived_channel_term,
+            is_common_narrow: true,
+            zulip_icon: "archive",
+            title: "archivedSub",
+            redirect_url_with_search: `/#narrow/channel/${archived_sub_id}-archivedSub`,
         },
         {
             terms: dm,

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -225,6 +225,7 @@ for (const stream_id of [stream1, stream2, stream3, stream4, stream6]) {
         color: "",
         invite_only: false,
         is_web_public: true,
+        is_archived: false,
         subscribed: true,
     });
 }
@@ -415,6 +416,7 @@ function generate_topic_data(topic_info_array) {
             invite_only: false,
             is_web_public: true,
             is_private: false,
+            is_archived: false,
             last_msg_time: "Just now",
             last_msg_url: "https://www.example.com",
             full_last_msg_date_time: "date at time",

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -716,6 +716,7 @@ test("delete_sub", () => {
 
     stream_data.add_sub(canada);
     const num_subscribed_subs = stream_data.num_subscribed_subs();
+    const archived_subs = stream_data.get_archived_subs();
 
     assert.ok(stream_data.is_subscribed(canada.stream_id));
     assert.equal(stream_data.get_sub("Canada").stream_id, canada.stream_id);
@@ -728,6 +729,7 @@ test("delete_sub", () => {
     assert.ok(stream_data.get_sub("Canada"));
     assert.ok(sub_store.get(canada.stream_id));
     assert.equal(stream_data.num_subscribed_subs(), num_subscribed_subs);
+    assert.equal(stream_data.get_archived_subs().length, archived_subs.length + 1);
 
     blueslip.expect("warn", "Failed to archive stream 99999");
     stream_data.delete_sub(99999);

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -727,7 +727,7 @@ test("delete_sub", () => {
     assert.ok(stream_data.is_subscribed(canada.stream_id));
     assert.ok(stream_data.get_sub("Canada"));
     assert.ok(sub_store.get(canada.stream_id));
-    assert.equal(stream_data.num_subscribed_subs(), num_subscribed_subs - 1);
+    assert.equal(stream_data.num_subscribed_subs(), num_subscribed_subs);
 
     blueslip.expect("warn", "Failed to archive stream 99999");
     stream_data.delete_sub(99999);

--- a/web/tests/stream_settings_ui.test.cjs
+++ b/web/tests/stream_settings_ui.test.cjs
@@ -209,6 +209,11 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
         populated_subs = data.subscriptions;
     });
 
+    const filters_dropdown_widget = {
+        render: function render() {},
+    };
+    stream_settings_ui.set_filters_for_tests(filters_dropdown_widget);
+
     stream_settings_ui.render_left_panel_superset();
 
     const sub_stubs = [];
@@ -222,6 +227,11 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
     }
 
     $.create("#channels_overlay_container .stream-row", {children: sub_stubs});
+
+    const $no_streams_message = $(".no-streams-to-show");
+    const $child_element = $(".subscribed_streams_tab_empty_text");
+    $no_streams_message.children = () => $child_element;
+    $child_element.hide = () => [];
 
     let ui_called = false;
     scroll_util.reset_scrollbar = ($elem) => {
@@ -360,6 +370,7 @@ run_test("redraw_left_panel", ({override, mock_template}) => {
     test_filter({input: "d", show_subscribed: true}, [poland]);
     assert.ok($(".stream-row-denmark").hasClass("active"));
 
+    $(".stream-row.active").attr("data-stream-id", 101);
     stream_settings_ui.switch_stream_tab("subscribed");
     assert.ok(!$(".stream-row-denmark").hasClass("active"));
     assert.ok(!$(".right .settings").visible());

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1339,9 +1339,7 @@ def build_message_edit_request(
     is_stream_edited = False
     target_stream = orig_stream
     if stream_id is not None:
-        target_stream = access_stream_by_id_for_message(
-            user_profile, stream_id, require_active=True
-        )[0]
+        target_stream = access_stream_by_id_for_message(user_profile, stream_id)[0]
         is_stream_edited = True
 
     return StreamMessageEditRequest(

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1280,6 +1280,12 @@ def apply_event(
                             id=stream["stream_id"]
                         ).first_message_id
 
+                for stream in state["never_subscribed"]:
+                    if stream["stream_id"] in deleted_stream_ids:
+                        stream["is_archived"] = True
+                        stream["first_message_id"] = Stream.objects.get(
+                            id=stream["stream_id"]
+                        ).first_message_id
             else:
                 state["subscriptions"] = [
                     stream
@@ -1293,11 +1299,11 @@ def apply_event(
                     if stream["stream_id"] not in deleted_stream_ids
                 ]
 
-            state["never_subscribed"] = [
-                stream
-                for stream in state["never_subscribed"]
-                if stream["stream_id"] not in deleted_stream_ids
-            ]
+                state["never_subscribed"] = [
+                    stream
+                    for stream in state["never_subscribed"]
+                    if stream["stream_id"] not in deleted_stream_ids
+                ]
 
         if event["op"] == "update":
             # For legacy reasons, we call stream data 'subscriptions' in

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -765,6 +765,7 @@ def access_stream_common(
     user_profile: UserProfile,
     stream: Stream,
     error: str,
+    *,
     require_content_access: bool = True,
 ) -> Subscription | None:
     """Common function for backend code where the target use attempts to
@@ -802,6 +803,7 @@ def access_stream_common(
 def access_stream_by_id(
     user_profile: UserProfile,
     stream_id: int,
+    *,
     require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     error = _("Invalid channel ID")
@@ -822,6 +824,7 @@ def access_stream_by_id(
 def access_stream_by_id_for_message(
     user_profile: UserProfile,
     stream_id: int,
+    *,
     require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     """
@@ -875,7 +878,7 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
 
 
 def access_stream_by_name(
-    user_profile: UserProfile, stream_name: str, require_content_access: bool = True
+    user_profile: UserProfile, stream_name: str, *, require_content_access: bool = True
 ) -> tuple[Stream, Subscription | None]:
     error = _("Invalid channel name '{channel_name}'").format(channel_name=stream_name)
     try:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -766,6 +766,7 @@ def access_stream_common(
     stream: Stream,
     error: str,
     *,
+    require_active_channel: bool = True,
     require_content_access: bool = True,
 ) -> Subscription | None:
     """Common function for backend code where the target use attempts to
@@ -787,7 +788,10 @@ def access_stream_common(
     except Subscription.DoesNotExist:
         sub = None
 
-    if not stream.deactivated and check_basic_stream_access(
+    if require_active_channel and stream.deactivated:
+        raise JsonableError(error)
+
+    if check_basic_stream_access(
         user_profile,
         stream,
         is_subscribed=sub is not None,
@@ -804,6 +808,7 @@ def access_stream_by_id(
     user_profile: UserProfile,
     stream_id: int,
     *,
+    require_active_channel: bool = True,
     require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     error = _("Invalid channel ID")
@@ -816,6 +821,7 @@ def access_stream_by_id(
         user_profile,
         stream,
         error,
+        require_active_channel=require_active_channel,
         require_content_access=require_content_access,
     )
     return (stream, sub)
@@ -825,6 +831,7 @@ def access_stream_by_id_for_message(
     user_profile: UserProfile,
     stream_id: int,
     *,
+    require_active_channel: bool = True,
     require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     """
@@ -841,6 +848,7 @@ def access_stream_by_id_for_message(
         user_profile,
         stream,
         error,
+        require_active_channel=require_active_channel,
         require_content_access=require_content_access,
     )
     return (stream, sub)
@@ -878,7 +886,11 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
 
 
 def access_stream_by_name(
-    user_profile: UserProfile, stream_name: str, *, require_content_access: bool = True
+    user_profile: UserProfile,
+    stream_name: str,
+    *,
+    require_active_channel: bool = True,
+    require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     error = _("Invalid channel name '{channel_name}'").format(channel_name=stream_name)
     try:
@@ -890,6 +902,7 @@ def access_stream_by_name(
         user_profile,
         stream,
         error,
+        require_active_channel=require_active_channel,
         require_content_access=require_content_access,
     )
     return (stream, sub)

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -765,7 +765,6 @@ def access_stream_common(
     user_profile: UserProfile,
     stream: Stream,
     error: str,
-    require_active: bool = True,
     require_content_access: bool = True,
 ) -> Subscription | None:
     """Common function for backend code where the target use attempts to
@@ -782,7 +781,7 @@ def access_stream_common(
     try:
         assert stream.recipient_id is not None
         sub = Subscription.objects.get(
-            user_profile=user_profile, recipient_id=stream.recipient_id, active=require_active
+            user_profile=user_profile, recipient_id=stream.recipient_id, active=True
         )
     except Subscription.DoesNotExist:
         sub = None
@@ -803,7 +802,6 @@ def access_stream_common(
 def access_stream_by_id(
     user_profile: UserProfile,
     stream_id: int,
-    require_active: bool = True,
     require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     error = _("Invalid channel ID")
@@ -816,7 +814,6 @@ def access_stream_by_id(
         user_profile,
         stream,
         error,
-        require_active=require_active,
         require_content_access=require_content_access,
     )
     return (stream, sub)
@@ -825,7 +822,6 @@ def access_stream_by_id(
 def access_stream_by_id_for_message(
     user_profile: UserProfile,
     stream_id: int,
-    require_active: bool = True,
     require_content_access: bool = True,
 ) -> tuple[Stream, Subscription | None]:
     """
@@ -842,7 +838,6 @@ def access_stream_by_id_for_message(
         user_profile,
         stream,
         error,
-        require_active=require_active,
         require_content_access=require_content_access,
     )
     return (stream, sub)

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -500,7 +500,7 @@ def access_stream_for_send_message(
         else:
             raise JsonableError(_("User not authorized for this query"))
 
-    # Deactivated streams are not accessible.
+    # You cannot send mesasges to archived channels
     if stream.deactivated:
         if archived_channel_notice:
             return
@@ -1262,9 +1262,7 @@ def filter_stream_authorization_for_adding_subscribers(
         )
 
     unauthorized_streams = [
-        stream
-        for stream in streams
-        if stream.deactivated or stream.id not in content_access_stream_ids
+        stream for stream in streams if stream.id not in content_access_stream_ids
     ]
     unauthorized_stream_ids = {stream.id for stream in unauthorized_streams}
 

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -737,9 +737,7 @@ def gather_subscriptions_helper(
                 unsubscribed.append(stream_dict)
 
     if user_profile.can_access_public_streams():
-        never_subscribed_stream_ids = {
-            stream["id"] for stream in all_stream_dicts if not stream["deactivated"]
-        } - sub_unsub_stream_ids
+        never_subscribed_stream_ids = set(all_streams_map) - sub_unsub_stream_ids
     else:
         web_public_stream_ids = {
             stream["id"] for stream in all_stream_dicts if stream["is_web_public"]

--- a/zerver/models/streams.py
+++ b/zerver/models/streams.py
@@ -313,7 +313,7 @@ def bulk_get_streams(realm: Realm, stream_names: set[str]) -> dict[str, Any]:
             "upper(zerver_stream.name::text) IN (SELECT upper(name) FROM unnest(%s) AS name)"
         )
         return (
-            get_active_streams(realm)
+            get_all_streams(realm, include_archived_channels=True)
             .select_related("can_send_message_group", "can_send_message_group__named_user_group")
             .extra(where=[where_clause], params=(list(stream_names),))  # noqa: S610
         )

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10662,7 +10662,10 @@ paths:
         to a specified channel depends on the [channel's permissions
         settings](/help/channel-permissions).
 
-        **Changes**: Before Zulip 10.0 (feature level 357), the
+        **Changes**: Before Zulip 10.0 (feature level 362),
+        subscriptions in archived channels could not be modified.
+
+        Before Zulip 10.0 (feature level 357), the
         `can_subscribe_group` permission, which allows members of the
         group to subscribe themselves to the channel, did not exist.
 
@@ -10931,6 +10934,9 @@ paths:
       tags: ["channels"]
       description: |
         Update which channels you are subscribed to.
+
+        **Changes**: Before Zulip 10.0 (feature level 362),
+        subscriptions in archived channels could not be modified.
       requestBody:
         required: false
         content:
@@ -11065,13 +11071,16 @@ paths:
           by the [`can_remove_subscribers_group`][can-remove-parameter]
           for the channel.
 
-        **Changes**: Before Zulip 8.0 (feature level 208), if a user
-        specified by the [`principals`][principals-param] parameter was
-        a deactivated user, or did not exist, then an HTTP status code
-        of 403 was returned with `code: "UNAUTHORIZED_PRINCIPAL"` in the
-        error response. As of this feature level, an HTTP status code of
-        400 is returned with `code: "BAD_REQUEST"` in the error response
-        for these cases.
+        **Changes**: Before Zulip 10.0 (feature level 362),
+        subscriptions in archived channels could not be modified.
+
+        Before Zulip 8.0 (feature level 208), if a user specified by
+        the [`principals`][principals-param] parameter was a
+        deactivated user, or did not exist, then an HTTP status code
+        of 403 was returned with `code: "UNAUTHORIZED_PRINCIPAL"` in
+        the error response. As of this feature level, an HTTP status
+        code of 400 is returned with `code: "BAD_REQUEST"` in the
+        error response for these cases.
 
         Before Zulip 8.0 (feature level 197),
         the `can_remove_subscribers_group` setting
@@ -15431,7 +15440,11 @@ paths:
                           Important for clients containing UI where one can browse channels to subscribe
                           to.
 
-                          **Changes**: Prior to Zulip 10.0 (feature level 349), if a user was
+                          **Changes**: Before Zulip 10.0 (feature level 362), archived channels did
+                          not appear in this list, even if the `archived_channels` [client
+                          capability][client-capabilities] was declared by the client.
+
+                          Prior to Zulip 10.0 (feature level 349), if a user was
                           in `can_administer_channel_group` of a channel that they never
                           subscribed to, but not an organization administrator, the channel
                           in question would not be part of this array.
@@ -20685,7 +20698,10 @@ paths:
         [private channel's permissions](/help/channel-permissions#private-channels)
         depends on them being subscribed to the channel.
 
-        **Changes**: Removed `stream_post_policy` and `is_announcement_only`
+        **Changes**: Before Zulip 10.0 (feature level 362), channel privacy could not be
+        edited for archived channels.
+
+        Removed `stream_post_policy` and `is_announcement_only`
         parameters in Zulip 10.0 (feature level 333), as permission to post
         in the channel is now controlled by `can_send_message_group`.
       x-curl-examples-parameters:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3435,7 +3435,9 @@ class NormalActionsTest(BaseAction):
     def test_deactivate_stream_neversubscribed(self) -> None:
         for i, include_streams in enumerate([True, False]):
             stream = self.make_stream(f"stream{i}")
-            with self.verify_action(include_streams=include_streams) as events:
+            with self.verify_action(
+                include_streams=include_streams, archived_channels=True
+            ) as events:
                 do_deactivate_stream(stream, acting_user=None)
             check_stream_delete("events[0]", events[0])
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -919,7 +919,7 @@ class StreamAdminTest(ZulipTestCase):
         }
         stream_id = get_stream("private_stream_1", user_profile.realm).id
         result = self.client_patch(f"/json/streams/{stream_id}", params)
-        self.assert_json_error(result, "Invalid channel ID")
+        self.assert_json_error(result, "Channel content access is required.")
 
         stream = self.subscribe(user_profile, "private_stream_1")
         self.assertFalse(stream.is_in_zephyr_realm)
@@ -2319,7 +2319,7 @@ class StreamAdminTest(ZulipTestCase):
                 "is_private": orjson.dumps(True).decode(),
             },
         )
-        self.assert_json_error(result, "Invalid channel ID")
+        self.assert_json_error(result, "Channel content access is required.")
 
     def test_non_admin_cannot_access_unsub_private_stream(self) -> None:
         iago = self.example_user("iago")
@@ -2911,7 +2911,7 @@ class StreamAdminTest(ZulipTestCase):
             params,
         )
         if setting_name in Stream.stream_permission_group_settings_requiring_content_access:
-            self.assert_json_error(result, "Invalid channel ID")
+            self.assert_json_error(result, "Channel content access is required.")
         else:
             self.assert_json_success(result)
             stream = get_stream("stream_name2", realm)
@@ -2937,7 +2937,7 @@ class StreamAdminTest(ZulipTestCase):
             params,
         )
         if setting_name in Stream.stream_permission_group_settings_requiring_content_access:
-            self.assert_json_error(result, "Invalid channel ID")
+            self.assert_json_error(result, "Channel content access is required.")
             do_change_stream_group_based_setting(
                 stream,
                 "can_add_subscribers_group",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -8522,6 +8522,12 @@ class AccessStreamTest(ZulipTestCase):
         access_stream_by_id(hamlet, public_stream.id)
         access_stream_by_name(hamlet, public_stream.name)
 
+        # Archive channel to verify require_active_channel code path
+        do_deactivate_stream(public_stream, acting_user=hamlet)
+        with self.assertRaisesRegex(JsonableError, "Invalid channel ID"):
+            access_stream_by_id(hamlet, public_stream.id, require_active_channel=True)
+        access_stream_by_id(hamlet, public_stream.id, require_active_channel=False)
+
         # Nobody can access a public stream in another realm
         mit_realm = get_realm("zephyr")
         mit_stream = ensure_stream(mit_realm, "mit_stream", invite_only=False, acting_user=None)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3362,6 +3362,8 @@ class StreamAdminTest(ZulipTestCase):
             result = self.client_delete("/json/streams/" + str(stream_id))
         self.assert_json_success(result)
 
+        stream.refresh_from_db()
+
         # We no longer send subscription events for stream deactivations.
         sub_events = [e for e in events if e["event"]["type"] == "subscription"]
         self.assertEqual(sub_events, [])


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #32255 

CZO: [UI for deactivated group](https://chat.zulip.org/#narrow/channel/101-design/topic/UI.20for.20viewing.20deactivated.20groups.20.2332877) , [display archived channels in UI ](https://chat.zulip.org/#narrow/channel/101-design/topic/display.20archived.20channels.20in.20the.20UI)

This PR implements the UI for viewing archived channels in Zulip. It introduces a menu to the "Filter channels" line in channel settings, with options to Show archived channels , show non-archived channels or show all channels, depending on the current state (default: archived channels are hidden). 

It displays archived channels in stream settings and It also ensures that an "archived" icon is always displayed next to the channel name in settings (both left and right panels) and also in left sidebar.

Additionally, when viewing an archived channel, settings that cannot be changed will be disabled, aligning with the current API functionality.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Dark mode| Light mode |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/6b8617dc-b1ac-4bc3-8b16-38716dc9617c) | ![image](https://github.com/user-attachments/assets/c0247316-e91a-4e82-9587-fb6a9bcac98c) |
| ![image](https://github.com/user-attachments/assets/8c9d070c-7d1d-48a5-a4d9-73420801566c) |  ![image](https://github.com/user-attachments/assets/4d174082-6e0e-4e3f-90fc-b4f7c6c5a638) |  
| ![{76ECBE1A-9927-4FE7-8298-2892FA9F6B49}](https://github.com/user-attachments/assets/eaa1b472-81df-4ad9-964b-29eb8b0b599b)  | ![{34ACE3A0-2773-4081-9E0A-7BA2F4025084}](https://github.com/user-attachments/assets/5929e647-4062-4587-81ea-928645a20541)  |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
