### PR TITLE
footer: Fix footer items mis-aligned in Russian.

### DIFF
--- a/web/styles/portico/footer.css
+++ b/web/styles/portico/footer.css
@@ -183,7 +183,7 @@
     }
 
     /* #footer responsivity and global fixes */
-    @media (width <= 940px) {
+    @media (width <= 1280px) {
         .footer__container {
             justify-content: flex-start;
             row-gap: 0;


### PR DESCRIPTION

Change alignment of footer rows to flex-start a bit earlier. `1280px` is chosen since that's the standard `max-width` for the screens on the page and that is width around which the massive gap before the first item on the footer is diminished which allows us to left align the elements.

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/48acdffe-3353-485f-a992-421479ee04be) | ![image](https://github.com/user-attachments/assets/4ff8ad03-39cb-47fe-a260-6ce6245786b8) |
