### PR TITLE
Add "Alphabetize choices" button for "List of options" type custom profile fields.

### DIFF
--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -509,15 +509,18 @@ function open_edit_form_modal(this: HTMLElement): void {
         // Set initial value in edit form
         $profile_field_form.find("input[name=name]").val(field.name);
         $profile_field_form.find("input[name=hint]").val(field.hint);
+        const $edit_profile_field_choices_container = $profile_field_form.find(
+            ".edit_profile_field_choices_container",
+        );
 
-        $profile_field_form
-            .find(".edit_profile_field_choices_container")
-            .on("input", ".choice-row input", add_choice_row);
-        $profile_field_form
-            .find(".edit_profile_field_choices_container")
-            .on("click", "button.delete-choice", function (this: HTMLElement) {
+        $edit_profile_field_choices_container.on("input", ".choice-row input", add_choice_row);
+        $edit_profile_field_choices_container.on(
+            "click",
+            "button.delete-choice",
+            function (this: HTMLElement) {
                 delete_choice_row_for_edit(this, $profile_field_form, field);
-            });
+            },
+        );
 
         $("#edit-custom-profile-field-form-modal .dialog_submit_button").prop("disabled", true);
         // Setup onInput event listeners to disable/enable submit button,
@@ -741,11 +744,12 @@ export function do_populate_profile_fields(profile_fields_data: CustomProfileFie
 
 function set_up_select_field(): void {
     const field_types = realm.custom_profile_field_types;
+    const $profile_field_choices = $("#profile_field_choices");
 
-    create_choice_row($("#profile_field_choices"));
+    create_choice_row($profile_field_choices);
 
     if (current_user.is_admin) {
-        const choice_list = util.the($("#profile_field_choices"));
+        const choice_list = util.the($profile_field_choices);
         SortableJS.create(choice_list, {
             onUpdate() {
                 // Do nothing on drag. We process the order on submission
@@ -774,8 +778,8 @@ function set_up_select_field(): void {
         },
     );
 
-    $("#profile_field_choices").on("input", ".choice-row input", add_choice_row);
-    $("#profile_field_choices").on("click", "button.delete-choice", function (this: HTMLElement) {
+    $profile_field_choices.on("input", ".choice-row input", add_choice_row);
+    $profile_field_choices.on("click", "button.delete-choice", function (this: HTMLElement) {
         delete_choice_row(this);
     });
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1721,6 +1721,11 @@ label.preferences-radio-choice-label {
     }
 }
 
+.profile-field-choices-wrapper > .alphabetize-choices-button {
+    display: block;
+    margin: 12px 0 0;
+}
+
 .custom_user_field,
 .bot_owner_user_field {
     .pill-container {

--- a/web/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/web/templates/settings/add_new_custom_profile_field_form.hbs
@@ -26,11 +26,12 @@
             <input type="text" id="profile_field_hint" class="modal_text_input" name="hint" autocomplete="off" maxlength="80" />
             <div class="alert" id="admin-profile-field-hint-status"></div>
         </div>
-        <div class="input-group" id="profile_field_choices_row">
+        <div class="input-group profile-field-choices-wrapper" id="profile_field_choices_row">
             <label for="profile_field_choices" class="modal-field-label">{{t "Field choices" }}</label>
             <table class="profile_field_choices_table">
                 <tbody id="profile_field_choices" class="profile-field-choices"></tbody>
             </table>
+            <button type="button" class="button white rounded alphabetize-choices-button">{{t "Alphabetize choices" }}</button>
         </div>
         <div class="input-group" id="custom_external_account_url_pattern">
             <label for="custom_field_url_pattern" class="modal-field-label">{{t "URL pattern" }}</label>

--- a/web/templates/settings/edit_custom_profile_field_form.hbs
+++ b/web/templates/settings/edit_custom_profile_field_form.hbs
@@ -9,7 +9,7 @@
         <input type="text" name="hint" id="id-custom-profile-field-hint" class="modal_text_input prop-element" value="{{ hint }}" maxlength="80" data-setting-widget-type="string" />
     </div>
     {{#if is_select_field }}
-    <div class="input-group prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
+    <div class="input-group prop-element profile-field-choices-wrapper" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">
         <label for="profile_field_choices_edit" class="modal-field-label">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">
             <div class="edit_profile_field_choices_container">
@@ -18,6 +18,7 @@
                 {{/each}}
             </div>
         </div>
+        <button type="button" class="button white rounded alphabetize-choices-button">{{t "Alphabetize choices" }}</button>
     </div>
     {{else if is_external_account_field}}
     <div class="prop-element" id="id-custom-profile-field-field-data" data-setting-widget-type="field-data-setting">


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR is based upon original work done in PR #30267, where an extra bug was fixed in 1st commit which was not supposed to be good approach to maintainers ([see here](https://github.com/zulip/zulip/pull/30267#issuecomment-2260358411)).

I fixed that bug in an additional PR #32619 using different approach.

Rest of the code change is same as previous.

Fixes: #28607.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>For Dark Mode: </summary>

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/bd020017-b4c3-4741-a023-6fade115d4a2) | ![After](https://github.com/user-attachments/assets/dc148d3a-0cb2-4fa3-a85a-2c55d7c8cd16) |
| ![Before](https://github.com/user-attachments/assets/116e1251-4894-43ea-8cc7-a51f159bcd00) | ![After](https://github.com/user-attachments/assets/5ea4bed5-287d-48a4-a074-2b4f7e071034) |

</details>

<details>
<summary>For Light Mode: </summary>

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/98877a55-e23e-4614-a980-680488f8ee01) | ![After](https://github.com/user-attachments/assets/51d7b981-26a2-4f02-a1df-1a006e235c47) |
| ![Before](https://github.com/user-attachments/assets/12fc36aa-1a8d-431b-b88e-4216742a9d26) | ![After](https://github.com/user-attachments/assets/a2e6e52a-c0e2-4ffc-bfdc-d50082687374) |

</details>




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
