### PR TITLE
conversation_participants: Track participants data in with message data.

### DIFF
--- a/web/src/conversation_participants.ts
+++ b/web/src/conversation_participants.ts
@@ -1,0 +1,43 @@
+/* We track participants in a narrow here by updating
+ * the data structure when a message is added / removed
+ * from MessageListData.
+ */
+
+import type {Message} from "./message_store.ts";
+import * as people from "./people.ts";
+
+export class ConversationParticipants {
+    humans: Set<number>;
+    bots: Set<number>;
+
+    constructor(messages: Message[]) {
+        this.humans = new Set();
+        this.bots = new Set();
+        this.add_from_messages(messages);
+    }
+
+    add_from_messages(messages: Message[]): void {
+        for (const msg of messages) {
+            if (msg.sent_by_me) {
+                this.humans.add(msg.sender_id);
+                continue;
+            }
+
+            const sender = people.maybe_get_user_by_id(msg.sender_id);
+            if (!sender) {
+                // `sender` is always defined but this checks helps use
+                // avoid patching all the tests.
+                continue;
+            }
+
+            if (sender.is_bot) {
+                this.bots.add(msg.sender_id);
+            } else {
+                this.humans.add(msg.sender_id);
+            }
+        }
+    }
+    // We don't support removal of a message due to deletion or message moves,
+    // because we aren't tracking the set of message IDs for each participant,
+    // so we currently just rebuild.
+}

--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -1,6 +1,7 @@
 import assert from "minimalistic-assert";
 
 import * as blueslip from "./blueslip.ts";
+import {ConversationParticipants} from "./conversation_participants.ts";
 import {FetchStatus} from "./fetch_status.ts";
 import type {Filter} from "./filter.ts";
 import type {Message} from "./message_store.ts";
@@ -50,6 +51,8 @@ export class MessageListData {
     // and to allow MessageList objects to be easily garbage collected.
     rendered_message_list_id: number | undefined;
 
+    // TODO: Use it as source of participants data in buddy list.
+    participants: ConversationParticipants;
     // MessageListData is a core data structure for keeping track of a
     // contiguous block of messages matching a given narrow that can
     // be displayed in a Zulip message feed.
@@ -60,6 +63,7 @@ export class MessageListData {
     constructor({excludes_muted_topics, filter}: {excludes_muted_topics: boolean; filter: Filter}) {
         this.filter = filter;
         this.fetch_status = new FetchStatus();
+        this.participants = new ConversationParticipants([]);
         this._all_items = [];
         this._items = [];
         this._hash = new Map();
@@ -162,6 +166,7 @@ export class MessageListData {
         this._all_items = [];
         this._items = [];
         this._hash.clear();
+        this.participants = new ConversationParticipants([]);
     }
 
     // TODO(typescript): Ideally this should only take a number.
@@ -265,6 +270,7 @@ export class MessageListData {
 
     update_items_for_muting(): void {
         this._items = this.unmuted_messages(this._all_items);
+        this.participants = new ConversationParticipants(this._items);
     }
 
     first_unread_message_id(): number | undefined {
@@ -364,6 +370,8 @@ export class MessageListData {
         this._items = [...viewable_messages, ...this._items];
         this._items.sort((a, b) => a.id - b.id);
 
+        this.participants.add_from_messages(viewable_messages);
+
         this._add_to_hash(messages);
         return viewable_messages;
     }
@@ -375,6 +383,8 @@ export class MessageListData {
         this._all_items = [...this._all_items, ...messages];
         this._items = [...this._items, ...viewable_messages];
 
+        this.participants.add_from_messages(viewable_messages);
+
         this._add_to_hash(messages);
         return viewable_messages;
     }
@@ -385,6 +395,8 @@ export class MessageListData {
 
         this._all_items = [...messages, ...this._all_items];
         this._items = [...viewable_messages, ...this._items];
+
+        this.participants.add_from_messages(viewable_messages);
 
         this._add_to_hash(messages);
         return viewable_messages;
@@ -404,7 +416,7 @@ export class MessageListData {
 
         this._items = this._items.filter((msg) => !msg_ids_to_remove.has(msg.id));
         this._all_items = this._all_items.filter((msg) => !msg_ids_to_remove.has(msg.id));
-
+        this.participants = new ConversationParticipants(this._items);
         return found_any_msgs_to_remove;
     }
 

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -21,6 +21,10 @@ function MessageListView() {
 mock_esm("../src/message_list_view", {
     MessageListView,
 });
+mock_esm("../src/people.ts", {
+    maybe_get_user_by_id: noop,
+});
+
 const stream_data = zrequire("stream_data");
 // Code we're actually using/testing
 const compose_closed_ui = zrequire("compose_closed_ui");

--- a/web/tests/conversation_participants.test.cjs
+++ b/web/tests/conversation_participants.test.cjs
@@ -1,0 +1,56 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const _ = require("lodash");
+
+const {make_user, make_bot} = require("./lib/example_user.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const people = zrequire("people");
+const {ConversationParticipants} = zrequire("../src/conversation_participants.ts");
+
+const user1 = make_user();
+const user2 = make_user();
+const bot1 = make_bot();
+const bot2 = make_bot();
+
+people._add_user(user1);
+people._add_user(user2);
+people._add_user(bot1);
+people._add_user(bot2);
+
+const human_messages = [
+    {
+        id: 1,
+        sender_id: user1.user_id,
+        sent_by_me: true,
+    },
+    {
+        id: 2,
+        sender_id: user2.user_id,
+        sent_by_me: false,
+    },
+];
+
+const bot_messages = [
+    {
+        id: 4,
+        sender_id: bot1.user_id,
+        sent_by_me: false,
+    },
+    {
+        id: 5,
+        sender_id: bot2.user_id,
+        sent_by_me: false,
+    },
+];
+
+const all_messages = [...human_messages, ...bot_messages];
+
+run_test("Add participants", () => {
+    const participants = new ConversationParticipants(all_messages);
+    assert.ok(_.isEqual(participants.humans, new Set([user1.user_id, user2.user_id])));
+    assert.ok(_.isEqual(participants.bots, new Set([bot1.user_id, bot2.user_id])));
+});

--- a/web/tests/message_list.test.cjs
+++ b/web/tests/message_list.test.cjs
@@ -40,6 +40,11 @@ function MessageListView() {
 mock_esm("../src/message_list_view", {
     MessageListView,
 });
+
+mock_esm("../src/people.ts", {
+    maybe_get_user_by_id: noop,
+});
+
 const {Filter} = zrequire("filter");
 const {set_current_user} = zrequire("state_data");
 

--- a/web/tests/message_list_data.test.cjs
+++ b/web/tests/message_list_data.test.cjs
@@ -2,8 +2,8 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 
 const user_topics = zrequire("user_topics");
@@ -35,6 +35,10 @@ function assert_msg_ids(messages, msg_ids) {
         messages.map((message) => message.id),
     );
 }
+
+mock_esm("../src/people.ts", {
+    maybe_get_user_by_id: noop,
+});
 
 run_test("basics", () => {
     const mld = new MessageListData({

--- a/web/tests/message_list_view.test.cjs
+++ b/web/tests/message_list_view.test.cjs
@@ -25,6 +25,7 @@ mock_esm("../src/people", {
     sender_is_guest: () => false,
     should_add_guest_user_indicator: () => false,
     small_avatar_url: () => "fake/small/avatar/url",
+    maybe_get_user_by_id: noop,
 });
 
 const {Filter} = zrequire("../src/filter");

--- a/web/tests/narrow_local.test.cjs
+++ b/web/tests/narrow_local.test.cjs
@@ -2,8 +2,12 @@
 
 const assert = require("node:assert/strict");
 
-const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
+
+mock_esm("../src/people.ts", {
+    maybe_get_user_by_id: noop,
+});
 
 const all_messages_data = zrequire("../src/all_messages_data");
 

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -7,6 +7,9 @@ const {run_test, noop} = require("./lib/test.cjs");
 
 const channel = mock_esm("../src/channel");
 const message_util = mock_esm("../src/message_util");
+mock_esm("../src/people.ts", {
+    maybe_get_user_by_id: noop,
+});
 
 const all_messages_data = zrequire("all_messages_data");
 const echo_state = zrequire("echo_state");


### PR DESCRIPTION
This will help us accurately track participants in every narrow to be used buddy list and other components.

https://chat.zulip.org/#narrow/channel/9-issues/topic/build_user_sidebar.20called.203x.20when.20changing.20view/near/1981270