### PR TITLE
Remove empty user groups from typeahead suggestion.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -546,6 +546,10 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
 
     function add_group_recipients(items: UserGroupPillData[]): void {
         for (const item of items) {
+            const is_empty_group = user_groups.is_empty_group(item.id);
+            if (is_empty_group) {
+                continue;
+            }
             recipients.push(item);
         }
     }

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -490,6 +490,23 @@ const call_center = user_group_item({
     deactivated: false,
 });
 
+const support = user_group_item({
+    name: "support",
+    id: 4,
+    creator_id: null,
+    date_created: 1596710000,
+    description: "Support team",
+    members: new Set([]),
+    is_system_group: false,
+    direct_subgroup_ids: new Set([]),
+    can_add_members_group: 2,
+    can_join_group: 2,
+    can_leave_group: 2,
+    can_manage_group: 2,
+    can_mention_group: 2,
+    deactivated: false,
+});
+
 const make_emoji = (emoji_dict) => ({
     emoji_name: emoji_dict.name,
     emoji_code: emoji_dict.emoji_code,
@@ -536,6 +553,7 @@ function test(label, f) {
         user_groups.add(hamletcharacters);
         user_groups.add(backend);
         user_groups.add(call_center);
+        user_groups.add(support);
 
         muted_users.set_muted_users([]);
 


### PR DESCRIPTION
Checks if user group is empty and omits them from suggestion.

Fixes: zulip#30890.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
