### PR TITLE
billing: Fix legacy plan strings in billing and sponsorship pages.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3415,9 +3415,7 @@ class BillingSession(ABC):
             plan = get_current_plan_by_customer(customer)
             if plan is not None:
                 context["plan_name"] = plan.name
-                context["is_server_on_legacy_plan"] = (
-                    plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
-                )
+                context["complimentary_access"] = plan.is_complimentary_access_plan()
 
         self.add_org_type_data_to_sponsorship_context(context)
         return context

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -3415,7 +3415,6 @@ class BillingSession(ABC):
             plan = get_current_plan_by_customer(customer)
             if plan is not None:
                 context["plan_name"] = plan.name
-                context["free_trial"] = plan.is_free_trial()
                 context["is_server_on_legacy_plan"] = (
                     plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
                 )

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1010,7 +1010,7 @@ class BillingSession(ABC):
         pass
 
     @abstractmethod
-    def add_sponsorship_info_to_context(self, context: dict[str, Any]) -> None:
+    def add_org_type_data_to_sponsorship_context(self, context: dict[str, Any]) -> None:
         pass
 
     @abstractmethod
@@ -3419,7 +3419,7 @@ class BillingSession(ABC):
                     plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY
                 )
 
-        self.add_sponsorship_info_to_context(context)
+        self.add_org_type_data_to_sponsorship_context(context)
         return context
 
     def request_sponsorship(self, form: SponsorshipRequestForm) -> None:
@@ -4202,7 +4202,7 @@ class RealmBillingSession(BillingSession):
         return self.realm.name
 
     @override
-    def add_sponsorship_info_to_context(self, context: dict[str, Any]) -> None:
+    def add_org_type_data_to_sponsorship_context(self, context: dict[str, Any]) -> None:
         context.update(
             realm_org_type=self.realm.org_type,
             sorted_org_types=sorted(
@@ -4646,7 +4646,7 @@ class RemoteRealmBillingSession(BillingSession):
         return self.remote_realm.host
 
     @override
-    def add_sponsorship_info_to_context(self, context: dict[str, Any]) -> None:
+    def add_org_type_data_to_sponsorship_context(self, context: dict[str, Any]) -> None:
         context.update(
             realm_org_type=self.remote_realm.org_type,
             sorted_org_types=sorted(
@@ -5095,7 +5095,9 @@ class RemoteServerBillingSession(BillingSession):
         return self.remote_server.hostname
 
     @override
-    def add_sponsorship_info_to_context(self, context: dict[str, Any]) -> None:  # nocoverage
+    def add_org_type_data_to_sponsorship_context(
+        self, context: dict[str, Any]
+    ) -> None:  # nocoverage
         context.update(
             realm_org_type=self.remote_server.org_type,
             sorted_org_types=sorted(

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -2579,7 +2579,7 @@ class BillingSession(ABC):
             ),
             "discount_percent": plan.discount,
             "is_self_hosted_billing": is_self_hosted_billing,
-            "is_server_on_legacy_plan": remote_server_legacy_plan_end_date is not None,
+            "complimentary_access_plan": remote_server_legacy_plan_end_date is not None,
             "remote_server_legacy_plan_end_date": remote_server_legacy_plan_end_date,
             "legacy_remote_server_next_plan_name": legacy_remote_server_next_plan_name,
             "using_min_licenses_for_plan": using_min_licenses_for_plan,

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -414,6 +414,8 @@ class CustomerPlan(AbstractCustomerPlan):
         TIER_SELF_HOSTED_ENTERPRISE,
     ]
 
+    COMPLIMENTARY_PLAN_TIERS = [TIER_SELF_HOSTED_LEGACY]
+
     ACTIVE = 1
     DOWNGRADE_AT_END_OF_CYCLE = 2
     FREE_TRIAL = 3
@@ -489,6 +491,9 @@ class CustomerPlan(AbstractCustomerPlan):
 
     def is_free_trial(self) -> bool:
         return self.status == CustomerPlan.FREE_TRIAL
+
+    def is_complimentary_access_plan(self) -> bool:
+        return self.tier in self.COMPLIMENTARY_PLAN_TIERS
 
     def is_a_paid_plan(self) -> bool:
         return self.tier in self.PAID_PLAN_TIERS

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -9057,8 +9057,8 @@ class TestRemoteServerBillingFlow(StripeTestCase, RemoteServerTestCase):
         with time_machine.travel(self.now, tick=False):
             response = self.client_get(f"{billing_base_url}/billing/", subdomain="selfhosting")
         for substring in [
-            "(legacy plan)",
-            f"This is a legacy plan that ends on {end_date.strftime('%B %d, %Y')}",
+            "(complimentary access)",
+            f"Your complimentary access to Zulip Basic ends on {end_date.strftime('%B %d, %Y')}",
             f"Your plan will automatically upgrade to Zulip Business on {end_date.strftime('%B %d, %Y')}",
             "Expected next charge",
             f"${80 * 25 - 20 * 12:,.2f}",

--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -12,7 +12,7 @@
         {% if is_sponsorship_pending %}
         <div class="alert alert-success billing-page-success" id="billing-sponsorship-pending-message-top">
             This organization has requested sponsorship for a
-            {% if sponsorship_plan_name == "Business" %}
+            {% if is_self_hosted_billing and sponsorship_plan_name != "Community" %}
             discounted
             {% endif %}
             <a href="{{ billing_base_url }}/plans/">{{ sponsorship_plan_name }}</a> plan.<br/><a href="mailto:support@zulip.com">Contact Zulip support</a> with any questions or updates.

--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -48,11 +48,11 @@
                         <a href="{{ billing_base_url }}/plans/">
                             {{ plan_name }} <i>(free trial)</i>
                         </a>
-                        {% elif is_server_on_legacy_plan %}
+                        {% elif complimentary_access_plan %}
                         <a href="{{ billing_base_url }}/plans/">
-                        {{ plan_name.replace(" (legacy plan)", "") -}}
+                        Zulip Basic
                         </a>
-                        <i>(legacy plan)</i>
+                        <i>(complimentary access)</i>
                         {% else %}
                         <a href="{{ billing_base_url }}/plans/">
                         {{ plan_name }}
@@ -60,10 +60,10 @@
                         {% endif %}
                     </div>
                 </div>
-                {% if is_server_on_legacy_plan %}
+                {% if complimentary_access_plan %}
                 <div class="input-box billing-page-field" id="legacy-server-push-notification-notice-wrapper">
                     <div id="legacy-server-push-notification-notice" class="not-editable-realm-field">
-                        <i>This is a legacy plan that ends on {{ remote_server_legacy_plan_end_date }}.</i>
+                        <i>Your complimentary access to Zulip Basic ends on {{ remote_server_legacy_plan_end_date }}.</i>
                     </div>
                 </div>
                 {% endif %}
@@ -74,7 +74,7 @@
                   {%if switch_to_monthly_at_end_of_cycle %}data-switch-to-monthly-eoc="true"{% endif %}
                   {%if switch_to_annual_at_end_of_cycle %}data-switch-to-annual-eoc="true"{% endif %}>
                     <label for="org-billing-frequency">Billing frequency</label>
-                    {% if downgrade_at_end_of_free_trial or downgrade_at_end_of_cycle or is_server_on_legacy_plan or fixed_price_plan or (free_trial and not charge_automatically) %}
+                    {% if downgrade_at_end_of_free_trial or downgrade_at_end_of_cycle or complimentary_access_plan or fixed_price_plan or (free_trial and not charge_automatically) %}
                     <div class="not-editable-realm-field">
                         {{ billing_frequency }}
                     </div>
@@ -106,7 +106,7 @@
                     </button>
                     <div id="org-billing-frequency-change-error" class="alert alert-danger billing-page-error"></div>
                 </div>
-                {% if is_server_on_legacy_plan or fixed_price_plan %}
+                {% if complimentary_access_plan or fixed_price_plan %}
                 {% elif automanage_licenses %}
                 <div class="input-box billing-page-field">
                     <label for="automatic-license-count" class="inline-block label-title">
@@ -258,7 +258,7 @@
                             This is a fixed-price plan.
                             {% endif %}
                             {% if charge_automatically %}
-                            {% if is_server_on_legacy_plan %}
+                            {% if complimentary_access_plan %}
                             Your plan will automatically upgrade to {{ legacy_remote_server_next_plan_name }} on {{ remote_server_legacy_plan_end_date }}.
                             {% else %}
                             Your plan will automatically renew on <strong>{{ renewal_date }}</strong>.
@@ -352,7 +352,7 @@
                                 <object class="loader billing-button-loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                             </button>
                         </div>
-                    {% elif is_server_on_legacy_plan %}
+                    {% elif complimentary_access_plan %}
                         <div class="plan-toggle-action input-box billing-page-field" id="cancel-legacy-server-upgrade">
                             <button class="cancel-legacy-server-upgrade-button plan-toggle-action-button">
                                 <span class="billing-button-text">Cancel upgrade</span>
@@ -373,7 +373,7 @@
                     <input name="status" type="hidden" value="{{ CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL }}" />
                     {% elif downgrade_at_end_of_free_trial %}
                     <input name="status" type="hidden" value="{{ CustomerPlan.FREE_TRIAL }}" />
-                    {% elif downgrade_at_end_of_cycle or is_server_on_legacy_plan %}
+                    {% elif downgrade_at_end_of_cycle or complimentary_access_plan %}
                     <input name="status" type="hidden" value="{{ CustomerPlan.ACTIVE }}" />
                     {% else %}
                     <input name="status" type="hidden" value="{{ CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE }}" />

--- a/templates/corporate/billing/sponsorship.html
+++ b/templates/corporate/billing/sponsorship.html
@@ -54,8 +54,6 @@
                     <div id="sponsored-org-current-plan" class="not-editable-realm-field">
                         {% if is_sponsored %}
                         <a href="{{ billing_base_url }}/plans/">{{ sponsorship_plan_name }}</a>
-                        {% elif free_trial %}
-                        <a href="{{ billing_base_url }}/plans/">{{ plan_name }}</a> <i>(free trial)</i>
                         {% elif is_server_on_legacy_plan %}
                         <a href="{{ billing_base_url }}/plans/">{{ plan_name.replace(" (legacy plan)", "") }}</a> <i>(legacy plan)</i>
                         {% else %}

--- a/templates/corporate/billing/sponsorship.html
+++ b/templates/corporate/billing/sponsorship.html
@@ -53,21 +53,13 @@
                     <label for="sponsored-org-current-plan" class="inline-block label-title">Your plan</label>
                     <div id="sponsored-org-current-plan" class="not-editable-realm-field">
                         {% if is_sponsored %}
-                        <a href="{{ billing_base_url }}/plans/">
-                        {{ sponsorship_plan_name }}
-                        </a>
+                        <a href="{{ billing_base_url }}/plans/">{{ sponsorship_plan_name }}</a>
                         {% elif free_trial %}
-                        <a href="{{ billing_base_url }}/plans/">
-                        {{ plan_name -}}
-                        </a> <i>(free trial)</i>
+                        <a href="{{ billing_base_url }}/plans/">{{ plan_name }}</a> <i>(free trial)</i>
                         {% elif is_server_on_legacy_plan %}
-                        <a href="{{ billing_base_url }}/plans/">
-                        {{ plan_name.replace(" (legacy plan)", "") -}}
-                        </a> <i>(legacy plan)</i>
+                        <a href="{{ billing_base_url }}/plans/">{{ plan_name.replace(" (legacy plan)", "") }}</a> <i>(legacy plan)</i>
                         {% else %}
-                        <a href="{{ billing_base_url }}/plans/">
-                        {{ plan_name }}
-                        </a>
+                        <a href="{{ billing_base_url }}/plans/">{{ plan_name }}</a>
                         {% endif %}
                     </div>
                 </div>

--- a/templates/corporate/billing/sponsorship.html
+++ b/templates/corporate/billing/sponsorship.html
@@ -31,7 +31,7 @@
             Zulip is sponsoring a free <a href="{{ billing_base_url }}/plans/">{{ sponsorship_plan_name }}</a> plan for this organization. 🎉
             {% else %}
             This organization has requested sponsorship for a
-            {% if sponsorship_plan_name == "Business" %}
+            {% if is_remotely_hosted and sponsorship_plan_name != "Community" %}
             discounted
             {% endif %}
             <a href="{{ billing_base_url }}/plans/">{{ sponsorship_plan_name }}</a> plan.<br/><a href="mailto:support@zulip.com">Contact Zulip support</a> with any questions or updates.

--- a/templates/corporate/billing/sponsorship.html
+++ b/templates/corporate/billing/sponsorship.html
@@ -54,8 +54,8 @@
                     <div id="sponsored-org-current-plan" class="not-editable-realm-field">
                         {% if is_sponsored %}
                         <a href="{{ billing_base_url }}/plans/">{{ sponsorship_plan_name }}</a>
-                        {% elif is_server_on_legacy_plan %}
-                        <a href="{{ billing_base_url }}/plans/">{{ plan_name.replace(" (legacy plan)", "") }}</a> <i>(legacy plan)</i>
+                        {% elif complimentary_access %}
+                        <a href="{{ billing_base_url }}/plans/">Zulip Basic</a> <i>(complimentary access)</i>
                         {% else %}
                         <a href="{{ billing_base_url }}/plans/">{{ plan_name }}</a>
                         {% endif %}


### PR DESCRIPTION
Updates the sponsorship and billing pages for current text for temporary complimentary access plans.

**Notes**:
- Fixes "discounted" not being shown when a request for a discounted Zulip Basic plan was submitted.
- Refactors some of the logic for the sponsorship page context:
  - Early return if a sponsorship request is submitted/pending and the customer is on a paid plan.
  - Removes free trial boolean from sponsorship as being on a free trial implies being on a paid plan, and therefore the early return noted above.
  - Renames helper function for clarity on what it adds to the sponsorship page context.
- Revises old "legacy plan" language for current "complimentary access" language.
- Some of the changes here are also preps for implementing a version of the complimentary access plan for Zulip Cloud.

---

**Screenshots and screen captures:**

<details>
<summary>Upgrade scheduled to Zulip Basic - on complimentary access - discount for Zulip Basic requested</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-12-11 20-17-31](https://github.com/user-attachments/assets/8c37f5fa-48fc-4745-9da6-4031f5c49f16) | ![Screenshot from 2024-12-11 20-18-01](https://github.com/user-attachments/assets/f727a709-bf7e-4e01-85ec-ddba8f39dd01) 
</details>
<details>
<summary>Request submitted for a discounted Zulip Basic plan - on complimentary access</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2024-12-11 20-13-28](https://github.com/user-attachments/assets/c582c0e8-13e1-4212-b951-aaeba7726748) | ![Screenshot from 2024-12-11 20-13-53](https://github.com/user-attachments/assets/c51a5f39-1dd5-46b0-bc83-486425ee5afd) 
</details>
<details>
<summary>Request submitted for a discounted Zulip Basic plan</summary>

| Before | After |
| --- | --- |
|![Screenshot from 2024-12-11 20-11-57](https://github.com/user-attachments/assets/90de2152-fbb1-4f0e-a092-b43e867f0ce5) | ![Screenshot from 2024-12-11 20-12-24](https://github.com/user-attachments/assets/1fb1b02f-78e8-42b3-856d-fe468fdc958d) 
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
