### PR TITLE
recent_view: Fix transparent avatar background color being changed.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -323,6 +323,10 @@
         background-color: hsl(0deg 0% 88%);
     }
 
+    .recent_view_participant_avatar {
+        background-color: transparent;
+    }
+
     .recent_view_participant_overflow {
         color: hsl(0deg 0% 0%);
         line-height: 24px;


### PR DESCRIPTION
We don't set a background color for transparent avatars to avoid changing what the avatar is supposed to be.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/transparent.20background.20profile.20picture.20reappears

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/38b36798-2e90-4b9a-a51c-08e562ed1ee1) | ![Screenshot from 2024-12-13 14-10-20](https://github.com/user-attachments/assets/e6c314eb-37fa-4cc5-ab6a-a464bf86ed21) |
