### PR TITLE
fix: prevent sending message when pressing Enter in topic box

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -17,6 +17,7 @@ import * as compose_validate from "./compose_validate.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as flatpickr from "./flatpickr.ts";
 import {$t_html} from "./i18n.ts";
+import {is_enter_event} from "./keydown_util.ts";
 import * as message_edit from "./message_edit.ts";
 import * as message_view from "./message_view.ts";
 import * as narrow_state from "./narrow_state.ts";
@@ -60,6 +61,12 @@ export function initialize() {
     $(".compose-control-buttons-container .audio_link").toggle(
         compose_call.compute_show_audio_chat_button(),
     );
+
+    $("input#stream_message_recipient_topic").on("keydown", (event) => {
+        if (is_enter_event(event)) {
+            event.preventDefault();
+        }
+    });
 
     $("textarea#compose-textarea").on("keydown", (event) => {
         compose_ui.handle_keydown(event, $("textarea#compose-textarea").expectOne());

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -335,7 +335,7 @@ function handle_keydown(
             target_sel = `#${CSS.escape(target_id)}`;
         }
 
-        const on_topic = target_sel === "input#stream_message_recipient_topic";
+        const on_topic = target_sel === "#stream_message_recipient_topic";
         const on_pm = target_sel === "#private_message_recipient";
         const on_compose = target_sel === "#compose-textarea";
 
@@ -373,6 +373,10 @@ function handle_keydown(
                 handle_enter($("textarea#compose-textarea"), e);
             }
         } else if (on_topic || on_pm) {
+            // Prevent form submission when pressing Enter in the topic or recipient box
+            if (keydown_util.is_enter_event(e)) {
+                e.preventDefault(); // Prevent default Enter behavior
+            }
             // We are doing the focusing on keyup to not abort the typeahead.
             $nextFocus = $("textarea#compose-textarea");
         }

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -335,7 +335,7 @@ function handle_keydown(
             target_sel = `#${CSS.escape(target_id)}`;
         }
 
-        const on_topic = target_sel === "#stream_message_recipient_topic";
+        const on_topic = target_sel === "input#stream_message_recipient_topic";
         const on_pm = target_sel === "#private_message_recipient";
         const on_compose = target_sel === "#compose-textarea";
 
@@ -373,10 +373,6 @@ function handle_keydown(
                 handle_enter($("textarea#compose-textarea"), e);
             }
         } else if (on_topic || on_pm) {
-            // Prevent form submission when pressing Enter in the topic or recipient box
-            if (keydown_util.is_enter_event(e)) {
-                e.preventDefault(); // Prevent default Enter behavior
-            }
             // We are doing the focusing on keyup to not abort the typeahead.
             $nextFocus = $("textarea#compose-textarea");
         }


### PR DESCRIPTION


Previously, pressing Enter in the topic box would send a message even when the typeahead was closed. This behavior was unintended, as the typeahead state should not influence message-sending behavior.

This commit ensures that pressing Enter, Shift + Enter, or Ctrl + Enter in the topic box does not send the message unless explicitly configured.

Fixes #32596.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
| Before                  | After                   |
|-------------------------|-------------------------|
| ![Before](https://raw.githubusercontent.com/Anmol-dev45/public-content/main/before.gif)   | ![After](https://raw.githubusercontent.com/Anmol-dev45/public-content/main/after.gif)     |

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
