### PR TITLE
node test: Fix some mocking related to the list widget.

### DIFF
--- a/web/tests/alert_words_ui.test.cjs
+++ b/web/tests/alert_words_ui.test.cjs
@@ -19,26 +19,29 @@ alert_words.initialize({
 run_test("rerender_alert_words_ui", ({mock_template}) => {
     let list_widget_create_called = false;
     alert_words_ui.reset();
-    const ListWidget = mock_esm("../src/list_widget", {
-        modifier_html: noop,
+
+    mock_esm("../src/list_widget", {
         create(_container, words, opts) {
-            const alert_words = [];
-            ListWidget.modifier_html = opts.modifier_html;
+            assert.deepEqual(words, [{word: "foo"}, {word: "bar"}]);
             for (const word of words) {
-                alert_words.push(opts.modifier_html(word));
+                opts.modifier_html(word);
             }
             list_widget_create_called = true;
-            return alert_words;
         },
         generic_sort_functions: noop,
     });
+
     mock_template("settings/alert_word_settings_item.hbs", false, (args) => {
         assert.ok(["foo", "bar"].includes(args.alert_word.word));
     });
+
     assert.equal(alert_words_ui.loaded, false);
-    alert_words_ui.rerender_alert_words_ui();
     assert.equal(list_widget_create_called, false);
+
+    // Invoke list_widget.create indirectly via these calls.
+    alert_words_ui.rerender_alert_words_ui();
     alert_words_ui.set_up_alert_words();
+
     assert.equal(alert_words_ui.loaded, true);
     assert.equal(list_widget_create_called, true);
 });

--- a/web/tests/alert_words_ui.test.cjs
+++ b/web/tests/alert_words_ui.test.cjs
@@ -31,8 +31,10 @@ run_test("rerender_alert_words_ui", ({mock_template}) => {
         generic_sort_functions: noop,
     });
 
-    mock_template("settings/alert_word_settings_item.hbs", false, (args) => {
+    mock_template("settings/alert_word_settings_item.hbs", true, (args, html) => {
         assert.ok(["foo", "bar"].includes(args.alert_word.word));
+        // do a super easy sanity check
+        assert.ok(html.includes("alert_word_listing"));
     });
 
     assert.equal(alert_words_ui.loaded, false);

--- a/web/tests/settings_profile_fields.test.cjs
+++ b/web/tests/settings_profile_fields.test.cjs
@@ -48,14 +48,7 @@ const Sortable = {create: noop};
 
 mock_esm("sortablejs", {default: Sortable});
 
-mock_esm("../src/list_widget", {
-    generic_sort_functions: noop,
-    create(_container, custom_profile_data, opts) {
-        for (const item of custom_profile_data) {
-            opts.modifier_html(item);
-        }
-    },
-});
+const list_widget = mock_esm("../src/list_widget");
 
 const settings_profile_fields = zrequire("settings_profile_fields");
 const {set_current_user, set_realm} = zrequire("state_data");
@@ -64,6 +57,14 @@ const current_user = {};
 set_current_user(current_user);
 const realm = {};
 set_realm(realm);
+
+function make_list_widget_only_render_items(override) {
+    override(list_widget, "create", (_container, custom_profile_data, opts) => {
+        for (const item of custom_profile_data) {
+            opts.modifier_html(item);
+        }
+    });
+}
 
 function test_populate(opts, template_data) {
     with_overrides(({override}) => {
@@ -84,6 +85,8 @@ function test_populate(opts, template_data) {
 }
 
 run_test("populate_profile_fields", ({mock_template, override}) => {
+    make_list_widget_only_render_items(override);
+
     override(realm, "custom_profile_fields", {});
     override(realm, "realm_default_external_accounts", JSON.stringify({}));
 

--- a/web/tests/settings_user_topics.test.cjs
+++ b/web/tests/settings_user_topics.test.cjs
@@ -6,9 +6,7 @@ const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
-const list_widget = mock_esm("../src/list_widget", {
-    generic_sort_functions: noop,
-});
+const list_widget = mock_esm("../src/list_widget");
 
 const settings_user_topics = zrequire("settings_user_topics");
 const stream_data = zrequire("stream_data");
@@ -31,7 +29,10 @@ run_test("settings", ({override, override_rewire}) => {
         user_topics.all_visibility_policies.MUTED,
         1577836800,
     );
+
     let populate_list_called = false;
+
+    override(list_widget, "generic_sort_functions", noop);
     override(list_widget, "create", (_$container, list) => {
         assert.deepEqual(list, [
             {


### PR DESCRIPTION
The first commit fixes things that were just obviously wonky.

The other commits attempt to avoid top-level setup in mock_esm, in favor of doing more explicit override calls in the individual tests.
