### PR TITLE
email: Update realm deactivation email for data deletion information.

### DIFF
--- a/templates/zerver/emails/realm_deactivated.html
+++ b/templates/zerver/emails/realm_deactivated.html
@@ -1,5 +1,8 @@
 {% extends "zerver/emails/email_base_default.html" %}
 {% set localized_date = event_date|localize %}
+{% if scheduled_deletion_date %}
+{% set deletion_date = scheduled_deletion_date|localize %}
+{% endif %}
 
 {% block illustration %}
 <img src="{{ email_images_base_url }}/email_logo.png" alt=""/>
@@ -13,6 +16,11 @@
         {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated by {{ deactivating_owner }} on {{ localized_date }}.{% endtrans %}
     {% else %}
         {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated on {{ localized_date }}.{% endtrans %}
+    {% endif %}
+    {% if data_already_deleted %}
+        {% trans %}All data associated with this organization has been permanently deleted.{% endtrans %}
+    {% elif scheduled_deletion_date %}
+        {% trans %}All data associated with this organization will be permanently deleted on {{ deletion_date }}.{% endtrans %}
     {% endif %}
 </p>
 <p>

--- a/templates/zerver/emails/realm_deactivated.txt
+++ b/templates/zerver/emails/realm_deactivated.txt
@@ -1,10 +1,19 @@
 {% set localized_date = event_date|localize %}
-{% if acting_user and initiated_deactivation %}
-    {% trans %}You have deactivated your Zulip organization, {{ realm_name }}, on {{ localized_date }}.{% endtrans %}
-{% elif acting_user %}
-    {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated by {{ deactivating_owner }} on {{ localized_date }}.{% endtrans %}
-{% else %}
-    {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated on {{ localized_date }}.{% endtrans %}
+{% if scheduled_deletion_date %}
+{% set deletion_date = scheduled_deletion_date|localize %}
 {% endif %}
+{% if acting_user and initiated_deactivation %}
+    {% trans %}You have deactivated your Zulip organization, {{ realm_name }}, on {{ localized_date }}. {% endtrans %}
+{% elif acting_user %}
+    {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated by {{ deactivating_owner }} on {{ localized_date }}. {% endtrans %}
+{% else %}
+    {% trans %}Your Zulip organization, {{ realm_name }}, was deactivated on {{ localized_date }}. {% endtrans %}
+{% endif %}
+{% if data_already_deleted %}
+    {% trans %}All data associated with this organization has been permanently deleted.{% endtrans %}
+{% elif scheduled_deletion_date %}
+    {% trans %}All data associated with this organization will be permanently deleted on {{ deletion_date }}.{% endtrans %}
+{% endif %}
+
 
 {% trans%}If you have any questions or concerns, please reply to this email as soon as possible.{% endtrans %}


### PR DESCRIPTION
Fixes #24686.

**Notes**:
- If there is a scheduled data deletion in the future, then the date is localized for the owner's language.
- In the case where no data deletion was scheduled when the realm was deactivated (e.g., via the support view or management command), then there is no change to the email content.

---

**Screenshots and screen captures:**

<details>
<summary>No data deletion done or scheduled when organization was deactivated</summary>

**No change from current email that's sent to organization owners.**
![Screenshot from 2024-12-19 14-08-11](https://github.com/user-attachments/assets/5bcb283d-48d6-4a97-ac55-d6d80ef36d6b)
![Screenshot from 2024-12-19 14-07-59](https://github.com/user-attachments/assets/d24734fa-94e5-4b36-91f5-9d31333e937a)
</details>
<details>
<summary>Data was immediately deleted when organization was deactivated</summary>

![Screenshot from 2024-12-19 14-07-18](https://github.com/user-attachments/assets/77f32682-3b21-4c9c-ab9e-ab2d6126c404)
![Screenshot from 2024-12-19 14-07-08](https://github.com/user-attachments/assets/9f1387de-fdb2-4d56-86e5-6f99da88d557)
</details>
<details>
<summary>Data is scheduled to be deleted in the future when organization was deactivated</summary>

**3 owners - Russian, Italian and English set for their default languages**

![Screenshot from 2024-12-19 14-05-03](https://github.com/user-attachments/assets/f11e1512-6209-4e91-b753-56153abb64ca)
![Screenshot from 2024-12-19 14-04-15](https://github.com/user-attachments/assets/116d3434-ac3d-4642-a96a-5f4469138643)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
