### PR TITLE
integrations: Add an instruction related to Slack Bridge setup.

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -4,6 +4,9 @@ Get Zulip notifications for messages on your team's public Slack
 channels! You can choose to map each **Slack channel** either to a
 **Zulip topic** or to a **Zulip channel**.
 
+If you'd like to set up a biderectional bridge to send messages from
+Zulip to Slack and vice versa, see the [Slack bridge][1].
+
 See also the [Zulip Slack incoming webhook integration][1].
 
 !!! warn ""
@@ -30,6 +33,11 @@ See also the [Zulip Slack incoming webhook integration][1].
     Otherwise, add `&channels_map_to_topics=0` to the generated URL.
     Note that any Zulip channel you specified when generating the URL
     will be ignored in this case.
+
+1. If you're setting up a **Slack Bridge**, switch the value of the
+   `?api_key=` query in the **integration URL** you generated with the
+   API key of the **Generic bot** used for the Slack Bridge. Make sure
+   to continue the setup with this new URL. Otherwise, skip this step.
 
 1. Create a new [Slack app][4], and open it. Navigate to the **OAuth
    & Permissions** menu, and scroll down to the **Scopes** section.
@@ -77,3 +85,4 @@ See also the [Zulip Slack incoming webhook integration][1].
 [3]: https://api.slack.com/apis/events-api
 [4]: https://api.slack.com/apps
 [5]: https://api.slack.com/legacy/custom-integrations/outgoing-webhooks
+[6]: https://github.com/zulip/python-zulip-api/blob/main/zulip/integrations/bridge_with_slack/README.md


### PR DESCRIPTION
To set up a Slack Bridge, we use generic bots instead of incoming webhook bots for the Slack webhook integration. This PR adds an optional instruction on how to do that if the user is setting up a Slack Bridge.

Part of https://github.com/zulip/python-zulip-api/pull/826

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Cross-linking to the Slack bridge:
![image](https://github.com/user-attachments/assets/4bcab0f3-1e3d-4a38-83ef-04e3999944f3)

The new instruction related to Slack Bridge setup is in step 4:
![image](https://github.com/user-attachments/assets/d4993b3e-472b-4369-9b96-d01b438645d9)

The new doc as a whole:
![image](https://github.com/user-attachments/assets/c9c0a25a-16eb-433c-846d-e552d42157e1)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
