### PR TITLE
help: Add a page on managing a user's group membership.

### DIFF
--- a/help/include/add-users-to-a-group.md
+++ b/help/include/add-users-to-a-group.md
@@ -1,0 +1,16 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|group|all}
+
+1. Select a user group.
+
+1. Select the **Members** tab on the right.
+
+1. Under **Add members**, enter users you want to add. You can enter a
+   `#channel` to add all subscribers to the group.
+
+1. Click **Add**. Zulip will notify everyone who is added to the group.
+
+{end_tabs}

--- a/help/include/depends-on-permissions.md
+++ b/help/include/depends-on-permissions.md
@@ -1,0 +1,4 @@
+!!! warn ""
+
+    You will see the options described only if you have permission
+    to take this action.

--- a/help/include/remove-from-a-group.md
+++ b/help/include/remove-from-a-group.md
@@ -1,0 +1,26 @@
+{start_tabs}
+
+{tab|via-group-settings}
+
+{relative|group|all}
+
+1. Select a user group.
+
+1. Select the **Members** tab on the right.
+
+1. Under **Members**, find the user or group you would like to remove.
+
+1. Click the **Remove** button in that row. Zulip will notify everyone who is
+   removed from the group.
+
+{tab|via-user-profile}
+
+{!right-sidebar-view-profile.md!}
+
+1. Select the **User groups** tab.
+
+1. Find the group you would like to remove the user from.
+
+1. Click the **Remove** button in that row.
+
+{end_tabs}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -199,6 +199,7 @@
 * [Change a user's role](/help/change-a-users-role)
 * [Change a user's name](/help/change-a-users-name)
 * [Manage a user's channel subscriptions](/help/manage-user-channel-subscriptions)
+* [Manage a user's group membership](/help/manage-user-group-membership)
 * [Restrict name and email changes](/help/restrict-name-and-email-changes)
 * [Restrict profile picture changes](/help/restrict-profile-picture-changes)
 * [Restrict permissions of new members](/help/restrict-permissions-of-new-members)

--- a/help/manage-user-channel-subscriptions.md
+++ b/help/manage-user-channel-subscriptions.md
@@ -17,9 +17,7 @@
 
 ## Subscribe a user to a channel
 
-Organization administrators can configure which
-[roles](/help/roles-and-permissions) have access to [subscribe
-other users to a channel][configure-invites].
+{!depends-on-permissions.md!}
 
 {start_tabs}
 
@@ -92,5 +90,3 @@ channel](/help/unsubscribe-from-a-channel).
 * [Add or remove users from a channel](/help/add-or-remove-users-from-a-channel)
 * [Unsubscribe from a channel](/help/unsubscribe-from-a-channel)
 * [View channel subscribers](/help/view-channel-subscribers)
-
-[configure-invites]: /help/configure-who-can-invite-to-channels

--- a/help/manage-user-group-membership.md
+++ b/help/manage-user-group-membership.md
@@ -1,0 +1,33 @@
+# Manage a user's group membership
+
+## View a user's group membership
+
+{start_tabs}
+
+{!right-sidebar-view-profile.md!}
+
+1. Select the **User groups** tab.
+
+{end_tabs}
+
+## Add a user to a group
+
+{!depends-on-permissions.md!}
+
+{!add-users-to-a-group.md!}
+
+## Remove user or group from a group
+
+{!depends-on-permissions.md!}
+
+{!remove-from-a-group.md!}
+
+## Related articles
+
+* [User groups](/help/user-groups)
+* [Manage user groups](/help/user-groups)
+* [Mention a user or group](/help/mention-a-user-or-group)
+* [Create user groups](/help/create-user-groups)
+* [Roles and permissions](/help/roles-and-permissions)
+
+[configure-invites]: /help/configure-who-can-invite-to-channels

--- a/help/manage-user-groups.md
+++ b/help/manage-user-groups.md
@@ -66,22 +66,7 @@
 
 ## Add users to a group
 
-{start_tabs}
-
-{tab|desktop-web}
-
-{relative|group|all}
-
-1. Select a user group.
-
-1. Select the **Members** tab on the right.
-
-1. Under **Add members**, enter users you want to add. You can enter a
-   `#channel` to add all subscribers to the group.
-
-1. Click **Add**. Zulip will notify everyone who is added to the group.
-
-{end_tabs}
+{!add-users-to-a-group.md!}
 
 ## Add user groups to a group
 
@@ -107,7 +92,7 @@
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-group-settings}
 
 {relative|group|all}
 
@@ -119,6 +104,16 @@
 
 1. Click the **Remove** button in that row. Zulip will notify everyone who is
    removed from the group.
+
+{tab|via-user-profile}
+
+{!right-sidebar-view-profile.md!}
+
+1. Select the **User groups** tab.
+
+1. Find the group you would like to remove the user from.
+
+1. Click the **Remove** button in that row.
 
 {end_tabs}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -88,6 +88,7 @@ TAB_SECTION_LABELS = {
     "via-organization-settings": "Via organization settings",
     "via-personal-settings": "Via personal settings",
     "via-channel-settings": "Via channel settings",
+    "via-group-settings": "Via group settings",
     "via-compose-box": "Via compose box",
     "default-subdomain": "Default subdomain",
     "custom-subdomain": "Custom subdomain",


### PR DESCRIPTION
Styling in the screenshots being messed up should be unrelated, and was reported separately.

Current: https://zulip.com/help/manage-user-channel-subscriptions#subscribe-a-user-to-a-channel
<details>
<summary>
Updated
</summary>

![Screenshot 2024-12-04 at 13 09 57@2x](https://github.com/user-attachments/assets/8a96e3a6-4d71-4aad-a1ab-acddbe244f0c)

</details>


<details>
<summary>
New page
</summary>

![Screenshot 2024-12-04 at 13 11 32@2x](https://github.com/user-attachments/assets/8858e220-f761-432d-8434-1ee40f095ba1)

![Screenshot 2024-12-04 at 13 11 54@2x](https://github.com/user-attachments/assets/331bb51f-f0d2-4405-ac18-b776eec49822)

</details>

<details>
<summary>
Left sidebar
</summary>
![Screenshot 2024-12-04 at 13 10 32@2x](https://github.com/user-attachments/assets/09c7802d-91e0-43b2-949f-d02a8f8041e0)


</details>