### PR TITLE
support: Use datetime for push notification data in remote support.

### DIFF
--- a/templates/corporate/support/push_status_details.html
+++ b/templates/corporate/support/push_status_details.html
@@ -1,6 +1,6 @@
 <div class="push-notification-status">
     <p class="support-section-header">📶 Push notification status:</p>
     <b>Can push</b>: {{ status.can_push }}<br />
-    <b>Expected end</b>: {{ format_optional_datetime(status.expected_end_timestamp, True) }}<br />
+    <b>Expected end</b>: {{ format_optional_datetime(status.expected_end, True) }}<br />
     <b>Message</b>: {{ status.message }}<br />
 </div>


### PR DESCRIPTION
In our remote support view, we want any data for the end date of a server or realm's push notifications to be an optional `datetime` object vs a timestamp `int`.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
