### PR TITLE
user_group: Don't open edit panel on remove members.

### DIFF
--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -224,6 +224,7 @@ function initialize_tooltip_for_membership_button(group_id) {
     settings_components.initialize_disable_button_hint_popover($tooltip_wrapper, tooltip_message);
 }
 
+// Group membership button only adds or removes direct membership.
 function update_group_membership_button(group_id) {
     const $group_settings_button = group_membership_button(group_id);
 
@@ -231,8 +232,12 @@ function update_group_membership_button(group_id) {
         return;
     }
 
-    const is_member = user_groups.is_user_in_group(group_id, people.my_current_user_id());
-    if (is_member) {
+    const is_direct_member = user_groups.is_user_in_group(
+        group_id,
+        people.my_current_user_id(),
+        true,
+    );
+    if (is_direct_member) {
         $group_settings_button.text($t({defaultMessage: "Leave group"}));
     } else {
         $group_settings_button.text($t({defaultMessage: "Join group"}));
@@ -242,9 +247,9 @@ function update_group_membership_button(group_id) {
     const can_leave_group = settings_data.can_leave_user_group(group_id);
 
     let can_update_membership = true;
-    if (!is_member && !can_join_group) {
+    if (!is_direct_member && !can_join_group) {
         can_update_membership = false;
-    } else if (is_member && !can_leave_group) {
+    } else if (is_direct_member && !can_leave_group) {
         can_update_membership = false;
     }
 
@@ -351,7 +356,7 @@ export function show_settings_for(group) {
         ),
         creator: stream_data.maybe_get_creator_details(group.creator_id),
         is_creator: group.creator_id === current_user.user_id,
-        is_member: user_groups.is_direct_member_of(people.my_current_user_id(), group.id),
+        is_direct_member: user_groups.is_direct_member_of(people.my_current_user_id(), group.id),
     });
 
     scroll_util.get_content_element($("#user_group_settings")).html(html);

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -675,7 +675,7 @@ export function change_state(section, left_side_tab, right_side_tab) {
 
         if (left_side_tab === undefined) {
             left_side_tab = "all-groups";
-            if (user_groups.is_direct_member_of(current_user.user_id, group_id)) {
+            if (user_groups.is_user_in_group(group_id, current_user.user_id)) {
                 left_side_tab = "your-groups";
             }
         }
@@ -885,10 +885,7 @@ export function setup_page(callback) {
             name: "user-groups-overlay",
             get_item: ListWidget.default_get_item,
             modifier_html(item) {
-                item.is_member = user_groups.is_direct_member_of(
-                    people.my_current_user_id(),
-                    item.id,
-                );
+                item.is_member = user_groups.is_user_in_group(item.id, people.my_current_user_id());
                 item.can_join = settings_data.can_join_user_group(item.id);
                 item.can_leave = settings_data.can_leave_user_group(item.id);
                 return render_browse_user_groups_list_item(item);

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -329,15 +329,6 @@ export function handle_member_edit_event(group_id, user_ids) {
 
         $row.replaceWith($new_row);
     }
-
-    if (
-        !is_editing_group(group_id) &&
-        user_ids.includes(people.my_current_user_id()) &&
-        user_groups.is_user_in_group(group_id, people.my_current_user_id())
-    ) {
-        const $group_row = row_for_group_id(group.id);
-        open_group_edit_panel_for_row($group_row);
-    }
 }
 
 export function update_group_details(group) {
@@ -736,6 +727,17 @@ export function add_or_remove_from_group(group, group_row) {
     function success_callback() {
         if (group_row.length) {
             hide_membership_toggle_spinner(group_row);
+            // This should only be triggered when a user is on another group
+            // edit panel and they join a group via the left panel plus button.
+            // In that case, the edit panel of the newly joined group should
+            // open. `is_user_in_group` with direct_members_only set to true acts
+            // as a proxy to check if it's an `add_members` event.
+            if (
+                !is_editing_group(group.id) &&
+                user_groups.is_user_in_group(group.id, user_id, true)
+            ) {
+                open_group_edit_panel_for_row(group_row);
+            }
         }
     }
 
@@ -752,15 +754,15 @@ export function add_or_remove_from_group(group, group_row) {
         user_group_edit_members.edit_user_group_membership({
             group,
             removed: [user_id],
-            success_callback,
-            error_callback,
+            success: success_callback,
+            error: error_callback,
         });
     } else {
         user_group_edit_members.edit_user_group_membership({
             group,
             added: [user_id],
-            success_callback,
-            error_callback,
+            success: success_callback,
+            error: error_callback,
         });
     }
 }

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -324,6 +324,16 @@ export function handle_member_edit_event(group_id, user_ids) {
         item.is_member = user_groups.is_user_in_group(group_id, people.my_current_user_id());
         item.can_join = settings_data.can_join_user_group(item.id);
         item.can_leave = settings_data.can_leave_user_group(item.id);
+        item.is_direct_member = user_groups.is_direct_member_of(
+            people.my_current_user_id(),
+            item.id,
+        );
+        const associated_subgroups = user_groups.get_associated_subgroups(
+            item,
+            people.my_current_user_id(),
+        );
+        item.associated_subgroup_names =
+            user_groups.group_list_to_comma_seperated_name(associated_subgroups);
         const html = render_browse_user_groups_list_item(item);
         const $new_row = $(html);
 
@@ -886,6 +896,16 @@ export function setup_page(callback) {
             get_item: ListWidget.default_get_item,
             modifier_html(item) {
                 item.is_member = user_groups.is_user_in_group(item.id, people.my_current_user_id());
+                item.is_direct_member = user_groups.is_direct_member_of(
+                    people.my_current_user_id(),
+                    item.id,
+                );
+                const associated_subgroups = user_groups.get_associated_subgroups(
+                    item,
+                    people.my_current_user_id(),
+                );
+                item.associated_subgroup_names =
+                    user_groups.group_list_to_comma_seperated_name(associated_subgroups);
                 item.can_join = settings_data.can_join_user_group(item.id);
                 item.can_leave = settings_data.can_leave_user_group(item.id);
                 return render_browse_user_groups_list_item(item);
@@ -1105,7 +1125,10 @@ export function initialize() {
     });
 
     $("#groups_overlay_container").on("click", ".join_leave_button", (e) => {
-        if ($(e.currentTarget).hasClass("disabled")) {
+        if (
+            $(e.currentTarget).hasClass("disabled") ||
+            $(e.currentTarget).hasClass("not-direct-member")
+        ) {
             // We return early if user is not allowed to join or leave a group.
             return;
         }

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_confirm_delete_user from "../templates/confirm_dialog/confirm_delete_user.hbs";
+import render_confirm_join_group_direct_member from "../templates/confirm_dialog/confirm_join_group_direct_member.hbs";
 import render_group_info_banner from "../templates/modal_banner/user_group_info_banner.hbs";
 import render_browse_user_groups_list_item from "../templates/user_group_settings/browse_user_groups_list_item.hbs";
 import render_cannot_deactivate_group_banner from "../templates/user_group_settings/cannot_deactivate_group_banner.hbs";
@@ -1135,8 +1136,35 @@ export function initialize() {
 
         const user_group_id = get_user_group_id(e.target);
         const user_group = user_groups.get_user_group_from_id(user_group_id);
-        const $group_row = row_for_group_id(user_group_id);
-        add_or_remove_from_group(user_group, $group_row);
+        const is_member = user_groups.is_user_in_group(user_group_id, people.my_current_user_id());
+        const is_direct_member = user_groups.is_direct_member_of(
+            people.my_current_user_id(),
+            user_group_id,
+        );
+
+        if (is_member && !is_direct_member) {
+            const associated_subgroups = user_groups.get_associated_subgroups(
+                user_group,
+                people.my_current_user_id(),
+            );
+            const associated_subgroup_names =
+                user_groups.group_list_to_comma_seperated_name(associated_subgroups);
+
+            confirm_dialog.launch({
+                html_heading: $t_html({defaultMessage: "Join group?"}),
+                html_body: render_confirm_join_group_direct_member({
+                    associated_subgroup_names,
+                }),
+                id: "confirm_join_group_direct_member",
+                on_click() {
+                    const $group_row = row_for_group_id(user_group_id);
+                    add_or_remove_from_group(user_group, $group_row);
+                },
+            });
+        } else {
+            const $group_row = row_for_group_id(user_group_id);
+            add_or_remove_from_group(user_group, $group_row);
+        }
     });
 
     $("#groups_overlay_container").on(

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -286,9 +286,7 @@ export function is_setting_group_empty(setting_group: GroupSettingValue): boolea
 
 export function get_user_groups_of_user(user_id: number): UserGroup[] {
     const user_groups_realm = get_realm_user_groups();
-    const groups_of_user = user_groups_realm.filter((group) =>
-        is_direct_member_of(user_id, group.id),
-    );
+    const groups_of_user = user_groups_realm.filter((group) => is_user_in_group(group.id, user_id));
     return groups_of_user;
 }
 

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -411,6 +411,25 @@ export function is_user_in_group(
     return false;
 }
 
+export function get_associated_subgroups(user_group: UserGroup, user_id: number): UserGroup[] {
+    const subgroup_ids = get_recursive_subgroups(user_group)!;
+    if (subgroup_ids === undefined) {
+        return [];
+    }
+
+    const subgroups = [];
+    for (const group_id of subgroup_ids) {
+        if (is_direct_member_of(user_id, group_id)) {
+            subgroups.push(user_group_by_id_dict.get(group_id)!);
+        }
+    }
+    return subgroups;
+}
+
+export function group_list_to_comma_seperated_name(user_groups: UserGroup[]): string {
+    return user_groups.map((user_group) => user_group.name).join(", ");
+}
+
 export function is_user_in_setting_group(
     setting_group: GroupSettingValue,
     user_id: number,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -600,6 +600,12 @@ h4.user_group_setting_subsection_title {
             fill: hsl(240deg 41% 50%);
         }
 
+        &.not-direct-member {
+            svg {
+                cursor: default;
+            }
+        }
+
         &.disabled {
             &:not(.checked) svg {
                 fill: hsl(0deg 0% 87%);

--- a/web/templates/confirm_dialog/confirm_join_group_direct_member.hbs
+++ b/web/templates/confirm_dialog/confirm_join_group_direct_member.hbs
@@ -1,0 +1,4 @@
+<p>
+    {{t "You are already a member of this group because you are a member of a subgroup"}} (<b>{{associated_subgroup_names}}</b>).
+    {{t "Are you sure you want to join it directly as well?" }}
+</p>

--- a/web/templates/user_group_settings/browse_user_groups_list_item.hbs
+++ b/web/templates/user_group_settings/browse_user_groups_list_item.hbs
@@ -1,10 +1,18 @@
 <div class="group-row" data-group-id="{{id}}" data-group-name="{{name}}">
     {{#if is_member}}
-        <div class="check checked join_leave_button tippy-zulip-tooltip {{#unless can_leave}}disabled{{/unless}}" data-tooltip-template-id="{{#if can_leave}}leave-{{name}}-group-tooltip-template{{else}}cannot-leave-{{name}}-group-tooltip-template{{/if}}">
+        <div class="check checked join_leave_button tippy-zulip-tooltip {{#unless can_leave}}disabled{{/unless}} {{#unless is_direct_member}}not-direct-member{{/unless}}" data-tooltip-template-id="{{#if can_leave}}{{#if is_direct_member}}leave-{{name}}-group-tooltip-template{{else}}cannot-leave-{{name}}-because-of-subgroup-tooltip-template{{/if}}{{else}}cannot-leave-{{name}}-group-tooltip-template{{/if}}">
             <template id="leave-{{name}}-group-tooltip-template">
                 <span>
                     {{#tr}}
                         Leave group {name}
+                    {{/tr}}
+                </span>
+            </template>
+
+            <template id="cannot-leave-{{name}}-because-of-subgroup-tooltip-template">
+                <span>
+                    {{#tr}}
+                        You are a member of this group because you are a member of a subgroup (<b>{associated_subgroup_names}</b>).
                     {{/tr}}
                 </span>
             </template>

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -3,7 +3,7 @@
     <div class="button-group">
         <div class="join_leave_button_wrapper inline-block">
             <button class="button small rounded join_leave_button" type="button" name="button">
-                {{#if is_member}}
+                {{#if is_direct_member}}
                     {{t "Leave group" }}
                 {{else}}
                     {{t "Join group" }}

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -324,6 +324,60 @@ run_test("get_recursive_group_members", () => {
     assert.deepEqual([...user_groups.get_recursive_group_members(test)].sort(), [3, 4, 5]);
 });
 
+run_test("get_associated_subgroups", () => {
+    const admins = {
+        name: "Admins",
+        description: "foo",
+        id: 1,
+        members: new Set([1]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([4]),
+    };
+    const all = {
+        name: "Everyone",
+        id: 2,
+        members: new Set([2, 3]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([1, 3]),
+    };
+    const test = {
+        name: "Test",
+        id: 3,
+        members: new Set([1, 4, 5]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([2]),
+    };
+    const foo = {
+        name: "Foo",
+        id: 4,
+        members: new Set([6, 7]),
+        is_system_group: false,
+        direct_subgroup_ids: new Set([]),
+    };
+
+    const admins_group = user_groups.add(admins);
+    const all_group = user_groups.add(all);
+    user_groups.add(test);
+    user_groups.add(foo);
+
+    // This test setup has a state that won't appear in real data: Groups 2 and 3
+    // each contain the other. We test this corner case because it is a simple way
+    // to verify whether our algorithm correctly avoids visiting groups multiple times
+    // when determining recursive subgroups.
+    // A test case that can occur in practice and would be problematic without this
+    // optimization is a tree where each layer connects to every node in the next layer.
+    let associated_subgroups = user_groups.get_associated_subgroups(admins_group, 6);
+    assert.deepEqual(associated_subgroups.length, 1);
+    assert.equal(associated_subgroups[0].id, 4);
+
+    associated_subgroups = user_groups.get_associated_subgroups(all_group, 1);
+    assert.deepEqual(associated_subgroups.length, 2);
+    assert.deepEqual(associated_subgroups.map((group) => group.id).sort(), [1, 3]);
+
+    associated_subgroups = user_groups.get_associated_subgroups(admins, 2);
+    assert.deepEqual(associated_subgroups.length, 0);
+});
+
 run_test("is_user_in_group", () => {
     const admins = {
         name: "Admins",

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -12,6 +12,19 @@ const {set_realm} = zrequire("state_data");
 const realm = {};
 set_realm(realm);
 
+const get_test_subgroup = (id) => ({
+    name: `Subgroup id: ${id} `,
+    id,
+    members: new Set([4]),
+    is_system_group: false,
+    direct_subgroup_ids: new Set([]),
+    can_join_group: 1,
+    can_leave_group: 1,
+    can_manage_group: 1,
+    can_mention_group: 1,
+    deactivated: false,
+});
+
 run_test("user_groups", () => {
     const students = {
         description: "Students group",
@@ -31,9 +44,15 @@ run_test("user_groups", () => {
     };
 
     const params = {};
-    params.realm_user_groups = [students];
+    params.realm_user_groups = [
+        students,
+        get_test_subgroup(4),
+        get_test_subgroup(5),
+        get_test_subgroup(6),
+    ];
     const user_id_not_in_any_group = 0;
     const user_id_part_of_a_group = 2;
+    const user_id_associated_via_subgroup = 4;
 
     user_groups.initialize(params);
     assert.deepEqual(user_groups.get_user_group_from_id(students.id), students);
@@ -120,12 +139,12 @@ run_test("user_groups", () => {
     user_groups.add(all);
     user_groups.add(deactivated_group);
     const user_groups_array = user_groups.get_realm_user_groups();
-    assert.equal(user_groups_array.length, 2);
+    assert.equal(user_groups_array.length, 5);
     assert.equal(user_groups_array[1].name, "Everyone");
     assert.equal(user_groups_array[0].name, "new admins");
 
     const all_user_groups_array = user_groups.get_realm_user_groups(true);
-    assert.equal(all_user_groups_array.length, 3);
+    assert.equal(all_user_groups_array.length, 6);
     assert.equal(all_user_groups_array[2].name, "Deactivated test group");
     assert.equal(all_user_groups_array[1].name, "Everyone");
     assert.equal(all_user_groups_array[0].name, "new admins");
@@ -133,6 +152,12 @@ run_test("user_groups", () => {
     const groups_of_users = user_groups.get_user_groups_of_user(user_id_part_of_a_group);
     assert.equal(groups_of_users.length, 1);
     assert.equal(groups_of_users[0].name, "Everyone");
+
+    const groups_of_users_via_subgroup = user_groups.get_user_groups_of_user(
+        user_id_associated_via_subgroup,
+    );
+    assert.deepEqual(groups_of_users_via_subgroup.map((group) => group.id).sort(), [2, 4, 5, 6]);
+    assert.equal(groups_of_users_via_subgroup.length, 4);
 
     const groups_of_users_nomatch = user_groups.get_user_groups_of_user(user_id_not_in_any_group);
     assert.equal(groups_of_users_nomatch.length, 0);


### PR DESCRIPTION
The second commit just fixes the text always being `leave group` for the group membership button for a group where the user is associated via a subgroup, but it does not add the confirmation dialog when trying to join group, that is done later.

I could not tell if we wanted a loading spinner in the confirm dialog or not, it currently does not have it, lmk if we need it.

Fixes #32484. #32486.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Join group confirmation dialog:
![Screenshot 2024-11-28 at 7 58 21 AM](https://github.com/user-attachments/assets/7c6876b6-4e7e-408a-9f00-00c885fa8b01)


Subgroup tooltip:
![Screenshot 2024-11-28 at 7 58 31 AM](https://github.com/user-attachments/assets/975703a1-8529-49d9-84c7-9866627ce1d2)




For #32486, screenshots would not explain a lot, it would just need manual testing. 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
