### PR TITLE
Experiment right sidebar font size responsiveness.

### DIFF
--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -12,6 +12,7 @@ const ms = 320; // Mobile small
 
 // Breakpoints for middle column
 const mc = 849; // Middle column as wide as it appears after the `sm` breakpoint
+const rc = 1275;
 
 // Breakpoints for showing and hiding compose buttons which do not always fit in
 // a single row below the compose box
@@ -26,6 +27,7 @@ export const media_breakpoints = {
     sm_min: sm + "px",
     md_min: md + "px",
     mc_min: mc + "px",
+    rc_min: rc + "px",
     lg_min: lg + "px",
     xl_min: xl + "px",
     ml_min: ml + "px",
@@ -49,4 +51,5 @@ export const media_breakpoints_num = {
     ml,
     mm,
     ms,
+    rc,
 };

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -54,7 +54,7 @@ export function show_userlist_sidebar(): void {
         return;
     }
 
-    if (window.innerWidth >= media_breakpoints_num.xl) {
+    if (window.innerWidth >= media_breakpoints_num.rc) {
         $("body").removeClass("hide-right-sidebar");
         fix_invite_user_button_flicker();
         return;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -261,7 +261,8 @@
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
-    --right-sidebar-width: 250px;
+    --right-column-width: 250px;
+    --right-sidebar-width: calc(var(--right-column-width) - 10px);
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to
        not touch the row outline. */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -261,7 +261,9 @@
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
-    --right-column-width: 250px;
+    /* 288px at 16px/1em */
+    --right-column-max-width: 18em;
+    --right-column-width: min(25%, var(--right-column-max-width));
     --right-sidebar-width: calc(var(--right-column-width) - 10px);
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -387,8 +387,8 @@ body.has-overlay-scrollbar {
 
 /* This applies to column-left both in navbar and app. */
 .column-right {
-    width: var(--right-sidebar-width);
-    max-width: var(--right-sidebar-width);
+    width: var(--right-column-width);
+    max-width: var(--right-column-width);
     position: absolute;
     right: 0;
     top: 0;
@@ -552,7 +552,7 @@ body.has-overlay-scrollbar {
 
     .column-right .right-sidebar {
         padding-left: 5px;
-        width: 240px;
+        width: var(--right-sidebar-width);
     }
 
     .column-middle {
@@ -563,7 +563,7 @@ body.has-overlay-scrollbar {
 
 .column-middle,
 #compose-content {
-    margin-right: var(--right-sidebar-width);
+    margin-right: var(--right-column-width);
     margin-left: calc(
         var(--left-sidebar-width) + var(--left-sidebar-padding-left)
     );
@@ -2046,7 +2046,7 @@ body:not(.hide-left-sidebar) {
     display: flex;
     /* Make the top navbar right column its full width,
        less 7px of space on the left and right. */
-    width: calc(var(--right-sidebar-width) - 7px - 7px);
+    width: calc(var(--right-column-width) - 7px - 7px);
     justify-content: flex-end;
     align-items: center;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1548,7 +1548,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
-@media (width < $xl_min) or (height < $short_navbar_cutoff_height) {
+@media (width < $rc_min) or (height < $short_navbar_cutoff_height) {
     .default-sidebar-behaviour {
         &.spectator-view.default-sidebar-behaviour {
             #navbar-middle {
@@ -1671,7 +1671,7 @@ body:not(.hide-left-sidebar) {
     }
 }
 
-@media (width < $xl_min) {
+@media (width < $rc_min) {
     .default-sidebar-behaviour {
         @extend %hide-right-sidebar;
 


### PR DESCRIPTION
We've changed the breakpoint at which the right sidebar appears from 1200 to 1350, you can play around with that value by changing the `rc` variable in `css_variables.ts`.

In terms of the actual width of the right sidebar, the two variables to play around will be `--right-column-max-width` and `--right-column-width`. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

12px:
![Screenshot 2024-12-17 at 6 19 05 PM](https://github.com/user-attachments/assets/0acd52e8-4339-4e5f-b895-ad188b9002d4)


14px:
![Screenshot 2024-12-17 at 6 18 54 PM](https://github.com/user-attachments/assets/6c803ec4-86a1-43b9-bc69-ac9bc295089f)


16px:
![Screenshot 2024-12-17 at 6 18 42 PM](https://github.com/user-attachments/assets/90f8ac20-fc58-46da-b9e8-9fdd183f123c)


18px:
![Screenshot 2024-12-17 at 6 18 20 PM](https://github.com/user-attachments/assets/24baa516-7771-47b0-a231-51fd4752e870)


20px:
![Screenshot 2024-12-17 at 6 18 06 PM](https://github.com/user-attachments/assets/f95f7129-798f-4c90-a959-bfc4e356e917)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
