### PR TITLE
invite-modal: Fix invalid custom input to not show "NaN".

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -274,7 +274,7 @@ function valid_to(): string {
 
     let time_in_minutes: number;
     if (time_input_value === "custom") {
-        if (!util.validate_custom_time_input(custom_expiration_time_input)) {
+        if (!util.validate_custom_time_input(custom_expiration_time_input, false)) {
             return $t({defaultMessage: "Invalid custom time"});
         }
         time_in_minutes = util.get_custom_time_in_minutes(
@@ -452,7 +452,10 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
                     .find(".selected")
                     .attr("data-tab-key");
             }
-            const valid_custom_time = util.validate_custom_time_input(custom_expiration_time_input);
+            const valid_custom_time = util.validate_custom_time_input(
+                custom_expiration_time_input,
+                false,
+            );
             const $button = $("#invite-user-modal .dialog_submit_button");
             $button.prop(
                 "disabled",
@@ -477,6 +480,9 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
         pills.onTextInputHook(toggle_invite_submit_button);
 
         $expires_in.on("change", () => {
+            if (!util.validate_custom_time_input(custom_expiration_time_input, false)) {
+                custom_expiration_time_input = 0;
+            }
             settings_components.set_custom_time_inputs_visibility(
                 $expires_in,
                 custom_expiration_time_unit,

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -499,9 +499,15 @@ export function check_time_input(input_value: string, keep_number_as_float = fal
     return Number.parseInt(input_value, 10);
 }
 
-export function validate_custom_time_input(time_input: number): boolean {
-    if (Number.isNaN(time_input) || time_input < 0) {
-        return false;
+export function validate_custom_time_input(time_input: number, can_be_zero = true): boolean {
+    if (can_be_zero) {
+        if (Number.isNaN(time_input) || time_input < 0) {
+            return false;
+        }
+    } else {
+        if (Number.isNaN(time_input) || time_input <= 0) {
+            return false;
+        }
     }
     return true;
 }

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -412,8 +412,14 @@ run_test("get_custom_time_in_minutes", () => {
 });
 
 run_test("check_and_validate_custom_time_input", () => {
+    const input_is_zero = 0;
+    let checked_input = util.check_time_input(input_is_zero);
+    assert.equal(checked_input, 0);
+    assert.equal(util.validate_custom_time_input(checked_input, true), true);
+    assert.equal(util.validate_custom_time_input(checked_input, false), false);
+
     const input_is_nan = "24abc";
-    let checked_input = util.check_time_input(input_is_nan);
+    checked_input = util.check_time_input(input_is_nan);
     assert.equal(checked_input, Number.NaN);
     assert.equal(util.validate_custom_time_input(checked_input), false);
 


### PR DESCRIPTION
Updates the invite modal so that if the custom input is 0, the submit button is deactivated, since an email invitation or invite link that immediately expired would be unusable.

Also, updates the custom input to show 0 if a user navigates away from and back to the custom input option afer putting in an invalid value, e.g. "abc" or "-20". Previously, the custom input showed "NaN" in that case.

---

**Screenshots and screen captures:**

<details>
<summary>Before - custom input set to zero</summary>

### Submit button is active
![Screenshot from 2024-12-31 17-33-01](https://github.com/user-attachments/assets/b1b77c75-ff2b-429e-9d9e-e4ea8d35bd08)
</details>
<details>
<summary>Before - custom input invalid</summary>

### Showing NaN because user set something invalid (e.g., "abc"), switched to preset option (e.g., "1 day") and switched back to custom time option
![Screenshot from 2024-12-31 17-32-46](https://github.com/user-attachments/assets/360623e5-0993-4af2-9263-855514be9532)
</details>
<details>
<summary>After - for both of the above cases</summary>

### Shows 0 for invalid input if navigating back to custom time option and submit button is not active
![Screenshot from 2024-12-31 17-33-45](https://github.com/user-attachments/assets/106ba9b7-e239-4e39-8f2f-b5a28b03b886)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
