### PR TITLE
modal: Remove fixed height of select menu.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -367,8 +367,12 @@
     }
 }
 
-.modal_select {
+#user-role-select,
+#bot-role-select {
     height: 30px;
+}
+
+.modal_select {
     width: 220px;
     padding: 0 25px 0 6px;
     color: hsl(0deg 0% 33%);


### PR DESCRIPTION
This allows the dropdown menus to adjust height
depending on the info density font size.

**20px before and after, for all uses of `modal_select`**

| before            |  after |
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/c69d97ac-e3f4-491d-8121-7fd0a1d5d63f) | ![image](https://github.com/user-attachments/assets/5fccc533-1ddc-4607-99e0-cf177dde3cec)
![image](https://github.com/user-attachments/assets/1d6b43b2-0d1b-404c-8841-05bb7e05f01e) | ![image](https://github.com/user-attachments/assets/9528e1d7-bd7f-48ac-b759-77e0b0bee515)
![image](https://github.com/user-attachments/assets/38a0c6e0-9ee3-455e-b48c-c5ebda67a3f8) | ![image](https://github.com/user-attachments/assets/b5fbb6d1-cd0d-4a90-b542-74c98ca403b9)
![image](https://github.com/user-attachments/assets/3d09d64e-98d8-4461-a6b5-964b47c589d9) | ![image](https://github.com/user-attachments/assets/451ae599-882e-4e00-aa60-1aedf68a8980)
![image](https://github.com/user-attachments/assets/e09229ac-9f8e-4e2c-b112-983dd7410ba2) | ![image](https://github.com/user-attachments/assets/1bc97e98-6b18-42ae-9bb7-ee75561556f0)

I skipped the "convert demo organization" modal, a custom profile field for external account dropdown, and edit outgoing webhook, since those are harder to test and not used much.

Two other dropdowns weren't changed, explained below.


**12px before and after**


| before            |  after |
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/60849219-ffcc-4e6b-aaec-02fd31b3445b) | ![image](https://github.com/user-attachments/assets/2d1943a4-7791-4325-8196-f9334d8af1fa)
![image](https://github.com/user-attachments/assets/1c792d4c-5c39-487a-b06f-2fe865391643) | ![image](https://github.com/user-attachments/assets/f8bf819d-b74d-45f0-a031-170481b5cbea)
![image](https://github.com/user-attachments/assets/41f08ff5-30a4-4f0d-b625-b06d6ae0e2a1) | ![image](https://github.com/user-attachments/assets/d3edf29c-f788-43bf-a10a-44fbc1d244a2) 
![image](https://github.com/user-attachments/assets/0f9102f6-46f8-4aaa-98bf-a447cf29588c) |  ![image](https://github.com/user-attachments/assets/b1c2d998-7c4d-4788-a63a-ea9d2acba0ef)


**Not changed in this PR**

I decided to keep the 30px heights for these dropdowns, which had negligable change at 20px (second two rows here) and looked worse at 12px (first two rows here) due to nearby input elements having different ways of calculating height. It would be great to standardize the styling of the dropdowns, but this seems low priority.

| before            |  after |
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/a9dd1187-4b18-4daf-a71c-d0c2e89b17e6) | ![image](https://github.com/user-attachments/assets/c52b23d8-6d7d-40da-abf2-6b67c527a651)
![image](https://github.com/user-attachments/assets/f8a023ed-4a88-4e72-b474-f86ff08add0d) | ![image](https://github.com/user-attachments/assets/1391151f-d80c-450e-bdd2-56a631595261)
![image](https://github.com/user-attachments/assets/52704c5c-9968-456f-a197-7fcb493b551e) | ![image](https://github.com/user-attachments/assets/9f5db4a9-52e1-43d8-8521-b38cc761b7b1)
![image](https://github.com/user-attachments/assets/d43633dc-936f-439d-851e-0645caa55184) | ![image](https://github.com/user-attachments/assets/65c90da3-0418-4a9c-840c-cdf934e5da21)


