### PR TITLE
Web: Use Intl.ListFormat instead of .join(", ")

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -215,7 +215,7 @@ async function test_restore_private_message_draft_via_draft_overlay(page: Page):
     await common.pm_recipient.expect(page, `${cordelia_internal_email},${hamlet_internal_email}`);
     assert.strictEqual(
         await common.get_text_from_selector(page, "title"),
-        "Cordelia, Lear's daughter, King Hamlet - Zulip Dev - Zulip",
+        "Cordelia, Lear's daughter and King Hamlet - Zulip Dev - Zulip",
         "Didn't narrow to the direct messages with cordelia and hamlet",
     );
     await page.click("#compose_close");

--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -259,7 +259,7 @@ export function get_title_data(user_ids_string: string, is_group: boolean): Titl
     if (is_group) {
         // For groups, just return a string with recipient names.
         return {
-            first_line: people.get_recipients(user_ids_string),
+            first_line: people.format_recipients(user_ids_string, "long"),
             second_line: "",
             third_line: "",
         };

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -310,7 +310,7 @@ function format_dm(
     const context = {
         conversation_key: user_ids_string,
         is_direct: true,
-        rendered_dm_with: util.format_array_as_list(rendered_dm_with, "long", "conjunction"),
+        rendered_dm_with: util.format_array_as_list_with_conjuction(rendered_dm_with, "long"),
         is_group: recipient_ids.length > 1,
         user_circle_class,
         is_bot,
@@ -746,7 +746,7 @@ function row_in_search_results(keyword: string, text: string): boolean {
 
 function filter_should_hide_dm_row({dm_key}: {dm_key: string}): boolean {
     const recipients_string = people.get_recipients(dm_key);
-    const text = recipients_string.toLowerCase();
+    const text = recipients_string.join(",").toLowerCase();
 
     if (!row_in_search_results(search_keyword, text)) {
         return true;

--- a/web/src/narrow_title.ts
+++ b/web/src/narrow_title.ts
@@ -55,7 +55,7 @@ export function compute_narrow_title(filter?: Filter): string {
         const user_ids = people.emails_strings_to_user_ids_string(emails);
 
         if (user_ids !== undefined) {
-            return people.get_recipients(user_ids);
+            return people.format_recipients(user_ids, "long");
         }
         if (emails.includes(",")) {
             return $t({defaultMessage: "Invalid users"});

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -455,20 +455,31 @@ function _calc_user_and_other_ids(user_ids_string: string): {
     return {user_ids, other_ids};
 }
 
-export function get_recipients(user_ids_string: string): string {
+export function get_recipients(user_ids_string: string): string[] {
     // See message_store.get_pm_full_names() for a similar function.
 
     const {other_ids} = _calc_user_and_other_ids(user_ids_string);
 
     if (other_ids.length === 0) {
         // direct message with oneself
-        return my_full_name();
+        return [my_full_name()];
     }
 
     const names = get_display_full_names(other_ids);
     const sorted_names = names.sort(util.make_strcmp());
 
-    return sorted_names.join(", ");
+    return sorted_names;
+}
+
+export function format_recipients(
+    users_ids_string: string,
+    join_strategy: "long" | "narrow",
+): string {
+    const formatted_recipients_string = util.format_array_as_list_with_conjuction(
+        get_recipients(users_ids_string),
+        join_strategy,
+    );
+    return formatted_recipients_string;
 }
 
 export function pm_reply_user_string(message: Message | MessageWithBooleans): string | undefined {

--- a/web/src/pm_list_data.ts
+++ b/web/src/pm_list_data.ts
@@ -80,7 +80,7 @@ export function get_conversations(search_string = ""): DisplayObject[] {
 
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
         assert(reply_to !== undefined);
-        const recipients_string = people.get_recipients(user_ids_string);
+        const recipients_string = people.format_recipients(user_ids_string, "narrow");
 
         const num_unread = unread.num_unread_for_user_ids_string(user_ids_string);
         const has_unread_mention =

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -6,6 +6,7 @@ import * as typeahead from "../shared/src/typeahead.ts";
 import {$t} from "./i18n.ts";
 import * as pygments_data from "./pygments_data.ts";
 import type {realm_playground_schema} from "./state_data.ts";
+import * as util from "./util.ts";
 
 export type RealmPlayground = z.output<typeof realm_playground_schema>;
 
@@ -87,7 +88,8 @@ export function get_pygments_typeahead_list_for_settings(query: string): Map<str
     }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
-        language_labels.set(key, key + " (" + values.join(", ") + ")");
+        const formatted_string = util.format_array_as_list_with_conjuction(values, "narrow");
+        language_labels.set(key, key + " (" + formatted_string + ")");
     }
 
     return language_labels;

--- a/web/src/scheduled_messages_overlay_ui.ts
+++ b/web/src/scheduled_messages_overlay_ui.ts
@@ -114,7 +114,8 @@ function format(
                 is_empty_string_topic: msg.topic === "",
             };
         } else {
-            const recipients = people.get_recipients(msg.to.join(","));
+            const user_ids_string = msg.to.join(",");
+            const recipients = people.format_recipients(user_ids_string, "long");
             msg_render_context = {
                 ...msg,
                 is_stream: false as const,

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -441,6 +441,14 @@ export function format_array_as_list(
     return list_formatter.format(array);
 }
 
+export function format_array_as_list_with_conjuction(
+    array: string[],
+    // long uses "and", narrow uses commas.
+    join_strategy: "long" | "narrow",
+): string {
+    return format_array_as_list(array, join_strategy, "conjunction");
+}
+
 export function format_array_as_list_with_highlighted_elements(
     array: string[],
     style: Intl.ListFormatStyle,

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -189,7 +189,7 @@ test("title_data", ({override}) => {
     let is_group = true;
     const user_ids_string = "9999,1000";
     let expected_group_data = {
-        first_line: "Human Selma, Old User",
+        first_line: "Human Selma and Old User",
         second_line: "",
         third_line: "",
     };

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -522,11 +522,11 @@ test_people("pm_lookup_key", () => {
 test_people("get_recipients", () => {
     people.add_active_user(isaac);
     people.add_active_user(linus);
-    assert.equal(people.get_recipients("30"), "Me Myself");
-    assert.equal(people.get_recipients("30,32"), "Isaac Newton");
+    assert.deepEqual(people.get_recipients("30"), ["Me Myself"]);
+    assert.deepEqual(people.get_recipients("30,32"), ["Isaac Newton"]);
 
     muted_users.add_muted_user(304);
-    assert.equal(people.get_recipients("304,32"), "Isaac Newton, translated: Muted user");
+    assert.deepEqual(people.get_recipients("304,32"), ["Isaac Newton", "translated: Muted user"]);
 });
 
 test_people("get_full_name", () => {

--- a/web/tests/realm_playground.test.cjs
+++ b/web/tests/realm_playground.test.cjs
@@ -9,6 +9,7 @@ const {$t} = zrequire("i18n");
 const pygments_data = zrequire("pygments_data");
 const realm_playground = zrequire("realm_playground");
 const typeahead_helper = zrequire("typeahead_helper");
+const {initialize_user_settings} = zrequire("user_settings");
 
 run_test("get_pygments_typeahead_list_for_composebox", () => {
     // When no Code Playground is configured, the list of candidates should
@@ -45,6 +46,8 @@ run_test("get_pygments_typeahead_list_for_composebox", () => {
 });
 
 run_test("get_pygments_typeahead_list_for_settings", () => {
+    initialize_user_settings({user_settings: {}});
+
     const custom_pygment_language = "custom_lang";
     const playground_data = [
         {

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -372,6 +372,16 @@ run_test("format_array_as_list", () => {
         "<b>apple</b>, <b>banana</b>, and <b>orange</b>",
     );
 
+    // Conjunction format
+    assert.equal(
+        util.format_array_as_list_with_conjuction(array, "narrow"),
+        "apple, banana, orange",
+    );
+    assert.equal(
+        util.format_array_as_list_with_conjuction(array, "long"),
+        "apple, banana, and orange",
+    );
+
     // when Intl.ListFormat does not exist
     with_overrides(({override}) => {
         override(global.Intl, "ListFormat", undefined);
@@ -382,6 +392,15 @@ run_test("format_array_as_list", () => {
         assert.equal(
             util.format_array_as_list_with_highlighted_elements(array, "long", "conjunction"),
             "<b>apple</b>, <b>banana</b>, <b>orange</b>",
+        );
+
+        assert.equal(
+            util.format_array_as_list_with_conjuction(array, "narrow"),
+            "apple, banana, orange",
+        );
+        assert.equal(
+            util.format_array_as_list_with_conjuction(array, "long"),
+            "apple, banana, orange",
         );
     });
 });


### PR DESCRIPTION
This PR continues the work left in #28453. 

This PR brings internationalization by replacing the inconsistent .join(", ") with Intl.ListFormat for accurate and localized list formatting, using a common utility function.

**#28453 is correct and requires correctly rebasing it. The only thing that lacks is correct testing. The `format_array_as_list` function fails tests because the `get_pygments_typeahead_list_for_settings` test previously did not take `user_settings.default_language` into consideration, so I have added that as well.**

## Screenshots of the changes

![image](https://github.com/user-attachments/assets/c97a99e4-91c6-4a54-a688-86a3d944755e)

</br>

![image](https://github.com/user-attachments/assets/61526344-785b-4043-9b40-f159e3e454c8)

<br/>

## Tasks Completed

- [x] Files which were to be internationalized are using Intl.ListFormat.
- [x] Uses { style: "long", type: "conjunction" } could be changed according to use.
- [x] Add a fallback system for MacOs.
- [x] Refactor tests to test with the new changes.

Fixes: #26936 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>



