### PR TITLE
Remove auto highlight of stream row when filtering.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1002,7 +1002,13 @@ export function process_hotkey(e, hotkey) {
             );
             return true;
         case "query_streams":
-            stream_list.initiate_search();
+            if (pm_list.is_zoomed_in()) {
+                pm_list.focus_pm_search_filter();
+            } else if (stream_list.is_zoomed_in()) {
+                topic_list.focus_topic_search_filter();
+            } else {
+                stream_list.initiate_search();
+            }
             return true;
         case "query_users":
             activity_ui.initiate_search();

--- a/web/src/pm_list.ts
+++ b/web/src/pm_list.ts
@@ -7,8 +7,10 @@ import {localstorage} from "./localstorage.ts";
 import * as pm_list_data from "./pm_list_data.ts";
 import * as pm_list_dom from "./pm_list_dom.ts";
 import type {PMNode} from "./pm_list_dom.ts";
+import * as popovers from "./popovers.ts";
 import * as resize from "./resize.ts";
 import * as scroll_util from "./scroll_util.ts";
+import * as sidebar_ui from "./sidebar_ui.ts";
 import * as ui_util from "./ui_util.ts";
 import type {FullUnreadCountsData} from "./unread.ts";
 import * as vdom from "./vdom.ts";
@@ -29,6 +31,13 @@ let zoomed = false;
 
 export function is_zoomed_in(): boolean {
     return zoomed;
+}
+
+export function focus_pm_search_filter(): void {
+    popovers.hide_all();
+    sidebar_ui.show_left_sidebar();
+    const $filter = $(".direct-messages-list-filter").expectOne();
+    $filter.trigger("focus");
 }
 
 function get_private_messages_section_header(): JQuery {

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -14,6 +14,7 @@ import * as message_lists from "./message_lists.ts";
 import * as message_viewport from "./message_viewport.ts";
 import {page_params} from "./page_params.ts";
 import * as popover_menus from "./popover_menus.ts";
+import * as popovers from "./popovers.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as resize from "./resize.ts";
 import * as settings_config from "./settings_config.ts";
@@ -71,6 +72,21 @@ export function show_streamlist_sidebar(): void {
     $(".app-main .column-left").addClass("expanded");
     resize.resize_stream_filters_container();
     left_sidebar_expanded_as_overlay = true;
+}
+
+// We use this to display left sidebar without setting
+// toggle status
+export function show_left_sidebar(): void {
+    if (
+        // Check if left column is a overlay and is not visible.
+        $("#streamlist-toggle").is(":visible") &&
+        !left_sidebar_expanded_as_overlay
+    ) {
+        popovers.hide_all();
+        show_streamlist_sidebar();
+    } else if (!left_sidebar_expanded_as_overlay) {
+        $("body").removeClass("hide-left-sidebar");
+    }
 }
 
 export function hide_streamlist_sidebar(): void {

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -1048,16 +1048,7 @@ export function initiate_search(): void {
 
     const $filter = $(".stream-list-filter").expectOne();
 
-    if (
-        // Check if left column is a overlay and is not visible.
-        $("#streamlist-toggle").is(":visible") &&
-        !sidebar_ui.left_sidebar_expanded_as_overlay
-    ) {
-        popovers.hide_all();
-        sidebar_ui.show_streamlist_sidebar();
-    } else if (!sidebar_ui.left_sidebar_expanded_as_overlay) {
-        $("body").removeClass("hide-left-sidebar");
-    }
+    sidebar_ui.show_left_sidebar();
     $filter.trigger("focus");
 
     stream_cursor.reset();

--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -8,7 +8,9 @@ import render_topic_list_item from "../templates/topic_list_item.hbs";
 
 import * as blueslip from "./blueslip.ts";
 import * as popover_menus from "./popover_menus.ts";
+import * as popovers from "./popovers.ts";
 import * as scroll_util from "./scroll_util.ts";
+import * as sidebar_ui from "./sidebar_ui.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
 import * as stream_topic_history_util from "./stream_topic_history_util.ts";
 import * as topic_list_data from "./topic_list_data.ts";
@@ -42,6 +44,13 @@ export function clear(): void {
     }
 
     active_widgets.clear();
+}
+
+export function focus_topic_search_filter(): void {
+    popovers.hide_all();
+    sidebar_ui.show_left_sidebar();
+    const $filter = $("#filter-topic-input").expectOne();
+    $filter.trigger("focus");
 }
 
 export function close(): void {

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -83,7 +83,9 @@ const reactions = mock_esm("../src/reactions");
 const read_receipts = mock_esm("../src/read_receipts");
 const search = mock_esm("../src/search");
 const settings_data = mock_esm("../src/settings_data");
-const stream_list = mock_esm("../src/stream_list");
+const stream_list = mock_esm("../src/stream_list", {
+    is_zoomed_in: () => false,
+});
 const stream_popover = mock_esm("../src/stream_popover");
 const stream_settings_ui = mock_esm("../src/stream_settings_ui");
 

--- a/web/tests/stream_search.test.cjs
+++ b/web/tests/stream_search.test.cjs
@@ -62,6 +62,7 @@ function clear_search_input() {
 
 run_test("basics", ({override, override_rewire}) => {
     override(popovers, "hide_all", noop);
+    override(sidebar_ui, "show_left_sidebar", noop);
 
     const $input = $(".stream-list-filter");
     const $section = $(".stream_search_section");
@@ -179,8 +180,8 @@ run_test("expanding_sidebar", ({override, override_rewire}) => {
         events.push("popovers.hide_all");
     });
 
-    override(sidebar_ui, "show_streamlist_sidebar", () => {
-        events.push("sidebar_ui.show_streamlist_sidebar");
+    override(sidebar_ui, "show_left_sidebar", () => {
+        events.push("popovers.hide_all", "sidebar_ui.show_streamlist_sidebar");
     });
 
     $("#streamlist-toggle").show();


### PR DESCRIPTION
Earlier, whenever pm_list or stream_list was zoomed in and channels filter was not visible, hitting `q` would trigger `stream_list.initiate_search` and `stream-row` would append highlight class in the background. Zooming out would then get in a state where stream filter is open without focus and `stream-row` is highlighted.

<!-- Describe your pull request here.-->

Steps to repro bug:

> 1. Expand the "Direct messages" section by hitting the "more conversations" link.
> 2. Click in the message feed to unfocus the "Filter direct messages" box.
> 3. Hit q. (Originally I'd done this in an attempt to focus the "Filter direct messages" box again. But in fact it has no visible effect.)
> 4. Hit the "back to channels" link to return to the full left sidebar.

Fixes: [czo](https://chat.zulip.org/#narrow/channel/9-issues/topic/left-sidebar.20filters.20in.20inconsistent.20state/near/1918586)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**
![Screenshot from 2025-01-08 00-01-16](https://github.com/user-attachments/assets/2c644346-9f15-40cd-b2fb-fe4276ac6885)

**After:**

[Screencast from 01-02-25 02:07:07 AM IST.webm](https://github.com/user-attachments/assets/aeb9b32e-e427-483c-9c89-bf8b0b4a4b6e)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
