### PR TITLE
settings: Fix emoji and buddy list style selectors for bigger fonts.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1207,10 +1207,12 @@ label.preferences-radio-choice-label {
 }
 
 .user_list_style_values {
-    max-width: 350px;
+    max-width: 25em; /* 350px / 14px em */
 
     .preferences-radio-choice-label {
-        justify-content: space-between;
+        display: grid;
+        grid-template-columns: 10.7143em auto; /* 150px / 14px em */
+        justify-content: left;
         margin-right: 6px;
 
         .right {
@@ -1219,10 +1221,8 @@ label.preferences-radio-choice-label {
     }
 
     .preview {
-        /* Match the 170px width of the right sidebar region for the name/status,
-           doing something reasonable if the window shrinks. */
-        width: 170px;
         white-space: nowrap;
+        overflow: hidden;
 
         .user-name-and-status-text {
             display: flex;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1198,7 +1198,7 @@ label.preferences-radio-choice-label {
 }
 
 .emojiset_choices {
-    width: 350px;
+    width: 25em; /* 350px / 14px em */
 
     .emoji {
         height: 22px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1206,11 +1206,8 @@ label.preferences-radio-choice-label {
     }
 }
 
-$right_sidebar_width: 170px;
-$option_title_width: 180px;
-
 .user_list_style_values {
-    max-width: calc($right_sidebar_width + $option_title_width);
+    max-width: 350px;
 
     .preferences-radio-choice-label {
         justify-content: space-between;
@@ -1224,7 +1221,7 @@ $option_title_width: 180px;
     .preview {
         /* Match the 170px width of the right sidebar region for the name/status,
            doing something reasonable if the window shrinks. */
-        width: calc(100% - $option_title_width);
+        width: 170px;
         white-space: nowrap;
 
         .user-name-and-status-text {


### PR DESCRIPTION
**20px before this PR**

<img width="410" alt="image" src="https://github.com/user-attachments/assets/c51cc40b-b7ee-47f3-b8e1-b2656b6a8969" />


<img width="448" alt="image" src="https://github.com/user-attachments/assets/46574f5b-4056-4902-aca1-d0bda3d5725c" />

----

**with this PR**

12px:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b58b504a-ca45-4e0c-b376-55b6cc93b950" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2c248ab0-95a0-4d3a-abac-eb6c95304f20" />


14px:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0614599d-ec10-4c3c-b550-8762d4a3e779" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/80c30b11-dd10-4436-82a5-b00f48aed207" />

18px:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6b4c2adf-f8c9-4ad9-90b1-c8c365ea2ebb" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0ada319e-be3c-4c64-a8b2-97712fd0587d" />

20px:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0df298b7-e985-4baf-ae43-35e8b6292517" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ba556685-3fcf-485f-8f03-99f06b4e4df6" />

