### PR TITLE
message_cache: Require can_access_sender for finalize_payload

### DIFF
--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -194,8 +194,8 @@ class MessageDict:
             can_access_sender = obj.get("can_access_sender", True)
             MessageDict.finalize_payload(
                 obj,
-                apply_markdown,
-                client_gravatar,
+                apply_markdown=apply_markdown,
+                client_gravatar=client_gravatar,
                 skip_copy=True,
                 can_access_sender=can_access_sender,
                 realm_host=realm.host,
@@ -204,12 +204,13 @@ class MessageDict:
     @staticmethod
     def finalize_payload(
         obj: dict[str, Any],
+        *,
         apply_markdown: bool,
         client_gravatar: bool,
         keep_rendered_content: bool = False,
         skip_copy: bool = False,
-        can_access_sender: bool = True,
-        realm_host: str = "",
+        can_access_sender: bool,
+        realm_host: str,
     ) -> dict[str, Any]:
         """
         By default, we make a shallow copy of the incoming dict to avoid

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -19,6 +19,7 @@ from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.queue import retry_event
 from zerver.lib.topic import get_topic_from_message_info
 from zerver.lib.url_encoding import near_message_url
+from zerver.lib.users import check_can_access_user
 from zerver.models import Realm, Service, UserProfile
 from zerver.models.bots import GENERIC_INTERFACE, SLACK_INTERFACE
 from zerver.models.clients import get_client
@@ -62,6 +63,10 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
             apply_markdown=False,
             client_gravatar=False,
             keep_rendered_content=True,
+            can_access_sender=check_can_access_user(
+                get_user_profile_by_id(event["message"]["sender_id"]), self.user_profile
+            ),
+            realm_host=realm.host,
         )
 
         request_data = {

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -80,6 +80,8 @@ class MessageDictTest(ZulipTestCase):
                 wide_dict,
                 apply_markdown=apply_markdown,
                 client_gravatar=client_gravatar,
+                can_access_sender=True,
+                realm_host=get_realm("zulip").host,
             )
             return narrow_dict
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -4042,6 +4042,8 @@ class GetOldMessagesTest(ZulipTestCase):
             wide_dict,
             apply_markdown=True,
             client_gravatar=False,
+            can_access_sender=True,
+            realm_host=get_realm("zulip").host,
         )
         self.assertEqual(final_dict["content"], "<p>test content</p>")
 


### PR DESCRIPTION
An access control parameter should never be optional with a default of open.

- Context: #27944 (cc @sahil839).