### PR TITLE
message_header: Use em instead of px for height and font-size.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -210,11 +210,6 @@
     font-weight: 600;
     overflow: hidden;
 
-    .recipient-row-stream-icon {
-        font-size: 12px;
-        line-height: 12px;
-    }
-
     .zulip-icon.zulip-icon-globe {
         position: relative;
         top: 1px;

--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -16,7 +16,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        height: 28px;
+        height: 2em; /* 28px at 14px em */
         border: 1px solid var(--color-message-header-contents-border);
         border-bottom-color: var(--color-message-header-contents-border-bottom);
         border-radius: 7px 7px 0 0;
@@ -49,8 +49,8 @@
         .stream_topic {
             display: inline-block;
             padding: 5px 6px 5px 2px;
-            height: 17px;
-            line-height: 17px;
+            height: 1.2142em; /* 17px at 14px em */
+            line-height: 1.2142em; /* 17px at 14px em */
             overflow: hidden;
             text-overflow: ellipsis;
 
@@ -67,7 +67,7 @@
         }
 
         .stream-privacy i {
-            font-size: 15px;
+            font-size: 1.0714em; /* 15px at 14px em */
 
             &.zulip-icon-globe,
             &.zulip-icon-hashtag {
@@ -122,8 +122,8 @@
         display: flex;
         padding: 5px 0 5px 10px;
         font-weight: 600;
-        height: 17px;
-        line-height: 17px;
+        height: 1.2142em; /* 17px at 14px em */
+        line-height: 1.2142em; /* 17px at 14px em */
         color: var(--color-text-message-header);
 
         &:hover {
@@ -132,11 +132,11 @@
         }
 
         .private_message_header_icon {
-            font-size: 15px;
+            font-size: 1.0714em; /* 15px at 14px em */
             position: relative;
             top: 1px;
-            width: 16px;
-            height: 16px;
+            width: 1.0666em; /* 16px at 15px em */
+            height: 1.0666em; /* 16px at 15px em */
         }
 
         .private_message_header_name {
@@ -202,8 +202,8 @@
     align-items: center;
     gap: 5px;
     padding: 5px 2px 5px 10px;
-    height: 17px;
-    line-height: 17px;
+    height: 1.2142em; /* 17px at 14px em */
+    line-height: 1.2142em; /* 17px at 14px em */
     position: relative;
     top: 0.5px;
     text-decoration: none;
@@ -221,14 +221,14 @@
 
     .stream-privacy {
         min-width: unset;
-        width: 16px;
-        height: 16px;
+        width: 1.1428em; /* 16px at 14px em */
+        height: 1.1428em; /* 16px at 14px em */
 
         .hashtag {
             padding-right: 0;
 
             &::after {
-                font-size: 16px;
+                font-size: 1.1428em; /* 16px at 14px em */
             }
         }
     }


### PR DESCRIPTION
Followup up on  #32924 with a more involved change.

---

12px before and after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6ff238cc-f950-46f4-af2f-6384c925f50d" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4041600b-a23c-4541-b12b-4736554f361f" />


14px before and after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/85ca35a4-7074-4ef6-9dc5-bc5898458691" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/63262a5a-cd8a-4218-b5b3-8fc05d1d3c12" />

16px before and after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b5f5db6a-c04c-4247-a13c-99509bdef0d9" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f27e7a47-22e4-4938-b5bc-42a6d3d7e62a" />


20px before and after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/119e583f-d0ff-406d-a5d1-0bb4f7eeec57" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e3536612-a5e4-4cec-9da8-bff583e8f5eb" />
