### PR TITLE
settings: Validate the Name input field while editing a user or a bot.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -990,11 +990,19 @@ function get_current_values(
 function toggle_submit_button($edit_form: JQuery): void {
     const current_values = get_current_values($edit_form);
     const $submit_button = $("#user-profile-modal .dialog_submit_button");
-    if (!_.isEqual(original_values, current_values)) {
-        $submit_button.prop("disabled", false);
-    } else {
+    const full_name_value = $edit_form.find<HTMLInputElement>("input[name='full_name']").val()!;
+
+    if (full_name_value.trim() === "") {
         $submit_button.prop("disabled", true);
+        return;
     }
+
+    if (_.isEqual(original_values, current_values)) {
+        $submit_button.prop("disabled", true);
+        return;
+    }
+
+    $submit_button.prop("disabled", false);
 }
 
 export function show_edit_user_info_modal(user_id: number, $container: JQuery): void {


### PR DESCRIPTION
This PR adds a validation step that disables the Submit button in the Manage user tab and the Manage bot tab when the Name input field is empty.

Fixes: #22904.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Disabling the Submit button when the Name input field is empty.</summary>

![disable submit on empty input](https://github.com/user-attachments/assets/018d7546-26f2-4301-9e43-a8eefb07e069)

</details>

<details>
<summary>Disabling the Submit button when the Name input field contains only spaces..</summary>

![disable submit on only spaces](https://github.com/user-attachments/assets/c61e3baa-5a5f-4e0c-b6ec-410a7aaff401)

</details>

---

**Previous PRs associated with the same issue:**
- The PR [#23405](https://github.com/zulip/zulip/pull/23405) (inactive since Nov 2023) aims to solve this issue via backend changes but it was suggested to make changes in the frontend over [here](https://github.com/zulip/zulip/pull/23405#issuecomment-1300426434).
- The PR [#29640](https://github.com/zulip/zulip/pull/29640) (inactive since April 2024) although solves the issue, but it has a limitation where the Name input field is not validated if it contains only spaces.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
