### PR TITLE
message_forwarding: Make forward message keep original topic by default.

### DIFF
--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -249,10 +249,14 @@ export function quote_message(opts: {
             : $<HTMLTextAreaElement>("textarea#compose-textarea");
 
     if (opts.forward_message) {
-        // Setting the stream_id to undefined will automatically open the recipient popover
+        let topic = "";
+        if (message.is_stream) {
+            topic = message.topic;
+        }
+
         compose_actions.start({
             message_type: message.type,
-            topic: "",
+            topic,
             keep_composebox_empty: opts.keep_composebox_empty,
             content: quoting_placeholder,
         });

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -250,8 +250,10 @@ export function quote_message(opts: {
 
     if (opts.forward_message) {
         let topic = "";
+        let stream_id: number | undefined;
         if (message.is_stream) {
             topic = message.topic;
+            stream_id = message.stream_id;
         }
 
         compose_actions.start({
@@ -259,6 +261,8 @@ export function quote_message(opts: {
             topic,
             keep_composebox_empty: opts.keep_composebox_empty,
             content: quoting_placeholder,
+            stream_id,
+            private_message_recipient: people.pm_reply_to(message) ?? "",
         });
         compose_recipient.open_compose_recipient_dropdown();
     } else {

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -440,7 +440,6 @@ run_test("quote_message", ({override, override_rewire}) => {
     let new_message = false;
     override_rewire(compose_actions, "start", (opts) => {
         assert.equal(opts.message_type, "stream");
-        assert.equal(opts.topic, "");
         assert.equal(opts.content, "translated: [Quoting…]");
         new_message = true;
     });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR makes forwarded messages keep their original topic in the topic field, as proposed in [CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/Explaining.20quote-and-reply/near/1993494)

Fixes: https://chat.zulip.org/#narrow/channel/101-design/topic/Explaining.20quote-and-reply/near/1993494 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Recording 2024-12-05 095708](https://github.com/user-attachments/assets/4477b8c5-4a4c-4f1a-8a3c-967083455c0a)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
