### PR TITLE
Assign bot role depending on owner's role

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -214,6 +214,13 @@ def create_user(
         force_date_joined=force_date_joined,
         email_address_visibility=user_email_address_visibility,
     )
+
+    if bot_type is not None and bot_owner is not None:
+        if bot_owner.role == UserProfile.ROLE_REALM_ADMINISTRATOR:
+           user_profile.role = UserProfile.ROLE_REALM_ADMINISTRATOR
+        elif bot_owner.role == UserProfile.ROLE_MEMBER:
+           user_profile.role = UserProfile.ROLE_MEMBER 
+    
     user_profile.avatar_source = avatar_source
     user_profile.timezone = timezone
     user_profile.default_sending_stream = default_sending_stream

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -217,10 +217,10 @@ def create_user(
 
     if bot_type is not None and bot_owner is not None:
         if bot_owner.role == UserProfile.ROLE_REALM_ADMINISTRATOR:
-           user_profile.role = UserProfile.ROLE_REALM_ADMINISTRATOR
+            user_profile.role = UserProfile.ROLE_REALM_ADMINISTRATOR
         elif bot_owner.role == UserProfile.ROLE_MEMBER:
-           user_profile.role = UserProfile.ROLE_MEMBER 
-    
+            user_profile.role = UserProfile.ROLE_MEMBER
+
     user_profile.avatar_source = avatar_source
     user_profile.timezone = timezone
     user_profile.default_sending_stream = default_sending_stream


### PR DESCRIPTION
Fixes: This PR fixes part of issue #32468 

This draft PR assigns the bot role to the bot creator’s role during bot creation. If the creator is an ADMINISTRATOR, the bot role is set to ADMINISTRATOR; if the creator is a MEMBER, the bot role is set to MEMBER.

I’ve written test cases that:
1. Create a bot as an admin.
2. Create a bot as a member.
Both test cases pass, confirming that the bot receives the desired role based on the creator's role.

I’m unsure how to assign a new member role to the bot creator, as the UserProfile class only supports roles like moderator, member, admin, and owner.

This PR is a draft to get early feedback on whether I’m heading in the right direction with my changes. If confirmed, I will proceed with making changes to the cron job that promotes full members, ensuring that the newly created full member’s bot role is updated to match the current role of their owner.

I am new to Zulip and still learning the project and its guidelines. Any suggestions or guidance on improving my approach would be greatly appreciated!

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
