### PR TITLE
search_box: Use 'zulip-icon-close' instead of 'fa-remove' in all search boxes.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -407,37 +407,6 @@ input.settings_text_input {
     margin: 0;
 }
 
-/* TODO: Once all layouts using this button
-   are modernized, the Font Awesome icon
-   should be replaced with a Zulip icon,
-   and its formatting should have no extra
-   space around its viewbox in SVG. */
-.old_clear_search_button {
-    &:hover {
-        color: var(--color-text-clear-search-button-hover);
-    }
-
-    &:disabled {
-        visibility: hidden;
-    }
-
-    &,
-    &:focus,
-    &:active,
-    &:disabled:hover {
-        background: none;
-        border: none;
-        text-align: center;
-        color: var(--color-text-clear-search-button);
-        text-shadow: none;
-        outline: none !important;
-        box-shadow: none;
-        z-index: 5;
-    }
-}
-
-/* This is new clear_search_button style, it'll replace all
-old_clear_search_button for consistency. */
 .clear_search_button {
     grid-area: 1 / 2 / 2 / 3;
     padding: 0;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -436,6 +436,33 @@ input.settings_text_input {
     }
 }
 
+/* This is new clear_search_button style, it'll replace all
+old_clear_search_button for consistency. */
+.clear_search_button {
+    grid-area: 1 / 2 / 2 / 3;
+    padding: 0;
+    background: none;
+    color: var(--color-icons-inbox);
+    opacity: 0.4;
+    display: grid;
+    border: none;
+
+    &:hover {
+        opacity: 1;
+    }
+
+    &:focus,
+    &:focus-visible,
+    &:active {
+        box-shadow: none;
+        outline: none;
+    }
+
+    .zulip-icon-close {
+        align-self: center;
+    }
+}
+
 .grey-box {
     margin: 0;
     padding: 5px 10px;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -498,16 +498,6 @@ old_clear_search_button for consistency. */
     margin: 15px 0 -5px 23px;
 }
 
-.topic-list-filter {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-
-    & input {
-        padding-right: 20px;
-    }
-}
-
 .stream-selection-header-colorblock {
     /* box-shadow: 0px 2px 3px hsl(0, 0%, 80%); */
     box-shadow:

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -412,7 +412,7 @@ input.settings_text_input {
    should be replaced with a Zulip icon,
    and its formatting should have no extra
    space around its viewbox in SVG. */
-.clear_search_button {
+.old_clear_search_button {
     &:hover {
         color: var(--color-text-clear-search-button-hover);
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -83,13 +83,6 @@
 
     .topic_search_section {
         margin: 3px 0;
-
-        .old_clear_search_button {
-            grid-area: clear-button;
-            /* Override app-component positioning. */
-            position: static;
-            padding: 0;
-        }
     }
 
     & li {
@@ -919,8 +912,7 @@ li.top_left_scheduled_messages {
 .left-sidebar-navigation-label-container,
 .dm-box,
 .subscription_block,
-.searching-for-more-topics,
-.topic_search_section {
+.searching-for-more-topics {
     display: grid;
     align-items: center;
     /* This general pattern of elements applies to every single row in the left
@@ -1142,12 +1134,10 @@ li.top_left_scheduled_messages {
 }
 
 .topic_search_section {
-    grid-template-columns:
-        var(--left-sidebar-toggle-width-offset) 0 0
-        [filter-box-start] minmax(0, 1fr)
-        minmax(0, max-content)
-        [clear-button-start] var(--left-sidebar-vdots-width)
-        [clear-button-end filter-box-end] 0;
+    padding: 8px 10px;
+    display: grid;
+    grid-template: "search-input clear-search" auto / minmax(0, 1fr) 30px;
+    border-bottom: 1px solid var(--color-border-modal-bar);
 }
 
 .topic-box .zero_count {
@@ -1218,7 +1208,13 @@ li.top_left_scheduled_messages {
 }
 
 .topic-list-filter {
-    grid-area: filter-box;
+    box-shadow: none;
+    padding-right: 28px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    grid-column: search-input-start / clear-search-end;
+    grid-row: search-input;
 }
 
 #filter-topic-input:placeholder-shown + #clear_search_topic_button {
@@ -1730,11 +1726,8 @@ li.topic-list-item {
 .direct-messages-search-section {
     .stream-list-filter,
     .direct-messages-list-filter {
-        /* Use the border-box model so flex
-           can do its thing despite whatever
-           padding and border we specify. */
         box-sizing: border-box;
-        flex: 1 0 100%;
+        width: 100%;
         /* Match the input height exactly
            with the row height for a perfect
            fit and better vertical alignment. */
@@ -1745,35 +1738,13 @@ li.topic-list-item {
         padding-right: 30px;
     }
 
-    .old_clear_search_button {
-        /* Use the border-box model so flex
-           can do its thing despite whatever
-           padding and border we specify. */
+    .clear_search_button {
         box-sizing: border-box;
-        /* Clear inherited positioning. */
         position: static;
-        /* We're going to use flexbox, not
-           positioning, to get the clear button
-           over top of the input. This -30px
-           margin accomplishes that, in tandem
-           with the 30px width of this element,
-           which is shared with the ending
-           anchor element in left sidebar header
-           rows. */
+        display: grid;
+        place-items: center;
         width: 30px;
         margin-left: -30px;
-        /* Flexbox respects z-index; this just
-           ensures the button remains over top
-           of the input. */
-        z-index: 1;
-        /* Make the button itself a flex container,
-           so we can perfectly center the X icon. */
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        /* Flexbox will pull the element open
-           to make a generous clickable area. */
-        padding: 0;
     }
 
     .direct-messages-list-filter:placeholder-shown

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -84,7 +84,7 @@
     .topic_search_section {
         margin: 3px 0;
 
-        .clear_search_button {
+        .old_clear_search_button {
             grid-area: clear-button;
             /* Override app-component positioning. */
             position: static;
@@ -1745,7 +1745,7 @@ li.topic-list-item {
         padding-right: 30px;
     }
 
-    .clear_search_button {
+    .old_clear_search_button {
         /* Use the border-box model so flex
            can do its thing despite whatever
            padding and border we specify. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1751,6 +1751,10 @@ li.topic-list-item {
         + #clear-direct-messages-search-button {
         display: none;
     }
+
+    .stream-list-filter:placeholder-shown + #clear_search_stream_button {
+        display: none;
+    }
 }
 
 /* Prepare an adjusted grid for the logged-out state,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -649,9 +649,8 @@ ul.popover-group-menu-member-list {
             margin-bottom: 0;
         }
 
-        #clear_stream_search {
-            display: none;
-            grid-area: clear-search;
+        .stream-search:placeholder-shown + #clear_stream_search {
+            visibility: hidden;
         }
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -642,7 +642,7 @@ ul.popover-group-menu-member-list {
         .stream-search {
             grid-column: search-input-start / clear-search-end;
             grid-row: search-input;
-            padding-right: 20px;
+            padding-right: 28px;
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -162,7 +162,7 @@
         overflow: hidden;
     }
 
-    .clear_search_button {
+    .old_clear_search_button {
         grid-area: clear-search;
         padding: 0;
     }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -156,15 +156,10 @@
     #recent_view_search {
         grid-column: search-input-start / clear-search-end;
         grid-row: search-input;
-        padding-right: 20px;
+        padding-right: 28px;
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
-    }
-
-    .old_clear_search_button {
-        grid-area: clear-search;
-        padding: 0;
     }
 
     .button-recent-filters {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -477,7 +477,7 @@ $user_status_emoji_width: 24px;
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;
-            /* Prevent text from colliding with #clear_search_button */
+            /* Prevent text from colliding with #old_clear_search_button */
             padding-right: 28px;
             height: var(--line-height-sidebar-row-prominent);
             box-sizing: border-box;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -477,33 +477,10 @@ $user_status_emoji_width: 24px;
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;
-            /* Prevent text from colliding with #old_clear_search_button */
+            /* Prevent text from colliding with #clear_search_button */
             padding-right: 28px;
             height: var(--line-height-sidebar-row-prominent);
             box-sizing: border-box;
-        }
-
-        #clear_search_people_button {
-            grid-area: 1 / 2 / 2 / 3;
-            padding: 0;
-            background: none;
-            color: var(--color-text-clear-search-button);
-            display: grid;
-
-            &:hover {
-                color: var(--color-text-clear-search-button-hover);
-            }
-
-            &:focus,
-            &:focus-visible,
-            &:active {
-                box-shadow: none;
-                outline: none;
-            }
-
-            .zulip-icon-close {
-                align-self: center;
-            }
         }
     }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -482,6 +482,10 @@ $user_status_emoji_width: 24px;
             height: var(--line-height-sidebar-row-prominent);
             box-sizing: border-box;
         }
+
+        .user-list-filter:placeholder-shown + #clear_search_people_button {
+            display: none;
+        }
     }
 
     #buddy-list-menu-icon {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -539,10 +539,8 @@ h4.user_group_setting_subsection_title {
     width: 100%;
 }
 
-#clear_search_stream_name,
-#clear_search_group_name {
-    grid-area: clear-search;
-    padding: 0;
+#search_group_name:placeholder-shown + #clear_search_group_name {
+    visibility: hidden;
 }
 
 #search_stream_name:placeholder-shown + #clear_search_stream_name {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -513,11 +513,8 @@ h4.user_group_setting_subsection_title {
 
 #search_stream_name,
 #search_group_name {
-    padding: 3px 5px;
-    display: inline-block;
-    border-radius: 5px;
     box-shadow: none;
-    padding-right: 20px;
+    padding-right: 28px;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -3,14 +3,18 @@
     width: 384px;
 
     .user-status-content-wrapper {
-        display: flex;
+        display: grid;
+        grid-template:
+            "status-icon search-input clear-search" auto / auto minmax(0, 1fr)
+            auto;
         align-items: center;
         border: 1px solid;
         border-color: hsl(0deg 0% 0% / 60%);
         border-radius: 5px;
+        height: 35px;
 
         & input.user-status {
-            flex: 1 1 0;
+            grid-area: search-input;
             width: 100%;
             border: none;
             outline: none;
@@ -23,9 +27,10 @@
             }
         }
 
-        .old_clear_search_button {
-            position: static;
-            padding: 6px;
+        .clear_search_button {
+            grid-area: clear-search;
+            width: 40px;
+            padding-left: 5px;
         }
 
         .status-emoji-wrapper {

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -23,7 +23,7 @@
             }
         }
 
-        .clear_search_button {
+        .old_clear_search_button {
             position: static;
             padding: 6px;
         }

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -33,6 +33,10 @@
             padding-left: 5px;
         }
 
+        #user-status-input:placeholder-shown + .clear_search_button {
+            visibility: hidden;
+        }
+
         .status-emoji-wrapper {
             padding: 4px 8px;
             border-right: 1px solid;

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,6 +1,6 @@
 <div class="topic_search_section filter-topics">
     <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
-    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_topic_button">
-        <i class="fa fa-remove" aria-hidden="true"></i>
+    <button type="button" class="clear_search_button" id="clear_search_topic_button">
+        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
     </button>
 </div>

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,6 +1,6 @@
 <div class="topic_search_section filter-topics">
     <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
-    <button type="button" class="bootstrap-btn clear_search_button" id="clear_search_topic_button">
+    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_topic_button">
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>
 </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -165,8 +165,8 @@
         </a>
         <div class="zoom-out-hide direct-messages-search-section">
             <input class="direct-messages-list-filter filter_text_input home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
-            <button type="button" class="bootstrap-btn old_clear_search_button" id="clear-direct-messages-search-button">
-                <i class="fa fa-remove" aria-hidden="true"></i>
+            <button type="button" class="clear_search_button" id="clear-direct-messages-search-button">
+                <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
             </button>
         </div>
     </div>
@@ -194,8 +194,8 @@
 
                 <div class="notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
-                    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_stream_button">
-                        <i class="fa fa-remove" aria-hidden="true"></i>
+                    <button type="button" class="clear_search_button" id="clear_search_stream_button">
+                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -165,7 +165,7 @@
         </a>
         <div class="zoom-out-hide direct-messages-search-section">
             <input class="direct-messages-list-filter filter_text_input home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
-            <button type="button" class="bootstrap-btn clear_search_button" id="clear-direct-messages-search-button">
+            <button type="button" class="bootstrap-btn old_clear_search_button" id="clear-direct-messages-search-button">
                 <i class="fa fa-remove" aria-hidden="true"></i>
             </button>
         </div>
@@ -194,7 +194,7 @@
 
                 <div class="notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
-                    <button type="button" class="bootstrap-btn clear_search_button" id="clear_search_stream_button">
+                    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -4,7 +4,7 @@
     </div>
     <div class="search_group" role="group">
         <input type="text" id="recent_view_search" class="filter_text_input" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics (t)' }}" />
-        <button type="button" class="bootstrap-btn clear_search_button" id="recent_view_search_clear">
+        <button type="button" class="bootstrap-btn old_clear_search_button" id="recent_view_search_clear">
             <i class="fa fa-remove" aria-hidden="true"></i>
         </button>
     </div>

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -4,8 +4,8 @@
     </div>
     <div class="search_group" role="group">
         <input type="text" id="recent_view_search" class="filter_text_input" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics (t)' }}" />
-        <button type="button" class="bootstrap-btn old_clear_search_button" id="recent_view_search_clear">
-            <i class="fa fa-remove" aria-hidden="true"></i>
+        <button type="button" class="clear_search_button" id="recent_view_search_clear">
+            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
         </button>
     </div>
 </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -4,7 +4,7 @@
             <div id="userlist-header">
                 <div id="userlist-header-search">
                     <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter users' }}" />
-                    <button type="button" class="bootstrap-btn hidden" id="clear_search_people_button">
+                    <button type="button" class="clear_search_button" id="clear_search_people_button">
                         <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                     </button>
                 </div>

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -5,7 +5,7 @@
         </div>
     </div>
     <input type="text" class="user-status modal_text_input" placeholder="{{t 'Your status' }}" maxlength="60"/>
-    <button type="button" class="bootstrap-btn clear_search_button" id="clear_status_message_button" disabled="disabled">
+    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_status_message_button" disabled="disabled">
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>
 </div>

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -4,9 +4,9 @@
             {{> status_emoji_selector .}}
         </div>
     </div>
-    <input type="text" class="user-status modal_text_input" placeholder="{{t 'Your status' }}" maxlength="60"/>
-    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_status_message_button" disabled="disabled">
-        <i class="fa fa-remove" aria-hidden="true"></i>
+    <input type="text" class="user-status modal_text_input" id="user-status-input" placeholder="{{t 'Your status' }}" maxlength="60"/>
+    <button type="button" class="clear_search_button" id="clear_status_message_button" disabled="disabled">
+        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
     </button>
 </div>
 <div class="user-status-options">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -22,7 +22,7 @@
                 <div class="input-append stream_name_search_section" id="stream_filter">
                     <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter channels' }}" value=""/>
-                    <button type="button" class="bootstrap-btn clear_search_button" id="clear_search_stream_name">
+                    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_stream_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -22,8 +22,8 @@
                 <div class="input-append stream_name_search_section" id="stream_filter">
                     <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter channels' }}" value=""/>
-                    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_stream_name">
-                        <i class="fa fa-remove" aria-hidden="true"></i>
+                    <button type="button" class="clear_search_button" id="clear_search_stream_name">
+                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                     </button>
                 </div>
                 <div class="no-streams-to-show">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -22,8 +22,8 @@
                 <div class="input-append group_name_search_section" id="group_filter">
                     <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter groups' }}" value=""/>
-                    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_group_name">
-                        <i class="fa fa-remove" aria-hidden="true"></i>
+                    <button type="button" class="clear_search_button" id="clear_search_group_name">
+                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                     </button>
                 </div>
                 <div class="no-groups-to-show">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -22,7 +22,7 @@
                 <div class="input-append group_name_search_section" id="group_filter">
                     <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter groups' }}" value=""/>
-                    <button type="button" class="bootstrap-btn clear_search_button" id="clear_search_group_name">
+                    <button type="button" class="bootstrap-btn old_clear_search_button" id="clear_search_group_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -119,8 +119,8 @@
                             </div>
                             <div class="stream-search-container">
                                 <input type="text" class="stream-search modal_text_input" placeholder="{{t 'Filter channels' }}" />
-                                <button type="button" class="old_clear_search_button" id="clear_stream_search">
-                                    <i class="fa fa-remove" aria-hidden="true"></i>
+                                <button type="button" class="clear_search_button" id="clear_stream_search">
+                                    <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -119,7 +119,7 @@
                             </div>
                             <div class="stream-search-container">
                                 <input type="text" class="stream-search modal_text_input" placeholder="{{t 'Filter channels' }}" />
-                                <button type="button" class="clear_search_button" id="clear_stream_search">
+                                <button type="button" class="old_clear_search_button" id="clear_stream_search">
                                     <i class="fa fa-remove" aria-hidden="true"></i>
                                 </button>
                             </div>


### PR DESCRIPTION
This is a follow-up PR for #32594, It replaces all '**x**' -`fa-remove` icons with `zulip-icon-close` icons
across all search boxes in the app. 

Additionally, it resolves some hovering and displaying issues, ensuring consistency.

Fixes: #32598 

### Screenshots

|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Recent Conversations  | ![recent](https://github.com/user-attachments/assets/439911fa-1e88-49e2-95fd-e7c83b79e919)    |
| User Groups                         | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/639495b5-e275-49ee-9b69-3ac1a51e1c87)    |
| Direct Messages Left Sidebar  | ![dm](https://github.com/user-attachments/assets/846f4ee2-06bb-4a46-abc7-3f27e4cd2fc6) |
| Channels Settings | ![dm](https://github.com/user-attachments/assets/6861fe59-69e8-46f8-b1cd-0caf6222433a) |
| Channels Left Sidebar | ![dm](https://github.com/user-attachments/assets/323c0899-93b4-4170-97fa-91f940838a5c) |
| User Profile Modal | ![dm](https://github.com/user-attachments/assets/9223677a-8f49-4297-a31f-76ea9aac8046) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
