### PR TITLE
web: Add support for empty topic names.

### DIFF
--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -114,6 +114,7 @@ IGNORED_PHRASES = [
     r"^moving messages$",
     r"^start a conversation$",
     r"^welcome to Zulip!$",
+    r"^general chat$",
     # These are used as example short names (e.g. an uncapitalized context):
     r"^marketing$",
     r"^cookie$",

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -77,12 +77,6 @@ export function show_preview_area() {
 }
 
 export function create_message_object(message_content = compose_state.message_content()) {
-    // Topics are optional, and we provide a placeholder if one isn't given.
-    let topic = compose_state.topic();
-    if (topic === "") {
-        topic = compose_state.empty_topic_placeholder();
-    }
-
     // Changes here must also be kept in sync with echo.try_deliver_locally
     const message = {
         type: compose_state.get_message_type(),
@@ -110,7 +104,7 @@ export function create_message_object(message_content = compose_state.message_co
             message.to = people.user_ids_string_to_ids_array(message.to_user_ids);
         }
     } else {
-        message.topic = topic;
+        message.topic = compose_state.topic();
         const stream_id = compose_state.stream_id();
         message.stream_id = stream_id;
         message.to = stream_id;

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -321,6 +321,7 @@ export function quote_message(opts: {
 
     void channel.get({
         url: "/json/messages/" + message_id,
+        data: {allow_empty_topic_name: true},
         success(raw_data) {
             const data = z.object({raw_content: z.string()}).parse(raw_data);
             replace_content(message, data.raw_content);

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -637,9 +637,7 @@ function validate_stream_message(scheduling_message: boolean): boolean {
 
     if (realm.realm_mandatory_topics) {
         const topic = compose_state.topic();
-        // TODO: We plan to migrate the empty topic to only using the
-        // `""` representation for i18n reasons, but have not yet done so.
-        if (topic === "" || topic === "(no topic)") {
+        if (topic === "") {
             compose_banner.show_error_message(
                 $t({defaultMessage: "Topics are required in this organization."}),
                 compose_banner.CLASSNAMES.topic_missing,

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -564,7 +564,8 @@ export type FormattedDraft =
           stream_name?: string | undefined;
           recipient_bar_color: string;
           stream_privacy_icon_color: string;
-          topic: string;
+          topic_display_name: string;
+          is_empty_string_topic: boolean;
           raw_content: string;
           stream_id: number | undefined;
           time_stamp: string;
@@ -621,7 +622,7 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
             invite_only = sub.invite_only;
             is_web_public = sub.is_web_public;
         }
-        const draft_topic = draft.topic || compose_state.empty_topic_placeholder();
+        const draft_topic_display_name = util.get_final_topic_display_name(draft.topic);
         const draft_stream_color = stream_data.get_color(draft.stream_id);
 
         return {
@@ -631,7 +632,8 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
             recipient_bar_color: stream_color.get_recipient_bar_color(draft_stream_color),
             stream_privacy_icon_color:
                 stream_color.get_stream_privacy_icon_color(draft_stream_color),
-            topic: draft_topic,
+            topic_display_name: draft_topic_display_name,
+            is_empty_string_topic: draft.topic === "",
             raw_content: draft.content,
             stream_id: draft.stream_id,
             time_stamp,

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -173,7 +173,7 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
 
         const raw_operand = hash[i + 1];
 
-        if (!raw_operand) {
+        if (raw_operand === undefined) {
             return undefined;
         }
 
@@ -181,6 +181,12 @@ export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
         if (operator.startsWith("-")) {
             negated = true;
             operator = operator.slice(1);
+        }
+
+        // We allow the empty string as a topic name.
+        // Any other operand being empty string is invalid.
+        if (operator !== "topic" && raw_operand === "") {
+            return undefined;
         }
 
         const operand = decode_operand(operator, raw_operand);

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -110,6 +110,8 @@ type TopicContext = {
     is_topic: boolean;
     stream_id: number;
     topic_name: string;
+    topic_display_name: string;
+    is_empty_string_topic: boolean;
     unread_count: number;
     conversation_key: string;
     topic_url: string;
@@ -126,6 +128,8 @@ const topic_context_properties: (keyof TopicContext)[] = [
     "is_topic",
     "stream_id",
     "topic_name",
+    "topic_display_name",
+    "is_empty_string_topic",
     "unread_count",
     "conversation_key",
     "topic_url",
@@ -438,6 +442,8 @@ function format_topic(
         is_topic: true,
         stream_id,
         topic_name: topic,
+        topic_display_name: util.get_final_topic_display_name(topic),
+        is_empty_string_topic: topic === "",
         unread_count: topic_unread_count,
         conversation_key: get_topic_key(stream_id, topic),
         topic_url: hash_util.by_stream_topic_url(stream_id, topic),

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -669,6 +669,7 @@ export function start($row: JQuery, edit_box_open_callback?: () => void): void {
     const msg_list = message_lists.current;
     void channel.get({
         url: "/json/messages/" + message.id,
+        data: {allow_empty_topic_name: true},
         success(data) {
             const {raw_content} = z.object({raw_content: z.string()}).parse(data);
             if (message_lists.current === msg_list) {
@@ -1582,6 +1583,7 @@ export function with_first_message_id(
             {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic_name},
         ]),
+        allow_empty_topic_name: true,
     };
 
     void channel.get({
@@ -1617,6 +1619,7 @@ export function is_message_oldest_or_newest(
             {operator: "channel", operand: stream_id},
             {operator: "topic", operand: topic_name},
         ]),
+        allow_empty_topic_name: true,
     };
 
     void channel.get({

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -114,7 +114,10 @@ export function fetch_and_render_message_history(message: Message): void {
     show_loading_indicator();
     void channel.get({
         url: "/json/messages/" + message.id + "/history",
-        data: {message_id: JSON.stringify(message.id)},
+        data: {
+            message_id: JSON.stringify(message.id),
+            allow_empty_topic_name: true,
+        },
         success(raw_data) {
             const data = server_message_history_schema.parse(raw_data);
 

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -192,6 +192,7 @@ export let update_views_filtered_on_message_property = (
                 data: {
                     message_ids: JSON.stringify(message_ids),
                     narrow: JSON.stringify(filter.terms()),
+                    allow_empty_topic_name: true,
                 },
                 success(data) {
                     const messages_to_add: Message[] = [];
@@ -216,6 +217,7 @@ export let update_views_filtered_on_message_property = (
                 url: "/json/messages",
                 data: {
                     message_ids: JSON.stringify(messages_to_fetch),
+                    allow_empty_topic_name: true,
                     // We don't filter by narrow here since we can
                     // apply the filter locally and the fetched message
                     // can be used to update other message lists and

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -59,6 +59,7 @@ type MessageFetchAPIParams = {
     num_after: number;
     client_gravatar: boolean;
     narrow?: string;
+    allow_empty_topic_name: boolean;
 };
 
 let first_messages_fetch = true;
@@ -329,6 +330,7 @@ function get_parameters_for_message_fetch_api(opts: MessageFetchOptions): Messag
         num_before: opts.num_before,
         num_after: opts.num_after,
         client_gravatar: true,
+        allow_empty_topic_name: true,
     };
     const msg_list_data = opts.msg_list_data;
 

--- a/web/src/message_flags.ts
+++ b/web/src/message_flags.ts
@@ -110,6 +110,7 @@ export function unstar_all_messages_in_topic(stream_id: number, topic: string): 
             {operator: "topic", operand: topic},
             {operator: "is", operand: "starred"},
         ]),
+        allow_empty_topic_name: true,
     };
 
     void channel.get({

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -102,6 +102,8 @@ export type MessageGroup = {
           is_archived: boolean;
           subscribed?: boolean;
           topic: string;
+          topic_display_name: string;
+          is_empty_string_topic: boolean;
           topic_is_resolved: boolean;
           topic_links: TopicLink[] | undefined;
           topic_url: string | undefined;
@@ -459,6 +461,8 @@ function populate_group_from_message(
         const invite_only = stream_data.is_invite_only_by_stream_id(message.stream_id);
         const is_web_public = stream_data.is_web_public(message.stream_id);
         const topic = message.topic;
+        const topic_display_name = util.get_final_topic_display_name(topic);
+        const is_empty_string_topic = topic === "";
         const match_topic = util.get_match_topic(message);
         const stream_url = hash_util.by_stream_url(message.stream_id);
         const is_archived = stream_data.is_stream_archived(message.stream_id);
@@ -496,6 +500,8 @@ function populate_group_from_message(
             date_unchanged,
             topic_links,
             topic,
+            topic_display_name,
+            is_empty_string_topic,
             recipient_bar_color,
             stream_privacy_icon_color,
             invite_only,

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -555,6 +555,7 @@ export let show = (raw_terms: NarrowTerm[], show_opts: ShowMessageViewOpts): voi
                 // for it.
                 channel.get({
                     url: `/json/messages/${id_info.target_id}`,
+                    data: {allow_empty_topic_name: true},
                     success(raw_data) {
                         const data = fetch_message_response_schema.parse(raw_data);
                         // After the message is fetched, we make the

--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -28,6 +28,7 @@ import * as user_status from "./user_status.ts";
 import type {UserStatusEmojiInfo} from "./user_status.ts";
 import * as user_topics from "./user_topics.ts";
 import type {AllVisibilityPolicies} from "./user_topics.ts";
+import * as util from "./util.ts";
 
 type ActionPopoverContext = {
     message_id: number;
@@ -50,7 +51,8 @@ type TopicPopoverContext = {
     stream_name: string;
     stream_id: number;
     stream_muted: boolean;
-    topic_name: string;
+    topic_display_name: string;
+    is_empty_string_topic: boolean;
     topic_unmuted: boolean;
     is_spectator: boolean;
     is_topic_empty: boolean;
@@ -255,7 +257,8 @@ export function get_topic_popover_content_context({
         stream_name: sub.name,
         stream_id: sub.stream_id,
         stream_muted: sub.is_muted,
-        topic_name,
+        topic_display_name: util.get_final_topic_display_name(topic_name),
+        is_empty_string_topic: topic_name === "",
         topic_unmuted,
         is_spectator,
         is_topic_empty,

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -570,6 +570,8 @@ type ConversationContext = {
           invite_only: boolean;
           is_web_public: boolean;
           topic: string;
+          topic_display_name: string;
+          is_empty_string_topic: boolean;
           topic_url: string;
           mention_in_unread: boolean;
           visibility_policy: number | false;
@@ -611,6 +613,8 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         const is_web_public = stream_info.is_web_public;
         // Topic info
         const topic = last_msg.topic;
+        const topic_display_name = util.get_final_topic_display_name(topic);
+        const is_empty_string_topic = topic === "";
         const topic_url = hash_util.by_stream_topic_url(stream_id, topic);
 
         // We hide the row according to filters or if it's muted.
@@ -642,6 +646,8 @@ function format_conversation(conversation_data: ConversationData): ConversationC
             invite_only,
             is_web_public,
             topic,
+            topic_display_name,
+            is_empty_string_topic,
             topic_url,
             mention_in_unread,
             visibility_policy,

--- a/web/src/scheduled_messages_overlay_ui.ts
+++ b/web/src/scheduled_messages_overlay_ui.ts
@@ -15,6 +15,7 @@ import * as stream_color from "./stream_color.ts";
 import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
 import * as timerender from "./timerender.ts";
+import * as util from "./util.ts";
 
 type ScheduledMessageRenderContext = ScheduledMessage &
     (
@@ -25,6 +26,8 @@ type ScheduledMessageRenderContext = ScheduledMessage &
               stream_id: number;
               stream_name: string;
               stream_privacy_icon_color: string;
+              topic_display_name: string;
+              is_empty_string_topic: boolean;
           }
         | {
               is_stream: false;
@@ -107,6 +110,8 @@ function format(
                 recipient_bar_color,
                 stream_privacy_icon_color,
                 formatted_send_at_time,
+                topic_display_name: util.get_final_topic_display_name(msg.topic),
+                is_empty_string_topic: msg.topic === "",
             };
         } else {
             const recipients = people.get_recipients(msg.to.join(","));

--- a/web/src/settings_user_topics.ts
+++ b/web/src/settings_user_topics.ts
@@ -8,6 +8,7 @@ import * as scroll_util from "./scroll_util.ts";
 import * as settings_config from "./settings_config.ts";
 import * as user_topics from "./user_topics.ts";
 import type {UserTopic} from "./user_topics.ts";
+import * as util from "./util.ts";
 
 export let loaded = false;
 
@@ -31,6 +32,8 @@ export function populate_list(): void {
         modifier_html(user_topic) {
             const context = {
                 user_topic,
+                topic_display_name: util.get_final_topic_display_name(user_topic.topic),
+                is_empty_string_topic: user_topic.topic === "",
                 user_topic_visibility_policy_values:
                     settings_config.user_topic_visibility_policy_values,
             };

--- a/web/src/starred_messages_ui.ts
+++ b/web/src/starred_messages_ui.ts
@@ -13,6 +13,7 @@ import * as starred_messages from "./starred_messages.ts";
 import * as sub_store from "./sub_store.ts";
 import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
+import * as util from "./util.ts";
 
 export function toggle_starred_and_update_server(message: Message): void {
     if (message.locally_echoed) {
@@ -92,7 +93,8 @@ export function confirm_unstar_all_messages_in_topic(stream_id: number, topic: s
 
     const html_body = render_confirm_unstar_all_messages_in_topic({
         stream_name,
-        topic,
+        topic_display_name: util.get_final_topic_display_name(topic),
+        is_empty_string_topic: topic === "",
     });
 
     confirm_dialog.launch({

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -334,6 +334,7 @@ export const realm_schema = z.object({
             config: z.record(z.string()),
         }),
     ),
+    realm_empty_topic_display_name: z.string(),
     realm_enable_guest_user_indicator: z.boolean(),
     realm_enable_read_receipts: z.boolean(),
     realm_enable_spectator_access: z.boolean(),

--- a/web/src/stream_topic_history_util.ts
+++ b/web/src/stream_topic_history_util.ts
@@ -56,6 +56,7 @@ export function update_topic_last_message_id(
             anchor: "newest",
             num_before: 1,
             num_after: 0,
+            allow_empty_topic_name: true,
         },
         success(data) {
             const {messages} = z

--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -18,6 +18,7 @@ export type TopicInfo = {
     topic_name: string;
     topic_resolved_prefix: string;
     topic_display_name: string;
+    is_empty_string_topic: boolean;
     unread: number;
     is_zero: boolean;
     is_muted: boolean;
@@ -127,7 +128,8 @@ function choose_topics(
             stream_id,
             topic_name,
             topic_resolved_prefix,
-            topic_display_name,
+            topic_display_name: util.get_final_topic_display_name(topic_display_name),
+            is_empty_string_topic: topic_display_name === "",
             unread: num_unread,
             is_zero: num_unread === 0,
             is_muted: is_topic_muted,

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -64,11 +64,14 @@ export function initialize(): void {
             onMount(instance) {
                 const $popper = $(instance.popper);
                 const {stream_id, topic_name, url} = get_conversation(instance);
-                const is_topic_empty = popover_menus_data.get_topic_popover_content_context({
+                const context = popover_menus_data.get_topic_popover_content_context({
                     stream_id,
                     topic_name,
                     url,
-                }).is_topic_empty;
+                });
+                const is_topic_empty = context.is_topic_empty;
+                const topic_display_name = context.topic_display_name;
+                const is_empty_string_topic = context.is_empty_string_topic;
 
                 if (!stream_id) {
                     popover_menus.hide_current_popover_if_visible(instance);
@@ -139,7 +142,10 @@ export function initialize(): void {
                 });
 
                 $popper.one("click", ".sidebar-popover-delete-topic-messages", () => {
-                    const html_body = render_delete_topic_modal({topic_name});
+                    const html_body = render_delete_topic_modal({
+                        topic_display_name,
+                        is_empty_string_topic,
+                    });
 
                     confirm_dialog.launch({
                         html_heading: $t_html({defaultMessage: "Delete topic"}),

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -709,6 +709,7 @@ $(() => {
                 // Set this to true when stream typing notifications are implemented.
                 stream_typing_notifications: false,
                 user_settings_object: true,
+                empty_topic_name: true,
             }),
             client_gravatar: false,
         };

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -2,8 +2,10 @@ import Handlebars from "handlebars/runtime.js";
 import _ from "lodash";
 
 import * as blueslip from "./blueslip.ts";
+import {$t} from "./i18n.ts";
 import type {MatchedMessage, Message, RawMessage} from "./message_store.ts";
 import type {UpdateMessageEvent} from "./server_event_types.ts";
+import {realm} from "./state_data.ts";
 import {user_settings} from "./user_settings.ts";
 
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
@@ -532,4 +534,14 @@ export function compare_a_b<T>(a: T, b: T): number {
         return 0;
     }
     return -1;
+}
+
+export function get_final_topic_display_name(topic_display_name: string): string {
+    if (topic_display_name === "") {
+        if (realm.realm_empty_topic_display_name === "general chat") {
+            return $t({defaultMessage: "general chat"});
+        }
+        return realm.realm_empty_topic_display_name;
+    }
+    return topic_display_name;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2115,3 +2115,7 @@ body:not(.hide-left-sidebar) {
         border: 1px solid var(--color-border-personal-menu-avatar);
     }
 }
+
+.empty-topic-display {
+    font-style: italic;
+}

--- a/web/templates/confirm_dialog/confirm_delete_topic.hbs
+++ b/web/templates/confirm_dialog/confirm_delete_topic.hbs
@@ -1,4 +1,9 @@
 <p>
     {{t "Deleting a topic will immediately remove it and its messages for everyone. Other users may find this confusing, especially if they had received an email or push notification related to the deleted messages." }}
 </p>
-<p class="white-space-preserve-wrap">{{#tr}}Are you sure you want to permanently delete <b>{topic_name}</b>?{{/tr}}</p>
+<p class="white-space-preserve-wrap">
+    {{#tr}}
+        Are you sure you want to permanently delete <z-topic-display-name></z-topic-display-name>?
+        {{#*inline "z-topic-display-name"}}<span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}><b>{{topic_display_name}}</b></span>{{/inline}}
+    {{/tr}}
+</p>

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -16,7 +16,7 @@
                 <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>
                 <span class="stream_topic">
                     <div class="message_label_clickable narrows_by_topic">
-                        <span class="stream-topic-inner">{{topic}}</span>
+                        <span class="stream-topic-inner {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
                     </div>
                 </span>
                 <span class="recipient_bar_controls"></span>

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -28,7 +28,7 @@
                         {{!-- Invisible user circle element for alignment of topic text with DM user name --}}
                         <span class="user-circle-active user-circle invisible"></span>
                         <div class="inbox-topic-name">
-                            <a tabindex="-1" href="{{topic_url}}">{{topic_name}}</a>
+                            <a tabindex="-1" href="{{topic_url}}" {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</a>
                         </div>
                         <span class="unread_mention_info tippy-zulip-tooltip
                           {{#unless mention_in_unread}}hidden{{/unless}}"

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -1,7 +1,7 @@
 <div class="popover-menu" id="topic-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="popover-topic-header text-item popover-menu-list-item">
-            <span class="popover-topic-name">{{topic_name}}</span>
+            <span class="popover-topic-name {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
         </li>
         {{!-- Group 1 --}}
         {{#unless is_spectator}}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -34,7 +34,7 @@
                 {{#if is_private}}
                 <a href="{{pm_url}}" class="recent-view-table-link {{#if is_group}}recent-view-dm-group{{/if}}">{{{rendered_pm_with}}}</a>
                 {{else}}
-                <a class="white-space-preserve-wrap recent-view-table-link" href="{{topic_url}}">{{topic}}</a>
+                <a class="white-space-preserve-wrap recent-view-table-link {{#if is_empty_string_topic}}empty-topic-display{{/if}}" href="{{topic_url}}">{{topic_display_name}}</a>
                 {{/if}}
             </div>
             <div class="right_part">

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -27,11 +27,11 @@
             {{! topic link }}
             <a class="message_label_clickable narrows_by_topic tippy-narrow-tooltip"
               href="{{topic_url}}"
-              data-tippy-content="{{t 'Go to #{display_recipient} > {topic}' }}">
+              data-tippy-content="{{t 'Go to #{display_recipient} > {topic_display_name}' }}">
                 {{#if use_match_properties}}
                     <span class="stream-topic-inner">{{{match_topic}}}</span>
                 {{else}}
-                    <span class="stream-topic-inner">{{topic}}</span>
+                    <span class="stream-topic-inner {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
                 {{/if}}
             </a>
         </span>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -13,7 +13,7 @@
                     <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>
                     <span class="stream_topic">
                         <div class="message_label_clickable narrows_by_topic">
-                            <span>{{topic}}</span>
+                            <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>
                         </div>
                     </span>
                     <span class="recipient_bar_controls"></span>

--- a/web/templates/stream_topic_widget.hbs
+++ b/web/templates/stream_topic_widget.hbs
@@ -1,3 +1,3 @@
 <strong>
-    <span class="stream">{{stream_name}}</span> &gt; <span class="topic white-space-preserve-wrap">{{topic}}</span>
+    <span class="stream">{{stream_name}}</span> &gt; <span class="topic white-space-preserve-wrap {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
 </strong>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -4,7 +4,7 @@
             {{topic_resolved_prefix}}
         </span>
         <a href="{{url}}" class="sidebar-topic-name">
-            <span class="sidebar-topic-name-inner">{{topic_display_name}}</span>
+            <span class="sidebar-topic-name-inner {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
         </a>
         <div class="topic-markers-and-unreads change_visibility_policy" data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}">
             {{#if contains_unread_mention}}

--- a/web/templates/user_topic_ui_row.hbs
+++ b/web/templates/user_topic_ui_row.hbs
@@ -1,7 +1,7 @@
 {{#with user_topic}}
 <tr data-stream-id="{{stream_id}}" data-stream="{{stream}}" data-topic="{{topic}}" data-date-updated="{{date_updated_str}}" data-visibility-policy="{{visibility_policy}}">
     <td class="user-topic-stream">{{stream}}</td>
-    <td class="white-space-preserve-wrap user-topic">{{topic}}</td>
+    <td class="white-space-preserve-wrap user-topic {{#if ../is_empty_string_topic}}empty-topic-display{{/if}}">{{../topic_display_name}}</td>
     <td>
         <select class="settings_user_topic_visibility_policy list_select bootstrap-focus-style" data-setting-widget-type="number">
             {{#each ../user_topic_visibility_policy_values}}

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -318,11 +318,6 @@ test_ui("validate", ({mock_template, override}) => {
     });
     assert.ok(!compose_validate.validate());
     assert.ok(missing_topic_error_rendered);
-
-    missing_topic_error_rendered = false;
-    compose_state.topic("(no topic)");
-    assert.ok(!compose_validate.validate());
-    assert.ok(missing_topic_error_rendered);
 });
 
 test_ui("get_invalid_recipient_emails", ({override, override_rewire}) => {

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -17,8 +17,12 @@ const compose_recipient = zrequire("compose_recipient");
 const sub_store = zrequire("sub_store");
 const stream_data = zrequire("stream_data");
 const {initialize_user_settings} = zrequire("user_settings");
+const {set_realm} = zrequire("state_data");
 
 initialize_user_settings({user_settings: {}});
+
+const REALM_EMPTY_TOPIC_DISPLAY_NAME = "test general chat";
+set_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME});
 
 const aaron = {
     email: "aaron@zulip.com",
@@ -482,6 +486,15 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         is_sending_saving: false,
         drafts_version: 1,
     };
+    const draft_6 = {
+        topic: "",
+        type: "stream",
+        stream_id: 40,
+        content: "Test stream message 3",
+        updatedAt: date(-11),
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
 
     const expected = [
         {
@@ -491,7 +504,8 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
             stream_id: 30,
             recipient_bar_color: "#ebebeb",
             stream_privacy_icon_color: "#9a9a9a",
-            topic: "topic",
+            topic_display_name: "topic",
+            is_empty_string_topic: false,
             raw_content: "Test stream message",
             time_stamp: "7:55 AM",
             invite_only: undefined,
@@ -525,9 +539,24 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
             stream_id: 40,
             recipient_bar_color: "#ebebeb",
             stream_privacy_icon_color: "#9a9a9a",
-            topic: "topic",
+            topic_display_name: "topic",
+            is_empty_string_topic: false,
             raw_content: "Test stream message 2",
             time_stamp: "Jan 21",
+            invite_only: false,
+            is_web_public: false,
+        },
+        {
+            draft_id: "id6",
+            is_stream: true,
+            stream_name: "stream 2",
+            stream_id: 40,
+            recipient_bar_color: "#ebebeb",
+            stream_privacy_icon_color: "#9a9a9a",
+            topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME,
+            is_empty_string_topic: true,
+            raw_content: "Test stream message 3",
+            time_stamp: "Jan 20",
             invite_only: false,
             is_web_public: false,
         },
@@ -537,7 +566,14 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
 
     const draft_model = drafts.draft_model;
     const ls = localstorage();
-    const data = {id1: draft_1, id2: draft_2, id3: draft_3, id4: draft_4, id5: draft_5};
+    const data = {
+        id1: draft_1,
+        id2: draft_2,
+        id3: draft_3,
+        id4: draft_4,
+        id5: draft_5,
+        id6: draft_6,
+    };
     ls.set("drafts", data);
     assert.deepEqual(draft_model.get(), data);
 
@@ -682,7 +718,8 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
             stream_id: 30,
             recipient_bar_color: "#ebebeb",
             stream_privacy_icon_color: "#9a9a9a",
-            topic: "topic",
+            topic_display_name: "topic",
+            is_empty_string_topic: false,
             raw_content: "Test stream message",
             time_stamp: "7:55 AM",
             invite_only: false,
@@ -695,7 +732,8 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
             stream_id: 40,
             recipient_bar_color: "#ebebeb",
             stream_privacy_icon_color: "#9a9a9a",
-            topic: "topic",
+            topic_display_name: "topic",
+            is_empty_string_topic: false,
             raw_content: "Test stream message 2",
             time_stamp: "Jan 21",
             invite_only: false,

--- a/web/tests/hash_util.test.cjs
+++ b/web/tests/hash_util.test.cjs
@@ -190,6 +190,18 @@ run_test("test_parse_narrow", () => {
     assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "42-bogus"]), [
         {negated: false, operator: "stream", operand: ""},
     ]);
+
+    // Empty string as a topic name is valid.
+    assert.deepEqual(hash_util.parse_narrow(["narrow", "stream", "99-frontend", "topic", ""]), [
+        {negated: false, operator: "stream", operand: frontend_id.toString()},
+        {negated: false, operator: "topic", operand: ""},
+    ]);
+
+    // Empty string used as an operand in other cases is invalid.
+    assert.deepEqual(
+        hash_util.parse_narrow(["narrow", "stream", "99-frontend", "topic", "", "near", ""]),
+        undefined,
+    );
 });
 
 run_test("test_channels_settings_edit_url", () => {

--- a/web/tests/message_flags.test.cjs
+++ b/web/tests/message_flags.test.cjs
@@ -143,6 +143,7 @@ run_test("unstar_all_in_topic", ({override}) => {
             {operator: "topic", operand: "topic"},
             {operator: "is", operand: "starred"},
         ]),
+        allow_empty_topic_name: true,
     });
 
     assert.deepEqual(channel_post_opts.data, {

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -207,8 +207,10 @@ const rt_data = zrequire("recent_view_data");
 const muted_users = zrequire("muted_users");
 const {set_realm} = zrequire("state_data");
 const sub_store = zrequire("sub_store");
+const util = zrequire("util");
 
-set_realm({});
+const REALM_EMPTY_TOPIC_DISPLAY_NAME = "test general chat";
+set_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME});
 
 for (const stream_id of [stream1, stream2, stream3, stream4, stream6]) {
     sub_store.add_hydrated_sub(stream_id, {
@@ -414,6 +416,8 @@ function generate_topic_data(topic_info_array) {
             stream_id,
             stream_url: "https://www.example.com",
             topic,
+            topic_display_name: util.get_final_topic_display_name(topic),
+            is_empty_string_topic: topic === "",
             conversation_key: get_topic_key(stream_id, topic),
             topic_url: "https://www.example.com",
             unread_count,
@@ -1162,4 +1166,6 @@ test("test_search", () => {
 
     assert.equal(rt.topic_in_search_results("\\", "general", "\\"), true);
     assert.equal(rt.topic_in_search_results("\\", "general", "\\\\"), true);
+
+    // TODO: Add a test for empty topic name after CZO discussion.
 });

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -426,6 +426,7 @@ test("ask_server_for_latest_topic_data", () => {
             narrow: '[{"operator":"stream","operand":1080},{"operator":"topic","operand":"Topic1"}]',
             num_after: 0,
             num_before: 1,
+            allow_empty_topic_name: true,
         });
         success_callback = opts.success;
     };

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -37,7 +37,9 @@ const stream_topic_history = zrequire("stream_topic_history");
 const topic_list_data = zrequire("topic_list_data");
 const unread = zrequire("unread");
 
-set_realm({});
+const REALM_EMPTY_TOPIC_DISPLAY_NAME = "test general chat";
+
+set_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME});
 
 const general = {
     stream_id: 556,
@@ -102,6 +104,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         topic_name: "topic 11",
         topic_resolved_prefix: "",
         topic_display_name: "topic 11",
+        is_empty_string_topic: false,
         unread: 0,
         is_zero: true,
         stream_id: 556,
@@ -132,6 +135,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         topic_display_name: "topic 9",
         topic_name: "✔ topic 9",
         topic_resolved_prefix: "✔ ",
+        is_empty_string_topic: false,
         unread: 0,
         url: "#narrow/channel/556-general/topic/.E2.9C.94.20topic.209",
     });
@@ -147,18 +151,44 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         topic_display_name: "topic 8",
         topic_name: "topic 8",
         topic_resolved_prefix: "",
+        is_empty_string_topic: false,
         unread: 0,
         url: "#narrow/channel/556-general/topic/topic.208",
+    });
+
+    // Empty string as topic name.
+    add_topic_message("", 2025);
+
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 8);
+    assert.equal(list_info.more_topics_unreads, 0);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, false);
+    assert.equal(list_info.num_possible_topics, 11);
+
+    assert.deepEqual(list_info.items[0], {
+        contains_unread_mention: false,
+        is_active_topic: false,
+        is_muted: false,
+        is_followed: false,
+        is_unmuted_or_followed: false,
+        is_zero: true,
+        stream_id: 556,
+        topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME,
+        topic_name: "",
+        topic_resolved_prefix: "",
+        is_empty_string_topic: true,
+        unread: 0,
+        url: "#narrow/channel/556-general/topic/",
     });
 
     // If we zoom in, our results are based on topic filter.
     // If topic search input is empty, we show all 10 topics.
     const zoomed = true;
     list_info = get_list_info(zoomed);
-    assert.equal(list_info.items.length, 10);
+    assert.equal(list_info.items.length, 11);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
-    assert.equal(list_info.num_possible_topics, 10);
+    assert.equal(list_info.num_possible_topics, 11);
 
     add_topic_message("After Brooklyn", 1008);
     add_topic_message("Catering", 1009);


### PR DESCRIPTION
Implemented the following behaviours:

* Send message with an empty topic box to send message in topic = ""
* Various narrow links work properly with empty topic name
* `realm_empty_topic_display_name` appears for empty topic names in:
   * left sidebar topic list
   * message headers
   * Inbox view
   * Recent conversations
   * Topic action popover
   * Delete topic modal
   * Unstar all messages in topic confirm modal
   * Drafts table
   * Scheduled message table
   * SETTINGS/TOPICS table
   
Tracking the following bugs to fix:
* Move messages modal
* Show it properly in banners
* https://github.com/zulip/zulip/pull/32963#issuecomment-2578675233
* Marking such topics as resolved removes "*test general chat*"

---

Screenshots:

<details><summary>Left Sidebar</summary>
<img width="334" alt="Screenshot 2025-01-09 at 2 09 17 AM" src="https://github.com/user-attachments/assets/b6e07f70-c39a-4298-8f71-d71797496059" />
</details> 

<details><summary><code>/#narrow/channel/7-Venice/topic/</code></summary>
<img width="745" alt="Screenshot 2025-01-09 at 2 09 27 AM" src="https://github.com/user-attachments/assets/bebc5aed-f37c-4e3b-95d0-e2bf3d8f745c" />
</details> 

<details><summary><code>/#feed</code></summary>
<img width="947" alt="Screenshot 2025-01-09 at 2 09 51 AM" src="https://github.com/user-attachments/assets/3b40104c-5518-4902-8609-28228d157547" />
</details>

<details><summary>Inbox</summary>
<img width="667" alt="Screenshot 2025-01-09 at 1 56 49 PM" src="https://github.com/user-attachments/assets/e3d8b67f-faf6-43f1-9e2b-881c45f2a832" />
</details> 

<details><summary>Recent conversations</summary>
<img width="951" alt="Screenshot 2025-01-09 at 1 57 11 PM" src="https://github.com/user-attachments/assets/0038a19a-bb04-47e8-9c08-a8dc71c04efe" />
</details> 

<details><summary>Topic action popover</summary>
<img width="287" alt="Screenshot 2025-01-09 at 11 59 54 PM" src="https://github.com/user-attachments/assets/868a5af2-bba6-4391-9aab-d5221ecd0844" />
</details> 

<details><summary>Delete Topic</summary>
<img width="557" alt="Screenshot 2025-01-09 at 5 25 37 PM" src="https://github.com/user-attachments/assets/e02f6dfc-6795-4e3f-bbdc-3cdd6b67cad5" />
</details> 

<details><summary>Unstar all messages</summary>
<img width="556" alt="Screenshot 2025-01-09 at 10 35 59 PM" src="https://github.com/user-attachments/assets/57df0a75-c4ee-4f06-a9eb-c0a50a024b28" />
</details> 

<details><summary>Drafts</summary>
<img width="899" alt="Screenshot 2025-01-10 at 12 03 34 AM" src="https://github.com/user-attachments/assets/a09e8729-ad9d-4255-974e-31d6d898915d" />
</details> 

<details><summary>Scheduled messages</summary>
<img width="873" alt="Screenshot 2025-01-09 at 10 11 13 PM" src="https://github.com/user-attachments/assets/ae9d6897-73ca-4b55-b198-8fe9845d523a" />
</details> 

<details><summary>SETTINGS/TOPIC</summary>
<img width="763" alt="Screenshot 2025-01-09 at 11 12 50 PM" src="https://github.com/user-attachments/assets/8a47248c-141c-47a3-8b06-ada421b220ef" />
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
