### PR TITLE
zerver: Remove unnecessary tusd logs during run-dev startup.

### DIFF
--- a/zerver/management/commands/runtusd.py
+++ b/zerver/management/commands/runtusd.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
             "-hooks-http-forward-headers=Cookie,Authorization",
             "--hooks-enabled-events=pre-create,pre-finish",
             "-disable-download",
+            "--show-startup-logs=false",
         ]
         env_vars = os.environ.copy()
         if settings.LOCAL_UPLOADS_DIR is not None:


### PR DESCRIPTION
Previously, tusd printed unnecessary logs on startup while running the tools/run-dev script. This commit resolves the issue by setting the verbose flag to false, which defaults to true if not specified.

The required PR adding this flag was introduced in https://github.com/tus/tusd/pull/1218.

Fixes #32301.

**This PR requires updating tusd version to https://github.com/tus/tusd/releases/tag/v2.6.0**

Related Discussions:
https://chat.zulip.org/#narrow/channel/3-backend/topic/Verbose.20tusd.20output/near/1983986

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/0ed0f4a2-299f-42e4-9371-f88dd43afc9d)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
