### PR TITLE
streams: Allow specifying sender for channel email generation.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 335**
+
+* [`GET /streams/{stream_id}/email_address`](/api/get-stream-email-address):
+  Added an optional `sender_id` parameter to specify the ID of a user or bot
+  which should appear as the sender when messages are sent to the channel using
+  the returned channel email address.
+
 **Feature level 334**
 
 * [`POST /register`](/api/register-queue): Added

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 334  # Last bumped for adding empty_topic_name client capability.
+API_FEATURE_LEVEL = 335  # Last bumped for adding sender_id in get channel email address endpoint.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -48,17 +48,17 @@ def get_email_gateway_message_string_from_address(address: str) -> str:
     return msg_string
 
 
-def encode_email_address(stream: Stream, show_sender: bool = False) -> str:
+def get_channel_email_token(stream: Stream) -> str:
     channel_email_address, ignored = ChannelEmailAddress.objects.get_or_create(
         realm=stream.realm,
         channel=stream,
         creator=stream.creator,
         sender=get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
     )
-    return encode_email_address_helper(stream.name, channel_email_address.email_token, show_sender)
+    return channel_email_address.email_token
 
 
-def encode_email_address_helper(name: str, email_token: str, show_sender: bool = False) -> str:
+def encode_email_address(name: str, email_token: str, show_sender: bool = False) -> str:
     # Some deployments may not use the email gateway
     if settings.EMAIL_GATEWAY_PATTERN == "":
         return ""

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -5,8 +5,7 @@ from typing import Any
 from django.conf import settings
 from django.utils.text import slugify
 
-from zerver.models import ChannelEmailAddress, Stream
-from zerver.models.users import get_system_bot
+from zerver.models import ChannelEmailAddress, Stream, UserProfile
 
 
 def default_option_handler_factory(address_option: str) -> Callable[[dict[str, Any]], None]:
@@ -48,12 +47,12 @@ def get_email_gateway_message_string_from_address(address: str) -> str:
     return msg_string
 
 
-def get_channel_email_token(stream: Stream) -> str:
+def get_channel_email_token(stream: Stream, *, creator: UserProfile, sender: UserProfile) -> str:
     channel_email_address, ignored = ChannelEmailAddress.objects.get_or_create(
         realm=stream.realm,
         channel=stream,
-        creator=stream.creator,
-        sender=get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
+        creator=creator,
+        sender=sender,
     )
     return channel_email_address.email_token
 

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -11,7 +11,7 @@ from django.core.management.base import CommandError, CommandParser
 from typing_extensions import override
 
 from zerver.lib.email_mirror import mirror_email_message
-from zerver.lib.email_mirror_helpers import encode_email_address
+from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.management import ZulipBaseCommand
 from zerver.models import Realm
 from zerver.models.realms import get_realm
@@ -111,6 +111,7 @@ Example:
 
     def _prepare_message(self, message: EmailMessage, realm: Realm, stream_name: str) -> None:
         stream = get_stream(stream_name, realm)
+        email_token = get_channel_email_token(stream)
 
         # The block below ensures that the imported email message doesn't have any recipient-like
         # headers that are inconsistent with the recipient we want (the stream address).
@@ -125,8 +126,8 @@ Example:
         for header in recipient_headers:
             if header in message:
                 del message[header]
-                message[header] = encode_email_address(stream)
+                message[header] = encode_email_address(stream.name, email_token)
 
         if "To" in message:
             del message["To"]
-        message["To"] = encode_email_address(stream)
+        message["To"] = encode_email_address(stream.name, email_token)

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -13,9 +13,10 @@ from typing_extensions import override
 from zerver.lib.email_mirror import mirror_email_message
 from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.management import ZulipBaseCommand
-from zerver.models import Realm
+from zerver.models import Realm, UserProfile
 from zerver.models.realms import get_realm
 from zerver.models.streams import get_stream
+from zerver.models.users import get_system_bot, get_user_profile_by_email, get_user_profile_by_id
 
 # This command loads an email from a specified file and sends it
 # to the email mirror. Simple emails can be passed in a JSON file,
@@ -55,11 +56,17 @@ Example:
             help="The name of the stream to which you'd like to send "
             "the message. Default: Denmark",
         )
+        parser.add_argument(
+            "--sender-id",
+            type=int,
+            help="The ID of a user or bot which should appear as the sender; "
+            "Default: ID of Email gateway bot",
+        )
 
         self.add_realm_args(parser, help="Specify which realm to connect to; default is zulip")
 
     @override
-    def handle(self, *args: Any, **options: str | None) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         if options["fixture"] is None:
             self.print_help("./manage.py", "send_to_email_mirror")
             raise CommandError
@@ -73,11 +80,25 @@ Example:
         if realm is None:
             realm = get_realm("zulip")
 
+        email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT, realm.id)
+        if options["sender_id"] is None:
+            sender = email_gateway_bot
+        else:
+            sender = get_user_profile_by_id(options["sender_id"])
+
         full_fixture_path = os.path.join(settings.DEPLOY_ROOT, options["fixture"])
 
         # parse the input email into EmailMessage type and prepare to process_message() it
         message = self._parse_email_fixture(full_fixture_path)
-        self._prepare_message(message, realm, stream)
+        creator = get_user_profile_by_email(message["From"])
+        if (
+            sender.id not in [creator.id, email_gateway_bot.id]
+            and sender.bot_owner_id != creator.id
+        ):
+            raise CommandError(
+                "The sender ID must be either the current user's ID, the email gateway bot's ID, or the ID of a bot owned by the user."
+            )
+        self._prepare_message(message, realm, stream, creator, sender)
 
         mirror_email_message(
             message["To"].addresses[0].addr_spec,
@@ -109,9 +130,16 @@ Example:
                     _class=EmailMessage, policy=email.policy.default
                 ).parse(fp)
 
-    def _prepare_message(self, message: EmailMessage, realm: Realm, stream_name: str) -> None:
+    def _prepare_message(
+        self,
+        message: EmailMessage,
+        realm: Realm,
+        stream_name: str,
+        creator: UserProfile,
+        sender: UserProfile,
+    ) -> None:
         stream = get_stream(stream_name, realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=creator, sender=sender)
 
         # The block below ensures that the imported email message doesn't have any recipient-like
         # headers that are inconsistent with the recipient we want (the stream address).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20390,6 +20390,25 @@ paths:
         **Changes**: New in Zulip 8.0 (feature level 226).
       parameters:
         - $ref: "#/components/parameters/ChannelIdInPath"
+        - name: sender_id
+          in: query
+          description: |
+            The ID of a user or bot which should appear as the sender when messages
+            are sent to the channel using the returned channel email address.
+
+            `sender_id` can be:
+
+            - ID of the current user.
+            - ID of the Email gateway bot. (Default value)
+            - ID of a bot owned by the current user.
+
+            **Changes**: New in Zulip 10.0 (feature level 335).
+
+            Previously, the sender was always Email gateway bot.
+          schema:
+            type: integer
+          example: 1
+          required: false
       responses:
         "200":
           description: Success.

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -14,7 +14,7 @@ from django.conf import settings
 
 from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.actions.streams import do_change_stream_group_based_setting, do_deactivate_stream
-from zerver.actions.users import do_deactivate_user
+from zerver.actions.users import do_change_user_role, do_deactivate_user
 from zerver.lib.email_mirror import (
     create_missed_message_address,
     filter_footer,
@@ -75,7 +75,8 @@ class TestEncodeDecode(ZulipTestCase):
         realm = get_realm("zulip")
         stream_name = "dev. help"
         stream = ensure_stream(realm, stream_name, acting_user=None)
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         email_address = encode_email_address(stream.name, email_token)
         self.assertEqual(email_address, f"dev-help.{email_token}@testserver")
 
@@ -131,7 +132,8 @@ class TestEncodeDecode(ZulipTestCase):
         realm = get_realm("zulip")
         stream_name = "Тестовы some ascii letters"
         stream = ensure_stream(realm, stream_name, acting_user=None)
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         email_address = encode_email_address(stream.name, email_token)
 
         msg_string = get_email_gateway_message_string_from_address(email_address)
@@ -147,13 +149,14 @@ class TestEncodeDecode(ZulipTestCase):
 
         asciiable_stream_name = "ąężć"
         stream = ensure_stream(realm, asciiable_stream_name, acting_user=None)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         email_address = encode_email_address(stream.name, email_token)
         self.assertTrue(email_address.startswith("aezc."))
 
     def test_decode_ignores_stream_name(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         stream_to_address = encode_email_address(stream.name, email_token)
         stream_to_address = stream_to_address.replace("denmark", "Some_name")
 
@@ -163,7 +166,8 @@ class TestEncodeDecode(ZulipTestCase):
 
     def test_encode_with_show_sender(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         stream_to_address = encode_email_address(stream.name, email_token, show_sender=True)
 
         token, options = decode_email_address(stream_to_address)
@@ -172,7 +176,8 @@ class TestEncodeDecode(ZulipTestCase):
 
     def test_decode_prefer_text_options(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         encode_email_address(stream.name, email_token)
         address_prefer_text = f"Denmark.{email_token}.prefer-text@testserver"
         address_prefer_html = f"Denmark.{email_token}.prefer-html@testserver"
@@ -238,7 +243,8 @@ class TestStreamEmailMessages(ZulipTestCase):
     def create_incoming_valid_message(
         self, msgtext: str, stream: Stream, include_quotes: bool
     ) -> EmailMessage:
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         address = Address(addr_spec=encode_email_address(stream.name, email_token))
         email_username = address.username + "+show-sender"
         if include_quotes:
@@ -261,7 +267,7 @@ class TestStreamEmailMessages(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -290,7 +296,7 @@ class TestStreamEmailMessages(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -318,7 +324,7 @@ class TestStreamEmailMessages(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -346,7 +352,7 @@ class TestStreamEmailMessages(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -378,7 +384,7 @@ class TestStreamEmailMessages(ZulipTestCase):
         self.subscribe(user_profile, "private_stream")
         stream = get_stream("private_stream", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -405,7 +411,7 @@ class TestStreamEmailMessages(ZulipTestCase):
         stream = get_stream("Denmark", user_profile.realm)
 
         # stream address is angle-addr within multiple addresses
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_addresses = [
             "A.N. Other <another@example.org>",
             f"Denmark <{encode_email_address(stream.name, email_token)}>",
@@ -522,7 +528,7 @@ and other things
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         address = Address(addr_spec=encode_email_address(stream.name, email_token))
         email_username = address.username + "+show-sender"
         stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
@@ -554,7 +560,7 @@ and other things
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         address = Address(addr_spec=encode_email_address(stream.name, email_token))
         email_username = address.username + "+include-footer"
         stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
@@ -583,7 +589,7 @@ and other things
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         address = Address(addr_spec=encode_email_address(stream.name, email_token))
         email_username = address.username + "+include-quotes"
         stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
@@ -609,13 +615,199 @@ and other things
         self.assertEqual(message.topic_name(), incoming_valid_message["Subject"])
 
 
+class TestChannelEmailMessagesPermissions(ZulipTestCase):
+    def create_incoming_valid_message(self, channel_email_address: str) -> EmailMessage:
+        incoming_valid_message = EmailMessage()
+        incoming_valid_message.set_content("message body")
+        incoming_valid_message["Subject"] = "test subject"
+        incoming_valid_message["To"] = channel_email_address
+        return incoming_valid_message
+
+    def test_valid_sender_id(self) -> None:
+        hamlet = self.example_user("hamlet")
+        realm = get_realm("zulip")
+        channel = get_stream("Denmark", realm)
+        self.login("hamlet")
+
+        # Sender is the current user itself.
+        result = self.client_get(
+            f"/json/streams/{channel.id}/email_address", {"sender_id": hamlet.id}
+        )
+        self.assert_json_success(result)
+
+        # Sender is the Email gateway bot.
+        email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT, realm.id)
+        result = self.client_get(
+            f"/json/streams/{channel.id}/email_address", {"sender_id": email_gateway_bot.id}
+        )
+        self.assert_json_success(result)
+
+        # Sender is a bot owned by the current user.
+        bot = self.create_test_bot("test2", hamlet, full_name="Test bot")
+        assert bot.bot_owner is not None
+        self.assertEqual(bot.bot_owner.id, hamlet.id)
+        result = self.client_get(f"/json/streams/{channel.id}/email_address", {"sender_id": bot.id})
+        self.assert_json_success(result)
+
+        # Sender is a random user ID. (None of the above three cases)
+        othello = self.example_user("othello")
+        result = self.client_get(
+            f"/json/streams/{channel.id}/email_address", {"sender_id": othello.id}
+        )
+        self.assert_json_error(result, "No such bot")
+
+    def test_creator_with_send_message_permission(self) -> None:
+        hamlet = self.example_user("hamlet")
+        realm = get_realm("zulip")
+        channel = get_stream("Denmark", realm)
+
+        do_change_user_role(hamlet, UserProfile.ROLE_MODERATOR, acting_user=None)
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm=realm, is_system_group=True
+        )
+        do_change_stream_group_based_setting(
+            channel, "can_send_message_group", moderators_group, acting_user=hamlet
+        )
+
+        # Sender is the current user itself.
+        email_token = get_channel_email_token(channel, creator=hamlet, sender=hamlet)
+        channel_email_address = encode_email_address(channel.name, email_token)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Successfully processed email to {channel.name} ({realm.string_id})"
+            ],
+        )
+
+        # Sender is the Email gateway bot.
+        email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT, realm.id)
+        email_token = get_channel_email_token(channel, creator=hamlet, sender=email_gateway_bot)
+        channel_email_address = encode_email_address(channel.name, email_token)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Successfully processed email to {channel.name} ({realm.string_id})"
+            ],
+        )
+
+        # Sender is a bot owned by the current user + has NO post permission.
+        bot = self.create_test_bot("test2", hamlet, full_name="Test bot")
+        assert bot.bot_owner is not None
+        self.assertEqual(bot.bot_owner.id, hamlet.id)
+        email_token = get_channel_email_token(channel, creator=hamlet, sender=bot)
+        channel_email_address = encode_email_address(channel.name, email_token)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Successfully processed email to {channel.name} ({realm.string_id})"
+            ],
+        )
+
+        # Sender is a bot owned by the current user + has the post permission.
+        do_change_user_role(bot, UserProfile.ROLE_MODERATOR, acting_user=None)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Successfully processed email to {channel.name} ({realm.string_id})"
+            ],
+        )
+
+    def test_creator_without_send_message_permission(self) -> None:
+        hamlet = self.example_user("hamlet")
+        realm = get_realm("zulip")
+        channel = get_stream("Denmark", realm)
+
+        do_change_user_role(hamlet, UserProfile.ROLE_MODERATOR, acting_user=None)
+        admins_group = NamedUserGroup.objects.get(
+            name=SystemGroups.ADMINISTRATORS, realm=realm, is_system_group=True
+        )
+        do_change_stream_group_based_setting(
+            channel, "can_send_message_group", admins_group, acting_user=hamlet
+        )
+
+        # Sender is the current user itself.
+        email_token = get_channel_email_token(channel, creator=hamlet, sender=hamlet)
+        channel_email_address = encode_email_address(channel.name, email_token)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Failed to process email to {channel.name} ({realm.string_id}): You do not have permission to post in this channel."
+            ],
+        )
+
+        # Sender is the Email gateway bot.
+        email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT, realm.id)
+        email_token = get_channel_email_token(channel, creator=hamlet, sender=email_gateway_bot)
+        channel_email_address = encode_email_address(channel.name, email_token)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Failed to process email to {channel.name} ({realm.string_id}): You do not have permission to post in this channel."
+            ],
+        )
+
+        # Sender is a bot owned by the current user + has NO post permission.
+        bot = self.create_test_bot("test2", hamlet, full_name="Test bot")
+        assert bot.bot_owner is not None
+        self.assertEqual(bot.bot_owner.id, hamlet.id)
+        email_token = get_channel_email_token(channel, creator=hamlet, sender=bot)
+        channel_email_address = encode_email_address(channel.name, email_token)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Failed to process email to {channel.name} ({realm.string_id}): You do not have permission to post in this channel."
+            ],
+        )
+
+        # Sender is a bot owned by the current user + has the post permission.
+        do_change_user_role(bot, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        incoming_valid_message = self.create_incoming_valid_message(channel_email_address)
+
+        with self.assertLogs(logger_name, level="INFO") as m:
+            process_message(incoming_valid_message)
+        self.assertEqual(
+            m.output,
+            [
+                f"INFO:{logger_name}:Successfully processed email to {channel.name} ({realm.string_id})"
+            ],
+        )
+
+
 class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
     def test_message_with_valid_attachment(self) -> None:
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -646,7 +838,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                 "image.png",
                 "image/png",
                 image_bytes,
-                get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
+                user_profile,
                 target_realm=user_profile.realm,
             )
 
@@ -661,7 +853,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -689,9 +881,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         attachment = Attachment.objects.last()
         assert attachment is not None
         self.assertEqual(list(attachment.messages.values_list("id", flat=True)), [message.id])
-        self.assertEqual(
-            message.sender, get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id)
-        )
+        self.assertEqual(message.sender, user_profile)
         self.assertEqual(attachment.realm, stream.realm)
         self.assertEqual(attachment.is_realm_public, True)
 
@@ -700,7 +890,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -728,9 +918,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         attachment = Attachment.objects.last()
         assert attachment is not None
         self.assertEqual(list(attachment.messages.values_list("id", flat=True)), [message.id])
-        self.assertEqual(
-            message.sender, get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id)
-        )
+        self.assertEqual(message.sender, user_profile)
         self.assertEqual(attachment.realm, stream.realm)
         self.assertEqual(attachment.is_realm_public, True)
 
@@ -743,7 +931,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -775,7 +963,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                 utf8_filename,
                 "image/png",
                 image_bytes,
-                get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
+                user_profile,
                 target_realm=user_profile.realm,
             )
 
@@ -787,7 +975,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -822,7 +1010,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                 "image.png",
                 "image/png",
                 image_bytes,
-                get_system_bot(settings.EMAIL_GATEWAY_BOT, stream.realm_id),
+                user_profile,
                 target_realm=user_profile.realm,
             )
 
@@ -834,7 +1022,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -865,7 +1053,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         encode_email_address(stream.name, email_token)
         stream_address = f"Denmark.{email_token}@testserver"
         stream_address_prefer_html = f"Denmark.{email_token}.prefer-html@testserver"
@@ -900,7 +1088,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         encode_email_address(stream.name, email_token)
         stream_address_prefer_html = f"Denmark.{email_token}.prefer-html@testserver"
 
@@ -969,7 +1157,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         # empty body
@@ -993,7 +1181,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         # No textual body
         incoming_valid_message = EmailMessage()
@@ -1027,7 +1215,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         headers = {}
         headers["Reply-To"] = self.example_email("othello")
@@ -1411,10 +1599,11 @@ class TestEmptyGatewaySetting(ZulipTestCase):
             self.assertEqual(mm_address, FromAddress.NOREPLY)
 
     def test_encode_email_addr(self) -> None:
+        user_profile = self.example_user("hamlet")
         stream = get_stream("Denmark", get_realm("zulip"))
 
         with self.settings(EMAIL_GATEWAY_PATTERN=""):
-            email_token = get_channel_email_token(stream)
+            email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
             test_address = encode_email_address(stream.name, email_token)
             self.assertEqual(test_address, "")
 
@@ -1440,7 +1629,7 @@ class TestReplyExtraction(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         text = """Reply
 
@@ -1478,7 +1667,7 @@ class TestReplyExtraction(ZulipTestCase):
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         html = """
         <html>
@@ -1526,9 +1715,10 @@ class TestScriptMTA(ZulipTestCase):
     def test_success(self) -> None:
         script = os.path.join(os.path.dirname(__file__), "../../scripts/lib/email-mirror-postfix")
 
+        user_profile = self.example_user("hamlet")
         sender = self.example_email("hamlet")
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         mail_template = self.fixture_data("simple.txt", type="email")
@@ -1543,9 +1733,10 @@ class TestScriptMTA(ZulipTestCase):
     def test_error_no_recipient(self) -> None:
         script = os.path.join(os.path.dirname(__file__), "../../scripts/lib/email-mirror-postfix")
 
+        user_profile = self.example_user("hamlet")
         sender = self.example_email("hamlet")
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         mail_template = self.fixture_data("simple.txt", type="email")
         mail = mail_template.format(stream_to_address=stream_to_address, sender=sender)
@@ -1613,14 +1804,16 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
 
     def test_success_stream(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        user_profile = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         result = self.send_offline_message(stream_to_address, self.example_user("hamlet"))
         self.assert_json_success(result)
 
     def test_error_to_stream_with_wrong_address(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        user_profile = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         # get the email_token:
         token = decode_email_address(stream_to_address)[0]
@@ -1635,7 +1828,8 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
 
     def test_success_to_stream_with_good_token_wrong_stream_name(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        user_profile = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         stream_to_address = stream_to_address.replace("denmark", "Wrong_name")
 
@@ -1670,7 +1864,7 @@ class TestStreamEmailMessagesSubjectStripping(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content("TestStreamEmailMessages body")
@@ -1713,7 +1907,7 @@ class TestContentTypeUnspecifiedCharset(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         del incoming_message["To"]
@@ -1739,7 +1933,7 @@ class TestContentTypeInvalidCharset(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         del incoming_message["To"]
@@ -1772,7 +1966,7 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
         self.login_user(user_profile)
         self.subscribe(user_profile, "errors")
         stream = get_stream("Denmark", user_profile.realm)
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
 
         incoming_valid_message = EmailMessage()
@@ -1805,7 +1999,7 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
         stream = get_stream("Denmark", user_profile.realm)
 
         # Test for a stream address:
-        email_token = get_channel_email_token(stream)
+        email_token = get_channel_email_token(stream, creator=user_profile, sender=user_profile)
         stream_to_address = encode_email_address(stream.name, email_token)
         address = Address(addr_spec=stream_to_address)
         scrubbed_stream_address = Address(

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -574,7 +574,8 @@ class WorkerTest(ZulipTestCase):
     def test_mirror_worker(self, mock_mirror_email: MagicMock) -> None:
         fake_client = FakeClient()
         stream = get_stream("Denmark", get_realm("zulip"))
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         stream_to_address = encode_email_address(stream.name, email_token)
         data = [
             dict(
@@ -600,7 +601,8 @@ class WorkerTest(ZulipTestCase):
         realm = get_realm("zulip")
         RateLimitedRealmMirror(realm).clear_history()
         stream = get_stream("Denmark", realm)
-        email_token = get_channel_email_token(stream)
+        hamlet = self.example_user("hamlet")
+        email_token = get_channel_email_token(stream, creator=hamlet, sender=hamlet)
         stream_to_address = encode_email_address(stream.name, email_token)
         data = [
             dict(

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -17,7 +17,7 @@ from django.test import override_settings
 from typing_extensions import override
 
 from zerver.lib.email_mirror import RateLimitedRealmMirror
-from zerver.lib.email_mirror_helpers import encode_email_address
+from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.queue import MAX_REQUEST_RETRIES
 from zerver.lib.rate_limiter import RateLimiterLockingError
 from zerver.lib.remote_server import PushNotificationBouncerRetryLaterError
@@ -574,7 +574,8 @@ class WorkerTest(ZulipTestCase):
     def test_mirror_worker(self, mock_mirror_email: MagicMock) -> None:
         fake_client = FakeClient()
         stream = get_stream("Denmark", get_realm("zulip"))
-        stream_to_address = encode_email_address(stream)
+        email_token = get_channel_email_token(stream)
+        stream_to_address = encode_email_address(stream.name, email_token)
         data = [
             dict(
                 msg_base64=base64.b64encode(b"\xf3test").decode(),
@@ -599,7 +600,8 @@ class WorkerTest(ZulipTestCase):
         realm = get_realm("zulip")
         RateLimitedRealmMirror(realm).clear_history()
         stream = get_stream("Denmark", realm)
-        stream_to_address = encode_email_address(stream)
+        email_token = get_channel_email_token(stream)
+        stream_to_address = encode_email_address(stream.name, email_token)
         data = [
             dict(
                 msg_base64=base64.b64encode(b"\xf3test").decode(),

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -55,7 +55,7 @@ from zerver.lib.default_streams import (
     get_default_stream_ids_for_realm,
     get_slim_realm_default_streams,
 )
-from zerver.lib.email_mirror_helpers import encode_email_address_helper
+from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import UnreadStreamInfo, aggregate_unread_data, get_raw_unread_data
 from zerver.lib.response import json_success
@@ -107,7 +107,6 @@ from zerver.lib.types import (
 from zerver.lib.user_groups import is_user_in_group
 from zerver.models import (
     Attachment,
-    ChannelEmailAddress,
     DefaultStream,
     DefaultStreamGroup,
     Message,
@@ -6164,10 +6163,8 @@ class GetStreamsTest(ZulipTestCase):
         denmark_stream = get_stream("Denmark", realm)
         result = self.client_get(f"/json/streams/{denmark_stream.id}/email_address")
         json = self.assert_json_success(result)
-        email_token = ChannelEmailAddress.objects.get(channel=denmark_stream).email_token
-        denmark_email = encode_email_address_helper(
-            denmark_stream.name, email_token, show_sender=True
-        )
+        email_token = get_channel_email_token(denmark_stream)
+        denmark_email = encode_email_address(denmark_stream.name, email_token, show_sender=True)
         self.assertEqual(json["email"], denmark_email)
 
         self.login("polonius")

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -48,7 +48,7 @@ from zerver.decorator import (
     require_realm_admin,
 )
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
-from zerver.lib.email_mirror_helpers import encode_email_address
+from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.exceptions import (
     CannotManageDefaultChannelError,
     JsonableError,
@@ -1133,6 +1133,7 @@ def get_stream_email_address(
         user_profile,
         stream_id,
     )
-    stream_email = encode_email_address(stream, show_sender=True)
+    email_token = get_channel_email_token(stream)
+    stream_email = encode_email_address(stream.name, email_token, show_sender=True)
 
     return json_success(request, data={"email": stream_email})


### PR DESCRIPTION
**Description:**

PR to add a `sender_id` parameter to the `GET /streams/{stream_id}/email_address` endpoint to specify the ID of a user or bot which should appear as the sender when messages are sent to a channel using the channel email address.
Earlier, Email gateway bot was always the sender.

[CZO API Design](https://chat.zulip.org/#narrow/channel/378-api-design/topic/channel.20email.20address/near/1991909)

**API Docs:**

<img width="632" alt="Screenshot 2025-01-02 at 12 06 45 PM" src="https://github.com/user-attachments/assets/9ca04176-9a52-4a65-bb6f-581dcde07dc5" />


**Manual testing using the `./manage.py send_to_email_mirror`**:

With `sender_id` as Hamlet, Email gateway bot (Default), and a Bot owned by Hamlet.

<img width="948" alt="Screenshot 2024-12-07 at 12 38 02 PM" src="https://github.com/user-attachments/assets/2080928e-5a0f-44c4-992a-b3e46f72fdac">

Fixes part of #31566 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
