### PR TITLE
textarea-caret: Reduce forced layout reflows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
       "handlebars": "patches/handlebars.patch",
       "source-sans@3.46.0": "patches/source-sans@3.46.0.patch",
       "svgicons2svgfont": "patches/svgicons2svgfont.patch",
-      "tippy.js@6.3.7": "patches/tippy.js@6.3.7.patch"
+      "tippy.js@6.3.7": "patches/tippy.js@6.3.7.patch",
+      "textarea-caret@3.1.0": "patches/textarea-caret@3.1.0.patch"
     }
   },
   "nyc": {

--- a/patches/textarea-caret@3.1.0.patch
+++ b/patches/textarea-caret@3.1.0.patch
@@ -1,0 +1,20 @@
+diff --git a/index.js b/index.js
+index 0b06d12bb550fbf8043645a8d680817909cb2b04..c94bbcbf0e65ecf370195f6f3b03a2be62012d0c 100644
+--- a/index.js
++++ b/index.js
+@@ -65,7 +65,6 @@ function getCaretCoordinates(element, position, options) {
+   // The mirror div will replicate the textarea's style
+   var div = document.createElement('div');
+   div.id = 'input-textarea-caret-position-mirror-div';
+-  document.body.appendChild(div);
+ 
+   var style = div.style;
+   var computed = window.getComputedStyle ? window.getComputedStyle(element) : element.currentStyle;  // currentStyle for IE < 9
+@@ -113,6 +112,7 @@ function getCaretCoordinates(element, position, options) {
+   // For inputs, just '.' would be enough, but no need to bother.
+   span.textContent = element.value.substring(position) || '.';  // || because a completely empty faux span doesn't render at all
+   div.appendChild(span);
++  document.body.appendChild(div);
+ 
+   var coordinates = {
+     top: span.offsetTop + parseInt(computed['borderTopWidth']),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ patchedDependencies:
   svgicons2svgfont:
     hash: d4mkid5oxxg6zfe7zsae2cikn4
     path: patches/svgicons2svgfont.patch
+  textarea-caret@3.1.0:
+    hash: 4l2w4ru66ocl2j45eog5vet7ve
+    path: patches/textarea-caret@3.1.0.patch
   tippy.js@6.3.7:
     hash: mlbmk5pq4q6iuwarqu6solgeeq
     path: patches/tippy.js@6.3.7.patch
@@ -258,7 +261,7 @@ importers:
         version: 4.1.1
       textarea-caret:
         specifier: ^3.1.0
-        version: 3.1.0
+        version: 3.1.0(patch_hash=4l2w4ru66ocl2j45eog5vet7ve)
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7(patch_hash=mlbmk5pq4q6iuwarqu6solgeeq)
@@ -18586,7 +18589,7 @@ snapshots:
 
   text-hex@1.0.0: {}
 
-  textarea-caret@3.1.0: {}
+  textarea-caret@3.1.0(patch_hash=4l2w4ru66ocl2j45eog5vet7ve): {}
 
   thingies@1.21.0(tslib@2.8.1):
     dependencies:


### PR DESCRIPTION
Forced reflows are reduced after this change but I couldn't find any concrete difference in the time taken to compute this value on multiple samples with and without this patch even after 6x CPU slowdown.

Note that `getCaretCoordinates` is called in a loop by tippy to get the best `placement` for the typeahead which doesn't look like can be avoided.

| before | after |
| --- | --- |
| ![Screenshot from 2024-12-11 13-43-44](https://github.com/user-attachments/assets/7387ab79-6475-43d4-94ab-513b1f3c32a8) | ![Screenshot from 2024-12-11 13-37-06](https://github.com/user-attachments/assets/b22cb23f-40f6-4110-9013-465d674a98cc) |
