### PR TITLE
Display emoji at the left of the status text.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -284,6 +284,23 @@ $user_status_emoji_width: 24px;
         overflow: hidden;
         text-overflow: ellipsis;
     }
+
+    .status {
+        display: flex;
+        margin-top: -3px;
+        gap: 3px;
+
+        .status_emoji {
+            margin-right: 3px;
+            margin-left: 0;
+        }
+
+        .status-text {
+            margin-top: 0;
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+        }
+    }
 }
 
 .user_sidebar_entry .selectable_sidebar_block {

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -3,13 +3,25 @@
         {{#if user_list_style.WITH_STATUS}}
             <span class="{{user_circle_class}} user_circle"></span>
             <a class="user-presence-link" href="{{href}}">
-                <div class="user-name-and-status-wrapper">
-                    <div class="user-name-and-status-emoji">
-                        {{> user_full_name .}}
-                        {{> status_emoji status_emoji_info}}
+                {{#if (and status_text status_emoji_info)}}
+                    <div class="user-name-and-status-wrapper">
+                        <div class="user-name">
+                            <span class="user-name">{{name}}</span>
+                        </div>
+                        <div class="status">
+                            {{> status_emoji status_emoji_info}}
+                            <span class="status-text">{{status_text}}</span>
+                        </div>
                     </div>
-                    <span class="status-text">{{status_text}}</span>
-                </div>
+                {{else}}
+                    <div class="user-name-and-status-wrapper">
+                        <div class="user-name-and-status-emoji">
+                            <span class="user-name">{{name}}</span>
+                            {{> status_emoji status_emoji_info}}
+                        </div>
+                        <span class="status-text">{{status_text}}</span>
+                    </div>
+                {{/if}}
             </a>
         {{else if user_list_style.WITH_AVATAR}}
             <div class="user-profile-picture avatar-preload-background">


### PR DESCRIPTION
This PR improves the way status and status emoji appears in the right sidebar. When the status text and emoji both are present, then the emoji is displayed at the left of the status text and when only emoji is present, then it is displayed at the right of the user name.

<table>
<tr>
<th colspan="2">
With Avatar
</th>
</tr>
<tr>
<th>
Without status text
</th>
<th>
With status text
</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/224ffd73-90ec-451c-b3c7-15ba60b421ab" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/7f0a94e2-e997-47ff-b266-5c160a7868c4"/>
</td>
</tr>
<tr>
<th colspan="2">
Without Avatar
</th>
</tr>
<tr>
<th>
Without status text
</th>
<th>
With status text
</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/875f2be4-617f-4d43-89d4-20a0aedb1e43"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/b78ac37f-93cd-46ff-8ff2-110b160d87d2"/>
</td>
</tr>
</table>

Fixes: #32710.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
