### PR TITLE
docs: Update `sending-messages.md` and `markdown.md` for variable/function updates.

### DIFF
--- a/docs/subsystems/markdown.md
+++ b/docs/subsystems/markdown.md
@@ -17,7 +17,7 @@ authoritatively render messages to HTML (and implements
 slow/expensive/complex features like querying the Twitter API to
 render tweets nicely). The frontend implementation is in JavaScript,
 based on [marked.js](https://github.com/chjj/marked)
-(`web/src/echo.js`), and is used to preview and locally echo
+(`web/src/echo.ts`), and is used to preview and locally echo
 messages the moment the sender hits Enter, without waiting for round
 trip from the server. Those frontend renderings are only shown to the
 sender of a message, and they are (ideally) identical to the backend

--- a/docs/subsystems/sending-messages.md
+++ b/docs/subsystems/sending-messages.md
@@ -131,7 +131,7 @@ messages.
   causes Zulip to insert the message into the relevant feed(s).
 - Since the message hasn't been confirmed by the server yet, it
   doesn't have a message ID. The frontend makes one up, via
-  `local_message.next_local_id`, by taking the highest message ID it
+  `local_message.get_next_id_float`, by taking the highest message ID it
   has seen and adding the decimal `0.01`. The use of a floating point
   value is critical, because it means the message should sort
   correctly with other messages (at the bottom) and also won't be
@@ -162,13 +162,13 @@ messages.
   properties (at the very least, message ID and timestamp) and
   rerenders it in any message lists where it appears. This is
   primarily done in the `process_from_server` function in
-  `web/src/echo.js`.
+  `web/src/echo.ts`.
 
 ### Local echo in message editing
 
 Zulip also supports local echo in the message editing code path for
 edits to just the content of a message. The approach is analogous
-(using `markdown.contains_backend_only_syntax`, etc.)), except we
+(using `markdown.contains_backend_only_syntax`, etc.), except we
 don't need any of the `local_id` tracking logic, because the message
 already has a permanent message id; as a result, the whole
 implementation was under 150 lines of code.
@@ -183,7 +183,7 @@ one place:
   echoes the message and then sends a request to the `POST /messages`
   API endpoint.
 - The Django URL routes and middleware run, and eventually call the
-  `send_message_backend` view function in `zerver/views/messages.py`.
+  `send_message_backend` view function in `zerver/views/message_send.py`.
   (Alternatively, for an API request to send a message via Zulip's
   REST API, things start here).
 - `send_message_backend` does some validation before triggering the


### PR DESCRIPTION
This PR updates the "Sending messages" and "Markdown implementation" documentation in the `sending-messages.md` and `markdown.md` files respectively to reflect the variable and function updates, ensuring consistency with changes in the codebase over time.

[CZO Thread](https://chat.zulip.org/#narrow/channel/19-documentation/topic/Sending.20Messages.20documentation)
[Sending messages documentation](https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html)
[Markdown implementation documentation](https://zulip.readthedocs.io/en/latest/subsystems/markdown.html)

The changes are as follows:

- Changes in `sending-messages.md`:

  - Rename `local_message.next_local_id` to `local_message.get_next_id_float` - see commit [`2ddd3d0`](https://github.com/zulip/zulip/commit/2ddd3d046a203cffa41953342eb6df22d31072ca) for details.

    <details>
    <summary>Screenshots</summary>

    **Before:**
    ![image](https://github.com/user-attachments/assets/f2e0c965-c7a4-4fce-b5aa-9e1b9f5f3fa8)

    **After:**
    ![img](https://github.com/user-attachments/assets/82681ea1-2098-4d0d-b85a-c510d6098c3b)

    </details>

  - Rename `echo.js` to `echo.ts` - see commit [`d8dd682`](https://github.com/zulip/zulip/commit/d8dd682944838c71468e8498889e840d6b384515) for details.

    <details>
    <summary>Screenshots</summary>

    **Before:**
    ![img](https://github.com/user-attachments/assets/0c149e39-4139-409a-9c85-a1dbeb659d62)

    **After:**
    ![img](https://github.com/user-attachments/assets/09d57501-82d8-402f-aef7-9a0560c30b48)

    </details>

  - Fixed a typo (double closing parentheses `))` were used).

    <details>
    <summary>Screenshots</summary>

    **Before:**
    ![image](https://github.com/user-attachments/assets/37bc3155-3d09-42a4-9ccd-ca88cadad4cb)

    **After:**
    ![image](https://github.com/user-attachments/assets/7133fdbb-7c3b-4d06-82c0-9e3b37198e3b)

    </details>

  - Changed the path of `send_message_backend` view function from `zerver/views/messages.py` to `zerver/views/message_send.py` - see commit [`3657717`](https://github.com/zulip/zulip/commit/3657717adee2bb056d4e587ffff7e9b62cc1980c) for details.

    <details>
    <summary>Screenshots</summary>

    **Before:**
    ![image](https://github.com/user-attachments/assets/02812f5a-4895-4acd-8521-b3d30f748d76)

    **After:**
    ![image](https://github.com/user-attachments/assets/a54def5a-0b78-401c-b893-b84dd2694f4d)

    </details>

- Changes in `markdown.md`:

  - Rename `echo.js` to `echo.ts` - see commit [`d8dd682`](https://github.com/zulip/zulip/commit/d8dd682944838c71468e8498889e840d6b384515) for details.

    <details>
    <summary>Screenshots</summary>

    **Before:**
    ![image](https://github.com/user-attachments/assets/95fe1a77-89c2-408b-b896-a2c51877d9b5)

    **After:**
    ![image](https://github.com/user-attachments/assets/b7f5e073-a3b8-4d78-bde6-6b8d11293fab)

    </details>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
