### PR TITLE
compose: Don't calculate preview height preemptively.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -60,23 +60,18 @@ export function show_preview_area() {
 
     const $compose_textarea = $("textarea#compose-textarea");
     const content = $compose_textarea.val();
-    const edit_height = $compose_textarea.height();
 
     $("#compose .markdown_preview").hide();
     $("#compose .undo_markdown_preview").show();
     $("#compose .undo_markdown_preview").trigger("focus");
 
     const $preview_message_area = $("#compose .preview_message_area");
-    // Set the preview area to the edit height to keep from
-    // having the preview jog the size of the compose box.
-    $preview_message_area.css({height: edit_height + "px"});
-    $preview_message_area.show();
-
     compose_ui.render_and_show_preview(
         $("#compose .markdown_preview_spinner"),
         $("#compose .preview_content"),
         content,
     );
+    $preview_message_area.show();
 }
 
 export function create_message_object(message_content = compose_state.message_content()) {

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1648,7 +1648,6 @@ export function is_message_oldest_or_newest(
 export function show_preview_area($element: JQuery): void {
     const $row = rows.get_closest_row($element);
     const $msg_edit_content = $row.find<HTMLTextAreaElement>("textarea.message_edit_content");
-    const edit_height = $msg_edit_content.height();
     const content = $msg_edit_content.val();
     assert(content !== undefined);
 
@@ -1661,16 +1660,12 @@ export function show_preview_area($element: JQuery): void {
     $row.find(".markdown_preview").hide();
     $row.find(".undo_markdown_preview").show();
     const $preview_message_area = $row.find(".preview_message_area");
-    // Set the preview area to the edit height to keep from
-    // having the preview jog the size of the message-edit box.
-    $preview_message_area.css({height: edit_height + "px"});
-    $preview_message_area.show();
-
     compose_ui.render_and_show_preview(
         $row.find(".markdown_preview_spinner"),
         $row.find(".preview_content"),
         content,
     );
+    $preview_message_area.show();
 }
 
 export function clear_preview_area($element: JQuery): void {

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -103,14 +103,10 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
     // We ensure that the last message is not overlapped by compose box.
     $("textarea#compose-textarea").css(
         "max-height",
-        // Because <textarea> max-height includes padding, we subtract
-        // 10 for the padding.
-        bottom_whitespace_height - compose_non_textarea_height - 10,
+        bottom_whitespace_height - compose_non_textarea_height,
     );
     $("#preview_message_area").css(
         "max-height",
-        // Because <div> max-height doesn't include padding, we do not
-        // subtract anything.
         bottom_whitespace_height - compose_non_textarea_height,
     );
     $("#scroll-to-bottom-button-container").css("bottom", compose_height);


### PR DESCRIPTION
This was preventing images form showing up properly, since they're only a short line of text but tallin the preview.

CZO thread:
https://chat.zulip.org/#narrow/channel/9-issues/topic/compose.20preview.20image.20bugs

![Kapture 2024-12-12 at 16 20 42](https://github.com/user-attachments/assets/c4e51a58-df51-44d5-b982-4c92fe282a47)
