### PR TITLE
left_sidebar: Rewrite left sidebar navigation area library.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -81,28 +81,22 @@ export function update_dom_with_unread_counts(
     }
 }
 
-// TODO: Rewrite how we handle activation of narrows when doing the redesign.
-// We don't want to adjust class for all the buttons when switching narrows.
+export let select_top_left_corner_item = function (narrow_to_activate: string): void {
+    $(".top-left-active-filter").removeClass("top-left-active-filter");
+    if (narrow_to_activate !== "") {
+        $(narrow_to_activate).addClass("top-left-active-filter");
+    }
+};
 
-function remove($elem: JQuery): void {
-    $elem.removeClass("active-filter active-sub-filter");
-}
-
-function deselect_top_left_corner_items(): void {
-    remove($(".top_left_all_messages"));
-    remove($(".top_left_starred_messages"));
-    remove($(".top_left_mentions"));
-    remove($(".top_left_recent_view"));
-    remove($(".top_left_inbox"));
-    remove($(".top_left_my_reactions"));
+export function rewire_select_top_left_corner_item(
+    func: (narrow_to_activate: string) => void,
+): void {
+    select_top_left_corner_item = func;
 }
 
 export function handle_narrow_activated(filter: Filter): void {
-    deselect_top_left_corner_items();
-
     let ops: string[];
     let filter_name: string;
-    let $filter_li: JQuery;
 
     // TODO: handle confused filters like "in:all stream:foo"
     ops = filter.operands("in");
@@ -110,17 +104,18 @@ export function handle_narrow_activated(filter: Filter): void {
         filter_name = ops[0];
         if (filter_name === "home") {
             highlight_all_messages_view();
+            return;
         }
     }
     ops = filter.operands("is");
     if (ops[0] !== undefined) {
         filter_name = ops[0];
         if (filter_name === "starred") {
-            $filter_li = $(".top_left_starred_messages");
-            $filter_li.addClass("active-filter");
+            select_top_left_corner_item(".top_left_starred_messages");
+            return;
         } else if (filter_name === "mentioned") {
-            $filter_li = $(".top_left_mentions");
-            $filter_li.addClass("active-filter");
+            select_top_left_corner_item(".top_left_mentions");
+            return;
         }
     }
     const term_types = filter.sorted_term_types();
@@ -128,9 +123,12 @@ export function handle_narrow_activated(filter: Filter): void {
         _.isEqual(term_types, ["sender", "has-reaction"]) &&
         filter.operands("sender")[0] === people.my_current_email()
     ) {
-        $filter_li = $(".top_left_my_reactions");
-        $filter_li.addClass("active-filter");
+        select_top_left_corner_item(".top_left_my_reactions");
+        return;
     }
+
+    // If we don't have a specific handler for this narrow, we just clear all.
+    select_top_left_corner_item("");
 }
 
 function toggle_condensed_navigation_area(): void {
@@ -181,27 +179,24 @@ function do_new_messages_animation($li: JQuery): void {
 }
 
 export function highlight_inbox_view(): void {
-    deselect_top_left_corner_items();
+    select_top_left_corner_item(".top_left_inbox");
 
-    $(".top_left_inbox").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
 }
 
 export function highlight_recent_view(): void {
-    deselect_top_left_corner_items();
+    select_top_left_corner_item(".top_left_recent_view");
 
-    $(".top_left_recent_view").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);
 }
 
 export function highlight_all_messages_view(): void {
-    deselect_top_left_corner_items();
+    select_top_left_corner_item(".top_left_all_messages");
 
-    $(".top_left_all_messages").addClass("active-filter");
     setTimeout(() => {
         resize.resize_stream_filters_container();
     }, 0);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -384,6 +384,7 @@
     }
 
     &.active-filter,
+    &.top-left-active-filter,
     &.active-sub-filter {
         &:has(.left_sidebar_menu_icon_visible) {
             background-color: var(--color-background-active-narrow-filter);
@@ -598,6 +599,7 @@ ul.filters {
 }
 
 li.active-filter,
+li.top-left-active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
     position: relative;
@@ -696,7 +698,7 @@ li.active-sub-filter {
         }
     }
 
-    .active-filter {
+    .top-left-active-filter {
         /* Don't display a background on condensed icons. */
         background: unset;
     }
@@ -865,7 +867,7 @@ li.top_left_scheduled_messages {
     }
 }
 
-.top_left_starred_messages.active-filter {
+.top_left_starred_messages.top-left-active-filter {
     &.hide_starred_message_count {
         .masked_unread_count {
             display: none;
@@ -1015,7 +1017,7 @@ li.top_left_scheduled_messages {
             }
             /* ...except when there is an active filter in place:
                that row should still be shown. */
-            & .top_left_row.active-filter {
+            & .top_left_row.top-left-active-filter {
                 display: grid;
                 /* In the absence of auto rows in the condensed state,
                    we set an explicit height on the active filter. */

--- a/web/tests/left_sidebar_navigation_area.test.cjs
+++ b/web/tests/left_sidebar_navigation_area.test.cjs
@@ -17,56 +17,76 @@ scheduled_messages.get_count = () => 555;
 const {Filter} = zrequire("../src/filter");
 const left_sidebar_navigation_area = zrequire("left_sidebar_navigation_area");
 
-run_test("narrowing", () => {
+run_test("narrowing", ({override_rewire}) => {
+    override_rewire(
+        left_sidebar_navigation_area,
+        "select_top_left_corner_item",
+        (narrow_to_activate) => {
+            const targets = [
+                ".top_left_mentions",
+                ".top_left_starred_messages",
+                ".top_left_all_messages",
+                ".top_left_recent_view",
+                ".top_left_inbox",
+            ];
+            for (const target of targets) {
+                $(target).removeClass("top-left-active-filter");
+            }
+            if (narrow_to_activate !== "") {
+                $(narrow_to_activate).addClass("top-left-active-filter");
+            }
+        },
+    );
+
     let filter = new Filter([{operator: "is", operand: "mentioned"}]);
 
     // activating narrow
 
     left_sidebar_navigation_area.handle_narrow_activated(filter);
-    assert.ok($(".top_left_mentions").hasClass("active-filter"));
+    assert.ok($(".top_left_mentions").hasClass("top-left-active-filter"));
 
     filter = new Filter([{operator: "is", operand: "starred"}]);
     left_sidebar_navigation_area.handle_narrow_activated(filter);
-    assert.ok($(".top_left_starred_messages").hasClass("active-filter"));
+    assert.ok($(".top_left_starred_messages").hasClass("top-left-active-filter"));
 
     filter = new Filter([{operator: "in", operand: "home"}]);
     left_sidebar_navigation_area.handle_narrow_activated(filter);
-    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
+    assert.ok($(".top_left_all_messages").hasClass("top-left-active-filter"));
 
     // deactivating narrow
 
     left_sidebar_navigation_area.handle_narrow_activated(new Filter([]));
 
-    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
-    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
+    assert.ok(!$(".top_left_all_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_mentions").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_recent_view").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_inbox").hasClass("top-left-active-filter"));
 
     set_global("setTimeout", (f) => {
         f();
     });
     left_sidebar_navigation_area.highlight_recent_view();
-    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
-    assert.ok($(".top_left_recent_view").hasClass("active-filter"));
+    assert.ok(!$(".top_left_all_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_mentions").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_inbox").hasClass("top-left-active-filter"));
+    assert.ok($(".top_left_recent_view").hasClass("top-left-active-filter"));
 
     left_sidebar_navigation_area.handle_narrow_activated(new Filter([]));
     left_sidebar_navigation_area.highlight_inbox_view();
-    assert.ok(!$(".top_left_all_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
-    assert.ok($(".top_left_inbox").hasClass("active-filter"));
+    assert.ok(!$(".top_left_all_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_mentions").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_recent_view").hasClass("top-left-active-filter"));
+    assert.ok($(".top_left_inbox").hasClass("top-left-active-filter"));
 
     left_sidebar_navigation_area.highlight_all_messages_view();
-    assert.ok(!$(".top_left_mentions").hasClass("active-filter"));
-    assert.ok(!$(".top_left_starred_messages").hasClass("active-filter"));
-    assert.ok(!$(".top_left_recent_view").hasClass("active-filter"));
-    assert.ok(!$(".top_left_inbox").hasClass("active-filter"));
-    assert.ok($(".top_left_all_messages").hasClass("active-filter"));
+    assert.ok(!$(".top_left_mentions").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_starred_messages").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_recent_view").hasClass("top-left-active-filter"));
+    assert.ok(!$(".top_left_inbox").hasClass("top-left-active-filter"));
+    assert.ok($(".top_left_all_messages").hasClass("top-left-active-filter"));
 });
 
 run_test("update_count_in_dom", () => {


### PR DESCRIPTION
This PR implements the following changes as suggested by @amanagr [here](https://github.com/zulip/zulip/pull/29536#issuecomment-2058655243):

- Rename `active-filter` to `top-left-active-filter`.
- Remove handling of `active-sub-filter` as it is not relevant in this context.
- Use `$(".top-left-active-filter").removeClass("top-left-active-filter")` to remove the class and then add the class to the desired element.

Fixes: #26686.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
