### PR TITLE
settings: Use text cursor for "Name" and "Email" field labels (if changes are disabled).

### DIFF
--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -83,9 +83,11 @@ export function update_email_change_display(): void {
     if (!settings_data.user_can_change_email()) {
         $("#change_email_button").prop("disabled", true);
         $("#change_email_button_container").addClass("disabled_setting_tooltip");
+        $("label[for='change_email_button']").addClass("cursor-text");
     } else {
         $("#change_email_button").prop("disabled", false);
         $("#change_email_button_container").removeClass("disabled_setting_tooltip");
+        $("label[for='change_email_button']").removeClass("cursor-text");
     }
 }
 

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -67,9 +67,11 @@ export function update_name_change_display(): void {
     if (!settings_data.user_can_change_name()) {
         $("#full_name").prop("disabled", true);
         $("#full_name_input_container").addClass("disabled_setting_tooltip");
+        $("label[for='full_name']").addClass("cursor-text");
     } else {
         $("#full_name").prop("disabled", false);
         $("#full_name_input_container").removeClass("disabled_setting_tooltip");
+        $("label[for='full_name']").removeClass("cursor-text");
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1659,6 +1659,10 @@ $option_title_width: 180px;
     margin-bottom: var(--margin-bottom-field-description);
 }
 
+.cursor-text {
+    cursor: text;
+}
+
 .profile-field-choices {
     display: inline-block;
 

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -7,7 +7,7 @@
             <form class="grid">
                 {{#if user_has_email_set}}
                 <div class="input-group">
-                    <label class="settings-field-label" for="change_email_button">{{t "Email" }}</label>
+                    <label class="settings-field-label {{#unless user_can_change_email}}cursor-text{{/unless}}" for="change_email_button">{{t "Email" }}</label>
                     <div id="change_email_button_container" class="{{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                         <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change your email' }}" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
                             {{current_user.delivery_email}}

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -6,7 +6,7 @@
                 <div class="full-name-change-container">
                     <div class="input-group inline-block grid user-name-parent">
                         <div class="user-name-section inline-block">
-                            <label for="full_name" class="settings-field-label inline-block">{{t "Name" }}</label>
+                            <label for="full_name" class="settings-field-label inline-block {{#unless user_can_change_name}}cursor-text{{/unless}}">{{t "Name" }}</label>
                             <div class="alert-notification full-name-status"></div>
                             <div class="settings-profile-user-field-hint">{{t "How your account is displayed in Zulip." }}</div>
                             <div id="full_name_input_container" {{#unless user_can_change_name}}class="disabled_setting_tooltip"{{/unless}}>

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -784,24 +784,28 @@ test("misc", ({override}) => {
     settings_account.update_name_change_display();
     assert.ok(!$("#full_name").prop("disabled"));
     assert.ok(!$("#full_name_input_container").hasClass("disabled_setting_tooltip"));
+    assert.ok(!$("label[for='full_name']").hasClass("cursor-text"));
 
     override(realm, "realm_name_changes_disabled", true);
     override(realm, "server_name_changes_disabled", false);
     settings_account.update_name_change_display();
     assert.ok($("#full_name").prop("disabled"));
     assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
+    assert.ok($("label[for='full_name']").hasClass("cursor-text"));
 
     override(realm, "realm_name_changes_disabled", true);
     override(realm, "server_name_changes_disabled", true);
     settings_account.update_name_change_display();
     assert.ok($("#full_name").prop("disabled"));
     assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
+    assert.ok($("label[for='full_name']").hasClass("cursor-text"));
 
     override(realm, "realm_name_changes_disabled", false);
     override(realm, "server_name_changes_disabled", true);
     settings_account.update_name_change_display();
     assert.ok($("#full_name").prop("disabled"));
     assert.ok($("#full_name_input_container").hasClass("disabled_setting_tooltip"));
+    assert.ok($("label[for='full_name']").hasClass("cursor-text"));
 
     override(realm, "realm_email_changes_disabled", false);
     settings_account.update_email_change_display();
@@ -833,6 +837,7 @@ test("misc", ({override}) => {
     settings_account.update_name_change_display();
     assert.ok(!$("#full_name").prop("disabled"));
     assert.ok(!$("#full_name_input_container").hasClass("disabled_setting_tooltip"));
+    assert.ok(!$("label[for='full_name']").hasClass("cursor-text"));
 
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email_button").prop("disabled"));

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -810,10 +810,12 @@ test("misc", ({override}) => {
     override(realm, "realm_email_changes_disabled", false);
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email_button").prop("disabled"));
+    assert.ok(!$("label[for='change_email_button']").hasClass("cursor-text"));
 
     override(realm, "realm_email_changes_disabled", true);
     settings_account.update_email_change_display();
     assert.ok($("#change_email_button").prop("disabled"));
+    assert.ok($("label[for='change_email_button']").hasClass("cursor-text"));
 
     override(realm, "realm_avatar_changes_disabled", false);
     override(realm, "server_avatar_changes_disabled", false);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR changes the behavior of the cursor with the "Name" and "Email" field labels in the Settings menu.
It includes the following changes:
- Introduces a class named `cursor-text` that sets the property `cursor: text;`.
- Uses a text cursor instead of a pointer cursor for the "Name" and "Email" field labels when the respective changes are disabled.
- Implements tests to verify the changes made.
 
This PR is a follow-up for [#32260(comment)](https://github.com/zulip/zulip/pull/32260#issuecomment-2521694570).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Name field</summary>

| Name changes enabled (Pointer Cursor) | Name changes disabled (Text Cursor) |
|---------------------------------------|-------------------------------------|
| ![Screenshot 2024-12-08 170146](https://github.com/user-attachments/assets/bdec4b14-8cdd-4984-a853-740f5e5fb19f) | ![Screenshot 2024-12-08 170511](https://github.com/user-attachments/assets/5f534f14-b201-4bb2-8bc0-b1ba39c06417) |

</details>

<details>
<summary>Email field</summary>

| Email changes enabled (Pointer Cursor) | Email changes disabled (Text Cursor) |
|---------------------------------------|-------------------------------------|
| ![Screenshot 2024-12-08 170249](https://github.com/user-attachments/assets/97100782-c13d-4d33-b82a-d847658c97a9) | ![Screenshot 2024-12-08 170722](https://github.com/user-attachments/assets/05735665-d814-4a70-8ede-7e11884838fa) |

</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
