### PR TITLE
buddy_list: Don't use transparent background for header hover.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1219,9 +1219,9 @@
     --color-background-tab-picker-tab-option-hover: hsl(0deg 0% 100% / 5%);
     --color-background-tab-picker-tab-option-active: hsl(0deg 0% 100% / 3%);
     --color-background-alert-word: hsl(22deg 70% 35%);
-    --color-buddy-list-highlighted-user: var(
-        --color-background-hover-narrow-filter
-    );
+    /* TODO: We can probably use this value for --color-background-hover-narrow-filter, but
+       that requires some followup checking.  */
+    --color-buddy-list-highlighted-user: hsl(0deg 0% 18%);
     --color-buddy-list-avatar-loading: hsl(0deg 0% 100% / 10%);
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
     --color-text-sidebar-base: hsl(0deg 0% 100%);


### PR DESCRIPTION
Reported here: https://chat.zulip.org/#narrow/channel/9-issues/topic/right.20sidebar.20headings.20problem/near/1989456

Before:

![image](https://github.com/user-attachments/assets/6714d087-3b3d-4846-b977-3e089f7c0d2c)


After:

<img width="277" alt="image" src="https://github.com/user-attachments/assets/5ef95c84-e791-4039-99a4-5a828ab33a64">
