### PR TITLE
Open subscribers tab on clicking subscribers count.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -678,11 +678,22 @@ export function initialize(): void {
         $(".dialog_submit_button").attr("data-stream-id", stream_id);
     });
 
-    $("#channels_overlay_container").on("click", ".stream-row", function (this: HTMLElement) {
-        if ($(this).closest(".check, .subscription_settings").length === 0) {
-            open_edit_panel_for_row(this);
-        }
+    $("#channels_overlay_container").on("click", ".stream-row", function (this: HTMLElement, e) {
+        e.preventDefault();
+        e.stopPropagation();
+        open_edit_panel_for_row(this);
     });
+
+    $("#channels_overlay_container").on(
+        "click",
+        ".subscriber-count",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
+            stream_edit_toggler.set_select_tab("subscribers");
+            open_edit_panel_for_row(this);
+        },
+    );
 
     $<HTMLSelectElement>("#channels_overlay_container").on(
         "change",


### PR DESCRIPTION
Currently, clicking the subscriber count for a channel in the stream list menu works the same way as clicking the entire tab for that channel. If the currently open tab is "General," clicking on another channel’s tab also opens the "General" tab for that channel. This behavior applied to the subscriber count as well, as there was no specific click action associated with it.

This PR implements a dedicated click action for the subscriber count. Clicking it now opens the "Subscribers" tab of the selected channel, regardless of which tab is currently open.

## Video demonstration

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/d8570b04-3bbe-49ee-9378-89ee84ac4d01


</td>
<td>

https://github.com/user-attachments/assets/f44a55ba-12da-417a-bf3e-f3ab9784f8bb

</td>
</tr>
</table>

Fixes: #32035 .

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
