### PR TITLE
Do not auto-discard drafts (32176)

### DIFF
--- a/help/view-and-edit-your-message-drafts.md
+++ b/help/view-and-edit-your-message-drafts.md
@@ -3,7 +3,7 @@
 Zulip automatically saves the content of your message as a draft when you close
 the compose box, ensuring that you never lose your work. When you start
 composing, the most recently edited draft for the conversation you are composing
-to automatically appears in the compose box. Drafts are saved for 30 days.
+to automatically appears in the compose box.
 
 !!! warn ""
 

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -1,4 +1,3 @@
-import {subDays} from "date-fns";
 import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
@@ -143,6 +142,7 @@ export const draft_model = (function () {
             // directly upgrade from Zulip 6.0beta1 and earlier development branch where the bug was present,
             // since we expect bugged drafts will have either been run through
             // this code or else been deleted after 30 (DRAFT_LIFETIME) days.
+            // update: drafts won't be deleted after 30 days anymore.
             if (draft.topic === undefined) {
                 draft.topic = "";
             }
@@ -457,8 +457,6 @@ export function rewire_update_draft(value: typeof update_draft): void {
     update_draft = value;
 }
 
-export const DRAFT_LIFETIME = 30;
-
 export function current_recipient_data(): {
     stream_name: string | undefined;
     topic: string | undefined;
@@ -558,16 +556,6 @@ export function get_last_restorable_draft_based_on_compose_state():
         .findLast((draft) => !draft.is_sending_saving && draft.drafts_version >= 1);
 }
 
-export function remove_old_drafts(): void {
-    const old_date = subDays(new Date(), DRAFT_LIFETIME).getTime();
-    const drafts = draft_model.get();
-    for (const [id, draft] of Object.entries(drafts)) {
-        if (draft.updatedAt !== undefined && draft.updatedAt < old_date) {
-            draft_model.deleteDraft(id);
-        }
-    }
-}
-
 export type FormattedDraft =
     | {
           is_stream: true;
@@ -665,8 +653,6 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
 }
 
 export function initialize(): void {
-    remove_old_drafts();
-
     // It's possible that drafts will get still have
     // `is_sending_saving` set to true if the page was
     // refreshed in the middle of sending a message. We

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -164,7 +164,6 @@ export function launch(): void {
             narrow_drafts_header,
             narrow_drafts,
             other_drafts,
-            draft_lifetime: drafts.DRAFT_LIFETIME,
         });
         const $drafts_table = $("#drafts_table");
         $drafts_table.append($(rendered));

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -10,7 +10,6 @@
                     <div class="removed-drafts-message">
                         {{t "Drafts are not synced to other devices and browsers." }}
                         <br />
-                        {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
                     </div>
                     <div class="delete-drafts-group">
                         <div class="delete-selected-drafts-button-container">

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -265,38 +265,6 @@ test("initialize", ({override_rewire}) => {
     drafts_overlay_ui.initialize();
 });
 
-test("remove_old_drafts", ({override_rewire}) => {
-    const draft_3 = {
-        topic: "topic",
-        type: "stream",
-        content: "Test stream message",
-        updatedAt: Date.now(),
-        is_sending_saving: false,
-        drafts_version: 1,
-    };
-    const draft_4 = {
-        private_message_recipient: "aaron@zulip.com",
-        reply_to: "aaron@zulip.com",
-        type: "private",
-        content: "Test direct message",
-        updatedAt: new Date().setDate(-30),
-        is_sending_saving: false,
-        drafts_version: 1,
-    };
-    const draft_model = drafts.draft_model;
-    const ls = localstorage();
-    const data = {id3: draft_3, id4: draft_4};
-    ls.set("drafts", data);
-    assert.deepEqual(draft_model.get(), data);
-
-    const $unread_count = $("<unread-count-stub>");
-    $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
-    override_rewire(drafts, "update_compose_draft_count", noop);
-
-    drafts.remove_old_drafts();
-    assert.deepEqual(draft_model.get(), {id3: draft_3});
-});
-
 test("update_draft", ({override, override_rewire}) => {
     compose_state.set_message_type(undefined);
     let draft_id = drafts.update_draft();


### PR DESCRIPTION
… the drafts will be discarded after 30 days

This pull request stops auto-discarding drafts older than 30 days. It also removes parts of the UI and the documentation that references the auto-discarding feature.

Fixes: #32176

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

UI before changes:
<img width="890" alt="before" src="https://github.com/user-attachments/assets/a7b66e13-75f2-4736-8aa1-3e209024c776">

UI after changes:
<img width="905" alt="after" src="https://github.com/user-attachments/assets/7fb2036c-9820-41e6-b4f7-ee3ae5b355a6">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
