### PR TITLE
Use :focus-visible to style link focus rings; remove link focus interference

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -95,7 +95,7 @@
     }
 
     /* Bootstrap 'a' tag styles for styling reload link */
-    a#reload-lnk:focus {
+    a#reload-lnk:focus-visible {
     outline: thin dotted #333;
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px;
@@ -110,7 +110,7 @@
     cursor: pointer;
     }
     a#reload-lnk:hover,
-    a#reload-lnk:focus {
+    a#reload-lnk:focus-visible {
     color: #005580;
     text-decoration: underline;
     }

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -38,7 +38,6 @@ import * as starred_messages_ui from "./starred_messages_ui.ts";
 import * as stream_list from "./stream_list.ts";
 import * as stream_popover from "./stream_popover.ts";
 import * as topic_list from "./topic_list.ts";
-import * as ui_util from "./ui_util.ts";
 import {parse_html} from "./ui_util.ts";
 import * as util from "./util.ts";
 
@@ -349,11 +348,6 @@ export function initialize() {
         message_edit.end_message_row_edit($row);
         e.stopPropagation();
     });
-    $("body").on("click", "a", function () {
-        if (document.activeElement === this) {
-            ui_util.blur_active_element();
-        }
-    });
     $("body").on("click", ".message_edit_form .compose_upload_file", function (e) {
         e.preventDefault();
 
@@ -646,18 +640,6 @@ export function initialize() {
 
     // MISC
 
-    {
-        const sel = [
-            "#stream_filters",
-            "#left-sidebar-navigation-list",
-            "#buddy-list-users-matching-view",
-        ].join(", ");
-
-        $(sel).on("click", "a", function () {
-            this.blur();
-        });
-    }
-
     $("body").on("click", ".logout_button", () => {
         $("#logout_form").trigger("submit");
     });
@@ -785,27 +767,6 @@ export function initialize() {
         // `#direct-messages-section-header.zoom-in`.
         e.stopPropagation();
     });
-
-    // disable the draggability for left-sidebar components
-    $("#stream_filters, #left-sidebar-navigation-list").on("dragstart", (e) => {
-        e.target.blur();
-        return false;
-    });
-
-    // Chrome focuses an element when dragging it which can be confusing when
-    // users involuntarily drag something and we show them the focus outline.
-    $("body").on("dragstart", "a", (e) => e.target.blur());
-
-    // Don't focus links on middle click.
-    $("body").on("mouseup", "a", (e) => {
-        if (e.button === 1) {
-            // middle click
-            e.target.blur();
-        }
-    });
-
-    // Don't focus links on context menu.
-    $("body").on("contextmenu", "a", (e) => e.target.blur());
 
     $("body").on("click", ".language_selection_widget button", (e) => {
         e.preventDefault();

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -645,10 +645,6 @@ export function initialize(): void {
         open_video($video);
     });
 
-    $("#lightbox_overlay .download").on("click", function () {
-        this.blur();
-    });
-
     $("#lightbox_overlay").on("click", ".image-list .image", function (this: HTMLElement) {
         // Remove any video players so sound does not continue when
         // navigating away from a video that might be playing

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -760,11 +760,11 @@
         }
     }
 
-    & a:not(:active):focus,
-    button:focus,
-    i.fa:focus,
-    i.zulip-icon:focus,
-    [role="button"]:focus {
+    & a:not(:active):focus-visible,
+    button:focus-visible,
+    i.fa:focus-visible,
+    i.zulip-icon:focus-visible,
+    [role="button"]:focus-visible {
         outline-color: hsl(0deg 0% 67%);
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -713,7 +713,7 @@
         }
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             color: var(--color-markdown-link-hover);
             text-decoration: underline;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -79,7 +79,7 @@ a {
 }
 
 a:hover,
-a:focus {
+a:focus-visible {
     color: var(--color-text-generic-link-interactive);
     text-decoration: underline;
 
@@ -583,12 +583,12 @@ label {
 }
 
 /* Bootstrap's focus outline uses -webkit-focus-ring-color which doesn't exist in Firefox */
-a:not(:active):focus,
-button:focus,
-label.checkbox input[type="checkbox"]:focus ~ .rendered-checkbox,
-i.fa:focus,
+a:not(:active):focus-visible,
+button:focus-visible,
+label.checkbox input[type="checkbox"]:focus-visible ~ .rendered-checkbox,
+i.fa:focus-visible,
 i.zulip-icon:focus-visible,
-[role="button"]:focus {
+[role="button"]:focus-visible {
     outline: 2px solid var(--color-outline-focus);
     /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */
 }

--- a/web/third/bootstrap/css/bootstrap.app.css
+++ b/web/third/bootstrap/css/bootstrap.app.css
@@ -13,7 +13,7 @@ nav,
 section {
   display: block;
 }
-a:focus {
+a:focus-visible {
   outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;


### PR DESCRIPTION
The browser only applies [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) when it decides the focus ring should be shown; for a link, it’s typically shown only when it was focused with the keyboard and not with the mouse.

We have many other uses of `:focus` that should be audited eventually; ideally, we would not have dozens of individual focus ring designs for different components, along with dozens of overrides that serve to disable incorrect `:focus` rules that were haphazardly inherited from other components. But these seem to be the main ones for links.

Having switched links to `:focus-visible`, remove the click handlers from #15822, #15823 and similar that removed focus from clicked links. This was a horrendous kludge and an accessibility problem; its intent was made obsolete by `:focus-visible`.