### PR TITLE
unresolved: Add support for searching for unresolved topics.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1422,7 +1422,7 @@ export class Filter {
                 case "is-dm":
                     return $t({defaultMessage: "Direct message feed"});
                 case "is-resolved":
-                    return $t({defaultMessage: "Topics marked as resolved"});
+                    return $t({defaultMessage: "Resolved topics"});
                 case "is-followed":
                     return $t({defaultMessage: "Followed topics"});
                 // These cases return false for is_common_narrow, and therefore are not

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -750,6 +750,20 @@ export class Filter {
             const operand = term.operand;
             const canonicalized_operator = Filter.canonicalize_operator(term.operator);
             if (canonicalized_operator === "is") {
+                // Some operands have their own negative words, like
+                // unresolved, rather than the default "exclude " prefix.
+                const custom_negated_operand_phrases: Record<string, string> = {
+                    resolved: "unresolved",
+                };
+                const negated_phrase = custom_negated_operand_phrases[operand];
+                if (term.negated && negated_phrase !== undefined) {
+                    return {
+                        type: "is_operator",
+                        verb: "",
+                        operand: negated_phrase,
+                    };
+                }
+
                 const verb = term.negated ? "exclude " : "";
                 return {
                     type: "is_operator",

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -704,7 +704,7 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
         },
         {
             search_string: "is:resolved",
-            description_html: "topics marked as resolved",
+            description_html: "resolved topics",
             is_people: false,
             incompatible_patterns: [
                 {operator: "is", operand: "resolved"},

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -44,7 +44,7 @@
             {{~!-- squash whitespace --~}}
         {{else if (eq this.operand "resolved")}}
             {{~!-- squash whitespace --~}}
-            {{this.verb}}topics marked as resolved
+            {{this.verb}}resolved topics
             {{~!-- squash whitespace --~}}
         {{else if (eq this.operand "followed")}}
             {{~!-- squash whitespace --~}}

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -50,6 +50,10 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}followed topics
             {{~!-- squash whitespace --~}}
+        {{else if (eq this.operand "unresolved")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}unresolved topics
+            {{~!-- squash whitespace --~}}
         {{else}}
             {{~!-- squash whitespace --~}}
             invalid {{this.operand}} operand for is operator

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -134,6 +134,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">-is:resolved</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages in unresolved topics.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">is:followed</td>
                         <td class="definition">
                             {{t 'Narrow to messages in followed topics.'}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1563,11 +1563,16 @@ test("describe", ({mock_template, override}) => {
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "resolved"}];
-    string = "topics marked as resolved";
+    string = "resolved topics";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "followed"}];
     string = "followed topics";
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    // operands with their own negative words, like resolved.
+    narrow = [{operator: "is", operand: "resolved", negated: true}];
+    string = "unresolved topics";
     assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "something_we_do_not_support"}];

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -2251,7 +2251,7 @@ test("navbar_helpers", ({override}) => {
             terms: is_resolved,
             is_common_narrow: true,
             icon: "check",
-            title: "translated: Topics marked as resolved",
+            title: "translated: Resolved topics",
             redirect_url_with_search: "/#narrow/topics/is/resolved",
         },
         {

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -396,7 +396,7 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
-    assert.equal(describe("is:resolved"), "Topics marked as resolved");
+    assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
     assert.equal(describe("sender:myself@zulip.com"), "Sent by me");
     assert.equal(describe("has:link"), "Messages with links");
@@ -496,7 +496,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
     assert.equal(describe("is:unread"), "Unread messages");
-    assert.equal(describe("is:resolved"), "Topics marked as resolved");
+    assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
 
     query = "-i";

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -377,6 +377,7 @@ test("empty_query_suggestions", () => {
         "is:alerted",
         "is:unread",
         "is:resolved",
+        "-is:resolved",
         "sender:myself@zulip.com",
         `channel:${devel_id}`,
         `channel:${office_id}`,
@@ -518,7 +519,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
     assert.equal(describe("-is:unread"), "Exclude unread messages");
-    assert.equal(describe("-is:resolved"), "Exclude topics marked as resolved");
+    assert.equal(describe("-is:resolved"), "Unresolved topics");
     assert.equal(describe("-is:followed"), "Exclude followed topics");
 
     // operand suggestions follow.


### PR DESCRIPTION
This PR adds support for searching unresolved topics.

It achieves this in the following ways:

- Rename "Topics marked as resolved" -> "Resolved topics".
- Adds 'Unresolved Topics' to the typeahead, which inserts `-is:resolved` into the search pill.  
- Updates conditions to display 'Unresolved Topics' instead of 'Exclude topic marked as resolved.'  
- Modifies conditions to correctly show the last searched option as 'Unresolved Topics.'

Fixes: #31725.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary> Unresolved and Resolved in the typeahead: </summary>
<img width="245" alt="Screenshot 2025-01-24 at 2 34 06 AM" src="https://github.com/user-attachments/assets/c26e962d-c957-494a-9634-d3295a904f95" />

<img width="879" alt="Screenshot 2025-01-15 at 8 00 38 PM" src="https://github.com/user-attachments/assets/d9262fce-c07e-4b17-b2c6-6dfe1f93d986" />

</details>
<details>
<summary> Unresolved in the history of last searched option: </summary>
<img width="879" alt="Screenshot 2025-01-15 at 8 00 59 PM" src="https://github.com/user-attachments/assets/0d31b123-0e1d-4017-b613-d375b115e2a4" />

</details>

<details>
<summary> Resolved Topics Heading: </summary>
<img width="881" alt="Screenshot 2025-01-24 at 2 33 34 AM" src="https://github.com/user-attachments/assets/1afd8d85-3f25-4169-9209-8b5d62024a92" />

</details>

<details>
<summary> Unresolved Topics in `?` menu: </summary>
<img width="609" alt="Screenshot 2025-01-24 at 2 37 26 AM" src="https://github.com/user-attachments/assets/feb4063d-706b-47dc-8da2-acc607a429e8" />

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
