### PR TITLE
buddy_list: Use opaque hover color for headings.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1141,7 +1141,9 @@
     --color-background-hover-narrow-filter: hsl(0deg 0% 97% / 8%);
     /* We mix an opaque version with the background for
        replicating the color on .sidebar-topic-check, which
-       will mask a portion of the topic-grouping bracket. */
+       will mask a portion of the topic-grouping bracket.
+       The same is necessary for buddy-list heading hovers
+       in the right sidebar. */
     --color-background-opaque-hover-narrow-filter: color-mix(
         in srgb,
         hsl(0deg 0% 97%) 8%,
@@ -1219,9 +1221,9 @@
     --color-background-tab-picker-tab-option-hover: hsl(0deg 0% 100% / 5%);
     --color-background-tab-picker-tab-option-active: hsl(0deg 0% 100% / 3%);
     --color-background-alert-word: hsl(22deg 70% 35%);
-    /* TODO: We can probably use this value for --color-background-hover-narrow-filter, but
-       that requires some followup checking.  */
-    --color-buddy-list-highlighted-user: hsl(0deg 0% 18%);
+    --color-buddy-list-highlighted-user: var(
+        --color-background-opaque-hover-narrow-filter
+    );
     --color-buddy-list-avatar-loading: hsl(0deg 0% 100% / 10%);
     --color-border-sidebar: hsl(0deg 0% 0% / 20%);
     --color-text-sidebar-base: hsl(0deg 0% 100%);


### PR DESCRIPTION
This updates @evykassirer's temporary fix from #32514 by referencing the already-defined opaque hover color. There is no visual change here, but it does ensure that future adjustments to the value are reflected in the right sidebar--eliminating the need to fiddle with the temporary fix's one-off color value.

[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/right.20sidebar.20headings.20problem/near/1989592)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![buddy-heading-hover-before](https://github.com/user-attachments/assets/9049124d-2b9e-4c02-a4f9-530f64af941f) | ![buddy-heading-hover-after](https://github.com/user-attachments/assets/865d7d24-d908-4cd1-9c7e-68e4348ca5d7) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
