### PR TITLE
Fix: focus outline cutoff issue in poll title editing

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -286,6 +286,8 @@ input {
     /* Ensure controls remain visible on narrower screens. */
     flex-flow: row wrap;
     gap: 5px;
+    /* Reserve space for the focus outline to prevent it from being cut off */
+    margin-right: 2px;
     margin-bottom: var(--markdown-interelement-space-px);
 }
 


### PR DESCRIPTION
This pull request addresses the issue described in **#32829** where the focus outline for the tick (✅) button is partially cut off while editing the title of a poll or to-do list. The problem occurs when the user clicks on the ✏️ edit icon to modify the title, and the focus outline around the checkmark button is clipped on the right side, making it difficult to see the focus state.

Fixes: #32829

The issue was fixed by adding a `margin-right: 2px;` to the `.poll-question-bar` class. This small adjustment ensures that the focus outline around the checkmark button is fully visible and no longer clipped, enhancing the accessibility and visual clarity of the UI.

### **Steps to Test:**
1. Create a poll or a to-do list using the `/poll` or `/todo` command, or via the UI buttons.
2. Click on the ✏️ icon near the title to edit the title.
3. Observe how focusing or clicking the ✅ button results in the outline.

**Screenshots and screen captures:**
**Before:**
![Screenshot from 2024-12-27 01-48-53](https://github.com/user-attachments/assets/7a0263c8-19ec-4377-be3a-ffc462b3996b)

**After:**
![Screenshot from 2024-12-27 01-50-31](https://github.com/user-attachments/assets/4d510b81-465a-4d65-8071-b465072ad163)

**Video:**
[Screencast from 2024-12-27 01-55-57.webm](https://github.com/user-attachments/assets/cabca641-e062-4ff0-9cae-c22e790b6317)
