### PR TITLE
compose: Size stream message arrow icon with em.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -232,8 +232,7 @@
             height: var(--compose-recipient-box-min-height);
 
             .conversation-arrow {
-                font-size: 16px;
-                line-height: 16px;
+                font-size: 1.1429em; /* 16px / 14px em */
                 border-radius: 50%;
                 padding: 2px;
                 margin: 0 3px;


### PR DESCRIPTION
20px before:

<img width="537" alt="image" src="https://github.com/user-attachments/assets/cd1d5a1f-1e1f-468b-bf99-fcb90a3616b0" />

20px after:

<img width="959" alt="image" src="https://github.com/user-attachments/assets/93278501-ba52-4b4d-8c58-288e42fad1ba" />


12px before:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/044e28ec-a3ac-4e03-9234-3872762177b2" />


12px after:

<img width="792" alt="image" src="https://github.com/user-attachments/assets/b3368f05-4f23-4f2d-887f-46f895b9a1e9" />
