### PR TITLE
Show red outline on invalid subscribers/members input pill

### DIFF
--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -166,14 +166,23 @@ export function set_up_handlers({
     }
 
     $parent_container.on("keyup", pill_selector, (e) => {
-        if (keydown_util.is_enter_event(e)) {
+        const pill_widget = get_pill_widget();
+        if (!pill_widget.is_pending() && keydown_util.is_enter_event(e)) {
             e.preventDefault();
             callback();
         }
     });
 
     $parent_container.on("click", button_selector, (e) => {
-        e.preventDefault();
-        callback();
+        const pill_widget = get_pill_widget();
+        if (!pill_widget.is_pending()) {
+            e.preventDefault();
+            callback();
+        } else {
+            // We are not appending any value here, but instead this is
+            // a proxy to invoke the error state for a pill widget
+            // that would usually get triggered on pressing enter.
+            pill_widget.appendValue(pill_widget.getCurrentText()!);
+        }
     });
 }

--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -75,6 +75,7 @@ export function create({
         get_text_from_item: add_subscribers_pill.get_text_from_item,
         get_display_value_from_item: add_subscribers_pill.get_display_value_from_item,
         generate_pill_html: add_subscribers_pill.generate_pill_html,
+        show_outline_on_invalid_input: true,
     });
     function get_users(): User[] {
         const potential_members = get_potential_members();
@@ -113,6 +114,7 @@ export function create_without_add_button({
         get_text_from_item: add_subscribers_pill.get_text_from_item,
         get_display_value_from_item: add_subscribers_pill.get_display_value_from_item,
         generate_pill_html: add_subscribers_pill.generate_pill_html,
+        show_outline_on_invalid_input: true,
     });
     function get_users(): User[] {
         const potential_members = user_group_create_members_data.get_potential_members();

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -256,14 +256,23 @@ export function set_up_handlers({
     }
 
     $parent_container.on("keyup", pill_selector, (e) => {
-        if (keydown_util.is_enter_event(e)) {
+        const pill_widget = get_pill_widget();
+        if (!pill_widget.is_pending() && keydown_util.is_enter_event(e)) {
             e.preventDefault();
             callback();
         }
     });
 
     $parent_container.on("click", button_selector, (e) => {
-        e.preventDefault();
-        callback();
+        const pill_widget = get_pill_widget();
+        if (!pill_widget.is_pending()) {
+            e.preventDefault();
+            callback();
+        } else {
+            // We are not appending any value here, but instead this is
+            // a proxy to invoke the error state for a pill widget
+            // that would usually get triggered on pressing enter.
+            pill_widget.appendValue(pill_widget.getCurrentText()!);
+        }
     });
 }

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -137,6 +137,7 @@ export function create({
         get_text_from_item,
         get_display_value_from_item,
         generate_pill_html,
+        show_outline_on_invalid_input: true,
     });
     function get_users(): User[] {
         const potential_subscribers = get_potential_subscribers();
@@ -167,6 +168,7 @@ export function create_without_add_button({
         get_text_from_item,
         get_display_value_from_item,
         generate_pill_html,
+        show_outline_on_invalid_input: true,
     });
     function get_users(): User[] {
         const potential_subscribers = get_potential_subscribers();

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -581,6 +581,19 @@ export function set_up_handlers(): void {
             stream_subscription_error.report_no_subs_to_stream();
             return;
         }
+
+        assert(stream_create_subscribers.pill_widget !== undefined);
+        assert(stream_create_subscribers.pill_widget !== null);
+        if (stream_create_subscribers.pill_widget.is_pending()) {
+            // We are not appending any value here, but instead this is
+            // a proxy to invoke the error state for a group widget
+            // that would usually get triggered on pressing enter.
+            stream_create_subscribers.pill_widget.appendValue(
+                stream_create_subscribers.pill_widget.getCurrentText()!,
+            );
+            return;
+        }
+
         if (!principals.includes(people.my_current_user_id()) && !current_user.is_admin) {
             stream_subscription_error.cant_create_stream_without_subscribing();
             return;

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -215,7 +215,7 @@ $("body").on("click", ".settings-sticky-footer #stream_creation_go_to_subscriber
             is_any_stream_group_widget_pending = true;
             // We are not appending any value here, but instead this is
             // a proxy to invoke the error state for a group widget
-            // that would usually get triggered on clicking enter.
+            // that would usually get triggered on pressing enter.
             widget.appendValue(widget.getCurrentText()!);
             break;
         }

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -12,7 +12,7 @@ import * as stream_create_subscribers_data from "./stream_create_subscribers_dat
 import type {CombinedPillContainer} from "./typeahead_helper.ts";
 import * as user_sort from "./user_sort.ts";
 
-let pill_widget: CombinedPillContainer;
+export let pill_widget: CombinedPillContainer;
 let all_users_list_widget: ListWidgetType<number, people.User>;
 
 export function get_principals(): number[] {

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -241,6 +241,18 @@ export function set_up_handlers(): void {
             return;
         }
 
+        assert(user_group_create_members.pill_widget !== undefined);
+        assert(user_group_create_members.pill_widget !== null);
+        if (user_group_create_members.pill_widget.is_pending()) {
+            // We are not appending any value here, but instead this is
+            // a proxy to invoke the error state for a group widget
+            // that would usually get triggered on pressing enter.
+            user_group_create_members.pill_widget.appendValue(
+                user_group_create_members.pill_widget.getCurrentText()!,
+            );
+            return;
+        }
+
         create_user_group();
     });
 

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -118,7 +118,7 @@ $("body").on("click", ".settings-sticky-footer #user_group_go_to_members", (e) =
             is_any_group_widget_pending = true;
             // We are not appending any value here, but instead this is
             // a proxy to invoke the error state for a group widget
-            // that would usually get triggered on clicking enter.
+            // that would usually get triggered on pressing enter.
             widget.appendValue(widget.getCurrentText()!);
             break;
         }

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -15,7 +15,7 @@ import * as user_group_components from "./user_group_components.ts";
 import * as user_group_create_members_data from "./user_group_create_members_data.ts";
 import type {UserGroup} from "./user_groups.ts";
 
-let pill_widget: CombinedPillContainer;
+export let pill_widget: CombinedPillContainer;
 let all_users_list_widget: ListWidgetType<User | UserGroup, User | UserGroup>;
 
 export function get_principals(): number[] {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Show red outline on invalid subscribers/members input pill and disable create/add button wherever applicable. For the disabling button part, manual testing would be better, attached screenshots for the red outline:




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Create channel add subscribers screen:
![Screenshot 2024-12-11 at 2 16 53 PM](https://github.com/user-attachments/assets/d2c09c1f-fe99-4052-85c2-06d8683b6879)

Edit channel add subscribers screen:
![Screenshot 2024-12-12 at 1 50 30 PM](https://github.com/user-attachments/assets/68f003d4-1446-4116-b4de-2e989d0170b3)


Create group members screen:
![Screenshot 2024-12-11 at 2 17 27 PM](https://github.com/user-attachments/assets/107ec8d4-978f-4859-bee0-d494dd1de032)

Edit group members screen:
![Screenshot 2024-12-12 at 1 50 57 PM](https://github.com/user-attachments/assets/22af9b5c-ca26-4cb7-9b42-3cf3c7439f29)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
