### PR TITLE
portico: Remove text centering on thanks page.

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -304,12 +304,6 @@ html {
     font-weight: 400;
 }
 
-.thanks-page {
-    .white-box {
-        text-align: center;
-    }
-}
-
 .lead {
     font-weight: bold;
 }


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/d067badf-31aa-4ac0-93e6-762dc6de5963) | ![Screenshot from 2024-11-26 09-52-53](https://github.com/user-attachments/assets/b594d7f2-e0c5-4dc4-a143-ed644d3beaa2) |

discussion: https://github.com/zulip/zulip/pull/31799#issuecomment-2499174669