### PR TITLE
cron: Add cron job logic to delete fully deactivated realms.

### DIFF
--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -725,6 +725,15 @@ def scrub_deactivated_realm(realm_to_scrub: Realm) -> None:
         logging.info("Scrubbed realm %s", realm_to_scrub.id)
 
 
+def clean_deactivated_realm_data() -> None:
+    realms_to_scrub = Realm.objects.filter(
+        deactivated=True,
+        scheduled_deletion_date__lte=timezone_now(),
+    )
+    for realm in realms_to_scrub:
+        scrub_deactivated_realm(realm)
+
+
 @transaction.atomic(durable=True)
 def do_change_realm_org_type(
     realm: Realm,

--- a/zerver/management/commands/archive_messages.py
+++ b/zerver/management/commands/archive_messages.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from typing_extensions import override
 
+from zerver.actions.realm_settings import clean_deactivated_realm_data
 from zerver.lib.management import ZulipBaseCommand, abort_unless_locked
 from zerver.lib.retention import archive_messages, clean_archived_data
 
@@ -12,3 +13,4 @@ class Command(ZulipBaseCommand):
     def handle(self, *args: Any, **options: str) -> None:
         clean_archived_data()
         archive_messages()
+        clean_deactivated_realm_data()


### PR DESCRIPTION
Adds cron job logic to delete fully deactivated realms.

Follow-up of PR #31957.

Fixes #32763.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
