### PR TITLE
help: Update channel permissions links.

### DIFF
--- a/api_docs/roles-and-permissions.md
+++ b/api_docs/roles-and-permissions.md
@@ -75,9 +75,9 @@ event](/api/get-events#realm_user-add), and the
 
 Many areas of Zulip are customizable by the roles
 above, such as (but not limited to) [restricting message editing and
-deletion](/help/restrict-message-editing-and-deletion) and
-[channels permissions](/help/channel-permissions). The potential
-permission levels are:
+deletion](/help/restrict-message-editing-and-deletion) and various
+permissions for different [channel types](/help/channel-permissions).
+The potential permission levels are:
 
 * Everyone / Any user including Guests (least restrictive)
 

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -1600,7 +1600,7 @@ _Released 2022-06-21_
 - CVE-2022-31017: Fixed message edit event exposure in
   protected-history streams.
   Zulip allows a stream to be configured as [private with protected
-  history](https://zulip.com/help/channel-permissions#channel-privacy-settings),
+  history](https://zulip.com/help/channel-permissions#private-channels),
   which means that new subscribers should only see messages sent after
   they join. However, due to a logic bug in Zulip Server 2.1.0 through
   5.2, when a message was edited, the server would incorrectly send an
@@ -3303,7 +3303,7 @@ _Released 2018-11-07_
 - Users can now configure email and mobile push notifications for
   all messages in a stream (useful for low-traffic
   streams/organizations), not just for messages mentioning them.
-- New [stream settings](https://zulip.com/help/channel-permissions)
+- New [stream settings](https://zulip.com/help/channel-permissions#private-channels)
   control whether private stream subscribers can access history
   from before they joined, and allow configuring streams to only
   allow administrators to post.

--- a/docs/production/security-model.md
+++ b/docs/production/security-model.md
@@ -118,7 +118,8 @@ strength allowed is controlled by two settings in
     figure out whether a channel with that name exists, but cannot see any
     other details about the channel.
 
-  - See [Channel permissions](https://zulip.com/help/channel-permissions) for more details.
+  - See [channel types and permissions](https://zulip.com/help/channel-permissions)
+    for more details.
 
 - Zulip supports editing the content and topics of messages that have
   already been sent. As a general philosophy, our policies provide

--- a/help/change-the-channel-description.md
+++ b/help/change-the-channel-description.md
@@ -46,6 +46,12 @@ disabled. Use Markdown formatting to include a link to a website, Zulip
 
 {!automated-notice-channel-event.md!}
 
+## Related articles
+
+* [Rename a channel](/help/rename-a-channel)
+* [Markdown formatting][markdown-formatting]
+* [Channel permissions](/help/channel-permissions)
+
 [markdown-formatting]: /help/format-your-message-using-markdown
 [message-link]: /help/link-to-a-message-or-conversation#get-a-link-to-a-specific-message
 [topic-link]: /help/link-to-a-message-or-conversation#get-a-link-to-a-specific-topic

--- a/help/change-the-privacy-of-a-channel.md
+++ b/help/change-the-privacy-of-a-channel.md
@@ -4,7 +4,7 @@
 
 Channels can be [web-public](/help/public-access-option), public or private,
 and private channels can have shared or protected history.
-See [channel permissions](/help/channel-permissions) for
+See [channel types and permissions](/help/channel-permissions) for
 details on channel privacy settings.
 
 As an organization administrator, you can always make a public channel
@@ -51,3 +51,9 @@ public.
 
     **Warning**: Be careful making a private channel public. All past messages
     will become accessible, even if the channel previously had protected history.
+
+## Related articles
+
+* [Channel permissions](/help/channel-permissions)
+* [Channel posting policy](/help/channel-posting-policy)
+* [Configure who can administer a channel](/help/configure-who-can-administer-a-channel)

--- a/help/channel-posting-policy.md
+++ b/help/channel-posting-policy.md
@@ -2,10 +2,9 @@
 
 {!admin-only.md!}
 
-By default, anyone who belongs to a channel can also send messages to
-the channel. However, sometimes it's useful to have a channel (often a
-[default channel](/help/set-default-channels-for-new-users)) where only
-certain users can send messages.
+You can restrict who can send messages to a channel. For example,
+you can set up an announcement channel where only a specific
+[group](/help/user-groups) of users can send messages.
 
 {start_tabs}
 
@@ -22,3 +21,11 @@ certain users can send messages.
 {end_tabs}
 
 {!automated-notice-channel-event.md!}
+
+## Related articles
+
+* [Channel permissions](/help/channel-permissions)
+* [User roles](/help/user-roles)
+* [User groups](/help/user-groups)
+* [Set default channels for new users](/help/set-default-channels-for-new-users)
+* [Configure who can administer a channel](/help/configure-who-can-administer-a-channel)

--- a/help/configure-automated-notices.md
+++ b/help/configure-automated-notices.md
@@ -14,7 +14,7 @@ language](/help/change-your-language).
 
 Notices about channel settings changes, such as [name](/help/rename-a-channel),
 [description](/help/change-the-channel-description),
-[permission](/help/channel-permissions) and
+[privacy](/help/change-the-privacy-of-a-channel) and
 [policy](/help/channel-posting-policy) updates are sent to the
 “channel events” topic in the channel that was modified.
 

--- a/help/configure-who-can-administer-a-channel.md
+++ b/help/configure-who-can-administer-a-channel.md
@@ -39,4 +39,8 @@ channel permissions.
 ## Related articles
 
 * [Channel permissions](/help/channel-permissions)
+* [User roles](/help/user-roles)
+* [User groups](/help/user-groups)
+* [Channel posting policy](/help/channel-posting-policy)
 * [Configure who can unsubscribe other users from a channel](/help/configure-who-can-unsubscribe-others)
+* [Archive a channel](/help/archive-a-channel)

--- a/help/configure-who-can-create-channels.md
+++ b/help/configure-who-can-create-channels.md
@@ -48,5 +48,7 @@ unadvertised web-public channel in a legitimate organization.
 
 ## Related articles
 
-* [Create a channel](/help/create-a-channel)
+* [Channel permissions](/help/channel-permissions)
 * [User roles](/help/user-roles)
+* [Create a channel](/help/create-a-channel)
+* [Introduction to channels](/help/introduction-to-channels)

--- a/help/configure-who-can-invite-to-channels.md
+++ b/help/configure-who-can-invite-to-channels.md
@@ -14,5 +14,8 @@
 
 ## Related articles
 
+* [Channel permissions](/help/channel-permissions)
+* [User roles](/help/user-roles)
+* [User groups](/help/user-groups)
 * [Configure who can unsubscribe other users from a channel](/help/configure-who-can-unsubscribe-others)
 * [Add or remove users from a channel](/help/add-or-remove-users-from-a-channel)

--- a/help/configure-who-can-unsubscribe-others.md
+++ b/help/configure-who-can-unsubscribe-others.md
@@ -24,6 +24,9 @@ Organization administrators can unsubscribe other users from any channel.
 
 ## Related articles
 
-* [Restrict who can subscribe other users to
-  channels](/help/configure-who-can-invite-to-channels)
+* [Channel permissions](/help/channel-permissions)
+* [User roles](/help/user-roles)
+* [User groups](/help/user-groups)
+* [Configure who can administer a channel](/help/configure-who-can-administer-a-channel)
+* [Restrict who can subscribe other users to channels](/help/configure-who-can-invite-to-channels)
 * [Add or remove users from a channel](/help/add-or-remove-users-from-a-channel)

--- a/help/configure-who-can-unsubscribe-others.md
+++ b/help/configure-who-can-unsubscribe-others.md
@@ -16,7 +16,7 @@ Organization administrators can unsubscribe other users from any channel.
 {!select-channel-view-general.md!}
 
 1. Under **Channel permissions**, configure **Who can unsubscribe others from
-   this channel**
+   this channel**.
 
 {!save-changes.md!}
 

--- a/help/configure-who-can-unsubscribe-others.md
+++ b/help/configure-who-can-unsubscribe-others.md
@@ -1,9 +1,9 @@
 # Configure who can unsubscribe other users from a channel
 
-If you have permission to administer a public channel, you can configure who
-can unsubscribe other users from it. For [private](/help/channel-permissions)
-channels, you additionally need to be a subscriber in order to change this
-configuration.
+If you have permission to administer a public channel, you can configure
+who can unsubscribe other users from it. For [private
+channels](/help/channel-permissions#private-channels), you additionally
+need to be a subscriber in order to change this configuration.
 
 Organization administrators can unsubscribe other users from any channel.
 

--- a/help/export-your-organization.md
+++ b/help/export-your-organization.md
@@ -13,14 +13,14 @@ available for all Zulip organizations:
 * [**Export of public
    data**](#export-for-migrating-to-zulip-cloud-or-a-self-hosted-server):
    Complete data for your organization *other than* [private
-   channel](/help/channel-permissions) messages and [direct
+   channel](/help/channel-permissions#private-channels) messages and [direct
    messages](/help/direct-messages). This export includes user settings and
    channel subscriptions.
 
 * [**Standard
   export**](#export-for-migrating-to-zulip-cloud-or-a-self-hosted-server):
   Everything in the export of public data, plus all the [private
-  channel](/help/channel-permissions) messages and [direct
+  channel](/help/channel-permissions#private-channels) messages and [direct
   messages](/help/direct-messages) that members who have
   [allowed](#configure-whether-administrators-can-export-your-private-data)
   administrators to export their private data can access.

--- a/help/manage-permissions.md
+++ b/help/manage-permissions.md
@@ -6,8 +6,8 @@ User groups offer a flexible way to manage permissions.
 
 !!! tip ""
 
-    Learn about [channel permissions](/help/channel-permissions), including
-    **public** and **private** channels.
+    Learn about channel [types and permissions](/help/channel-permissions),
+    including **public** and **private** channels.
 
 ## Manage organization permissions
 

--- a/help/rename-a-channel.md
+++ b/help/rename-a-channel.md
@@ -39,3 +39,8 @@ and Unicode emoji.
 {end_tabs}
 
 {!automated-notice-channel-event.md!}
+
+## Related articles
+
+* [Change a channel's description](/help/change-the-channel-description)
+* [Channel permissions](/help/channel-permissions)

--- a/help/set-default-channels-for-new-users.md
+++ b/help/set-default-channels-for-new-users.md
@@ -27,3 +27,10 @@ that default set.
 2. Find the channel you would like to remove, and click **Remove from default**.
 
 {end_tabs}
+
+## Related articles
+
+* [User roles](/help/user-roles)
+* [User groups](/help/user-groups)
+* [Channel permissions](/help/channel-permissions)
+* [Create channels for a new organization](/help/create-channels)

--- a/web/templates/start_export_modal.hbs
+++ b/web/templates/start_export_modal.hbs
@@ -4,7 +4,7 @@
         A public data export is a complete data export for your organization other than
         <z-private-channel-link>private channel</z-private-channel-link> messages and
         <z-direct-messages-link>direct messages</z-direct-messages-link>.
-        {{#*inline "z-private-channel-link"}}<a href="/help/channel-permissions" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+        {{#*inline "z-private-channel-link"}}<a href="/help/channel-permissions#private-channels" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
         {{#*inline "z-direct-messages-link"}}<a href="/help/direct-messages" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
     {{/tr}}
 </p>

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8566,7 +8566,7 @@ paths:
                           a target message ID of `first_message_id_allowed_to_move`, if the user
                           desires to move only the portion of the topic that they can.
 
-                          Note that in a channel with [protected history](/help/channel-permissions),
+                          Note that in a [private channel with protected history][private-channels],
                           the Zulip security model requires that the above calculations only include
                           messages the acting user has access to. So in the rare case of a user
                           attempting to move a topic that started before the user joined a private
@@ -8575,6 +8575,8 @@ paths:
                           dialog.
 
                           **Changes**: New in Zulip 7.0 (feature level 172).
+
+                          [private-channels]: /help/channel-permissions#private-channels
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
                       - example:
@@ -10049,12 +10051,13 @@ paths:
       description: |
         Get all topics the user has access to in a specific channel.
 
-        Note that for private channels with [protected
-        history](/help/channel-permissions), the user will only have access to
-        topics of messages sent after they [subscribed to](/api/subscribe) the
-        channel. Similarly, a user's [bot](/help/bots-overview#bot-type)
-        will only have access to messages sent after the bot was subscribed to
-        the channel, instead of when the user subscribed.
+        Note that for [private channels with
+        protected history](/help/channel-permissions#private-channels),
+        the user will only have access to topics of messages sent after they
+        [subscribed to](/api/subscribe) the channel. Similarly, a user's
+        [bot](/help/bots-overview#bot-type) will only have access to messages
+        sent after the bot was subscribed to the channel, instead of when the
+        user subscribed.
       parameters:
         - $ref: "#/components/parameters/ChannelIdInPath"
       responses:
@@ -10212,7 +10215,8 @@ paths:
         by the optional parameters, like `invite_only`, detailed below.
 
         Note that the ability to subscribe oneself and/or other users to a specified
-        channel depends on the [channel's privacy settings](/help/channel-permissions).
+        channel depends on the [channel's type: private, public, or
+        web-public](/help/channel-permissions).
 
         **Changes**: Before Zulip 8.0 (feature level 208), if a user
         specified by the [`principals`][principals-param] parameter was
@@ -20042,8 +20046,8 @@ paths:
                     newly subscribed members, or users can only access messages
                     they actually received while subscribed to the channel.
 
-                    Corresponds to the [shared history](/help/channel-permissions)
-                    option in documentation.
+                    Corresponds to the shared history option for
+                    [private channels](/help/channel-permissions#private-channels).
 
                     It's an error for this parameter to be false for a public or
                     web-public channel and when is_private is false.
@@ -24631,8 +24635,8 @@ components:
         newly subscribed members, or users can only access messages
         they actually received while subscribed to the channel.
 
-        Corresponds to the [shared history](/help/channel-permissions)
-        option in documentation.
+        Corresponds to the shared history option for
+        [private channels](/help/channel-permissions#private-channels).
       type: boolean
       example: false
     Principals:


### PR DESCRIPTION
Follow-up task from #32709:

> - Go through the channel management section and adjust Related articles links as needed.
> - Go through git grep "help/channel-permissions" outside of /help/ and /templates/corporate/ and see if anything needs to be adjusted. In particular, we may want to link anchor tags (e.g., /help/channel-permissions#private-channels) in some places.

**Notes**:
- Changed some descriptive text for links to `help/channel-permissions` as well as the noted tasks above.

---

**Screenshots and screen captures:**

*Updates that didn't change the content of the page, e.g. the link changed from `channel-permissions` to `channel-permissions#private-channels` are not shown below.*

<details>
<summary>Manage permissions</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/manage-permissions)
![Screenshot from 2025-01-02 18-52-37](https://github.com/user-attachments/assets/5812efdf-abc1-4231-abf1-ee6eca7d822f)
</details>
<details>
<summary>Set default channels for new users</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/set-default-channels-for-new-users)
![Screenshot from 2025-01-02 18-52-03](https://github.com/user-attachments/assets/b1cc4073-d500-48f8-9ff3-0357cb8abd92)
</details>
<details>
<summary>Rename a channel</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/rename-a-channel)
![Screenshot from 2025-01-02 18-51-50](https://github.com/user-attachments/assets/c5187d2a-d0e9-4a74-9c28-2a2d4ad15d57)
</details>
<details>
<summary>Configure who can unsubscribe</summary>

[CURRENT CZO DOCUMENTATION](https://chat.zulip.org/help/configure-who-can-unsubscribe-others)
![Screenshot from 2025-01-02 18-51-32](https://github.com/user-attachments/assets/1a135adb-90f5-4969-875d-4c24826f513f)
</details>
<details>
<summary>Restrict who can subscribe</summary>

[CURRENT CZO DOCUMENTATION](https://chat.zulip.org/help/configure-who-can-invite-to-channels)
![Screenshot from 2025-01-02 18-51-16](https://github.com/user-attachments/assets/52db2e3f-9743-4997-b7fa-6f9ed02ad199)
</details>
<details>
<summary>Restrict channel creation</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/configure-who-can-create-channels)
![Screenshot from 2025-01-02 18-51-02](https://github.com/user-attachments/assets/a8043b7e-1af3-41a0-b534-6417357736d1)
</details>
<details>
<summary>Configure who can administer a channel</summary>

[CURRENT CZO DOCUMENTATION](https://chat.zulip.org/help/configure-who-can-administer-a-channel)
![Screenshot from 2025-01-02 18-50-40](https://github.com/user-attachments/assets/c01eb10b-ddcf-42d2-a918-368de8b5a08b)
</details>
<details>
<summary>Configure automated notices</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/configure-automated-notices)
![Screenshot from 2025-01-02 18-50-21](https://github.com/user-attachments/assets/6672e8da-d7ba-4d2c-8803-6df008bdd68b)
</details>
<details>
<summary>Channel posting policy</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/channel-posting-policy)
![Screenshot from 2025-01-02 18-49-26](https://github.com/user-attachments/assets/68b8d9ee-a476-49b3-bbc3-578edf44e356)
</details>
<details>
<summary>Change the privacy of a channel</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/change-the-privacy-of-a-channel)
![Screenshot from 2025-01-02 18-49-07](https://github.com/user-attachments/assets/93136a20-bbf6-4e1c-995f-60d5262bf47c)
</details>
<details>
<summary>Change a channel's description</summary>

[CURRENT DOCUMENTATION](https://zulip.com/help/change-the-channel-description)
![Screenshot from 2025-01-02 18-48-48](https://github.com/user-attachments/assets/f33ed42c-92d1-4fbe-8253-629839bba127)
</details>

<details>
<summary>API docs changes</summary>

### history_public_to_subscribers parameter for update a channel - [CURRENT](https://zulip.com/api/update-stream#parameter-history_public_to_subscribers)
![Screenshot from 2025-01-02 18-39-30](https://github.com/user-attachments/assets/4fc5feb6-3a2a-4d33-b783-a09cd9d1cd2b)
### Subscribe to a channel main description - [CURRENT](https://zulip.com/api/subscribe)
![Screenshot from 2025-01-02 18-37-38](https://github.com/user-attachments/assets/c425ce08-ac12-473c-b87e-0c063788e752)
### history_public_to_subscribers parameter for subscribe to channel - [CURRENT](https://zulip.com/api/subscribe#parameter-history_public_to_subscribers)
![Screenshot from 2025-01-02 18-40-49](https://github.com/user-attachments/assets/3eec83a6-95d0-4dc2-a7ff-e9dbccff0c43)
### Get topics in a channel - [CURRENT](https://zulip.com/api/get-stream-topics)
![Screenshot from 2025-01-02 18-37-03](https://github.com/user-attachments/assets/d76ef5d6-29d7-4b42-8e90-f7372434313a)
### Edit message error response text - [CURRENT](https://zulip.com/api/update-message#response)
![Screenshot from 2025-01-02 18-36-23](https://github.com/user-attachments/assets/38f819d1-9346-41e4-89bb-0a596a408492)
### Roles and permissions - [CURRENT](https://zulip.com/api/roles-and-permissions#permission-levels)
![Screenshot from 2025-01-02 18-34-21](https://github.com/user-attachments/assets/67e28498-ec0f-4bd5-9e54-6b698751045f)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
