### PR TITLE
portico: Replace "Find accounts" button with "Log in" button.

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -176,7 +176,7 @@
             {% endif %}
             {% if find_team_link_disabled %}
             {% else %}
-            <a class='top-menu-item' href="/accounts/find/">Find accounts</a>
+            <a class='top-menu-item' href="/accounts/go/">Log in</a>
             {% endif %}
         </div>
     </div>
@@ -331,7 +331,7 @@
         {% endif %}
         {% if find_team_link_disabled %}
         {% else %}
-        <div class='top-menu-mobile-item'><a href="/accounts/find/">Find accounts</a></div>
+        <div class='top-menu-mobile-item'><a href="/accounts/go/">Log in</a></div>
         {% endif %}
     </div>
 </details>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -48,7 +48,7 @@
             {% endif %}
 
             {% if not is_self_hosting_management_page and not find_team_link_disabled %}
-            <a class= "find-accounts-link" href="{{ root_domain_url }}/accounts/find/">{{ _('Find accounts') }}</a>
+            <a class= "find-accounts-link" href="{{ root_domain_url }}/accounts/go/">{{ _('Log in') }}</a>
             <a href="{{ root_domain_url }}/new/">{{ _('New organization') }}</a>
             {% endif %}
         </div>


### PR DESCRIPTION
This pull request replaces the "Find accounts" button in the top navigation area with a more standard "Log in" button that goes to `/accounts/go/`.

This applies to both the landing page navigation area, and the help center.

Fixes: #32199.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
