### PR TITLE
Updated the left and right sidebar icons with dot and solid line Icon

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -128,6 +128,10 @@ export function initialize(): void {
         e.preventDefault();
         e.stopPropagation();
 
+            // Toggle the visibility of the right side icon
+        $("#rightside-open-dot").toggle(); 
+        $("#rightside-close-dot").toggle();
+
         if (window.innerWidth >= media_breakpoints_num.xl) {
             $("body").toggleClass("hide-right-sidebar");
             if (!$("body").hasClass("hide-right-sidebar")) {
@@ -147,6 +151,10 @@ export function initialize(): void {
     $(".left-sidebar-toggle-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
+
+            // Toggle the visibility of the left side icon
+        $("#leftside-open-dot").toggle();
+        $("#leftside-close-solid").toggle();
 
         if (window.innerWidth >= media_breakpoints_num.md) {
             $("body").toggleClass("hide-left-sidebar");

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -1,9 +1,19 @@
 <div class="header">
     <nav class="header-main" id="top_navbar">
         <div class="column-left">
-            <a class="left-sidebar-toggle-button {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" tabindex="0" role="button">
-                <i class="fa fa-reorder" aria-hidden="true"></i>
-                <span class="left-sidebar-toggle-unreadcount">0</span>
+           <a class="left-sidebar-toggle-button {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" tabindex="0" role="button">
+           <svg id="leftside-open-dot" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-panel-left-dashed">
+                <rect width="18" height="18" x="3" y="3" rx="2"/>
+                <path d="M9 14v1"/>
+                <path d="M9 19v2"/>
+                <path d="M9 3v2"/>
+                <path d="M9 9v1"/>
+            </svg>
+            <svg id="leftside-close-solid" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-panel-left" style="display: none;">
+                <rect width="18" height="18" x="3" y="3" rx="2"/>
+                <path d="M9 3v18"/>
+            </svg>
+            <span class="left-sidebar-toggle-unreadcount">0</span>
             </a>
             <a href="" class="brand no-style">
                 <img id="realm-navbar-wide-logo" src="" alt="" class="nav-logo no-drag"/>
@@ -41,11 +51,6 @@
                     {{t 'Log in' }}
                 </a>
             </div>
-            <div id="userlist-toggle" class="hidden-for-spectators">
-                <a id="userlist-toggle-button" role="button" class="header-button navbar-item" tabindex="0">
-                    <i class="zulip-icon zulip-icon-user-list"></i>
-                </a>
-            </div>
             <div id="help-menu" class="navbar-item">
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="help-menu-tooltip-template">
                     <i class="zulip-icon zulip-icon-help-bigger" aria-hidden="true"></i>
@@ -64,6 +69,18 @@
             <div class="spectator_narrow_login_button only-visible-for-spectators" data-tippy-content="{{t 'Log in' }}" data-tippy-placement="bottom">
                 <a id="login_button" class="header-button login_button navbar-item" tabindex="0">
                     <i class="zulip-icon zulip-icon-log-in"></i>
+                </a>
+            </div>
+            <div id="userlist-toggle" class="hidden-for-spectators">
+                <a id="userlist-toggle-button" role="button" class="header-button navbar-item" tabindex="0">
+                    <svg id="rightside-open-dot" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-panel-right-dashed">
+                        <rect width="18" height="18" x="3" y="3" rx="2"/>
+                        <path d="M15 14v1"/><path d="M15 19v2"/><path d="M15 3v2"/><path d="M15 9v1"/>
+                    </svg>
+                    <svg id="rightside-close-dot" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-panel-right" style="display: none;">
+                        <rect width="18" height="18" x="3" y="3" rx="2"/>
+                        <path d="M15 3v18"/>
+                    </svg>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
The sidebar toggle functionality now dynamically switches icons based on the sidebar's state, enhancing usability. Font-awesome icons were replaced with modern SVGs for improved visuals and performance.

Fixes: [#32825](https://github.com/zulip/zulip/issues/32825)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|    Section    | open      | close    |
|-----------------|----------------|----------------|
| leftside |![image](https://github.com/user-attachments/assets/3bb21632-326a-4385-a543-acdf8661f0e3) | ![image](https://github.com/user-attachments/assets/3e58df7b-5fac-4389-b1c0-f454c62b633f)|
| rightside  |![image](https://github.com/user-attachments/assets/625c2441-9ea0-4c8b-a8f9-f285dbdd188a) |![image](https://github.com/user-attachments/assets/ffc15e32-6900-40d6-a4d0-c601c3d9ba1f)|
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
