### PR TITLE
code_block: Exclude 🔥 emoji alias for mojo.

### DIFF
--- a/tools/setup/build_pygments_data
+++ b/tools/setup/build_pygments_data
@@ -15,6 +15,7 @@ with open(DATA_PATH) as f:
         **pygments_data["default"], **pygments_data["custom"], **pygments_data["aliases"]
     )
 
+excluded_aliases = {"🔥"}
 lexers = get_all_lexers()
 langs = {
     alias: {
@@ -23,6 +24,7 @@ langs = {
     }
     for longname, aliases, filename_patterns, mimetypes in lexers
     for alias in aliases
+    if alias not in excluded_aliases
 }
 
 langs |= {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/Code.20block.20for.20.F0.9F.94.A5.28Mojo.29.20doesn't.20work/near/2024596

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before                                                                                                     | After                                                                                                      |
|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
| ![Before Image](https://github.com/user-attachments/assets/5401aafc-2020-43ba-9a00-cd42387cfeac)          | ![After Image](https://github.com/user-attachments/assets/3f2a1fbd-0730-4030-9a99-66b04fbe35b9)           |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
