### PR TITLE
Improve sort order for @-mention typeahead

### DIFF
--- a/web/src/recent_senders.ts
+++ b/web/src/recent_senders.ts
@@ -56,7 +56,7 @@ export function clear_for_testing(): void {
     topic_senders.clear();
 }
 
-function max_id_for_stream_topic_sender(opts: {
+export function max_id_for_stream_topic_sender(opts: {
     stream_id: number;
     topic: string;
     sender_id: number;
@@ -74,7 +74,7 @@ function max_id_for_stream_topic_sender(opts: {
     return id_tracker ? id_tracker.max_id() : -1;
 }
 
-function max_id_for_stream_sender(opts: {stream_id: number; sender_id: number}): number {
+export function max_id_for_stream_sender(opts: {stream_id: number; sender_id: number}): number {
     const {stream_id, sender_id} = opts;
     const sender_dict = stream_senders.get(stream_id);
     if (!sender_dict) {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -138,7 +138,7 @@ function compare_by_direct_message_group(
         if (diff !== 0) {
             return diff;
         }
-        return typeahead_helper.compare_by_pms(person1, person2);
+        return typeahead_helper.compare_users_for_pms(person1, person2);
     };
 }
 
@@ -329,7 +329,7 @@ function make_people_getter(last: NarrowTerm): () => User[] {
         }
 
         persons = people.get_people_for_search_bar(query);
-        persons.sort(typeahead_helper.compare_by_pms);
+        persons.sort(typeahead_helper.compare_users_for_pms);
         return persons;
     };
 }

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -11,6 +11,7 @@ import * as buddy_data from "./buddy_data.ts";
 import * as compose_state from "./compose_state.ts";
 import type {LanguageSuggestion, SlashCommandSuggestion} from "./composebox_typeahead.ts";
 import type {InputPillContainer} from "./input_pill.ts";
+import {pm_ids_set} from "./narrow_state.ts";
 import * as people from "./people.ts";
 import type {PseudoMentionUser, User} from "./people.ts";
 import * as pm_conversations from "./pm_conversations.ts";
@@ -223,93 +224,200 @@ export function sorter<T>(query: string, objs: T[], get_item: (x: T) => string):
     return [...results.matches, ...results.rest];
 }
 
-export function compare_by_pms(user_a: User, user_b: User): number {
-    const count_a = people.get_recipient_count(user_a);
-    const count_b = people.get_recipient_count(user_b);
+export function compare_users_for_streams(
+    user_a: User,
+    user_b: User,
+    stream_id: number,
+    topic: string,
+): number {
+    // Typeahead sorting priority order for stream conversations:
 
-    if (count_a > count_b) {
+    // 1. Subscribers over non-subscribers.
+    const a_is_sub = stream_data.is_user_subscribed(stream_id, user_a.user_id);
+    const b_is_sub = stream_data.is_user_subscribed(stream_id, user_b.user_id);
+    if (a_is_sub && !b_is_sub) {
         return -1;
-    } else if (count_a < count_b) {
+    } else if (!a_is_sub && b_is_sub) {
         return 1;
     }
 
+    // 2. Users who have sent messages to the current topic over those who haven't sent to the current topic.
+    // 3. Users who have sent messages to the stream over those who haven't sent to the stream.
+    const result = recent_senders.compare_by_recency(user_a, user_b, stream_id, topic);
+    if (result > 0) {
+        return 1;
+    } else if (result < 0) {
+        return -1;
+    }
+
+    // 4. Users have PMed with, over users haven't PMed with.
     const a_is_partner = pm_conversations.is_partner(user_a.user_id);
     const b_is_partner = pm_conversations.is_partner(user_b.user_id);
+    if (a_is_partner && !b_is_partner) {
+        return -1;
+    } else if (!a_is_partner && b_is_partner) {
+        return 1;
+    }
+    return 0;
+}
 
-    // This code will never run except in the rare case that one has no
-    // recent DM message history with a user, but does have some older
-    // message history that's outside the "recent messages only"
-    // data set powering people.get_recipient_count.
+export function compare_users_for_pms(user_a: User, user_b: User): number {
+    // Typeahead sorting priority order for PM conversations:
+
+    // 1. Users who have PMed with each other over those who haven't.
+    const a_is_partner = pm_conversations.is_partner(user_a.user_id);
+    const b_is_partner = pm_conversations.is_partner(user_b.user_id);
     if (a_is_partner && !b_is_partner) {
         return -1;
     } else if (!a_is_partner && b_is_partner) {
         return 1;
     }
 
+    // 2. Recipients with higher counts.
+    const count_a = people.get_recipient_count(user_a);
+    const count_b = people.get_recipient_count(user_b);
+    if (count_a > count_b) {
+        return -1;
+    } else if (count_a < count_b) {
+        return 1;
+    }
+
+    // 3. Normal users over bots.
     if (!user_a.is_bot && user_b.is_bot) {
         return -1;
     } else if (user_a.is_bot && !user_b.is_bot) {
         return 1;
     }
 
-    // We use alpha sort as a tiebreaker, which might be helpful for
-    // new users.
-    if (user_a.full_name < user_b.full_name) {
+    // 4. Users with shorter names over those with longer names
+    if (user_a.full_name.length < user_b.full_name.length) {
         return -1;
-    } else if (user_a === user_b) {
-        return 0;
+    } else if (user_a.full_name.length > user_b.full_name.length) {
+        return 1;
     }
-    return 1;
+    return 0;
 }
 
-export function compare_people_for_relevance(
+// The properties from which at least one should be satisfied by the user to be kept above wildcards.
+export function get_properties_to_satisy(
+    user: User,
+    stream_id?: number,
+    topic?: string,
+): boolean[] {
+    let properties_to_satisfy;
+    const user_pmed = pm_conversations.is_partner(user.user_id);
+
+    if (stream_id === undefined || topic === undefined) {
+        // PM conversations
+
+        // Wildcard gets higher priority over:
+        // Users who have not PMed with the current user.
+        properties_to_satisfy = [user_pmed];
+    } else {
+        // Stream conversations
+
+        // Wildcard gets higher priority over:
+        // The non-subscribers who have neither participated in the topic nor stream
+        // and also with whom the current user hasn't PMed.
+
+        const user_is_sub = stream_data.is_user_subscribed(stream_id, user.user_id);
+
+        // The max_id_for_stream_topic_sender() will be > 0 if the user have sent at least one message to the topic
+        const user_is_sender_to_current_topic =
+            recent_senders.max_id_for_stream_topic_sender({
+                stream_id,
+                topic,
+                sender_id: user.user_id,
+            }) > 0;
+
+        const user_is_sender_to_current_stream =
+            recent_senders.max_id_for_stream_sender({
+                stream_id,
+                sender_id: user.user_id,
+            }) > 0;
+
+        properties_to_satisfy = [
+            user_is_sub,
+            user_is_sender_to_current_topic,
+            user_is_sender_to_current_stream,
+            user_pmed,
+        ];
+    }
+    return properties_to_satisfy;
+}
+
+export function compare_people_for_streams(
     person_a: UserOrMentionPillData | UserPillData,
     person_b: UserOrMentionPillData | UserPillData,
-    compare_by_current_conversation?: (user_a: User, user_b: User) => number,
-    current_stream_id?: number,
+    stream_id: number,
+    topic: string,
 ): number {
-    // give preference to "all", "everyone" or "stream"
-    if (compose_state.get_message_type() !== "private") {
-        if (person_a.type === "broadcast") {
-            if (person_b.type === "broadcast") {
-                return person_a.user.idx - person_b.user.idx;
-            }
-            return -1;
-        } else if (person_b.type === "broadcast") {
-            return 1;
+    if (person_a.type === "user") {
+        if (person_b.type === "user") {
+            // If both are users
+            return compare_users_for_streams(person_a.user, person_b.user, stream_id, topic);
         }
-    } else {
-        if (person_a.type === "broadcast") {
-            if (person_b.type === "broadcast") {
-                return person_a.user.idx - person_b.user.idx;
-            }
-            return 1;
-        } else if (person_b.type === "broadcast") {
-            return -1;
-        }
+        // a is user, b is wildcard
+        return compare_user_wildcard(
+            get_properties_to_satisy(person_a.user, stream_id, topic),
+            true,
+        );
+    }
+    if (person_b.type === "user") {
+        // a is wildcard, b is user
+        return -compare_user_wildcard(
+            get_properties_to_satisy(person_b.user, stream_id, topic),
+            true,
+        );
     }
 
-    // Now handle actual people users.
-    // give preference to subscribed users first
-    if (current_stream_id !== undefined) {
-        const a_is_sub = stream_data.is_user_subscribed(current_stream_id, person_a.user.user_id);
-        const b_is_sub = stream_data.is_user_subscribed(current_stream_id, person_b.user.user_id);
+    // Both a and b are wildcards
+    return person_a.user.idx - person_b.user.idx;
+}
 
-        if (a_is_sub && !b_is_sub) {
-            return -1;
-        } else if (!a_is_sub && b_is_sub) {
-            return 1;
+export function compare_people_for_pms(
+    person_a: UserOrMentionPillData | UserPillData,
+    person_b: UserOrMentionPillData | UserPillData,
+): number {
+    if (person_a.type === "user") {
+        if (person_b.type === "user") {
+            // Both a and b are users
+            return compare_users_for_pms(person_a.user, person_b.user);
         }
+        // a: user, b: wildcard
+        return compare_user_wildcard(get_properties_to_satisy(person_a.user), false);
+    }
+    if (person_b.type === "user") {
+        // a: wildcard, b: user
+        return -compare_user_wildcard(get_properties_to_satisy(person_b.user), false);
     }
 
-    if (compare_by_current_conversation !== undefined) {
-        const preference = compare_by_current_conversation(person_a.user, person_b.user);
-        if (preference !== 0) {
-            return preference;
-        }
+    // Both a and b are wildcards
+    return person_a.user.idx - person_b.user.idx;
+}
+
+export function compare_user_wildcard(
+    properties_to_satisfy: boolean[],
+    view_is_stream: boolean,
+): number {
+    // Assumption for convenience: Assuming that the user is user_a and wildcard is b.
+    // If the other way around is true, just change the sign (multiplying with -1)
+
+    // If message type is private or not viewing a stream conversation, with being it a 1:1 DM, wildcards are put at the bottom
+    const message_type = compose_state.get_message_type();
+    const pm_members_count = pm_ids_set().size;
+    if ((message_type === "private" || !view_is_stream) && pm_members_count <= 1) {
+        return -1;
     }
 
-    return compare_by_pms(person_a.user, person_b.user);
+    // Streams or Group DMs
+    const atleast_one_satisifies = properties_to_satisfy.some(Boolean);
+    if (atleast_one_satisifies) {
+        return -1;
+    }
+
+    // If any rule didn't get satisfy for a user, put wildcard at the top.
+    return 1;
 }
 
 export function sort_people_for_relevance<UserType extends UserOrMentionPillData | UserPillData>(
@@ -320,24 +428,17 @@ export function sort_people_for_relevance<UserType extends UserOrMentionPillData
     // If sorting for recipientbox typeahead and not viewing a stream / topic, then current_stream = ""
     const current_stream =
         current_stream_id !== undefined ? stream_data.get_sub_by_id(current_stream_id) : undefined;
+
     if (current_stream === undefined) {
-        objs.sort((person_a, person_b) => compare_people_for_relevance(person_a, person_b));
+        // Viewing PM conversations
+        objs.sort((person_a, person_b) => compare_people_for_pms(person_a, person_b));
     } else {
         assert(current_stream_id !== undefined);
         assert(current_topic !== undefined);
+
+        // Viewing Stream messages
         objs.sort((person_a, person_b) =>
-            compare_people_for_relevance(
-                person_a,
-                person_b,
-                (user_a, user_b) =>
-                    recent_senders.compare_by_recency(
-                        user_a,
-                        user_b,
-                        current_stream_id,
-                        current_topic,
-                    ),
-                current_stream_id,
-            ),
+            compare_people_for_streams(person_a, person_b, current_stream_id, current_topic),
         );
     }
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -558,14 +558,14 @@ const make_emoji = (emoji_dict) => ({
 const sorted_user_list = [
     ali_item,
     alice_item,
-    cordelia_item,
-    hal_item, // Early Hal
-    gael_item,
     harry_item,
-    hamlet_item, // King Hamlet
+    hal_item, // Early Hal
     lear_item,
     twin1_item, // Mark Twin
     twin2_item,
+    gael_item,
+    hamlet_item, // King Hamlet
+    cordelia_item,
     othello_item,
 ];
 
@@ -1054,14 +1054,14 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                 let expected_value = [
                     ali_item,
                     alice_item,
-                    cordelia_item,
-                    hal_item,
-                    gael_item,
                     harry_item,
-                    hamlet_item,
+                    hal_item,
                     lear_item,
                     twin1_item,
                     twin2_item,
+                    gael_item,
+                    hamlet_item,
+                    cordelia_item,
                     othello_item,
                     hamletcharacters,
                     backend,
@@ -1642,7 +1642,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals(
         "test @_*k",
         mentions_with_silent_marker(
-            [hamlet_item, lear_item, twin1_item, twin2_item, backend],
+            [lear_item, hamlet_item, twin1_item, twin2_item, backend],
             true,
         ),
     );
@@ -1676,12 +1676,12 @@ test("begins_typeahead", ({override, override_rewire}) => {
             [
                 ali_item,
                 alice_item,
-                cordelia_item,
-                gael_item,
-                hamlet_item,
                 lear_item,
                 twin1_item,
                 twin2_item,
+                gael_item,
+                hamlet_item,
+                cordelia_item,
                 othello_item,
             ],
             false,
@@ -1693,12 +1693,12 @@ test("begins_typeahead", ({override, override_rewire}) => {
             [
                 ali_item,
                 alice_item,
-                cordelia_item,
-                gael_item,
-                hamlet_item,
                 lear_item,
                 twin1_item,
                 twin2_item,
+                gael_item,
+                hamlet_item,
+                cordelia_item,
                 othello_item,
                 admins,
             ],
@@ -1709,8 +1709,8 @@ test("begins_typeahead", ({override, override_rewire}) => {
         "test\n @l",
         mentions_with_silent_marker(
             [
-                cordelia_item,
                 lear_item,
+                cordelia_item,
                 ali_item,
                 alice_item,
                 hal_item,
@@ -1726,8 +1726,8 @@ test("begins_typeahead", ({override, override_rewire}) => {
         "test\n @_l",
         mentions_with_silent_marker(
             [
-                cordelia_item,
                 lear_item,
+                cordelia_item,
                 ali_item,
                 alice_item,
                 hal_item,
@@ -2054,7 +2054,7 @@ test("filter_and_sort_mentions (normal)", ({override}) => {
     const mention_all = broadcast_item(ct.broadcast_mentions()[0]);
     assert.deepEqual(
         suggestions,
-        possibly_silent_list([mention_all, ali_item, alice_item, hal_item, call_center], is_silent),
+        possibly_silent_list([ali_item, alice_item, mention_all, hal_item, call_center], is_silent),
     );
 
     // call_center group is shown in typeahead even when user is member of
@@ -2063,7 +2063,7 @@ test("filter_and_sort_mentions (normal)", ({override}) => {
     suggestions = ct.filter_and_sort_mentions(is_silent, "al");
     assert.deepEqual(
         suggestions,
-        possibly_silent_list([mention_all, ali_item, alice_item, hal_item, call_center], is_silent),
+        possibly_silent_list([ali_item, alice_item, mention_all, hal_item, call_center], is_silent),
     );
 
     // call_center group is not shown in typeahead when user is neither
@@ -2073,7 +2073,7 @@ test("filter_and_sort_mentions (normal)", ({override}) => {
     suggestions = ct.filter_and_sort_mentions(is_silent, "al");
     assert.deepEqual(
         suggestions,
-        possibly_silent_list([mention_all, ali_item, alice_item, hal_item], is_silent),
+        possibly_silent_list([ali_item, alice_item, mention_all, hal_item], is_silent),
     );
 });
 
@@ -2203,7 +2203,7 @@ test("typeahead_results", ({override}) => {
     assert_mentions_matches("oor ", []);
     assert_mentions_matches("oor o", []);
     assert_mentions_matches("oor of venice", []);
-    assert_mentions_matches("King ", [not_silent(hamlet_item), not_silent(lear_item)]);
+    assert_mentions_matches("King ", [not_silent(lear_item), not_silent(hamlet_item)]);
     assert_mentions_matches("King H", [not_silent(hamlet_item)]);
     assert_mentions_matches("King L", [not_silent(lear_item)]);
     assert_mentions_matches("delia lear", []);
@@ -2225,13 +2225,13 @@ test("typeahead_results", ({override}) => {
     // Here, we suggest only "everyone" instead of both the matching
     // "everyone" and "stream" wildcard mentions.
     assert_mentions_matches("e", [
-        not_silent(mention_everyone),
         not_silent(hal_item),
+        not_silent(mention_everyone),
         not_silent(alice_item),
-        not_silent(cordelia_item),
+        not_silent(lear_item),
         not_silent(gael_item),
         not_silent(hamlet_item),
-        not_silent(lear_item),
+        not_silent(cordelia_item),
         not_silent(othello_item),
         not_silent(hamletcharacters),
         not_silent(call_center),
@@ -2243,9 +2243,9 @@ test("typeahead_results", ({override}) => {
     // Here, we suggest both "everyone" and "topic".
     assert_mentions_matches("o", [
         not_silent(othello_item),
+        not_silent(cordelia_item),
         not_silent(mention_everyone),
         not_silent(mention_topic),
-        not_silent(cordelia_item),
     ]);
 
     // Autocomplete by slash commands.

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -152,11 +152,11 @@ test("dm_suggestions", ({override, mock_template}) => {
     let suggestions = get_suggestions(query);
     let expected = [
         "is:dm",
-        "dm:alice@zulip.com",
-        "dm:bob@zulip.com",
-        "dm:jeff@zulip.com",
         "dm:myself@zulip.com",
         "dm:ted@zulip.com",
+        "dm:bob@zulip.com",
+        "dm:alice@zulip.com",
+        "dm:jeff@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -860,12 +860,12 @@ test("people_suggestions", ({override, mock_template}) => {
 
     let expected = [
         "te",
-        "dm:bob@zulip.com", // bob térry
         "dm:ted@zulip.com",
-        "sender:bob@zulip.com",
+        "dm:bob@zulip.com", // bob térry
         "sender:ted@zulip.com",
-        "dm-including:bob@zulip.com",
+        "sender:bob@zulip.com",
         "dm-including:ted@zulip.com",
+        "dm-including:bob@zulip.com",
     ];
 
     assert.deepEqual(suggestions.strings, expected);
@@ -880,14 +880,14 @@ test("people_suggestions", ({override, mock_template}) => {
 
     expected = [
         "te",
-        "dm:bob@zulip.com",
         "dm:ted@zulip.com",
+        "dm:bob@zulip.com",
         "dm:user299@zulipdev.com",
-        "sender:bob@zulip.com",
         "sender:ted@zulip.com",
+        "sender:bob@zulip.com",
         "sender:user299@zulipdev.com",
-        "dm-including:bob@zulip.com",
         "dm-including:ted@zulip.com",
+        "dm-including:bob@zulip.com",
         "dm-including:user299@zulipdev.com",
     ];
     assert.deepEqual(suggestions.strings, expected);

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -492,18 +492,18 @@ test("sort_recipients", () => {
         "b_user_3@zulip.net",
         "b_bot@example.com",
         "a_bot@zulip.com",
-        "a_user@zulip.org",
         "zman@test.net",
+        "a_user@zulip.org",
     ]);
 
     // Typeahead for direct message [query, "", ""]
     assert.deepEqual(get_typeahead_result("a", "", ""), [
         "a_user@zulip.org",
         "a_bot@zulip.com",
+        "zman@test.net",
         "b_user_1@zulip.net",
         "b_user_2@zulip.net",
         "b_user_3@zulip.net",
-        "zman@test.net",
         "b_bot@example.com",
     ]);
 
@@ -570,9 +570,9 @@ test("sort_recipients", () => {
         "b_user_3@zulip.net",
         "a_user@zulip.org",
         "b_bot@example.com",
+        "a_bot@zulip.com",
         "b_user_1@zulip.net",
         "b_user_2@zulip.net",
-        "a_bot@zulip.com",
     ]);
 });
 
@@ -596,13 +596,13 @@ test("sort_recipients all mention", () => {
 
     assertSameEmails(results, [
         broadcast_item(all_obj),
-        a_user_item,
         a_bot_item,
+        a_user_item,
         b_user_1_item,
         b_user_2_item,
         b_user_3_item,
-        zman_item,
         b_bot_item,
+        zman_item,
     ]);
 });
 
@@ -630,26 +630,21 @@ test("sort_recipients pm counts", () => {
 
     assert.deepEqual(get_typeahead_result("b", linux_sub.stream_id, "Linux topic"), [
         "b_user_3@zulip.net",
-        "b_user_2@zulip.net",
         "b_user_1@zulip.net",
+        "b_user_2@zulip.net",
         "b_bot@example.com",
         "a_bot@zulip.com",
         "a_user@zulip.org",
         "zman@test.net",
     ]);
 
-    /* istanbul ignore next */
-    function compare() {
-        throw new Error("We do not expect to need a tiebreaker here.");
-    }
-
     // get some line coverage
     assert.equal(
-        th.compare_people_for_relevance(b_user_1_item, b_user_3_item, compare, linux_sub.stream_id),
+        th.compare_people_for_streams(b_user_1_item, b_user_3_item, linux_sub.stream_id, ""),
         1,
     );
     assert.equal(
-        th.compare_people_for_relevance(b_user_3_item, b_user_1_item, compare, linux_sub.stream_id),
+        th.compare_people_for_streams(b_user_3_item, b_user_1_item, linux_sub.stream_id, ""),
         -1,
     );
 });
@@ -671,8 +666,8 @@ test("sort_recipients dup bots", () => {
         "b_bot@example.com",
         "a_bot@zulip.com",
         "a_bot@zulip.com",
-        "a_user@zulip.org",
         "zman@test.net",
+        "a_user@zulip.org",
     ];
     assert.deepEqual(recipients_email, expected);
 });
@@ -774,7 +769,7 @@ test("sort broadcast mentions for stream message type", () => {
     compose_state.set_message_type("stream");
     const mentions = ct.broadcast_mentions().reverse();
     const broadcast_items = mentions.map((broadcast) => broadcast_item(broadcast));
-    const results = th.sort_people_for_relevance(broadcast_items, "", "");
+    const results = th.sort_people_for_relevance(broadcast_items, linux_sub.stream_id, "");
 
     assert.deepEqual(
         results.map((r) => r.user.email),
@@ -792,11 +787,11 @@ test("sort broadcast mentions for stream message type", () => {
             .reverse(),
         a_user_item,
     ];
-    const results2 = th.sort_people_for_relevance(user_or_mention_items, "", "");
+    const results2 = th.sort_people_for_relevance(user_or_mention_items, linux_sub.stream_id, "");
 
     assert.deepEqual(
         results2.map((r) => r.user.email),
-        ["all", "everyone", "stream", "channel", "topic", a_user.email, zman.email],
+        ["all", "everyone", "stream", "channel", "topic", zman.email, a_user.email],
     );
 });
 
@@ -823,7 +818,7 @@ test("sort broadcast mentions for direct message type", () => {
 
     assert.deepEqual(
         results2.map((r) => r.user.email),
-        [a_user.email, zman.email, "all", "everyone"],
+        [zman.email, a_user.email, "all", "everyone"],
     );
 });
 
@@ -835,9 +830,9 @@ test("test compare directly for stream message type", () => {
     const all_obj = ct.broadcast_mentions()[0];
     const all_obj_item = broadcast_item(all_obj);
 
-    assert.equal(th.compare_people_for_relevance(all_obj_item, all_obj_item), 0);
-    assert.equal(th.compare_people_for_relevance(all_obj_item, zman_item), -1);
-    assert.equal(th.compare_people_for_relevance(zman_item, all_obj_item), 1);
+    assert.equal(th.compare_people_for_streams(all_obj_item, all_obj_item, 1, ""), 0);
+    assert.equal(th.compare_people_for_streams(all_obj_item, zman_item, 1, ""), -1);
+    assert.equal(th.compare_people_for_streams(zman_item, all_obj_item, 1, ""), 1);
 });
 
 test("test compare directly for direct message", () => {
@@ -845,9 +840,168 @@ test("test compare directly for direct message", () => {
     const all_obj = ct.broadcast_mentions()[0];
     const all_obj_item = broadcast_item(all_obj);
 
-    assert.equal(th.compare_people_for_relevance(all_obj_item, all_obj_item), 0);
-    assert.equal(th.compare_people_for_relevance(all_obj_item, zman_item), 1);
-    assert.equal(th.compare_people_for_relevance(zman_item, all_obj_item), -1);
+    assert.equal(th.compare_people_for_pms(all_obj_item, all_obj_item), 0);
+    assert.equal(th.compare_people_for_pms(all_obj_item, zman_item), 1);
+    assert.equal(th.compare_people_for_pms(zman_item, all_obj_item), -1);
+});
+
+test("sort_people_for_relevance", () => {
+    // For Test coverage
+    peer_data.add_subscriber(dev_sub.stream_id, b_user_1.user_id);
+
+    assert.deepEqual(
+        th.sort_people_for_relevance([b_user_2_item, b_user_1_item], dev_sub.stream_id, ""),
+        [b_user_1_item, b_user_2_item],
+    );
+
+    pm_conversations.set_partner(b_user_1.user_id);
+    assert.deepEqual(th.sort_people_for_relevance([b_user_2_item, b_user_1_item]), [
+        b_user_1_item,
+        b_user_2_item,
+    ]);
+    assert.deepEqual(th.sort_people_for_relevance([b_user_2_item, b_user_1_item], "", ""), [
+        b_user_1_item,
+        b_user_2_item,
+    ]);
+});
+
+test("compare_people_for_streams", () => {
+    // For Test coverage
+    peer_data.add_subscriber(dev_sub.stream_id, a_user.user_id);
+
+    // Two users
+    assert.equal(
+        th.compare_people_for_streams(b_user_1_item, a_user_item, dev_sub.stream_id, ""),
+        1,
+    );
+
+    compose_state.set_message_type("stream");
+    const mentions = ct.broadcast_mentions();
+    const all_item = broadcast_item(mentions[0]);
+    const everyone_item = broadcast_item(mentions[1]);
+
+    // a: user, b: wildcard
+    assert.equal(th.compare_people_for_streams(a_user_item, all_item, dev_sub.stream_id, ""), -1);
+
+    // b: user, a: wildcard
+    assert.equal(th.compare_people_for_streams(b_user_1_item, all_item, dev_sub.stream_id, ""), 1);
+
+    // both wildcards
+    assert.equal(
+        th.compare_people_for_streams(all_item, everyone_item, dev_sub.stream_id, ""),
+        all_item.user.idx - everyone_item.user.idx,
+    );
+});
+
+test("compare_people_for_pms", () => {
+    // For Test coverage
+    pm_conversations.set_partner(a_user.user_id);
+
+    // Two users
+    assert.equal(
+        th.compare_people_for_streams(b_user_1_item, a_user_item, dev_sub.stream_id, ""),
+        1,
+    );
+
+    compose_state.set_message_type("stream");
+    const mentions = ct.broadcast_mentions();
+    const all_item = broadcast_item(mentions[0]);
+    const everyone_item = broadcast_item(mentions[1]);
+
+    // a: user, b: wildcard
+    assert.equal(th.compare_people_for_streams(a_user_item, all_item, dev_sub.stream_id, ""), -1);
+
+    // b: user, a: wildcard
+    assert.equal(th.compare_people_for_streams(b_user_1_item, all_item, dev_sub.stream_id, ""), 1);
+
+    // both wildcards
+    assert.equal(
+        th.compare_people_for_streams(all_item, everyone_item, dev_sub.stream_id, ""),
+        all_item.user.idx - everyone_item.user.idx,
+    );
+});
+
+test("compare_users_for_streams", () => {
+    peer_data.add_subscriber(dev_sub.stream_id, a_user.user_id);
+    recent_senders.process_stream_message({
+        sender_id: a_bot.user_id,
+        stream_id: dev_sub.stream_id,
+        topic: "Dev topic 1",
+        id: (next_id += 1),
+    });
+    recent_senders.process_stream_message({
+        sender_id: b_user_1.user_id,
+        stream_id: dev_sub.stream_id,
+        topic: "Dev topic 2",
+        id: (next_id += 1),
+    });
+    pm_conversations.set_partner(b_user_2.user_id);
+
+    // 1. Subscribers over non-subscribers.
+    assert.equal(th.compare_users_for_streams(a_user, b_user_3, dev_sub.stream_id, ""), -1);
+    assert.equal(th.compare_users_for_streams(b_user_3, a_user, dev_sub.stream_id, ""), 1);
+
+    // 2. Users who have sent messages to the current topic over those who haven't sent to the current topic.
+    assert.equal(
+        th.compare_users_for_streams(a_bot, b_user_3, dev_sub.stream_id, "Dev topic 1"),
+        -1,
+    );
+    assert.equal(
+        th.compare_users_for_streams(b_user_3, a_bot, dev_sub.stream_id, "Dev topic 1"),
+        1,
+    );
+
+    // 3. Users who have sent messages to the stream over those who haven't sent to the stream.
+    assert.equal(
+        th.compare_users_for_streams(b_user_1, b_user_3, dev_sub.stream_id, "Dev topic 2"),
+        -1,
+    );
+    assert.equal(
+        th.compare_users_for_streams(b_user_3, b_user_1, dev_sub.stream_id, "Dev topic 2"),
+        1,
+    );
+
+    // 4. Users have PMed with over users haven't PMed with.
+    assert.equal(th.compare_users_for_streams(b_user_2, b_user_3, dev_sub.stream_id, ""), -1);
+    assert.equal(th.compare_users_for_streams(b_user_3, b_user_2, dev_sub.stream_id, ""), 1);
+
+    // 5. No matches:
+    assert.equal(th.compare_users_for_streams(b_user_3, b_bot, dev_sub.stream_id, ""), 0);
+});
+
+test("compare_users_for_pms", () => {
+    pm_conversations.set_partner(a_user.user_id);
+    people.set_recipient_count_for_testing(b_user_1.user_id, 50);
+
+    // 1. Users who have PMed with over users haven't PMed with.
+    assert.equal(th.compare_users_for_pms(a_user, b_user_2), -1);
+    assert.equal(th.compare_users_for_pms(b_user_2, a_user), 1);
+
+    // 2. Recipients with higher counts.
+    assert.equal(th.compare_users_for_pms(b_user_1, b_user_2), -1);
+    assert.equal(th.compare_users_for_pms(b_user_2, b_user_1), 1);
+
+    // 3. Normal users over bots.
+    assert.equal(th.compare_users_for_pms(b_user_2, a_bot), -1);
+    assert.equal(th.compare_users_for_pms(a_bot, b_user_2), 1);
+
+    // 4. Users with shorter names over those with longer names (alpha sort)
+    assert.equal(th.compare_users_for_pms(zman, b_user_2), -1);
+    assert.equal(th.compare_users_for_pms(b_user_2, zman), 1);
+
+    // 5. No matches:
+    assert.equal(th.compare_users_for_pms(b_user_2, b_user_2), 0);
+});
+
+test("compare_user_wildcard", () => {
+    compose_state.set_message_type("private");
+    assert.equal(th.compare_user_wildcard([], ""), -1);
+
+    compose_state.set_message_type("stream");
+    assert.equal(th.compare_user_wildcard([], false), -1);
+
+    assert.equal(th.compare_user_wildcard([true, false, false, false], true), -1);
+    assert.equal(th.compare_user_wildcard([false, false, false, false], true), 1);
 });
 
 test("highlight_with_escaping", () => {
@@ -1045,8 +1199,8 @@ test("compare_language", () => {
 
 // TODO: This is incomplete for testing this function, and
 // should be filled out more. This case was added for codecov.
-test("compare_by_pms", () => {
-    assert.equal(th.compare_by_pms(a_user, a_user), 0);
+test("compare_users_for_pms", () => {
+    assert.equal(th.compare_users_for_pms(a_user, a_user), 0);
 });
 
 test("sort_group_setting_options", ({override_rewire}) => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This pull request updates the logic of sort order in @-mention typeahead. 

Fixes #26838
- [x] Improved sort order as described in the issue by introducing separate functions for streams, PMs and wildcards.
- [x] Updated tests to work with the new logic.
- [x] Wrote new tests for the introduced functions, thus increasing code coverage.
- [x] Tasks that was not in issue, but implemented in PR (upon discussing in CZO): Smaller names mean in length; Wildcards are put at the bottom if PM is a 1:1 DM, otherwise (Group DM) following the natural flow.  

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Streams Before:

![image](https://github.com/user-attachments/assets/6a8894e3-0a86-4d54-ba1a-ca9c57e2e831)

Streams After (There are also users below wildcard, just not visible in this pic):

![image](https://github.com/user-attachments/assets/1ea0c1a9-f73f-4280-bbaf-05b8e7d15989)

1:1 DMs now:

![image](https://github.com/user-attachments/assets/ea95e81a-94fc-47c2-a85c-a97b92af53b6)

Group DMs now:

![image](https://github.com/user-attachments/assets/01271d2c-1e0a-4afc-b351-84d6fb521d4e)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
