### PR TITLE
Fixed alignment of recent conversations headers.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -241,7 +241,7 @@
     }
 
     .flex_container .right_part {
-        margin-left: auto;
+        margin-left: auto; 
         display: inline-flex;
         align-items: center;
     }
@@ -398,11 +398,12 @@
 
     .recent-view-topic-header {
         width: 35%;
+        display: flex;
+        justify-content: space-between;
     }
 
     .recent-view-unread-header {
         width: 5%;
-
         .zulip-icon-unread {
             position: relative;
             top: 3px;

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -11,7 +11,7 @@
                 </span>
                 <a href="{{topic_url}}" class="recent-view-table-link">{{stream_name}}</a>
                 {{/if}}
-            </div>
+            </div> 
             {{!-- For presence/group indicator --}}
             {{#if is_private}}
             <div class="right_part">

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -12,13 +12,15 @@
 <div class="table_fix_head">
     <div class="recent-view-container">
         <table class="table table-responsive">
-            <thead id="recent-view-table-headers">
+            <thead id="recent-view-table-headers"> 
                 <tr>
                     <th class="recent-view-stream-header" data-sort="stream_sort">{{t 'Channel' }}</th>
-                    <th class="recent-view-topic-header" data-sort="topic_sort">{{t 'Topic' }}</th>
-                    <th data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}" class="recent-view-unread-header unread_sort tippy-zulip-delayed-tooltip hidden-for-spectators">
-                        <i class="zulip-icon zulip-icon-unread"></i>
+                    <th class="recent-view-topic-header" data-sort="topic_sort">{{t 'Topic' }}
+                        <span data-sort="unread_sort" data-tippy-content="{{t 'Sort by unread message count' }}" class="recent-view-unread-header unread_sort tippy-zulip-delayed-tooltip hidden-for-spectators">
+                            <i class="zulip-icon zulip-icon-unread"></i>
+                        </span>
                     </th>
+                    
                     <th class='recent-view-participants-header participants_header'>{{t 'Participants' }}</th>
                     <th data-sort="numeric" data-sort-prop="last_msg_id" class="recent-view-last-msg-time-header last_msg_time_header active descend">{{t 'Time' }}</th>
                 </tr>

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -13,7 +13,7 @@
             <span class="message-header-stream-name">
                 {{~display_recipient~}}
             </span>
-            {{#if is_archived}}
+            {{#if is_archived}} 
             <span class="message-header-stream-archived"><i class="archived-indicator">({{t 'archived' }})</i></span>
             {{/if}}
         </a>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: In the header there were 5 columns but table data has only 4 column. So I shifted the unread header (envelope icon) to the previous table head Topic making a span, just like in table data the topic and unread messages in same column but in different div. Hope this fixes the issue.