### PR TITLE
settings_ui: Prevent password change when old and new passwords match.

### DIFF
--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -519,6 +519,19 @@ export function set_up(): void {
 
         const $new_pw_field = $("#new_password");
         const new_pw = data.new_password;
+        const old_pw = data.old_password;
+        // Check if the new password is the same as the old password
+        if (new_pw === old_pw) {
+            ui_report.error(
+                $t_html({
+                    defaultMessage: "The new password cannot be the same as the current password",
+                }),
+                undefined,
+                $("#dialog_error"),
+            );
+            dialog_widget.hide_dialog_spinner();
+            return;
+        }
         if (new_pw !== "") {
             if (password_quality === undefined) {
                 // password_quality didn't load, for whatever reason.


### PR DESCRIPTION
Previously, the password change function did not check if the new password was the same as the old password, which could lead to user confusion as no actual change would occur.

This commit introduces a check that ensures the new password is different from the old password, preventing unnecessary password updates and improving the user experience.

Fixes: #32938

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Before:**
[Screencast from 2025-01-07 21-36-42.webm](https://github.com/user-attachments/assets/9824de73-431c-4f4f-ba30-b10eb04536a8)

**After:**
[Screencast from 2025-01-07 21-40-45.webm](https://github.com/user-attachments/assets/62c82f60-7035-4c88-bc6b-76e2ff3f2fe6)

![Screenshot from 2025-01-07 21-41-58](https://github.com/user-attachments/assets/11bc4c5d-ece1-4547-8d1b-3811dbe746ec)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
