### PR TITLE
show more/less: Use em for height of button.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -971,7 +971,7 @@ div.focused-message-list {
 .message_length_controller {
     .message_length_toggle {
         width: 100%;
-        height: 24px;
+        height: 1.714em; /* 24px / 14px em */
         margin-bottom: var(--message-box-markdown-aligned-vertical-space);
         color: var(--color-text-show-more-less-button);
         background-color: var(--color-show-more-less-button-background);


### PR DESCRIPTION
20px before:

![image](https://github.com/user-attachments/assets/553e00ce-0b66-478b-8e42-dd71d11fe53d)

20px after:

<img width="974" alt="image" src="https://github.com/user-attachments/assets/070911a9-ee80-40dd-ac74-a026f339316d" />

12px before:

<img width="777" alt="image" src="https://github.com/user-attachments/assets/bc832c12-59e2-4654-bfaf-d18cc5380c1f" />


12px after:

<img width="691" alt="image" src="https://github.com/user-attachments/assets/3c81d4c5-4bf0-492d-98fd-e3b34941e58f" />
