### PR TITLE
export: Add banner if admin's private data export setting is disabled.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -765,6 +765,9 @@ export function dispatch_normal_event(event) {
                 if (event.property === "presence_enabled") {
                     activity_ui.redraw_user(current_user.user_id);
                 }
+                if (event.property === "allow_private_data_export") {
+                    settings_exports.refresh_allow_private_data_export_banner();
+                }
                 break;
             }
 

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -3,12 +3,14 @@ import type * as tippy from "tippy.js";
 import {z} from "zod";
 
 import render_confirm_delete_data_export from "../templates/confirm_dialog/confirm_delete_data_export.hbs";
+import render_allow_private_data_export_banner from "../templates/modal_banner/allow_private_data_export_banner.hbs";
 import render_admin_export_consent_list from "../templates/settings/admin_export_consent_list.hbs";
 import render_admin_export_list from "../templates/settings/admin_export_list.hbs";
 import render_start_export_modal from "../templates/start_export_modal.hbs";
 
 import * as channel from "./channel.ts";
 import * as components from "./components.ts";
+import * as compose_banner from "./compose_banner.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
@@ -23,6 +25,7 @@ import * as settings_config from "./settings_config.ts";
 import * as timerender from "./timerender.ts";
 import type {HTMLSelectOneElement} from "./types.ts";
 import * as ui_report from "./ui_report.ts";
+import {user_settings} from "./user_settings.ts";
 
 const export_consent_schema = z.object({
     user_id: z.number(),
@@ -257,6 +260,32 @@ export function populate_export_consents_table(): void {
     filter_by_consent_dropdown_widget.setup();
 }
 
+function maybe_show_allow_private_data_export_banner(): void {
+    if (!user_settings.allow_private_data_export) {
+        const context = {
+            banner_type: compose_banner.WARNING,
+            classname: "allow_private_data_export_warning",
+            hide_close_button: true,
+        };
+        $("#allow_private_data_export_banner_container").html(
+            render_allow_private_data_export_banner(context),
+        );
+    }
+}
+
+export function refresh_allow_private_data_export_banner(): void {
+    if (user_settings.allow_private_data_export) {
+        $(".allow_private_data_export_warning").remove();
+    } else if ($("#allow_private_data_export_banner_container").length > 0) {
+        maybe_show_allow_private_data_export_banner();
+        const $export_type = $<HTMLSelectOneElement>("select:not([multiple])#export_type");
+        const selected_export_type = Number.parseInt($export_type.val()!, 10);
+        if (selected_export_type === settings_config.export_type_values.export_public.value) {
+            $(".allow_private_data_export_warning").hide();
+        }
+    }
+}
+
 function show_start_export_modal(): void {
     const html_body = render_start_export_modal({
         export_type_values: settings_config.export_type_values,
@@ -300,6 +329,9 @@ function show_start_export_modal(): void {
                 {users_consented_for_export_count, total_users_count},
             ),
         );
+
+        maybe_show_allow_private_data_export_banner();
+
         const $export_type = $<HTMLSelectOneElement>("select:not([multiple])#export_type");
         $export_type.on("change", () => {
             const selected_export_type = Number.parseInt($export_type.val()!, 10);
@@ -308,8 +340,10 @@ function show_start_export_modal(): void {
                 settings_config.export_type_values.export_full_with_consent.value
             ) {
                 $("#allow_private_data_export_stats").show();
+                $(".allow_private_data_export_warning").show();
             } else {
                 $("#allow_private_data_export_stats").hide();
+                $(".allow_private_data_export_warning").hide();
             }
         });
     }

--- a/web/templates/modal_banner/allow_private_data_export_banner.hbs
+++ b/web/templates/modal_banner/allow_private_data_export_banner.hbs
@@ -1,0 +1,8 @@
+{{#> modal_banner . }}
+    <p class="banner_message">
+        {{#tr}}
+            Do you want to <z-link>allow your private data to be exported</z-link>?
+            {{#*inline "z-link"}}<a href="#settings/account-and-privacy">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    </p>
+{{/modal_banner}}

--- a/web/templates/start_export_modal.hbs
+++ b/web/templates/start_export_modal.hbs
@@ -1,3 +1,4 @@
+<p id="allow_private_data_export_banner_container"></p>
 <p>
     {{#tr}}
         A public data export is a complete data export for your organization other than

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -1208,6 +1208,12 @@ run_test("user_settings", ({override}) => {
         dispatch(event);
         assert.equal($("#automatically_offer_update_time_zone").prop("checked"), false);
     }
+
+    event = event_fixtures.user_settings__allow_private_data_export;
+    override(user_settings, "allow_private_data_export", false);
+    override(settings_exports, "refresh_allow_private_data_export_banner", noop);
+    dispatch(event);
+    assert_same(user_settings.allow_private_data_export, true);
 });
 
 run_test("update_message (read)", ({override}) => {

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -883,6 +883,13 @@ exports.fixtures = {
         },
     },
 
+    user_settings__allow_private_data_export: {
+        type: "user_settings",
+        op: "update",
+        property: "allow_private_data_export",
+        value: true,
+    },
+
     user_settings__color_scheme_automatic: {
         type: "user_settings",
         op: "update",


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/Add.20export.20consent.20privacy.20setting.20.2331201/near/2000411)

This PR introduces a banner on the "Start Export" modal to notify the admin that their personal setting to export private data is not toggled ON.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<!-- <img width="423" alt="Screenshot 2024-12-24 at 4 48 49 PM" src="https://github.com/user-attachments/assets/0641b62b-b102-49f1-a651-53782a257a77" /> -->

<img width="478" alt="Screenshot 2024-12-26 at 11 18 58 AM" src="https://github.com/user-attachments/assets/430c7a90-2949-4be2-824f-6a5c80d54c2c" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
