### PR TITLE
compose: Correct and improve button dimensions.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1508,7 +1508,7 @@
     --color-border-compose-new-message-button: hsl(0deg 0% 0% / 60%);
     --color-border-compose-new-message-button-hover: hsl(0deg 0% 0% / 60%);
     --color-border-compose-new-message-button-active: hsl(0deg 0% 0% / 60%);
-    --color-background-popover: hsl(212deg 32% 14%);
+    --color-background-popover: hsl(0deg 0% 17%);
     --color-limit-indicator: hsl(38deg 100% 70%);
     --color-limit-indicator-over-limit: hsl(3deg 80% 60%);
     --color-narrow-to-compose-recipients-background: hsl(227deg 80% 60% / 25%);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -770,6 +770,7 @@
     --color-message-content-container-border: hsl(0deg 0% 0% / 10%);
     --color-message-content-container-border-focus: hsl(0deg 0% 57%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 0% / 5%);
+    --color-compose-formatting-button-divider: hsl(0deg 0% 75%);
     --color-compose-focus-ring: var(--color-outline-focus);
 
     /* Text colors */
@@ -1524,6 +1525,7 @@
     --color-message-content-container-border-focus: hsl(0deg 0% 100% / 27%);
     --color-message-content-container-border-over-limit: hsl(0deg 76% 65%);
     --color-compose-control-button-background-hover: hsl(0deg 0% 100% / 5%);
+    --color-compose-formatting-button-divider: hsl(236deg 33% 90% / 25%);
     --color-compose-focus-ring: hsl(0deg 0% 67%);
 
     /* Text colors */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1189,6 +1189,9 @@ textarea.new_message_textarea {
     .compose_control_button {
         /* 22px at 14px/1em */
         font-size: 1.5714em;
+        /* Constrain icon fonts to a perfect
+           box (22px at 14px/1em) */
+        line-height: 1;
         /* Coordinate with the value of
            --compose-formatting-buttons-row-height */
         /* 28px at 22px/1em */
@@ -1235,6 +1238,9 @@ textarea.new_message_textarea {
         padding: 0 1px;
         /* 18px at 14px/1em */
         font-size: 1.2857em;
+        /* Constrain icon font to a perfect
+           box (18px at 14px/1em) */
+        line-height: 1;
         /* Coordinate with the value of
            --compose-formatting-buttons-row-height */
         /* 28px at 18px/1em */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1270,8 +1270,8 @@ textarea.new_message_textarea {
         margin: 0 5px;
         /* Coordinate with the value of
            --compose-formatting-buttons-row-height */
-        /* 22px at 14px/1em */
-        height: 1.5714em;
+        /* 16px at 14px/1em */
+        height: 1.1429em;
         width: 1.5px;
         /* Prevent dividers from growing or shrinking. */
         flex: 0 0 auto;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1234,7 +1234,7 @@ textarea.new_message_textarea {
     .compose_control_menu {
         padding: 0 1px;
         /* 18px at 14px/1em */
-        font-size: 1.2957em;
+        font-size: 1.2857em;
         /* Coordinate with the value of
            --compose-formatting-buttons-row-height */
         /* 28px at 18px/1em */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1267,14 +1267,15 @@ textarea.new_message_textarea {
     }
 
     .divider {
-        color: hsl(0deg 0% 75%);
-        /* 20px at 14px/1em */
-        font-size: 1.4286em;
-        margin: 0 3px;
+        margin: 0 5px;
         /* Coordinate with the value of
            --compose-formatting-buttons-row-height */
-        /* 28px at 20px/1em */
-        height: 1.4em;
+        /* 22px at 14px/1em */
+        height: 1.5714em;
+        width: 1.5px;
+        /* Prevent dividers from growing or shrinking. */
+        flex: 0 0 auto;
+        background-color: var(--color-compose-formatting-button-divider);
 
         @media (width < 400px) {
             /* Remove at mobile widths to make more space

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -399,10 +399,6 @@
         border-color: hsl(0deg 0% 0% / 90%);
     }
 
-    .compose-control-buttons-container .divider {
-        color: hsl(236deg 33% 90% / 25%);
-    }
-
     .compose_control_button:hover {
         color: inherit;
     }

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -17,7 +17,7 @@
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add voice call' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-voice-call audio_link" aria-label="{{t 'Add voice call' }}" tabindex=0></a>
     </div>
-    <div class="divider">|</div>
+    <div class="divider"></div>
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add emoji' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-smile-bigger emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></a>
     </div>
@@ -33,11 +33,11 @@
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
     </div>
     <div class="show_popover_buttons_2">
-        <div class="divider">|</div>
+        <div class="divider"></div>
         {{> popovers/compose_control_buttons/compose_control_buttons_in_popover_2 .}}
     </div>
     <div class="show_popover_buttons">
-        <div class="divider">|</div>
+        <div class="divider"></div>
         {{> popovers/compose_control_buttons/compose_control_buttons_in_popover .}}
     </div>
     <div class="compose_control_menu_wrapper" role="button" tabindex=0>

--- a/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover.hbs
+++ b/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover.hbs
@@ -1,11 +1,11 @@
 <div class="compose-control-buttons-container preview_mode_disabled">
     <a role="button" data-format-type="numbered" class="compose_control_button zulip-icon zulip-icon-ordered-list formatting_button" aria-label="{{t 'Numbered list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Numbered list' }}"></a>
     <a role="button" data-format-type="bulleted" class="compose_control_button zulip-icon zulip-icon-unordered-list formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
-    <div class="divider">|</div>
+    <div class="divider"></div>
     <a role="button" data-format-type="quote" class="compose_control_button zulip-icon zulip-icon-quote formatting_button" aria-label="{{t 'Quote' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Quote' }}"></a>
     <a role="button" data-format-type="spoiler" class="compose_control_button zulip-icon zulip-icon-spoiler formatting_button" aria-label="{{t 'Spoiler' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Spoiler' }}"></a>
     <a role="button" data-format-type="code" class="compose_control_button zulip-icon zulip-icon-code formatting_button" aria-label="{{t 'Code' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Code' }}"></a>
     <a role="button" data-format-type="latex" class="compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'Math (LaTeX)' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Math (LaTeX)' }}"></a>
-    <div class="divider">|</div>
+    <div class="divider"></div>
 </div>
 <a role="button" class="compose_control_button compose_help_button zulip-icon zulip-icon-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover_2.hbs
+++ b/web/templates/popovers/compose_control_buttons/compose_control_buttons_in_popover_2.hbs
@@ -4,6 +4,6 @@
     <a role="button" data-format-type="italic" class="compose_control_button zulip-icon zulip-icon-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="italic-tooltip" data-tippy-maxWidth="none"></a>
     <a role="button" data-format-type="strikethrough" class="compose_control_button zulip-icon zulip-icon-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Strikethrough' }}"></a>
     {{#if inside_popover}}
-        <div class="divider">|</div>
+        <div class="divider"></div>
     {{/if}}
 </div>


### PR DESCRIPTION
This PR achieves two primary things, both in preparation for scrolling formatting buttons (#31215):

1. Buttons are now accurately sized to the height available in the grid (2em, or 28px at 14px/1em). Despite a `height` value on the icons, the larger line-height spilled out beneath the icon box's and grid area's bottom edges, creating problems for centering in relation to those icons, and a vertical overscroll (the overscroll behavior is not visible in this PR or in `main`).
2. Dividers between groups of formatting buttons are now drawn using CSS (previously, dividers were a difficult-to-center pipe character, `|`). That means both better control over the look of the dividers and, as is evident in the screenshots below, dividers that are properly centered for the first time (and that more easily match the height specified in Vlad's design).

It includes also two minor fixes:

1. It corrects an inaccurate `em` unit on the vdots icon, which is likely owing to a typo when the conversion was made.
2. It fixes the `--color-background-popover` color to match `--color-background-popover-menu`, as is done in light theme. The previous `--color-background-popover` had the previous dark-theme blue tint to it.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Following Vlad's design at https://terpimost.github.io/compose-decomposed/, dividers match the approximate height of the formatting icons:_

| Divider height, main | Divider height, PR |
| --- | --- |
| ![dividers-as-in-main](https://github.com/user-attachments/assets/fba87bcb-1a7b-46e0-980c-ae24ebd77605) | ![icon-matched-dividers](https://github.com/user-attachments/assets/120225e2-ffdb-4cf0-bc0d-ea8ce1760909) |

_The other screenshots below still verify, but do not reflect the shorter, em-based icon-matched dividers as above:_

| Before | After |
| --- | --- |
| ![light-narrow-before](https://github.com/user-attachments/assets/7c45e27f-feee-46f5-be83-60711b750a57) | ![light-narrow-after](https://github.com/user-attachments/assets/df71481d-1a63-4e3a-996a-889ef652c3d6) |
| ![dark-narrow-before](https://github.com/user-attachments/assets/0f079218-fb98-4139-8076-0b376b62ef3e) | ![dark-narrow-after](https://github.com/user-attachments/assets/99a1aa52-53f0-4522-9f28-18604ee0f162) |
| ![light-wide-before](https://github.com/user-attachments/assets/3c760731-9755-47a6-a102-c27bcff261d2) | ![light-wide-after](https://github.com/user-attachments/assets/5bcf076e-4ebc-457b-9256-8377f8d4dde8) |
| ![dark-wide-before](https://github.com/user-attachments/assets/ee1aaae7-a2fb-4c82-8643-5c00c4d1aa66) | ![dark-wide-after](https://github.com/user-attachments/assets/c19a7093-63c5-4e06-be90-bf84ac01f42b) |

| Dark-theme popover, before | Dark-theme popover, after |
| --- | --- |
| ![dark-popover-before](https://github.com/user-attachments/assets/a99e6372-515a-473d-9e15-01b93716e66e) | ![dark-popover-after](https://github.com/user-attachments/assets/3d15b0ec-371a-4a6a-ac14-ff73cdfeadbf) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>