### PR TITLE
dev-buttons: Use portico bundle

### DIFF
--- a/web/webpack.dev-assets.json
+++ b/web/webpack.dev-assets.json
@@ -16,10 +16,8 @@
         "./src/channel.ts"
     ],
     "dev-buttons": [
-        "./src/bundles/common.ts",
-        "./src/portico/header.ts",
+        "./src/bundles/portico.ts",
         "./src/portico/design-testing.ts",
-        "./styles/portico/portico_styles.css",
         "./styles/portico/dev-buttons.css",
         "./styles/app_variables.css",
         "./styles/app_components.css",


### PR DESCRIPTION
This includes bootstrap.portico.css and happens to prevent webpack from kicking it out of the chunk with the rest of the portico CSS and misordering it.