### PR TITLE
tooltip_templates: Remove unused `data-view-code` attribute.

### DIFF
--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -107,14 +107,14 @@
     </div>
 </template>
 <template id="all-message-tooltip-template">
-    <div class="views-tooltip-container" data-view-code="all_messages">
+    <div class="views-tooltip-container">
         <div>{{t 'Combined feed' }}</div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>
     {{tooltip_hotkey_hints "A"}}
 </template>
 <template id="recent-conversations-tooltip-template">
-    <div class="views-tooltip-container" data-view-code="recent_topics">
+    <div class="views-tooltip-container">
         <div>{{t 'Recent conversations' }}</div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>
@@ -127,12 +127,12 @@
     {{tooltip_hotkey_hints "*"}}
 </template>
 <template id="my-reactions-tooltip-template">
-    <div class="views-tooltip-container" data-view-code="recent_topics">
+    <div class="views-tooltip-container">
         <div>{{t 'Reactions to your messages' }}</div>
     </div>
 </template>
 <template id="inbox-tooltip-template">
-    <div class="views-tooltip-container" data-view-code="inbox">
+    <div class="views-tooltip-container">
         <div>{{t 'Inbox' }}</div>
         <div class="tooltip-inner-content views-tooltip-home-view-note italic hide">{{t 'This is your home view.' }}</div>
     </div>


### PR DESCRIPTION
This attribute is only usable on clickable targets as per the existing click handler logic which these tooltips are not.
