### PR TITLE
settings: Disable the move-handle for new-choice-row.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -298,6 +298,7 @@ function add_choice_row(this: HTMLElement, e: JQuery.TriggeredEvent): void {
     // Display delete buttons for all existing choices before creating the new row,
     // which will not have the delete button so that there is at least one option present.
     $curr_choice_row.find("button.delete-choice").show();
+    $curr_choice_row.find("span.move-handle").removeClass("invisible");
     assert(e.delegateTarget instanceof HTMLElement);
     const choices_div = e.delegateTarget;
     create_choice_row($(choices_div));

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -1,5 +1,5 @@
 <div class='choice-row movable-row' data-value="{{value}}">
-    <span class="move-handle">
+    <span class="move-handle {{#if new_empty_choice_row}}invisible{{/if}}">
         <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
         <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     </span>


### PR DESCRIPTION
This pull request includes changes to the `settings_profile_fields.ts` and `profile_field_choice.hbs` files to improve the user interface for managing profile field choices. The most important changes include displaying move handles for all existing choice rows and conditionally hiding move handles for new empty choice rows.

Improvements to user interface for managing profile field choices:

* [`web/src/settings_profile_fields.ts`](diffhunk://#diff-cc690fe2bdfd038f1288155c79b26151351fb9472e7b5377fc7da8d872cfe771R301): Added code to display move handles for all existing choice rows when creating a new row.
* [`web/templates/settings/profile_field_choice.hbs`](diffhunk://#diff-0751f27f4e5530cf74ab170afee0ea136792fc5ff8ac4cfa932809f51bac4e15L2-R2): Modified the template to conditionally hide move handles for new empty choice rows.


Fixes: #32612.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/85d42a79-fd53-4d1c-bbac-90bb5e0b909b) | ![After](https://github.com/user-attachments/assets/67a78fd6-ad6e-4f95-aec5-6fc83253cc23) |
| ![Before](https://github.com/user-attachments/assets/ff1e3d4d-4435-4923-941c-17076896e064) | ![After](https://github.com/user-attachments/assets/82863453-4875-4ec5-94fa-8d7c929227c5) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
