### PR TITLE
deactivated_user: Correctly display deactivated users in the right sidebar.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -53,7 +53,7 @@ function get_total_human_subscriber_count(
 
         let human_user_count = 0;
         for (const pm_id of all_recipient_user_ids_set) {
-            if (!people.is_valid_bot_user(pm_id) && people.is_person_active(pm_id)) {
+            if (!people.is_valid_bot_user(pm_id)) {
                 human_user_count += 1;
             }
         }

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -217,8 +217,8 @@ export const update_person = function update(person: UserUpdate): void {
             stream_events.remove_deactivated_user_from_all_streams(person.user_id);
             user_group_edit.remove_deactivated_user_from_all_groups(person.user_id);
             settings_users.update_view_on_deactivate(person.user_id);
-            buddy_list.maybe_remove_user_id({user_id: person.user_id});
         }
+        buddy_list.insert_or_move([person.user_id]);
         settings_account.maybe_update_deactivate_account_button();
         if (people.is_valid_bot_user(person.user_id)) {
             settings_users.update_bot_data(person.user_id);

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -155,6 +155,11 @@
         line-height: 1;
         /* ...which is approximately 11px at 16px/1em. */
         font-size: 0.6875em;
+
+        &.user-circle-deactivated {
+            color: var(--color-user-circle-offline);
+            font-size: 0.85em;
+        }
     }
 
     .user_sidebar_entry.with_avatar {

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -1,7 +1,11 @@
 <li data-user-id="{{user_id}}" data-name="{{name}}" class="user_sidebar_entry {{#if user_list_style.WITH_AVATAR}}with_avatar{{/if}} {{#if has_status_text}}with_status{{/if}} {{#if is_current_user}}user_sidebar_entry_me {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
     <div class="selectable_sidebar_block">
         {{#if user_list_style.WITH_STATUS}}
+            {{#if (eq user_circle_class "user-circle-deactivated")}}
+            <span class="fa fa-ban {{user_circle_class}} user-circle"></span>
+            {{else}}
             <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+            {{/if}}
             <a class="user-presence-link" href="{{href}}">
                 <div class="user-name-and-status-wrapper">
                     <div class="user-name-and-status-emoji">
@@ -14,7 +18,11 @@
         {{else if user_list_style.WITH_AVATAR}}
             <div class="user-profile-picture avatar-preload-background">
                 <img loading="lazy" src="{{profile_picture}}"/>
+                {{#if (eq user_circle_class "user-circle-deactivated")}}
+                <span class="fa fa-ban {{user_circle_class}} user-circle"></span>
+                {{else}}
                 <span class="zulip-icon zulip-icon-{{user_circle_class}} {{user_circle_class}} user-circle"></span>
+                {{/if}}
             </div>
             <a class="user-presence-link" href="{{href}}">
                 <div class="user-name-and-status-wrapper">

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -175,6 +175,10 @@ test("user_circle, level", ({override}) => {
     set_presence(fred.user_id, undefined);
     assert.equal(buddy_data.get_user_circle_class(fred.user_id), "user-circle-offline");
     assert.equal(buddy_data.level(fred.user_id), 3);
+
+    set_presence(fred.user_id, undefined);
+    assert.equal(buddy_data.get_user_circle_class(fred.user_id, true), "user-circle-deactivated");
+    assert.equal(buddy_data.level(fred.user_id), 3);
 });
 
 test("title_data", ({override}) => {

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -26,6 +26,15 @@ mock_esm("../src/user_profile", {
 });
 const stream_events = mock_esm("../src/stream_events");
 
+const buddy_list = mock_esm("../src/buddy_list", {
+    BuddyList: class {
+        insert_or_move = noop;
+    },
+});
+
+const buddy_data = new buddy_list.BuddyList();
+buddy_list.buddy_list = buddy_data;
+
 mock_esm("../src/activity_ui", {
     redraw() {},
 });
@@ -278,6 +287,7 @@ run_test("updates", ({override}) => {
         assert.equal(user_id, isaac.user_id);
         user_removed_from_streams = true;
     };
+    buddy_list.BuddyList.insert_or_move = noop;
     user_events.update_person({user_id: isaac.user_id, is_active: false});
     assert.ok(!people.is_person_active(isaac.user_id));
     assert.ok(user_removed_from_streams);


### PR DESCRIPTION
In DMs that include a deactivated user, it shows the deactivated user with a special deactivated status icon (slashed circle) in the right sidebar. 
Currently, these users appear with no special indicator in the right sidebar.
In all other contexts, we shouldn't show deactivated users in the right sidebar.

Fixes part of #30797.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before  | After  |
|---------|--------|
| <img width="250" alt="Screenshot 2025-01-30 at 5 42 58 PM" src="https://github.com/user-attachments/assets/d4fecc95-2746-48b9-b8b0-6f38326a9c1b" />  | <img width="250" alt="Screenshot 2025-01-30 at 5 34 02 PM" src="https://github.com/user-attachments/assets/ec18580d-ac01-4466-9856-acae65ab0366" />  |
| <img width="249" alt="Screenshot 2025-01-30 at 5 42 48 PM" src="https://github.com/user-attachments/assets/cc6f3afd-772b-4564-9a32-af92a71c5773" />  | <img width="251" alt="Screenshot 2025-01-30 at 5 33 52 PM" src="https://github.com/user-attachments/assets/b5e1a052-c581-47de-a4d8-e2677165b134" />  |
| <img width="252" alt="Screenshot 2025-01-30 at 5 43 09 PM" src="https://github.com/user-attachments/assets/d0cece68-f1d3-44c9-bc0b-d85e6ae58bd5" />  | <img width="254" alt="Screenshot 2025-01-30 at 5 34 12 PM" src="https://github.com/user-attachments/assets/64a9c607-8249-44f7-80b1-427a4f7c9b44" />  |
| <img width="251" alt="Screenshot 2025-01-30 at 5 43 16 PM" src="https://github.com/user-attachments/assets/08354bd5-ad76-4e91-9036-d25cd6f8a086" />  | <img width="244" alt="Screenshot 2025-01-30 at 5 34 21 PM" src="https://github.com/user-attachments/assets/0a9029ee-6fdf-442b-9f84-1a7b30903550" />  |


<details>
<summary>Interaction Demo: </summary>

https://github.com/user-attachments/assets/68051729-3ff6-48f4-8a08-3ad9682aebb3


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
