### PR TITLE
compose: Use em for enter send setting font size.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1133,14 +1133,17 @@ textarea.new_message_textarea {
     }
 
     .enter_sends_major {
-        font-size: 15px;
+        /* 15px at 14px/1em */
+        font-size: 1.0714em;
     }
 
     .enter_sends_minor {
-        font-size: 12px;
+        /* 12px at 14px/1em */
+        font-size: 0.8571em;
 
         .popover-menu-hotkey-hint {
-            font-size: 12px;
+            /* 12px at 14px/1em */
+            font-size: 0.8571em;
             padding: 1px 4px;
         }
     }


### PR DESCRIPTION
The changes aren't super visible below 20px, but it seems good to scale it regardless.

---

12px before and after

![image](https://github.com/user-attachments/assets/286cd64a-e112-4b3c-8a0e-b42e51475c5a) ![image](https://github.com/user-attachments/assets/e3af433d-4b65-4af5-83e0-1d7862de701c)

14px before and after

![image](https://github.com/user-attachments/assets/16e50097-7966-49a6-b386-8cb70a0b2298) ![image](https://github.com/user-attachments/assets/6ccbd27a-9d11-4130-b8ed-78aa59837d0f)


18px before and after

![image](https://github.com/user-attachments/assets/01316642-0046-494a-9236-09f52a324a1e) ![image](https://github.com/user-attachments/assets/d4d104fd-c780-4f10-bd50-991159910011)

20px before and after

![image](https://github.com/user-attachments/assets/4a2ee7e8-d8a6-4492-96cb-b1272d942cac) ![image](https://github.com/user-attachments/assets/f0594b31-a632-49df-a342-e9ea73fa43ca)
