### PR TITLE
streams: Tweak query in update_stream_active_status_for_realm.

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1208,15 +1208,14 @@ def get_subscribed_private_streams_for_user(user_profile: UserProfile) -> QueryS
 
 @transaction.atomic(durable=True)
 def update_stream_active_status_for_realm(realm: Realm, date_days_ago: datetime) -> int:
-    active_stream_ids = (
-        Message.objects.filter(
-            date_sent__gte=date_days_ago, recipient__type=Recipient.STREAM, realm=realm
-        )
-        .values_list("recipient__type_id", flat=True)
-        .distinct()
+    recent_messages_subquery = Message.objects.filter(
+        date_sent__gte=date_days_ago,
+        realm=realm,
+        recipient__type=Recipient.STREAM,
+        recipient__type_id=OuterRef("id"),
     )
-    streams_to_mark_inactive = Stream.objects.filter(is_recently_active=True, realm=realm).exclude(
-        id__in=active_stream_ids
+    streams_to_mark_inactive = Stream.objects.filter(
+        ~Exists(recent_messages_subquery), is_recently_active=True, realm=realm
     )
 
     # Send events to notify the users about the change in the stream's active status.


### PR DESCRIPTION
We probably want to test in prod first before merging.

The NOT EXISTS structure might be better optimized by the Postgres query planner and might lead to slightly better performance than the id NOT IN (<subquery>) structure.

Generated SQL looks like this:
```
SELECT 
  "zerver_stream"."id", 
  "zerver_stream"."name", 
  "zerver_stream"."realm_id", 
  "zerver_stream"."date_created", 
  "zerver_stream"."creator_id", 
  "zerver_stream"."deactivated", 
  "zerver_stream"."description", 
  "zerver_stream"."rendered_description", 
  "zerver_stream"."recipient_id", 
  "zerver_stream"."invite_only", 
  "zerver_stream"."history_public_to_subscribers", 
  "zerver_stream"."is_web_public", 
  "zerver_stream"."stream_post_policy", 
  "zerver_stream"."is_in_zephyr_realm", 
  "zerver_stream"."message_retention_days", 
  "zerver_stream"."can_administer_channel_group_id", 
  "zerver_stream"."can_remove_subscribers_group_id", 
  "zerver_stream"."first_message_id", 
  "zerver_stream"."is_recently_active" 
FROM 
  "zerver_stream" 
WHERE 
  (
    NOT EXISTS(
      SELECT 
        1 AS "a" 
      FROM 
        "zerver_message" U0 
        INNER JOIN "zerver_recipient" U2 ON (U0."recipient_id" = U2."id") 
      WHERE 
        (
          U0."date_sent" >= 2024 - 12 - 08 19 : 25 : 20.518922 + 00 : 00 
          AND U0."realm_id" = 14 
          AND U2."type" = 2 
          AND U2."type_id" = ("zerver_stream"."id")
        ) 
      LIMIT 
        1
    ) AND "zerver_stream"."is_recently_active" 
    AND "zerver_stream"."realm_id" = 14
  )
```