### PR TITLE
compose: Clear preview area when starting a new draft.

### DIFF
--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -216,6 +216,7 @@ export function initialize() {
                 // time.
                 compose_state.prevent_draft_restoring();
                 compose.clear_compose_box();
+                compose.clear_preview_area();
                 popover_menus.hide_current_popover_if_visible(instance);
             });
         },


### PR DESCRIPTION
Reported here: https://chat.zulip.org/#narrow/channel/9-issues/topic/Msg.20preview.20prevents.20saving.20draft.20.26.20start.20new.20action