### PR TITLE
stream: Only realm admins can change default channels.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -922,25 +922,17 @@ export function check_group_property_changed(elem: HTMLElement, group: UserGroup
     const property_name = extract_property_name($elem) as keyof UserGroup;
     const current_val = get_group_property_value(property_name, group);
     let proposed_val;
-    switch (property_name) {
-        case "can_add_members_group":
-        case "can_join_group":
-        case "can_leave_group":
-        case "can_manage_group":
-        case "can_mention_group":
-        case "can_remove_members_group": {
-            const pill_widget = get_group_setting_widget(property_name);
-            assert(pill_widget !== null);
-            proposed_val = get_group_setting_widget_value(pill_widget);
-            break;
-        }
-        default:
-            if (current_val !== undefined) {
-                proposed_val = get_input_element_value(elem, typeof current_val);
-            } else {
-                blueslip.error("Element refers to unknown property", {property_name});
-            }
+
+    if (Object.keys(realm.server_supported_permission_settings.group).includes(property_name)) {
+        const pill_widget = get_group_setting_widget(property_name);
+        assert(pill_widget !== null);
+        proposed_val = get_group_setting_widget_value(pill_widget);
+    } else if (current_val !== undefined) {
+        proposed_val = get_input_element_value(elem, typeof current_val);
+    } else {
+        blueslip.error("Element refers to unknown property", {property_name});
     }
+
     return !_.isEqual(current_val, proposed_val);
 }
 

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -859,14 +859,15 @@ export function check_stream_settings_property_changed(
     const property_name = extract_property_name($elem) as StreamSettingProperty;
     const current_val = get_stream_settings_property_value(property_name, sub);
     let proposed_val;
+
+    if (Object.keys(realm.server_supported_permission_settings.stream).includes(property_name)) {
+        const pill_widget = get_group_setting_widget(property_name);
+        assert(pill_widget !== null);
+        proposed_val = get_group_setting_widget_value(pill_widget);
+        return !_.isEqual(current_val, proposed_val);
+    }
+
     switch (property_name) {
-        case "can_remove_subscribers_group":
-        case "can_administer_channel_group": {
-            const pill_widget = get_group_setting_widget(property_name);
-            assert(pill_widget !== null);
-            proposed_val = get_group_setting_widget_value(pill_widget);
-            break;
-        }
         case "message_retention_days":
             assert(elem instanceof HTMLSelectElement);
             proposed_val = get_message_retention_setting_value($(elem), false);

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -602,17 +602,19 @@ export function discard_stream_property_element_changes(
         stream_settings_property_schema.parse(property_name),
         sub,
     );
+
+    if (Object.keys(realm.server_supported_permission_settings.stream).includes(property_name)) {
+        const pill_widget = settings_components.get_group_setting_widget(property_name);
+        assert(pill_widget !== null);
+        settings_components.set_group_setting_widget_value(
+            pill_widget,
+            group_setting_value_schema.parse(property_value),
+        );
+        update_dependent_subsettings(property_name);
+        return;
+    }
+
     switch (property_name) {
-        case "can_remove_subscribers_group":
-        case "can_administer_channel_group": {
-            const pill_widget = settings_components.get_group_setting_widget(property_name);
-            assert(pill_widget !== null);
-            settings_components.set_group_setting_widget_value(
-                pill_widget,
-                group_setting_value_schema.parse(property_value),
-            );
-            break;
-        }
         case "stream_privacy": {
             assert(typeof property_value === "string");
             $elem.find(`input[value='${CSS.escape(property_value)}']`).prop("checked", true);

--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -20,6 +20,7 @@ import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
 import * as settings_notifications from "./settings_notifications.ts";
+import {realm} from "./state_data.ts";
 import * as stream_color_events from "./stream_color_events.ts";
 import * as stream_create from "./stream_create.ts";
 import * as stream_data from "./stream_data.ts";
@@ -27,8 +28,10 @@ import * as stream_list from "./stream_list.ts";
 import * as stream_muting from "./stream_muting.ts";
 import * as stream_settings_api from "./stream_settings_api.ts";
 import * as stream_settings_ui from "./stream_settings_ui.ts";
+import {stream_permission_group_settings_schema} from "./stream_types.ts";
 import * as sub_store from "./sub_store.ts";
 import type {StreamSubscription} from "./sub_store.ts";
+import {group_setting_value_schema} from "./types.ts";
 import * as unread_ui from "./unread_ui.ts";
 import * as user_profile from "./user_profile.ts";
 
@@ -78,6 +81,15 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
             property,
             value,
         });
+        return;
+    }
+
+    if (Object.keys(realm.server_supported_permission_settings.stream).includes(property)) {
+        stream_settings_ui.update_stream_permission_group_setting(
+            stream_permission_group_settings_schema.parse(property),
+            sub,
+            group_setting_value_schema.parse(value),
+        );
         return;
     }
 
@@ -145,23 +157,9 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
         message_retention_days(value) {
             stream_settings_ui.update_message_retention_setting(sub, value);
         },
-        can_remove_subscribers_group(value) {
-            stream_settings_ui.update_stream_permission_group_setting(
-                "can_remove_subscribers_group",
-                sub,
-                value,
-            );
-        },
         is_recently_active(value) {
             update_stream_setting(sub, value, "is_recently_active");
             stream_list.update_streams_sidebar();
-        },
-        can_administer_channel_group(value) {
-            stream_settings_ui.update_stream_permission_group_setting(
-                "can_administer_channel_group",
-                sub,
-                value,
-            );
         },
     };
 

--- a/web/tests/lib/example_settings.cjs
+++ b/web/tests/lib/example_settings.cjs
@@ -1,0 +1,40 @@
+"use strict";
+
+exports.server_supported_permission_settings = {
+    stream: {
+        can_administer_channel_group: {
+            require_system_group: true,
+            allow_internet_group: false,
+            allow_nobody_group: true,
+            allow_everyone_group: false,
+            default_group_name: "stream_creator_or_nobody",
+            allowed_system_groups: [],
+        },
+        can_remove_subscribers_group: {
+            require_system_group: true,
+            allow_internet_group: false,
+            allow_nobody_group: false,
+            allow_everyone_group: true,
+            default_group_name: "role:administrators",
+            allowed_system_groups: [],
+        },
+    },
+    realm: {
+        create_multiuse_invite_group: {
+            require_system_group: true,
+            allow_internet_group: false,
+            allow_nobody_group: true,
+            allow_everyone_group: false,
+            default_group_name: "role:administrators",
+            allowed_system_groups: [],
+        },
+        can_access_all_users_group: {
+            require_system_group: true,
+            allow_internet_group: false,
+            allow_nobody_group: false,
+            allow_everyone_group: true,
+            default_group_name: "role:everyone",
+            allowed_system_groups: ["role:everyone", "role:members"],
+        },
+    },
+};

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 
+const example_settings = require("./lib/example_settings.cjs");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {make_stub} = require("./lib/stub.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
@@ -52,8 +53,9 @@ const stream_create = zrequire("stream_create");
 const stream_data = zrequire("stream_data");
 const stream_events = zrequire("stream_events");
 
+const realm = {};
 set_current_user({});
-set_realm({});
+set_realm(realm);
 
 const george = {
     email: "george@zulip.com",
@@ -106,7 +108,11 @@ function test(label, f) {
 test("update_property", ({override}) => {
     override(compose_recipient, "possibly_update_stream_name_in_compose", noop);
     override(compose_recipient, "on_compose_select_recipient_update", noop);
-
+    override(
+        realm,
+        "server_supported_permission_settings",
+        example_settings.server_supported_permission_settings,
+    );
     const sub = {...frontend};
     stream_data.add_sub(sub);
 

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 
+const example_settings = require("./lib/example_settings.cjs");
 const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
@@ -542,44 +543,11 @@ run_test("get_realm_user_groups_for_dropdown_list_widget", ({override}) => {
         direct_subgroup_ids: new Set([4, 5]),
     };
 
-    override(realm, "server_supported_permission_settings", {
-        stream: {
-            can_administer_channel_group: {
-                require_system_group: true,
-                allow_internet_group: false,
-                allow_nobody_group: true,
-                allow_everyone_group: false,
-                default_group_name: "stream_creator_or_nobody",
-                allowed_system_groups: [],
-            },
-            can_remove_subscribers_group: {
-                require_system_group: true,
-                allow_internet_group: false,
-                allow_nobody_group: false,
-                allow_everyone_group: true,
-                default_group_name: "role:administrators",
-                allowed_system_groups: [],
-            },
-        },
-        realm: {
-            create_multiuse_invite_group: {
-                require_system_group: true,
-                allow_internet_group: false,
-                allow_nobody_group: true,
-                allow_everyone_group: false,
-                default_group_name: "role:administrators",
-                allowed_system_groups: [],
-            },
-            can_access_all_users_group: {
-                require_system_group: true,
-                allow_internet_group: false,
-                allow_nobody_group: false,
-                allow_everyone_group: true,
-                default_group_name: "role:everyone",
-                allowed_system_groups: ["role:everyone", "role:members"],
-            },
-        },
-    });
+    override(
+        realm,
+        "server_supported_permission_settings",
+        example_settings.server_supported_permission_settings,
+    );
 
     let expected_groups_list = [
         {name: "translated: Admins, moderators, members and guests", unique_id: 6},

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -743,3 +743,13 @@ class CannotAdministerChannelError(JsonableError):
     @override
     def msg_format() -> str:
         return _("You do not have permission to administer this channel.")
+
+
+class CannotManageDefaultChannelError(JsonableError):
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("You do not have permission to change default channels.")

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -877,6 +877,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
             return False
         return self.has_permission("can_create_web_public_channel_group")
 
+    def can_manage_default_streams(self) -> bool:
+        return self.is_realm_admin
+
     def can_subscribe_other_users(self) -> bool:
         return self.has_permission("invite_to_stream_policy")
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -45,7 +45,11 @@ from zerver.context_processors import get_valid_realm_from_request
 from zerver.decorator import require_non_guest_user, require_realm_admin
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.email_mirror_helpers import encode_email_address
-from zerver.lib.exceptions import JsonableError, OrganizationOwnerRequiredError
+from zerver.lib.exceptions import (
+    CannotManageDefaultChannelError,
+    JsonableError,
+    OrganizationOwnerRequiredError,
+)
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.message import bulk_access_stream_messages_query
 from zerver.lib.response import json_success
@@ -345,6 +349,8 @@ def update_stream_backend(
         )
 
     if is_default_stream is not None:
+        if not user_profile.can_manage_default_streams():
+            raise CannotManageDefaultChannelError
         if is_default_stream:
             do_add_default_stream(stream)
         else:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

I've kept the switch case around where possible since it feels more readable than a long list of if conditions.

- First commit fixes the bug mentioned in https://github.com/zulip/zulip/pull/32429#issuecomment-2516045904.
- Second commit loops over stream permission group settings for some files.
- For third commit, I saw an opportunity to loop over user group group settings at one place and just added a commit for that. Those group of settings could have further similar optimisations but i haven't looked into it.
- 4th commit loops over stream permission group settings for stream_events.
- 5th commit loops over stream permission group settings for test_events.
- 6th commit shifts the realm admin check to `can_administer_channel`, not sure if the `stream.realm_id != user_profile.realm_id` check should also be inside that.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
