### PR TITLE
message_send: Fix stream still inactive after sending message.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -99,7 +99,12 @@ from zerver.models.groups import SystemGroups
 from zerver.models.recipients import get_direct_message_group_user_ids
 from zerver.models.scheduled_jobs import NotificationTriggers
 from zerver.models.streams import get_stream, get_stream_by_id_in_realm
-from zerver.models.users import get_system_bot, get_user_by_delivery_email, is_cross_realm_bot_email
+from zerver.models.users import (
+    active_user_ids,
+    get_system_bot,
+    get_user_by_delivery_email,
+    is_cross_realm_bot_email,
+)
 from zerver.tornado.django_api import send_event_on_commit
 
 
@@ -1170,6 +1175,18 @@ def do_send_messages(
             if not send_request.stream.is_recently_active:
                 send_request.stream.is_recently_active = True
                 stream_update_fields.append("is_recently_active")
+                stream_update_event = dict(
+                    type="stream",
+                    op="update",
+                    property="is_recently_active",
+                    value=True,
+                    stream_id=send_request.stream.id,
+                    name=send_request.stream.name,
+                )
+                send_event_on_commit(
+                    send_request.realm, stream_update_event, active_user_ids(send_request.realm.id)
+                )
+
             if len(stream_update_fields) > 0:
                 send_request.stream.save(update_fields=stream_update_fields)
 


### PR DESCRIPTION
We updated the stream property but forgot to inform the client.

Tested by marking a stream inactive in db shell and then checking if sending a message live updated it to become active.