### PR TITLE
modals: Help heading, timestamp follow-ups.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -366,6 +366,11 @@
     justify-content: center;
 }
 
+.time-input-formatted-description {
+    font-style: italic;
+    opacity: 0.7;
+}
+
 #copy_email_address_modal {
     width: 800px;
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -30,10 +30,14 @@
 }
 
 .modal__header {
-    padding: 16px 24px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    padding: 16px 16px 16px 24px;
+    display: grid;
+    /* 25px at 16px/1em = 1.6667
+       29px at 16px/1em = 1.8125 */
+    grid-template:
+        "heading close-button" 1.6667em "heading ." auto / minmax(0, 1fr)
+        1.8125em;
+    grid-column-gap: 4px;
 }
 
 .modal__footer {
@@ -100,7 +104,6 @@
     &::before {
         content: "\2715";
     }
-    margin-right: -4px;
     background: transparent;
     border: 0;
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -974,6 +974,8 @@ ul.popover-group-menu-member-list {
 
     #move_messages_count {
         margin-top: -20px;
+        font-style: italic;
+        opacity: 0.7;
     }
 
     .topic_stream_edit_header {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -918,8 +918,8 @@ ul.popover-group-menu-member-list {
     }
 
     .modal__title {
-        white-space: nowrap;
-        text-overflow: ellipsis;
+        /* Grid defined in modal.css */
+        grid-area: heading;
 
         .stream-privacy-type-icon {
             padding-left: 3px;


### PR DESCRIPTION
This PR is a follow-up to #32760, and includes commits that were destined for that PR, but were left out owing to end-of-day sloppiness.

Specifically, this PR:

1. Introduces a grid-based heading layout in the Move/Rename modals that allows for multiline headings.
2. Introduces an italic, lowered-opacity styling on the indicator for how many messages are to be moved in the Move/Rename modals, and parallel lines on invitation and realm-deactivation modals.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/move.20topic.20.2F.20message.20menu.20design/near/2009259)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![move-modal-before](https://github.com/user-attachments/assets/3f296e21-4fc1-4091-a9fb-151d1e5ff262) | ![move-modal-after](https://github.com/user-attachments/assets/3e2f1ba5-a1d8-4846-beec-c269ac3ff2bb) |
| ![invite-modal-before](https://github.com/user-attachments/assets/7462e1fd-77d6-4d72-8056-ebb02718720e) | ![invite-modal-after](https://github.com/user-attachments/assets/90048db8-2451-4b7e-b426-19a11efc4a71) |
| ![deactivate-modal-before](https://github.com/user-attachments/assets/19484caf-4079-4f9b-92dd-a16958227917) | ![deactivate-modal-after](https://github.com/user-attachments/assets/a81d0a93-6d69-4209-8fc5-02ebf312d518) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
