### PR TITLE
test_classes: Refine assert_json_success output with exception chaining

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -55,6 +55,7 @@ from zerver.lib.message import access_message
 from zerver.lib.notification_data import UserMessageNotificationsData
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.lib.redis_utils import bounce_redis_key_prefix_for_testing
+from zerver.lib.response import MutableJsonResponse
 from zerver.lib.sessions import get_session_dict_user
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.stream_subscription import get_subscribed_stream_ids_for_user
@@ -1230,23 +1231,32 @@ Output:
             json = orjson.loads(result.content)
         except orjson.JSONDecodeError:  # nocoverage
             json = {"msg": "Error parsing JSON in response!"}
-        self.assertEqual(result.status_code, 200, json["msg"])
-        self.assertEqual(json.get("result"), "success")
-        # We have a msg key for consistency with errors, but it typically has an
-        # empty value.
-        self.assertIn("msg", json)
-        self.assertNotEqual(json["msg"], "Error parsing JSON in response!")
-        # Check ignored parameters.
-        if ignored_parameters is None:
-            self.assertNotIn("ignored_parameters_unsupported", json)
-        else:
-            self.assertIn("ignored_parameters_unsupported", json)
-            self.assert_length(json["ignored_parameters_unsupported"], len(ignored_parameters))
-            for param in ignored_parameters:
-                self.assertTrue(param in json["ignored_parameters_unsupported"])
+
+        try:
+            self.assertEqual(result.status_code, 200, json["msg"])
+            self.assertEqual(json.get("result"), "success")
+            # We have a msg key for consistency with errors, but it typically has an
+            # empty value.
+            self.assertIn("msg", json)
+            self.assertNotEqual(json["msg"], "Error parsing JSON in response!")
+            # Check ignored parameters.
+            if ignored_parameters is None:
+                self.assertNotIn("ignored_parameters_unsupported", json)
+            else:
+                self.assertIn("ignored_parameters_unsupported", json)
+                self.assert_length(json["ignored_parameters_unsupported"], len(ignored_parameters))
+                for param in ignored_parameters:
+                    self.assertTrue(param in json["ignored_parameters_unsupported"])
+        except AssertionError as e:  # nocoverage
+            if isinstance(result, MutableJsonResponse):
+                raise e from result.exception
+            raise
+
         return json
 
-    def get_json_error(self, result: "TestHttpResponse", status_code: int = 400) -> str:
+    def get_json_error(
+        self, result: Union["TestHttpResponse", HttpResponse], status_code: int = 400
+    ) -> str:
         try:
             json = orjson.loads(result.content)
         except orjson.JSONDecodeError:  # nocoverage
@@ -1256,13 +1266,18 @@ Output:
         return json["msg"]
 
     def assert_json_error(
-        self, result: "TestHttpResponse", msg: str, status_code: int = 400
+        self, result: Union["TestHttpResponse", HttpResponse], msg: str, status_code: int = 400
     ) -> None:
         """
         Invalid POSTs return an error status code and JSON of the form
         {"result": "error", "msg": "reason"}.
         """
-        self.assertEqual(self.get_json_error(result, status_code=status_code), msg)
+        try:
+            self.assertEqual(self.get_json_error(result, status_code=status_code), msg)
+        except AssertionError as e:  # nocoverage
+            if isinstance(result, MutableJsonResponse):
+                raise e from result.exception
+            raise
 
     def assert_length(self, items: Collection[Any] | QuerySet[Any, Any], count: int) -> None:
         actual_count = len(items)
@@ -1308,9 +1323,17 @@ Output:
             )
 
     def assert_json_error_contains(
-        self, result: "TestHttpResponse", msg_substring: str, status_code: int = 400
+        self,
+        result: Union["TestHttpResponse", HttpResponse],
+        msg_substring: str,
+        status_code: int = 400,
     ) -> None:
-        self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
+        try:
+            self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
+        except AssertionError as e:  # nocoverage
+            if isinstance(result, MutableJsonResponse):
+                raise e from result.exception
+            raise
 
     def assert_in_response(
         self, substring: str, response: Union["TestHttpResponse", HttpResponse]

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -392,7 +392,9 @@ class JsonErrorHandler(MiddlewareMixin):
                 # just return the response without logging further.
                 return response
         elif RequestNotes.get_notes(request).error_format == "JSON" and not settings.TEST_SUITE:
-            response = json_response(res_type="error", msg=_("Internal server error"), status=500)
+            response = json_response(
+                res_type="error", msg=_("Internal server error"), status=500, exception=exception
+            )
         else:
             return None
 


### PR DESCRIPTION
Now a failure from `assert_json_success` and friends shows the full server-side traceback from the `JsonableError` that caused the failure, not just the test-side traceback for `AssertionError: 400 != 200 : {message}`.

### Before

```pytb
======================================================================
FAIL: test_api (zerver.tests.test_users.ActivateTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip/zerver/tests/test_users.py", line 1830, in test_api
    self.assert_json_success(result)
  File "/srv/zulip/zerver/lib/test_classes.py", line 1233, in assert_json_success
    self.assertEqual(result.status_code, 200, json["msg"])
  File "/srv/zulip/zerver/lib/test_classes.py", line 296, in assertEqual
    super().assertEqual(first, second, msg)
AssertionError: 400 != 200 : Insufficient permission

----------------------------------------------------------------------
```

### After

```pytb
======================================================================
FAIL: test_api (zerver.tests.test_users.ActivateTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/srv/zulip/zerver/lib/rest.py", line 40, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "/srv/zulip/zerver/lib/rest.py", line 204, in rest_dispatch
    return target_function(request, **kwargs)
  File "/srv/zulip/zerver/decorator.py", line 851, in _wrapped_view_func
    return view_func(request, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/utils/decorators.py", line 188, in _view_wrapper
    result = _process_exception(request, e)
  File "/srv/zulip-py3-venv/lib/python3.10/site-packages/django/utils/decorators.py", line 186, in _view_wrapper
    response = view_func(request, *args, **kwargs)
  File "/srv/zulip/zerver/decorator.py", line 916, in _wrapped_view_func
    return view_func(request, user_profile, *args, **kwargs)
  File "/srv/zulip/zerver/lib/typed_endpoint.py", line 545, in _wrapped_view_func
    return_value = view_func(request, *args, **kwargs)
  File "/srv/zulip/zerver/views/users.py", line 125, in deactivate_user_backend
    target = access_user_by_id(user_profile, user_id, for_admin=True)
  File "/srv/zulip/zerver/lib/users.py", line 320, in access_user_by_id
    return access_user_common(target, user_profile, allow_deactivated, allow_bots, for_admin)
  File "/srv/zulip/zerver/lib/users.py", line 298, in access_user_common
    raise JsonableError(_("Insufficient permission"))
zerver.lib.exceptions.JsonableError: Insufficient permission

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/srv/zulip/zerver/tests/test_users.py", line 1830, in test_api
    self.assert_json_success(result)
  File "/srv/zulip/zerver/lib/test_classes.py", line 1252, in assert_json_success
    raise e from result.exception
  File "/srv/zulip/zerver/lib/test_classes.py", line 1236, in assert_json_success
    self.assertEqual(result.status_code, 200, json["msg"])
  File "/srv/zulip/zerver/lib/test_classes.py", line 297, in assertEqual
    super().assertEqual(first, second, msg)
AssertionError: 400 != 200 : Insufficient permission

----------------------------------------------------------------------
```