### PR TITLE
modal: Use em instead of rem for modal title.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -32,10 +32,12 @@
 .modal__header {
     padding: 16px 16px 16px 24px;
     display: grid;
-    /* 25px at 16px/1em = 1.6667
+    /* 1.8em is the shortest round value for heading at which none of
+       the letters of the english alphabet get cut by overflow:hidden
+       at em = 20px
        29px at 16px/1em = 1.8125 */
     grid-template:
-        "heading close-button" 1.6667em "heading ." auto / minmax(0, 1fr)
+        "heading close-button" 1.8em "heading ." auto / minmax(0, 1fr)
         1.8125em;
     grid-column-gap: 4px;
 }
@@ -48,8 +50,10 @@
 }
 
 .modal__title {
+    grid-area: heading;
     margin: 0;
-    font-size: 1.375rem;
+    /* 16 / 14 * 1.375 = 1.5714, from original 1.375rem */
+    font-size: 1.5714em;
     font-weight: 600;
     line-height: 1.25;
     overflow: hidden;
@@ -447,10 +451,6 @@
     to fit in without need for scrolling */
     height: 32.1428em; /* 450px / 14px em */
     overflow: hidden;
-
-    .modal__title {
-        font-size: 1.375em; /* Replace default rem */
-    }
 
     .modal__content {
         flex-grow: 1;


### PR DESCRIPTION
This commit makes the modal title responsive for font-sizes 12px to 20px.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


| Old | New |
| --- | --- |
| 12px | 12px |
| ![old_modal_title_12px](https://github.com/user-attachments/assets/862b44be-9639-4a0a-88f4-658dfa334500) | ![new_modal_title_12px](https://github.com/user-attachments/assets/e703e881-723d-4129-b096-b20a2d1ff6ca) |
| 14px | 14px |
| ![old_modal_title_14px](https://github.com/user-attachments/assets/060c01ae-eb06-484a-8c7e-400d7b34eccb)  | ![new_modal_title_14px](https://github.com/user-attachments/assets/30596a61-8e0d-4929-960b-5d1bda9977e2)
| 16px | 16px |
  | ![old_modal_title_16px](https://github.com/user-attachments/assets/7943e5eb-27b0-46fe-a3f5-67bdfcbb8af7)  | ![new_modal_title_16px](https://github.com/user-attachments/assets/d0538591-bb19-41a5-b850-8384212ad337)
| 18px | 18px |
  | ![old_modal_title_18px](https://github.com/user-attachments/assets/acc1e4b6-80f7-470b-a5e2-de8ee719c385)  | ![new_modal_title_18px](https://github.com/user-attachments/assets/e442a4f7-760f-4d5a-a96e-d5947e4b4399)
| 20px | 20px |
  | ![old_modal_title_20px](https://github.com/user-attachments/assets/9594e289-8451-4285-a487-536c69101e27)  | ![new_modal_title_20px](https://github.com/user-attachments/assets/25316b89-6ccd-447f-a1e6-309853447b6e)

Overflow hidden check with all letters:
![screenshot with all letters](https://github.com/user-attachments/assets/d36d2b4f-1794-450b-b942-3d1f8ea8e35d)

Long sentence in title:
<img width="522" alt="Screenshot 2025-01-09 at 11 54 55 AM" src="https://github.com/user-attachments/assets/f523e198-03d0-4210-8ff9-59956c2cf774" />

I haven't had a look at the billing and upgrade modals, since they will not be affected by change in font sizes. Let me know if there needs to be a check there too. 

For #add-poll-modal, we remove the .modal__title rule for
font-size set to 1.375em. That removal technically increases it's font
size from 1.375em to 1.5714em, but that new font size is the same as the
previous 1.375rem that was changed in
https://github.com/zulip/zulip/pull/32913/files/e80a23642d9fce1dc1fbc174e0b25bdb154934a8#r1904958062

I've uploaded poll modal screenshots just to show no new visual issues have been introduced. Let me know if you need before and after comparisons. There will be a font size increase in before and after screenshots here since we are making the poll modal title size same as the other modals.

12px:
<img width="527" alt="poll_modal_12px" src="https://github.com/user-attachments/assets/b4805fbe-1793-49b8-9327-8cc57616fc44" />

14px:
<img width="527" alt="poll_modal_14px" src="https://github.com/user-attachments/assets/bd708b24-16a5-4651-b8ef-ed6775cfcfeb" />

16px:
<img width="527" alt="poll_modal_16px" src="https://github.com/user-attachments/assets/ff3f6eff-ffd0-40f8-aed3-478ecd48780e" />

18px:
<img width="527" alt="poll_modal_18px" src="https://github.com/user-attachments/assets/46a36646-63c1-4ff9-813d-8e10f9264213" />

20px:
<img width="527" alt="poll_modal_20px" src="https://github.com/user-attachments/assets/8ae06aaa-2b2d-444d-b3da-1de8f0b6896f" />


<details>
<summary>Self-review checklist</summary>



<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
