### PR TITLE
settings: Replace the Theme select dropdown with the Theme switcher.

### DIFF
--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -963,6 +963,7 @@ export function check_realm_default_settings_property_changed(elem: HTMLElement)
     const current_val = get_realm_default_setting_property_value(property_name);
     let proposed_val;
     switch (property_name) {
+        case "color_scheme":
         case "emojiset":
         case "user_list_style":
             proposed_val = get_input_element_value(elem, "radio-group");

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -683,6 +683,7 @@ export function discard_realm_default_property_element_changes(elem: HTMLElement
             );
             settings_components.set_input_element_value($elem, property_value);
             break;
+        case "color_scheme":
         case "emojiset":
         case "user_list_style":
             // Because this widget has a radio button structure, it

--- a/web/src/settings_preferences.ts
+++ b/web/src/settings_preferences.ts
@@ -218,7 +218,11 @@ export function set_up(settings_panel: SettingsPanel): void {
     $container
         .find(".setting_demote_inactive_streams")
         .val(settings_object.demote_inactive_streams);
-    $container.find(".setting_color_scheme").val(settings_object.color_scheme);
+    $container
+        .find(
+            `.setting_color_scheme[value='${CSS.escape(settings_object.color_scheme.toString())}']`,
+        )
+        .prop("checked", true);
     $container.find(".setting_web_home_view").val(settings_object.web_home_view);
     $container
         .find(".setting_twenty_four_hour_time")
@@ -299,6 +303,39 @@ export function set_up(settings_panel: SettingsPanel): void {
             change_display_setting(data, $status_element, success_continuation);
         },
     );
+
+    $container.find(".setting_color_scheme").on("change", function () {
+        const $input_elem = $(this);
+        const new_theme_code = $input_elem.val();
+        assert(new_theme_code !== undefined);
+        const data = {color_scheme: new_theme_code};
+
+        const $status_element = $input_elem
+            .closest(".subsection-parent")
+            .find(".alert-notification");
+
+        const opts: RequestOpts = {
+            error_continuation() {
+                setTimeout(() => {
+                    const prev_theme_code = user_settings.color_scheme;
+                    $input_elem
+                        .parent()
+                        .find(
+                            `.setting_color_scheme[value='${CSS.escape(prev_theme_code.toString())}']`,
+                        )
+                        .prop("checked", true);
+                }, 500);
+            },
+        };
+
+        settings_ui.do_settings_change(
+            channel.patch,
+            "/json/settings",
+            data,
+            $status_element,
+            opts,
+        );
+    });
 
     $container.find(".setting_emojiset_choice").on("click", function () {
         const data = {emojiset: $(this).val()};

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -435,6 +435,12 @@ input[type="checkbox"] {
     }
 }
 
+.preferences-settings-form {
+    .tab-picker {
+        width: 325px;
+    }
+}
+
 .information-density-settings {
     max-width: 325px;
 

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -23,9 +23,21 @@
     </div>
     <div class="input-group">
         <label for="{{prefix}}color_scheme" class="settings-field-label">{{t "Theme" }}</label>
-        <select name="color_scheme" class="setting_color_scheme prop-element settings_select bootstrap-focus-style" id="{{prefix}}color_scheme" data-setting-widget-type="number">
-            {{> dropdown_options_widget option_values=color_scheme_values}}
-        </select>
+        <div id="{{prefix}}color_scheme" class="tab-picker prop-element" data-setting-widget-type="radio-group">
+            <input type="radio" id="{{prefix}}theme_select_automatic" class="tab-option setting_color_scheme" data-setting-widget-type="number" name="{{prefix}}theme_select" value="{{color_scheme_values.automatic.code}}" />
+            <label class="tab-option-content tippy-zulip-delayed-tooltip" for="{{prefix}}theme_select_automatic" aria-label="{{t 'Select automatic theme' }}" data-tooltip-template-id="automatic-theme-template" tabindex="0">
+                <i class="zulip-icon zulip-icon-monitor" aria-hidden="true"></i>
+            </label>
+            <input type="radio" id="{{prefix}}theme_select_light" class="tab-option setting_color_scheme" data-setting-widget-type="number" name="{{prefix}}theme_select" value="{{color_scheme_values.light.code}}" />
+            <label class="tab-option-content tippy-zulip-delayed-tooltip" for="{{prefix}}theme_select_light" aria-label="{{t 'Select light theme' }}" data-tippy-content="{{t 'Light theme' }}" tabindex="0">
+                <i class="zulip-icon zulip-icon-sun" aria-hidden="true"></i>
+            </label>
+            <input type="radio" id="{{prefix}}theme_select_dark" class="tab-option setting_color_scheme" data-setting-widget-type="number" name="{{prefix}}theme_select" value="{{color_scheme_values.dark.code}}" />
+            <label class="tab-option-content tippy-zulip-delayed-tooltip" for="{{prefix}}theme_select_dark" aria-label="{{t 'Select dark theme' }}" data-tippy-content="{{t 'Dark theme' }}" tabindex="0">
+                <i class="zulip-icon zulip-icon-moon" aria-hidden="true"></i>
+            </label>
+            <span class="slider"></span>
+        </div>
     </div>
 
     {{> settings_checkbox


### PR DESCRIPTION
This PR includes the following changes:
 - The theme select dropdown in the Preferences section of the Personal settings is replaced with the theme switcher, similar to the one in the personal menu popover.
 - The theme select dropdown in the Default User Settings section of the Organization settings also follows the same set of changes.

Fixes: #32111.
[CZO Thread](https://chat.zulip.org/#narrow/channel/101-design/topic/dark.20theme.20setting/near/1964206)

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Interaction of Theme switcher in Personal Settings - Preferences</summary>

![theme switcher preferences](https://github.com/user-attachments/assets/bfc9eabc-7732-4973-9655-ceca3fc4de2f)

</details>

<details>
<summary>Interaction of Theme switcher in Organization Settings - Default user settings</summary>

![theme switcher default user](https://github.com/user-attachments/assets/cdd6d3cc-e099-4921-9446-7f0ce99406df)

</details>

<details>
<summary>Reverting back to the previous theme in Personal Settings - Preferences (when an error occurs).</summary>

![preferences theme error revert](https://github.com/user-attachments/assets/fa9ba805-f644-435b-b86c-d1870302c4c5)

</details>

<details>
<summary>Reverting back to the previous theme in Organization Settings - Default user settings (when changes are discarded).</summary>

![default user settings discard revert](https://github.com/user-attachments/assets/a453efdc-3c55-46a5-917d-1a931cf7dc88)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
