### PR TITLE
copy_and_paste: Don't add code syntax if backtick is already present.

### DIFF
--- a/web/tests/copy_and_paste.test.cjs
+++ b/web/tests/copy_and_paste.test.cjs
@@ -127,6 +127,27 @@ run_test("paste_handler_converter", () => {
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
     assert.equal(copy_and_paste.paste_handler_converter(input), "`single line`");
 
+    // No code formatting if the given text area has a backtick at the cursor position
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
+    assert.equal(
+        copy_and_paste.paste_handler_converter(input, {
+            caret: () => 6,
+            val: () => "e.g. `",
+        }),
+        "single line",
+    );
+
+    // Yes code formatting if the given text area has a backtick but not at the cursor position
+    input =
+        '<meta http-equiv="content-type" content="text/html; charset=utf-8"><pre><code>single line</code></pre>';
+    assert.equal(
+        copy_and_paste.paste_handler_converter(input, {
+            caret: () => 0,
+        }),
+        "`single line`",
+    );
+
     // Raw links without custom text
     input =
         '<meta http-equiv="content-type" content="text/html; charset=utf-8"><a href="https://zulip.readthedocs.io/en/latest/subsystems/logging.html" target="_blank" title="https://zulip.readthedocs.io/en/latest/subsystems/logging.html" style="color: hsl(200, 100%, 40%); text-decoration: none; cursor: pointer; font-family: &quot;Source Sans 3&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: hsl(0, 0%, 100%);">https://zulip.readthedocs.io/en/latest/subsystems/logging.html</a>';


### PR DESCRIPTION
discussed [here](https://chat.zulip.org/#narrow/channel/9-issues/topic/pasting.20code/near/1987276):

> When I paste code, I appreciate that it sometimes adds backticks for me, but it's annoying when I've already written a backtick, and I end up in a situation like
>
> (before I paste)
>
> ```
> `
> ```
>
> (after I paste)
>
> ```
> ``some code`
> ```
>
> It would be nice if we checked for an existing backtick before adding them like that.
