### PR TITLE
Stream settings prep

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -23,19 +23,10 @@ from zerver.lib.create_user import create_user
 from zerver.lib.management import ZulipBaseCommand
 from zerver.lib.storage import static_path
 from zerver.lib.stream_color import STREAM_ASSIGNMENT_COLORS
+from zerver.lib.streams import get_default_group_setting_values
 from zerver.lib.timestamp import floor_to_day
 from zerver.lib.upload import upload_message_attachment_from_request
-from zerver.models import (
-    Client,
-    NamedUserGroup,
-    Realm,
-    RealmAuditLog,
-    Recipient,
-    Stream,
-    Subscription,
-    UserProfile,
-)
-from zerver.models.groups import SystemGroups
+from zerver.models import Client, Realm, RealmAuditLog, Recipient, Stream, Subscription, UserProfile
 from zerver.models.realm_audit_logs import AuditLogEventType
 
 
@@ -115,14 +106,11 @@ class Command(ZulipBaseCommand):
             force_date_joined=installation_time,
         )
 
-        administrators_user_group = NamedUserGroup.objects.get(
-            name=SystemGroups.ADMINISTRATORS, realm=realm, is_system_group=True
-        )
         stream = Stream.objects.create(
             name="all",
             realm=realm,
             date_created=installation_time,
-            can_remove_subscribers_group=administrators_user_group,
+            **get_default_group_setting_values(realm),
         )
         recipient = Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
         stream.recipient = recipient

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -55,6 +55,7 @@ from zerver.lib.push_notifications import (
     get_message_payload_gcm,
     hex_to_b64,
 )
+from zerver.lib.streams import get_default_group_setting_values
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import activate_push_notification_service
 from zerver.lib.timestamp import TimeZoneNotUTCError, ceiling_to_day, floor_to_day
@@ -164,7 +165,7 @@ class AnalyticsTestCase(ZulipTestCase):
             "name": f"stream name {self.name_counter}",
             "realm": self.default_realm,
             "date_created": self.TIME_LAST_HOUR,
-            "can_remove_subscribers_group": self.administrators_user_group,
+            **get_default_group_setting_values(self.default_realm),
         }
         for key, value in defaults.items():
             kwargs[key] = kwargs.get(key, value)

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -30,7 +30,10 @@ import type {CustomProfileField, GroupSettingValue} from "./state_data.ts";
 import {current_user, realm, realm_schema} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_settings_containers from "./stream_settings_containers.ts";
-import type {StreamPermissionGroupSetting} from "./stream_types.ts";
+import {
+    type StreamPermissionGroupSetting,
+    stream_permission_group_settings_schema,
+} from "./stream_types.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import {stream_subscription_schema} from "./sub_store.ts";
 import type {GroupSettingPillContainer} from "./typeahead_helper.ts";
@@ -1104,8 +1107,7 @@ export function populate_data_for_stream_settings_request(
                     continue;
                 }
 
-                const stream_group_settings = new Set(["can_remove_subscribers_group"]);
-                if (stream_group_settings.has(property_name)) {
+                if (stream_permission_group_settings_schema.safeParse(property_name).success) {
                     const old_value = get_stream_settings_property_value(
                         stream_settings_property_schema.parse(property_name),
                         sub,
@@ -1386,7 +1388,7 @@ function should_disable_save_button_for_group_settings(settings: string[]): bool
                 setting_name_without_prefix,
                 "realm",
             );
-        } else if (setting_name === "can_remove_subscribers_group") {
+        } else if (stream_permission_group_settings_schema.safeParse(setting_name).success) {
             group_setting_config = group_permission_settings.get_group_permission_setting_config(
                 setting_name,
                 "stream",

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -30,6 +30,7 @@ import type {CustomProfileField, GroupSettingValue} from "./state_data.ts";
 import {current_user, realm, realm_schema} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as stream_settings_containers from "./stream_settings_containers.ts";
+import type {StreamPermissionGroupSetting} from "./stream_types.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import {stream_subscription_schema} from "./sub_store.ts";
 import type {GroupSettingPillContainer} from "./typeahead_helper.ts";
@@ -1681,15 +1682,13 @@ export function create_realm_group_setting_widget({
     });
 }
 
-type stream_setting_name = "can_remove_subscribers_group";
-
 export function create_stream_group_setting_widget({
     $pill_container,
     setting_name,
     sub,
 }: {
     $pill_container: JQuery;
-    setting_name: stream_setting_name;
+    setting_name: StreamPermissionGroupSetting;
     sub?: StreamSubscription;
 }): GroupSettingPillContainer {
     const pill_widget = group_setting_pill.create_pills($pill_container, setting_name, "stream");

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -11,7 +11,7 @@ import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import type {GroupSettingValue, StateData} from "./state_data.ts";
 import {current_user, realm} from "./state_data.ts";
-import type {StreamPostPolicy} from "./stream_types.ts";
+import type {StreamPermissionGroupSetting, StreamPostPolicy} from "./stream_types.ts";
 import * as sub_store from "./sub_store.ts";
 import type {
     ApiStreamSubscription,
@@ -424,11 +424,12 @@ export function update_message_retention_setting(
     sub.message_retention_days = message_retention_days;
 }
 
-export function update_can_remove_subscribers_group(
+export function update_stream_permission_group_setting(
+    setting_name: StreamPermissionGroupSetting,
     sub: StreamSubscription,
-    can_remove_subscribers_group: GroupSettingValue,
+    group_setting: GroupSettingValue,
 ): void {
-    sub.can_remove_subscribers_group = can_remove_subscribers_group;
+    sub[setting_name] = group_setting;
 }
 
 export function receives_notifications(

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -38,6 +38,7 @@ import * as stream_settings_containers from "./stream_settings_containers.ts";
 import * as stream_settings_data from "./stream_settings_data.ts";
 import type {SettingsSubscription} from "./stream_settings_data.ts";
 import {
+    stream_permission_group_settings_schema,
     stream_properties_schema,
     stream_specific_notification_settings_schema,
 } from "./stream_types.ts";
@@ -233,11 +234,13 @@ export function stream_settings(sub: StreamSubscription): StreamSetting[] {
 }
 
 function setup_group_setting_widgets(sub: StreamSubscription): void {
-    settings_components.create_stream_group_setting_widget({
-        $pill_container: $("#id_can_remove_subscribers_group"),
-        setting_name: "can_remove_subscribers_group",
-        sub,
-    });
+    for (const setting_name of Object.keys(realm.server_supported_permission_settings.stream)) {
+        settings_components.create_stream_group_setting_widget({
+            $pill_container: $("#id_" + setting_name),
+            setting_name: stream_permission_group_settings_schema.parse(setting_name),
+            sub,
+        });
+    }
 }
 
 export function show_settings_for(node: HTMLElement): void {

--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -146,7 +146,11 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
             stream_settings_ui.update_message_retention_setting(sub, value);
         },
         can_remove_subscribers_group(value) {
-            stream_settings_ui.update_can_remove_subscribers_group(sub, value);
+            stream_settings_ui.update_stream_permission_group_setting(
+                "can_remove_subscribers_group",
+                sub,
+                value,
+            );
         },
         is_recently_active(value) {
             update_stream_setting(sub, value, "is_recently_active");

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -41,7 +41,7 @@ import * as stream_list from "./stream_list.ts";
 import * as stream_settings_api from "./stream_settings_api.ts";
 import * as stream_settings_components from "./stream_settings_components.ts";
 import * as stream_settings_data from "./stream_settings_data.ts";
-import type {StreamPostPolicy} from "./stream_types.ts";
+import type {StreamPermissionGroupSetting, StreamPostPolicy} from "./stream_types.ts";
 import * as stream_ui_updates from "./stream_ui_updates.ts";
 import * as sub_store from "./sub_store.ts";
 import type {StreamSubscription} from "./sub_store.ts";
@@ -213,12 +213,13 @@ export function update_message_retention_setting(
     stream_ui_updates.update_setting_element(sub, "message_retention_days");
 }
 
-export function update_can_remove_subscribers_group(
+export function update_stream_permission_group_setting(
+    setting_name: StreamPermissionGroupSetting,
     sub: StreamSubscription,
     new_value: GroupSettingValue,
 ): void {
-    stream_data.update_can_remove_subscribers_group(sub, new_value);
-    stream_ui_updates.update_setting_element(sub, "can_remove_subscribers_group");
+    stream_data.update_stream_permission_group_setting(setting_name, sub, new_value);
+    stream_ui_updates.update_setting_element(sub, setting_name);
     stream_edit_subscribers.rerender_subscribers_list(sub);
 }
 

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -9,6 +9,9 @@ export const enum StreamPostPolicy {
     MODERATORS = 4,
 }
 
+export const stream_permission_group_settings_schema = z.enum(["can_remove_subscribers_group"]);
+export type StreamPermissionGroupSetting = z.infer<typeof stream_permission_group_settings_schema>;
+
 // These types are taken from the `zerver/lib/types.py`.
 export const stream_schema = z.object({
     creator_id: z.number().nullable(),

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -67,7 +67,6 @@
               is_business_type_org=../is_business_type_org
               org_level_message_retention_setting=../org_level_message_retention_setting
               is_stream_edit=true
-              can_remove_subscribers_setting_widget_name="can_remove_subscribers_group"
               prefix="id_"
               }}
             {{/with}}

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -538,7 +538,11 @@ test("stream_settings", ({override}) => {
     });
     stream_data.update_stream_post_policy(sub, 1);
     stream_data.update_message_retention_setting(sub, -1);
-    stream_data.update_can_remove_subscribers_group(sub, moderators_group.id);
+    stream_data.update_stream_permission_group_setting(
+        "can_remove_subscribers_group",
+        sub,
+        moderators_group.id,
+    );
     assert.equal(sub.invite_only, false);
     assert.equal(sub.history_public_to_subscribers, false);
     assert.equal(sub.stream_post_policy, settings_config.stream_post_policy_values.everyone.code);

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -278,10 +278,11 @@ test("update_property", ({override}) => {
     // Test stream can_remove_subscribers_group change event
     {
         const stub = make_stub();
-        override(stream_settings_ui, "update_can_remove_subscribers_group", stub.f);
+        override(stream_settings_ui, "update_stream_permission_group_setting", stub.f);
         stream_events.update_property(stream_id, "can_remove_subscribers_group", 3);
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("sub", "val");
+        const args = stub.get_args("setting_name", "sub", "val");
+        assert.equal(args.setting_name, "can_remove_subscribers_group");
         assert.equal(args.sub.stream_id, stream_id);
         assert.equal(args.val, 3);
     }

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1449,7 +1449,7 @@ def check_stream_update(
     elif prop == "stream_post_policy":
         assert extra_keys == set()
         assert value in Stream.STREAM_POST_POLICY_TYPES
-    elif prop == "can_remove_subscribers_group":
+    elif prop in Stream.stream_permission_group_settings:
         assert extra_keys == set()
         assert isinstance(value, int | AnonymousSettingGroupDict)
     elif prop == "first_message_id":

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -41,7 +41,6 @@ from zerver.models import (
     UserGroupMembership,
     UserProfile,
 )
-from zerver.models.groups import SystemGroups
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.streams import (
     bulk_get_streams,
@@ -140,6 +139,25 @@ def send_stream_creation_event(
     send_event_on_commit(realm, event, user_ids)
 
 
+def get_stream_permission_default_group(setting_name: str, realm: Realm) -> UserGroup:
+    setting_default_name = Stream.stream_permission_group_settings[setting_name].default_group_name
+    return NamedUserGroup.objects.get(
+        name=setting_default_name,
+        realm=realm,
+        is_system_group=True,
+    )
+
+
+def get_default_group_setting_values(realm: Realm) -> dict[str, UserGroup]:
+    group_setting_values = {}
+    for setting_name in Stream.stream_permission_group_settings:
+        group_setting_values[setting_name] = get_stream_permission_default_group(
+            setting_name, realm
+        )
+
+    return group_setting_values
+
+
 @transaction.atomic(savepoint=False)
 def create_stream_if_needed(
     realm: Realm,
@@ -159,14 +177,21 @@ def create_stream_if_needed(
         realm, invite_only, history_public_to_subscribers
     )
 
-    if can_remove_subscribers_group is None:
-        can_remove_subscribers_group = NamedUserGroup.objects.get(
-            name=SystemGroups.ADMINISTRATORS, is_system_group=True, realm=realm
-        )
+    group_setting_values = {}
+    request_settings_dict = locals()
+    for setting_name in Stream.stream_permission_group_settings:
+        if setting_name not in request_settings_dict:  # nocoverage
+            continue
+
+        if request_settings_dict[setting_name] is None:
+            group_setting_values[setting_name] = get_stream_permission_default_group(
+                setting_name, realm
+            )
+        else:
+            group_setting_values[setting_name] = request_settings_dict[setting_name]
 
     stream_name = stream_name.strip()
 
-    assert can_remove_subscribers_group is not None
     (stream, created) = Stream.objects.get_or_create(
         realm=realm,
         name__iexact=stream_name,
@@ -180,7 +205,7 @@ def create_stream_if_needed(
             history_public_to_subscribers=history_public_to_subscribers,
             is_in_zephyr_realm=realm.is_zephyr_mirror_realm,
             message_retention_days=message_retention_days,
-            can_remove_subscribers_group=can_remove_subscribers_group,
+            **group_setting_values,
         ),
     )
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -60,6 +60,7 @@ from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.stream_subscription import get_subscribed_stream_ids_for_user
 from zerver.lib.streams import (
     create_stream_if_needed,
+    get_default_group_setting_values,
     get_default_value_for_history_public_to_subscribers,
 )
 from zerver.lib.subscription_info import gather_subscriptions
@@ -103,7 +104,6 @@ from zerver.models import (
     UserProfile,
     UserStatus,
 )
-from zerver.models.groups import SystemGroups
 from zerver.models.realms import clear_supported_auth_backends_cache, get_realm
 from zerver.models.streams import get_realm_stream, get_stream
 from zerver.models.users import get_system_bot, get_user, get_user_by_delivery_email
@@ -1377,9 +1377,6 @@ Output:
         history_public_to_subscribers = get_default_value_for_history_public_to_subscribers(
             realm, invite_only, history_public_to_subscribers
         )
-        administrators_user_group = NamedUserGroup.objects.get(
-            name=SystemGroups.ADMINISTRATORS, realm=realm, is_system_group=True
-        )
 
         try:
             stream = Stream.objects.create(
@@ -1388,7 +1385,7 @@ Output:
                 invite_only=invite_only,
                 is_web_public=is_web_public,
                 history_public_to_subscribers=history_public_to_subscribers,
-                can_remove_subscribers_group=administrators_user_group,
+                **get_default_group_setting_values(realm),
             )
         except IntegrityError:  # nocoverage -- this is for bugs in the tests
             raise Exception(

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -868,12 +868,11 @@ def bulk_create_system_user_groups(groups: list[dict[str, str]], realm: Realm) -
 
 
 @transaction.atomic(savepoint=False)
-def create_system_user_groups_for_realm(realm: Realm) -> dict[int, NamedUserGroup]:
+def create_system_user_groups_for_realm(realm: Realm) -> dict[str, NamedUserGroup]:
     """Any changes to this function likely require a migration to adjust
     existing realms.  See e.g. migration 0382_create_role_based_system_groups.py,
     which is a copy of this function from when we introduced system groups.
     """
-    role_system_groups_dict: dict[int, NamedUserGroup] = {}
 
     system_groups_info_list: list[dict[str, str]] = []
 
@@ -906,9 +905,6 @@ def create_system_user_groups_for_realm(realm: Realm) -> dict[int, NamedUserGrou
     bulk_create_system_user_groups(system_groups_info_list, realm)
 
     system_groups_name_dict: dict[str, NamedUserGroup] = get_role_based_system_groups_dict(realm)
-    for role in NamedUserGroup.SYSTEM_USER_GROUP_ROLE_MAP:
-        group_name = NamedUserGroup.SYSTEM_USER_GROUP_ROLE_MAP[role]["name"]
-        role_system_groups_dict[role] = system_groups_name_dict[group_name]
 
     # Order of this list here is important to create correct GroupGroupMembership objects
     # Note that because we do not create user memberships here, no audit log entries for
@@ -982,7 +978,7 @@ def create_system_user_groups_for_realm(realm: Realm) -> dict[int, NamedUserGrou
     GroupGroupMembership.objects.bulk_create(subgroup_objects)
     RealmAuditLog.objects.bulk_create(realmauditlog_objects)
 
-    return role_system_groups_dict
+    return system_groups_name_dict
 
 
 def get_system_user_group_for_user(user_profile: UserProfile) -> NamedUserGroup:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -81,6 +81,7 @@ from zerver.lib.user_groups import (
     GroupSettingChangeRequest,
     access_user_group_for_setting,
     get_group_setting_value_for_api,
+    get_role_based_system_groups_dict,
     parse_group_setting_value,
     validate_group_setting_value_change,
 )
@@ -594,6 +595,9 @@ def add_subscriptions_backend(
     setting_groups_dict = {}
     group_settings_map = {}
     request_settings_dict = locals()
+    # We don't want to calculate this value if no default values are
+    # needed.
+    system_groups_name_dict = None
     for setting_name, permission_configuration in Stream.stream_permission_group_settings.items():
         assert setting_name in request_settings_dict
         if request_settings_dict[setting_name] is not None:
@@ -607,8 +611,10 @@ def add_subscriptions_backend(
             )
             setting_groups_dict[group_settings_map[setting_name].id] = setting_value
         else:
+            if system_groups_name_dict is None:
+                system_groups_name_dict = get_role_based_system_groups_dict(realm)
             group_settings_map[setting_name] = get_stream_permission_default_group(
-                setting_name, realm
+                setting_name, system_groups_name_dict
             )
             setting_groups_dict[group_settings_map[setting_name].id] = group_settings_map[
                 setting_name


### PR DESCRIPTION
A lot of the dict generalisations for backend couldn't be done because of mypy issue no. 5382 (don't want to spam the issue with a link to this PR)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
