### PR TITLE
dependencies: Downgrade @uppy/tus from 4.1.4 to 4.1.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 4.0.1(@uppy/core@4.2.3)
       '@uppy/tus':
         specifier: ^4.1.0
-        version: 4.1.4(@uppy/core@4.2.3)
+        version: 4.1.3(@uppy/core@4.2.3)
       '@zxcvbn-ts/core':
         specifier: ^3.0.1
         version: 3.0.4
@@ -2687,8 +2687,8 @@ packages:
   '@uppy/store-default@4.1.1':
     resolution: {integrity: sha512-VP02Q44Cziw8mLH6v2txToqF2SwsNr+jSxpkvcC7/EaZhG26XnseTd3Ydv2wYxv7YALQY2xhF2/LCXZzzx4fYQ==}
 
-  '@uppy/tus@4.1.4':
-    resolution: {integrity: sha512-QnJI66ws6xJEt/qnThgy9Lmg18JxEm3nmTKw8KxF4MTVQG5SmTMWb+qC22uOTiBU82bsdwORQWtd7huCVOcs3Q==}
+  '@uppy/tus@4.1.3':
+    resolution: {integrity: sha512-oX6Krds1iygLsTbYnvkP7pnGZa2UeiHq0RRxm40IDtVcfeHnNS3lD84VDTYfwxdWzdvfezCHnWBkgNXC+mjWNw==}
     peerDependencies:
       '@uppy/core': ^4.2.3
 
@@ -11646,7 +11646,7 @@ snapshots:
 
   '@uppy/store-default@4.1.1': {}
 
-  '@uppy/tus@4.1.4(@uppy/core@4.2.3)':
+  '@uppy/tus@4.1.3(@uppy/core@4.2.3)':
     dependencies:
       '@uppy/companion-client': 4.1.1(@uppy/core@4.2.3)
       '@uppy/core': 4.2.3

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 323  # Last bumped for "GET /streams `is_recently_active`"
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (304, 0)  # bumped 2024-11-26 to upgrade JavaScript dependencies
+PROVISION_VERSION = (305, 0)  # bumped 2024-11-27 to downgrade @uppy/tus


### PR DESCRIPTION
It seems 4.1.4 is causing the client to ask the server to delete each upload immediately when it succeeds.

https://chat.zulip.org/#narrow/channel/9-issues/topic/broken.20image.20uploads/near/1989833

Cc @alexmv