### PR TITLE
api: Remove `user` object from reactions objects in the API.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 328**
+
+* [`GET /messages`](/api/get-messages), [`GET /events`](/api/get-events):
+  Removed deprecated `user` dictionary from the `reactions` objects returned
+  by the API, as the clients now use `user_id` field instead.
+
 **Feature level 327**
 
 * [`GET /messages`](/api/get-messages), [`GET

--- a/tools/check-schemas
+++ b/tools/check-schemas
@@ -76,9 +76,6 @@ EXEMPT_OPENAPI_NAMES = [
     "realm_user_add_event",
     # OpenAPI is incomplete
     "realm_update_dict_event",
-    # is_mirror_dummy
-    "reaction_add_event",
-    "reaction_remove_event",
 ]
 
 # This is a list of events still documented in the OpenAPI that

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 327  # Last bumped to adjust recipient_id in incoming 1:1 DMs
+API_FEATURE_LEVEL = 328  # Last bumped for removing `user` dictionary from `reactions` object.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -236,11 +236,6 @@ exports.fixtures = {
         emoji_name: "airplane",
         emoji_code: "2708",
         user_id: test_user.user_id,
-        user: {
-            email: test_user.email,
-            full_name: test_user.full_name,
-            user_id: test_user.user_id,
-        },
     },
 
     reaction__remove: {
@@ -251,11 +246,6 @@ exports.fixtures = {
         emoji_name: "8ball",
         emoji_code: "1f3b1",
         user_id: test_user.user_id,
-        user: {
-            email: test_user.email,
-            full_name: test_user.full_name,
-            user_id: test_user.user_id,
-        },
     },
 
     realm__deactivated: {

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -20,20 +20,10 @@ from zerver.tornado.django_api import send_event_on_commit
 def notify_reaction_update(
     user_profile: UserProfile, message: Message, reaction: Reaction, op: str
 ) -> None:
-    user_dict = {
-        "user_id": user_profile.id,
-        "email": user_profile.email,
-        "full_name": user_profile.full_name,
-    }
-
     event: dict[str, Any] = {
         "type": "reaction",
         "op": op,
         "user_id": user_profile.id,
-        # TODO: We plan to remove this redundant user_dict object once
-        # clients are updated to support accessing use user_id.  See
-        # https://github.com/zulip/zulip/pull/14711 for details.
-        "user": user_dict,
         "message_id": message.id,
         "emoji_name": reaction.emoji_name,
         "emoji_code": reaction.emoji_code,

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -564,18 +564,6 @@ def check_presence(
     assert event_presence_value["status"] == status
 
 
-# Type for the legacy user field; the `user_id` field is intended to
-# replace this and we expect to remove this once clients have migrated
-# to support the modern API.
-reaction_legacy_user_type = DictType(
-    required_keys=[
-        ("email", str),
-        ("full_name", str),
-        ("user_id", int),
-    ]
-    # We should probably declare is_mirror_dummy as an optional field here.
-)
-
 reaction_add_event = event_dict_type(
     required_keys=[
         ("type", Equals("reaction")),
@@ -585,7 +573,6 @@ reaction_add_event = event_dict_type(
         ("emoji_code", str),
         ("reaction_type", EnumType(["unicode_emoji", "realm_emoji", "zulip_extra_emoji"])),
         ("user_id", int),
-        ("user", reaction_legacy_user_type),
     ]
 )
 check_reaction_add = make_checker(reaction_add_event)
@@ -600,7 +587,6 @@ reaction_remove_event = event_dict_type(
         ("emoji_code", str),
         ("reaction_type", EnumType(["unicode_emoji", "realm_emoji", "zulip_extra_emoji"])),
         ("user_id", int),
-        ("user", reaction_legacy_user_type),
     ]
 )
 check_reaction_remove = make_checker(reaction_remove_event)

--- a/zerver/lib/message_cache.py
+++ b/zerver/lib/message_cache.py
@@ -25,8 +25,6 @@ class RawReactionRow(TypedDict):
     emoji_name: str
     message_id: int
     reaction_type: str
-    user_profile__email: str
-    user_profile__full_name: str
     user_profile_id: int
 
 
@@ -113,18 +111,6 @@ class ReactionDict:
             "emoji_name": row["emoji_name"],
             "emoji_code": row["emoji_code"],
             "reaction_type": row["reaction_type"],
-            # TODO: We plan to remove this redundant user dictionary once
-            # clients are updated to support accessing use user_id.  See
-            # https://github.com/zulip/zulip/pull/14711 for details.
-            #
-            # When we do that, we can likely update the `.values()` query to
-            # not fetch the extra user_profile__* fields from the database
-            # as a small performance optimization.
-            "user": {
-                "email": row["user_profile__email"],
-                "id": row["user_profile_id"],
-                "full_name": row["user_profile__full_name"],
-            },
             "user_id": row["user_profile_id"],
         }
 

--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -398,9 +398,7 @@ class Reaction(AbstractReaction):
             "emoji_name",
             "emoji_code",
             "reaction_type",
-            "user_profile__email",
             "user_profile_id",
-            "user_profile__full_name",
         ]
         # The ordering is important here, as it makes it convenient
         # for clients to display reactions in order without

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1564,18 +1564,11 @@ paths:
                                     emoji_name: {}
                                     reaction_type: {}
                                     user_id: {}
-                                    user: {}
                                   example:
                                     {
                                       "type": "reaction",
                                       "op": "add",
                                       "user_id": 10,
-                                      "user":
-                                        {
-                                          "user_id": 10,
-                                          "email": "user10@zulip.testserver",
-                                          "full_name": "King Hamlet",
-                                        },
                                       "message_id": 32,
                                       "emoji_name": "tada",
                                       "emoji_code": "1f389",
@@ -1610,18 +1603,11 @@ paths:
                                     emoji_name: {}
                                     reaction_type: {}
                                     user_id: {}
-                                    user: {}
                                   example:
                                     {
                                       "type": "reaction",
                                       "op": "remove",
                                       "user_id": 10,
-                                      "user":
-                                        {
-                                          "user_id": 10,
-                                          "email": "user10@zulip.testserver",
-                                          "full_name": "King Hamlet",
-                                        },
                                       "message_id": 52,
                                       "emoji_name": "tada",
                                       "emoji_code": "1f389",
@@ -23178,41 +23164,10 @@ components:
 
                 **Changes**: New in Zulip 3.0 (feature level 2). The `user`
                 object is deprecated and will be removed in the future.
-            user:
-              type: object
-              additionalProperties: false
-              deprecated: true
-              description: |
-                Dictionary with data on the user who added the
-                reaction, including the user ID as the `id`
-                field. Note that reactions data received from the
-                [events API](/api/get-events) has a slightly different
-                `user` dictionary format, with the user ID field
-                called `user_id` instead.
 
-                **Changes**: Deprecated and to be removed in a future release
-                once core clients have migrated to use the adjacent `user_id`
-                field, which was introduced in Zulip 3.0 (feature level 2).
-                Clients supporting older Zulip server versions should use
-                the user ID mentioned in the description above as they would
-                the `user_id` field.
-              properties:
-                id:
-                  type: integer
-                  description: |
-                    ID of the user.
-                email:
-                  type: string
-                  description: |
-                    Zulip API email of the user.
-                full_name:
-                  type: string
-                  description: |
-                    Full name of the user.
-                is_mirror_dummy:
-                  type: boolean
-                  description: |
-                    Whether the user is a mirror dummy.
+                In Zulip 10.0 (feature level 328), the deprecated `user` object
+                was removed which contained the following properties: `id`, `email`,
+                `full_name` and `is_mirror_dummy`.
     EmojiBase:
       type: object
       properties:
@@ -23258,38 +23213,10 @@ components:
 
                 **Changes**: New in Zulip 3.0 (feature level 2). The `user`
                 object is deprecated and will be removed in the future.
-            user:
-              type: object
-              additionalProperties: false
-              deprecated: true
-              description: |
-                Dictionary with data on the user who added the
-                reaction, including the user ID as the `user_id`
-                field.
 
-                **Changes**: Deprecated and to be removed in a future release
-                once core clients have migrated to use the adjacent `user_id`
-                field, which was introduced in Zulip 3.0 (feature level 2).
-                Clients supporting older Zulip server versions should use
-                the user ID mentioned in the description above as they would
-                the `user_id` field.
-              properties:
-                user_id:
-                  type: integer
-                  description: |
-                    ID of the user.
-                email:
-                  type: string
-                  description: |
-                    Zulip API email of the user.
-                full_name:
-                  type: string
-                  description: |
-                    Full name of the user.
-                is_mirror_dummy:
-                  type: boolean
-                  description: |
-                    Whether the user is a mirror dummy.
+                In Zulip 10.0 (feature level 328), the deprecated `user` object
+                was removed which contained the following properties: `user_id`,
+                `email`, `full_name` and `is_mirror_dummy`.
     MessagesEvent:
       allOf:
         - $ref: "#/components/schemas/MessagesBase"

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -305,9 +305,6 @@ class MessageDictTest(ZulipTestCase):
         msg_dict = MessageDict.ids_to_dict([message.id])[0]
         self.assertEqual(msg_dict["reactions"][0]["emoji_name"], reaction.emoji_name)
         self.assertEqual(msg_dict["reactions"][0]["user_id"], sender.id)
-        self.assertEqual(msg_dict["reactions"][0]["user"]["id"], sender.id)
-        self.assertEqual(msg_dict["reactions"][0]["user"]["email"], sender.email)
-        self.assertEqual(msg_dict["reactions"][0]["user"]["full_name"], sender.full_name)
 
     def test_missing_anchor(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -109,11 +109,6 @@ class ReactionEmojiTest(ZulipTestCase):
                 "emoji_name": emoji,
                 "emoji_code": emoji_code,
                 "reaction_type": "unicode_emoji",
-                "user": {
-                    "email": f"user{sender.id}@zulip.testserver",
-                    "id": sender.id,
-                    "full_name": sender.full_name,
-                },
                 "user_id": sender.id,
             }
             # It's important that we preserve the loop order in this
@@ -446,7 +441,6 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "add")
         self.assertEqual(event["emoji_name"], "smile")
@@ -492,7 +486,6 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "remove")
         self.assertEqual(event["emoji_name"], "smile")
@@ -1067,9 +1060,6 @@ class ReactionAPIEventTest(EmojiReactionBase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["user_id"], reaction_sender.id)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
-        self.assertEqual(event["user"]["full_name"], reaction_sender.full_name)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "add")
         self.assertEqual(event["message_id"], pm_id)
@@ -1112,9 +1102,6 @@ class ReactionAPIEventTest(EmojiReactionBase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
-        self.assertEqual(event["user"]["user_id"], reaction_sender.id)
-        self.assertEqual(event["user"]["email"], reaction_sender.email)
-        self.assertEqual(event["user"]["full_name"], reaction_sender.full_name)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "remove")
         self.assertEqual(event["message_id"], pm_id)


### PR DESCRIPTION
Removes deprecated `user` object from reactions objects returned by the API as it is redundant because of the presence of `user_id` field in the API and is not used by any clients now.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
