### PR TITLE
presence_data: Fetch presence data when user card is opened.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -160,7 +160,10 @@ function get_num_unread(user_id: number): number {
     return unread.num_unread_for_user_ids_string(user_id.toString());
 }
 
-export function user_last_seen_time_status(user_id: number): string {
+export function user_last_seen_time_status(
+    user_id: number,
+    missing_data_callback?: (user_id: number) => void,
+): string {
     const status = presence.get_status(user_id);
     if (status === "active") {
         return $t({defaultMessage: "Active now"});
@@ -182,6 +185,11 @@ export function user_last_seen_time_status(user_id: number): string {
         // history on a user. This can happen when users are deactivated,
         // or when the user's last activity is older than what we fetch.
         assert(page_params.presence_history_limit_days_for_web_app === 365);
+
+        if (missing_data_callback !== undefined) {
+            missing_data_callback(user_id);
+            return "";
+        }
         return $t({defaultMessage: "Not active in the last year"});
     }
     return timerender.last_seen_status_from_date(last_active_date);

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -24,6 +24,21 @@ export const presence_info_from_event_schema = z.object({
 });
 export type PresenceInfoFromEvent = z.output<typeof presence_info_from_event_schema>;
 
+export const user_last_seen_response_schema = z.object({
+    result: z.string(),
+    msg: z.string().optional(),
+    presence: z
+        .object({
+            /* We ignore the keys other than aggregated, since they just contain
+               duplicate data. */
+            aggregated: z.object({
+                status: z.enum(["active", "idle", "offline"]),
+                timestamp: z.number(),
+            }),
+        })
+        .optional(),
+});
+
 // This module just manages data.  See activity.js for
 // the UI of our buddy list.
 

--- a/web/src/user_card_popover.ts
+++ b/web/src/user_card_popover.ts
@@ -21,7 +21,7 @@ import {show_copied_confirmation} from "./copied_tooltip.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {is_overlay_hash} from "./hash_parser.ts";
 import * as hash_util from "./hash_util.ts";
-import {$t_html} from "./i18n.ts";
+import {$t, $t_html} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
 import {user_can_send_direct_message} from "./message_util.ts";
 import * as message_view from "./message_view.ts";
@@ -32,6 +32,7 @@ import type {User} from "./people.ts";
 import * as people from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
 import {hide_all} from "./popovers.ts";
+import * as presence from "./presence.ts";
 import * as rows from "./rows.ts";
 import * as settings_panel_menu from "./settings_panel_menu.ts";
 import * as sidebar_ui from "./sidebar_ui.ts";
@@ -237,6 +238,52 @@ type UserCardPopoverData = {
     bot_owner?: User;
 };
 
+export let fetch_presence_for_popover = (user_id: number): void => {
+    if (!people.is_active_user_for_popover(user_id) || people.get_by_user_id(user_id).is_bot) {
+        return;
+    }
+
+    const url = `json/users/${user_id}/presence`;
+    const selector_to_update = `#user_card_popover .popover-menu-list[data-user-id="${CSS.escape(user_id.toString())}"] .user-last-seen-time`;
+    channel.get({
+        url,
+        success(data: unknown) {
+            const parsed_data = presence.user_last_seen_response_schema.safeParse(data);
+
+            if (!parsed_data.success) {
+                blueslip.error("Failed to parse presence API response");
+                return;
+            }
+
+            const response = parsed_data.data;
+
+            if (response.result === "success" && response.presence) {
+                const {aggregated} = response.presence;
+                presence.presence_info.set(user_id, {
+                    status: aggregated.status,
+                    last_active: aggregated.timestamp,
+                });
+
+                // Update the user's last seen time in the user card
+                // popover once we have their presence information, if
+                // we still have that user card still open.
+                $(selector_to_update).text(buddy_data.user_last_seen_time_status(user_id));
+            }
+        },
+        error(xhr: JQuery.jqXHR) {
+            // Fallback logic for users who haven't generated any
+            // presence data. We want to show the normal "Not active
+            // in last year" text.
+            blueslip.error(channel.xhr_error_message("Error fetching presence", xhr));
+            $(selector_to_update).text(buddy_data.user_last_seen_time_status(user_id));
+        },
+    });
+};
+
+export function rewire_fetch_presence_for_popover(value: (user_id: number) => string): void {
+    fetch_presence_for_popover = value;
+}
+
 function get_user_card_popover_data(
     user: User,
     has_message_context: boolean,
@@ -283,6 +330,10 @@ function get_user_card_popover_data(
     const can_send_private_message =
         user_can_send_direct_message(user_id_string) && is_active && !is_me;
 
+    const user_last_seen_time_status =
+        buddy_data.user_last_seen_time_status(user.user_id, fetch_presence_for_popover) ||
+        $t({defaultMessage: "Loading…"});
+
     const args: UserCardPopoverData = {
         invisible_mode,
         can_send_private_message,
@@ -299,7 +350,7 @@ function get_user_card_popover_data(
         user_email: user.delivery_email,
         user_full_name: user.full_name,
         user_id: user.user_id,
-        user_last_seen_time_status: buddy_data.user_last_seen_time_status(user.user_id),
+        user_last_seen_time_status,
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
         status_content_available: Boolean(status_text ?? status_emoji_info),

--- a/web/templates/popovers/user_card/user_card_popover.hbs
+++ b/web/templates/popovers/user_card/user_card_popover.hbs
@@ -100,7 +100,7 @@
             {{#unless is_bot}}
                 <li role="none" class="popover-menu-list-item text-item hidden-for-spectators">
                     <i class="popover-menu-icon zulip-icon zulip-icon-past-time" aria-hidden="true"></i>
-                    <span class="popover-menu-label">{{user_last_seen_time_status}}</span>
+                    <span class="popover-menu-label user-last-seen-time">{{user_last_seen_time_status}}</span>
                 </li>
             {{/unless}}
             {{#if user_time}}

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -595,6 +595,12 @@ test("user_last_seen_time_status", ({override}) => {
 
     set_presence(selma.user_id, "idle");
     assert.equal(buddy_data.user_last_seen_time_status(selma.user_id), "translated: Idle");
+
+    presence.presence_info.set(old_user.user_id, {last_active: undefined});
+    const missing_callback = (user_id) => {
+        assert.equal(user_id, old_user.user_id);
+    };
+    assert.equal(buddy_data.user_last_seen_time_status(old_user.user_id, missing_callback), "");
 });
 
 test("get_items_for_users", ({override}) => {


### PR DESCRIPTION
This pull request introduces changes to enhance the user presence functionality and refactor the user card popover handling. The user card now pops up instantaneously when clicked and re-renders once the user's last active data is fetched.

When a user's card is opened, the web app fetches presence data for users who have been idle for an extended period. 

Initially, it displays `Loading...` if no `last_active` data is available, and this value is updated as soon as the data fetch is completed.  

See the attached screenshot below for the new behavior.

Fixes: #31037.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Loading Indicator: </summary>
<img width="287" alt="Screenshot 2024-12-19 at 5 26 28 PM" src="https://github.com/user-attachments/assets/f86c9edf-52fd-405b-aef3-0ce48db3a69f" />

</details>
<details>
<summary>Exact date after fetch is completed: </summary>
<img width="286" alt="Screenshot 2024-12-19 at 5 26 51 PM" src="https://github.com/user-attachments/assets/0afa57d3-fece-4bc9-afab-2b55a79ecd97" />

</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
