### PR TITLE
docs: Renaming AzureAD to Entra ID, part two.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -1195,7 +1195,7 @@ Facebook, Twitter, etc.) is easy to do if you're willing to write a
 bit of code, and pull requests to add new backends are welcome.
 
 For example, the
-[Azure Active Directory integration](https://github.com/zulip/zulip/commit/49dbd85a8985b12666087f9ea36acb6f7da0aa4f)
+[Microsoft Entra ID integration](https://github.com/zulip/zulip/commit/49dbd85a8985b12666087f9ea36acb6f7da0aa4f)
 was about 30 lines of code, plus some documentation and an
 [automatically generated migration][schema-migrations]. We also have
 helpful developer documentation on

--- a/help/configure-authentication-methods.md
+++ b/help/configure-authentication-methods.md
@@ -12,7 +12,7 @@ your organization. The following options are available on all
 The following options are available for organizations on Zulip Cloud Standard,
 Zulip Cloud Plus, and all self-hosted Zulip servers:
 
-- Oauth2 with Azure Active Directory
+- Oauth2 with Microsoft Entra ID (AzureAD)
 
 The following options are available for organizations on Zulip Cloud Plus, and all self-hosted Zulip servers:
 

--- a/help/saml-authentication.md
+++ b/help/saml-authentication.md
@@ -132,7 +132,7 @@ providers.
         * Certificate downloaded from **Certificate (Base64)**
      1. From the **Set up** section
         * **Login URL**
-        * **Azure AD Identifier**
+        * **Microsoft Entra Identifier**
      {!saml-login-button.md!}
 
 {tab|keycloak}

--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -711,7 +711,7 @@
             </tr>
             <tr>
                 <td class="comparison-table-feature">
-                    <a href="https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#plug-and-play-sso-google-github-gitlab">SSO with Azure Active Directory</a>
+                    <a href="https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#plug-and-play-sso-google-github-gitlab">SSO with Microsoft Entra ID</a>
                 </td>
                 <td class="comparison-value-negative cloud-cell"><i class="icon icon-x"></i></td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-check"></i></td>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -299,7 +299,7 @@
                                 <li><span>Complete team chat solution, with <a href="{{ billing_base_url }}/plans/#self-hosted-plan-comparison">all Zulip features</a> included</span></li>
                                 <li><span>Unlimited <a href="https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html">mobile notifications</a></span></li>
                                 <li class="support-note"><span>Email and chat support for:</span></li>
-                                <li><span><a href="/help/saml-authentication">SSO with SAML, Azure AD</a></span></li>
+                                <li><span><a href="/help/saml-authentication">SSO with SAML, Microsoft Entra ID</a></span></li>
                                 <li><span><a href="https://zulip.readthedocs.io/en/stable/production/authentication-methods.html">AD/LDAP user sync </a></span></li>
                                 <li><span><a href="/help/guest-users">Guests</a> with configurable access</span></li>
                                 <li><span><a href="/help/export-your-organization">Full</a> and <a href="https://zulip.readthedocs.io/en/stable/production/export-and-import.html#compliance-exports">compliance</a> data exports</span></li>

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18538,7 +18538,7 @@ paths:
                             type: boolean
                           azuread:
                             description: |
-                              Whether the user can authenticate using their Azure Active Directory account.
+                              Whether the user can authenticate using their Microsoft Entra ID account.
                             type: boolean
                           gitlab:
                             description: |

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -153,7 +153,7 @@ AUTHENTICATION_BACKENDS: tuple[str, ...] = (
     # "zproject.backends.GoogleAuthBackend",  # Google auth, setup below
     # "zproject.backends.GitHubAuthBackend",  # GitHub auth, setup below
     # "zproject.backends.GitLabAuthBackend",  # GitLab auth, setup below
-    # "zproject.backends.AzureADAuthBackend",  # Microsoft Azure Active Directory auth, setup below
+    # "zproject.backends.AzureADAuthBackend",  # Microsoft Entra ID (AzureAD) auth, setup below
     # "zproject.backends.AppleAuthBackend",  # Apple auth, setup below
     # "zproject.backends.SAMLAuthBackend",  # SAML, setup below
     # "zproject.backends.ZulipLDAPAuthBackend",  # LDAP, setup below
@@ -536,9 +536,9 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 # SOCIAL_AUTH_APPLE_KEY = "<your Key ID>"
 
 ########
-## Azure Active Directory OAuth.
+## Microsoft Entra ID (AzureAD) OAuth.
 ##
-## To set up Microsoft Azure AD authentication, you'll need to do the following:
+## To set up Microsoft Entra ID authentication, you'll need to do the following:
 ##
 ## (1) Open "App registrations" at
 ## https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade


### PR DESCRIPTION
This is a follow-up to #32693, which missed a bunch of places due to varying ways of typing Azure AD. (Azure AD, Azure Active Directory etc.)

In the diff there's an apparent inconsistency with renaming, in some places renaming to just "Microsoft Entra ID" and in others "Microsoft Entra ID (AzureAD)".
The idea is to add (AzureAD) in ordinary documentation, as it can help clarity since many people still think of this as AzureAD, while sticking with brevity and cleanliness of just using the official name in marketing focused material.

---------------

The most important place to consider renaming is the:
1. in Organization settings -> Authentication methods we still show `AzureAD`
2. If enabled, on the login page the 'Login with AzureAD' button. The logo it uses is also outdated I think:
![image](https://github.com/user-attachments/assets/3ee17c4d-04c3-4f56-962a-507a3cf4a812)

So we should probably change that, but on the other hand it might cause user confusion? Not sure... 

And finally, less important, there's the non-user-facing backend name in the codebase:
`zproject.backends.AzureADAuthBackend` as @timabbott pointed out. This is just admin-facing and if we rename it, then servers will either have to rename it in their `settings.py` when upgrading or we need to add backwards-compatibility translation. Honestly I'd rather leave it as it is, any admin using this backend probably knows this product as `AzureAD` anyway. `python-social-auth` hasn't renamed these either.

I'll open a #backend thread later. Just not sure if we want to discuss just the backend name change there, or also the UI elements from point (1) and (2) above.