### PR TITLE
messages_lists: Show recipient header in conversation view with "near".

### DIFF
--- a/web/src/message_lists.ts
+++ b/web/src/message_lists.ts
@@ -57,7 +57,10 @@ export function update_current_message_list(msg_list: MessageList | undefined): 
         current.view.$list.addClass("focused-message-list");
     }
 
-    if (current?.data.filter.is_conversation_view()) {
+    if (
+        current?.data.filter.is_conversation_view() ||
+        current?.data.filter.is_conversation_view_with_near()
+    ) {
         $(".focused-message-list").addClass("is-conversation-view");
     } else {
         $(".focused-message-list").removeClass("is-conversation-view");


### PR DESCRIPTION
In addition to the regular conversation view, we want to ensure the recipient bar remains consistently visible in the conversation view when using "near."

 ## Before

[Screencast from 2025-01-08 02-19-59.webm](https://github.com/user-attachments/assets/d0858bba-bd7d-40a0-9e3f-2b37807dfcc0)

## After

[Screencast from 2025-01-08 02-21-41.webm](https://github.com/user-attachments/assets/652c687d-1ff7-4d58-bb40-4f62fa2bb8a3)


Fixes a bug introduced in #32233.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
