### PR TITLE
portico: Add Rush Stack case study.

### DIFF
--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -219,6 +219,11 @@ landing_page_urls = [
         landing_view,
         {"template_name": "corporate/case-studies/recurse-center-case-study.html"},
     ),
+    path(
+        "case-studies/rush-stack/",
+        landing_view,
+        {"template_name": "corporate/case-studies/rush-stack-case-study.html"},
+    ),
     path("communities/", communities_view),
 ]
 

--- a/templates/corporate/case-studies/rush-stack-case-study.html
+++ b/templates/corporate/case-studies/rush-stack-case-study.html
@@ -1,0 +1,38 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
+
+{% set PAGE_TITLE = "Case study: Rush Stack open-source community | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn how Zulip makes it easy for the Rush Stack
+  community to provide the level of support required for mission-critical
+  enterprise tools." %}
+
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page solutions-page case-study-page">
+    <div class="hero bg-pycon">
+        <div class="bg-dimmer"></div>
+        <div class="content">
+            <h1 class="center">Case study: Rush Stack <br /> open-source community</h1>
+        </div>
+        <div class="hero-text">
+            Learn more about using Zulip for<br /> <a href="/for/open-source/">open
+            source projects</a> and <a href="/for/communities/">communities</a>.
+        </div>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content markdown">
+                {{ render_markdown_path('corporate/case-studies/rush-stack-case-study.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/corporate/case-studies/rush-stack-case-study.md
+++ b/templates/corporate/case-studies/rush-stack-case-study.md
@@ -1,0 +1,117 @@
+[Rush Stack](https://rushstack.io/) is an open-source collection of specialized
+tooling for working with the world's largest source code repositories.
+
+Providing support is often a challenge for open-source projects, especially when
+maintainers are juggling internal investigations at work alongside their
+open-source correspondence.  Yet to be successful, the Rush Stack community
+needs to systematically handle questions and feedback.
+
+Zulip makes it easy for the Rush Stack community to provide the level of support
+required for mission-critical enterprise tools. “With Zulip, we have a system
+that feels professional, where once a topic is opened, we can make sure that it
+gets resolved,” says Rush Stack maintainer [Pete
+Gonzalez](https://github.com/octogonz).
+
+
+> “With Zulip, we have a system that feels professional.”
+>
+> — Rush Stack maintainer Pete Gonzalez
+
+
+## Choosing a chat product? Focus on the features that matter.
+
+Pete Gonzalez started researching chat platform options for the Rush Stack
+community in early 2020, looking to replace Gitter. “I had worked on
+[Yammer](https://en.wikipedia.org/wiki/Viva_Engage), and even wrote my own
+client, so I was thinking about chat apps very deeply,” Pete recalls. “Although
+chat apps may seem similar, there are actually many subtle design tradeoffs
+whose combination determines whether an app will work well for a particular use
+case.”
+
+Rush Stack needed a space for maintainers and community members to have serious,
+long-running conversations. “Rush Stack discussions have the character of
+support tickets,” Pete explains. “Someone can ask a question that might take two
+years to finally solve.”
+
+Pete identified Zulip as the best fit for the needs of the community. With
+Zulip’s topic-based organization, conversations can run their course, with the
+full context of the discussion easily at hand when someone has a new idea.
+“Zulip gives you control,” Pete points out. “You can edit or move messages to
+fix anything that might be incorrect or confusing, which is important for
+long-running discussions.”
+
+
+> “Zulip gives you control.”
+>
+> — Rush Stack maintainer Pete Gonzalez
+
+To make the transition, Rush Stack imported the project’s full chat history from
+Gitter into Zulip, making it an easily searchable resource. Enabling Zulip’s
+feature for logging in with GitHub meant that users didn’t have to make new
+accounts. Users could also control how their messages looked with familiar
+Markdown formatting.
+
+
+## “Zulip has better features for the way we use it”
+
+Over the years, Pete had continued to keep an eye on the evolution of team chat
+products. “Compared to Discord, Slack, GitHub discussions… Zulip has better
+features for the way we use it,” he says.
+
+Pete has seen open-source maintainers struggle to manage a Discord community:
+“There are all these people asking questions… If an important question scrolls
+out of view, how would you follow up? Maintainers end up giving up on community
+management, leaving casual participants to sort things out on their own.”
+
+Slack’s paid plans, which start at $8.75/user/month, are unaffordable for
+community use. “You have to pay a lot for Slack history, and users can’t log in
+with their GitHub account,” Pete says. On the free plan, communities have access
+to just 90 days of message history, which is unworkable for a community with a
+large knowledge base and long-running investigations.
+
+
+> “Of all the apps I tested, Zulip’s approach stood out as the best fit for how
+> we work.”
+>
+> — Rush Stack maintainer Pete Gonzalez
+
+
+## Software that’s built in the open and always improving
+
+Pete has been impressed by how Zulip handles user feedback. “I can go into the
+development community to talk to them, and often the tech lead of the team will
+reply,” he notes. “Even if their answer is that my request is a lower priority
+right now, there is context to understand that. New features are always being
+added, and with the team’s daily discussions being public, I can see what they
+are working on and why. It’s a really different dynamic from trying to make
+feature requests or bug reports for a closed source product with an invisible
+engineering team.”
+
+
+> “New features are always being added, and with the team’s daily discussions
+> being public, I can see what they are working on and why.”
+>
+> — Rush Stack maintainer Pete Gonzalez
+
+Pete was pleased to learn that organizations can now allow [public
+access](/help/public-access-option) to channels. It lowers the bar for people to
+view Zulip discussions that are linked from Rush Stack GitHub issues.
+
+Pete has also seen Zulip’s onboarding experience transform over the past few
+years. “In the past, Zulip was optimized for daily users, and so had a bit of a
+learning curve for occasional Rush Stack participants. But the UX has improved a
+lot in this regard. The [recent conversations](/help/recent-conversations) view
+that’s been added has largely addressed the challenge for new users,” Pete says.
+This view lists the topics being discussed, and is also the go-to for Pete to
+check in on what’s happening.
+
+
+> “The folks who make Zulip listen to customers, and the product continues to
+> improve.”
+>
+> — Rush Stack maintainer Pete Gonzalez
+
+---
+
+Check out our guide on using Zulip for [open source](/for/open-source/), and
+learn how Zulip [helps communities scale](/for/communities/)!

--- a/templates/corporate/for/communities.html
+++ b/templates/corporate/for/communities.html
@@ -28,7 +28,9 @@
         <div class="hero-text">
             Learn how the <a href="/case-studies/recurse-center/">Recurse
             Center</a>, <a href="/case-studies/rust/">Rust language</a>,
-            <br />and <a href="/case-studies/asciidoctor/">Asciidoctor</a> communities are using Zulip.
+            <a href="/case-studies/asciidoctor/">Asciidoctor</a>, and&nbsp;<a
+            href="/case-studies/rush-stack/">Rush&nbsp;Stack</a> communities are
+            using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -29,7 +29,9 @@
         <div class="hero-text">
             Learn how the <a href="/case-studies/rust/">Rust language</a>,
             <a href="/case-studies/lean/">Lean theorem prover</a>,
-            <br />and <a href="/case-studies/asciidoctor/">Asciidoctor</a> communities are using Zulip.
+            <a href="/case-studies/asciidoctor/">Asciidoctor</a>, and&nbsp;<a
+            href="/case-studies/rush-stack/">Rush&nbsp;Stack</a> communities are
+            using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">

--- a/templates/corporate/for/use-cases.md
+++ b/templates/corporate/for/use-cases.md
@@ -28,3 +28,4 @@
 * [Asciidoctor open-source community](/case-studies/asciidoctor/)
 * [Rust language community](/case-studies/rust/)
 * [Recurse Center](/case-studies/recurse-center/)
+* [Rush Stack](/case-studies/rush-stack/)

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -101,6 +101,7 @@
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/asciidoctor/">Inclusive discussion in the open-source Asciidoctor community</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/rust/">Faster decision-making in the Rust language community</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/recurse-center/">Platform for a worldwide community since 2013 at Recurse Center</a></li>
+                            <li class="top-menu-submenu-list-item"><a href="/case-studies/rush-stack/">Professional community support at Rush Stack</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/communities/">Open communities directory</a></li>
                         </ul>
                     </div>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -282,6 +282,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/case-studies/end-point/", ["Case study: End Point"])
         self._test("/case-studies/atolio/", ["Case study: Atolio"])
         self._test("/case-studies/asciidoctor/", ["Case study: Asciidoctor"])
+        self._test("/case-studies/rush-stack/", ["Case study: Rush Stack"])
 
     def test_oddball_attributions_page(self) -> None:
         # Look elsewhere in the code--this page never allows robots nor does


### PR DESCRIPTION
<details>
<summary>
Selected screenshots
</summary>
![Screenshot 2024-12-16 at 11 46 17](https://github.com/user-attachments/assets/b57e47e8-d420-46b8-b685-c1eb3d171a4e)
![Screenshot 2024-12-16 at 11 54 59](https://github.com/user-attachments/assets/3688a994-1651-4559-868b-9d7c91d68885)
![Screenshot 2024-12-16 at 11 51 53](https://github.com/user-attachments/assets/c519e4ca-9826-49ab-96aa-e78c7dc315a0)
![Screenshot 2024-12-16 at 11 50 00](https://github.com/user-attachments/assets/8b33d945-3c80-4eff-a8f5-c9f2893f6334)
</details>

Notes:
- The /for/communities and /for/open-source hero areas don't look perfect on narrow screens, but I think using the two `&nbsp;` is better than not doing so. 