### PR TITLE
Change compose box color when approaching/exceeding message length limit 

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -765,6 +765,8 @@ export function check_overflow_text($container: JQuery): number {
     const is_edit_container = $textarea.closest(".message_row").length > 0;
 
     if (text.length > max_length) {
+        $indicator.removeClass("textarea-approaching-limit");
+        $textarea.removeClass("textarea-approaching-limit");
         $indicator.addClass("textarea-over-limit");
         $textarea.addClass("textarea-over-limit");
         $indicator.html(
@@ -780,6 +782,8 @@ export function check_overflow_text($container: JQuery): number {
     } else if (remaining_characters <= 900) {
         $indicator.removeClass("textarea-over-limit");
         $textarea.removeClass("textarea-over-limit");
+        $indicator.addClass("textarea-approaching-limit");
+        $textarea.addClass("textarea-approaching-limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -793,6 +797,7 @@ export function check_overflow_text($container: JQuery): number {
     } else {
         $indicator.text("");
         $textarea.removeClass("textarea-over-limit");
+        $textarea.removeClass("textarea-approaching-limit");
 
         if (is_edit_container) {
             set_message_too_long_for_edit(false, $container);

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -765,8 +765,8 @@ export function check_overflow_text($container: JQuery): number {
     const is_edit_container = $textarea.closest(".message_row").length > 0;
 
     if (text.length > max_length) {
-        $indicator.addClass("over_limit");
-        $textarea.addClass("over_limit");
+        $indicator.addClass("textarea-over-limit");
+        $textarea.addClass("textarea-over-limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -778,8 +778,8 @@ export function check_overflow_text($container: JQuery): number {
             set_message_too_long_for_compose(true);
         }
     } else if (remaining_characters <= 900) {
-        $indicator.removeClass("over_limit");
-        $textarea.removeClass("over_limit");
+        $indicator.removeClass("textarea-over-limit");
+        $textarea.removeClass("textarea-over-limit");
         $indicator.html(
             render_compose_limit_indicator({
                 remaining_characters,
@@ -792,7 +792,7 @@ export function check_overflow_text($container: JQuery): number {
         }
     } else {
         $indicator.text("");
-        $textarea.removeClass("over_limit");
+        $textarea.removeClass("textarea-over-limit");
 
         if (is_edit_container) {
             set_message_too_long_for_edit(false, $container);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -721,6 +721,10 @@
     /* Compose box colors */
     --color-compose-box-background: hsl(232deg 30% 92%);
     --color-compose-message-content-background: hsl(0deg 0% 100%);
+    --color-compose-message-content-background-over-limit: hsl(3deg 35% 90%);
+    --color-compose-message-content-background-approaching-limit: hsl(
+        50deg 75% 92%
+    );
     --color-compose-send-button-icon-color: hsl(0deg 0% 100%);
     --color-compose-send-button-background: hsl(240deg 96% 68%);
     --color-compose-send-button-background-interactive: hsl(240deg 41% 50%);
@@ -788,6 +792,10 @@
     --color-message-formatting-controls-container: hsl(232deg 30% 96%);
     --color-message-content-container-border: hsl(0deg 0% 0% / 10%);
     --color-message-content-container-border-focus: hsl(0deg 0% 57%);
+    --color-message-content-container-border-over-limit: hsl(0deg 76% 65%);
+    --color-message-content-container-border-approaching-limit: hsl(
+        38deg 70% 50%
+    );
     --color-compose-control-button-background-hover: hsl(0deg 0% 0% / 5%);
     --color-compose-formatting-button-divider: hsl(0deg 0% 75%);
     --color-compose-focus-ring: var(--color-outline-focus);
@@ -1634,6 +1642,10 @@
         var(--color-compose-box-background),
         hsl(0deg 0% 0%) 20%
     );
+    --color-compose-message-content-background-over-limit: hsl(3deg 50% 12%);
+    --color-compose-message-content-background-approaching-limit: hsl(
+        50deg 75% 12%
+    );
     --color-compose-send-button-focus-shadow: hsl(0deg 0% 100% / 80%);
     --color-compose-send-control-button: hsl(240deg 30% 70%);
     --color-compose-send-control-button-background: transparent;
@@ -1690,7 +1702,6 @@
     --color-message-formatting-controls-container: hsl(0deg 0% 0% / 8%);
     --color-message-content-container-border: hsl(0deg 0% 0% / 80%);
     --color-message-content-container-border-focus: hsl(0deg 0% 100% / 27%);
-    --color-message-content-container-border-over-limit: hsl(0deg 76% 65%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 100% / 5%);
     --color-compose-formatting-button-divider: hsl(236deg 33% 90% / 25%);
     --color-compose-focus-ring: hsl(0deg 0% 67%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -336,16 +336,16 @@
     }
 }
 
-#message-content-container:has(.new_message_textarea.over_limit),
-#message-content-container:has(.new_message_textarea.over_limit:focus),
-.edit-content-container:has(.message_edit_content.over_limit),
-.edit-content-container:has(.message_edit_content.over_limit:focus) {
+#message-content-container:has(.new_message_textarea.textarea-over-limit),
+#message-content-container:has(.new_message_textarea.textarea-over-limit:focus),
+.edit-content-container:has(.message_edit_content.textarea-over-limit),
+.edit-content-container:has(.message_edit_content.textarea-over-limit:focus) {
     box-shadow: 0 0 0 1pt
         var(--color-message-content-container-border-over-limit);
 }
 
-#message-content-container:has(.new_message_textarea.over_limit.flash),
-.edit-content-container:has(.message_edit_content.over_limit.flash) {
+#message-content-container:has(.new_message_textarea.textarea-over-limit.flash),
+.edit-content-container:has(.message_edit_content.textarea-over-limit.flash) {
     animation: message-limit-flash 0.5s ease-in-out 3;
 }
 
@@ -478,7 +478,7 @@
     margin-top: auto;
     padding: 3px 3px 3px 0;
 
-    &.over_limit {
+    &.textarea-over-limit {
         color: var(--color-limit-indicator-over-limit);
         font-weight: bold;
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -337,15 +337,27 @@
 }
 
 #message-content-container:has(.new_message_textarea.textarea-over-limit),
-#message-content-container:has(.new_message_textarea.textarea-over-limit:focus),
-.edit-content-container:has(.message_edit_content.textarea-over-limit),
-.edit-content-container:has(.message_edit_content.textarea-over-limit:focus) {
+.edit-content-container:has(.message_edit_content.textarea-over-limit) {
     box-shadow: 0 0 0 1pt
         var(--color-message-content-container-border-over-limit);
 }
 
+#message-content-container:has(
+        .new_message_textarea.textarea-approaching-limit
+    ),
+.edit-content-container:has(.message_edit_content.textarea-approaching-limit) {
+    box-shadow: 0 0 0 1pt
+        var(--color-message-content-container-border-approaching-limit);
+}
+
 #message-content-container:has(.new_message_textarea.textarea-over-limit.flash),
-.edit-content-container:has(.message_edit_content.textarea-over-limit.flash) {
+#message-content-container:has(
+        .new_message_textarea.textarea-approaching-limit.flash
+    ),
+.edit-content-container:has(.message_edit_content.textarea-over-limit.flash),
+.edit-content-container:has(
+        .message_edit_content.textarea-approaching-limit.flash
+    ) {
     animation: message-limit-flash 0.5s ease-in-out 3;
 }
 
@@ -406,6 +418,18 @@
     padding-right: var(--composebox-buttons-width);
     background-color: var(--color-compose-message-content-background);
     color: var(--color-text-default);
+
+    &.textarea-over-limit {
+        background-color: var(
+            --color-compose-message-content-background-over-limit
+        );
+    }
+
+    &.textarea-approaching-limit {
+        background-color: var(
+            --color-compose-message-content-background-approaching-limit
+        );
+    }
 }
 
 .surround-formatting-buttons-row {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -669,6 +669,18 @@
 
     .message-edit-textbox {
         position: relative;
+
+        .textarea-over-limit {
+            background-color: var(
+                --color-compose-message-content-background-over-limit
+            );
+        }
+
+        .textarea-approaching-limit {
+            background-color: var(
+                --color-compose-message-content-background-approaching-limit
+            );
+        }
     }
 }
 

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -564,25 +564,25 @@ test_ui("test_check_overflow_text", ({mock_template, override}) => {
     });
     $textarea.val("a".repeat(10000 + 1));
     compose_validate.check_overflow_text($elem);
-    assert.ok($indicator.hasClass("over_limit"));
+    assert.ok($indicator.hasClass("textarea-over-limit"));
     assert.equal(limit_indicator_html, "-1\n");
-    assert.ok($textarea.hasClass("over_limit"));
+    assert.ok($textarea.hasClass("textarea-over-limit"));
     assert.ok($(".message-send-controls").hasClass("disabled-message-send-controls"));
 
     // Indicator should show orange colored text
     $textarea.val("a".repeat(9100));
     compose_validate.check_overflow_text($elem);
-    assert.ok(!$indicator.hasClass("over_limit"));
+    assert.ok(!$indicator.hasClass("textarea-over-limit"));
     assert.equal(limit_indicator_html, "900\n");
-    assert.ok(!$textarea.hasClass("over_limit"));
+    assert.ok(!$textarea.hasClass("textarea-over-limit"));
     assert.ok(!$(".message-send-controls").hasClass("disabled-message-send-controls"));
 
     // Indicator must be empty
     $textarea.val("a".repeat(9100 - 1));
     compose_validate.check_overflow_text($elem);
-    assert.ok(!$indicator.hasClass("over_limit"));
+    assert.ok(!$indicator.hasClass("textarea-over-limit"));
     assert.equal($indicator.text(), "");
-    assert.ok(!$textarea.hasClass("over_limit"));
+    assert.ok(!$textarea.hasClass("textarea-over-limit"));
 });
 
 test_ui("needs_subscribe_warning", () => {


### PR DESCRIPTION
This PR implements the feature of the compose box notifying users by changing colors when approaching or exceeding the message content limit.  

## Tasks completed  

- [x] The background changes to a tinted yellow when the yellow counter is shown, and to red once the limit is exceeded.  
- [x] Added a yellow border when the yellow countdown is shown and a red border when the limit is exceeded.  
- [x] The above styling applies to both composing a new message and editing an existing one.  
- [x] The color specifications for both themes have been addressed.  

## Color scheme used

- Light theme
  * background color when approaching the limit:
  ```css
     --color-compose-message-content-background-approaching-limit: hsl(50deg 75% 92%);
  ```
  * baclground color when exceeding the limit:
  ```css
     --color-compose-message-content-background-over-limit: hsl(3deg 35% 90%);
  ```
  *  border when approaching the limit:
  ```css
   --color-message-content-container-border-approaching-limit: hsl(038deg 70% 50%);
  ```
  * border when exceeding the limit:
  ```css
   --color-message-content-container-border-over-limit: hsl(0deg 76% 65%);
  ```

- Dark theme  
  * background color when approaching the limit:
  ```css
      --color-compose-message-content-background-approaching-limit: hsl(50deg 75% 12%);
  ```
  * border when exceeded the limit:
  ```css
     --color-compose-message-content-background-over-limit: hsl(3deg 50% 12%);
  ```
  *  border when approaching the limit:
  ```css
   --color-message-content-container-border-approaching-limit: hsl(038deg 70% 50%);
  ```
  * border when exceeding the limit:
  ```css
   --color-message-content-container-border-over-limit: hsl(0deg 76% 65%);
  ```

<details>
<summary> Screenshots </summary>

<table>
<tr>
<th colspan="2">
Light Mode
</th>
</tr>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td colspan="2">
Approaching towards the limit
</td>
</tr>
<tr>
<td>

<img src="https://github.com/user-attachments/assets/08ea132f-194a-4b6f-94ca-ab4957bf2763" />

</td>
<td>

<img src="https://github.com/user-attachments/assets/78b4f1f9-acdb-4733-ab1a-1f0a1e84cd2f" />

</td>
</tr>
<tr>
<td colspan="2">
Exceeded the limit
</td>
</tr>
<tr>
<td>

<img src="https://github.com/user-attachments/assets/1fad7062-bf07-4a7e-9e20-c93b27ccbf27" />

</td>
<td>

<img src="https://github.com/user-attachments/assets/d8f95eb9-d04e-4213-bdaa-bf2dadd0227d" />

</td>
</tr>
<tr>
<th colspan="2">
Dark Mode
</th>
</tr>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td colspan="2">
Approaching towards the limit
</td>
</tr>
<tr>
<td>

<img src="https://github.com/user-attachments/assets/f9eb4c77-6ce8-4a02-857c-8c24067c2d6d" />

</td>
<td>

<img src="https://github.com/user-attachments/assets/f75ca1db-be95-4cab-bc11-5732d8a7b49e" />

</td>
</tr>
<tr>
<td colspan="2">
Exceeded the limit
</td>
</tr>
<tr>
<td>

<img src="https://github.com/user-attachments/assets/df1337b7-e841-4d75-87db-15453f5e5ef8" />

</td>
<td>

<img src="https://github.com/user-attachments/assets/5b17128e-612b-4848-810a-549d25379143" />

</td>
</tr>
</table>

</details>

Fixes : #32171 .


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
