### PR TITLE
api_docs: add missing parameter for botserver

### DIFF
--- a/api_docs/deploying-bots.md
+++ b/api_docs/deploying-bots.md
@@ -143,7 +143,7 @@ Botserver process.  You can do this with the following procedure.
     site=http://hostname
     token=aQVQmSd6j6IHphJ9m1jhgHdbnhl5ZcsY
     ```
-    
+
     If the bot needs a configuration file to run, it can be specified using
     `bot-config-file=`.
     ```

--- a/api_docs/deploying-bots.md
+++ b/api_docs/deploying-bots.md
@@ -143,6 +143,17 @@ Botserver process.  You can do this with the following procedure.
     site=http://hostname
     token=aQVQmSd6j6IHphJ9m1jhgHdbnhl5ZcsY
     ```
+    
+    If the bot needs a configuration file to run, it can be specified using
+    `bot-config-file=`.
+    ```
+    [helloworld]
+    email=foo-bot@hostname
+    key=dOHHlyqgpt5g0tVuVl6NHxDLlc9eFRX4
+    site=http://hostname
+    token=aQVQmSd6j6IHphJ9m1jhgHdbnhl5ZcsY
+    bot-config-file=~/path/to/helloworld.conf
+    ```
 
     To run an external bot, enter the path to the bot's python file in the square
     brackets `[]`. For example, if we want to run `~/Documents/my_new_bot.py`, our


### PR DESCRIPTION
Updated documentation for deploying bots in junction with https://github.com/zulip/python-zulip-api/pull/832.

There was a parameter missing in the description of deploying bots with the botserver.

[Current documentation](https://chat.zulip.org/api/deploying-bots)

Image After:
![image-after](https://github.com/user-attachments/assets/5716a9a9-5b81-4d62-912e-c2240171451d)

