### PR TITLE
message_send: Fix checking permission to send DMs.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1565,7 +1565,8 @@ def check_can_send_direct_message(
         user_ids = [recipient_user.id for recipient_user in recipient_users] + [sender.id]
         if not is_any_user_in_group(direct_message_permission_group, user_ids):
             is_nobody_group = (
-                direct_message_permission_group.named_user_group.name == SystemGroups.NOBODY
+                hasattr(direct_message_permission_group, "named_user_group")
+                and direct_message_permission_group.named_user_group.name == SystemGroups.NOBODY
             )
             raise DirectMessagePermissionError(is_nobody_group)
 


### PR DESCRIPTION
This PR fixes the code to add a check for whether the setting is set to an anonymous group
or not before checking if the setting is set to "Nobody" group by checking the group name.

<!-- Describe your pull request here.-->
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
