### PR TITLE
Indicate when DM reply is not allowed in interleaved views.

### DIFF
--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1394,7 +1394,7 @@ function handle_post_view_change(
 
     if (filter.contains_only_private_messages()) {
         compose_closed_ui.update_buttons_for_private();
-    } else if (filter.is_conversation_view() || filter.includes_full_stream_history()) {
+    } else if (filter.includes_full_stream_history()) {
         compose_closed_ui.update_buttons_for_stream_views();
     } else {
         compose_closed_ui.update_buttons_for_non_specific_views();


### PR DESCRIPTION
The PR implements a functioning where we disable the compose reply button for DMs in case the user is not allowed to send a DM. Previously, we do this for DM view only but this PR implements it for all the view including **DM feed view**, **Combined feed view**, **Mentions view**, **Reactions view**, **Starred messages view** and **Search view**,

<details>
<summary> Video description for all the views </summary>
<br/>


> NOTE:
> Desdemona is the only one who can authorize or initiate a DM. This is required for the differentiation.
> Before column contains same video in all the tables, as all the view share the same behavior.

## DM Feed 

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>


https://github.com/user-attachments/assets/4f73ed15-9728-4435-bc0f-26f76ffd7b43



</td>
<td>

https://github.com/user-attachments/assets/50e4eba8-155a-428b-b7e6-0e8e9cfad076

</td>
</tr>
</table>

## Combined Feed

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/4f73ed15-9728-4435-bc0f-26f76ffd7b43


</td>
<td>

https://github.com/user-attachments/assets/d574fd25-83f7-4053-b42e-6729255bdb75

</td>
</tr>
</table>

## Mentions

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/4f73ed15-9728-4435-bc0f-26f76ffd7b43


</td>
<td>


https://github.com/user-attachments/assets/21c2953c-1f5b-4423-be2e-03ed8b834d44



</td>
</tr>
</table>

## Reactions

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/4f73ed15-9728-4435-bc0f-26f76ffd7b43


</td>
<td>


https://github.com/user-attachments/assets/86dd9bf5-6386-4d24-a5d4-385207533232



</td>
</tr>
</table>

## Starred Messages

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/4f73ed15-9728-4435-bc0f-26f76ffd7b43


</td>
<td>


https://github.com/user-attachments/assets/5919f2b3-8e49-4841-9912-09d146a2bf3c



</td>
</tr>
</table>

## Search View

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/4f73ed15-9728-4435-bc0f-26f76ffd7b43


</td>
<td>


https://github.com/user-attachments/assets/f2a17ef0-85cb-422e-affb-d4c1c64c9f97



</td>
</tr>
</table>

</details>

Fixes: #32597 .

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
