### PR TITLE
user_profile: Hide error when receiving a successful response.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -787,6 +787,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
             processData: false,
             contentType: false,
             success() {
+                $("#bot-edit-form-error").hide();
                 avatar_widget.clear();
                 hide_button_spinner($submit_button);
                 original_values = get_current_values($("#bot-edit-form"));
@@ -1099,6 +1100,7 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
             url,
             data,
             success() {
+                $("#edit-user-form-error").hide();
                 hide_button_spinner($submit_button);
                 original_values = get_current_values($("#edit-user-form"));
                 toggle_submit_button($("#edit-user-form"));


### PR DESCRIPTION
When editing a user or bot profile via the Manage User or Manage Bot overlay, an error was not hidden after receiving a successful response from the server. This PR ensures the error is hidden upon a successful response.

<!-- Describe your pull request here.-->

<details>
  <summary>Steps to reproduce the bug in development environment.</summary>

  1. Log in as Desdemona. Open the Manage user tab from the User Profile modal for a Normal user (e.g. here, Aaron).
  
  2. Enter a name that is too short (like "a"), and click the Save changes button. An error shows up `Failed: Name too short!`.
  
  3. Now, enter a valid name (like "aaron_updated"), and click the Save changes button.
  
  4. The name in the title of the modal gets updated. The `Saved` confirmation message appears and gets removed after a delay but the error `Failed: Name too short!` is not removed.

   This behavior is the same for the Manage bot tab.
   
   ---

</details>


Fixes: [CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/Error.20and.20success.20shows.20up.20simultaneously.20in.20Manage.20user.20tab/near/2015897)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Manage user tab.</summary>

![user](https://github.com/user-attachments/assets/4a754dcf-9668-4dbd-82cb-dce0ea875d3e)

</details>

<details>
<summary>Manage bot tab.</summary>

![bot](https://github.com/user-attachments/assets/1f552f97-3d8f-4f55-aa22-d1b93ae91fa8)

</details>

<details>
<summary>Error banner doesn't disappear and reappears if the error is still applicable.</summary>

**Context:**
  `Alya Abbott` [said](https://chat.zulip.org/#narrow/channel/9-issues/topic/Error.20and.20success.20shows.20up.20simultaneously.20in.20Manage.20user.20tab/near/2024695):
  > Ideally we'd avoid having the banner disappear and reappear if the error is still applicable (e.g., you try to save the same one-letter name again).
  
  Please note that here, first, we enter "a" in name input -> Save changes -> error occurs -> enter "b" in name input -> Save changes -> again error occurs, but, the error banner doesn't disappear and reappears (in both Manage user and Manage bot tabs).
  
  **Manage user tab:**
![error not again user](https://github.com/user-attachments/assets/9f8fcf04-1c73-47b7-b61f-7134d2d5c69f)

 **Manage bot tab:**
![error not again bot](https://github.com/user-attachments/assets/646d8754-9884-4005-ae54-9a244b600a58)
  
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
