### PR TITLE
user_groups: Refactor code creating group objects for creation events.

### DIFF
--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -176,6 +176,12 @@ def do_send_create_user_group_event(
     assert user_group.date_created is not None
     date_created = datetime_to_timestamp(user_group.date_created)
 
+    setting_values = {}
+    for setting_name in NamedUserGroup.GROUP_PERMISSION_SETTINGS:
+        setting_values[setting_name] = get_group_setting_value_for_api(
+            getattr(user_group, setting_name)
+        )
+
     event = dict(
         type="user_group",
         op="add",
@@ -188,14 +194,7 @@ def do_send_create_user_group_event(
             id=user_group.id,
             is_system_group=user_group.is_system_group,
             direct_subgroup_ids=[direct_subgroup.id for direct_subgroup in direct_subgroups],
-            can_add_members_group=get_group_setting_value_for_api(user_group.can_add_members_group),
-            can_join_group=get_group_setting_value_for_api(user_group.can_join_group),
-            can_leave_group=get_group_setting_value_for_api(user_group.can_leave_group),
-            can_manage_group=get_group_setting_value_for_api(user_group.can_manage_group),
-            can_mention_group=get_group_setting_value_for_api(user_group.can_mention_group),
-            can_remove_members_group=get_group_setting_value_for_api(
-                user_group.can_remove_members_group
-            ),
+            **setting_values,
             deactivated=False,
         ),
     )


### PR DESCRIPTION
This PR refactors code to use a loop over `GROUP_PERMISSION_SETTINGS`
for adding setting values to the group objects sent in group creation events.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
