### PR TITLE
recent_view: Fix UI fails to update when marking messages read.

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -565,14 +565,17 @@ export function maybe_load_older_messages(opts: {
         }
 
         if (fetched_substantial_history && found_first_unread) {
-            recent_view_ui.set_backfill_in_progress(false);
-            return;
+            // Once we have fetched enough history, we just do fetches in
+            // `consts.recent_view_fetch_more_batch_size`.
+            opts.cont = () => {
+                recent_view_ui.set_backfill_in_progress(false);
+            };
+        } else {
+            opts.cont = () =>
+                setTimeout(() => {
+                    maybe_load_older_messages(opts);
+                }, consts.catch_up_backfill_delay);
         }
-
-        opts.cont = () =>
-            setTimeout(() => {
-                maybe_load_older_messages(opts);
-            }, consts.catch_up_backfill_delay);
     }
     do_backfill({
         msg_list: opts.msg_list,

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -369,6 +369,12 @@ export function get_focused_row_message(): Message | undefined {
 
         const $topic_rows = $("#recent-view-content-tbody tr");
         const $topic_row = $topic_rows.eq(row_focus);
+        if ($topic_row.length === 0) {
+            // There are less items in the table than `row_focus`.
+            // We don't reset `row_focus` here since that is not the
+            // purpose of this function.
+            return undefined;
+        }
         const topic_id = $topic_row.attr("id");
         assert(topic_id !== undefined);
         const conversation_id = topic_id.slice(recent_conversation_key_prefix.length);


### PR DESCRIPTION
When bulk marking messages as read, it can happen that the there are less number of rows visible than the current `row_focus`. This can lead to an error in the updated code here which results in the bulk mark as read operation from successfully updating the UI.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Unable.20to.20mark.20all.20as.20read.20at.20Lean.20Prover
