### PR TITLE
buddy_list: Use 0.75 opacity for the user counts.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -264,6 +264,10 @@ $user_status_emoji_width: 24px;
     margin-right: 2px;
 }
 
+.buddy-list-heading-user-count-with-parens {
+    opacity: 0.75;
+}
+
 .buddy-list-subsection-header.no-display {
     display: none;
 }

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,5 +1,7 @@
 <i class="buddy-list-section-toggle zulip-icon zulip-icon-heading-triangle-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>
 <h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
     <span class="buddy-list-heading-text">{{header_text}}</span>
-    (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
+    <span class="buddy-list-heading-user-count-with-parens">
+        (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
+    </span>
 </h5>


### PR DESCRIPTION
Discussed here:
https://chat.zulip.org/#narrow/channel/101-design/topic/right.20sidebar.20heading.20dot/near/2013034

<img width="263" alt="image" src="https://github.com/user-attachments/assets/f19017c6-b21e-4498-9624-f9b47f252f38" />
<img width="289" alt="image" src="https://github.com/user-attachments/assets/fc182cbc-41f7-4a63-8c32-74ba72c4f15a" />
