### PR TITLE
user_group: Fix broken edit description functionality.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1334,8 +1334,9 @@ export function initialize(): void {
         });
     });
 
-    function save_group_info(this: HTMLElement): void {
-        const group = get_user_group_for_target(this);
+    function save_group_info(e: JQuery.ClickEvent): void {
+        assert(e.currentTarget instanceof HTMLElement);
+        const group = get_user_group_for_target(e.currentTarget);
         assert(group !== undefined);
         const url = `/json/user_groups/${group.id}`;
         let name;


### PR DESCRIPTION
This commit fixes the currently broken feature of being able to change the group info using the edit icon that triggers the dialog_widget to let users edit their group description.

A new function `get_user_group_for_save` is introduced that picks out the save button from the DOM and the corresponding id for the group.

<!-- Describe your pull request here.-->

Fixes: #32767.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Videos containing Before and After</summary>

Before:

https://github.com/user-attachments/assets/5f26c5c7-1d7d-4193-a7f9-e53a5ac4e3dd



After:

https://github.com/user-attachments/assets/65d716e5-1981-4b2f-835c-9d02880104e8


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
