### PR TITLE
Adds "x" button to the table filters in settings.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -467,6 +467,14 @@ export function create<Key, Item = Key>(
                 widget.set_filter_value(value);
                 widget.hard_redraw();
             });
+
+            opts.filter?.$element?.siblings(".clear-filter").on("click", () => {
+                assert(opts.filter?.$element !== undefined);
+                const $filter = opts.filter?.$element;
+                $filter.val("");
+                widget.set_filter_value("");
+                widget.clean_redraw();
+            });
         },
 
         clear_event_handlers() {
@@ -474,6 +482,7 @@ export function create<Key, Item = Key>(
 
             if (opts.$parent_container) {
                 opts.$parent_container.off("click.list_widget_sort", "[data-sort]");
+                opts.filter?.$element?.siblings(".clear-filter").off("click");
             }
 
             opts.filter?.$element?.off("input.list_widget_filter");

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -480,6 +480,17 @@ function active_create_table(active_users: number[]): void {
     $("#admin_users_table").show();
 }
 
+function handle_clear_button_for_users($tbody: JQuery): void {
+    const $container = $tbody.closest(".user-settings-section");
+    $container.on("click", ".clear-filter", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const $filter = $container.find(".search");
+        set_text_search_value($tbody, "");
+        $filter.trigger("input");
+    });
+}
+
 function deactivated_create_table(deactivated_users: number[]): void {
     const $deactivated_users_table = $("#admin_deactivated_users_table");
     deactivated_section.list_widget = ListWidget.create(
@@ -712,6 +723,7 @@ function active_handle_events(): void {
     handle_deactivation($tbody);
     handle_reactivation($tbody);
     handle_edit_form($tbody);
+    handle_clear_button_for_users($tbody);
 }
 
 function deactivated_handle_events(): void {
@@ -721,6 +733,7 @@ function deactivated_handle_events(): void {
     handle_deactivation($tbody);
     handle_reactivation($tbody);
     handle_edit_form($tbody);
+    handle_clear_button_for_users($tbody);
 }
 
 function bots_handle_events(): void {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2029,6 +2029,43 @@ label.preferences-radio-choice-label {
         margin-right: auto;
     }
 
+    & .search-container {
+        display: grid;
+        grid-template: "search-input clear-search" auto / minmax(0, 1fr) 30px;
+
+        & input.search {
+            grid-column: search-input-start / clear-search-end;
+            grid-row: search-input;
+            padding-right: 23px;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            margin: 0;
+        }
+
+        & .clear-filter {
+            grid-area: clear-search;
+            padding: 0;
+            background: none;
+            color: var(--color-text-clear-search-button);
+            border: none;
+            outline: none;
+            display: grid;
+
+            &:hover {
+                color: var(--color-text-clear-search-button-hover);
+            }
+
+            .zulip-icon-close {
+                align-self: center;
+            }
+        }
+
+        input.search:placeholder-shown + .clear-filter {
+            display: none;
+        }
+    }
+
     & input.search {
         /* Without explicitly mentioning the height, it used be just a little
         bit short of 20px, since we need to maintain the same height with

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -5,7 +5,7 @@
         <div class="alert-notification" id="user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=active_user_list_dropdown_widget_name}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+            {{> filter_text_input placeholder=(t 'Filter users') aria_label=(t 'Filter users')}}
         </div>
     </div>
 

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -2,7 +2,7 @@
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
         <h3>{{t "Your uploads"}}</h3>
-        <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
+        {{> filter_text_input id="upload_file_search" placeholder=(t 'Filter uploaded files') aria_label=(t 'Filter uploads')}}
     </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -21,7 +21,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>
         <div class="alert-notification" id="bot-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
+        {{> filter_text_input placeholder=(t 'Filter bots') aria_label=(t 'Filter bots')}}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -55,7 +55,7 @@
             <h3>{{t "Export permissions"}}</h3>
             <div class="user_filters">
                 {{> ../dropdown_widget widget_name="filter_by_consent"}}
-                <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+                {{> filter_text_input placeholder=(t 'Filter users') aria_label=(t 'Filter users')}}
             </div>
         </div>
 

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -8,7 +8,7 @@
         <div class="alert-notification" id="deactivated-user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=deactivated_user_list_dropdown_widget_name}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
+            {{> filter_text_input placeholder=(t 'Filter deactivated users') aria_label=(t 'Filter deactivated users')}}
         </div>
     </div>
 

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -7,7 +7,7 @@
             {{#if is_admin}}
                 <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
             {{/if}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default channels' }}" aria-label="{{t 'Filter channels' }}"/>
+            {{> filter_text_input placeholder=(t 'Filter default channels') aria_label=(t 'Filter default channels')}}
         </div>
     </div>
 

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -11,8 +11,7 @@
 
     <div class="settings_panel_list_header">
         <h3>{{t "Custom emoji"}}</h3>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter emoji' }}"
-          aria-label="{{t 'Filter emoji' }}"/>
+        {{> filter_text_input placeholder=(t 'Filter emoji') aria_label=(t 'Filter emoji')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table admin_emoji_table">

--- a/web/templates/settings/filter_text_input.hbs
+++ b/web/templates/settings/filter_text_input.hbs
@@ -1,0 +1,6 @@
+<div class="search-container">
+    <input type="text" {{#if id}}id="{{id}}"{{/if}} class="search filter_text_input" placeholder="{{placeholder}}" aria-label="{{aria_label}}"/>
+    <button type="button" class="clear-filter">
+        <i class="zulip-icon zulip-icon-close"></i>
+    </button>
+</div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -8,7 +8,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Invitations "}}</h3>
         <div class="alert-notification" id="invites-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter invitations' }}" aria-label="{{t 'Filter invitations' }}"/>
+        {{> filter_text_input placeholder=(t 'Filter invitations') aria_label=(t 'Filter invitations')}}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -57,7 +57,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Linkifiers"}}</h3>
         <div class="alert-notification edit-linkifier-status" id="linkifier-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
+        {{> filter_text_input placeholder=(t 'Filter linkifiers') aria_label=(t 'Filter linkifiers')}}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -1,7 +1,7 @@
 <div id="muted-user-settings" class="settings-section" data-name="muted-users">
     <div class="settings_panel_list_header">
         <h3>{{t "Muted users"}}</h3>
-        <input id="muted_users_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
+        {{> filter_text_input id="muted_users_search" placeholder=(t 'Filter muted users') aria_label=(t 'Filter muted users')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -64,7 +64,7 @@
 
         <div class="settings_panel_list_header">
             <h3>{{t "Code playgrounds"}}</h3>
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter code playgrounds' }}" aria-label="{{t 'Filter code playgrounds' }}"/>
+            {{> filter_text_input placeholder=(t 'Filter code playgrounds') aria_label=(t 'Filter code playgrounds')}}
         </div>
 
         <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -12,7 +12,7 @@
             {{> ../help_link_widget link="/help/topic-notifications" }}
         </h3>
         {{> settings_save_discard_widget section_name="user-topics-settings" show_only_indicator=true }}
-        <input id="user_topics_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter topics' }}" aria-label="{{t 'Filter topics' }}"/>
+        {{> filter_text_input id="user_topics_search" placeholder=(t 'Filter topics') aria_label=(t 'Filter invitations')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -105,6 +105,7 @@ function make_filter_element() {
     const $element = {};
 
     $element.cleared = false;
+    $element.clear_button_elem_cleared = false;
 
     $element.on = (ev, f) => {
         assert.equal(ev, "input.list_widget_filter");
@@ -114,6 +115,23 @@ function make_filter_element() {
     $element.off = (ev) => {
         assert.equal(ev, "input.list_widget_filter");
         $element.cleared = true;
+    };
+
+    const clear_input_element = {};
+
+    clear_input_element.on = (ev, f) => {
+        assert.equal(ev, "click");
+        clear_input_element.f = f;
+    };
+
+    clear_input_element.off = (ev) => {
+        assert.equal(ev, "click");
+        $element.clear_button_elem_cleared = true;
+    };
+
+    $element.siblings = (selector) => {
+        assert.equal(selector, ".clear-filter");
+        return clear_input_element;
     };
 
     return $element;
@@ -135,6 +153,20 @@ function make_search_input() {
             };
             f.call(elem);
         };
+    };
+
+    const clear_search_button_element = {};
+
+    clear_search_button_element.on = (event, f) => {
+        assert.equal(event, "click");
+        $element.simulate_clear_search = () => {
+            f.call();
+        };
+    };
+
+    $element.siblings = (selector) => {
+        assert.equal(selector, ".clear-filter");
+        return clear_search_button_element;
     };
 
     return $element;
@@ -280,6 +312,13 @@ run_test("filtering", () => {
     assert.deepEqual(widget.get_current_list(), ["dog", "egg", "grape"]);
     expected_html = "<div>dog</div><div>egg</div><div>grape</div>";
     assert.deepEqual($container.$appended_data.html(), expected_html);
+
+    $search_input.simulate_clear_search();
+    assert.deepEqual(widget.get_current_list(), list);
+
+    // Reset the search input value to test that list is updated correctly.
+    $search_input.val = () => "g";
+    $search_input.simulate_input_event();
 
     // We can insert new data into the widget.
     const new_data = ["greta", "faye", "gary", "frank", "giraffe", "fox"];
@@ -561,12 +600,14 @@ run_test("clear_event_handlers", () => {
     assert.equal($sort_container.cleared, false);
     assert.equal($scroll_container.cleared, false);
     assert.equal($filter_element.cleared, false);
+    assert.equal($filter_element.clear_button_elem_cleared, false);
 
     // The second time we'll clear the old events.
     ListWidget.create($container, list, opts);
     assert.equal($sort_container.cleared, true);
     assert.equal($scroll_container.cleared, true);
     assert.equal($filter_element.cleared, true);
+    assert.equal($filter_element.clear_button_elem_cleared, true);
 });
 
 run_test("sort helpers", () => {


### PR DESCRIPTION
This PR adds an "x" button to the table filters in settings.

Fixes: #32599.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Table | Before | After |
|--------|--------|--------|
| Users | ![image](https://github.com/user-attachments/assets/60ef4c8b-0555-41c9-92d7-4e0eb41807f3) | ![image](https://github.com/user-attachments/assets/9016014c-4486-4330-84ac-de53a9ba7137) |
| Deactivated Users | ![image](https://github.com/user-attachments/assets/deec1e1c-4ecf-438d-9ead-cfb9a9336f93) | ![image](https://github.com/user-attachments/assets/0526109a-6aca-43e6-a048-204fc53bad99) |
| Invitations | ![image](https://github.com/user-attachments/assets/e7499fbd-ddf9-42a1-bccb-3ad968e2ae1d) | ![image](https://github.com/user-attachments/assets/db6f2f5d-7002-4de4-a411-50a10f7d7dc6) |
| Bots | ![image](https://github.com/user-attachments/assets/02f74d8b-39b9-4060-987b-daa3b35e46dc) | ![image](https://github.com/user-attachments/assets/3b8a0def-5d87-440d-955c-941ba129673c) |
| Default channels | ![image](https://github.com/user-attachments/assets/ba2aab08-5e1a-45ab-9b05-f993602d7637) | ![image](https://github.com/user-attachments/assets/a1bd3e10-4b87-4ebc-ba34-95f50e1f16df) | 
| Export permissions | ![image](https://github.com/user-attachments/assets/e05e7973-88c3-4a9d-a02d-3b594dab0671) | ![image](https://github.com/user-attachments/assets/7e8fe9ea-81fe-4b79-bf02-3509535b7236) |
| Upload files | ![image](https://github.com/user-attachments/assets/f997effb-b4c5-46fb-ac24-4ca34861cf68) | ![image](https://github.com/user-attachments/assets/ca412879-910d-4d29-8b4c-23bb5042846d) |
| Topic settings | ![image](https://github.com/user-attachments/assets/f6e38cc5-c575-42df-88b9-ef1eae6c945f) | ![image](https://github.com/user-attachments/assets/2f61d989-18ca-492e-a0fd-5527f52d1972) | 
| Muted users | ![image](https://github.com/user-attachments/assets/7cf145cc-bd0d-45a5-9f99-1dcd25c416d0) | ![image](https://github.com/user-attachments/assets/36047a62-129f-4678-8025-c16ba1afc7f2) | 

<details><summary>Behavior of these filters:</summary>
<p>

Each filter has the following behavior:

![working](https://github.com/user-attachments/assets/7d760511-18d0-4d82-a628-018812b47136)


</p>
</details> 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
