### PR TITLE
Improve experience for when `old_unreads_missing` and navigating to first unread.

### DIFF
--- a/web/src/banners.ts
+++ b/web/src/banners.ts
@@ -28,17 +28,23 @@ export type AlertBanner = Banner & {
 export function open(banner: Banner | AlertBanner, $banner_container: JQuery): void {
     const banner_html = render_banner(banner);
     $banner_container.html(banner_html);
+    // TODO: Only do a resize for navbar_alerts banners, and try to
+    // avoid doing that at all. Resizes have major side effects.
     $(window).trigger("resize");
 }
 
 export function append(banner: Banner | AlertBanner, $banner_container: JQuery): void {
     const $banner_html = render_banner(banner);
     $banner_container.append($banner_html);
+    // TODO: Only do a resize for navbar_alerts banners, and try to
+    // avoid doing that at all. Resizes have major side effects.
     $(window).trigger("resize");
 }
 
 export function close($banner: JQuery): void {
     $banner.remove();
+    // TODO: Only do a resize for navbar_alerts banners, and try to
+    // avoid doing that at all. Resizes have major side effects.
     $(window).trigger("resize");
 }
 
@@ -46,7 +52,8 @@ export function fade_out_popup_banner($banner: JQuery): void {
     $banner.addClass("fade-out");
     // The delay is the same as the animation duration for fade-out.
     setTimeout(() => {
-        close($banner);
+        // We don't use close, because it triggers a resize, which is disruptive.
+        $banner.remove();
     }, 300);
 }
 

--- a/web/src/banners.ts
+++ b/web/src/banners.ts
@@ -42,6 +42,14 @@ export function close($banner: JQuery): void {
     $(window).trigger("resize");
 }
 
+export function fade_out_popup_banner($banner: JQuery): void {
+    $banner.addClass("fade-out");
+    // The delay is the same as the animation duration for fade-out.
+    setTimeout(() => {
+        close($banner);
+    }, 300);
+}
+
 export function initialize(): void {
     $("body").on("click", ".banner .banner-close-action", function (this: HTMLElement, e) {
         e.preventDefault();

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -29,7 +29,7 @@ import * as stream_data from "./stream_data.ts";
 import * as stream_list from "./stream_list.ts";
 import * as util from "./util.ts";
 
-const response_schema = z.object({
+export const response_schema = z.object({
     anchor: z.number(),
     found_newest: z.boolean(),
     found_oldest: z.boolean(),
@@ -341,7 +341,9 @@ export function get_narrow_for_message_fetch(filter: Filter): string {
     return narrow_param_string;
 }
 
-function get_parameters_for_message_fetch_api(opts: MessageFetchOptions): MessageFetchAPIParams {
+export function get_parameters_for_message_fetch_api(
+    opts: MessageFetchOptions,
+): MessageFetchAPIParams {
     if (typeof opts.anchor === "number") {
         // Messages that have been locally echoed messages have
         // floating point temporary IDs, which is intended to be a.

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -47,6 +47,7 @@ import * as narrow_title from "./narrow_title.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
+import * as popup_banners from "./popup_banners.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
 import * as recent_view_util from "./recent_view_util.ts";
 import * as resize from "./resize.ts";
@@ -78,6 +79,7 @@ const fetch_message_response_schema = z.object({
 export function reset_ui_state(opts: {trigger?: string}): void {
     // Resets the state of various visual UI elements that are
     // a function of the current narrow.
+    popup_banners.close_found_missing_unreads_banner();
     narrow_banner.hide_empty_narrow_message();
     message_feed_top_notices.hide_top_of_narrow_notices();
     message_feed_loading.hide_indicators();
@@ -134,6 +136,7 @@ type TargetMessageIdInfo = {
     target_id: number | undefined;
     final_select_id: number | undefined;
     local_select_id: number | undefined;
+    first_unread_msg_id_pending_server_verification: number | undefined;
 };
 
 function create_and_update_message_list(
@@ -363,6 +366,7 @@ export function get_id_info(): TargetMessageIdInfo {
         target_id: undefined,
         final_select_id: undefined,
         local_select_id: undefined,
+        first_unread_msg_id_pending_server_verification: undefined,
     };
 }
 
@@ -776,6 +780,69 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
             select_opts,
             then_select_offset,
         );
+        if (id_info.first_unread_msg_id_pending_server_verification) {
+            const params = message_fetch.get_parameters_for_message_fetch_api({
+                anchor: "first_unread",
+                num_before: 0,
+                num_after: 0,
+                cont() {
+                    // Success callback is sufficient to do what we need to do
+                    // here, we don't need another post fetch callback.
+                },
+                msg_list_data: msg_list.data,
+            });
+            void channel.get({
+                url: "/json/messages",
+                data: params,
+                success(raw_data) {
+                    // If we switched narrow, there is nothing to do.
+                    if (
+                        msg_list.id !== message_lists.current?.id ||
+                        !id_info.first_unread_msg_id_pending_server_verification
+                    ) {
+                        return;
+                    }
+                    const data = message_fetch.response_schema.parse(raw_data);
+                    const first_unread_message_id = data.anchor;
+                    const current_selected_id = msg_list.selected_id();
+                    if (
+                        first_unread_message_id <
+                        id_info.first_unread_msg_id_pending_server_verification
+                    ) {
+                        // We convert the current narrow into a `near` narrow so that
+                        // user doesn't accidentally mark msgs read which they haven't seen.
+                        const terms = [
+                            ...msg_list.data.filter.terms(),
+                            {
+                                operator: "near",
+                                operand: current_selected_id.toString(),
+                            },
+                        ];
+                        const opts = {
+                            trigger: "old_unreads_missing",
+                        };
+                        show(terms, opts);
+
+                        const on_jump_to_first_unread = (): void => {
+                            // This is a no-op if the user has already switched narrow.
+                            if (msg_list.id !== message_lists.current?.id) {
+                                return;
+                            }
+
+                            show(
+                                message_lists.current.data.filter
+                                    .terms()
+                                    .filter((term) => term.operator !== "near"),
+                                {then_select_id: first_unread_message_id},
+                            );
+                        };
+                        // Show user a banner with a button to allow user to navigate
+                        // to the first unread if required.
+                        popup_banners.open_found_missing_unreads_banner(on_jump_to_first_unread);
+                    }
+                },
+            });
+        }
 
         const post_span_context = {
             name: "post-narrow busy time",
@@ -1005,6 +1072,13 @@ export function maybe_add_local_messages(opts: {
         // need to look at unread here.
         id_info.final_select_id = min_defined(id_info.target_id, unread_info.msg_id);
         assert(id_info.final_select_id !== undefined);
+
+        // We found a message id to select from the unread data available
+        // locally but if we didn't have the complete unread data locally
+        // cached, we need to check from server if it is the first unread.
+        if (unread.old_unreads_missing) {
+            id_info.first_unread_msg_id_pending_server_verification = unread_info.msg_id;
+        }
 
         if (!load_local_messages(msg_data, superset_data)) {
             // We don't have the message we want to select locally,

--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -21,6 +21,46 @@ const CONNECTION_ERROR_POPUP_BANNER: Banner = {
     custom_classes: "connection-error-banner popup-banner",
 };
 
+// Show user a banner with a button to allow user to navigate
+// to the first unread if required.
+const FOUND_MISSING_UNREADS_IN_CURRENT_NARROW: Banner = {
+    intent: "warning",
+    label: $t({
+        defaultMessage: "This conversation also has older unread messages.",
+    }),
+    buttons: [
+        {
+            attention: "quiet",
+            label: $t({defaultMessage: "Jump to first unread"}),
+            custom_classes: "found-missing-unreads-jump-to-first-unread",
+        },
+    ],
+    close_button: true,
+    custom_classes: "found-missing-unreads popup-banner",
+};
+
+export function open_found_missing_unreads_banner(on_jump_to_first_unread: () => void): void {
+    banners.append(FOUND_MISSING_UNREADS_IN_CURRENT_NARROW, $("#popup_banners_wrapper"));
+
+    $("#popup_banners_wrapper").on(
+        "click",
+        ".found-missing-unreads-jump-to-first-unread",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const $banner = $(this).closest(".banner");
+            banners.fade_out_popup_banner($banner);
+            on_jump_to_first_unread();
+        },
+    );
+}
+
+export function close_found_missing_unreads_banner(): void {
+    const $banner = $("#popup_banners_wrapper").find(".found-missing-unreads");
+    banners.fade_out_popup_banner($banner);
+}
+
 export function open_connection_error_popup_banner(opts: {
     on_retry_callback: () => void;
     is_get_events_error?: boolean;
@@ -64,11 +104,7 @@ export function close_connection_error_popup_banner(check_if_get_events_error = 
     if (check_if_get_events_error && $banner.hasClass("get-events-error")) {
         return;
     }
-    $banner.addClass("fade-out");
-    // The delay is the same as the animation duration for fade-out.
-    setTimeout(() => {
-        banners.close($banner);
-    }, 300);
+    banners.fade_out_popup_banner($banner);
 }
 
 export function initialize(): void {


### PR DESCRIPTION
![Screenshot from 2024-12-21 11-32-01](https://github.com/user-attachments/assets/d1f638ad-3290-41b5-b80e-e627374f1fd6)

I think this should mostly work but might still require some tweaks after some broader testing.

Tested by setting `MAX_UNREAD_MESSAGES` to `10` and reducing `message_fetch.consts` to single digits. 