### PR TITLE
integrations: Add support for BigBlueButton voice only calls.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 337**
+
+* `POST /calls/bigbluebutton/create`: Added a `voice_only` parameter
+  controlling whether the call should be voice-only, in which case we
+  keep cameras disabled for this call. Now the call creator is a
+  moderator and all other joinees are viewers.
+
 **Feature level 336**
 
 * [Markdown message formatting](/api/message-formatting#image-previews): Added

--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -74,7 +74,7 @@ in the Zulip organizations where you want to use it.
 
 To use the [BigBlueButton](https://bigbluebutton.org/) video call
 integration on a self-hosted Zulip installation, you'll need to have a
-BigBlueButton server and configure it:
+BigBlueButton server (version 2.4+) and configure it:
 
 1. Get the Shared Secret using the `bbb-conf --secret` command on your
    BigBlueButton Server. See also [the BigBlueButton

--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -90,14 +90,10 @@ supported by Zulip are:
 * [Zoom integration](/integrations/doc/zoom)
 * [BigBlueButton integration](/integrations/doc/big-blue-button)
 
-If you choose BigBlueButton as the call provider, there will be a single button
-(<i class="zulip-icon zulip-icon-video-call"></i>) for starting a call in the
-compose box. The call is initiated with cameras turned off.
-
 !!! tip ""
 
-    It is also possible to disable the video and voice call buttons for your organization
-    by setting the provider to "None".
+    You can disable the video and voice call buttons for your organization
+    by setting the **call provider** to "None".
 
 ### Change your organization's call provider
 

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 336  # Last bumped for data-original-content-type and data-transcoded-image
+API_FEATURE_LEVEL = 337  # Last bumped for voice_only param addition for BigBlueButton
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/compose_call.ts
+++ b/web/src/compose_call.ts
@@ -39,7 +39,9 @@ export function compute_show_audio_chat_button(): boolean {
             get_jitsi_server_url() !== null &&
             realm.realm_video_chat_provider === available_providers.jitsi_meet.id) ||
         (available_providers.zoom &&
-            realm.realm_video_chat_provider === available_providers.zoom.id)
+            realm.realm_video_chat_provider === available_providers.zoom.id) ||
+        (available_providers.big_blue_button &&
+            realm.realm_video_chat_provider === available_providers.big_blue_button.id)
     ) {
         return true;
     }

--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -120,19 +120,21 @@ export function generate_and_insert_audio_or_video_call_link(
         available_providers.big_blue_button &&
         realm.realm_video_chat_provider === available_providers.big_blue_button.id
     ) {
-        if (is_audio_call) {
-            // TODO: Add support for audio-only BigBlueButton calls here.
-            return;
-        }
         const meeting_name = get_recipient_label() + " meeting";
+        const request = {
+            meeting_name,
+            voice_only: is_audio_call,
+        };
         void channel.get({
             url: "/json/calls/bigbluebutton/create",
-            data: {
-                meeting_name,
-            },
+            data: request,
             success(response) {
                 const data = call_response_schema.parse(response);
-                insert_video_call_url(data.url, $target_textarea);
+                if (is_audio_call) {
+                    insert_audio_call_url(data.url, $target_textarea);
+                } else {
+                    insert_video_call_url(data.url, $target_textarea);
+                }
             },
         });
     } else {

--- a/web/tests/compose_video.test.cjs
+++ b/web/tests/compose_video.test.cjs
@@ -217,7 +217,7 @@ test("videos", ({override}) => {
         assert.match(syntax_to_insert, audio_link_regex);
     })();
 
-    (function test_bbb_video_link_compose_clicked() {
+    (function test_bbb_audio_and_video_links_compose_clicked() {
         let syntax_to_insert;
         let called = false;
 
@@ -237,7 +237,6 @@ test("videos", ({override}) => {
             called = true;
         });
 
-        const handler = $("body").get_on_handler("click", ".video_link");
         $("textarea#compose-textarea").val("");
 
         override(
@@ -254,15 +253,28 @@ test("videos", ({override}) => {
             options.success({
                 result: "success",
                 msg: "",
-                url: "/calls/bigbluebutton/join?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22",
+                url:
+                    "/calls/bigbluebutton/join?meeting_id=%22zulip-1%22&moderator=%22AAAAAAAAAA%22&lock_settings_disable_cam=" +
+                    options.data.voice_only +
+                    "&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22",
             });
         };
 
-        handler(ev);
+        $("textarea#compose-textarea").val("");
+
+        const video_handler = $("body").get_on_handler("click", ".video_link");
+        video_handler(ev);
         const video_link_regex =
-            /\[translated: Join video call\.]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&password=%22AAAAAAAAAA%22&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
+            /\[translated: Join video call\.]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&moderator=%22AAAAAAAAAA%22&lock_settings_disable_cam=false&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
+
+        const audio_handler = $("body").get_on_handler("click", ".audio_link");
+        audio_handler(ev);
+        const audio_link_regex =
+            /\[translated: Join voice call\.]\(\/calls\/bigbluebutton\/join\?meeting_id=%22zulip-1%22&moderator=%22AAAAAAAAAA%22&lock_settings_disable_cam=true&checksum=%2232702220bff2a22a44aee72e96cfdb4c4091752e%22\)/;
+        assert.ok(called);
+        assert.match(syntax_to_insert, audio_link_regex);
     })();
 });
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21864,8 +21864,14 @@ paths:
       summary: Create BigBlueButton video call
       description: |
         Create a video call URL for a BigBlueButton video call.
-        Requires [BigBlueButton](/integrations/doc/big-blue-button)
+        Requires [BigBlueButton 2.4+](/integrations/doc/big-blue-button)
         to be configured on the Zulip server.
+
+        The acting user will be given the moderator role on the call.
+
+        **Changes**: Prior to Zulip 10.0 (feature level 337), every
+        user was given the moderator role on BigBlueButton calls, via
+        encoding a moderator password in the generated URLs.
       parameters:
         - in: query
           name: meeting_name
@@ -21875,6 +21881,18 @@ paths:
           description: |
             Meeting name for the BigBlueButton video call.
           example: "test_channel meeting"
+        - in: query
+          name: voice_only
+          schema:
+            type: boolean
+          required: false
+          description: |
+            Configures whether the call is voice-only; if true,
+            disables cameras for all users. Only the call
+            creator/moderator can edit this configuration.
+
+            **Changes**: New in Zulip 10.0 (feature level 337).
+          example: true
       responses:
         "200":
           description: Success.


### PR DESCRIPTION
(This just fixes a couple conflicts that were unresolved in #27555)

We now allow users to create voice calls when their call provider is BigBlueButton. This is done by creating a call where cameras are disabled for all participants in the call -- a voice call, and making only the call creator the moderator, so no one else can switch a voice only call to a video call.

Also, we stop using the deprecated fields "attendeePW" and "moderatorPW" in the Big Blue Button API, and use "role" instead.

The side effects are that now we only support BigBlueButton 2.4 and above, and that only the call creator is a moderator and all other joinees are viewers for all BigBlueButton calls.

Fixes: #26550.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
