### PR TITLE
dev_docs: Establish Other Linux tab.

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -90,10 +90,11 @@ the internet.)
 :::{tab-item} Other Linux
 :sync: os-other-linux
 
-- Other Linux distributions work great too, but we don't maintain
-  documentation for installing Vagrant and Docker on those systems, so
-  you'll need to find a separate guide to reference while working
-  through the setup instructions here.
+- Any Linux distribution should work, if it supports Git, Vagrant and
+  Docker. We don't maintain documentation for installing Vagrant,
+  Docker, and other dependencies on those systems, so you'll want to
+  roughly follow the Ubuntu/Debian instructions, using upstream
+  documentation for installing dependencies.
   :::
 
 ::::

--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -87,11 +87,16 @@ the internet.)
 - tested for Fedora 36
   :::
 
-::::
+:::{tab-item} Other Linux
+:sync: os-other-linux
 
-Other Linux distributions work great too, but we don't maintain
-documentation for installing Vagrant and Docker on those systems, so
-you'll need to find a separate guide and crib from these docs.
+- Other Linux distributions work great too, but we don't maintain
+  documentation for installing Vagrant and Docker on those systems, so
+  you'll need to find a separate guide to reference while working
+  through the setup instructions here.
+  :::
+
+::::
 
 ### Step 0: Set up Git & GitHub
 


### PR DESCRIPTION
This moves a confusing message about other Linuxes into its own tab, and clarifies a bit of ambiguous language in the message, too.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![other-linux-before](https://github.com/user-attachments/assets/a3b68e36-ee02-4aff-843a-117d1ba0bf45) | ![other-linux-after](https://github.com/user-attachments/assets/cdfefa1a-ce3e-4f1a-86b6-c47578efab02) |
