### PR TITLE
zulip_updates: Skip zulip updates if configured stream is deactivated.

### DIFF
--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -456,6 +456,8 @@ def send_zulip_update_announcements_to_realm(
             timezone_now() - level_none_to_initial_auditlog.event_time < timedelta(days=7)
         ):
             new_zulip_update_announcements_level = latest_zulip_update_announcements_level
+    elif realm.zulip_update_announcements_stream.deactivated:
+        new_zulip_update_announcements_level = latest_zulip_update_announcements_level
     else:
         # Wait for 24 hours after sending group DM to allow admins to change the
         # stream for zulip update announcements from it's default value if desired.

--- a/zerver/tests/test_zulip_update_announcements.py
+++ b/zerver/tests/test_zulip_update_announcements.py
@@ -9,6 +9,7 @@ from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
 from zerver.actions.create_realm import do_create_realm
+from zerver.actions.streams import do_deactivate_stream
 from zerver.data_import.mattermost import do_convert_data
 from zerver.lib.import_realm import do_import_realm
 from zerver.lib.message import remove_single_newlines
@@ -199,6 +200,30 @@ class ZulipUpdateAnnouncementsTest(ZulipTestCase):
             self.assertEqual(stream_messages[0].content, "Announcement message 3.")
             self.assertEqual(stream_messages[1].content, "Announcement message 4.")
             self.assertEqual(realm.zulip_update_announcements_level, 4)
+
+            # One new update added.
+            new_updates = [
+                ZulipUpdateAnnouncement(
+                    level=5,
+                    message="Announcement message 5.",
+                ),
+            ]
+            self.zulip_update_announcements.extend(new_updates)
+
+            # Verify that update message is skipped if configured channel gets deactivated.
+            do_deactivate_stream(realm.zulip_update_announcements_stream, acting_user=None)
+
+            with time_machine.travel(now + timedelta(days=3), tick=False):
+                send_zulip_update_announcements(skip_delay=False)
+            realm.refresh_from_db()
+            channel_messages = Message.objects.filter(
+                realm=realm,
+                sender=notification_bot,
+                recipient__type_id=realm.zulip_update_announcements_stream.id,
+                date_sent__gte=now + timedelta(days=3),
+            ).order_by("id")
+            self.assert_length(channel_messages, 0)
+            self.assertEqual(realm.zulip_update_announcements_level, 5)
 
     def test_send_zulip_update_announcements_skip_delay(self) -> None:
         with mock.patch(


### PR DESCRIPTION
PR to fix a runtime error caused by attempting to send zulip update messages to deactivated channels.

The bug is resolved by skipping these messages and directly updating the `zulip_update_announcements_level` to the latest level.

So if the configured `zulip_update_announcements_stream` is deactivated, the realm will miss zulip updates.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
