### PR TITLE
combined_feed_ui: Add placeholder text to empty combined feed.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -124,12 +124,28 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
                   },
               ),
     };
+    const combined_feed_banner = {
+        title: $t({defaultMessage: "There are no messages in your combined feed."}),
+        // Spectators cannot start a conversation.
+        html: page_params.is_spectator
+            ? ""
+            : $t_html(
+                  {
+                      defaultMessage:
+                          "Would you like to <z-link>view messages in all public channels</z-link>?",
+                  },
+                  {
+                      "z-link": (content_html) =>
+                          `<a href="#narrow/streams/public">${content_html.join("")}</a>`,
+                  },
+              ),
+    };
     const default_banner_for_multiple_filters = $t({defaultMessage: "No search results."});
 
     const current_filter = narrow_state.filter();
 
     if (current_filter === undefined || current_filter.is_in_home()) {
-        return default_banner;
+        return combined_feed_banner;
     }
 
     const first_term = current_filter.terms()[0]!;

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -243,8 +243,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: There are no messages here.",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
+            "translated: There are no messages in your combined feed.",
+            'translated HTML: Would you like to <a href="#narrow/streams/public">view messages in all public channels</a>?',
         ),
     );
 


### PR DESCRIPTION
This pull request introduces a new banner message for empty combined feeds.

* Added a new `combined_feed_banner` with a title and an HTML message for spectators and non-spectators. Updated the function to return this new banner when the current filter is undefined or in the home view.

Fixes: #31602.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
