### PR TITLE
onboarding: Add a one-time intro tooltip for the "go to conversation" button.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -10,6 +10,7 @@ import * as compose_notifications from "./compose_notifications.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_tooltips from "./compose_tooltips.ts";
 import * as compose_ui from "./compose_ui.ts";
 import type {ComposeTriggeredOptions} from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
@@ -191,12 +192,15 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     $(document).trigger(new $.Event("compose_started.zulip", opts));
     compose_recipient.update_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
-    // We explicitly call this function here apart from compose_setup.js
-    // as this helps to show banner when responding in an interleaved view.
+    // We explicitly call these functions here apart from compose_setup.js
+    // as this helps to show banner and toolip when responding in an interleaved view.
     // While responding, the compose box opens before fading resulting in
-    // the function call in compose_setup.js not displaying banner.
+    // the function call in compose_setup.js not displaying banner or tooltip.
     if (!narrow_state.narrowed_by_reply()) {
         compose_notifications.maybe_show_one_time_interleaved_view_messages_fading_banner();
+        if (compose_tooltips.can_show_go_to_conversation_button_intro_tooltip()) {
+            compose_tooltips.show_go_to_conversation_button_intro_tooltip();
+        }
     }
 };
 
@@ -455,6 +459,7 @@ export let cancel = (): void => {
     compose_state.set_message_type(undefined);
     compose_pm_pill.clear();
     $(document).trigger("compose_canceled.zulip");
+    compose_tooltips.hide_go_to_conversation_button_intro_tooltip();
 };
 
 export function rewire_cancel(value: typeof cancel): void {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -259,3 +259,19 @@ export function show_stream_not_subscribed_error(sub: StreamSubscription): void 
 export function has_error(): boolean {
     return $("#compose_banners .error:visible").length > 0;
 }
+
+export function is_any_banner_visible(): boolean {
+    const $compose_banner_container = $("#compose_banners");
+
+    if ($compose_banner_container.length === 0) {
+        return false;
+    }
+
+    for (const class_name of Object.keys(CLASSNAMES)) {
+        if ($(`#compose_banners .${CSS.escape(class_name)}`).length > 0) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -12,6 +12,7 @@ import * as compose_notifications from "./compose_notifications.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_send_menu_popover from "./compose_send_menu_popover.js";
 import * as compose_state from "./compose_state.ts";
+import * as compose_tooltips from "./compose_tooltips.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
 import * as dialog_widget from "./dialog_widget.ts";
@@ -490,6 +491,16 @@ export function initialize() {
     $("#compose").on("click", ".narrow_to_compose_recipients", (e) => {
         e.preventDefault();
         message_view.to_compose_target();
+        compose_tooltips.hide_go_to_conversation_button_intro_tooltip();
+        if (
+            onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has(
+                "intro_go_to_conversation_button_tooltip",
+            )
+        ) {
+            onboarding_steps.post_onboarding_step_as_read(
+                "intro_go_to_conversation_button_tooltip",
+            );
+        }
     });
 
     $("#compose").on("click", ".collapse-composebox-button", (e) => {
@@ -505,6 +516,9 @@ export function initialize() {
             compose_notifications.maybe_show_one_time_non_interleaved_view_messages_fading_banner();
         } else {
             compose_notifications.maybe_show_one_time_interleaved_view_messages_fading_banner();
+        }
+        if (compose_tooltips.can_show_go_to_conversation_button_intro_tooltip()) {
+            compose_tooltips.show_go_to_conversation_button_intro_tooltip();
         }
     });
 

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -6,17 +6,20 @@ import * as tippy from "tippy.js";
 import render_drafts_tooltip from "../templates/drafts_tooltip.hbs";
 import render_narrow_to_compose_recipients_tooltip from "../templates/narrow_to_compose_recipients_tooltip.hbs";
 
+import * as compose_banner from "./compose_banner.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
 import {pick_empty_narrow_banner} from "./narrow_banner.ts";
 import * as narrow_state from "./narrow_state.ts";
+import * as onboarding_steps from "./onboarding_steps.ts";
 import * as popover_menus from "./popover_menus.ts";
 import {realm} from "./state_data.ts";
 import {EXTRA_LONG_HOVER_DELAY, INSTANT_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs.ts";
 import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
+import {the} from "./util.ts";
 
 export function initialize(): void {
     tippy.delegate("body", {
@@ -288,4 +291,71 @@ export function hide_compose_control_button_tooltips($row: JQuery): void {
     ).each(function (this: tippy.ReferenceElement) {
         this._tippy?.hide();
     });
+}
+
+export function show_go_to_conversation_button_intro_tooltip(): void {
+    const $go_to_conversation_button = $(".conversation-arrow");
+    const element: tippy.ReferenceElement = the($go_to_conversation_button);
+
+    const tippy_instance =
+        element._tippy ??
+        tippy.default(element, {
+            hideOnClick: false,
+            trigger: "manual",
+            appendTo: document.body,
+        });
+    tippy_instance.setContent(
+        parse_html($("#compose_go_to_conversation_button_tootltip_template").html()),
+    );
+
+    tippy_instance.show();
+}
+
+export let can_show_go_to_conversation_button_intro_tooltip = (): boolean => {
+    // The tooltip is shown only if:
+    // The tooltip hasn't been shown before.
+    // The user has confirmed a topic recipient change to a topic that is not the current view.
+    // The "Go to conversation" button is active.
+    // There are no compose banners currently visible.
+    // The user hasn't clicked the button (which dismisses the tooltip).
+
+    // This helps in updating tooltip when switching between topics.
+    hide_go_to_conversation_button_intro_tooltip();
+
+    if (
+        !onboarding_steps.ONE_TIME_NOTICES_TO_DISPLAY.has("intro_go_to_conversation_button_tooltip")
+    ) {
+        return false;
+    }
+
+    const faded_messages_exist = $(".focused-message-list .recipient_row").hasClass("message-fade");
+    if (!faded_messages_exist) {
+        return false;
+    }
+
+    const $go_to_conversation_button = $(".conversation-arrow");
+    if (!$go_to_conversation_button.hasClass("narrow_to_compose_recipients")) {
+        return false;
+    }
+
+    const is_any_compose_banner_visible = compose_banner.is_any_banner_visible();
+    if (is_any_compose_banner_visible) {
+        return false;
+    }
+
+    return true;
+};
+
+export let hide_go_to_conversation_button_intro_tooltip = (): void => {
+    const element: tippy.ReferenceElement = the($(".conversation-arrow"));
+    const instance = element._tippy;
+    if (instance?.state.isVisible) {
+        instance.destroy();
+    }
+};
+
+export function rewire_can_show_go_to_conversation_button_intro_tooltip(
+    value: typeof can_show_go_to_conversation_button_intro_tooltip,
+): void {
+    can_show_go_to_conversation_button_intro_tooltip = value;
 }

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -21,6 +21,10 @@
     {{t 'Reply to selected conversation' }}
     {{tooltip_hotkey_hints "R"}}
 </template>
+<template id="compose_go_to_conversation_button_tootltip_template">
+    <div>{{t "Click here to go to the conversation you're composing to."}}</div>
+    {{tooltip_hotkey_hints "Ctrl" "."}}
+</template>
 <template id="left_bar_compose_mobile_button_tooltip_template">
     {{t 'Start new conversation' }}
 </template>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -37,6 +37,7 @@ const compose_actions = mock_esm("../src/compose_actions", {
 const compose_fade = mock_esm("../src/compose_fade");
 const compose_notifications = mock_esm("../src/compose_notifications");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
+const compose_tooltips = zrequire("compose_tooltips");
 const loading = mock_esm("../src/loading");
 const markdown = mock_esm("../src/markdown");
 const narrow_state = mock_esm("../src/narrow_state");
@@ -666,6 +667,7 @@ test_ui("on_events", ({override, override_rewire}) => {
     initialize_handlers({override});
 
     override(rendered_markdown, "update_elements", noop);
+    override_rewire(compose_tooltips, "can_show_go_to_conversation_button_intro_tooltip", noop);
 
     (function test_attach_files_compose_clicked() {
         const handler = $("#compose").get_on_handler("click", ".compose_upload_file");

--- a/zerver/lib/onboarding_steps.py
+++ b/zerver/lib/onboarding_steps.py
@@ -55,6 +55,9 @@ ONE_TIME_NOTICES: list[OneTimeNotice] = [
     OneTimeNotice(
         name="intro_resolve_topic",
     ),
+    OneTimeNotice(
+        name="intro_go_to_conversation_button_tooltip",
+    ),
 ]
 
 ONE_TIME_ACTIONS = [OneTimeAction(name="narrow_to_dm_with_welcome_bot_new_user")]

--- a/zerver/tests/test_onboarding_steps.py
+++ b/zerver/tests/test_onboarding_steps.py
@@ -25,14 +25,15 @@ class TestGetNextOnboardingSteps(ZulipTestCase):
 
         do_mark_onboarding_step_as_read(self.user, "intro_inbox_view_modal")
         onboarding_steps = get_next_onboarding_steps(self.user)
-        self.assert_length(onboarding_steps, 7)
+        self.assert_length(onboarding_steps, 8)
         self.assertEqual(onboarding_steps[0]["name"], "intro_recent_view_modal")
         self.assertEqual(onboarding_steps[1]["name"], "first_stream_created_banner")
         self.assertEqual(onboarding_steps[2]["name"], "jump_to_conversation_banner")
         self.assertEqual(onboarding_steps[3]["name"], "non_interleaved_view_messages_fading")
         self.assertEqual(onboarding_steps[4]["name"], "interleaved_view_messages_fading")
         self.assertEqual(onboarding_steps[5]["name"], "intro_resolve_topic")
-        self.assertEqual(onboarding_steps[6]["name"], "narrow_to_dm_with_welcome_bot_new_user")
+        self.assertEqual(onboarding_steps[6]["name"], "intro_go_to_conversation_button_tooltip")
+        self.assertEqual(onboarding_steps[7]["name"], "narrow_to_dm_with_welcome_bot_new_user")
 
         with self.settings(TUTORIAL_ENABLED=False):
             onboarding_steps = get_next_onboarding_steps(self.user)


### PR DESCRIPTION
This PR adds a one-time intro tooltip for the "go to conversation" button. It includes the following changes:
 - Add a one-time go-to conversation tooltip as an onboarding step.
 - Implement tests to verify the tooltip.
 
 Fixes #32166.
[CZO thread](https://chat.zulip.org/#narrow/channel/101-design/topic/.22go.20to.20conversation.22.20button.20intro/near/1969306)
 
 The tooltip is displayed highlighting the "go to conversation" button without being hovered.
 Conditions for showing the tooltip as mentioned in the issue #32166:

- The "Go to conversation" button is active.
- You just confirmed a topic recipient change to a topic that we believe contains messages and is not the current view.
- You have no compose banners showing.
- You haven't clicked the button (which is the mechanism that would dismiss it).
- You haven't been shown the same tooltip before.


<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
