### PR TITLE
search: Parse "sender:me" as a search pill when no option is selected.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -507,6 +507,10 @@ export class Filter {
                     }
                 }
 
+                if (operator === "sender" && operand.toString().toLowerCase() === "me") {
+                    operand = people.my_current_email();
+                }
+
                 // We use Filter.operator_to_prefix() to check if the
                 // operator is known.  If it is not known, then we treat
                 // it as a search for the given string (which may contain

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -1035,7 +1035,8 @@ export function get_search_result(
         attacher.push([...attacher.base, ...suggestion_line]);
     } else if (
         all_search_terms.length > 0 &&
-        all_search_terms.every((term) => Filter.is_valid_search_term(term))
+        all_search_terms.every((term) => Filter.is_valid_search_term(term)) &&
+        !(last.operator === "sender" && last.operand === people.my_current_email())
     ) {
         suggestion_line = get_default_suggestion_line(all_search_terms);
         attacher.push(suggestion_line);

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1345,6 +1345,14 @@ test("parse", () => {
     terms = [{operator: "sender", operand: "leo+test@zulip.com"}];
     _test();
 
+    string = "sender:me";
+    terms = [{operator: "sender", operand: `${me.email}`}];
+    _test();
+
+    string = "-sender:me";
+    terms = [{operator: "sender", operand: `${me.email}`, negated: true}];
+    _test();
+
     string = "https://www.google.com";
     terms = [{operator: "search", operand: "https://www.google.com"}];
     _test();


### PR DESCRIPTION
This PR changes the behavior of parsing "sender:me" as a search pill. The changes made allow the parsing of "sender:me" as a search pill when no typeahead option is selected.

Fixes: #31315.
The above issue is a follow-up to [#31173(comment)](https://github.com/zulip/zulip/pull/31173#discussion_r1704884030).

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Searching for <code>sender:me</code>.</summary>

**Before:**

![sender me error](https://github.com/user-attachments/assets/50f5b020-cf81-49c0-a1e9-c14a4182b52c)

**After:**
Please note that, here, the search query `sender:me` is parsed into `sender:<email_of_current_user>`. Therefore, it is not converted to a pill. This behavior is similar to when we currently search for `sender:<email_of_current_user>`.

![sender me](https://github.com/user-attachments/assets/839cd3c1-843f-46e1-8551-d43661159d73)

</details>

<details>
<summary>Searching for <code>sender:me has:image turtle</code>.</summary>

**Before:**

![sender me has image turtle error](https://github.com/user-attachments/assets/b8a18e46-3e85-4b8f-a04f-d4d019c3e8a1)

**After:**

![sender me has image turtle](https://github.com/user-attachments/assets/a7a1b0e2-3c67-45ec-8f42-525b36129487)

</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
