### PR TITLE
settings: Correct icon alignment in channel settings.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -917,7 +917,7 @@ h4.user_group_setting_subsection_title {
     .group-header,
     .stream-header {
         white-space: nowrap;
-        padding-top: 10px;
+        padding-top: 5px;
         display: flex;
         align-items: center;
 
@@ -927,7 +927,6 @@ h4.user_group_setting_subsection_title {
             font-size: 1.5em;
             font-weight: 600;
             margin-left: -3px;
-            margin-top: -5px;
             white-space: nowrap;
             max-width: 90%;
             flex: auto;
@@ -954,10 +953,8 @@ h4.user_group_setting_subsection_title {
         }
 
         .large-icon {
-            display: inline-block;
-            vertical-align: top;
+            display: flex;
             margin-right: 8px;
-            margin-top: -5px;
 
             &.hash::after {
                 top: -1px;

--- a/web/templates/stream_settings/stream_privacy_icon.hbs
+++ b/web/templates/stream_settings/stream_privacy_icon.hbs
@@ -1,14 +1,14 @@
 {{! This controls whether the swatch next to streams in the stream edit page has a lock icon. }}
 {{#if invite_only}}
-<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}"{{/if}}>
     <i class="zulip-icon zulip-icon-lock" aria-hidden="true"></i>
 </div>
 {{else if is_web_public}}
-<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}"{{/if}}>
     <i class="zulip-icon zulip-icon-globe" aria-hidden="true"></i>
 </div>
 {{else}}
-<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}{{/if}}">
+<div class="large-icon" {{#if title_icon_color}}style="color: {{title_icon_color}}"{{/if}}>
     <i class="zulip-icon zulip-icon-hashtag" aria-hidden="true"></i>
 </div>
 {{/if}}


### PR DESCRIPTION
This also corrects some stray closing quotation marks that were improperly outside of an if-statement in the privacy-icon template.

[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/channel.20privacy.20icon.20misaligned.20.28channel.20settings.29/near/2007667)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![public-before](https://github.com/user-attachments/assets/a39d239b-fe02-402e-8653-8d253949e899) | ![public-after](https://github.com/user-attachments/assets/d1d7d7d0-4093-404b-bbd8-472e4c08b8f2) |
| ![private-before](https://github.com/user-attachments/assets/aef2c378-c6e2-4346-8633-bbcbe7cf8d57) | ![private-after](https://github.com/user-attachments/assets/f32bee93-ae58-4684-9ebb-7b2883edf22c) |
| ![channel-before](https://github.com/user-attachments/assets/e4a4513f-43ed-495a-a2ac-c0c422822320) | ![channel-after](https://github.com/user-attachments/assets/b23088ce-2cc8-4f88-840a-b9d1067bd61c) |
| ![groups-after-no-change](https://github.com/user-attachments/assets/4a9f9282-ba4d-43a3-be40-30d96b076506) | ![groups-before](https://github.com/user-attachments/assets/deaf8b61-7902-44b6-99ed-2fd601695182) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>