### PR TITLE
openapi: Document the various `/avatar/` endpoints.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1750,6 +1750,13 @@ No changes; feature level used for Zulip 10.0 release.
   data (such as an API key) for that incoming webhook integration, but this
   functionality has not been implemented for any existing integrations.
 
+* [`GET /avatar/{user_id}`](/api/get-user-avatar),
+  [`GET /avatar/{email}`](/api/get-user-avatar-by-email),
+  [`GET /avatar/{user_id}/medium`](/api/get-user-medium-avatar),
+  [`GET /avatar/{email}/medium`](/api/get-user-medium-avatar-by-email): Replaced
+  the `GET /avatar/{email_or_id}` endpoint with two distinct endpoints for
+  retrieving avatars, one by email and one by user ID.
+
 **Feature level 317**
 
 * [`POST /user_groups/create`](/api/create-user-group):

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -123,6 +123,10 @@
 * [Regenerate your API key](/api/regenerate-api-key)
 * [Get a bot's API key](/api/get-bot-api-key)
 * [Regenerate a bot's API key](/api/regenerate-bot-api-key)
+* [Get a user's avatar](/api/get-user-avatar)
+* [Get a user's medium avatar](/api/get-user-medium-avatar)
+* [Get a user's avatar by email](/api/get-user-avatar-by-email)
+* [Get a user's medium avatar by email](/api/get-user-medium-avatar-by-email)
 
 ## Invitations
 

--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -115,6 +115,10 @@ in the [API changelog](https://zulip.com/api/changelog), see
 Endpoints that only administrators can use should be tagged with the
 custom `x-requires-administrator` field in the OpenAPI definition.
 
+Endpoints that don't follow the `api/v1` or `json` pattern should be
+tagged with the custom `x-non-api-v1-or-json-pattern` field in the OpenAPI
+definition.
+
 All of this information is rendered via a Markdown preprocessor,
 specifically the `APIHeaderPreprocessor` class defined in
 `zerver/openapi/markdown_extension.py`.

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -26,6 +26,7 @@ from zerver.openapi.openapi import (
     NO_EXAMPLE,
     Parameter,
     check_additional_imports,
+    check_non_api_v1_or_json_pattern,
     check_requires_administrator,
     check_requires_owner,
     generate_openapi_fixture,
@@ -205,10 +206,17 @@ def render_javascript_code_example(
     return code_example
 
 
-def curl_method_arguments(endpoint: str, method: str, api_url: str) -> list[str]:
+def curl_method_arguments(
+    method: str, api_url: str, *, endpoint: str, example_endpoint: str
+) -> list[str]:
+    if check_non_api_v1_or_json_pattern(endpoint, method):
+        api_url = api_url.removesuffix("/api")
+        url = f"{api_url}{example_endpoint}"
+    else:
+        url = f"{api_url}/v1{example_endpoint}"
+
     # We also include the -sS verbosity arguments here.
     method = method.upper()
-    url = f"{api_url}/v1{endpoint}"
     valid_methods = ["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS"]
     if method == "GET":
         # Then we need to make sure that each -d option translates to becoming
@@ -309,9 +317,16 @@ def generate_curl_example(
             continue
         example_value = get_openapi_param_example_value_as_string(endpoint, method, parameter)
         format_dict[parameter.name] = example_value
-    example_endpoint = endpoint.format_map(format_dict)
 
-    curl_first_line_parts = ["curl", *curl_method_arguments(example_endpoint, method, api_url)]
+    curl_first_line_parts = [
+        "curl",
+        *curl_method_arguments(
+            method,
+            api_url,
+            endpoint=endpoint,
+            example_endpoint=endpoint.format_map(format_dict),
+        ),
+    ]
     lines.append(shlex.join(curl_first_line_parts))
 
     if operation_security is None:
@@ -525,12 +540,19 @@ class APIHeaderPreprocessor(BasePreprocessor):
         path, method = function.rsplit(":", 1)
         raw_title = get_openapi_summary(path, method)
         description_dict = get_openapi_description(path, method)
+
+        if check_non_api_v1_or_json_pattern(path, method):
+            base_url = self.api_url.removesuffix("/api")
+        else:
+            base_url = f"{self.api_url}/v1"
+        method_and_url = f"`{method.upper()} {base_url}{path}`"
+
         return [
             *("# " + line for line in raw_title.splitlines()),
             *(["{!api-admin-only.md!}"] if check_requires_administrator(path, method) else []),
             *(["{!api-owner-only.md!}"] if check_requires_owner(path, method) else []),
             "",
-            f"`{method.upper()} {self.api_url}/v1{path}`",
+            method_and_url,
             "",
             *description_dict.splitlines(),
         ]

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -36,6 +36,7 @@ from zerver.openapi.openapi import (
     get_openapi_summary,
     get_parameters_description,
     get_responses_description,
+    is_avatar_endpoint,
     openapi_spec,
 )
 
@@ -215,6 +216,11 @@ def curl_method_arguments(
     else:
         url = f"{api_url}/v1{example_endpoint}"
 
+    if is_avatar_endpoint(endpoint, method):
+        # Avatar endpoints redirect to the requested avatar URL, so we just need
+        # to show the details in the response header.
+        return ["-si", url]
+
     # We also include the -sS verbosity arguments here.
     method = method.upper()
     valid_methods = ["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS"]
@@ -353,6 +359,8 @@ def generate_curl_example(
         auth_email = "ZULIP_ORG_ID" if is_zilencer_endpoint else DEFAULT_AUTH_EMAIL
         auth_api_key = "ZULIP_ORG_KEY" if is_zilencer_endpoint else DEFAULT_AUTH_API_KEY
         lines.append("    -u " + shlex.quote(f"{auth_email}:{auth_api_key}"))
+    if is_avatar_endpoint(endpoint, method):
+        lines.append("    | grep -i ^location:")
 
     for parameter in parameters:
         if parameter.kind == "path":

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -256,6 +256,13 @@ def check_additional_imports(endpoint: str, method: str) -> list[str] | None:
     )
 
 
+def check_non_api_v1_or_json_pattern(endpoint: str, method: str) -> bool:
+    """Fetch if the endpoint is not v1_api_and_json_patterns."""
+    return openapi_spec.openapi()["paths"][endpoint][method.lower()].get(
+        "x-non-api-v1-or-json-pattern", False
+    )
+
+
 def get_responses_description(endpoint: str, method: str) -> str:
     """Fetch responses description of an endpoint."""
     return openapi_spec.openapi()["paths"][endpoint][method.lower()].get(

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -349,6 +349,12 @@ def get_openapi_paths() -> set[str]:
     return set(openapi_spec.openapi()["paths"].keys())
 
 
+# We should generalize this to check if the endpoint returns HTTP redirect
+# once we have other redirect endpoints.
+def is_avatar_endpoint(path: str, method: str) -> bool:
+    return path.startswith("/avatar/") and method.upper() == "GET"
+
+
 NO_EXAMPLE = object()
 
 

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -31,6 +31,8 @@ EXCLUDE_UNDOCUMENTED_ENDPOINTS = {
 # These are skipped but return true as the validator cannot exclude objects
 EXCLUDE_DOCUMENTED_ENDPOINTS: set[tuple[str, str]] = set()
 
+ZULIP_API_REDIRECT_RESPONSE_STATUS_CODES: set[str] = {"302"}
+
 
 # Most of our code expects allOf to be preprocessed away because that is what
 # yamole did.  Its algorithm for doing so is not standards compliant, but we
@@ -181,26 +183,29 @@ openapi_spec = OpenAPISpec(OPENAPI_SPEC_PATH)
 
 
 def get_schema(endpoint: str, method: str, status_code: str) -> dict[str, Any]:
+    schema_response = openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"]
+    content_type = "application/json"
+    if status_code[:3] in ZULIP_API_REDIRECT_RESPONSE_STATUS_CODES:  # nocoverage
+        # The only endpoints that redirect are the avatar URL
+        # endpoints, they all respond with "text/html" as the
+        # content type.
+        content_type = "text/html"
+
     if len(status_code) == 3 and (
-        "oneOf"
-        in openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][status_code][
-            "content"
-        ]["application/json"]["schema"]
+        "oneOf" in schema_response[status_code]["content"][content_type]["schema"]
     ):
         # Currently at places where multiple schemas are defined they only
         # differ in example so either can be used.
         status_code += "_0"
     if len(status_code) == 3:
-        schema = openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][
-            status_code
-        ]["content"]["application/json"]["schema"]
+        schema = schema_response[status_code]["content"][content_type]["schema"]
         return schema
     else:
         subschema_index = int(status_code[4])
         status_code = status_code[0:3]
-        schema = openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][
-            status_code
-        ]["content"]["application/json"]["schema"]["oneOf"][subschema_index]
+        schema = schema_response[status_code]["content"][content_type]["schema"]["oneOf"][
+            subschema_index
+        ]
         return schema
 
 
@@ -271,6 +276,13 @@ def generate_openapi_fixture(endpoint: str, method: str) -> list[str]:
     for status_code in sorted(
         openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"]
     ):
+        if status_code in ZULIP_API_REDIRECT_RESPONSE_STATUS_CODES:  # nocoverage
+            # For endpoints that redirect the caller, there is no response
+            # body, so render the schema description instead of a JSON example.
+            description = get_schema(endpoint, method, status_code)["description"]
+            fixture.extend(description.strip().splitlines())
+            continue
+
         if (
             "oneOf"
             in openapi_spec.openapi()["paths"][endpoint][method.lower()]["responses"][status_code][
@@ -414,13 +426,19 @@ def get_openapi_parameters(
 
 def get_openapi_return_values(endpoint: str, method: str) -> dict[str, Any]:
     operation = openapi_spec.openapi()["paths"][endpoint][method.lower()]
-    schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
-    # We do not currently have documented endpoints that have multiple schemas
-    # ("oneOf", "anyOf", "allOf") for success ("200") responses. If this changes,
-    # then the assertion below will need to be removed, and this function updated
-    # so that endpoint responses will be rendered as expected.
-    assert "properties" in schema
-    return schema["properties"]
+    status_code = next(iter(operation["responses"].keys()))
+    if status_code in ZULIP_API_REDIRECT_RESPONSE_STATUS_CODES:  # nocoverage
+        # Skip for endpoints that redirect the caller, as they do not return a
+        # JSON body.
+        return {}
+    else:
+        schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+        # We do not currently have documented endpoints that have multiple schemas
+        # ("oneOf", "anyOf", "allOf") for success ("200") responses. If this changes,
+        # then the assertion below will need to be removed, and this function updated
+        # so that endpoint responses will be rendered as expected.
+        assert "properties" in schema
+        return schema["properties"]
 
 
 def find_openapi_endpoint(path: str) -> str | None:

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -20,11 +20,13 @@ from email.headerregistry import Address
 from functools import wraps
 from typing import Any, TypeVar
 
+import requests
 from django.core.files.base import File
 from typing_extensions import ParamSpec
 from zulip import Client
 
 from zerver.actions.realm_emoji import check_add_realm_emoji
+from zerver.lib.avatar import avatar_url
 from zerver.lib.storage import static_path
 from zerver.models.realm_emoji import RealmEmoji
 from zerver.models.realms import get_realm
@@ -91,6 +93,15 @@ def ensure_users(ids_list: list[int], user_names: list[str]) -> None:
 def assert_success_response(response: dict[str, Any]) -> None:
     assert "result" in response
     assert response["result"] == "success"
+
+
+def assert_success_avatar_endpoint_response(
+    response: requests.Response, result: str, user_profile: UserProfile, medium: bool
+) -> None:
+    assert response.status_code == 302
+    response_headers = response.headers
+    assert result == avatar_url(user_profile, medium)
+    assert response_headers["Content-Type"] == "text/html; charset=utf-8"
 
 
 def assert_error_response(response: dict[str, Any], code: str = "BAD_REQUEST") -> None:
@@ -2117,6 +2128,80 @@ def add_channel(client: Client) -> None:
     validate_against_openapi_schema(result, "/channels/create", "post", "200")
 
 
+@openapi_test_function("/avatar/{user_id}:get")
+def get_user_avatar_by_id(client: Client, user_profile: UserProfile) -> None:
+    # {code_example|start}
+    realm_settings = client.get_server_settings()
+    realm_url = realm_settings["realm_url"]
+
+    # Get a users avatar URL given a user id.
+    response = requests.get(f"{realm_url}/avatar/{user_profile.id}", allow_redirects=False)
+    response_headers = response.headers
+    result = response_headers["Location"]
+    # {code_example|end}
+    assert_success_avatar_endpoint_response(response, result, user_profile, False)
+
+
+@openapi_test_function("/avatar/{email}:get")
+def get_user_avatar_by_email(client: Client, user_profile: UserProfile) -> None:
+    user_email = user_profile.delivery_email
+    api_key = user_profile.api_key
+
+    # {code_example|start}
+    realm_settings = client.get_server_settings()
+    realm_url = realm_settings["realm_url"]
+    auth = (user_email, api_key)
+    target_user_email = user_profile.delivery_email
+
+    # Get a users avatar URL given a user email.
+    response = requests.get(
+        f"{realm_url}/avatar/{target_user_email}",
+        allow_redirects=False,
+        auth=auth,
+    )
+    response_headers = response.headers
+    result = response_headers["Location"]
+    # {code_example|end}
+    assert_success_avatar_endpoint_response(response, result, user_profile, False)
+
+
+@openapi_test_function("/avatar/{user_id}/medium:get")
+def get_medium_user_avatar_by_id(client: Client, user_profile: UserProfile) -> None:
+    # {code_example|start}
+    realm_settings = client.get_server_settings()
+    realm_url = realm_settings["realm_url"]
+
+    # Get a users medium avatar URL given a user id.
+    response = requests.get(f"{realm_url}/avatar/{user_profile.id}/medium", allow_redirects=False)
+    response_headers = response.headers
+    result = response_headers["Location"]
+    # {code_example|end}
+    assert_success_avatar_endpoint_response(response, result, user_profile, True)
+
+
+@openapi_test_function("/avatar/{email}/medium:get")
+def get_medium_user_avatar_by_email(client: Client, user_profile: UserProfile) -> None:
+    user_email = user_profile.delivery_email
+    api_key = user_profile.api_key
+
+    # {code_example|start}
+    realm_settings = client.get_server_settings()
+    realm_url = realm_settings["realm_url"]
+    auth = (user_email, api_key)
+    target_user_email = user_profile.delivery_email
+
+    # Get a users medium avatar URL given a user email.
+    response = requests.get(
+        f"{realm_url}/avatar/{target_user_email}/medium",
+        allow_redirects=False,
+        auth=auth,
+    )
+    response_headers = response.headers
+    result = response_headers["Location"]
+    # {code_example|end}
+    assert_success_avatar_endpoint_response(response, result, user_profile, True)
+
+
 def test_invalid_api_key(client_with_invalid_key: Client) -> None:
     result = client_with_invalid_key.get_subscriptions()
     assert_error_response(result, code="UNAUTHORIZED")
@@ -2233,6 +2318,15 @@ def test_users(client: Client, owner_client: Client) -> None:
     register_push_device(client)
     register_device(client)
     remove_device(client)
+    # The Python examples for some of the avatar endpoints uses
+    # the user's API key.
+    user_id = 10
+    ensure_users([user_id], ["hamlet"])
+    hamlet = UserProfile.objects.get(id=user_id)
+    get_user_avatar_by_id(client, hamlet)
+    get_user_avatar_by_email(client, hamlet)
+    get_medium_user_avatar_by_id(client, hamlet)
+    get_medium_user_avatar_by_email(client, hamlet)
 
 
 def test_streams(client: Client, nonadmin_client: Client) -> None:

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -40,6 +40,12 @@ UNTESTED_GENERATED_CURL_EXAMPLES = {
     "create-constructor-groups-video-call",
     "create-nextcloud-talk-video-call",
     "create-webex-video-call",
+    # These return a 302 with no JSON body and the example uses a shell
+    # pipe, neither of which the curl test currently supports.
+    "get-user-avatar",
+    "get-user-avatar-by-email",
+    "get-user-medium-avatar",
+    "get-user-medium-avatar-by-email",
 }
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -27019,6 +27019,191 @@ paths:
                         "result": "success",
                         "url": "/calls/bigbluebutton/join?meeting_id=%22zulip-something%22&password=%22something%22&checksum=%22somechecksum%22",
                       }
+  /avatar/{user_id}:
+    get:
+      operationId: get-user-avatar
+      summary: Get a user's avatar
+      tags: ["users"]
+      x-non-api-v1-or-json-pattern: true
+      x-python-examples-extra-imports: ["requests"]
+      description: |
+        Fetch the avatar for a single user in the organization, identified by their
+        user ID. This endpoint responds with an HTTP redirect to the avatar's URL.
+        The client can retrieve the actual avatar by following the redirect.
+
+        To optimize performance, these endpoints should only be used as a fallback
+        when the avatar URL is not available in user or message data returned by
+        APIs such as [**Get a user**](/api/get-user) or [**Get messages**](/api/get-messages).
+
+        You can also fetch a user's avatar
+        [by their Zulip API email](/api/get-user-avatar-by-email).
+
+        The avatar URL or file may originate from one of the following sources:
+
+        - **User-uploaded** file, if the user has uploaded their own avatar.
+        - **Jdenticon** generated avatar.
+        - **Gravatar** URL.
+        - **Static files**, for system bots only.
+
+        Organization administrators can [configure the default profile
+        pictures](/help/configure-default-profile-pictures) for users. The
+        available options are Jdenticon and Gravatar.
+
+        **File size**: `100x100` px (default).
+
+        For all types of avatars, there's a larger `500x500` px (medium) version,
+        which can be fetched by using the
+        [`GET /avatar/{user_id}/medium`](/api/get-user-medium-avatar) endpoint.
+
+        **File types**: Avatar files are served in `.png` format.
+
+        Gravatar URLs can also support an optional `.jpg` extension. Refer to the
+        [Gravatar documentation](https://docs.gravatar.com/api/avatars/images/) for
+        details on customizing Gravatar URLs.
+
+        **Changes**: New in Zulip 12.0 (feature level 466). Jdenticon is now supported
+        as an avatar source, it can be set as the realm's default avatar.
+
+        Before Zulip 10.0 (feature level 318), there was only one endpoint for requesting
+        the default-sized avatar image, which accepted either a user's email or user ID.
+        That endpoint has now been split into two separate endpoints, one that accepts a
+        user ID and another that accepts an email.
+      x-curl-examples-parameters:
+        oneOf:
+          - type: include
+            parameters:
+              enum:
+                - ""
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      responses:
+        "302":
+          $ref: "#/components/responses/AvatarSuccessRedirect"
+
+  /avatar/{email}:
+    get:
+      operationId: get-user-avatar-by-email
+      summary: Get a user's avatar by email
+      tags: ["users"]
+      x-non-api-v1-or-json-pattern: true
+      x-python-examples-extra-imports: ["requests"]
+      description: |
+        Fetch the avatar for a single user in the organization, identified by their
+        email. This endpoint responds with an HTTP redirect to the avatar's URL,
+        the client can retrieve the actual avatar by following the redirect.
+
+        **File size**: `100x100` px (default).
+
+        **File types**: Avatar files are served in `.png` format.
+
+        For more details such as fetching medium avatar size, types of avatar URL,
+        customizing Gravatar URL, and the full API changelog for the avatar endpoints,
+        you can read the description in the [**Get a user's avatar**](/api/get-user-avatar)
+        documentation.
+
+        Fetching by user ID is generally recommended when possible,
+        as a user might [change their email address](/help/change-your-email-address)
+        or change their [email address visibility](/help/configure-email-visibility),
+        either of which could change the client's ability to look them up by that
+        email address.
+
+        **Changes**: Before Zulip 10.0 (feature level 318), there was only one endpoint
+        for requesting the default-sized avatar image, which accepted either a user's
+        email or user ID. That endpoint has now been split into two separate endpoints,
+        one that accepts a user ID and another that accepts an email.
+      x-curl-examples-parameters:
+        oneOf:
+          - type: include
+            parameters:
+              enum:
+                - ""
+      parameters:
+        - $ref: "#/components/parameters/UserEmailOrDeliveryEmail"
+      responses:
+        "302":
+          $ref: "#/components/responses/AvatarSuccessRedirect"
+
+  /avatar/{user_id}/medium:
+    get:
+      operationId: get-user-medium-avatar
+      summary: Get a user's medium avatar
+      tags: ["users"]
+      x-non-api-v1-or-json-pattern: true
+      x-python-examples-extra-imports: ["requests"]
+      description: |
+        Fetch the medium-sized avatar for a single user in the organization,
+        identified by their user ID. This endpoint responds with an HTTP
+        redirect to the avatar's URL, the client can retrieve the actual avatar
+        by following the redirect.
+
+        **File size**: `500x500` px (medium).
+
+        **File types**: Avatar files are served in `.png` format.
+
+        For more details such as fetching default avatar size, types of avatar URL,
+        customizing Gravatar URL, and the full API changelog for the avatar endpoints,
+        you can read the description in the [**Get a user's avatar**](/api/get-user-avatar)
+        documentation.
+
+        **Changes**: Before Zulip 10.0 (feature level 318), there was only one endpoint
+        for requesting the medium-sized avatar image, which accepted either a user's
+        email or user ID. That endpoint has now been split into two separate endpoints,
+        one that accepts a user ID and another that accepts an email.
+      x-curl-examples-parameters:
+        oneOf:
+          - type: include
+            parameters:
+              enum:
+                - ""
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      responses:
+        "302":
+          $ref: "#/components/responses/AvatarSuccessRedirect"
+
+  /avatar/{email}/medium:
+    get:
+      operationId: get-user-medium-avatar-by-email
+      summary: Get a user's medium avatar by email
+      tags: ["users"]
+      x-non-api-v1-or-json-pattern: true
+      x-python-examples-extra-imports: ["requests"]
+      description: |
+        Fetch the medium-sized avatar for a single user in the organization,
+        identified by their email. This endpoint responds with an HTTP redirect
+        to the avatar's URL, the client can retrieve the actual avatar by
+        following the redirect.
+
+        **File size**: `500x500` px (medium).
+
+        **File types**: Avatar files are served in `.png` format.
+
+        For more details such as fetching default avatar size, types of avatar URL,
+        customizing Gravatar URL, and the full API changelog for the avatar endpoints,
+        you can read the description in the [**Get a user's avatar**](/api/get-user-avatar)
+        documentation.
+
+        Fetching by user ID is generally recommended when possible,
+        as a user might [change their email address](/help/change-your-email-address)
+        or change their [email address visibility](/help/configure-email-visibility),
+        either of which could change the client's ability to look them up by that
+        email address.
+
+        **Changes**: Before Zulip 10.0 (feature level 318), there was only one endpoint
+        for requesting the medium-sized avatar image, which accepted either a user's
+        email or user ID. That endpoint has now been split into two separate endpoints,
+        one that accepts a user ID and another that accepts an email.
+      x-curl-examples-parameters:
+        oneOf:
+          - type: include
+            parameters:
+              enum:
+                - ""
+      parameters:
+        - $ref: "#/components/parameters/UserEmailOrDeliveryEmail"
+      responses:
+        "302":
+          $ref: "#/components/responses/AvatarSuccessRedirect"
 
   /calls/nextcloud_talk/create:
     post:
@@ -28820,6 +29005,13 @@ components:
             sender's email address, which corresponds in this case to their
             real email address.
 
+            The default avatar size is `100x100` px. To get the medium version
+            (`500x500` px) without calling the server, see the `avatar_url`
+            field's description in the [**Get a user**](/api/get-user) page.
+
+            See the [**Get a user's avatar**](/api/get-user-avatar) page for
+            other details.
+
             **Changes**: Before Zulip 7.0 (feature level 163), access to a
             user's real email address was a realm-level setting. As of this
             feature level, `email_address_visibility` is a user setting.
@@ -29791,12 +29983,28 @@ components:
             URL for the user's avatar.
 
             If the client has the `user_avatar_url_field_optional` capability,
-            this will be missing at the server's sole discretion.
+            this will be missing at the server's sole discretion. When it's missing,
+            clients should instead use [these get-avatar endpoints](/api/get-user-avatar).
 
             Will be `null` if the `client_gravatar`
             query parameter was set to `true`, the current user has access to
             this user's real email address, and this user's avatar is hosted by
             the Gravatar provider (i.e. this user has never uploaded an avatar).
+
+            The default avatar size is `100x100` px. For user-uploaded, Jdenticon,
+            and static avatars, you can get the medium version (`500x500` px) by
+            modifying the default-sized avatar URL. This can be done by inserting
+            a `-medium` string immediately after the file hash and before the file
+            type extension, for example:
+
+                # For user uploaded avatar
+                http://example.zulipchat.com/user_avatars/2/f641fe6b0cdca129f1ad583f6388672bf8ab64d8-medium.png
+
+                # For static avatar
+                http://example.zulipchat.com/static/images/static_avatars/emailgateway.2f97461a9420-medium.png
+
+            To modify the size of Gravatar avatars, refer to the [Gravatar
+            documentation](https://docs.gravatar.com/api/avatars/images/).
 
             **Changes**: Before Zulip 7.0 (feature level 163), access to a
             user's real email address was a realm-level setting. As of this
@@ -29950,6 +30158,14 @@ components:
           type: boolean
           description: |
             Whether the channel folder is archived or not.
+    AvatarRedirectResponse:
+      description: |
+        An HTTP 302 redirect to the URL of the user's avatar image. The response
+        has no body; clients should follow the Location header to fetch the avatar.
+
+        If the endpoint is authenticated, clients should be careful not to pass the
+        user's authentication credentials to the redirect URL, especially if it is
+        external (e.g., Gravatar).
     JsonResponseBase:
       type: object
       properties:
@@ -31016,6 +31232,12 @@ components:
           schema:
             allOf:
               - $ref: "#/components/schemas/IgnoredParametersSuccess"
+    AvatarSuccessRedirect:
+      description: Success.
+      content:
+        text/html:
+          schema:
+            $ref: "#/components/schemas/AvatarRedirectResponse"
 
   ################
   # Shared request bodies
@@ -31239,3 +31461,22 @@ components:
         type: integer
       example: 17
       required: true
+    UserEmailOrDeliveryEmail:
+      name: email
+      in: path
+      description: |
+        The email address of the user to fetch. Two forms are supported:
+
+        - The real email address of the user (`delivery_email`). The lookup will
+          succeed if and only if the user exists and their email address visibility
+          setting permits the client to see the email address.
+
+        - The dummy Zulip API email address of the form `user{user_id}@{realm_host}`. This
+          is identical to simply [getting user by ID](/api/get-user). If the server or
+          realm change domains, the dummy email address used has to be adjusted to
+          match the new realm domain. This is legacy behavior for
+          backwards-compatibility, and will be removed in a future release.
+      schema:
+        type: string
+      required: true
+      example: iago@zulip.com

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -29790,6 +29790,9 @@ components:
           description: |
             URL for the user's avatar.
 
+            If the client has the `user_avatar_url_field_optional` capability,
+            this will be missing at the server's sole discretion.
+
             Will be `null` if the `client_gravatar`
             query parameter was set to `true`, the current user has access to
             this user's real email address, and this user's avatar is hosted by
@@ -29799,9 +29802,8 @@ components:
             user's real email address was a realm-level setting. As of this
             feature level, `email_address_visibility` is a user setting.
 
-            In Zulip 3.0 (feature level 18), if the client has the
-            `user_avatar_url_field_optional` capability, this will be missing at
-            the server's sole discretion.
+            Before Zulip 3.0 (feature level 18), this field was always present;
+            the client capability `user_avatar_url_field_optional` did not exist.
         avatar_version:
           type: integer
           description: |

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -214,10 +214,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         # (No /api/v1/ or /json prefix).
         "/thumbnail",
         "/user_avatars/{path}",
-        "/avatar/{user_id}",
-        "/avatar/{email}",
-        "/avatar/{user_id}/medium",
-        "/avatar/{email}/medium",
         ## These aren't really representable
         # "/user_uploads/{realm_id_str}/{filename}",
         "/user_uploads/temporary/{token}/{filename}",
@@ -915,6 +911,48 @@ class TestCurlExampleGeneration(ZulipTestCase):
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)
 
+    def test_generate_and_render_curl_example_for_user_id_avatar_endpoints(self) -> None:
+        generated_curl_example = self.curl_example("/avatar/{user_id}", "GET")
+        expected_curl_example = [
+            "```curl",
+            "curl -si http://localhost:9991/avatar/12 \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    | grep -i ^location:",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+        generated_curl_example = self.curl_example("/avatar/{user_id}/medium", "GET")
+        expected_curl_example = [
+            "```curl",
+            "curl -si http://localhost:9991/avatar/12/medium \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    | grep -i ^location:",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+    def test_generate_and_render_curl_example_for_email_avatar_endpoints(self) -> None:
+        generated_curl_example = self.curl_example("/avatar/{email}", "GET")
+        expected_curl_example = [
+            "```curl",
+            "curl -si http://localhost:9991/avatar/iago@zulip.com \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    | grep -i ^location:",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
+        generated_curl_example = self.curl_example("/avatar/{email}/medium", "GET")
+        expected_curl_example = [
+            "```curl",
+            "curl -si http://localhost:9991/avatar/iago@zulip.com/medium \\",
+            "    -u EMAIL_ADDRESS:API_KEY \\",
+            "    | grep -i ^location:",
+            "```",
+        ]
+        self.assertEqual(generated_curl_example, expected_curl_example)
+
 
 class OpenAPIAttributesTest(ZulipTestCase):
     def test_attributes(self) -> None:
@@ -925,7 +963,16 @@ class OpenAPIAttributesTest(ZulipTestCase):
         * All example events in `/get-events` match an event schema.
         * That no opaque object exists.
         """
-        EXCLUDE = ["/real-time"]
+        EXCLUDE = [
+            "/real-time",
+            # The avatar endpoints doesn't return a JSON body, instead it
+            # redirects to the requested avatar URL. So their schema don't
+            # have attributes like `examples` and `type`.
+            "/avatar/{user_id}",
+            "/avatar/{email}",
+            "/avatar/{user_id}/medium",
+            "/avatar/{email}/medium",
+        ]
         VALID_TAGS = [
             "users",
             "server_and_organizations",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -208,12 +208,21 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         #### For current endpoint documentation priorities see
         #### https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/Undocumented.20endpoint.20priorities/with/2397881
         #### TODO: These endpoints are a priority to document:
-        # These are a priority to document but don't match our normal URL schemes
-        # and thus may be complicated to document with our current tooling.
+        #### non_v1_api_or_json_media_endpoints - These are a priority to document but
+        # don't match our normal URL schemes and thus may be complicated to document
+        # with our current tooling.
         # (No /api/v1/ or /json prefix).
-        "/avatar/{email_or_id}",
-        ## This one isn't really representable
+        "/thumbnail",
+        "/user_avatars/{path}",
+        "/avatar/{user_id}",
+        "/avatar/{email}",
+        "/avatar/{user_id}/medium",
+        "/avatar/{email}/medium",
+        ## These aren't really representable
         # "/user_uploads/{realm_id_str}/{filename}",
+        "/user_uploads/temporary/{token}/{filename}",
+        "/user_uploads/download/{realm_id_str}/{filename}",
+        "/user_uploads/thumbnail/{realm_id_str}/{filename}/{thumbnail_format}",
         #### These realm administration settings are valuable to document:
         # Delete a data export.
         "/export/realm/{export_id}",
@@ -559,6 +568,7 @@ so maybe we shouldn't include it in pending_endpoints.
             + urlconf.v1_api_mobile_patterns
             + zilencer_urlconf.v1_api_bouncer_patterns
             + tornado_urlconf.api_and_json_patterns
+            + urlconf.non_v1_api_or_json_media_endpoints
         ):
             methods_endpoints: dict[str, Any] = {}
             if p.callback not in [rest_dispatch, remote_server_dispatch]:

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -784,7 +784,7 @@ urls += [
 # easily support the mobile apps fetching uploaded files without
 # having to rewrite URLs, and is implemented using the
 # 'override_api_url_scheme' flag passed to rest_dispatch
-urls += [
+non_v1_api_or_json_media_endpoints = [
     path(
         "user_uploads/temporary/<token>/<filename>",
         serve_file_unauthed_from_token,
@@ -838,6 +838,8 @@ urls += [
         name="local_avatar_unauthed",
     ),
 ]
+
+urls += non_v1_api_or_json_media_endpoints
 
 # This URL serves as a way to receive CSP violation reports from the users.
 # We use this endpoint to just log these reports.


### PR DESCRIPTION
CZO: [#api documentation > avatar_url: Request specific size](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/avatar_url.3A.20Request.20specific.20size)

Example of response header from our `/avatar/` endpoints:
```
curl -i https://chat.zulip.org/avatar/30223
HTTP/2 302 
content-type: text/html; charset=utf-8
content-length: 0
location: /user_avatars/2/f641fe6b0cdca129f1ad583f6388672bf8ab64d8.png
expires: Thu, 21 Aug 2025 11:03:04 GMT
cache-control: max-age=0, no-cache, no-store, must-revalidate, private
vary: Accept-Language, Cookie
content-language: en
x-ratelimit-limit: 100
x-ratelimit-remaining: 98
x-ratelimit-reset: 1755774244
x-frame-options: DENY
x-content-type-options: nosniff
access-control-allow-origin: *
access-control-allow-headers: Authorization
access-control-allow-methods: GET, POST, DELETE, PUT, PATCH, HEAD
date: Thu, 21 Aug 2025 11:03:04 GMT
alt-svc: h3=":443"; ma=93600
strict-transport-security: max-age=15768000
```
**Screenshots and screen captures:**
Last updated on 12/06/2026

- `api/get-user`'s `avatar_url` field:
  <img width="800" height="798" alt="image" src="https://github.com/user-attachments/assets/4b3170d7-a62a-4ea5-b9b1-b56b40d8b018" />

- message object's `avatar_url` in `api/get-messages`:
  <img width="870" height="536" alt="image" src="https://github.com/user-attachments/assets/d7d06935-dd37-4c50-afcd-2c1f154bb98d" />

- `api/get-user-avatar`:
  <img width="886" height="2160" alt="image" src="https://github.com/user-attachments/assets/94dd796f-789e-4339-8bd5-46110f8885b4" />
  Curl example:
  <img width="866" height="321" alt="image" src="https://github.com/user-attachments/assets/4289d300-d100-422e-8200-f4277d0ee8f9" />

- `api/get-user-medium-avatar`:
  <img width="895" height="1664" alt="image" src="https://github.com/user-attachments/assets/cc69e310-c9a2-4b94-963b-ca44cc2fbdf1" />
  Curl example:
  <img width="855" height="260" alt="image" src="https://github.com/user-attachments/assets/f6540328-eecd-4b88-a287-45603c9a4e0e" />

- `api/get-user-avatar-by-email`:
  <img width="901" height="2061" alt="image" src="https://github.com/user-attachments/assets/15700dc5-839e-431e-9ec3-48c7dc66ffc4" />
  Curl example:
  <img width="865" height="331" alt="image" src="https://github.com/user-attachments/assets/de684d45-9e67-49ef-9037-ad3800f3b1cb" />

- `api/get-user-medium-avatar-by-email`:
  <img width="919" height="2066" alt="image" src="https://github.com/user-attachments/assets/b782a014-3872-4439-8c85-1e2945a525a7" />
  Curl example:
  <img width="858" height="314" alt="image" src="https://github.com/user-attachments/assets/c0ba0c6a-0813-4af7-8b3b-5dd12c119885" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
