### PR TITLE
compose: Remove extra blank line before lists.

### DIFF
--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -658,14 +658,10 @@ export let format_text = (
                 .split("\n")
                 .map((line, i) => mark(line, i))
                 .join("\n");
-            // We always ensure a blank line before and after the list, as we want
+            // We always ensure a blank line after the list, as we want
             // a clean separation between the list and the rest of the text, especially
             // when the markdown is rendered.
 
-            // Add blank line between text before and list if not already present.
-            if (before_lines.length > 0 && before_lines.at(-1) !== "\n") {
-                before_lines += "\n";
-            }
             // Add blank line between list and rest of text if not already present.
             if (after_lines.length > 0 && after_lines.at(0) !== "\n") {
                 after_lines = "\n" + after_lines;

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -696,6 +696,10 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
     compose_ui.format_text($textarea, "bulleted");
     assert.equal(get_textarea_state(), "<first_item\nsecond_item>");
 
+    init_textarea_state("before_first\n<* first_item\n* second_item>\nafter_last");
+    compose_ui.format_text($textarea, "bulleted");
+    assert.equal(get_textarea_state(), "before_first\n<first_item\nsecond_item>\nafter_last");
+
     // Toggling on numbered list
     init_textarea_state("<first_item\nsecond_item>");
     compose_ui.format_text($textarea, "numbered");
@@ -707,12 +711,12 @@ run_test("format_text - bulleted and numbered lists", ({override_rewire}) => {
 
     init_textarea_state("before_first\nfirst_<item\nsecond>_item\nafter_last");
     compose_ui.format_text($textarea, "numbered");
-    // // Notice the blank lines inserted right before and after the list to visually demarcate it.
+    // // Notice the blank lines inserted right after the list to visually demarcate it.
     // // Had the blank line after `second_item` not been inserted, `after_last` would have been
     // // (wrongly) indented as part of the list's last item too.
     assert.equal(
         get_textarea_state(),
-        "before_first\n\n<1. first_item\n2. second_item>\n\nafter_last",
+        "before_first\n<1. first_item\n2. second_item>\n\nafter_last",
     );
 
     // Toggling off numbered list


### PR DESCRIPTION
Previously, inserting a bulleted or numbered list via the compose box added an extra blank line before and after the list.

This commit removes the extra blank line inserted before the list.

Fixes #32607.

---

**Screenshots and screen captures:**
| **State**        | **Screenshot**                                                                                             |
|-------------------|----------------------------------------------------------------------------------------------------------|
| **Before**        | ![Before Recording](https://github.com/user-attachments/assets/dbbe124b-5034-4969-bed1-33cd1b1380ae)                         |
| **After**         | ![After Recording](https://github.com/user-attachments/assets/79f57f8c-89b9-42d1-b1f2-9cbea03f1e0f)                           |

---



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
