### PR TITLE
compose tests: Clean up zjquery usage

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -270,7 +270,7 @@ export function rewire_send_message(value) {
     send_message = value;
 }
 
-export function enter_with_preview_open(ctrl_pressed = false) {
+export function handle_enter_key_with_preview_open(ctrl_pressed = false) {
     if (
         (user_settings.enter_sends && !ctrl_pressed) ||
         (!user_settings.enter_sends && ctrl_pressed)

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -532,7 +532,7 @@ export function process_enter_key(e) {
     }
 
     if ($("#preview_message_area").is(":visible")) {
-        compose.enter_with_preview_open();
+        compose.handle_enter_key_with_preview_open();
         return true;
     }
 
@@ -583,7 +583,7 @@ export function process_enter_key(e) {
 export function process_ctrl_enter_key() {
     if ($("#preview_message_area").is(":visible")) {
         const ctrl_pressed = true;
-        compose.enter_with_preview_open(ctrl_pressed);
+        compose.handle_enter_key_with_preview_open(ctrl_pressed);
         return true;
     }
 

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -483,11 +483,6 @@ test_ui("finish", ({override, override_rewire}) => {
             assert.equal(classname, "invalid");
             assert.equal(value, true);
         };
-        $("#compose_invite_users").show();
-        $("#compose-send-button").prop("disabled", false);
-        $("#compose-send-button").trigger("focus");
-        $(".compose-submit-button .loader").hide();
-        $("textarea#compose-textarea").off("select");
         $("textarea#compose-textarea").val("");
         override_rewire(compose_ui, "compose_spinner_visible", false);
         const res = compose.finish();
@@ -684,10 +679,6 @@ test_ui("on_events", ({override, override_rewire}) => {
     })();
 
     (function test_markdown_preview_compose_clicked() {
-        // Tests setup
-        $("textarea#compose-textarea").set_height(50);
-        $("#compose .preview_message_area").css = noop;
-
         function setup_visibilities() {
             $("#compose .markdown_preview").show();
             $("#compose .undo_markdown_preview").hide();

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -167,7 +167,7 @@ test_ui("send_message_success", ({override, override_rewire}) => {
     let draft_deleted;
     let reify_message_id_checked;
     function reset() {
-        $("textarea#compose-textarea").val("foobarfoobar");
+        $("textarea#compose-textarea").val("default message");
         $("textarea#compose-textarea").trigger("blur");
         $(".compose-submit-button .loader").show();
         draft_deleted = false;
@@ -392,7 +392,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
             return "<banner-stub>";
         });
         stub_state = initialize_state_stub_dict();
-        $("textarea#compose-textarea").val("foobarfoobar");
+        $("textarea#compose-textarea").val("default message");
         $("textarea#compose-textarea").trigger("blur");
         $(".compose-submit-button .loader").show();
         $("textarea#compose-textarea").off("select");
@@ -411,7 +411,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.deepEqual(stub_state, state);
         assert.ok(!echo_error_msg_checked);
         assert.ok(banner_rendered);
-        assert.equal($("textarea#compose-textarea").val(), "foobarfoobar");
+        assert.equal($("textarea#compose-textarea").val(), "default message");
         assert.ok($("textarea#compose-textarea").is_focused());
         assert.ok(!$(".compose-submit-button .loader").visible());
     })();
@@ -498,7 +498,7 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose .preview_message_area").show();
         $("#compose .markdown_preview").hide();
         $("#compsoe").addClass("preview_mode");
-        $("textarea#compose-textarea").val("foobarfoobar");
+        $("textarea#compose-textarea").val("default message");
         override_rewire(compose_ui, "compose_spinner_visible", false);
         compose_state.set_message_type("private");
         override(compose_pm_pill, "get_emails", () => "bob@example.com");
@@ -711,10 +711,10 @@ test_ui("on_events", ({override, override_rewire}) => {
             const resp = {
                 msg: "",
                 result: "success",
-                rendered: "Server: foobarfoobar",
+                rendered: "Server: default message",
             };
             success_callback(resp);
-            assert.equal($("#compose .preview_content").html(), "Server: foobarfoobar");
+            assert.equal($("#compose .preview_content").html(), "Server: default message");
         }
 
         function test_post_error(error_callback) {
@@ -766,17 +766,17 @@ test_ui("on_events", ({override, override_rewire}) => {
         assert_visibilities();
 
         let make_indicator_called = false;
-        $("textarea#compose-textarea").val("```foobarfoobar```");
+        $("textarea#compose-textarea").val("```default message```");
         setup_visibilities();
-        setup_mock_markdown_contains_backend_only_syntax("```foobarfoobar```", true);
-        setup_mock_markdown_is_status_message("```foobarfoobar```", false);
+        setup_mock_markdown_contains_backend_only_syntax("```default message```", true);
+        setup_mock_markdown_is_status_message("```default message```", false);
 
         override(loading, "make_indicator", ($spinner) => {
             assert.equal($spinner.selector, "#compose .markdown_preview_spinner");
             make_indicator_called = true;
         });
 
-        current_message = "```foobarfoobar```";
+        current_message = "```default message```";
 
         handler(event);
 
@@ -784,15 +784,15 @@ test_ui("on_events", ({override, override_rewire}) => {
         assert_visibilities();
 
         let render_called = false;
-        $("textarea#compose-textarea").val("foobarfoobar");
+        $("textarea#compose-textarea").val("default message");
         setup_visibilities();
-        setup_mock_markdown_contains_backend_only_syntax("foobarfoobar", false);
-        setup_mock_markdown_is_status_message("foobarfoobar", false);
+        setup_mock_markdown_contains_backend_only_syntax("default message", false);
+        setup_mock_markdown_is_status_message("default message", false);
 
-        current_message = "foobarfoobar";
+        current_message = "default message";
 
         override(markdown, "render", (raw_content) => {
-            assert.equal(raw_content, "foobarfoobar");
+            assert.equal(raw_content, "default message");
             render_called = true;
         });
 
@@ -800,7 +800,7 @@ test_ui("on_events", ({override, override_rewire}) => {
 
         assert.ok(render_called);
         assert_visibilities();
-        assert.equal($("#compose .preview_content").html(), "Server: foobarfoobar");
+        assert.equal($("#compose .preview_content").html(), "Server: default message");
     })();
 
     (function test_undo_markdown_preview_clicked() {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -417,7 +417,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     })();
 });
 
-test_ui("enter_with_preview_open", ({override, override_rewire}) => {
+test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
     $("textarea#compose-textarea").toggleClass = noop;
     override_rewire(compose_banner, "clear_message_sent_banners", noop);
@@ -445,7 +445,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
         send_message_called = true;
     });
     $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
-    compose.enter_with_preview_open();
+    compose.handle_enter_key_with_preview_open();
     assert.ok(!$("#compose .undo_markdown_preview").visible());
     assert.ok(!$("#compose .preview_message_area").visible());
     assert.ok($("#compose .markdown_preview").visible());
@@ -455,7 +455,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 
     override(user_settings, "enter_sends", false);
     $("textarea#compose-textarea").trigger("blur");
-    compose.enter_with_preview_open();
+    compose.handle_enter_key_with_preview_open();
     assert.ok($("textarea#compose-textarea").is_focused());
 
     // Test sending a message without content.
@@ -463,7 +463,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     $("#compose .preview_message_area").show();
     override(user_settings, "enter_sends", true);
 
-    compose.enter_with_preview_open();
+    compose.handle_enter_key_with_preview_open();
 });
 
 test_ui("finish", ({override, override_rewire}) => {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -140,15 +140,6 @@ const everyone = {
 
 user_groups.initialize({realm_user_groups: [nobody, everyone]});
 
-function stub_message_row($textarea) {
-    const $stub = $.create("message_row_stub");
-    $textarea.closest = (selector) => {
-        assert.equal(selector, ".message_row");
-        $stub.length = 0;
-        return $stub;
-    };
-}
-
 function test_ui(label, f) {
     // TODO: initialize data more aggressively.
     run_test(label, f);
@@ -161,15 +152,161 @@ function initialize_handlers({override}) {
     compose_setup.initialize();
 }
 
-test_ui("send_message_success", ({override, override_rewire}) => {
-    mock_banners();
+function disable_document_triggers(override) {
+    override(document, "to_$", () => $("document-stub"));
+}
 
-    let draft_deleted;
-    let reify_message_id_checked;
-    function reset() {
+function on_compose_finished_trigger_do(f) {
+    $(document).on("compose_finished.zulip", f);
+}
+
+function simulate_draft_ui_interactions() {
+    // Simulate DOM relationships so that code can execute,
+    // but we won't actually examine these values.
+    $(".top_left_drafts").set_find_results(".unread_count", $.create("draft-unread-count-stub"));
+}
+
+function assert_compose_send_button_attr_is_undefined() {
+    assert.equal($("#compose-send-button").attr(), undefined);
+}
+
+class FakeComposeBox {
+    constructor() {
+        // Simulate DOM relationships
+        // stub_message_row($("textarea#compose-textarea"));
+        $("#send_message_form").set_find_results(
+            ".message-textarea",
+            $("textarea#compose-textarea"),
+        );
+        $("#send_message_form").set_find_results(
+            ".message-limit-indicator",
+            $.create("limit-indicator-stub"),
+        );
+        $("textarea#compose-textarea").toggleClass = noop;
+
+        const $message_row_stub = $.create("message_row_stub");
+        $("textarea#compose-textarea").closest = (selector) => {
+            assert.equal(selector, ".message_row");
+            $message_row_stub.length = 0;
+            return $message_row_stub;
+        };
+
+        this.reset();
+    }
+
+    reset() {
         $("textarea#compose-textarea").val("default message");
         $("textarea#compose-textarea").trigger("blur");
         $(".compose-submit-button .loader").show();
+    }
+
+    show_message_preview() {
+        $("#compose .undo_markdown_preview").show();
+        $("#compose .preview_message_area").show();
+        $("#compose .markdown_preview").hide();
+        $("#compose").addClass("preview_mode");
+    }
+
+    hide_message_preview() {
+        $("#compose .markdown_preview").show();
+        $("#compose .undo_markdown_preview").hide();
+        $("#compose .preview_message_area").hide();
+        $("#compose").removeClass("preview_mode");
+    }
+
+    textarea_val() {
+        return $("textarea#compose-textarea").val();
+    }
+
+    preview_content_html() {
+        return $("#compose .preview_content").html();
+    }
+
+    compose_spinner_selector() {
+        return ".compose-submit-button .loader";
+    }
+
+    markdown_spinner_selector() {
+        return "#compose .markdown_preview_spinner";
+    }
+
+    set_topic_val(topic_name) {
+        $("input#stream_message_recipient_topic").val(topic_name);
+    }
+
+    set_textarea_val(val) {
+        $("textarea#compose-textarea").val(val);
+    }
+
+    blur_textarea() {
+        $("textarea#compose-textarea").trigger("blur");
+    }
+
+    show_submit_button_spinner() {
+        $(".compose-submit-button .loader").show();
+    }
+
+    set_textarea_toggle_class_function(f) {
+        $("textarea#compose-textarea").toggleClass = f;
+    }
+
+    is_recipient_not_subscribed_banner_visible() {
+        return $("#compose_banners .recipient_not_subscribed").visible();
+    }
+
+    is_textarea_focused() {
+        return $("textarea#compose-textarea").is_focused();
+    }
+
+    is_submit_button_spinner_visible() {
+        return $(this.compose_spinner_selector()).visible();
+    }
+
+    trigger_submit_handler_on_compose_form(event) {
+        $("#compose form").get_on_handler("submit")(event);
+    }
+
+    click_on_markdown_preview_icon(event) {
+        $("#compose").get_on_handler("click", ".markdown_preview")(event);
+    }
+
+    click_on_undo_markdown_preview_icon(event) {
+        $("#compose").get_on_handler("click", ".undo_markdown_preview")(event);
+    }
+
+    click_on_upload_attachment_icon(event) {
+        $("#compose").get_on_handler("click", ".compose_upload_file")(event);
+    }
+
+    set_click_handler_for_upload_file_input_element(f) {
+        $("#compose .file_input").on("click", f);
+    }
+
+    assert_preview_mode_is_off() {
+        assert.ok(!$("#compose .undo_markdown_preview").visible());
+        assert.ok(!$("#compose .preview_message_area").visible());
+        assert.ok($("#compose .markdown_preview").visible());
+        assert.ok(!$("#compose").hasClass("preview_mode"));
+    }
+
+    assert_preview_mode_is_on() {
+        assert.ok(!$("#compose .markdown_preview").visible());
+        assert.ok($("#compose .undo_markdown_preview").visible());
+        assert.ok($("#compose .preview_message_area").visible());
+        assert.ok($("#compose").hasClass("preview_mode"));
+    }
+}
+
+test_ui("send_message_success", ({override, override_rewire}) => {
+    mock_banners();
+
+    const fake_compose_box = new FakeComposeBox();
+
+    let draft_deleted;
+    let reify_message_id_checked;
+
+    function reset() {
+        fake_compose_box.reset();
         draft_deleted = false;
         reify_message_id_checked = false;
     }
@@ -186,13 +323,6 @@ test_ui("send_message_success", ({override, override_rewire}) => {
         assert.equal(message_id, 12);
         reify_message_id_checked = true;
     });
-
-    const $elem = $("#send_message_form");
-    const $textarea = $("textarea#compose-textarea");
-    const $indicator = $("#compose-limit-indicator");
-    stub_message_row($textarea);
-    $elem.set_find_results(".message-textarea", $textarea);
-    $elem.set_find_results(".message-limit-indicator", $indicator);
 
     override(
         onboarding_steps,
@@ -219,9 +349,9 @@ test_ui("send_message_success", ({override, override_rewire}) => {
     let data = {id: 12, automatic_new_visibility_policy: 2};
     compose.send_message_success(request, data);
 
-    assert.equal($("textarea#compose-textarea").val(), "");
-    assert.ok($("textarea#compose-textarea").is_focused());
-    assert.ok(!$(".compose-submit-button .loader").visible());
+    assert.equal(fake_compose_box.textarea_val(), "");
+    assert.ok(fake_compose_box.is_textarea_focused());
+    assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
     assert.ok(reify_message_id_checked);
     assert.ok(draft_deleted);
 
@@ -244,9 +374,9 @@ test_ui("send_message_success", ({override, override_rewire}) => {
     data = {id: 12};
     compose.send_message_success(request, data);
 
-    assert.equal($("textarea#compose-textarea").val(), "");
-    assert.ok($("textarea#compose-textarea").is_focused());
-    assert.ok(!$(".compose-submit-button .loader").visible());
+    assert.equal(fake_compose_box.textarea_val(), "");
+    assert.ok(fake_compose_box.is_textarea_focused());
+    assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
     assert.ok(reify_message_id_checked);
     assert.ok(draft_deleted);
 });
@@ -255,12 +385,13 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     mock_banners();
     MockDate.set(new Date(fake_now * 1000));
     override_rewire(drafts, "sync_count", noop);
-    const $elem = $("#send_message_form");
-    const $textarea = $("textarea#compose-textarea");
-    const $indicator = $("#compose-limit-indicator");
-    stub_message_row($textarea);
-    $elem.set_find_results(".message-textarea", $textarea);
-    $elem.set_find_results(".message-limit-indicator", $indicator);
+
+    const fake_compose_box = new FakeComposeBox();
+
+    // Draft UI side-effects are out of the scope of this test,
+    // but we need the code to not fail.
+    // TODO: probably mock at a higher level.
+    simulate_draft_ui_interactions();
 
     // This is the common setup stuff for all of the four tests.
     let stub_state;
@@ -272,9 +403,6 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         return stub_state;
     }
 
-    const $container = $(".top_left_drafts");
-    const $child = $(".unread_count");
-    $container.set_find_results(".unread_count", $child);
     override_rewire(drafts, "update_compose_draft_count", noop);
 
     override(server_events, "assert_get_events_running", () => {
@@ -337,9 +465,9 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
             stub_state.reify_message_id_checked += 1;
         });
 
-        $("textarea#compose-textarea").val("[foobar](/user_uploads/123456)");
-        $("textarea#compose-textarea").trigger("blur");
-        $(".compose-submit-button .loader").show();
+        fake_compose_box.set_textarea_val("[foobar](/user_uploads/123456)");
+        fake_compose_box.blur_textarea();
+        fake_compose_box.show_submit_button_spinner();
 
         compose.send_message();
 
@@ -349,9 +477,9 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
             send_msg_called: 1,
         };
         assert.deepEqual(stub_state, state);
-        assert.equal($("textarea#compose-textarea").val(), "");
-        assert.ok($("textarea#compose-textarea").is_focused());
-        assert.ok(!$(".compose-submit-button .loader").visible());
+        assert.equal(fake_compose_box.textarea_val(), "");
+        assert.ok(fake_compose_box.is_textarea_focused());
+        assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
     })();
 
     // This is the additional setup which is common to both the tests below.
@@ -392,10 +520,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
             return "<banner-stub>";
         });
         stub_state = initialize_state_stub_dict();
-        $("textarea#compose-textarea").val("default message");
-        $("textarea#compose-textarea").trigger("blur");
-        $(".compose-submit-button .loader").show();
-        $("textarea#compose-textarea").off("select");
+        fake_compose_box.reset();
         echo_error_msg_checked = false;
         override_rewire(echo, "try_deliver_locally", noop);
 
@@ -411,20 +536,24 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.deepEqual(stub_state, state);
         assert.ok(!echo_error_msg_checked);
         assert.ok(banner_rendered);
-        assert.equal($("textarea#compose-textarea").val(), "default message");
-        assert.ok($("textarea#compose-textarea").is_focused());
-        assert.ok(!$(".compose-submit-button .loader").visible());
+        assert.equal(fake_compose_box.textarea_val(), "default message");
+        assert.ok(fake_compose_box.is_textarea_focused());
+        assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
     })();
 });
 
 test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
-    $("textarea#compose-textarea").toggleClass = noop;
     override_rewire(compose_banner, "clear_message_sent_banners", noop);
-    override(document, "to_$", () => $("document-stub"));
+
+    disable_document_triggers(override);
+
     let show_button_spinner_called = false;
+
+    const fake_compose_box = new FakeComposeBox();
+
     override(loading, "show_button_spinner", ($spinner) => {
-        assert.equal($spinner.selector, ".compose-submit-button .loader");
+        assert.equal($spinner.selector, fake_compose_box.compose_spinner_selector());
         show_button_spinner_called = true;
     });
 
@@ -434,33 +563,29 @@ test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
     compose_state.set_message_type("stream");
     compose_state.set_stream_id(social.stream_id);
 
-    $("textarea#compose-textarea").val("message me");
-    $("#compose .undo_markdown_preview").show();
-    $("#compose .preview_message_area").show();
-    $("#compose .markdown_preview").hide();
-    $("#compose").addClass("preview_mode");
+    fake_compose_box.set_textarea_val("message me");
+    fake_compose_box.show_message_preview();
+
     override(user_settings, "enter_sends", true);
     let send_message_called = false;
     override_rewire(compose, "send_message", () => {
         send_message_called = true;
     });
-    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
+
     compose.handle_enter_key_with_preview_open();
-    assert.ok(!$("#compose .undo_markdown_preview").visible());
-    assert.ok(!$("#compose .preview_message_area").visible());
-    assert.ok($("#compose .markdown_preview").visible());
-    assert.ok(!$("#compose").hasClass("preview_mode"));
+    fake_compose_box.assert_preview_mode_is_off();
+
     assert.ok(send_message_called);
     assert.ok(show_button_spinner_called);
 
     override(user_settings, "enter_sends", false);
-    $("textarea#compose-textarea").trigger("blur");
+    fake_compose_box.blur_textarea();
     compose.handle_enter_key_with_preview_open();
-    assert.ok($("textarea#compose-textarea").is_focused());
+    assert.ok(fake_compose_box.is_textarea_focused());
 
     // Test sending a message without content.
-    $("textarea#compose-textarea").val("");
-    $("#compose .preview_message_area").show();
+    fake_compose_box.set_textarea_val("");
+    fake_compose_box.show_message_preview();
     override(user_settings, "enter_sends", true);
 
     compose.handle_enter_key_with_preview_open();
@@ -468,37 +593,41 @@ test_ui("handle_enter_key_with_preview_open", ({override, override_rewire}) => {
 
 test_ui("finish", ({override, override_rewire}) => {
     mock_banners();
+    disable_document_triggers(override);
+
+    const fake_compose_box = new FakeComposeBox();
 
     override_rewire(compose_banner, "clear_message_sent_banners", noop);
-    override(document, "to_$", () => $("document-stub"));
-    $("#send_message_form").set_find_results(".message-textarea", $("textarea#compose-textarea"));
+
     let show_button_spinner_called = false;
     override(loading, "show_button_spinner", ($spinner) => {
-        assert.equal($spinner.selector, ".compose-submit-button .loader");
+        assert.equal($spinner.selector, fake_compose_box.compose_spinner_selector());
         show_button_spinner_called = true;
     });
 
     (function test_when_compose_validation_fails() {
-        $("textarea#compose-textarea").toggleClass = (classname, value) => {
+        fake_compose_box.set_textarea_toggle_class_function((classname, value) => {
             assert.equal(classname, "invalid");
             assert.equal(value, true);
-        };
-        $("textarea#compose-textarea").val("");
+        });
+
+        fake_compose_box.set_textarea_val("");
+
         override_rewire(compose_ui, "compose_spinner_visible", false);
         const res = compose.finish();
         assert.equal(res, false);
-        assert.ok(!$("#compose_banners .recipient_not_subscribed").visible());
-        assert.ok(!$(".compose-submit-button .loader").visible());
+
+        assert.ok(!fake_compose_box.is_recipient_not_subscribed_banner_visible());
+        assert.ok(!fake_compose_box.is_submit_button_spinner_visible());
+
         assert.ok(show_button_spinner_called);
     })();
 
     (function test_when_compose_validation_succeed() {
         // Testing successfully sending of a message.
-        $("#compose .undo_markdown_preview").show();
-        $("#compose .preview_message_area").show();
-        $("#compose .markdown_preview").hide();
-        $("#compsoe").addClass("preview_mode");
-        $("textarea#compose-textarea").val("default message");
+        fake_compose_box.show_message_preview();
+        fake_compose_box.set_textarea_val("default message");
+
         override_rewire(compose_ui, "compose_spinner_visible", false);
         compose_state.set_message_type("private");
         override(compose_pm_pill, "get_emails", () => "bob@example.com");
@@ -507,18 +636,19 @@ test_ui("finish", ({override, override_rewire}) => {
         override(realm, "realm_direct_message_initiator_group", everyone.id);
 
         let compose_finished_event_checked = false;
-        $(document).on("compose_finished.zulip", () => {
+
+        on_compose_finished_trigger_do(() => {
             compose_finished_event_checked = true;
         });
+
         let send_message_called = false;
         override_rewire(compose, "send_message", () => {
             send_message_called = true;
         });
+
         assert.ok(compose.finish());
-        assert.ok(!$("#compose .undo_markdown_preview").visible());
-        assert.ok(!$("#compose .preview_message_area").visible());
-        assert.ok($("#compose .markdown_preview").visible());
-        assert.ok(!$("#compose").hasClass("preview_mode"));
+
+        fake_compose_box.assert_preview_mode_is_off();
         assert.ok(send_message_called);
         assert.ok(compose_finished_event_checked);
     })();
@@ -593,7 +723,8 @@ test_ui("initialize", ({override}) => {
 
         compose_setup.abort_xhr();
 
-        assert.equal($("#compose-send-button").attr(), undefined);
+        // I'm not sure this proves anything interesting.
+        assert_compose_send_button_attr_is_undefined();
         assert.ok(uppy_cancel_all_called);
     })();
 });
@@ -640,18 +771,16 @@ test_ui("trigger_submit_compose_form", ({override, override_rewire}) => {
 
     let prevent_default_checked = false;
     let compose_finish_checked = false;
-    const e = {
-        preventDefault() {
-            prevent_default_checked = true;
-        },
-    };
+
     override_rewire(compose, "finish", () => {
         compose_finish_checked = true;
     });
 
-    const submit_handler = $("#compose form").get_on_handler("submit");
-
-    submit_handler(e);
+    new FakeComposeBox().trigger_submit_handler_on_compose_form({
+        preventDefault() {
+            prevent_default_checked = true;
+        },
+    });
 
     assert.ok(prevent_default_checked);
     assert.ok(compose_finish_checked);
@@ -662,37 +791,28 @@ test_ui("on_events", ({override, override_rewire}) => {
 
     override(rendered_markdown, "update_elements", noop);
 
+    const fake_compose_box = new FakeComposeBox();
+
     (function test_attach_files_compose_clicked() {
-        const handler = $("#compose").get_on_handler("click", ".compose_upload_file");
         let compose_file_input_clicked = false;
-        $("#compose .file_input").on("click", () => {
+
+        // For some reason clicking on the attachment icon
+        // triggers a click handler on #compose .file_input
+        // as part of our upload code, and we verify this
+        // codepath.
+        fake_compose_box.set_click_handler_for_upload_file_input_element(() => {
             compose_file_input_clicked = true;
         });
 
-        const event = {
+        fake_compose_box.click_on_upload_attachment_icon({
             preventDefault: noop,
             stopPropagation: noop,
-        };
+        });
 
-        handler(event);
         assert.ok(compose_file_input_clicked);
     })();
 
     (function test_markdown_preview_compose_clicked() {
-        function setup_visibilities() {
-            $("#compose .markdown_preview").show();
-            $("#compose .undo_markdown_preview").hide();
-            $("#compose .preview_message_area").hide();
-            $("#compose").removeClass("preview_mode");
-        }
-
-        function assert_visibilities() {
-            assert.ok(!$("#compose .markdown_preview").visible());
-            assert.ok($("#compose .undo_markdown_preview").visible());
-            assert.ok($("#compose .preview_message_area").visible());
-            assert.ok($("#compose").hasClass("preview_mode"));
-        }
-
         function setup_mock_markdown_contains_backend_only_syntax(msg_content, return_val) {
             override(markdown, "contains_backend_only_syntax", (msg) => {
                 assert.equal(msg, msg_content);
@@ -714,13 +834,14 @@ test_ui("on_events", ({override, override_rewire}) => {
                 rendered: "Server: default message",
             };
             success_callback(resp);
-            assert.equal($("#compose .preview_content").html(), "Server: default message");
+
+            assert.equal(fake_compose_box.preview_content_html(), "Server: default message");
         }
 
         function test_post_error(error_callback) {
             error_callback();
             assert.equal(
-                $("#compose .preview_content").html(),
+                fake_compose_box.preview_content_html(),
                 "translated HTML: Failed to generate preview",
             );
         }
@@ -735,7 +856,7 @@ test_ui("on_events", ({override, override_rewire}) => {
             function test(func, param) {
                 let destroy_indicator_called = false;
                 override(loading, "destroy_indicator", ($spinner) => {
-                    assert.equal($spinner, $("#compose .markdown_preview_spinner"));
+                    assert.equal($spinner.selector, fake_compose_box.markdown_spinner_selector());
                     destroy_indicator_called = true;
                 });
                 setup_mock_markdown_contains_backend_only_syntax(current_message, true);
@@ -749,43 +870,46 @@ test_ui("on_events", ({override, override_rewire}) => {
             test(test_post_success, payload.success);
         });
 
-        const handler = $("#compose").get_on_handler("click", ".markdown_preview");
-
         // Tests start here
-        $("textarea#compose-textarea").val("");
-        setup_visibilities();
+        fake_compose_box.set_textarea_val("");
+        fake_compose_box.hide_message_preview();
 
-        const event = {
+        fake_compose_box.click_on_markdown_preview_icon({
             preventDefault: noop,
             stopPropagation: noop,
-        };
+        });
 
-        handler(event);
-
-        assert.equal($("#compose .preview_content").html(), "translated HTML: Nothing to preview");
-        assert_visibilities();
+        assert.equal(
+            fake_compose_box.preview_content_html(),
+            "translated HTML: Nothing to preview",
+        );
+        fake_compose_box.assert_preview_mode_is_on();
 
         let make_indicator_called = false;
-        $("textarea#compose-textarea").val("```default message```");
-        setup_visibilities();
+
+        fake_compose_box.set_textarea_val("```default message```");
+        fake_compose_box.hide_message_preview();
         setup_mock_markdown_contains_backend_only_syntax("```default message```", true);
         setup_mock_markdown_is_status_message("```default message```", false);
 
         override(loading, "make_indicator", ($spinner) => {
-            assert.equal($spinner.selector, "#compose .markdown_preview_spinner");
+            assert.equal($spinner.selector, fake_compose_box.markdown_spinner_selector());
             make_indicator_called = true;
         });
 
         current_message = "```default message```";
 
-        handler(event);
+        fake_compose_box.click_on_markdown_preview_icon({
+            preventDefault: noop,
+            stopPropagation: noop,
+        });
 
         assert.ok(make_indicator_called);
-        assert_visibilities();
+        fake_compose_box.assert_preview_mode_is_on();
 
         let render_called = false;
-        $("textarea#compose-textarea").val("default message");
-        setup_visibilities();
+        fake_compose_box.set_textarea_val("default message");
+        fake_compose_box.hide_message_preview();
         setup_mock_markdown_contains_backend_only_syntax("default message", false);
         setup_mock_markdown_is_status_message("default message", false);
 
@@ -796,25 +920,18 @@ test_ui("on_events", ({override, override_rewire}) => {
             render_called = true;
         });
 
-        handler(event);
+        fake_compose_box.click_on_markdown_preview_icon({
+            preventDefault: noop,
+            stopPropagation: noop,
+        });
 
         assert.ok(render_called);
-        assert_visibilities();
-        assert.equal($("#compose .preview_content").html(), "Server: default message");
+        fake_compose_box.assert_preview_mode_is_on();
+        assert.equal(fake_compose_box.preview_content_html(), "Server: default message");
     })();
 
     (function test_undo_markdown_preview_clicked() {
-        const handler = $("#compose").get_on_handler("click", ".undo_markdown_preview");
-
-        $("#compose .undo_markdown_preview").show();
-        $("#compose .preview_message_area").show();
-        $("#compose .markdown_preview").hide();
-        $("#compose").removeClass("preview_mode");
-
-        const event = {
-            preventDefault: noop,
-            stopPropagation: noop,
-        };
+        fake_compose_box.show_message_preview();
 
         override_rewire(compose_recipient, "update_placeholder_text", noop);
         override(narrow_state, "narrowed_by_reply", () => true);
@@ -824,21 +941,24 @@ test_ui("on_events", ({override, override_rewire}) => {
             noop,
         );
 
-        handler(event);
+        fake_compose_box.click_on_undo_markdown_preview_icon({
+            preventDefault: noop,
+            stopPropagation: noop,
+        });
 
-        assert.ok(!$("#compose .undo_markdown_preview").visible());
-        assert.ok(!$("#compose .preview_message_area").visible());
-        assert.ok($("#compose .markdown_preview").visible());
-        assert.ok(!$("#compose").hasClass("preview_mode"));
+        fake_compose_box.assert_preview_mode_is_off();
     })();
 });
 
 test_ui("create_message_object", ({override, override_rewire}) => {
     mock_banners();
 
+    const fake_compose_box = new FakeComposeBox();
+
     compose_state.set_stream_id(social.stream_id);
-    $("input#stream_message_recipient_topic").val("lunch");
-    $("textarea#compose-textarea").val("burrito");
+
+    fake_compose_box.set_topic_val("lunch");
+    fake_compose_box.set_textarea_val("burrito");
 
     compose_state.set_message_type("stream");
 


### PR DESCRIPTION
This PR affects only test code (apart from a trivial search/replace).