### PR TITLE
clear_search_button: Add clear search button to search bar.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -467,6 +467,12 @@ export function create<Key, Item = Key>(
                 widget.set_filter_value(value);
                 widget.hard_redraw();
             });
+
+            opts.filter?.$element?.siblings(".clear_search_button").on("click", () => {
+                opts.filter?.$element?.val("");
+                widget.set_filter_value("");
+                widget.clean_redraw();
+            });
         },
 
         clear_event_handlers() {
@@ -477,6 +483,7 @@ export function create<Key, Item = Key>(
             }
 
             opts.filter?.$element?.off("input.list_widget_filter");
+            opts.filter?.$element?.siblings(".clear_search_button").off("click");
         },
 
         increase_rendered_offset() {

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -697,12 +697,18 @@ function handle_filter_change($tbody: JQuery, section: UserSettingsSection): voi
     // ListWidget for the input.list_widget_filter event type, but we
     // can't use that, because we're also filtering on Role with our
     // custom predicate.
-    $tbody
+    const $search_input = $tbody
         .closest(".user-settings-section")
-        .find<HTMLInputElement>(".search")
-        .on("input.list_widget_filter", function (this: HTMLInputElement) {
-            add_value_to_filters(section, "text_search", this.value.toLocaleLowerCase());
-        });
+        .find<HTMLInputElement>(".search");
+
+    $search_input.on("input.list_widget_filter", function (this: HTMLInputElement) {
+        add_value_to_filters(section, "text_search", this.value.toLocaleLowerCase());
+    });
+
+    $search_input.siblings(".clear_search_button").on("click", () => {
+        $search_input.val("");
+        add_value_to_filters(section, "text_search", "");
+    });
 }
 
 function active_handle_events(): void {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1299,6 +1299,39 @@ label.preferences-radio-choice-label {
         margin: 10px 0;
     }
 
+    .settings-table-search-section {
+        position: relative;
+        display: inline-block;
+        height: 32px;
+    }
+
+    .settings-table-search-section input {
+        padding-right: 0;
+        height: 100%;
+        box-sizing: border-box;
+    }
+
+    .settings-table-search-section .clear_search_button {
+        position: absolute;
+        right: 5px;
+        top: 50%;
+        transform: translateY(-50%);
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        line-height: 16px;
+        align-items: center;
+        display: none;
+    }
+
+    /* Show button when input has text */
+    .settings-table-search-section
+        input:not(:placeholder-shown)
+        ~ .clear_search_button {
+        display: block;
+    }
+
     .sidebar-wrapper {
         float: left;
         position: relative;

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -5,7 +5,10 @@
         <div class="alert-notification" id="user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=active_user_list_dropdown_widget_name}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+            {{> clear_search_button
+              placeholder=(t 'Filter users')
+              aria-label=(t 'Filter users')
+              }}
         </div>
     </div>
 

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -2,7 +2,11 @@
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
         <h3>{{t "Your uploads"}}</h3>
-        <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
+        {{> clear_search_button
+          id="upload_file_search"
+          placeholder=(t 'Filter uploaded files')
+          aria-label=(t 'Filter uploads')
+          }}
     </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -21,7 +21,10 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>
         <div class="alert-notification" id="bot-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
+        {{> clear_search_button
+          placeholder=(t 'Filter bots')
+          aria-label=(t 'Filter bots')
+          }}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/clear_search_button.hbs
+++ b/web/templates/settings/clear_search_button.hbs
@@ -1,0 +1,6 @@
+<div class="input-append settings-table-search-section">
+    <input class="search filter_text_input input_field" type="text" placeholder="{{placeholder}}" aria-label="{{aria-label}}" {{#if id}}id="{{id}}"{{/if}}/>
+    <button type="button" class="btn clear_search_button">
+        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+    </button>
+</div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -55,7 +55,10 @@
             <h3>{{t "Export permissions"}}</h3>
             <div class="user_filters">
                 {{> ../dropdown_widget widget_name="filter_by_consent"}}
-                <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+                {{> clear_search_button
+                  placeholder=(t 'Filter users')
+                  aria-label=(t 'Filter users')
+                  }}
             </div>
         </div>
 

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -8,7 +8,10 @@
         <div class="alert-notification" id="deactivated-user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=deactivated_user_list_dropdown_widget_name}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
+            {{> clear_search_button
+              placeholder=(t 'Filter deactivated users')
+              aria-label=(t 'Filter deactivated users')
+              }}
         </div>
     </div>
 

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -7,7 +7,10 @@
             {{#if is_admin}}
                 <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
             {{/if}}
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default channels' }}" aria-label="{{t 'Filter channels' }}"/>
+            {{> clear_search_button
+              placeholder=(t 'Filter default channels')
+              aria-label=(t 'Filter channels')
+              }}
         </div>
     </div>
 

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -11,8 +11,10 @@
 
     <div class="settings_panel_list_header">
         <h3>{{t "Custom emoji"}}</h3>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter emoji' }}"
-          aria-label="{{t 'Filter emoji' }}"/>
+        {{> clear_search_button
+          placeholder=(t 'Filter emojis')
+          aria-label=(t 'Filter emojis')
+          }}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table admin_emoji_table">

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -8,7 +8,10 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Invitations "}}</h3>
         <div class="alert-notification" id="invites-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter invitations' }}" aria-label="{{t 'Filter invitations' }}"/>
+        {{> clear_search_button
+          placeholder=(t 'Filter invitations')
+          aria-label=(t 'Filter invitations')
+          }}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -57,7 +57,10 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Linkifiers"}}</h3>
         <div class="alert-notification edit-linkifier-status" id="linkifier-field-status"></div>
-        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
+        {{> clear_search_button
+          placeholder=(t 'Filter linkifiers')
+          aria-label=(t 'Filter linkifiers')
+          }}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -1,7 +1,11 @@
 <div id="muted-user-settings" class="settings-section" data-name="muted-users">
     <div class="settings_panel_list_header">
         <h3>{{t "Muted users"}}</h3>
-        <input id="muted_users_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
+        {{> clear_search_button
+          id="muted_users_search"
+          placeholder=(t 'Filter muted users')
+          aria-label=(t 'Filter muted users')
+          }}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -64,7 +64,10 @@
 
         <div class="settings_panel_list_header">
             <h3>{{t "Code playgrounds"}}</h3>
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter code playgrounds' }}" aria-label="{{t 'Filter code playgrounds' }}"/>
+            {{> clear_search_button
+              placeholder=(t 'Filter code playgrounds')
+              aria-label=(t 'Filter code playgrounds')
+              }}
         </div>
 
         <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/tests/list_widget.test.cjs
+++ b/web/tests/list_widget.test.cjs
@@ -105,6 +105,7 @@ function make_filter_element() {
     const $element = {};
 
     $element.cleared = false;
+    $element.clear_button_elem_cleared = false;
 
     $element.on = (ev, f) => {
         assert.equal(ev, "input.list_widget_filter");
@@ -114,6 +115,23 @@ function make_filter_element() {
     $element.off = (ev) => {
         assert.equal(ev, "input.list_widget_filter");
         $element.cleared = true;
+    };
+
+    const clear_input_element = {};
+
+    clear_input_element.on = (ev, f) => {
+        assert.equal(ev, "click");
+        clear_input_element.f = f;
+    };
+
+    clear_input_element.off = (ev) => {
+        assert.equal(ev, "click");
+        $element.clear_button_elem_cleared = true;
+    };
+
+    $element.siblings = (selector) => {
+        assert.equal(selector, ".clear_search_button");
+        return clear_input_element;
     };
 
     return $element;
@@ -135,6 +153,20 @@ function make_search_input() {
             };
             f.call(elem);
         };
+    };
+
+    const clear_search_button_element = {};
+
+    clear_search_button_element.on = (event, f) => {
+        assert.equal(event, "click");
+        $element.simulate_clear_search = () => {
+            f.call();
+        };
+    };
+
+    $element.siblings = (selector) => {
+        assert.equal(selector, ".clear_search_button");
+        return clear_search_button_element;
     };
 
     return $element;
@@ -280,6 +312,13 @@ run_test("filtering", () => {
     assert.deepEqual(widget.get_current_list(), ["dog", "egg", "grape"]);
     expected_html = "<div>dog</div><div>egg</div><div>grape</div>";
     assert.deepEqual($container.$appended_data.html(), expected_html);
+
+    $search_input.simulate_clear_search();
+    assert.deepEqual(widget.get_current_list(), list);
+
+    // Reset the search input value to test that list is updated correctly.
+    $search_input.val = () => "g";
+    $search_input.simulate_input_event();
 
     // We can insert new data into the widget.
     const new_data = ["greta", "faye", "gary", "frank", "giraffe", "fox"];
@@ -561,12 +600,14 @@ run_test("clear_event_handlers", () => {
     assert.equal($sort_container.cleared, false);
     assert.equal($scroll_container.cleared, false);
     assert.equal($filter_element.cleared, false);
+    assert.equal($filter_element.clear_button_elem_cleared, false);
 
     // The second time we'll clear the old events.
     ListWidget.create($container, list, opts);
     assert.equal($sort_container.cleared, true);
     assert.equal($scroll_container.cleared, true);
     assert.equal($filter_element.cleared, true);
+    assert.equal($filter_element.clear_button_elem_cleared, true);
 });
 
 run_test("sort helpers", () => {


### PR DESCRIPTION
This pull request introduces a new "clear search" button for various search input fields across the settings pages, along with the necessary event handling and styling updates.

**Key changes include**:

- Created a new partial template for the clear search button.
- Updated various settings templates to include the new clear search button partial:
  * `web/templates/settings/attachments_settings.hbs`
  * `web/templates/settings/bot_list_admin.hbs`
  * `web/templates/settings/default_streams_list_admin.hbs`
  * `web/templates/settings/emoji_settings_admin.hbs`
  * `web/templates/settings/invites_list_admin.hbs`
  * `web/templates/settings/active_user_list_admin.hbs`
  *  `web/templates/settings/active_user_list_admin.hbs`
  * `web/templates/settings/linkifier_settings_admin.hbs`
  * `web/templates/settings/muted_users_settings.hbs`
  * `web/templates/settings/playground_settings_admin.hbs`
  * ` web/templates/settings/default_streams_list_admin.hbs`
 
Fixes: #17263.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before Typing Anything | After Typing|
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/b2ced10b-f6cb-43c1-a07c-ecf3295bff53) | ![After](https://github.com/user-attachments/assets/992a390d-0808-4aed-9793-576317effd5b) |
| ![Before](https://github.com/user-attachments/assets/40f3643b-fe32-4e5c-bc50-00a2efa9cfdb) | ![After](https://github.com/user-attachments/assets/f4df192e-9d60-4f8d-853d-25b2b76f1abb) |




<details>
<summary>Demo Video: </summary>


https://github.com/user-attachments/assets/ee6b4aa4-b4af-4f61-8539-1d3d32c4b233



</details>

**Previous PR**:

There was a PR #19578 fixing this issue, have been reviewed by `sahil` and `alya` and was almost complelete but left unmarked.
I have built this PR based upon that original work done.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
