### PR TITLE
Improve presentation of auto-follow topics settings page

### DIFF
--- a/help/include/automatically-follow-topics.md
+++ b/help/include/automatically-follow-topics.md
@@ -7,7 +7,7 @@
 {settings_tab|notifications}
 
 1. Under **Topic notifications**, select the desired option from the
-   **Automatically follow topics** dropdown.
+   **Automatically follow topics based on my participation** dropdown.
 
 {end_tabs}
 

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -550,7 +550,7 @@ export const preferences_settings_labels = {
 
 export const notification_settings_labels = {
     automatically_follow_topics_policy: $t({
-        defaultMessage: "Automatically follow topics",
+        defaultMessage: "Automatically follow topics based on my participation",
     }),
     automatically_follow_topics_where_mentioned: $t({
         defaultMessage: "Automatically follow topics where I'm mentioned",

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -80,6 +80,12 @@
             </select>
         </div>
 
+        {{> settings_checkbox
+          setting_name="automatically_follow_topics_where_mentioned"
+          is_checked=(lookup settings_object "automatically_follow_topics_where_mentioned")
+          label=(lookup settings_label "automatically_follow_topics_where_mentioned")
+          prefix=prefix}}
+
         <div class="input-group">
             <label for="{{prefix}}automatically_unmute_topics_in_muted_streams_policy" class="settings-field-label">
                 {{ settings_label.automatically_unmute_topics_in_muted_streams_policy }}
@@ -90,12 +96,6 @@
                 {{> dropdown_options_widget option_values=automatically_unmute_topics_in_muted_streams_policy_values}}
             </select>
         </div>
-
-        {{> settings_checkbox
-          setting_name="automatically_follow_topics_where_mentioned"
-          is_checked=(lookup settings_object "automatically_follow_topics_where_mentioned")
-          label=(lookup settings_label "automatically_follow_topics_where_mentioned")
-          prefix=prefix}}
     </div>
 
     <div class="desktop_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR improves the presentation of auto-follow topics section in Notification Settings.

Fixes: #32761 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
From
<img width="691" alt="Screenshot 2024-12-18 at 10 10 08 PM" src="https://github.com/user-attachments/assets/57ab6bd0-efab-4366-975a-c37b29eec793" />


To
<img width="723" alt="Screenshot 2024-12-18 at 10 04 03 PM" src="https://github.com/user-attachments/assets/e4003155-a9b4-4269-b59a-b489dfab70c9" />

Modify [documetation](https://zulip.com/help/follow-a-topic)
<img width="1078" alt="Screenshot 2024-12-18 at 10 06 01 PM" src="https://github.com/user-attachments/assets/7e1cda53-0674-4525-9b6e-2899241fc87c" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
