### PR TITLE
 Add confirm_dialog for marking messages as unread in interleaved view.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1690,10 +1690,7 @@ export class Filter {
     }
 
     is_interleaved_view(): boolean {
-        if (
-            this.can_bucket_by("dm") ||
-            this.can_bucket_by("channel", "topic")
-        ) {
+        if (this.can_bucket_by("dm") || this.can_bucket_by("channel", "topic")) {
             return false;
         }
         return true;

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1689,6 +1689,16 @@ export class Filter {
         return false;
     }
 
+    is_interleaved_view(): boolean {
+        if (
+            this.can_bucket_by("dm") ||
+            this.can_bucket_by("channel", "topic")
+        ) {
+            return false;
+        }
+        return true;
+    }
+
     excludes_muted_topics(): boolean {
         return (
             // not narrowed to a topic

--- a/web/templates/confirm_dialog/confirm_mark_as_unread_from_here.hbs
+++ b/web/templates/confirm_dialog/confirm_mark_as_unread_from_here.hbs
@@ -1,0 +1,7 @@
+<p>
+    {{#if is_count_too_low}}
+        {{t "Are you sure you want to mark messages as unread? Messages in multiple conversations may be affected."}}
+    {{else}}
+        {{t "Are you sure you want to mark {N} messages as unread? Messages in multiple conversations may be affected."}}
+    {{/if}}
+</p>

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -136,6 +136,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -176,6 +177,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -194,6 +196,7 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel"));
     assert.ok(filter.can_bucket_by("channel", "topic"));
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -212,6 +215,7 @@ test("basics", () => {
     assert.ok(filter.can_bucket_by("channel"));
     assert.ok(filter.can_bucket_by("channel", "topic"));
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(filter.is_conversation_view_with_near());
     assert.ok(filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
@@ -227,6 +231,7 @@ test("basics", () => {
     assert.ok(filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     // Negated searches are just like positive searches for our purposes, since
     // the search logic happens on the backend and we need to have can_apply_locally()
@@ -240,6 +245,7 @@ test("basics", () => {
     assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -254,6 +260,7 @@ test("basics", () => {
     assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     terms = [{operator: "channels", operand: "public", negated: true}];
     filter = new Filter(terms);
@@ -265,6 +272,7 @@ test("basics", () => {
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     terms = [{operator: "channels", operand: "public"}];
     filter = new Filter(terms);
@@ -277,6 +285,7 @@ test("basics", () => {
     assert.ok(filter.includes_full_stream_history());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     // "streams" was renamed to "channels"
     terms = [{operator: "streams", operand: "public"}];
@@ -294,6 +303,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(filter.can_show_next_unread_dm_conversation_button());
 
@@ -314,6 +324,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
     assert.ok(!filter.can_show_next_unread_topic_conversation_button());
     assert.ok(!filter.can_show_next_unread_dm_conversation_button());
 
@@ -326,6 +337,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     terms = [{operator: "dm", operand: "joe@example.com"}];
     filter = new Filter(terms);
@@ -337,6 +349,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(!filter.is_conversation_view_with_near());
 
     terms = [
@@ -352,6 +365,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(filter.is_conversation_view_with_near());
 
     terms = [{operator: "dm", operand: "joe@example.com,jack@example.com"}];
@@ -363,6 +377,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(!filter.is_conversation_view_with_near());
 
     terms = [
@@ -376,6 +391,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(!filter.is_conversation_view_with_near());
 
     // "pm-with" was renamed to "dm"
@@ -394,6 +410,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     // "group-pm-with" was replaced with "dm-including"
     terms = [{operator: "group-pm-with", operand: "joe@example.com"}];
@@ -410,6 +427,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     // Highly complex query to exercise
     // filter.supports_collapsing_recipients loop.
@@ -433,6 +451,7 @@ test("basics", () => {
     assert.ok(!filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
+    assert.ok(filter.is_interleaved_view());
 
     terms = [
         {operator: "channel", operand: foo_stream_id.toString()},
@@ -449,6 +468,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(!filter.is_conversation_view_with_near());
 
     terms = [
@@ -467,6 +487,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(filter.can_bucket_by("channel", "topic", "with"));
     assert.ok(!filter.is_conversation_view_with_near());
 
@@ -486,6 +507,7 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
+    assert.ok(!filter.is_interleaved_view());
     assert.ok(!filter.is_conversation_view_with_near());
 });
 


### PR DESCRIPTION
This PR is the updated version of #31319 authored by @Niloth-p . 

This PR adds a confirmation model for marking messages as unread (from here) in the interleaved views.

**Updation: Corrected the error in message count calculation.**

Known number: (All Fetched)

N < 50 - no confirmation dialog
N >= 50 - confirmation dialog with the number of messages

Unknown number:

N < 10 - no confirmation dialog
N >= 10 - confirmation dialog with the minimum number of messages, rounded down to the nearest multiple of 25.

<details>
<summary> Example Screenshots</summary>


**When numbers are known**

![image](https://github.com/user-attachments/assets/29a3b691-3694-4cd0-ba9e-a027558f4d5b)

**When numbers are unknown**

![image](https://github.com/user-attachments/assets/0c44829f-be91-432c-b568-869e55be7368)

</details>

<details>
<summary> Video demonstration of count changes and calculation</summary>

## Showing how the count is calculated when there are already some unread messages in the view

**When numbers are known**

[Screencast from 2024-12-27 00-02-02.webm](https://github.com/user-attachments/assets/bb420e1f-911b-4943-840f-ca7e094d8795)

**When numbers are not known**

[Screencast from 2024-12-27 00-05-58.webm](https://github.com/user-attachments/assets/4ade29b4-c3f7-4eb3-917d-d3b88714ebca)

</details>

Fixes : #31292 .

[CZO Thread](https://chat.zulip.org/#narrow/stream/137-feedback/topic/unintentionally.20marking.20messages.20as.20unread/near/1638015)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
