### PR TITLE
channel_settings: Add error handling for stream creation.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 338**
+
+* [`POST /users/me/subscriptions`](/api/subscribe): Added
+  `PERMISSION_DENIED` code for specificifying the error when a user
+  tries to access a channel they don't have permission to access.
+
 **Feature level 337**
 
 * `POST /calls/bigbluebutton/create`: Added a `voice_only` parameter

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 337  # Last bumped for voice_only param addition for BigBlueButton
+API_FEATURE_LEVEL = 338  # Last bumped for adding PERMISSION_DENIED error code.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -56,6 +56,7 @@ class ErrorCode(Enum):
     SYSTEM_GROUP_REQUIRED = auto()
     CANNOT_DEACTIVATE_GROUP_IN_USE = auto()
     CANNOT_ADMINISTER_CHANNEL = auto()
+    PERMISSION_DENIED = auto()
 
 
 class JsonableError(Exception):
@@ -753,3 +754,18 @@ class CannotManageDefaultChannelError(JsonableError):
     @override
     def msg_format() -> str:
         return _("You do not have permission to change default channels.")
+
+
+class CannotAccessChannelError(JsonableError):
+    code = ErrorCode.PERMISSION_DENIED
+    data_fields = []
+
+    def __init__(self, channel_name: str) -> None:
+        self._msg = _("Unable to access channel ({channel_name}).").format(
+            channel_name=channel_name
+        )
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return "{_msg}"

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -170,7 +170,7 @@ def test_authorization_errors_fatal(client: Client, nonadmin_client: Client) -> 
         ],
         authorization_errors_fatal=True,
     )
-    assert_error_response(result)
+    assert_error_response(result, code="PERMISSION_DENIED")
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "400")
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10592,11 +10592,14 @@ paths:
                       {
                         "msg": "Unable to access channel (private).",
                         "result": "error",
-                        "code": "BAD_REQUEST",
+                        "code": "PERMISSION_DENIED",
                       }
                     description: |
                       An example JSON response for when the requesting user does not have
                       access to a private channel and `"authorization_errors_fatal": true`:
+
+                      **Changes**: In Zulip 10.0 (feature level 338), added the specific error code
+                      `PERMISSION_DENIED` for this, which was previously a more generic name of `BAD_REQUEST`.
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -50,6 +50,7 @@ from zerver.decorator import (
 from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.email_mirror_helpers import encode_email_address, get_channel_email_token
 from zerver.lib.exceptions import (
+    CannotAccessChannelError,
     CannotManageDefaultChannelError,
     JsonableError,
     OrganizationOwnerRequiredError,
@@ -676,11 +677,8 @@ def add_subscriptions_backend(
         user_profile, existing_streams
     )
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
-        raise JsonableError(
-            _("Unable to access channel ({channel_name}).").format(
-                channel_name=unauthorized_streams[0].name,
-            )
-        )
+        raise CannotAccessChannelError(unauthorized_streams[0].name)
+
     # Newly created streams are also authorized for the creator
     streams = authorized_streams + created_streams
 


### PR DESCRIPTION
This pull request introduces a new error code `PERMISSION_DENIED` to improve error handling when users attempt to access channels they do not have permission to access. 

API updates:

* Documented the new `PERMISSION_DENIED` error code for the `POST /users/me/subscriptions` endpoint.
* Bumped the `API_FEATURE_LEVEL` to 337 to reflect the addition of the `PERMISSION_DENIED` error code.
* Updated the OpenAPI documentation to include the new `PERMISSION_DENIED` error code in the response examples.

Frontend adjustments:

* Modified the error handling logic in the `create_stream` function to use the new `PERMISSION_DENIED` error code instead of parsing error messages.

Fixes: #32138 .<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
