### PR TITLE
Fix buggy move messages count problem.

### DIFF
--- a/web/src/message_list_data.ts
+++ b/web/src/message_list_data.ts
@@ -99,6 +99,12 @@ export class MessageListData {
         return this._items;
     }
 
+    // Callers asking what this view has loaded, rather than what it
+    // displays, want this one; muting only hides messages.
+    all_messages_including_muted(): Message[] {
+        return this._all_items;
+    }
+
     num_items(): number {
         return this._items.length;
     }

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -81,6 +81,10 @@ export function get_count_of_messages_in_topic_sent_after_current_message(
     return all_messages.filter((msg) => msg.id >= message_id).length;
 }
 
+export function get_count_of_messages_in_topic(stream_id: number, topic: string): number {
+    return get_loaded_messages_in_topic(stream_id, topic).length;
+}
+
 export function get_loaded_messages_in_topic(stream_id: number, topic: string): Message[] {
     return recent_view_messages_data
         .all_messages_after_mute_filtering()

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -72,17 +72,60 @@ export function do_unread_count_updates(messages: Message[], expect_no_new_unrea
     }
 }
 
-export function get_count_of_messages_in_topic_sent_after_current_message(
+export function get_count_of_loaded_messages_in_view_sent_after_current_message(
     stream_id: number,
     topic: string,
     message_id: number,
 ): number {
-    const all_messages = get_loaded_messages_in_topic(stream_id, topic);
-    return all_messages.filter((msg) => msg.id >= message_id).length;
+    const loaded_messages_in_current_view = get_loaded_messages_in_view_currently_focused(
+        stream_id,
+        topic,
+    );
+    let count = loaded_messages_in_current_view.filter((msg) => msg.id >= message_id).length;
+
+    if (count === 0) {
+        // If we have no messages in the view, we should check if we have
+        // messages in the all_messages_data store.
+        const loaded_messages_in_topic_in_current_view = get_loaded_messages_in_topic(
+            stream_id,
+            topic,
+        );
+        count = loaded_messages_in_topic_in_current_view.filter(
+            (msg) => msg.id >= message_id,
+        ).length;
+    }
+    return count;
 }
 
-export function get_count_of_messages_in_topic(stream_id: number, topic: string): number {
-    return get_loaded_messages_in_topic(stream_id, topic).length;
+export function get_count_of_loaded_messages_in_view_currently_focused(
+    stream_id: number,
+    topic: string,
+): number {
+    let count = get_loaded_messages_in_view_currently_focused(stream_id, topic).length;
+    if (count === 0) {
+        // If we have no messages in the view, we should check if we have
+        // messages in the all_messages_data store.
+        count = get_loaded_messages_in_topic(stream_id, topic).length;
+    }
+    return count;
+}
+
+export function get_loaded_messages_in_view_currently_focused(
+    stream_id: number,
+    topic: string,
+): Message[] {
+    const loaded_messages_in_all_messages = message_lists.current?.all_messages();
+
+    if (!loaded_messages_in_all_messages) {
+        return [];
+    }
+
+    return loaded_messages_in_all_messages.filter(
+        (x) =>
+            x.type === "stream" &&
+            x.stream_id === stream_id &&
+            x.topic.toLowerCase() === topic.toLowerCase(),
+    );
 }
 
 export function get_loaded_messages_in_topic(stream_id: number, topic: string): Message[] {

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -12,6 +12,7 @@ import {realm} from "./state_data.ts";
 import * as unread from "./unread.ts";
 import * as unread_ui from "./unread_ui.ts";
 import * as user_groups from "./user_groups.ts";
+import * as util from "./util.ts";
 
 type DirectMessagePermissionHints = {
     is_known_empty_conversation: boolean;
@@ -72,24 +73,42 @@ export function do_unread_count_updates(messages: Message[], expect_no_new_unrea
     }
 }
 
-export function get_count_of_messages_in_topic_sent_after_current_message(
-    stream_id: number,
-    topic: string,
-    message_id: number,
-): number {
-    const all_messages = get_loaded_messages_in_topic(stream_id, topic);
-    return all_messages.filter((msg) => msg.id >= message_id).length;
+function is_message_in_topic(message: Message, stream_id: number, topic: string): boolean {
+    return (
+        message.type === "stream" &&
+        message.stream_id === stream_id &&
+        util.lower_same(message.topic, topic)
+    );
 }
 
+// Returns the messages in the topic that the current message list has
+// loaded. It can see the whole history that list has fetched, but it
+// only describes the topic if that list contains all of it, which is a
+// question about the list's filter that callers answer for themselves.
+export function get_loaded_messages_in_topic_in_current_view(
+    stream_id: number,
+    topic: string,
+): Message[] {
+    if (message_lists.current === undefined) {
+        // Views rendered without a message list, such as the inbox and
+        // recent conversations, have no messages of their own.
+        return [];
+    }
+
+    // Muting only hides messages from the view; a move still moves them.
+    return message_lists.current.data
+        .all_messages_including_muted()
+        .filter((message) => is_message_in_topic(message, stream_id, topic));
+}
+
+// Returns the messages in the topic that are cached for recent
+// conversations. This works whatever view we are in, but the cache
+// holds only the newest slice of history, so it can be missing older
+// messages of a topic that has not been active recently.
 export function get_loaded_messages_in_topic(stream_id: number, topic: string): Message[] {
     return recent_view_messages_data
         .all_messages_after_mute_filtering()
-        .filter(
-            (x) =>
-                x.type === "stream" &&
-                x.stream_id === stream_id &&
-                x.topic.toLowerCase() === topic.toLowerCase(),
-        );
+        .filter((message) => is_message_in_topic(message, stream_id, topic));
 }
 
 export function get_messages_in_dm_conversations(user_ids_strings: Set<string>): Message[] {

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -375,6 +375,87 @@ async function get_message_placement_in_conversation(
     );
 }
 
+// The following logic is correct only when
+// both message_lists.current.data.fetch_status.has_found_newest
+// and message_lists.current.data.fetch_status.has_found_oldest are true;
+// otherwise, we cannot be certain of the correct count.
+export function get_count_of_messages_to_be_moved(
+    selected_option: string,
+    current_stream_id: number,
+    topic_name: string,
+    message_id?: number,
+): number {
+    if (selected_option === "change_one") {
+        return 1;
+    }
+    if (selected_option === "change_later" && message_id !== undefined) {
+        return message_util.get_count_of_messages_in_topic_sent_after_current_message(
+            current_stream_id,
+            topic_name,
+            message_id,
+        );
+    }
+    return message_util.get_count_of_messages_in_topic(current_stream_id, topic_name);
+}
+
+export function update_move_messages_count_text(
+    selected_option: string,
+    current_stream_id: number,
+    topic_name: string,
+    message_id?: number,
+): void {
+    let exact_message_count = false;
+    if (selected_option === "change_one") {
+        exact_message_count = true;
+    } else {
+        const is_topic_narrowed = narrow_state.narrowed_by_topic_reply();
+        const is_stream_narrowed = narrow_state.narrowed_by_stream_reply();
+        const is_same_stream = narrow_state.stream_id() === current_stream_id;
+        const is_same_topic = narrow_state.topic() === topic_name;
+
+        const can_have_exact_count_in_narrow =
+            (is_stream_narrowed && is_same_stream) ||
+            (is_topic_narrowed && is_same_stream && is_same_topic);
+        if (can_have_exact_count_in_narrow) {
+            const has_found_newest = message_lists.current?.data.fetch_status.has_found_newest();
+            const has_found_oldest = message_lists.current?.data.fetch_status.has_found_oldest();
+
+            if (selected_option === "change_later" && has_found_newest) {
+                exact_message_count = true;
+            }
+            if (selected_option === "change_all" && has_found_newest && has_found_oldest) {
+                exact_message_count = true;
+            }
+        }
+    }
+
+    const message_move_count = get_count_of_messages_to_be_moved(
+        selected_option,
+        current_stream_id,
+        topic_name,
+        message_id,
+    );
+    let message_text;
+    if (exact_message_count) {
+        message_text = $t(
+            {
+                defaultMessage:
+                    "{count, plural, one {# message} other {# messages}} will be moved.",
+            },
+            {count: message_move_count},
+        );
+    } else {
+        message_text = $t(
+            {
+                defaultMessage: "{count}+ messages will be moved.",
+            },
+            {count: message_move_count},
+        );
+    }
+
+    $("#move_messages_count").text(message_text);
+}
+
 export async function build_move_topic_to_stream_popover(
     current_stream_id: number,
     topic_name: string,
@@ -981,74 +1062,6 @@ export async function build_move_topic_to_stream_popover(
         }
     }
 
-    // The following logic is correct only when
-    // both message_lists.current.data.fetch_status.has_found_newest
-    // and message_lists.current.data.fetch_status.has_found_oldest are true;
-    // otherwise, we cannot be certain of the correct count.
-    function get_count_of_messages_to_be_moved(
-        selected_option: string,
-        message_id?: number,
-    ): number {
-        if (selected_option === "change_one") {
-            return 1;
-        }
-        if (selected_option === "change_later" && message_id !== undefined) {
-            return message_util.get_count_of_messages_in_topic_sent_after_current_message(
-                current_stream_id,
-                topic_name,
-                message_id,
-            );
-        }
-        return message_util.get_loaded_messages_in_topic(current_stream_id, topic_name).length;
-    }
-
-    function update_move_messages_count_text(selected_option: string, message_id?: number): void {
-        const message_move_count = get_count_of_messages_to_be_moved(selected_option, message_id);
-        const is_topic_narrowed = narrow_state.narrowed_by_topic_reply();
-        const is_stream_narrowed = narrow_state.narrowed_by_stream_reply();
-        const is_same_stream = narrow_state.stream_id() === current_stream_id;
-        const is_same_topic = narrow_state.topic() === topic_name;
-
-        const can_have_exact_count_in_narrow =
-            (is_stream_narrowed && is_same_stream) ||
-            (is_topic_narrowed && is_same_stream && is_same_topic);
-        let exact_message_count = false;
-        if (selected_option === "change_one") {
-            exact_message_count = true;
-        } else if (can_have_exact_count_in_narrow) {
-            const has_found_newest = message_lists.current?.data.fetch_status.has_found_newest();
-            const has_found_oldest = message_lists.current?.data.fetch_status.has_found_oldest();
-
-            if (selected_option === "change_later" && has_found_newest) {
-                exact_message_count = true;
-            }
-            if (selected_option === "change_all" && has_found_newest && has_found_oldest) {
-                exact_message_count = true;
-            }
-        }
-
-        let message_text;
-        if (exact_message_count) {
-            message_text = $t(
-                {
-                    defaultMessage:
-                        "{count, plural, one {# message} other {# messages}} will be moved.",
-                },
-                {count: message_move_count},
-            );
-        } else {
-            message_text = $t(
-                {
-                    defaultMessage:
-                        "At least {count, plural, one {# message} other {# messages}} will be moved.",
-                },
-                {count: message_move_count},
-            );
-        }
-
-        $("#move_messages_count").text(message_text);
-    }
-
     function update_topic_input_placeholder(): void {
         const $topic_not_mandatory_placeholder = $(".move-topic-new-topic-placeholder");
         const $topic_input = $<HTMLInputElement>("#move_topic_form input.move_messages_edit_topic");
@@ -1200,7 +1213,7 @@ export async function build_move_topic_to_stream_popover(
         update_topic_input_placeholder();
 
         if (!args.from_message_actions_popover) {
-            update_move_messages_count_text("change_all");
+            update_move_messages_count_text("change_all", current_stream_id, topic_name);
         } else {
             // Generate unique key for this conversation
             const conversation_key = `${current_stream_id}_${topic_name}`;
@@ -1217,14 +1230,24 @@ export async function build_move_topic_to_stream_popover(
                 $("#message_move_select_options").val(selected_option);
             }
 
-            update_move_messages_count_text(selected_option, message?.id);
+            update_move_messages_count_text(
+                selected_option,
+                current_stream_id,
+                topic_name,
+                message?.id,
+            );
 
             $("#message_move_select_options").on("change", function () {
                 selected_option = String($(this).val());
                 last_propagate_mode_for_conversation.set(conversation_key, selected_option);
                 void warn_unsubscribed_participants(selected_option);
                 maybe_show_topic_already_exists_warning();
-                update_move_messages_count_text(selected_option, message?.id);
+                update_move_messages_count_text(
+                    selected_option,
+                    current_stream_id,
+                    topic_name,
+                    message?.id,
+                );
             });
         }
         disable_topic_input_if_topics_are_disabled_in_channel(current_stream_id);

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -389,13 +389,16 @@ export function get_count_of_messages_to_be_moved(
         return 1;
     }
     if (selected_option === "change_later" && message_id !== undefined) {
-        return message_util.get_count_of_messages_in_topic_sent_after_current_message(
+        return message_util.get_count_of_loaded_messages_in_view_sent_after_current_message(
             current_stream_id,
             topic_name,
             message_id,
         );
     }
-    return message_util.get_count_of_messages_in_topic(current_stream_id, topic_name);
+    return message_util.get_count_of_loaded_messages_in_view_currently_focused(
+        current_stream_id,
+        topic_name,
+    );
 }
 
 export function update_move_messages_count_text(

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -52,7 +52,11 @@ import * as util from "./util.ts";
 // that pop up from the left sidebar.
 let stream_widget_value: number | undefined;
 let move_topic_to_stream_topic_typeahead: Typeahead<string> | undefined;
-const last_propagate_mode_for_conversation = new Map<string, string>();
+
+const propagate_mode_schema = z.enum(["change_one", "change_later", "change_all"]);
+type PropagateMode = z.infer<typeof propagate_mode_schema>;
+
+const last_propagate_mode_for_conversation = new Map<string, PropagateMode>();
 
 export function stream_sidebar_menu_handle_keyboard(key: string): void {
     if (popover_menus.is_color_picker_popover_displayed()) {
@@ -376,6 +380,89 @@ async function get_message_placement_in_conversation(
     );
 }
 
+// The following logic is correct only when
+// both message_lists.current.data.fetch_status.has_found_newest
+// and message_lists.current.data.fetch_status.has_found_oldest are true;
+// otherwise, we cannot be certain of the correct count.
+export function get_count_of_messages_to_be_moved(
+    selected_option: PropagateMode,
+    current_stream_id: number,
+    topic_name: string,
+    message_id?: number,
+): number {
+    if (selected_option === "change_one") {
+        return 1;
+    }
+    if (selected_option === "change_later") {
+        // Only the message actions popover offers this option, and it
+        // always knows which message the user selected.
+        assert(message_id !== undefined);
+        return message_util.get_count_of_messages_in_topic_sent_after_current_message(
+            current_stream_id,
+            topic_name,
+            message_id,
+        );
+    }
+    return message_util.get_loaded_messages_in_topic(current_stream_id, topic_name).length;
+}
+
+export function update_move_messages_count_text(
+    selected_option: PropagateMode,
+    current_stream_id: number,
+    topic_name: string,
+    message_id?: number,
+): void {
+    const message_move_count = get_count_of_messages_to_be_moved(
+        selected_option,
+        current_stream_id,
+        topic_name,
+        message_id,
+    );
+    const is_topic_narrowed = narrow_state.narrowed_by_topic_reply();
+    const is_stream_narrowed = narrow_state.narrowed_by_stream_reply();
+    const is_same_stream = narrow_state.stream_id() === current_stream_id;
+    const is_same_topic = narrow_state.topic() === topic_name;
+
+    const can_have_exact_count_in_narrow =
+        (is_stream_narrowed && is_same_stream) ||
+        (is_topic_narrowed && is_same_stream && is_same_topic);
+    let exact_message_count = false;
+    if (selected_option === "change_one") {
+        exact_message_count = true;
+    } else if (can_have_exact_count_in_narrow) {
+        const has_found_newest = message_lists.current?.data.fetch_status.has_found_newest();
+        const has_found_oldest = message_lists.current?.data.fetch_status.has_found_oldest();
+
+        if (selected_option === "change_later" && has_found_newest) {
+            exact_message_count = true;
+        }
+        if (selected_option === "change_all" && has_found_newest && has_found_oldest) {
+            exact_message_count = true;
+        }
+    }
+
+    let message_text;
+    if (exact_message_count) {
+        message_text = $t(
+            {
+                defaultMessage:
+                    "{count, plural, one {# message} other {# messages}} will be moved.",
+            },
+            {count: message_move_count},
+        );
+    } else {
+        message_text = $t(
+            {
+                defaultMessage:
+                    "At least {count, plural, one {# message} other {# messages}} will be moved.",
+            },
+            {count: message_move_count},
+        );
+    }
+
+    $("#move_messages_count").text(message_text);
+}
+
 export async function build_move_topic_to_stream_popover(
     current_stream_id: number,
     topic_name: string,
@@ -502,7 +589,7 @@ export async function build_move_topic_to_stream_popover(
         current_stream_id: z.string(),
         new_topic_name: z.optional(z.string()),
         old_topic_name: z.string(),
-        propagate_mode: z.optional(z.enum(["change_one", "change_later", "change_all"])),
+        propagate_mode: z.optional(propagate_mode_schema),
         send_notification_to_new_thread: z.optional(z.literal("on")),
         send_notification_to_old_thread: z.optional(z.literal("on")),
     });
@@ -982,74 +1069,6 @@ export async function build_move_topic_to_stream_popover(
         }
     }
 
-    // The following logic is correct only when
-    // both message_lists.current.data.fetch_status.has_found_newest
-    // and message_lists.current.data.fetch_status.has_found_oldest are true;
-    // otherwise, we cannot be certain of the correct count.
-    function get_count_of_messages_to_be_moved(
-        selected_option: string,
-        message_id?: number,
-    ): number {
-        if (selected_option === "change_one") {
-            return 1;
-        }
-        if (selected_option === "change_later" && message_id !== undefined) {
-            return message_util.get_count_of_messages_in_topic_sent_after_current_message(
-                current_stream_id,
-                topic_name,
-                message_id,
-            );
-        }
-        return message_util.get_loaded_messages_in_topic(current_stream_id, topic_name).length;
-    }
-
-    function update_move_messages_count_text(selected_option: string, message_id?: number): void {
-        const message_move_count = get_count_of_messages_to_be_moved(selected_option, message_id);
-        const is_topic_narrowed = narrow_state.narrowed_by_topic_reply();
-        const is_stream_narrowed = narrow_state.narrowed_by_stream_reply();
-        const is_same_stream = narrow_state.stream_id() === current_stream_id;
-        const is_same_topic = narrow_state.topic() === topic_name;
-
-        const can_have_exact_count_in_narrow =
-            (is_stream_narrowed && is_same_stream) ||
-            (is_topic_narrowed && is_same_stream && is_same_topic);
-        let exact_message_count = false;
-        if (selected_option === "change_one") {
-            exact_message_count = true;
-        } else if (can_have_exact_count_in_narrow) {
-            const has_found_newest = message_lists.current?.data.fetch_status.has_found_newest();
-            const has_found_oldest = message_lists.current?.data.fetch_status.has_found_oldest();
-
-            if (selected_option === "change_later" && has_found_newest) {
-                exact_message_count = true;
-            }
-            if (selected_option === "change_all" && has_found_newest && has_found_oldest) {
-                exact_message_count = true;
-            }
-        }
-
-        let message_text;
-        if (exact_message_count) {
-            message_text = $t(
-                {
-                    defaultMessage:
-                        "{count, plural, one {# message} other {# messages}} will be moved.",
-                },
-                {count: message_move_count},
-            );
-        } else {
-            message_text = $t(
-                {
-                    defaultMessage:
-                        "At least {count, plural, one {# message} other {# messages}} will be moved.",
-                },
-                {count: message_move_count},
-            );
-        }
-
-        $("#move_messages_count").text(message_text);
-    }
-
     function update_topic_input_placeholder(): void {
         const $topic_not_mandatory_placeholder = $(".move-topic-new-topic-placeholder");
         const $topic_input = $<HTMLInputElement>("#move_topic_form input.move_messages_edit_topic");
@@ -1201,11 +1220,17 @@ export async function build_move_topic_to_stream_popover(
         update_topic_input_placeholder();
 
         if (!args.from_message_actions_popover) {
-            update_move_messages_count_text("change_all");
+            update_move_messages_count_text("change_all", current_stream_id, topic_name);
         } else {
+            // The modal is opened from the message actions popover
+            // exactly when we have the message the user clicked on.
+            assert(message !== undefined);
+
             // Generate unique key for this conversation
             const conversation_key = `${current_stream_id}_${topic_name}`;
-            let selected_option = String($("#message_move_select_options").val());
+            let selected_option = propagate_mode_schema.parse(
+                $("#message_move_select_options").val(),
+            );
 
             // If a user has changed the smart defaults of `propagate_mode` to "change_one", we
             // remember that forced change and apply the same default for `propagate_mode` next
@@ -1218,14 +1243,24 @@ export async function build_move_topic_to_stream_popover(
                 $("#message_move_select_options").val(selected_option);
             }
 
-            update_move_messages_count_text(selected_option, message?.id);
+            update_move_messages_count_text(
+                selected_option,
+                current_stream_id,
+                topic_name,
+                message.id,
+            );
 
             $("#message_move_select_options").on("change", function () {
-                selected_option = String($(this).val());
+                selected_option = propagate_mode_schema.parse($(this).val());
                 last_propagate_mode_for_conversation.set(conversation_key, selected_option);
                 void warn_unsubscribed_participants(selected_option);
                 maybe_show_topic_already_exists_warning();
-                update_move_messages_count_text(selected_option, message?.id);
+                update_move_messages_count_text(
+                    selected_option,
+                    current_stream_id,
+                    topic_name,
+                    message.id,
+                );
             });
         }
         disable_topic_input_if_topics_are_disabled_in_channel(current_stream_id);

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -497,10 +497,7 @@ export function update_move_messages_count_text(
         );
     } else {
         message_text = $t(
-            {
-                defaultMessage:
-                    "At least {count, plural, one {# message} other {# messages}} will be moved.",
-            },
+            {defaultMessage: "{count}+ messages will be moved."},
             {count: message_move_count},
         );
     }

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -380,30 +380,97 @@ async function get_message_placement_in_conversation(
     );
 }
 
-// The following logic is correct only when
-// both message_lists.current.data.fetch_status.has_found_newest
-// and message_lists.current.data.fetch_status.has_found_oldest are true;
-// otherwise, we cannot be certain of the correct count.
-export function get_count_of_messages_to_be_moved(
+// The current message list contains the topic being moved when it is
+// narrowed to that topic, or to the channel the topic is in. Any other
+// list -- an interleaved view, a search, another conversation, a view
+// of the channel that also filters by something else -- holds only
+// whichever of the topic's messages happen to match it, and views
+// rendered without a message list have none of them, so neither can
+// tell us how many messages the topic has.
+//
+// Containing the topic is not the same as having fetched all of it;
+// `fetch_status` answers that question.
+function current_message_list_contains_topic(stream_id: number, topic_name: string): boolean {
+    const current_filter = message_lists.current?.data.filter;
+    if (current_filter === undefined || narrow_state.stream_id(current_filter) !== stream_id) {
+        return false;
+    }
+
+    // A `near` or `with` term points at one message of the view without
+    // narrowing down which messages the view contains.
+    const term_types = current_filter
+        .sorted_term_types()
+        .filter((term_type) => term_type !== "near" && term_type !== "with");
+
+    // A channel view contains every topic in the channel.
+    if (term_types.length === 1 && term_types[0] === "channel") {
+        return true;
+    }
+
+    // A conversation view contains a single topic.
+    return (
+        term_types.length === 2 &&
+        term_types[0] === "channel" &&
+        term_types[1] === "topic" &&
+        util.lower_same(narrow_state.topic(current_filter), topic_name)
+    );
+}
+
+type MoveMessagesCount = {
+    count: number;
+    // False when the messages we counted may not be all of the ones the
+    // move will take, which makes the count a lower bound.
+    is_exact: boolean;
+};
+
+export function get_move_messages_count(
     selected_option: PropagateMode,
     current_stream_id: number,
     topic_name: string,
     message_id?: number,
-): number {
+): MoveMessagesCount {
     if (selected_option === "change_one") {
-        return 1;
+        return {count: 1, is_exact: true};
     }
+
+    // We prefer the current message list, which can see the whole
+    // history it has fetched for the topic, and fall back to the recent
+    // conversations cache, which is missing the older messages of a
+    // topic that has not been active recently.
+    const contains_topic = current_message_list_contains_topic(current_stream_id, topic_name);
+    const loaded_messages_in_topic = contains_topic
+        ? message_util.get_loaded_messages_in_topic_in_current_view(current_stream_id, topic_name)
+        : message_util.get_loaded_messages_in_topic(current_stream_id, topic_name);
+
+    let count;
     if (selected_option === "change_later") {
         // Only the message actions popover offers this option, and it
         // always knows which message the user selected.
         assert(message_id !== undefined);
-        return message_util.get_count_of_messages_in_topic_sent_after_current_message(
-            current_stream_id,
-            topic_name,
-            message_id,
-        );
+        count = loaded_messages_in_topic.filter((message) => message.id >= message_id).length;
+    } else {
+        count = loaded_messages_in_topic.length;
     }
-    return message_util.get_loaded_messages_in_topic(current_stream_id, topic_name).length;
+
+    if (!contains_topic) {
+        return {count, is_exact: false};
+    }
+
+    // We counted all the messages the move will take only if the list
+    // has fetched to the end of the range it takes them from.
+    assert(message_lists.current !== undefined);
+    const fetch_status = message_lists.current.data.fetch_status;
+    if (selected_option === "change_later") {
+        return {count, is_exact: fetch_status.has_found_newest()};
+    }
+
+    // A move also takes the messages that plan restrictions kept out of
+    // our fetch, which we cannot see to count.
+    const is_exact =
+        fetch_status.has_found_newest() &&
+        fetch_status.has_found_oldest() &&
+        !fetch_status.history_limited();
+    return {count, is_exact};
 }
 
 export function update_move_messages_count_text(
@@ -412,37 +479,15 @@ export function update_move_messages_count_text(
     topic_name: string,
     message_id?: number,
 ): void {
-    const message_move_count = get_count_of_messages_to_be_moved(
+    const {count: message_move_count, is_exact} = get_move_messages_count(
         selected_option,
         current_stream_id,
         topic_name,
         message_id,
     );
-    const is_topic_narrowed = narrow_state.narrowed_by_topic_reply();
-    const is_stream_narrowed = narrow_state.narrowed_by_stream_reply();
-    const is_same_stream = narrow_state.stream_id() === current_stream_id;
-    const is_same_topic = narrow_state.topic() === topic_name;
-
-    const can_have_exact_count_in_narrow =
-        (is_stream_narrowed && is_same_stream) ||
-        (is_topic_narrowed && is_same_stream && is_same_topic);
-    let exact_message_count = false;
-    if (selected_option === "change_one") {
-        exact_message_count = true;
-    } else if (can_have_exact_count_in_narrow) {
-        const has_found_newest = message_lists.current?.data.fetch_status.has_found_newest();
-        const has_found_oldest = message_lists.current?.data.fetch_status.has_found_oldest();
-
-        if (selected_option === "change_later" && has_found_newest) {
-            exact_message_count = true;
-        }
-        if (selected_option === "change_all" && has_found_newest && has_found_oldest) {
-            exact_message_count = true;
-        }
-    }
 
     let message_text;
-    if (exact_message_count) {
+    if (is_exact) {
         message_text = $t(
             {
                 defaultMessage:

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -748,8 +748,15 @@ ul.popover-group-menu-member-list {
     }
 
     #move_messages_count {
-        /* Disabled pending fixes to the logic. */
-        display: none;
+        margin-top: -20px;
+        font-style: italic;
+        opacity: 0.7;
+
+        /* For cases where the count isn't displayed, which may primarily
+           occur due to bugs, avoid applying the above negative margin. */
+        &:empty {
+            margin-top: unset;
+        }
     }
 
     .topic_stream_edit_header {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -748,8 +748,16 @@ ul.popover-group-menu-member-list {
     }
 
     #move_messages_count {
-        /* Disabled pending fixes to the logic. */
-        display: none;
+        /* The count describes the control above it, so we pull it up
+           into part of that group's bottom margin, and keep the rest of
+           that spacing below the count. */
+        margin: -0.625em 0 0.625em; /* -10px and 10px at 16px/em */
+
+        /* With no count to show, the paragraph should take up no space
+           at all. */
+        &:empty {
+            margin: 0;
+        }
     }
 
     .topic_stream_edit_header {

--- a/web/tests/message_move_count.test.cjs
+++ b/web/tests/message_move_count.test.cjs
@@ -14,7 +14,6 @@ const message_lists = zrequire("message_lists");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 
-const all_messages_data = mock_esm("../src/all_messages_data");
 const narrow_state = mock_esm("../src/narrow_state");
 
 const alice = make_user({email: "alice@example.com", user_id: 1, full_name: "Alice"});
@@ -44,7 +43,7 @@ for (const message of messages) {
     });
 }
 
-run_test("test_get_count_of_messages_to_be_moved", ({override}) => {
+run_test("test_get_count_of_messages_to_be_moved", () => {
     const selected_message_id = 102;
 
     const filter_terms = [
@@ -54,11 +53,7 @@ run_test("test_get_count_of_messages_to_be_moved", ({override}) => {
     ];
 
     message_lists.set_current(make_message_list(filter_terms));
-    override(all_messages_data, "all_messages_data", {
-        all_messages() {
-            return messages;
-        },
-    });
+    message_lists.current.all_messages = () => messages;
 
     let count = stream_popover.get_count_of_messages_to_be_moved(
         "change_one",
@@ -94,11 +89,7 @@ run_test("test_update_move_messages_count", ({override}) => {
         {operator: "with", operand: selected_message_id.toString()},
     ];
     message_lists.set_current(make_message_list(filter_terms));
-    override(all_messages_data, "all_messages_data", {
-        all_messages() {
-            return messages;
-        },
-    });
+    message_lists.current.all_messages = () => messages;
 
     // Case 1: selected_option === "change_one"
     stream_popover.update_move_messages_count_text(

--- a/web/tests/message_move_count.test.cjs
+++ b/web/tests/message_move_count.test.cjs
@@ -1,0 +1,235 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_user} = require("./lib/example_user.cjs");
+const {make_message_list} = require("./lib/message_list.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const $ = require("./lib/zjquery.cjs");
+
+const message_store = zrequire("message_store");
+const stream_popover = zrequire("stream_popover");
+const message_lists = zrequire("message_lists");
+const people = zrequire("people");
+const stream_data = zrequire("stream_data");
+
+const all_messages_data = mock_esm("../src/all_messages_data");
+const narrow_state = mock_esm("../src/narrow_state");
+
+const alice = make_user({email: "alice@example.com", user_id: 1, full_name: "Alice"});
+const bob = make_user({email: "bob@example.com", user_id: 2, full_name: "Bob"});
+const carol = make_user({email: "carol@example.com", user_id: 3, full_name: "Carol"});
+
+people.add_active_user(alice);
+people.add_active_user(bob);
+people.add_active_user(carol);
+
+const rome_sub = {name: "Rome", subscribed: true, stream_id: 1001};
+stream_data.add_sub_for_tests(rome_sub);
+
+const messages = [
+    {id: 101, stream_id: rome_sub.stream_id, topic: "foo", sender_id: 1, type: "stream"},
+    {id: 102, stream_id: rome_sub.stream_id, topic: "foo", sender_id: 2, type: "stream"},
+    {id: 103, stream_id: rome_sub.stream_id, topic: "foo", sender_id: 3, type: "stream"},
+    {id: 104, stream_id: rome_sub.stream_id, topic: "boo", sender_id: 1, type: "stream"},
+    {id: 105, stream_id: rome_sub.stream_id, topic: "boo", sender_id: 2, type: "stream"},
+    {id: 106, stream_id: rome_sub.stream_id, topic: "boo", sender_id: 3, type: "stream"},
+];
+
+for (const message of messages) {
+    message_store.update_message_cache({
+        type: "server_message",
+        message,
+    });
+}
+
+run_test("test_get_count_of_messages_to_be_moved", ({override}) => {
+    const selected_message_id = 102;
+
+    const filter_terms = [
+        {operator: "channel", operand: rome_sub.stream_id.toString()},
+        {operator: "topic", operand: "foo"},
+        {operator: "with", operand: selected_message_id.toString()},
+    ];
+
+    message_lists.set_current(make_message_list(filter_terms));
+    override(all_messages_data, "all_messages_data", {
+        all_messages() {
+            return messages;
+        },
+    });
+
+    let count = stream_popover.get_count_of_messages_to_be_moved(
+        "change_one",
+        rome_sub.stream_id,
+        "foo",
+        selected_message_id,
+    );
+    assert.equal(count, 1);
+
+    count = stream_popover.get_count_of_messages_to_be_moved(
+        "change_later",
+        rome_sub.stream_id,
+        "foo",
+        selected_message_id,
+    );
+    assert.equal(count, 2);
+
+    count = stream_popover.get_count_of_messages_to_be_moved(
+        "change_all",
+        rome_sub.stream_id,
+        "foo",
+        selected_message_id,
+    );
+    assert.equal(count, 3);
+});
+
+run_test("test_update_move_messages_count", ({override}) => {
+    const selected_message_id = 102;
+
+    const filter_terms = [
+        {operator: "channel", operand: rome_sub.stream_id.toString()},
+        {operator: "topic", operand: "foo"},
+        {operator: "with", operand: selected_message_id.toString()},
+    ];
+    message_lists.set_current(make_message_list(filter_terms));
+    override(all_messages_data, "all_messages_data", {
+        all_messages() {
+            return messages;
+        },
+    });
+
+    // Case 1: selected_option === "change_one"
+    stream_popover.update_move_messages_count_text(
+        "change_one",
+        rome_sub.stream_id,
+        "foo",
+        selected_message_id,
+    );
+    assert.equal($("#move_messages_count").text(), "translated: 1 message will be moved.");
+
+    // Case 2: selected_option === "change_later"
+
+    // This is the general case when we are in topic narrow.
+    override(narrow_state, "narrowed_by_topic_reply", () => true);
+    override(narrow_state, "narrowed_by_stream_reply", () => false);
+    override(narrow_state, "stream_id", () => rome_sub.stream_id);
+    override(narrow_state, "topic", () => "foo");
+
+    message_lists.current.data.fetch_status.finish_newer_batch([], {
+        update_loading_indicator: false,
+        found_newest: true,
+    });
+    message_lists.current.data.fetch_status.finish_older_batch({
+        update_loading_indicator: false,
+        found_oldest: true,
+        history_limited: false,
+    });
+
+    assert.ok(message_lists.current.data.fetch_status.has_found_newest());
+    assert.ok(message_lists.current.data.fetch_status.has_found_oldest());
+
+    stream_popover.update_move_messages_count_text(
+        "change_later",
+        rome_sub.stream_id,
+        "foo",
+        selected_message_id,
+    );
+    assert.equal($("#move_messages_count").text(), "translated: 2 messages will be moved.");
+
+    // This is the case when we are in an interleaved view.
+    override(narrow_state, "narrowed_by_topic_reply", () => false);
+    override(narrow_state, "narrowed_by_stream_reply", () => false);
+    override(narrow_state, "stream_id", () => rome_sub.stream_id);
+    override(narrow_state, "topic", () => "foo");
+
+    message_lists.current.data.fetch_status.finish_newer_batch([], {
+        update_loading_indicator: false,
+        found_newest: false,
+    });
+    message_lists.current.data.fetch_status.finish_older_batch({
+        update_loading_indicator: false,
+        found_oldest: false,
+        history_limited: false,
+    });
+
+    assert.ok(!message_lists.current.data.fetch_status.has_found_newest());
+    assert.ok(!message_lists.current.data.fetch_status.has_found_oldest());
+
+    stream_popover.update_move_messages_count_text(
+        "change_later",
+        rome_sub.stream_id,
+        "foo",
+        selected_message_id,
+    );
+    assert.equal($("#move_messages_count").text(), "translated: 2+ messages will be moved.");
+
+    // Case 3: selected_option === "change_all"
+
+    // This is the general case when we are in topic narrow.
+    override(narrow_state, "narrowed_by_topic_reply", () => true);
+    override(narrow_state, "narrowed_by_stream_reply", () => false);
+    override(narrow_state, "stream_id", () => rome_sub.stream_id);
+    override(narrow_state, "topic", () => "foo");
+
+    message_lists.current.data.fetch_status.finish_newer_batch([], {
+        update_loading_indicator: false,
+        found_newest: true,
+    });
+    message_lists.current.data.fetch_status.finish_older_batch({
+        update_loading_indicator: false,
+        found_oldest: true,
+        history_limited: false,
+    });
+
+    assert.ok(message_lists.current.data.fetch_status.has_found_newest());
+    assert.ok(message_lists.current.data.fetch_status.has_found_oldest());
+
+    stream_popover.update_move_messages_count_text("change_all", rome_sub.stream_id, "foo");
+    assert.equal($("#move_messages_count").text(), "translated: 3 messages will be moved.");
+
+    // This is case when we are in stream narrow and the topic is not the same.
+    override(narrow_state, "narrowed_by_topic_reply", () => true);
+    override(narrow_state, "narrowed_by_stream_reply", () => false);
+    override(narrow_state, "stream_id", () => rome_sub.stream_id);
+    override(narrow_state, "topic", () => "boo");
+
+    message_lists.current.data.fetch_status.finish_newer_batch([], {
+        update_loading_indicator: false,
+        found_newest: false,
+    });
+    message_lists.current.data.fetch_status.finish_older_batch({
+        update_loading_indicator: false,
+        found_oldest: false,
+        history_limited: false,
+    });
+
+    assert.ok(!message_lists.current.data.fetch_status.has_found_newest());
+    assert.ok(!message_lists.current.data.fetch_status.has_found_oldest());
+
+    stream_popover.update_move_messages_count_text("change_all", rome_sub.stream_id, "foo");
+    assert.equal($("#move_messages_count").text(), "translated: 3+ messages will be moved.");
+
+    // This is the case when we are in an interleaved view.
+    override(narrow_state, "narrowed_by_topic_reply", () => false);
+    override(narrow_state, "narrowed_by_stream_reply", () => false);
+    override(narrow_state, "stream_id", () => rome_sub.stream_id);
+    override(narrow_state, "topic", () => "foo");
+
+    message_lists.current.data.fetch_status.finish_newer_batch([], {
+        update_loading_indicator: false,
+        found_newest: false,
+    });
+    message_lists.current.data.fetch_status.finish_older_batch({
+        update_loading_indicator: false,
+        found_oldest: false,
+        history_limited: false,
+    });
+
+    assert.ok(!message_lists.current.data.fetch_status.has_found_newest());
+    assert.ok(!message_lists.current.data.fetch_status.has_found_oldest());
+
+    stream_popover.update_move_messages_count_text("change_all", rome_sub.stream_id, "foo");
+    assert.equal($("#move_messages_count").text(), "translated: 3+ messages will be moved.");
+});

--- a/web/tests/stream_popover.test.cjs
+++ b/web/tests/stream_popover.test.cjs
@@ -144,7 +144,7 @@ run_test("count text in a conversation view", () => {
     // A view that has not fetched the whole topic can only give a
     // lower bound.
     set_current_view(topic_view_terms("foo"), foo_messages, {found_oldest: false});
-    assert.equal(count_text("change_all", "foo"), "translated: At least 3 messages will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3+ messages will be moved.");
 
     // A `near` term points at one message of the conversation without
     // narrowing the view any further, so the count stays exact.
@@ -197,17 +197,17 @@ run_test("count text in views that cannot answer for the topic", () => {
     // we count from the recent conversations cache and say the count is
     // a lower bound.
     set_current_view([], foo_messages);
-    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 1+ messages will be moved.");
 
     set_current_channel_topics_view(rome.stream_id);
-    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 1+ messages will be moved.");
 });
 
 run_test("count text when the channel's history is limited", () => {
     // The user cannot see the messages older than the ones the server
     // sent us, but moving the topic moves those too.
     set_current_view(topic_view_terms("foo"), foo_messages, {history_limited: true});
-    assert.equal(count_text("change_all", "foo"), "translated: At least 3 messages will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3+ messages will be moved.");
 
     // The messages we cannot see are all older than the selected one,
     // so this count is still exact.

--- a/web/tests/stream_popover.test.cjs
+++ b/web/tests/stream_popover.test.cjs
@@ -91,12 +91,12 @@ function topic_view_terms(topic_name) {
 }
 
 function count_of_messages_to_be_moved(selected_option, topic_name, message_id) {
-    return stream_popover.get_count_of_messages_to_be_moved(
+    return stream_popover.get_move_messages_count(
         selected_option,
         rome.stream_id,
         topic_name,
         message_id,
-    );
+    ).count;
 }
 
 function count_text(selected_option, topic_name, message_id) {
@@ -119,10 +119,10 @@ run_test("count of messages to be moved", () => {
 
     assert.equal(count_of_messages_to_be_moved("change_one", "foo", selected_message_id), 1);
 
-    // The count comes from recent conversations rather than from the
-    // view, so it misses the messages that only the view has.
-    assert.equal(count_of_messages_to_be_moved("change_later", "foo", selected_message_id), 1);
-    assert.equal(count_of_messages_to_be_moved("change_all", "foo"), 1);
+    // The count comes from the view, so it sees the whole topic: two of
+    // its messages are at or after the selected one.
+    assert.equal(count_of_messages_to_be_moved("change_later", "foo", selected_message_id), 2);
+    assert.equal(count_of_messages_to_be_moved("change_all", "foo"), 3);
 });
 
 run_test("count text in a conversation view", () => {
@@ -133,42 +133,41 @@ run_test("count text in a conversation view", () => {
         "translated: 1 message will be moved.",
     );
 
-    // Wrong: the count is presented as exact, because this view is
-    // narrowed to the topic and has fetched all of it, but the number
-    // itself came from the recent conversations cache.
+    // This view is narrowed to the topic and has fetched all of it, so
+    // the count is exact.
     assert.equal(
         count_text("change_later", "foo", selected_message_id),
-        "translated: 1 message will be moved.",
+        "translated: 2 messages will be moved.",
     );
-    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3 messages will be moved.");
 
     // A view that has not fetched the whole topic can only give a
     // lower bound.
     set_current_view(topic_view_terms("foo"), foo_messages, {found_oldest: false});
-    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: At least 3 messages will be moved.");
 
-    // Wrong: this view is narrowed to the topic and has fetched all of
-    // it, so the count could be exact, but a `near` term stops us from
-    // recognizing it as a conversation view.
+    // A `near` term points at one message of the conversation without
+    // narrowing the view any further, so the count stays exact.
     set_current_view(
         [...topic_view_terms("foo"), {operator: "near", operand: selected_message_id.toString()}],
         foo_messages,
     );
-    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3 messages will be moved.");
 });
 
 run_test("count text in a channel view", () => {
     const channel_view_terms = [{operator: "channel", operand: rome.stream_id.toString()}];
     set_current_view(channel_view_terms, foo_messages);
-    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3 messages will be moved.");
 
-    // Wrong for the same reason as in the conversation view above: a
-    // `near` term stops us from recognizing this as a channel view.
+    // A `near` term points at one message without narrowing the
+    // view, so a channel view that has one still contains the whole
+    // topic.
     set_current_view(
         [...channel_view_terms, {operator: "near", operand: selected_message_id.toString()}],
         foo_messages,
     );
-    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3 messages will be moved.");
 
     // Muting a topic hides its messages from a channel view, but a move
     // still moves them, so the count should not change.
@@ -181,7 +180,7 @@ run_test("count text in a channel view", () => {
     );
     const message_list = set_current_view(channel_view_terms, foo_messages);
     assert.deepEqual(message_list.all_messages(), []);
-    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+    assert.equal(count_text("change_all", "foo"), "translated: 3 messages will be moved.");
 
     user_topics.update_user_topics(
         rome.stream_id,
@@ -192,10 +191,11 @@ run_test("count text in a channel view", () => {
     );
 });
 
-run_test("count text in views that have no message list", () => {
-    // The messages of the topic loaded in an interleaved view are only
-    // the ones that happen to match it, so we count from the recent
-    // conversations cache and say so.
+run_test("count text in views that cannot answer for the topic", () => {
+    // An interleaved view can hold messages of the topic without
+    // holding all of them, and cannot tell us which of those it is, so
+    // we count from the recent conversations cache and say the count is
+    // a lower bound.
     set_current_view([], foo_messages);
     assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
 
@@ -207,11 +207,12 @@ run_test("count text when the channel's history is limited", () => {
     // The user cannot see the messages older than the ones the server
     // sent us, but moving the topic moves those too.
     set_current_view(topic_view_terms("foo"), foo_messages, {history_limited: true});
+    assert.equal(count_text("change_all", "foo"), "translated: At least 3 messages will be moved.");
 
-    // Wrong: the count is presented as exact.
-    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+    // The messages we cannot see are all older than the selected one,
+    // so this count is still exact.
     assert.equal(
         count_text("change_later", "foo", selected_message_id),
-        "translated: 1 message will be moved.",
+        "translated: 2 messages will be moved.",
     );
 });

--- a/web/tests/stream_popover.test.cjs
+++ b/web/tests/stream_popover.test.cjs
@@ -1,0 +1,217 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_user} = require("./lib/example_user.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const {$} = require("./lib/zjquery.cjs");
+
+const {Filter} = zrequire("filter");
+const inbox_util = zrequire("inbox_util");
+const {MessageList} = zrequire("message_list");
+const {MessageListData} = zrequire("message_list_data");
+const message_lists = zrequire("message_lists");
+const message_util = zrequire("message_util");
+const people = zrequire("people");
+const {recent_view_messages_data} = zrequire("recent_view_messages_data");
+const stream_data = zrequire("stream_data");
+const stream_popover = zrequire("stream_popover");
+const user_topics = zrequire("user_topics");
+
+const rome = {name: "Rome", stream_id: 1001, subscribed: true};
+stream_data.add_sub_for_tests(rome);
+
+// Adding messages to a message list records their senders as
+// participants of the conversation, so the sender has to be a user we
+// know about.
+const sender = make_user();
+people.add_active_user(sender);
+
+function make_channel_message(id, topic) {
+    return {id, type: "stream", stream_id: rome.stream_id, topic, sender_id: sender.user_id};
+}
+
+const foo_messages = [
+    make_channel_message(101, "foo"),
+    make_channel_message(102, "foo"),
+    make_channel_message(103, "foo"),
+];
+const selected_message_id = 102;
+
+// Recent conversations caches the newest slice of the user's history.
+// Here that window starts at the topic's last message: the two older
+// ones were sent long enough ago to have fallen out of it, which is
+// the situation the count was reported wrong in.
+recent_view_messages_data.add_messages(
+    [foo_messages.at(-1), make_channel_message(104, "boo"), make_channel_message(105, "boo")],
+    true,
+);
+
+function set_current_view(filter_terms, messages, fetch_state = {}) {
+    const {found_oldest = true, found_newest = true, history_limited = false} = fetch_state;
+    const filter = new Filter(filter_terms);
+    const message_list = new MessageList({
+        data: new MessageListData({
+            filter,
+            excludes_muted_topics: filter.excludes_muted_topics(),
+            excludes_muted_users: filter.excludes_muted_users(),
+        }),
+        is_node_test: true,
+    });
+    message_list.data.add_messages(messages, true);
+    message_list.data.fetch_status.finish_older_batch({
+        update_loading_indicator: false,
+        found_oldest,
+        history_limited,
+    });
+    message_list.data.fetch_status.finish_newer_batch([], {
+        update_loading_indicator: false,
+        found_newest,
+    });
+
+    inbox_util.set_visible(false);
+    message_lists.set_current(message_list);
+    return message_list;
+}
+
+function set_current_channel_topics_view(stream_id) {
+    // The list of topics in a channel, like the inbox it is rendered
+    // with, has no message list of its own.
+    message_lists.set_current(undefined);
+    inbox_util.set_filter(new Filter([{operator: "channel", operand: stream_id.toString()}]));
+    inbox_util.set_visible(true);
+}
+
+function topic_view_terms(topic_name) {
+    return [
+        {operator: "channel", operand: rome.stream_id.toString()},
+        {operator: "topic", operand: topic_name},
+    ];
+}
+
+function count_of_messages_to_be_moved(selected_option, topic_name, message_id) {
+    return stream_popover.get_count_of_messages_to_be_moved(
+        selected_option,
+        rome.stream_id,
+        topic_name,
+        message_id,
+    );
+}
+
+function count_text(selected_option, topic_name, message_id) {
+    stream_popover.update_move_messages_count_text(
+        selected_option,
+        rome.stream_id,
+        topic_name,
+        message_id,
+    );
+    return $("#move_messages_count").text();
+}
+
+run_test("count of messages to be moved", () => {
+    const message_list = set_current_view(topic_view_terms("foo"), foo_messages);
+
+    // The view we are in has the whole topic loaded; recent
+    // conversations has only its newest message.
+    assert.equal(message_list.all_messages().length, 3);
+    assert.equal(message_util.get_loaded_messages_in_topic(rome.stream_id, "foo").length, 1);
+
+    assert.equal(count_of_messages_to_be_moved("change_one", "foo", selected_message_id), 1);
+
+    // The count comes from recent conversations rather than from the
+    // view, so it misses the messages that only the view has.
+    assert.equal(count_of_messages_to_be_moved("change_later", "foo", selected_message_id), 1);
+    assert.equal(count_of_messages_to_be_moved("change_all", "foo"), 1);
+});
+
+run_test("count text in a conversation view", () => {
+    set_current_view(topic_view_terms("foo"), foo_messages);
+
+    assert.equal(
+        count_text("change_one", "foo", selected_message_id),
+        "translated: 1 message will be moved.",
+    );
+
+    // Wrong: the count is presented as exact, because this view is
+    // narrowed to the topic and has fetched all of it, but the number
+    // itself came from the recent conversations cache.
+    assert.equal(
+        count_text("change_later", "foo", selected_message_id),
+        "translated: 1 message will be moved.",
+    );
+    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+
+    // A view that has not fetched the whole topic can only give a
+    // lower bound.
+    set_current_view(topic_view_terms("foo"), foo_messages, {found_oldest: false});
+    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+
+    // Wrong: this view is narrowed to the topic and has fetched all of
+    // it, so the count could be exact, but a `near` term stops us from
+    // recognizing it as a conversation view.
+    set_current_view(
+        [...topic_view_terms("foo"), {operator: "near", operand: selected_message_id.toString()}],
+        foo_messages,
+    );
+    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+});
+
+run_test("count text in a channel view", () => {
+    const channel_view_terms = [{operator: "channel", operand: rome.stream_id.toString()}];
+    set_current_view(channel_view_terms, foo_messages);
+    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+
+    // Wrong for the same reason as in the conversation view above: a
+    // `near` term stops us from recognizing this as a channel view.
+    set_current_view(
+        [...channel_view_terms, {operator: "near", operand: selected_message_id.toString()}],
+        foo_messages,
+    );
+    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+
+    // Muting a topic hides its messages from a channel view, but a move
+    // still moves them, so the count should not change.
+    user_topics.update_user_topics(
+        rome.stream_id,
+        rome.name,
+        "foo",
+        user_topics.all_visibility_policies.MUTED,
+        0,
+    );
+    const message_list = set_current_view(channel_view_terms, foo_messages);
+    assert.deepEqual(message_list.all_messages(), []);
+    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+
+    user_topics.update_user_topics(
+        rome.stream_id,
+        rome.name,
+        "foo",
+        user_topics.all_visibility_policies.INHERIT,
+        0,
+    );
+});
+
+run_test("count text in views that have no message list", () => {
+    // The messages of the topic loaded in an interleaved view are only
+    // the ones that happen to match it, so we count from the recent
+    // conversations cache and say so.
+    set_current_view([], foo_messages);
+    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+
+    set_current_channel_topics_view(rome.stream_id);
+    assert.equal(count_text("change_all", "foo"), "translated: At least 1 message will be moved.");
+});
+
+run_test("count text when the channel's history is limited", () => {
+    // The user cannot see the messages older than the ones the server
+    // sent us, but moving the topic moves those too.
+    set_current_view(topic_view_terms("foo"), foo_messages, {history_limited: true});
+
+    // Wrong: the count is presented as exact.
+    assert.equal(count_text("change_all", "foo"), "translated: 1 message will be moved.");
+    assert.equal(
+        count_text("change_later", "foo", selected_message_id),
+        "translated: 1 message will be moved.",
+    );
+});


### PR DESCRIPTION
This PR fixes the bug introduced by #32155 .

The count of messages to be moved was observed to be incorrect occasionally because the function named `messages_util.get_messages_in_topic` was used which relied on the `recent conversations` cache for the history.
    
Now, we introduced a new function named `get_messages_in_view_currenlty_focused` to fetch the count specifically for the view in focus. If we don't have this, then we use `get_messages_in_topic` as before.

---

For the different cases when the user opens the **Move Messages** modal from the left sidebar, we implement `get_count_of_messages_in_view_currently_focused`, which counts the messages in two scenarios:  

- **When the currently focused view is "stream," and the user opens the message modal for the topic they are currently focused on.**  
  In this case, we retrieve the messages of that topic using `get_messages_in_view_currently_focused`.  

- **When the currently focused view is "stream," and the user opens the message modal for a different topic within the same stream.**  
  In this case, `get_messages_in_view_currently_focused` fails to give the message count correctly. This is exactly the bug mentioned by @gnprice in [#issues > 📂 wrong message count in move-messages dialog](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20wrong.20message.20count.20in.20move-messages.20dialog/with/2208651).  
To handle this case, we use the `get_messages_in_topic` function instead to obtain the correct message count.  

- **Difference between the two functions:**  
  `get_messages_in_view_currently_focused` retrieves messages for the topic that is currently in focus, whereas `get_messages_in_topic` fetches messages for the selected topic, regardless of the current focus.  

---
**Note: I have also changed the count display text from `Atleast N messages will be moved.` to `N+ messages will be moved` in a separate commit.** 

For more info, see [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/wrong.20message.20count.20in.20move-messages.20dialog/near/2025435).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
