### PR TITLE
css: Use --color-active-row-modal for settings overlay active rows.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -609,6 +609,7 @@
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 80%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
+    --color-active-row-modal: hsl(0deg 0% 98%);
     --color-background-modal: #ededed;
     --color-background-modal-bar: #f5f5f5;
     --color-border-modal: color-mix(in srgb, #8c8c8c 25%, transparent);
@@ -1367,6 +1368,7 @@
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: hsl(0deg 0% 30%);
+    --color-active-row-modal: hsl(0deg 0% 0% / 20%);
     --color-background-modal: #242424;
     --color-background-modal-bar: #333;
     --color-border-modal: color-mix(in srgb, #fff 8%, transparent);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -546,7 +546,6 @@
     .white-box,
     .stream-email,
     #generate-integration-url-modal .integration-url,
-    #settings_page .sidebar li.active,
     .table-striped tbody tr:nth-child(odd) th {
         background-color: hsl(0deg 0% 0% / 20%);
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1383,7 +1383,7 @@ $option_title_width: 180px;
             &.active {
                 /* TODO: Check with Vlad about highlight
                    colors such as this. */
-                background-color: hsl(0deg 0% 98%);
+                background-color: var(--color-active-row-modal);
             }
 
             .sidebar-item-icon {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -703,7 +703,7 @@ h4.user_group_setting_subsection_title {
     }
 
     &.active {
-        background-color: hsl(0deg 0% 93%);
+        background-color: var(--color-active-row-modal);
     }
 
     .check:not(.checked, .disabled):hover svg,


### PR DESCRIPTION
This fixes a bug introduced in f40e1e9ad022d1ad73962cf2613621e9484c9bed We changed the settings overlay container background color in that commit, from hsl(0deg 0% 98%) to #ededed. #ededed is same as hsl(0deg 0% 93%). The latter is the exact same color for stream and group row active background. While we changed the settings overlay background color, we did not change the active row color for stream and group rows.
Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/Lack.20of.20highlighting.20of.20selected.20group.2E/near/1993630

Screenshots:




| Dark Mode | Light Mode |
| --- | --- |
| Org settings | Org settings |
| <img width="896" alt="Screenshot 2024-12-05 at 11 30 38 PM" src="https://github.com/user-attachments/assets/263ec9b5-eaca-4718-8cc7-7cdb14543139"> | <img width="896" alt="Screenshot 2024-12-05 at 11 30 27 PM" src="https://github.com/user-attachments/assets/d2d549a5-6edc-4531-8385-86569fc3dfd1"> | 
| Groups | Groups |
| <img width="896" alt="Screenshot 2024-12-05 at 11 30 59 PM" src="https://github.com/user-attachments/assets/84cc980f-6253-4299-a641-c87de857a822"> | <img width="896" alt="Screenshot 2024-12-05 at 11 29 48 PM" src="https://github.com/user-attachments/assets/72985445-ee2c-442e-989f-ebfbb329729d"> |
| Channel settings | Channel settings |
| <img width="896" alt="Screenshot 2024-12-05 at 11 30 50 PM" src="https://github.com/user-attachments/assets/32728fb2-3c3a-49ff-9c8b-872e597c6b47"> | <img width="896" alt="Screenshot 2024-12-05 at 11 30 02 PM" src="https://github.com/user-attachments/assets/8e3eab84-11d6-48fc-ad32-16c1397220a6"> |