### PR TITLE
settings_config: Allow using new user list style in production.

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -90,14 +90,11 @@ export const user_list_style_values: {
         code: 2,
         description: $t({defaultMessage: "Show status text"}),
     },
-};
-
-if (page_params.development_environment) {
-    user_list_style_values.with_avatar = {
+    with_avatar: {
         code: 3,
         description: $t({defaultMessage: "Show avatar"}),
-    };
-}
+    },
+};
 
 export const web_animate_image_previews_values = {
     always: {


### PR DESCRIPTION
We've fixed the various issues that made us leave this disabled by default.
