### PR TITLE
buddy_list: Fix bug where participants weren't filtered on search.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -450,10 +450,9 @@ function get_filtered_user_id_list(
         }
     }
 
-    const user_ids = filter_user_ids(user_filter_text, base_user_id_list);
     // Make sure all the participants are in the list, even if they're inactive.
-    const user_ids_set = new Set([...user_ids, ...conversation_participants]);
-    return [...user_ids_set];
+    const user_ids_set = new Set([...base_user_id_list, ...conversation_participants]);
+    return filter_user_ids(user_filter_text, [...user_ids_set]);
 }
 
 export function get_conversation_participants(): Set<number> {


### PR DESCRIPTION
This was introduced in ebe15dcf2577249dd3c8b1f011cb194643167716 where I mistakenly had us include _all_ participants  _always_ even if there was filter text present. This commit fixes that.