### PR TITLE
popovers: Quoting for a  "(deleted)" tombstone messages will be allowed

### DIFF
--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -191,7 +191,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
     const should_display_uncollapse =
         !message.locally_echoed && !message.is_me_message && message.collapsed;
 
-    const should_display_quote_message = message.content !== "<p>(deleted)</p>" && not_spectator;
+    const should_display_quote_message = not_spectator;
 
     const conversation_time_url = hash_util.by_conversation_and_time_url(message);
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Allows the user to Quote a deleted message  as asked in [CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/message.20actions.20popover.20acts.20differently.20in.20dev.20environment/near/2029573)

As:
- It could not be correctly internationalized.
- We see a reason a user might want to do this.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/user-attachments/assets/585ebc37-b9e1-4315-abce-4402ba02b851)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
