### PR TITLE
left_sidebar: Adjust and improve alignment on Browse More Channels row.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -433,8 +433,11 @@
     .subscribe-more-link {
         display: grid;
         grid-template:
-            "plus-icon row-text" var(--line-height-sidebar-row-prominent)
-            / auto 1fr;
+            "plus-icon . row-text" var(--line-height-sidebar-row-prominent)
+            / var(--left-sidebar-icon-column-width) var(
+                --left-sidebar-icon-content-gap
+            )
+            minmax(0, 1fr);
         align-items: center;
         line-height: var(--line-height-sidebar-row-prominent);
         color: var(--color-text-sidebar-action-heading);
@@ -442,6 +445,7 @@
     }
 
     .subscribe-more-label {
+        grid-area: row-text;
         font-size: var(--font-size-sidebar-action-heading);
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);
@@ -455,15 +459,6 @@
 #login-link-container,
 #subscribe-to-more-streams {
     text-decoration: none;
-
-    .subscribe-more-icon {
-        min-width: 19px;
-        text-align: center;
-
-        &::before {
-            padding-right: 3px;
-        }
-    }
 }
 
 #login-link-container {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -436,8 +436,12 @@
             "plus-icon row-text" var(--line-height-sidebar-row-prominent)
             / auto 1fr;
         align-items: center;
+        line-height: var(--line-height-sidebar-row-prominent);
         color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
+    }
+
+    .subscribe-more-label {
         font-size: var(--font-size-sidebar-action-heading);
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -446,6 +446,18 @@
 
     .subscribe-more-label {
         grid-area: row-text;
+        /* Because the label is run in small caps, we do a font-metrics-based
+           adjustment of its top margin to keep the text vertically aligned
+           with the square [+] icon (whose shape leaves absolutely no room
+           for error when it comes to centering). Going back to the font metrics
+           outlined in web/src/information_density.ts, we can offset against the
+           space reserved for descenders, and take half that value to pull the
+           text up: 400 / (400 + 1025) ~= 0.28; half of 0.28 is 0.14, so
+           `margin-top: -0.14em`. However, it looks as though a slight adjustment
+           to -0.12em produces a slightly more pleasing result, which makes sense
+           because mathematical centering and the perception of center don't
+           always match. */
+        margin-top: -0.12em;
         font-size: var(--font-size-sidebar-action-heading);
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,16 +1,16 @@
 {{#if exactly_one_unsubscribed_stream}}
     <a class="subscribe-more-link" href="#channels/notsubscribed">
         <i class="subscribe-more-icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
-        {{~t "BROWSE 1 MORE CHANNEL" ~}}
+        <span class="subscribe-more-label">{{~t "BROWSE 1 MORE CHANNEL" ~}}</span>
     </a>
 {{else if can_subscribe_stream_count}}
     <a class="subscribe-more-link" href="#channels/notsubscribed">
         <i class="subscribe-more-icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
-        {{~t "BROWSE {can_subscribe_stream_count} MORE CHANNELS" ~}}
+        <span class="subscribe-more-label">{{~t "BROWSE {can_subscribe_stream_count} MORE CHANNELS" ~}}</span>
     </a>
 {{else if can_create_streams}}
     <a class="subscribe-more-link" href="#channels/new">
         <i class="subscribe-more-icon zulip-icon zulip-icon-square-plus" aria-hidden="true" ></i>
-        {{~t "CREATE A CHANNEL" ~}}
+        <span class="subscribe-more-label">{{~t "CREATE A CHANNEL" ~}}</span>
     </a>
 {{/if}}


### PR DESCRIPTION
This PR improves the horizontal layout and vertical alignment of the Browse More Channels row. It fixes a subtle font-size bug that was making the icon too large, and blowing open the row's line-height to larger than the other prominent sidebar rows.

It also uses existing variables used on other left-sidebar rows for icon placement and gaps.
[
CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/invite.20users.20link.20in.20right.20sidebar.20.20.2332332/near/1995066)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Grid shown in second set to illustrate the less immediately perceptible changes._

| Before | After |
| --- | --- |
| ![browse-more-before](https://github.com/user-attachments/assets/e4574236-2196-4574-a45d-6eb64c1fa9a3) | ![browse-more-after](https://github.com/user-attachments/assets/28ad9340-de24-46dd-95a3-5725bc60cef7) |
| ![browse-more-before-grid](https://github.com/user-attachments/assets/765fe86b-cde0-4848-b3dc-faf9e7c25436) | ![browse-more-after-grid](https://github.com/user-attachments/assets/e15aacb7-3a5e-4f10-9533-1cf8294838d9) |






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
