### PR TITLE
markdown: Catch OverflowErrors in global times.

### DIFF
--- a/web/src/markdown.ts
+++ b/web/src/markdown.ts
@@ -1,4 +1,4 @@
-import {isValid} from "date-fns";
+import {getUnixTime, isValid} from "date-fns";
 import katex from "katex";
 import _ from "lodash";
 import assert from "minimalistic-assert";
@@ -580,7 +580,7 @@ function handleTimestamp(time_string: string): string {
     }
 
     const escaped_time = _.escape(time_string);
-    if (!isValid(timeobject)) {
+    if (!isValid(timeobject) || getUnixTime(timeobject) < 0) {
         // Unsupported time format: rerender accordingly.
 
         // We do not show an error on these formats in local echo because

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1455,7 +1455,7 @@ class Timestamp(markdown.inlinepatterns.Pattern):
         if timestamp.tzinfo:
             try:
                 timestamp = timestamp.astimezone(timezone.utc)
-            except ValueError:
+            except (ValueError, OverflowError):
                 error_element = Element("span")
                 error_element.set("class", "timestamp-error")
                 error_element.text = markdown.util.AtomicString(

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -846,6 +846,13 @@
       "text_content": "Invalid time format: 1969-12-31T00:00:00+32:00"
     },
     {
+      "name": "timestamp_overflow",
+      "input": "<time:0001-01-01T01:00:00+02:00>",
+      "expected_output": "<p><span class=\"timestamp-error\">Invalid time format: 0001-01-01T01:00:00+02:00</span></p>",
+      "marked_expected_output": "<p><span>0001-01-01T01:00:00+02:00</span></p>",
+      "text_content": "Invalid time format: 0001-01-01T01:00:00+02:00"
+    },
+    {
       "name": "timestamp_unix",
       "input": "Let's meet at <time:1496701800>.",
       "expected_output": "<p>Let's meet at <time datetime=\"2017-06-05T22:30:00Z\">1496701800</time>.</p>",


### PR DESCRIPTION
This also matches the except in the block above.

