### PR TITLE
read-receipts: Auto-refresh read-receipts dialog every minute.

### DIFF
--- a/web/src/read_receipts.ts
+++ b/web/src/read_receipts.ts
@@ -15,91 +15,111 @@ import * as people from "./people.ts";
 import * as ui_report from "./ui_report.ts";
 import * as util from "./util.ts";
 
+const read_receipts_polling_interval_ms = 60 * 1000;
 const read_receipts_api_response_schema = z.object({
     user_ids: z.array(z.number()),
 });
+
+let interval_id: number | null = null;
+let has_initial_data = false;
+
+export function fetch_read_receipts(message_id: number): void {
+    const message = message_store.get(message_id);
+    assert(message !== undefined, "message is undefined");
+
+    if (message.sender_email === "notification-bot@zulip.com") {
+        $("#read_receipts_modal .read_receipts_info").text(
+            $t({
+                defaultMessage: "Read receipts are not available for Notification Bot messages.",
+            }),
+        );
+        $("#read_receipts_modal .modal__content").addClass("compact");
+        return;
+    }
+
+    if (!has_initial_data) {
+        loading.make_indicator($("#read_receipts_modal .loading_indicator"));
+    }
+
+    void channel.get({
+        url: `/json/messages/${message_id}/read_receipts`,
+        success(raw_data) {
+            const $modal = $("#read_receipts_modal").filter(`[data-message-id=${message_id}]`);
+            // If the read receipts modal for the selected message ID is closed
+            // by the time we receive the response, return immediately.
+            if ($modal.length === 0) {
+                return;
+            }
+
+            has_initial_data = true;
+            $("#read_receipts_modal .read_receipts_error").removeClass("show");
+            const data = read_receipts_api_response_schema.parse(raw_data);
+            const users = data.user_ids.map((id) => people.get_user_by_id_assert_valid(id));
+            users.sort(people.compare_by_name);
+
+            const context = {
+                users: users.map((user) => ({
+                    user_id: user.user_id,
+                    full_name: user.full_name,
+                    avatar_url: people.small_avatar_url_for_person(user),
+                })),
+            };
+
+            if (users.length === 0) {
+                $("#read_receipts_modal .read_receipts_info").text(
+                    $t({defaultMessage: "No one has read this message yet."}),
+                );
+                $modal.find(".read_receipts_list").hide();
+            } else {
+                $("#read_receipts_modal .read_receipts_info").html(
+                    $t_html(
+                        {
+                            defaultMessage:
+                                "{num_of_people, plural, one {This message has been <z-link>read</z-link> by {num_of_people} person:} other {This message has been <z-link>read</z-link> by {num_of_people} people:}}",
+                        },
+                        {
+                            num_of_people: users.length,
+                            "z-link": (content_html) =>
+                                `<a href="/help/read-receipts" target="_blank" rel="noopener noreferrer">${content_html.join(
+                                    "",
+                                )}</a>`,
+                        },
+                    ),
+                );
+                $modal.find(".read_receipts_list").html(render_read_receipts(context)).show();
+                $("#read_receipts_modal .modal__container").addClass("showing_read_receipts_list");
+                new SimpleBar(util.the($("#read_receipts_modal .modal__content")), {
+                    tabIndex: -1,
+                });
+            }
+            loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
+        },
+        error(xhr) {
+            ui_report.error(
+                $t({defaultMessage: "Failed to load read receipts."}),
+                xhr,
+                $("#read_receipts_modal #read_receipts_error"),
+            );
+            loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
+        },
+    });
+}
 
 export function show_user_list(message_id: number): void {
     $("#read-receipts-modal-container").html(render_read_receipts_modal({message_id}));
     modals.open("read_receipts_modal", {
         autoremove: true,
         on_shown() {
-            const message = message_store.get(message_id);
-            assert(message !== undefined, "message is undefined");
-
-            if (message.sender_email === "notification-bot@zulip.com") {
-                $("#read_receipts_modal .read_receipts_info").text(
-                    $t({
-                        defaultMessage:
-                            "Read receipts are not available for Notification Bot messages.",
-                    }),
-                );
-                $("#read_receipts_modal .modal__content").addClass("compact");
-            } else {
-                loading.make_indicator($("#read_receipts_modal .loading_indicator"));
-                void channel.get({
-                    url: `/json/messages/${message_id}/read_receipts`,
-                    success(raw_data) {
-                        const $modal = $("#read_receipts_modal").filter(
-                            "[data-message-id=" + message_id + "]",
-                        );
-                        // If the read receipts modal for the selected message ID is closed
-                        // by the time we receive the response, return immediately.
-                        if ($modal.length === 0) {
-                            return;
-                        }
-                        const data = read_receipts_api_response_schema.parse(raw_data);
-                        const users = data.user_ids.map((id) => {
-                            const user = people.get_user_by_id_assert_valid(id);
-                            return user;
-                        });
-                        users.sort(people.compare_by_name);
-
-                        const context = {
-                            users: users.map((user) => ({
-                                user_id: user.user_id,
-                                full_name: user.full_name,
-                                avatar_url: people.small_avatar_url_for_person(user),
-                            })),
-                        };
-
-                        loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
-                        if (users.length === 0) {
-                            $("#read_receipts_modal .read_receipts_info").text(
-                                $t({defaultMessage: "No one has read this message yet."}),
-                            );
-                        } else {
-                            $("#read_receipts_modal .read_receipts_info").html(
-                                $t_html(
-                                    {
-                                        defaultMessage:
-                                            "{num_of_people, plural, one {This message has been <z-link>read</z-link> by {num_of_people} person:} other {This message has been <z-link>read</z-link> by {num_of_people} people:}}",
-                                    },
-                                    {
-                                        num_of_people: users.length,
-                                        "z-link": (content_html) =>
-                                            `<a href="/help/read-receipts" target="_blank" rel="noopener noreferrer">${content_html.join(
-                                                "",
-                                            )}</a>`,
-                                    },
-                                ),
-                            );
-                            $("#read_receipts_modal .modal__container").addClass(
-                                "showing_read_receipts_list",
-                            );
-                            $("#read_receipts_modal .read_receipts_list").html(
-                                render_read_receipts(context),
-                            );
-                            new SimpleBar(util.the($("#read_receipts_modal .modal__content")), {
-                                tabIndex: -1,
-                            });
-                        }
-                    },
-                    error(xhr) {
-                        ui_report.error("", xhr, $("#read_receipts_error"));
-                        loading.destroy_indicator($("#read_receipts_modal .loading_indicator"));
-                    },
-                });
+            has_initial_data = false;
+            fetch_read_receipts(message_id);
+            interval_id = window.setInterval(() => {
+                fetch_read_receipts(message_id);
+            }, read_receipts_polling_interval_ms);
+        },
+        on_hidden() {
+            if (interval_id !== null) {
+                clearInterval(interval_id);
+                interval_id = null;
             }
         },
     });


### PR DESCRIPTION
Previously, the read-receipts dialog did not update if someone viewed the focused message while the dialog box was open. Users had to close and reopen it to see the updated receipts. Now, the dialog refreshes every minute to keep the read-receipts updated while open.

This issue solves the second part only as the first part was already solved by [#28799](https://github.com/zulip/zulip/pull/28799).


https://github.com/user-attachments/assets/22ae55d5-6f3f-4e26-b6dc-ada342b74cd2


Fixes: #24716.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
