### PR TITLE
unread: Add check to debug missing unreads in combined feed.

### DIFF
--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -584,6 +584,26 @@ function process_scrolled_to_bottom(): void {
         // feed, so it would not be correct to instead ask the server
         // to mark all messages matching this entire narrow as read.
         notify_server_messages_read(message_lists.current.all_messages());
+        if (
+            message_lists.current.data.filter.is_in_home() &&
+            message_lists.current.should_preserve_current_rendered_state()
+        ) {
+            const with_msg_ids = true;
+            const unread_counts = unread.get_counts(with_msg_ids);
+            const home_unread_count = unread_counts.home_unread_messages;
+            if (home_unread_count !== 0) {
+                const unread_msgs = unread_counts.home_stream_msg_ids;
+                const combined_feed_msgs = new Set(
+                    message_lists.current.all_messages().map((msg) => msg.id),
+                );
+                const missing_unread_msgs = unread_msgs.filter(
+                    (msg) => !combined_feed_msgs.has(msg),
+                );
+                blueslip.error("Combined feed missing unread messages", {
+                    missing_unread_msg_ids: JSON.stringify(missing_unread_msgs),
+                });
+            }
+        }
         return;
     }
 

--- a/web/tests/example7.test.cjs
+++ b/web/tests/example7.test.cjs
@@ -59,7 +59,7 @@ const message_lists = mock_esm("../src/message_lists");
 const message_viewport = mock_esm("../src/message_viewport");
 const unread_ui = mock_esm("../src/unread_ui");
 
-message_lists.current = {view: {}};
+message_lists.current = {view: {}, data: {filter: {is_in_home: noop}}};
 message_lists.all_rendered_message_lists = () => [message_lists.current];
 
 const message_store = zrequire("message_store");


### PR DESCRIPTION
This will help us know which messages are missing in combined feed when there is a mismatch between unread counts and the messages in the combined feed.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.E2.9D.93combined.20feed.20missing.20messages
