### PR TITLE
integrations: Clean up Slack integration.

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -35,8 +35,8 @@ See also the [Zulip Slack incoming webhook integration][1].
    & Permissions** menu, and scroll down to the **Scopes** section.
 
 1. Make sure **Bot Token Scopes** includes `channels:read`,
-   `channels:history`, `users:read`, `emoji:read`, `team:read`,
-   `users:read`, and `users:read.email`.
+   `channels:history`, `emoji:read`, `team:read`, `users:read`, and
+   `users:read.email`.
 
     !!! tip ""
 

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -8,13 +8,11 @@ from django.utils.translation import gettext as _
 from zerver.actions.message_send import send_rate_limited_pm_notification_to_bot_owner
 from zerver.data_import.slack import check_token_access, get_slack_api_data
 from zerver.data_import.slack_message_conversion import (
-    SLACK_BOLD_REGEX,
-    SLACK_ITALIC_REGEX,
-    SLACK_STRIKETHROUGH_REGEX,
     SLACK_USERMENTION_REGEX,
     convert_link_format,
     convert_mailto_format,
-    convert_markdown_syntax,
+    convert_slack_formatting,
+    convert_slack_workspace_mentions,
 )
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import JsonableError, UnsupportedWebhookEventTypeError
@@ -94,22 +92,6 @@ def convert_to_zulip_markdown(text: str, slack_app_token: str) -> str:
     text = convert_slack_formatting(text)
     text = convert_slack_workspace_mentions(text)
     text = convert_slack_user_and_channel_mentions(text, slack_app_token)
-    return text
-
-
-def convert_slack_formatting(text: str) -> str:
-    text = convert_markdown_syntax(text, SLACK_BOLD_REGEX, "**")
-    text = convert_markdown_syntax(text, SLACK_STRIKETHROUGH_REGEX, "~~")
-    text = convert_markdown_syntax(text, SLACK_ITALIC_REGEX, "*")
-    return text
-
-
-def convert_slack_workspace_mentions(text: str) -> str:
-    # Map Slack's <!everyone>, <!channel> and <!here> mentions to @**all**.
-    # No regex for this as it can be present anywhere in the sentence.
-    text = text.replace("<!everyone>", "@**all**")
-    text = text.replace("<!channel>", "@**all**")
-    text = text.replace("<!here>", "@**all**")
     return text
 
 

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -211,6 +211,7 @@ def api_slack_webhook(
     # Handle initial URL verification handshake for Slack Events API.
     if is_challenge_handshake(payload):
         challenge = payload.get("challenge").tame(check_string)
+        check_token_access(slack_app_token)
         check_send_webhook_message(
             request,
             user_profile,
@@ -238,8 +239,6 @@ def api_slack_webhook(
 
     if event_type != "message":
         raise UnsupportedWebhookEventTypeError(event_type)
-
-    check_token_access(slack_app_token)
 
     raw_files = event_dict.get("files")
     files = convert_raw_file_data(raw_files) if raw_files else []


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR:
- Fixes a typo in the Slack webhook doc.
- Make `check_token_access` accept a `required_scopes` parameter.
- Refactors the `check_token_access` in Slack webhook integration to be called only when handling Slack handshake (when first registering webhook endpoint) and have it send DM to the owner if there are any problems.
- Clean up duplicate functions now that we've refactored part of `slack_message_conversion.py`. (only `replace_links` left)

Fixes part of #30827
> Improve token checking to do fewer callbacks: https://github.com/zulip/zulip/pull/30465#discussion_r1880969823.

>  Remove Duplicative Code. To convert Slack text to Zulip markdown, a function in slack_message_conversion.py called convert_to_zulip_markdown is copied and adapted to be used in the Slack integration (under the same function name). We couldn't use it directly because of the difference in data being handled. We could probably break up the real convert_to_zulip_markdown and reuse it at Slack integration to minimize duplicative code.
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
