### PR TITLE
docs: Finish renaming AzureAD to Entra ID.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -30,7 +30,7 @@ authentication providers:
 - Google accounts, with `GoogleAuthBackend`
 - GitHub accounts, with `GitHubAuthBackend`
 - GitLab accounts, with `GitLabAuthBackend`
-- Microsoft Azure Active Directory, with `AzureADAuthBackend`
+- Microsoft Entra ID (AzureAD), with `AzureADAuthBackend`
 
 Each of these requires one to a handful of lines of configuration in
 `settings.py`, as well as a secret in `zulip-secrets.conf`. Details

--- a/help/configure-authentication-methods.md
+++ b/help/configure-authentication-methods.md
@@ -16,7 +16,7 @@ Zulip Cloud Plus, and all self-hosted Zulip servers:
 
 The following options are available for organizations on Zulip Cloud Plus, and all self-hosted Zulip servers:
 
-- [SAML authentication](/help/saml-authentication), including Okta, OneLogin, AzureAD, Keycloak, Auth0
+- [SAML authentication](/help/saml-authentication), including Okta, OneLogin, Entra ID (AzureAD), Keycloak, Auth0
 - [SCIM provisioning](/help/scim)
 
 The following authentication and identity management options are available for

--- a/help/saml-authentication.md
+++ b/help/saml-authentication.md
@@ -9,7 +9,7 @@ This page describes how to configure SAML authentication with several common pro
 
 * Okta
 * OneLogin
-* AzureAD
+* Entra ID (AzureAD)
 * Keycloak
 * Auth0
 
@@ -92,14 +92,14 @@ providers.
 
 {!upgrade-to-plus-if-needed.md!}
 
-1. From your AzureAD Dashboard, navigate to **Enterprise applications**,
+1. From your Entra ID Dashboard, navigate to **Enterprise applications**,
    click **New application**, followed by **Create your own application**.
 
-1. Enter a name (e.g., `Zulip Cloud`) for the new AzureAD application,
+1. Enter a name (e.g., `Zulip Cloud`) for the new Entra ID application,
    choose **Integrate any other application you don't find in the
    gallery (Non-gallery)**, and click **Create**.
 
-1. From your new AzureAD application's **Overview** page that opens, go to
+1. From your new Entra ID application's **Overview** page that opens, go to
    **Single sign-on**, and select **SAML**.
 
 1.  In the **Basic SAML Configuration** section, specify the following fields:

--- a/templates/corporate/security.md
+++ b/templates/corporate/security.md
@@ -66,7 +66,7 @@ priority.
 ## Authentication
 
 - Zulip supports integrated single sign-on with Google, GitHub, SAML
-  (including Okta), AzureAD, and Active Directory/LDAP.  With Zulip
+  (including Okta), Entra ID (AzureAD), and Active Directory/LDAP.  With Zulip
   on-premise, we can support any of the 100+ authentication tools
   supported by
   [python-social-auth](https://python-social-auth.readthedocs.io/en/latest/backends/index.html#social-backends)

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -100,7 +100,7 @@ TAB_SECTION_LABELS = {
     "self-hosting": "Self hosting",
     "okta": "Okta",
     "onelogin": "OneLogin",
-    "azuread": "AzureAD",
+    "azuread": "Entra ID (AzureAD)",
     "entraid": "Microsoft Entra ID",
     "keycloak": "Keycloak",
     "auth0": "Auth0",


### PR DESCRIPTION
Microsoft has been renaming AzureAD to Entra ID. Though both names still seem to function, even if unofficially, so this mostly renames to `Entra ID (AzureAD)` to reference both for clarity.

