### PR TITLE
compose: Set a min-height before showing preview area.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -71,6 +71,8 @@ export function show_preview_area() {
         $("#compose .preview_content"),
         content,
     );
+    const edit_height = $compose_textarea.height();
+    $preview_message_area.css({"min-height": edit_height + "px"});
     $preview_message_area.show();
 }
 

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1665,6 +1665,8 @@ export function show_preview_area($element: JQuery): void {
         $row.find(".preview_content"),
         content,
     );
+    const edit_height = $msg_edit_content.height();
+    $preview_message_area.css({"min-height": edit_height + "px"});
     $preview_message_area.show();
 }
 


### PR DESCRIPTION
Changes in #32695 wrongly assumed the preview box can only expand from the composebox, but for some situations like links it can also have a preview block that is less high than the raw text.

Reported on CZO:
https://chat.zulip.org/#narrow/channel/9-issues/topic/Preview.20breaks.20when.20the.20compose.20box.20is.20expanded.20by.20itself.2E/near/2029447
