### PR TITLE
usernames: Run usernames and status emoji as inline elements.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -656,8 +656,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
                     status_emoji_info: user_status.get_status_emoji(user.id),
                 }),
             )
-            .sort()
-            .join(", ");
+            .sort();
         const recipient_id = last_msg.recipient_id;
         const pm_url = last_msg.pm_with_url;
         const is_group = last_msg.display_recipient.length > 2;
@@ -691,7 +690,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
 
         dm_context = {
             user_ids_string,
-            rendered_pm_with,
+            rendered_pm_with: util.format_array_as_list(rendered_pm_with, "long", "conjunction"),
             recipient_id,
             pm_url,
             is_group,

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -600,6 +600,21 @@ input.settings_text_input {
     }
 }
 
+.user_status_icon_wrapper {
+    display: inline;
+    white-space: nowrap;
+}
+
+.user-status-microlayout {
+    display: inline-grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+
+    .user-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}
+
 /* We are mostly consistent in how we style
    unread counts, except for starred messages.
    This is the common section.

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -291,7 +291,9 @@
                 }
 
                 .inbox-left-part {
-                    grid-template: auto / min-content auto min-content min-content;
+                    grid-template:
+                        auto / min-content minmax(0, 1fr)
+                        min-content min-content;
                     grid-template-areas: "match_topic_and_dm_start recipient_info unread_mention_info unread_count";
                 }
 
@@ -420,7 +422,6 @@
                     flex-wrap: wrap;
                     column-gap: 10px;
                     grid-area: recipient_info;
-                    word-break: break-word;
 
                     .user_block {
                         display: flex;

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -415,6 +415,17 @@
                 .inbox-group-or-bot-dm {
                     position: relative;
                     left: -3px;
+
+                    /* We don't display status emoji in group DMs,
+                       so prepare an ordinary inline layout... */
+                    .user-status-microlayout {
+                        display: inline;
+                        white-space: collapse;
+                    }
+                    /* ...and hide the status emoji. */
+                    .status-emoji {
+                        display: none;
+                    }
                 }
 
                 .recipients_info {

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -78,6 +78,10 @@
         }
     }
 
+    .white-space-preserve-wrap {
+        word-break: break-word;
+    }
+
     .empty-table-message {
         background-color: var(--color-background);
         padding: 3em 1em;
@@ -450,14 +454,6 @@
     .recent_topic_name {
         width: 40%;
 
-        & a {
-            word-break: break-word;
-            /* No hyphes for word break since it caused hyphens to appear before
-                the ellipsis `longText-...` which is not desirable. Ellipsis appears due
-                to the line clamp applied below.
-            */
-        }
-
         .line_clamp {
             /* This -webkit-box display property is webkit-specific, but
                 it appears that line clamping works fine for this component
@@ -525,12 +521,6 @@
                 float: left;
                 position: unset;
             }
-        }
-
-        .user_status_icon_wrapper {
-            /* Keep status emoji with usernames,
-               and better vertically align the emoji. */
-            display: inline-flex;
         }
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -522,6 +522,19 @@
                 position: unset;
             }
         }
+
+        .recent-view-dm-group {
+            /* We don't display status emoji in group DMs,
+               so prepare an ordinary inline layout... */
+            .user-status-microlayout {
+                display: inline;
+                white-space: collapse;
+            }
+            /* ...and hide the status emoji. */
+            .status-emoji {
+                display: none;
+            }
+        }
     }
 
     .stream-privacy .zulip-icon {

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -32,7 +32,7 @@
         <div class="flex_container">
             <div class="left_part recent_view_focusable line_clamp" data-col-index="{{ column_indexes.topic }}">
                 {{#if is_private}}
-                <a href="{{pm_url}}" class="recent-view-table-link">{{{rendered_pm_with}}}</a>
+                <a href="{{pm_url}}" class="recent-view-table-link {{#if is_group}}recent-view-dm-group{{/if}}">{{{rendered_pm_with}}}</a>
                 {{else}}
                 <a class="white-space-preserve-wrap recent-view-table-link" href="{{topic_url}}">{{topic}}</a>
                 {{/if}}

--- a/web/templates/user_with_status_icon.hbs
+++ b/web/templates/user_with_status_icon.hbs
@@ -1,5 +1,9 @@
 <span class="user_status_icon_wrapper">
-    <span class="user-name">{{name}}</span>
-    {{~> status_emoji status_emoji_info ~}}
+    <span class="user-status-microlayout">
+        <span class="user-name">{{name}}</span>
+        {{~!-- --~}}
+        {{~> status_emoji status_emoji_info ~}}
+    </span>
+    {{~!-- --~}}
 </span>
 {{~!-- --~}}

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -7,6 +7,11 @@ const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
+const {initialize_user_settings} = zrequire("user_settings");
+
+const user_settings = {};
+initialize_user_settings({user_settings});
+
 window.scrollTo = noop;
 const test_url = () => "https://www.example.com";
 
@@ -680,6 +685,7 @@ test("test_filter_pm", ({mock_template}) => {
     mock_template("user_with_status_icon.hbs", false, (data) => {
         assert.deepEqual(data, expected_user_with_icon[i]);
         i += 1;
+        return "<user_with_status_icon stub>";
     });
 
     mock_template("recent_view_row.hbs", true, (_data, html) => {


### PR DESCRIPTION
This PR runs usernames + status emoji as inline elements in the DM portions of Inbox and Recent views, employing CSS Grid to better allow ellipses to appear in the usernames in narrow views, much like is already done in the right sidebar. 

This has also been updated to suppress status emoji for group DMs in the Inbox and Recent conversations views, keeping those in line with a similar status-emoji-suppressed design that has long been part of the left sidebar's treatment of group DMs.

With those design improvements in hand, it also extends the use of `Intl.ListFormat` to DM groups in Recent conversations.

Fixes: #29778
[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20status.20emoji.20line.20wrapping/near/1783055)

As the screenshots below illustrate, this cleans up a bunch of little pain points with username and status emoji (including emoji that have been drooping too low in Inbox view), in addition to making sure that commas stay with the element that precedes them.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Group DM emoji, before | Group DM emoji, after |
| --- | --- |
| ![inbox-showing-emoji-main](https://github.com/user-attachments/assets/b46de5b3-8d08-45ea-87bf-54f60e239075) | ![inbox-suppressed-emoji](https://github.com/user-attachments/assets/1df27efe-6cc1-4871-a2d4-4e7fadb829cf) |
| ![recents-showing-emoji-main](https://github.com/user-attachments/assets/6c5de18e-d7a4-4739-b7f5-ab22210feee8) | ![recents-suppressed-emoji](https://github.com/user-attachments/assets/6511a2b7-675f-4f21-9aa3-77e2b18db215) |

_The screenshots below are outdated in that they show status emoji on group DMs; but the screenshots verify otherwise._

| Narrow viewports, before | Narrow viewports, after |
| --- | --- |
| ![inbox-narrow-before](https://github.com/user-attachments/assets/98159e75-ed0b-438d-b3ee-5b8f2d1f1b37) | ![inbox-narrow-after](https://github.com/user-attachments/assets/75d25fe5-4a45-4be7-818a-0a1d76d3db66) |
| ![recents-very-narrow-before](https://github.com/user-attachments/assets/749fd2b5-c9ba-4b80-9443-3d5eec50a3b2) | ![recents-very-narrow-after](https://github.com/user-attachments/assets/ad69de2c-3eb6-44b5-b282-7cc11ee54121) |
| ![recents-narrow-before](https://github.com/user-attachments/assets/8c249e3f-0f64-42a9-b8f3-3b3c32342d6f) | ![recents-narrow-after](https://github.com/user-attachments/assets/30e99d92-18cc-4842-9f62-1e423afc6431) | 

| Wide viewports, before | Wide viewports, after |
| --- | --- |
| ![inbox-wide-before](https://github.com/user-attachments/assets/e2c7b053-d2d5-4734-aa3a-1c4445929890) | ![inbox-wide-after](https://github.com/user-attachments/assets/77c8bd55-6d3c-4fde-9de3-47e55b8604fd) |
| ![recents-wide-before](https://github.com/user-attachments/assets/776cb889-f56f-4f2d-b3c2-f605efe1c750) | ![recents-wide-after](https://github.com/user-attachments/assets/96441c37-d76e-4f13-9889-22ce30da1b96) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>