### PR TITLE
Allow removing user from groups via user profile.

### DIFF
--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -279,10 +279,7 @@ export function handle_subgroup_edit_event(group_id) {
     }
 }
 
-export function handle_member_edit_event(group_id, user_ids) {
-    if (!overlays.groups_open()) {
-        return;
-    }
+function update_settings_for_group_overlay(group_id, user_ids) {
     const group = user_groups.get_user_group_from_id(group_id);
 
     // update members list if currently rendered.
@@ -344,6 +341,12 @@ export function handle_member_edit_event(group_id, user_ids) {
         }
 
         $row.replaceWith($new_row);
+    }
+}
+
+export function handle_member_edit_event(group_id, user_ids) {
+    if (overlays.groups_open()) {
+        update_settings_for_group_overlay(group_id, user_ids);
     }
 }
 

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -35,6 +35,7 @@ import * as user_group_components from "./user_group_components.ts";
 import * as user_group_create from "./user_group_create.ts";
 import * as user_group_edit_members from "./user_group_edit_members.ts";
 import * as user_groups from "./user_groups.ts";
+import * as user_profile from "./user_profile.ts";
 import * as util from "./util.ts";
 
 export let toggler;
@@ -348,6 +349,7 @@ export function handle_member_edit_event(group_id, user_ids) {
     if (overlays.groups_open()) {
         update_settings_for_group_overlay(group_id, user_ids);
     }
+    user_profile.update_user_profile_groups_list_for_users(user_ids);
 }
 
 export function update_group_details(group) {

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -306,12 +306,25 @@ function format_user_group_list_item_html(group: UserGroup, user: User): string 
     const is_direct_member = group.members.has(user.user_id);
     const is_me = user.user_id === current_user.user_id;
     const can_leave_user_group = is_me && settings_data.can_leave_user_group(group.id);
+    const subgroups_name = [];
+    if (!is_direct_member) {
+        const subgroups = user_groups.get_direct_subgroups_of_group(group).sort(compare_by_name);
+        subgroups_name.push(
+            ...subgroups
+                .filter((subgroup) =>
+                    user_groups.is_user_in_group(subgroup.id, user.user_id, false),
+                )
+                .map((subgroup) => subgroup.name),
+        );
+    }
     return render_user_group_list_item({
         group_id: group.id,
         name: group.name,
         group_edit_url: hash_util.group_edit_url(group, "general"),
         is_guest: current_user.is_guest,
         is_direct_member,
+        subgroups_name: subgroups_name.join(", "),
+        is_me,
         can_remove_members: settings_data.can_manage_user_group(group.id) || can_leave_user_group,
     });
 }

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -77,6 +77,7 @@ export type CustomProfileFieldData = {
 };
 
 let user_streams_list_widget: ListWidgetType<StreamSubscription> | undefined;
+let user_groups_list_widget: ListWidgetType<UserGroup> | undefined;
 let user_profile_subscribe_widget: DropdownWidget | undefined;
 let toggler: components.Toggle;
 let bot_owner_dropdown_widget: DropdownWidget | undefined;
@@ -119,6 +120,15 @@ export function update_user_profile_streams_list_for_users(user_ids: number[]): 
         const user_streams = stream_data.get_streams_for_user(user_id).subscribed;
         user_streams.sort(compare_by_name);
         user_streams_list_widget.replace_list_data(user_streams);
+    }
+}
+
+export function update_user_profile_groups_list_for_users(user_ids: number[]): void {
+    const user_id = get_user_id_if_user_profile_modal_open();
+    if (user_id && user_ids.includes(user_id) && user_groups_list_widget !== undefined) {
+        const user_groups_list = user_groups.get_user_groups_of_user(user_id);
+        user_groups_list.sort(compare_by_name);
+        user_groups_list_widget.replace_list_data(user_groups_list);
     }
 }
 
@@ -332,7 +342,7 @@ function render_user_group_list(groups: UserGroup[], user: User): void {
     groups.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-group-list");
     $container.empty();
-    ListWidget.create($container, groups, {
+    user_groups_list_widget = ListWidget.create($container, groups, {
         name: `user-${user.user_id}-group-list`,
         get_item: ListWidget.default_get_item,
         callback_after_render() {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -588,6 +588,10 @@ ul.popover-group-menu-member-list {
             margin-bottom: 8px;
         }
 
+        .user-profile-group-list-alert {
+            margin-bottom: 8px;
+        }
+
         .stream-privacy {
             display: inline-block;
         }
@@ -641,7 +645,8 @@ ul.popover-group-menu-member-list {
         margin-bottom: 5px;
         -webkit-overflow-scrolling: touch;
 
-        .remove-subscription-button {
+        .remove-subscription-button,
+        .remove-member-button {
             padding-top: 2px;
             padding-bottom: 2px;
         }
@@ -674,7 +679,8 @@ ul.popover-group-menu-member-list {
                         padding-right: 10px;
                     }
 
-                    &.remove_subscription {
+                    &.remove_subscription,
+                    &.remove_member {
                         text-align: right;
                     }
                 }

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -9,9 +9,11 @@
     {{#if can_remove_members }}
     <td class="remove_member">
         <div class="group_list_remove">
-            <button type="button" name="remove" class="remove-member-button button small rounded button-danger" {{#unless is_direct_member}}disabled="disabled"{{/unless}} >
-                {{t 'Remove' }}
-            </button>
+            <span {{#unless is_direct_member}}class="tippy-zulip-tooltip" data-tippy-content="{{#if is_me}}{{t 'You are a member of {name} because you are a member of a subgroup ({subgroups_name}).'}} {{else}}{{t 'This user is a member of {name} because they are a member of a subgroup ({subgroups_name}).'}}{{/if}}"{{/unless}}>
+                <button type="button" name="remove" class="remove-member-button button small rounded button-danger" {{#unless is_direct_member}}disabled="disabled"{{/unless}} >
+                    {{t 'Remove' }}
+                </button>
+            </span>
         </div>
     </td>
     {{/if}}

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -6,4 +6,13 @@
             <a class="group_list_item_link" href="{{group_edit_url}}">{{name}}</a>
         {{/if}}
     </td>
+    {{#if can_remove_members }}
+    <td class="remove_member">
+        <div class="group_list_remove">
+            <button type="button" name="remove" class="remove-member-button button small rounded button-danger" {{#unless is_direct_member}}disabled="disabled"{{/unless}} >
+                {{t 'Remove' }}
+            </button>
+        </div>
+    </td>
+    {{/if}}
 </tr>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -128,6 +128,7 @@
                     </div>
 
                     <div class="tabcontent" id="user-profile-groups-tab">
+                        <div class="alert user-profile-group-list-alert"></div>
                         <div class="subscription-group-list empty-list">
                             <table class="user-group-list" data-empty="{{t 'No user group subscriptions.'}}"></table>
                         </div>


### PR DESCRIPTION
In the User groups tab of the user profile, we add a "Remove" button to the row for each group.

Adding tooltip for disabled buttons is remaining

Fixes: zulip#32487.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2024-11-28 23-54-01](https://github.com/user-attachments/assets/a1b9255b-a98d-4365-a8b2-878e5c4795cf)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
