### PR TITLE
Integrations: Replace account IDs with display names in Jira comments.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -30,6 +30,7 @@ IGNORED_PHRASES = [
     r"IP",
     r"JSON",
     r"Jitsi",
+    r"Jira",
     r"Jotform",
     r"Kerberos",
     r"LinkedIn",

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -515,6 +515,22 @@ WEBHOOK_INTEGRATIONS: list[WebhookIntegration] = [
         function="zerver.webhooks.ifttt.view.api_iftt_app_webhook",
         display_name="IFTTT",
     ),
+    WebhookIntegration(
+        "jira",
+        ["project-management"],
+        config_options=[
+            WebhookConfigOption(
+                name="jira_api_token",
+                description="Your Jira API token",
+                validator=check_string,
+            ),
+            WebhookConfigOption(
+                name="email",
+                description="Your Jira email",
+                validator=check_string,
+            ),
+        ],
+    ),
     WebhookIntegration("insping", ["monitoring"]),
     WebhookIntegration("intercom", ["customer-support"]),
     # Avoid collision with jira-plugin's doc "jira/doc.md".

--- a/zerver/webhooks/jira/fixtures/comment_created_with_account_mention.json
+++ b/zerver/webhooks/jira/fixtures/comment_created_with_account_mention.json
@@ -1,0 +1,95 @@
+{
+  "timestamp": 1734246496661,
+  "webhookEvent": "comment_created",
+  "comment": {
+    "self": "https://harshmeena.atlassian.net/rest/api/2/issue/10011/comment/10036",
+    "id": "10036",
+    "author": {
+      "self": "https://harshmeena.atlassian.net/rest/api/2/user?accountId=6420c1740152b5f4f9f28a08",
+      "accountId": "6420c1740152b5f4f9f28a08",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png",
+        "24x24": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png",
+        "16x16": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png",
+        "32x32": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png"
+      },
+      "displayName": "Harsh Meena",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "body": "This should work ~ [~accountid:6420c1740152b5f4f9f28a08]",
+    "updateAuthor": {
+      "self": "https://harshmeena.atlassian.net/rest/api/2/user?accountId=6420c1740152b5f4f9f28a08",
+      "accountId": "6420c1740152b5f4f9f28a08",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png",
+        "24x24": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png",
+        "16x16": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png",
+        "32x32": "https://secure.gravatar.com/avatar/0e5de317a36e0d57b59acac30f64ad80?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHM-1.png"
+      },
+      "displayName": "Harsh Meena",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "created": "2024-12-15T12:38:16.661+0530",
+    "updated": "2024-12-15T12:38:16.661+0530",
+    "jsdPublic": true
+  },
+  "issue": {
+    "id": "10011",
+    "self": "https://harshmeena.atlassian.net/rest/api/2/10011",
+    "key": "CPG-12",
+    "fields": {
+      "summary": "Test for zulip.",
+      "issuetype": {
+        "self": "https://harshmeena.atlassian.net/rest/api/2/issuetype/10001",
+        "id": "10001",
+        "description": "A small, distinct piece of work.",
+        "iconUrl": "https://harshmeena.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium",
+        "name": "Task",
+        "subtask": false,
+        "avatarId": 10318,
+        "entityId": "a7a1956c-9ef0-481b-bc21-d6a24a46081b",
+        "hierarchyLevel": 0
+      },
+      "project": {
+        "self": "https://harshmeena.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "CPG",
+        "name": "zulip",
+        "projectTypeKey": "software",
+        "simplified": true,
+        "avatarUrls": {
+          "48x48": "https://harshmeena.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10404",
+          "24x24": "https://harshmeena.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10404?size=small",
+          "16x16": "https://harshmeena.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10404?size=xsmall",
+          "32x32": "https://harshmeena.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10404?size=medium"
+        }
+      },
+      "assignee": null,
+      "priority": {
+        "self": "https://harshmeena.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://harshmeena.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://harshmeena.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://harshmeena.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://harshmeena.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  },
+  "eventType": "primaryAction"
+}

--- a/zerver/webhooks/jira/jira-doc.md
+++ b/zerver/webhooks/jira/jira-doc.md
@@ -13,6 +13,12 @@ Get Zulip notifications for your Jira projects!
 1. {!create-an-incoming-webhook.md!}
 
 1. {!generate-webhook-url-basic.md!}
+   By default, mentioned users in your Jira comment will appear as
+   `unknown Jira user (ACCOUNT ID...)` in Zulip. To get a mentioned
+   user's display name in your Zulip notifications, you can fill the
+   **Your Jira API token** and **Your Jira email** fields when
+   creating the **integration URL**. For instructions on generating
+   your `JIRA_API_TOKEN`, refer to this [Jira documentation][1].
 
 1. Go to your Jira **Site administration** page. Click on the menu icon
    ( <i class="fa fa-ellipsis-h"></i> ) under **Actions** for your
@@ -22,7 +28,7 @@ Get Zulip notifications for your Jira projects!
 
 1. Set **Name** to a name of your choice, such as `Zulip`. Set
    **Status** to **Enabled**, and set **URL** to the URL generated
-   above. Select the [events](#filtering-incoming-events) you'd like
+   above. Select the [events][2] you'd like
    to be notified about, and click **Create**.
 
 {end_tabs}
@@ -38,3 +44,6 @@ Get Zulip notifications for your Jira projects!
 - [Jira's webhook guide](https://developer.atlassian.com/server/jira/platform/webhooks/)
 
 {!webhooks-url-specification.md!}
+
+[1]: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+[2]: #filtering-incoming-events

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -2,13 +2,22 @@
 import re
 import string
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import unquote, urlsplit, urlunsplit
 
+import requests
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import gettext as _
 
 from zerver.decorator import webhook_view
-from zerver.lib.exceptions import AnomalousWebhookPayloadError, UnsupportedWebhookEventTypeError
+from zerver.lib.exceptions import (
+    AnomalousWebhookPayloadError,
+    JsonableError,
+    UnsupportedWebhookEventTypeError,
+)
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import JsonBodyPayload, typed_endpoint
 from zerver.lib.validator import WildValue, check_none_or, check_string
@@ -28,6 +37,14 @@ IGNORED_EVENTS = [
     "worklog_updated",
 ]
 
+MAX_LENGTH = 15
+
+
+@dataclass
+class Auth:
+    email: str
+    jira_api_token: str
+
 
 def guess_zulip_user_from_jira(jira_username: str, realm: Realm) -> UserProfile | None:
     try:
@@ -44,9 +61,11 @@ def guess_zulip_user_from_jira(jira_username: str, realm: Realm) -> UserProfile 
         return None
 
 
-def convert_jira_markup(content: str, realm: Realm) -> str:
+def convert_jira_markup(payload: WildValue, realm: Realm, auth: Auth | None) -> str:
     # Attempt to do some simplistic conversion of Jira
     # formatting to Markdown, for consumption in Zulip
+
+    content = get_in(payload, ["comment", "body"]).tame(check_string)
 
     # Jira uses *word* for bold, we use **word**
     content = re.sub(r"\*([^\*]+)\*", r"**\1**", content)
@@ -78,19 +97,11 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     full_link_re = re.compile(r"\[(?:(?P<title>[^|~]+)\|)(?P<url>[^\]]*)\]")
     content = re.sub(full_link_re, r"[\g<title>](\g<url>)", content)
 
-    # Try to convert a Jira user mention of format [~username] into a
-    # Zulip user mention. We don't know the email, just the Jira username,
-    # so we naively guess at their Zulip account using this
-    mention_re = re.compile(r"\[~(.*?)\]")
-    for username in mention_re.findall(content):
-        # Try to look up username
-        user_profile = guess_zulip_user_from_jira(username, realm)
-        if user_profile:
-            replacement = f"**{user_profile.full_name}**"
-        else:
-            replacement = f"**{username}**"
-
-        content = content.replace(f"[~{username}]", replacement)
+    # We replace mentioned account [~accountid:60e5a86a471e61006a4c51fd]
+    # with their corresponding usernames fetched by Jira API.
+    url = get_jira_api_url(payload, "rest/api/2/user")
+    if url != "":
+        content = replace_account_ids_with_usernames(content, realm, url, auth)
 
     # Here's how Jira escapes special characters in their payload:
     # ,.?\\!\n\"'\n\\[]\\{}()\n@#$%^&*\n~`|/\\\\
@@ -98,6 +109,43 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     content = content.replace("\\!", "!")
 
     return content
+
+
+def get_jira_api_data(jira_api_url: str, get_param: str, auth: Auth | None, **kwargs: Any) -> Any:
+    if get_param == "displayName" and auth is None:
+        return f"unknown Jira user ({kwargs['accountId'][: MAX_LENGTH - 3] + '...'})"
+    if auth:
+        response = requests.get(jira_api_url, auth=(auth.email, auth.jira_api_token), params=kwargs)
+        if response.status_code != requests.codes.ok:
+            if get_param == "displayName":
+                return f"unknown Jira user ({kwargs['accountId'][: MAX_LENGTH - 3] + '...'})"
+            raise JsonableError(_("Error accessing Jira API."))
+        result = response.json()
+        return result[get_param]
+
+
+def replace_account_ids_with_usernames(
+    comment: str, realm: Realm, url: str, auth: Auth | None
+) -> str:
+    pattern = re.compile(r"\[~accountid:([\w\-:]+)\]")
+    matches = list(pattern.finditer(comment))
+    for match in matches:
+        account_id = match.group(1)
+        username = get_jira_api_data(url, "displayName", auth, accountId=account_id)
+        # We also try to find the Zulip user corresponding to the mention Jira
+        # user. We don't know the email, just the Jira username, so we naively
+        # guess at their Zulip account using this
+        user_profile = guess_zulip_user_from_jira(username, realm)
+        if user_profile:
+            username = user_profile.full_name
+        comment = comment.replace(match.group(0), f"**{username}**")
+    return comment
+
+
+def get_jira_api_url(payload: WildValue, jira_api_path: str) -> str:
+    url = get_in(payload, ["comment", "author", "self"]).tame(check_string)
+    split_url = urlsplit(url)
+    return urlunsplit(split_url._replace(path=jira_api_path, query="", fragment=""))
 
 
 def get_in(payload: WildValue, keys: list[str], default: str = "") -> WildValue:
@@ -204,7 +252,9 @@ def add_change_info(
     return content
 
 
-def handle_updated_issue_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_updated_issue_event(
+    payload: WildValue, user_profile: UserProfile, auth: Auth | None
+) -> str:
     # Reassigned, commented, reopened, and resolved events are all bundled
     # into this one 'updated' event type, so we try to extract the meaningful
     # event that happened
@@ -238,7 +288,7 @@ def handle_updated_issue_event(payload: WildValue, user_profile: UserProfile) ->
         content = f"{author} {verb} {issue}{assignee_blurb}"
         comment = get_in(payload, ["comment", "body"]).tame(check_string)
         if comment:
-            comment = convert_jira_markup(comment, user_profile.realm)
+            comment = convert_jira_markup(payload, user_profile.realm, auth)
             content = f"{content}:\n\n``` quote\n{comment}\n```"
         else:
             content = f"{content}."
@@ -277,7 +327,9 @@ def handle_updated_issue_event(payload: WildValue, user_profile: UserProfile) ->
     return content
 
 
-def handle_created_issue_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_created_issue_event(
+    payload: WildValue, user_profile: UserProfile, auth: Auth | None
+) -> str:
     template = """
 {author} created {issue_string}:
 
@@ -295,7 +347,9 @@ def handle_created_issue_event(payload: WildValue, user_profile: UserProfile) ->
     )
 
 
-def handle_deleted_issue_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_deleted_issue_event(
+    payload: WildValue, user_profile: UserProfile, auth: Auth | None
+) -> str:
     template = "{author} deleted {issue_string}{punctuation}"
     title = get_issue_title(payload)
     punctuation = "." if title[-1] not in string.punctuation else ""
@@ -306,34 +360,42 @@ def handle_deleted_issue_event(payload: WildValue, user_profile: UserProfile) ->
     )
 
 
-def handle_comment_created_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_created_event(
+    payload: WildValue, user_profile: UserProfile, auth: Auth | None
+) -> str:
     return "{author} commented on {issue_string}\
 \n``` quote\n{comment}\n```\n".format(
         author=payload["comment"]["author"]["displayName"].tame(check_string),
         issue_string=get_issue_string(payload, with_title=True),
-        comment=convert_jira_markup(payload["comment"]["body"].tame(check_string),user_profile.realm),
+        comment=convert_jira_markup(payload, user_profile.realm, auth),
     )
 
 
-def handle_comment_updated_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_updated_event(
+    payload: WildValue, user_profile: UserProfile, auth: Auth | None
+) -> str:
     return "{author} updated their comment on {issue_string}\
 \n``` quote\n{comment}\n```\n".format(
         author=payload["comment"]["author"]["displayName"].tame(check_string),
         issue_string=get_issue_string(payload, with_title=True),
-        comment=convert_jira_markup(payload["comment"]["body"].tame(check_string),user_profile.realm),
+        comment=convert_jira_markup(payload, user_profile.realm, auth),
     )
 
 
-def handle_comment_deleted_event(payload: WildValue, user_profile: UserProfile) -> str:
+def handle_comment_deleted_event(
+    payload: WildValue, user_profile: UserProfile, auth: Auth | None
+) -> str:
     return "{author} deleted their comment on {issue_string}\
 \n``` quote\n~~{comment}~~\n```\n".format(
         author=payload["comment"]["author"]["displayName"].tame(check_string),
         issue_string=get_issue_string(payload, with_title=True),
-        comment=convert_jira_markup(payload["comment"]["body"].tame(check_string),user_profile.realm),
+        comment=convert_jira_markup(payload, user_profile.realm, auth),
     )
 
 
-JIRA_CONTENT_FUNCTION_MAPPER: dict[str, Callable[[WildValue, UserProfile], str] | None] = {
+JIRA_CONTENT_FUNCTION_MAPPER: dict[
+    str, Callable[[WildValue, UserProfile, Auth | None], str] | None
+] = {
     "jira:issue_created": handle_created_issue_event,
     "jira:issue_deleted": handle_deleted_issue_event,
     "jira:issue_updated": handle_updated_issue_event,
@@ -352,6 +414,8 @@ def api_jira_webhook(
     user_profile: UserProfile,
     *,
     payload: JsonBodyPayload[WildValue],
+    jira_api_token: str | None = None,
+    email: str | None = None,
 ) -> HttpResponse:
     event = get_event_type(payload)
     if event in IGNORED_EVENTS:
@@ -366,8 +430,16 @@ def api_jira_webhook(
     if content_func is None:
         raise UnsupportedWebhookEventTypeError(event)
 
+    auth = None
+
+    if email and jira_api_token is not None:
+        # Jira encodes URLs before sending requests to our webhook,
+        # which results into double encoding. To address this, we
+        # decode the parameters to remove the extra layer of encoding.
+        auth = Auth(unquote(email), unquote(jira_api_token))
+
     topic_name = get_issue_topic(payload)
-    content: str = content_func(payload, user_profile)
+    content: str = content_func(payload, user_profile, auth)
 
     check_send_webhook_message(
         request, user_profile, topic_name, content, event, unquote_url_parameters=True


### PR DESCRIPTION
This PR enhances the Jira integration by fetching account display names for mentions in comments using  
the Jira API. Account IDs are replaced with their corresponding display names to make Zulip notifications  
easier to read.  

Changes:  
- Update `view.py` to fetch account display names via the Jira API and replace `[~accountid: id]` with  
  the respective display names.  
- Document the process for generating `JIRA_API_TOKEN` in `/integrations/doc/jira`.  
- Add a new test case in `tests.py` to validate this functionality.  
- Add a new fixture `comment_created_with_account_mention.json` for testing account mentions.  

Fixes: #32646  

**Screenshots and screen captures:**
|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Jira    | ![recent](https://github.com/user-attachments/assets/a8e6ceb7-70c7-486f-8fcf-84a1c64c7cb1)    |
| Zulip                          | ![Display Names](https://github.com/user-attachments/assets/7b2890e5-fbb2-463f-85de-01e682e0d06d)    |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
