### PR TITLE
markdown: Add support of new message-link syntax in local echo.

### DIFF
--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -647,6 +647,33 @@ function handleStreamTopic({
     )}" href="/${_.escape(href)}">${_.escape(text)}</a>`;
 }
 
+function handleStreamTopicMessage({
+    stream_name,
+    topic,
+    message_id,
+    get_stream_by_name,
+    stream_topic_hash,
+}: {
+    stream_name: string;
+    topic: string;
+    message_id: number;
+    get_stream_by_name: (stream_name: string) =>
+        | {
+              stream_id: number;
+              name: string;
+          }
+        | undefined;
+    stream_topic_hash: (stream_id: number, topic: string) => string;
+}): string | undefined {
+    const stream = get_stream_by_name(stream_name);
+    if (stream === undefined || !topic) {
+        return undefined;
+    }
+    const href = stream_topic_hash(stream.stream_id, topic) + "/near/" + message_id;
+    const text = `#${stream.name} > ${topic} @ 💬`;
+    return `<a class="message-link" href="/${_.escape(href)}">${_.escape(text)}</a>`;
+}
+
 function handleTex(tex: string, fullmatch: string): string {
     try {
         return katex.renderToString(tex);
@@ -755,6 +782,20 @@ export function parse({
         });
     }
 
+    function streamTopicMessageHandler(
+        stream_name: string,
+        topic: string,
+        message_id: number,
+    ): string | undefined {
+        return handleStreamTopicMessage({
+            stream_name,
+            topic,
+            message_id,
+            get_stream_by_name: helper_config.get_stream_by_name,
+            stream_topic_hash: helper_config.stream_topic_hash,
+        });
+    }
+
     function emojiHandler(emoji_name: string): string {
         return handleEmoji({
             emoji_name,
@@ -782,6 +823,7 @@ export function parse({
         unicodeEmojiHandler,
         streamHandler,
         streamTopicHandler,
+        streamTopicMessageHandler,
         texHandler: handleTex,
         timestampHandler: handleTimestamp,
         gfm: true,

--- a/web/tests/markdown.test.cjs
+++ b/web/tests/markdown.test.cjs
@@ -421,6 +421,15 @@ test("marked", ({override}) => {
             expected: "<p>This is not a #**Denmark&gt;** stream_topic link</p>",
         },
         {
+            input: "Look at #**Denmark>message_link@100**",
+            expected:
+                '<p>Look at <a class="message-link" href="/#narrow/channel/1-Denmark/topic/message_link/near/100">#Denmark &gt; message_link @ 💬</a></p>',
+        },
+        {
+            input: "Look at #**Unknown>message_link@100**",
+            expected: "<p>Look at #**Unknown&gt;message_link@100**</p>",
+        },
+        {
             input: "mmm...:burrito:s",
             expected:
                 '<p>mmm...<img alt=":burrito:" class="emoji" src="/static/generated/emoji/images/emoji/burrito.png" title="burrito">s</p>',

--- a/web/third/marked/lib/marked.cjs
+++ b/web/third/marked/lib/marked.cjs
@@ -940,7 +940,7 @@ InlineLexer.prototype.stream = function (streamName, orig) {
 
 InlineLexer.prototype.stream_topic = function (streamName, topic, orig) {
   orig = escape(orig);
-  if (typeof this.options.streamHandler !== 'function')
+  if (typeof this.options.streamTopicHandler !== 'function')
     return orig;
 
   var handled = this.options.streamTopicHandler(streamName, topic);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Follow up to #31965 
The frontend markdown processor didn't local
echo the syntax properly, resulting in a
rendering glitch when sending them.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
