### PR TITLE
navbar: Scale navbar with app font size, using em.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -167,24 +167,24 @@
     /*
     This is the header, aka the navbar.
     */
-    --header-height: 40px;
+    --header-height: 2.5em; /* 40px at 16px em */
 
     /*
     At 600px, the header starts taking up more than 5%
     of the screen. We make it shorter to leave more space
     to see the rest of the app. */
     @media (height < $short_navbar_cutoff_height) {
-        --header-height: 30px;
+        --header-height: 1.875em; /* 30px at 16px em */
     }
 
     /*
     Height of the search box, which appears in the header.
     */
-    --search-box-height: 32px;
-    --search-box-width: 150px;
+    --search-box-height: 2em; /* 32px at 16px em */
+    --search-box-width: 9.375em; /* 150px at 16px em */
 
     @media (width < $md_min) {
-        --search-box-width: 40px;
+        --search-box-width: 2.5em; /* 40px at 16px em */
     }
 
     /*
@@ -192,7 +192,7 @@
         is reduced to fit the available space.
     */
     @media (height < $short_navbar_cutoff_height) {
-        --search-box-height: 28px;
+        --search-box-height: 1.75em; /* 28px at 16px em */
     }
 
     /*

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -69,7 +69,7 @@
         }
 
         .pill-close-button {
-            font-size: 10px;
+            font-size: 0.7142em; /* 10px at 14px em */
             text-decoration: none;
             /* Let the close button's box stretch,
                but no larger than the height of the

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -3,7 +3,7 @@
     height: var(--header-height);
 
     .navbar-search {
-        margin: 3.5px 0;
+        margin: 0.2187em 0; /* 3.5px at 16px em */
         border-radius: 5px;
         position: absolute;
         overflow: hidden;
@@ -13,8 +13,8 @@
         grid-area: search-icon;
         align-self: center;
         text-decoration: none;
-        padding: 0 7px;
-        font-size: 17px;
+        padding: 0 0.4117em; /* 7px at 17px em */
+        font-size: 1.0625em; /* 17px at 16px em */
         border: none;
         background-color: transparent;
         color: var(--color-search-icons);
@@ -33,7 +33,7 @@
 
     .search_close_button {
         grid-area: search-close;
-        width: 28px;
+        width: 1.75em; /* 28px at 16px em */
         height: 100%;
         background: none;
         border: none;
@@ -64,7 +64,7 @@
         display: flex;
         padding: 0;
         flex-wrap: wrap;
-        gap: 2px;
+        gap: 0.125em; /* 2px at 16px em */
         align-self: center;
     }
 
@@ -206,7 +206,8 @@
         border: none;
         grid-template:
             "search-icon search-pills search-close" var(--search-box-height)
-            ". search-pills ." auto / auto minmax(0, 1fr) 28px;
+            ". search-pills ." auto / auto minmax(0, 1fr)
+            1.75em; /* 28px at 16px em */
         align-content: center;
         cursor: pointer;
 
@@ -216,7 +217,7 @@
                color as the search typeahead. */
             background-color: var(--color-background-search);
             /* Maintain only a column gap. */
-            gap: 0 5px;
+            gap: 0 0.3125em; /* 5px at 16px em */
             /* Override padding. */
             padding: 0;
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1104,11 +1104,11 @@ nav {
 
         .nav-logo {
             display: inline-block;
-            height: 20px;
-            max-width: 200px;
+            height: 1.25em; /* 20px at 16px em */
+            max-width: 12.5em; /* 200px at 16px em */
 
             @media (height < $short_navbar_cutoff_height) {
-                height: 15px;
+                height: 0.9375em; /* 15px at 16px em */
             }
         }
 
@@ -1793,8 +1793,8 @@ body:not(.hide-left-sidebar) {
     }
 
     #top_navbar .column-right #personal-menu .header-button-avatar {
-        width: 20px;
-        height: 20px;
+        width: 1.25em; /* 20px at 16px em */
+        height: 1.25em; /* 20px at 16px em */
     }
 }
 
@@ -2064,12 +2064,12 @@ body:not(.hide-left-sidebar) {
     }
 
     .zulip-icon-gear {
-        font-size: 18px;
+        font-size: 1.125em; /* 18px at 16px em */
     }
 
     .zulip-icon-help-bigger,
     .zulip-icon-user-list {
-        font-size: 20px;
+        font-size: 1.25em; /* 20px at 16px em */
     }
 
     .zulip-icon-help {
@@ -2081,8 +2081,8 @@ body:not(.hide-left-sidebar) {
 
 #personal-menu {
     .header-button-avatar {
-        width: 24px;
-        height: 24px;
+        width: 1.5em; /* 24px at 16px em */
+        height: 1.5em; /* 24px at 16px em */
         background-size: cover;
         border-radius: 4px;
         background-color: var(--color-background-image-loader);


### PR DESCRIPTION
<details>
<summary>screenshots: simple navbar</summary>

12px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/a38e175f-bcca-4fe3-bbdf-f8736c2b92fd" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/17902c45-07ac-487c-a300-55edf023f7dd" />


14px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/777e6e9e-05e9-4748-a653-ce088c584df3" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/bff293ec-9f9e-4835-a8ea-342ee28a0eca" />


16px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/9be61447-d4e6-4190-aaa3-31fc5a5bcbb0" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/a146a9b9-0c97-48b8-a56a-3c8baad993aa" />


20px before after

<img width="616" alt="image" src="https://github.com/user-attachments/assets/d09e2040-6848-4fd1-b673-3f1413841ea2" />

<img width="616" alt="image" src="https://github.com/user-attachments/assets/4d9a6c41-2ff1-46fc-b50b-762f173de32e" />

</details>





<details>
<summary>screenshots: search with pills</summary>

12px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/55c12bf4-9fb5-488d-be7f-2486e5bebe72" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/c6f9d6a3-7ae7-47e5-a41c-a6c3bc36fb01" />

14px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/c90c4840-44a8-4d62-88c7-2ab206c532f1" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/3277cb5b-f6bd-45e9-a391-30ea470477b8" />

16px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/8e5e2f33-17ae-45f7-b8c0-412017cb0c70" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/bb5a12cd-01b3-4f1c-8062-60ff2b12c8dc" />

20px before and after

<img width="618" alt="image" src="https://github.com/user-attachments/assets/7d29b1dc-667a-48b4-9810-dbdac4bc470c" />

<img width="619" alt="image" src="https://github.com/user-attachments/assets/7cecb93c-5df7-4864-ac7d-ca9a53d382e2" />


</details>





<details>
<summary>screenshots: short navbar</summary>

12px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/f9f35ea4-151f-406a-980a-fbcb56960abf" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/f9027a0a-8189-4786-8245-281d9d83a67a" />


14px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/a447cd1d-a1d7-497f-a976-9690efd75685" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/66b55ade-fc8d-432f-9edc-26a6789fe49e" />


16px before and after

<img width="619" alt="image" src="https://github.com/user-attachments/assets/67dba76c-44da-4058-8eb1-6f253851478a" />

<img width="619" alt="image" src="https://github.com/user-attachments/assets/629f86eb-f824-41ef-b521-49037cae0966" />


20px before and after

<img width="617" alt="image" src="https://github.com/user-attachments/assets/b54deb6b-cf27-483c-9542-fc808c3010fb" />

<img width="617" alt="image" src="https://github.com/user-attachments/assets/22b3c897-0547-4606-add6-d25c16eb47fc" />



</details>