### PR TITLE
stream_color: Color picker popover improvements.

### DIFF
--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -25,6 +25,7 @@ import "../../third/bootstrap/css/bootstrap-btn.css";
 import "../../styles/typeahead.css";
 import "../../styles/app_variables.css";
 import "../../styles/tooltips.css";
+import "../../styles/buttons.css";
 import "../../styles/components.css";
 import "../../styles/app_components.css";
 import "../../styles/rendered_markdown.css";

--- a/web/src/color_picker_popover.ts
+++ b/web/src/color_picker_popover.ts
@@ -110,6 +110,10 @@ export function toggle_color_picker_popover(
                     update_stream_color_debounced(new_color, stream_id, $popper);
                 },
             );
+
+            $popper.on("click", ".color_picker_confirm_button", () => {
+                popover_menus.hide_current_popover_if_visible(instance);
+            });
         },
         onHidden(instance) {
             instance.destroy();

--- a/web/src/color_picker_popover.ts
+++ b/web/src/color_picker_popover.ts
@@ -12,8 +12,6 @@ import * as stream_settings_api from "./stream_settings_api.ts";
 import * as ui_util from "./ui_util.ts";
 
 const update_color_picker_preview = (color: string, $popper: JQuery): void => {
-    const $custom_color_option_icon = $popper.find(".custom-color-option-icon");
-    $custom_color_option_icon.css("background-color", color);
     const $stream_header = $popper.find(".message_header_stream");
     stream_color.update_stream_recipient_color($stream_header, color);
 };

--- a/web/src/color_picker_popover.ts
+++ b/web/src/color_picker_popover.ts
@@ -27,6 +27,90 @@ const update_stream_color_debounced = _.debounce(
     {leading: false},
 );
 
+export function handle_keyboard(key: string): void {
+    const instance = popover_menus.get_color_picker_popover();
+    if (!instance) {
+        return;
+    }
+    const $items = popover_menus.get_popover_items_for_instance(instance);
+    if (!$items) {
+        return;
+    }
+
+    const $element = $items.filter(":focus");
+
+    if ($element.hasClass("color-swatch-label")) {
+        const color_hex_code = $element.attr("data-swatch-color");
+        if (!color_hex_code) {
+            return;
+        }
+        const color_palette_matrix = stream_color.stream_color_palette;
+        if (!color_palette_matrix) {
+            return;
+        }
+        const max_row = color_palette_matrix.length - 1;
+        const max_column = color_palette_matrix[0]!.length - 1;
+        const row = Number.parseInt($element.attr("data-row")!, 10);
+        const column = Number.parseInt($element.attr("data-column")!, 10);
+
+        const $swatch_color_list = $(instance.popper).find(".color-swatch-list");
+
+        if (key === "down_arrow" || key === "vim_down") {
+            if (row < max_row) {
+                $swatch_color_list
+                    .find(`[data-row="${row + 1}"][data-column="${column}"]`)
+                    .trigger("focus");
+            } else if (row === max_row) {
+                $swatch_color_list
+                    .parent()
+                    .nextAll(".link-item")
+                    .find("[tabindex='0']")
+                    .trigger("focus");
+            }
+            return;
+        }
+
+        if (key === "up_arrow" || key === "vim_up") {
+            if (row > 0) {
+                $swatch_color_list
+                    .find(`[data-row="${row - 1}"][data-column="${column}"]`)
+                    .trigger("focus");
+            } else {
+                $(instance.popper).find(".color_picker_confirm_button").trigger("focus");
+            }
+            return;
+        }
+
+        if (key === "left_arrow" || key === "vim_left") {
+            if (column > 0) {
+                $swatch_color_list
+                    .find(`[data-row="${row}"][data-column="${column - 1}"]`)
+                    .trigger("focus");
+            } else {
+                $swatch_color_list
+                    .find(`[data-row="${row - 1}"][data-column="${max_column}"]`)
+                    .trigger("focus");
+            }
+            return;
+        }
+
+        if (key === "right_arrow" || key === "vim_right") {
+            if (column < max_column) {
+                $swatch_color_list
+                    .find(`[data-row="${row}"][data-column="${column + 1}"]`)
+                    .trigger("focus");
+            } else {
+                $swatch_color_list
+                    .find(`[data-row="${row + 1}"][data-column="0"]`)
+                    .trigger("focus");
+            }
+            return;
+        }
+    }
+
+    popover_menus.popover_items_handle_keyboard(key, $items);
+}
+
 export function toggle_color_picker_popover(
     target: tippy.ReferenceElement,
     stream_id: number,
@@ -55,7 +139,7 @@ export function toggle_color_picker_popover(
             const stream_privacy_icon_color = stream_color.get_stream_privacy_icon_color(color);
             const invite_only = stream_data.is_invite_only_by_stream_id(stream_id);
             const is_web_public = stream_data.is_web_public(stream_id);
-            const stream_color_palette = stream_color.stream_color_palette.flat();
+            const stream_color_palette = stream_color.stream_color_palette;
 
             instance.setContent(
                 ui_util.parse_html(

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -4,6 +4,7 @@ import assert from "minimalistic-assert";
 import * as activity from "./activity.ts";
 import * as activity_ui from "./activity_ui.ts";
 import * as browser_history from "./browser_history.ts";
+import * as color_picker_popover from "./color_picker_popover.ts";
 import * as common from "./common.ts";
 import * as compose from "./compose.js";
 import * as compose_actions from "./compose_actions.ts";
@@ -74,7 +75,17 @@ function do_narrow_action(action) {
 }
 
 // For message actions and user profile menu.
-const menu_dropdown_hotkeys = new Set(["down_arrow", "up_arrow", "vim_up", "vim_down", "enter"]);
+const menu_dropdown_hotkeys = new Set([
+    "down_arrow",
+    "up_arrow",
+    "left_arrow",
+    "right_arrow",
+    "vim_up",
+    "vim_down",
+    "vim_left",
+    "vim_right",
+    "enter",
+]);
 
 // Note that multiple keys can map to the same event_name, which
 // we'll do in cases where they have the exact same semantics.
@@ -407,6 +418,11 @@ function handle_popover_events(event_name) {
 
     if (popover_menus.is_stream_actions_popover_displayed()) {
         stream_popover.stream_sidebar_menu_handle_keyboard(event_name);
+        return true;
+    }
+
+    if (popover_menus.is_color_picker_popover_displayed()) {
+        color_picker_popover.handle_keyboard(event_name);
         return true;
     }
 

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -163,7 +163,7 @@ export function is_color_picker_popover_displayed(): boolean | undefined {
     return popover_instances.color_picker_popover?.state.isVisible;
 }
 
-function get_popover_items_for_instance(instance: tippy.Instance): JQuery | undefined {
+export function get_popover_items_for_instance(instance: tippy.Instance): JQuery | undefined {
     const $current_elem = $(instance.popper);
     const class_name = $current_elem.attr("class");
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -585,6 +585,11 @@
     --size-color-swatch: 1em;
     --grid-gap-color-swatch: 1em;
     --padding-color-swatch-list: 0.6666em;
+    --color-background-custom-swatch-gradient: conic-gradient(
+        from 0deg at 50% 50% in oklch longer hue,
+        oklch(70% 0.3 0deg) 0%,
+        oklch(70% 0.3 0deg) 100%
+    );
 
     /* Colors used across the app */
     --color-date: hsl(0deg 0% 15% / 75%);

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -29,6 +29,11 @@
         );
         scale: 0.96;
     }
+
+    &:focus {
+        /* Override common button outline style set in zulip.css and dark_theme.css */
+        outline: none;
+    }
 }
 
 .action-button-label {
@@ -365,6 +370,11 @@
     cursor: pointer;
     border: none;
     border-radius: 4px;
+
+    &:focus {
+        /* Override common button outline style set in zulip.css and dark_theme.css */
+        outline: none;
+    }
 }
 
 .icon-button-neutral {

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -364,6 +364,9 @@
     /* This class should always be used with an icon-button-* class
        defining the color scheme of the button, defined below. */
     display: flex;
+    justify-content: center;
+    align-items: center;
+    aspect-ratio: 1;
     font-size: var(--base-font-size-px);
     background-color: transparent; /* Override button default background color */
     padding: 0.375em;

--- a/web/styles/color_picker.css
+++ b/web/styles/color_picker.css
@@ -37,8 +37,7 @@
     left: 0;
     width: 100%;
     height: 100% !important;
-    opacity: 0 !important;
-    cursor: pointer;
+    visibility: hidden;
 }
 
 .custom-color-swatch-icon {
@@ -50,6 +49,11 @@
     border: none;
 }
 
-.color-picker-popover .stream_label {
-    padding-right: 5px;
+.color_picker_confirm_button {
+    height: 100%;
+
+    &:focus-visible {
+        outline: 1px solid var(--color-outline-focus);
+        outline-offset: -2px;
+    }
 }

--- a/web/styles/color_picker.css
+++ b/web/styles/color_picker.css
@@ -41,13 +41,9 @@
     cursor: pointer;
 }
 
-.custom-color-option-icon {
-    width: 17px;
-    height: 17px;
-    margin-top: 1px;
+.custom-color-swatch-icon {
     border-radius: 50%;
-    border: 1px solid var(--color-border-zulip-button);
-    box-sizing: border-box;
+    background: var(--color-background-custom-swatch-gradient);
 }
 
 .color-picker-popover .message-header-contents {

--- a/web/templates/popovers/color_picker_popover.hbs
+++ b/web/templates/popovers/color_picker_popover.hbs
@@ -29,11 +29,11 @@
         </li>
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-list-item">
-            <a role="menuitem" class="custom-color-picker popover-menu-link" tabindex="0">
+            <label role="menuitem" class="custom-color-picker popover-menu-link" tabindex="0">
                 <i class="custom-color-swatch-icon popover-menu-icon" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Custom color"}}</span>
                 <input type="color" class="color-picker-input" tabindex="-1" value="{{stream_color}}" />
-            </a>
+            </label>
         </li>
     </ul>
 </div>

--- a/web/templates/popovers/color_picker_popover.hbs
+++ b/web/templates/popovers/color_picker_popover.hbs
@@ -21,9 +21,11 @@
     <ul role="menu" class="popover-menu-list">
         <li role="none">
             <div role="group" class="color-swatch-list" aria-label="{{t 'Stream color' }}">
-                {{#each stream_color_palette as |hex_color|}}
-                    <input type="radio" id="color-{{hex_color}}" class="color-swatch-input" name="color-picker-select" data-swatch-color="{{hex_color}}" {{#if (eq hex_color ../stream_color )}}checked{{/if}} />
-                    <label role="menuitemradio" class="color-swatch-label tippy-zulip-delayed-tooltip" for="color-{{hex_color}}" style="background-color: {{hex_color}};" aria-label="{{hex_color}}" data-tippy-content="{{hex_color}}" tabindex="0"></label>
+                {{#each stream_color_palette as |row|}}
+                    {{#each row as |hex_color|}}
+                        <input type="radio" id="color-{{hex_color}}" class="color-swatch-input" name="color-picker-select" data-swatch-color="{{hex_color}}" {{#if (eq hex_color ../stream_color )}}checked{{/if}} />
+                        <label role="menuitemradio" class="color-swatch-label tippy-zulip-delayed-tooltip" for="color-{{hex_color}}" style="background-color: {{hex_color}};" aria-label="{{hex_color}}" data-tippy-content="{{hex_color}}" data-swatch-color="{{hex_color}}" data-row="{{@../index}}" data-column="{{@index}}" tabindex="0"></label>
+                    {{/each}}
                 {{/each}}
             </div>
         </li>

--- a/web/templates/popovers/color_picker_popover.hbs
+++ b/web/templates/popovers/color_picker_popover.hbs
@@ -13,6 +13,9 @@
                 &nbsp;
                 {{/if}}
             </div>
+            <button class="color_picker_confirm_button icon-button icon-button-square icon-button-neutral tippy-zulip-delayed-tooltip" data-tooltip-template-id="color-picker-confirm-button-tooltip-template" aria-label="{{t 'Confirm new color' }}" tabindex="0">
+                <i class="zulip-icon zulip-icon-check"></i>
+            </button>
         </div>
     </div>
     <ul role="menu" class="popover-menu-list">

--- a/web/templates/popovers/color_picker_popover.hbs
+++ b/web/templates/popovers/color_picker_popover.hbs
@@ -27,7 +27,7 @@
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" class="custom-color-picker popover-menu-link" tabindex="0">
-                <i class="custom-color-option-icon" style="background-color: {{stream_color}};" aria-hidden="true"></i>
+                <i class="custom-color-swatch-icon popover-menu-icon" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Custom color"}}</span>
                 <input type="color" class="color-picker-input" tabindex="-1" value="{{stream_color}}" />
             </a>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -260,3 +260,6 @@
 <template id="mobile-push-notification-tooltip-template">
     {{t 'Mobile push notifications are not enabled on this server.' }}
 </template>
+<template id="color-picker-confirm-button-tooltip-template">
+    {{t 'Confirm new color' }}
+</template>

--- a/web/webpack.dev-assets.json
+++ b/web/webpack.dev-assets.json
@@ -18,9 +18,9 @@
     "dev-buttons": [
         "./src/bundles/portico.ts",
         "./src/portico/design-testing.ts",
-        "./styles/portico/dev-buttons.css",
         "./styles/app_variables.css",
-        "./styles/app_components.css",
-        "./styles/buttons.css"
+        "./styles/portico/dev-buttons.css",
+        "./styles/buttons.css",
+        "./styles/app_components.css"
     ]
 }


### PR DESCRIPTION
This PR is a follow-up for #32063, and makes the following changes:
- Updates custom color swatch icon to use rainbow gradient.
- Adds `buttons.css` file to `app.ts` bundle for production usage.
- Overrides the on-focus outline style in action-button and icon-button.
- Adds confirm button to the color picker popover.

Fixes:  [CZO Discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/colorpicker.20migration.20and.20redesign/near/2013004)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## Screenshots and screen captures:

### Screenshots:
| Header | Header |
|--------|--------|
| <img width="271" alt="Screenshot 2025-01-09 at 1 48 18 AM" src="https://github.com/user-attachments/assets/7ed13a68-f59d-4b68-aee9-bf594e3d01c9" /> | <img width="271" alt="Screenshot 2025-01-09 at 1 14 57 AM" src="https://github.com/user-attachments/assets/fbce3e81-607f-4f22-bcf4-d11d96196278" /> |
| <img width="271" alt="Screenshot 2025-01-09 at 1 48 02 AM" src="https://github.com/user-attachments/assets/211a8737-1178-49f6-9627-6cca5d99f929" /> | <img width="271" alt="Screenshot 2025-01-09 at 1 15 08 AM" src="https://github.com/user-attachments/assets/2f51116b-a5ff-4b44-aab6-72a19307b5ac" /> | 

### Screen captures:
![color-picker-popover-w-confirm](https://github.com/user-attachments/assets/5e386a08-a34f-4ba4-84f6-03043e5a81a5)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
