### PR TITLE
lightbox_css: Update lightbox css to fix UI issues of media previews

### DIFF
--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -54,7 +54,6 @@
 
         color: hsl(0deg 0% 100% / 80%);
         font-size: 2rem;
-        margin: 6px 20px 0 0;
 
         transform: scaleY(0.75);
         font-weight: 300;
@@ -71,19 +70,19 @@
     }
 
     .media-info-wrapper {
-        background-color: transparent;
         display: flex;
-        flex-flow: row wrap;
+        justify-content: end;
+        align-items: start;
+        gap: 20px;
+        padding: 20px;
+
+        background-color: transparent;
     }
 
-    .media-description,
     .media-actions {
-        margin: 20px;
-    }
-
-    .media-actions {
+        display: flex;
         flex-shrink: 0;
-        margin-left: auto;
+        gap: 10px;
 
         .button {
             font-size: 0.9rem;
@@ -95,7 +94,6 @@
             border-radius: 4px;
             text-decoration: none;
             display: inline-block;
-            margin: 0 5px;
 
             &:hover {
                 background-color: hsl(0deg 0% 100%);
@@ -156,7 +154,6 @@
     .player-container {
         flex: 1;
         display: flex;
-        text-align: center;
         justify-content: center;
         align-items: center;
 
@@ -171,13 +168,12 @@
     .center {
         display: flex;
         justify-content: center;
+        align-items: center;
+        gap: 2px;
+        padding: 12px 20px;
 
         .arrow {
-            display: inline-block;
-            vertical-align: top;
-            margin-top: 25px;
-            padding: 5px 10px;
-
+            padding: 0 10px;
             color: hsl(0deg 0% 100%);
             font-size: 1.8em;
             font-weight: 200;
@@ -196,8 +192,6 @@
         .image-list {
             position: relative;
             display: inline-block;
-            padding: 15px 0 12px;
-            height: 50px;
             font-size: 0;
 
             max-width: 40vw;

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -115,13 +115,8 @@
     }
 
     .media-description {
-        display: flex;
-        flex-direction: column;
-        max-width: calc(100% - 400px);
-        /* add some extra margin top and remove some bottom to keep the
-        height the same. and vertically center the text with the buttons. */
-        margin-top: 25px;
-        margin-bottom: 15px;
+        flex: 1;
+        min-width: 0;
 
         font-size: 1.1rem;
         color: hsl(0deg 0% 100%);

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -1,13 +1,16 @@
 #lightbox_overlay {
     background-color: hsl(227deg 40% 16%);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
 
     .image-preview {
+        flex: 1;
         display: flex;
         align-items: center;
         justify-content: center;
         position: relative;
         width: 100%;
-        height: calc(100% - 65px - 95px);
         margin: 0;
         overflow: hidden;
 
@@ -32,9 +35,9 @@
     }
 
     .video-player {
+        flex: 1;
         display: flex;
         width: 100%;
-        height: calc(100% - 65px - 95px);
         align-items: center;
         justify-content: center;
         margin: 0;
@@ -151,7 +154,7 @@
     }
 
     .player-container {
-        height: calc(100% - 65px - 95px);
+        flex: 1;
         display: flex;
         text-align: center;
         justify-content: center;

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -116,6 +116,8 @@
     }
 
     .media-description {
+        container: media-description / inline-size;
+
         flex: 1;
         min-width: 0;
 
@@ -222,4 +224,15 @@
     }
 }
 
+/* hide media-description if it has width less than 100px  */
+@container media-description (max-width: 100px) {
+    .media-description {
+        .title {
+            display: none;
+        }
 
+        .user {
+            display: none;
+        }
+    }
+}

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -54,6 +54,7 @@
 
         color: hsl(0deg 0% 100% / 80%);
         font-size: 2rem;
+        line-height: 1.8rem;
 
         transform: scaleY(0.75);
         font-weight: 300;
@@ -170,7 +171,8 @@
         .arrow {
             padding: 0 10px;
             color: hsl(0deg 0% 100%);
-            font-size: 1.8em;
+            font-size: 1.8rem;
+            line-height: 1.6rem;
             font-weight: 200;
 
             transform: scaleY(2);

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -154,10 +154,10 @@
         align-items: center;
 
         & iframe {
-            /* maintain 16:9 ratio. */
-            width: calc((100vh - 65px - 95px) * 16 / 9);
-            height: 100%;
-            margin: auto;
+            aspect-ratio: 16/9;
+            width: 100%;
+            max-width: $lg_min;
+            max-height: calc(100vh - 200px);
         }
     }
 

--- a/web/styles/lightbox.css
+++ b/web/styles/lightbox.css
@@ -222,45 +222,4 @@
     }
 }
 
-@media only screen and ($ms_min <= width < $md_min) {
-    #lightbox_overlay {
-        .media-actions {
-            width: 100%;
-            padding-left: 15px;
-            margin-top: 0;
-        }
 
-        .media-description {
-            max-width: calc(100% - 100px);
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            margin-bottom: 5px;
-        }
-
-        .center .image-list {
-            max-width: 80vw;
-        }
-
-        .player-container iframe {
-            /* maintain 16:9 ratio. */
-            width: 100%;
-            height: calc((100vw) * 9 / 16);
-            margin: auto;
-        }
-
-        .image-preview {
-            height: calc(100% - 101px - 104px);
-        }
-
-        .media-info-wrapper {
-            align-items: flex-end;
-        }
-
-        .exit {
-            position: absolute;
-            right: 5px;
-            top: 6px;
-        }
-    }
-}


### PR DESCRIPTION

This PR fixes issues and improves css code of `lightbox` which is responsible for media previews.

---
<details>
<summary>Quick Overview</summary>

| Before | After |
| ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| Issue: Misplaced Open button in smaller screens for YouTube preview. Large gap below image list at the bottom. | Fix: UI remain consistent for smaller screens. |
| ![image](https://github.com/user-attachments/assets/91af83a1-f1db-459a-a10b-34ed3576ca9c) | ![image](https://github.com/user-attachments/assets/80f154cd-5f30-4b35-9ee9-2e91e225138c) |
| Issue: The Action buttons are moved down in smaller screen for image preview. | Fix: Buttons stay in their initial position. The name gets truncated. The arrow buttons are vertically more close to center. |
| ![image](https://github.com/user-attachments/assets/999435d8-a80a-47da-89cf-ed97447c1c82) | ![image](https://github.com/user-attachments/assets/adc44edd-90a3-48a5-a969-ed3b0fe27ce8) |
| Issue: The image list goes out of screen for video preview. | Fix: UI remains consistent throughout all types of preview. |
| ![image](https://github.com/user-attachments/assets/b35c32b6-7c6d-4029-9025-7223ae0c6823) | ![image](https://github.com/user-attachments/assets/2e9e815b-6bda-4485-b5e8-6c679c3f6cc0) |
| Layout Before: | Layout After: |
| ![image](https://github.com/user-attachments/assets/678c41eb-da85-40ed-a4b0-43e09bfd7686) | ![image](https://github.com/user-attachments/assets/d31ca722-cbdc-45ca-b908-ba46fa0f3452) |

</details>

---

<details>
<summary>On Smaller Screen (320x747) (After)</summary>
<br>

The media-description gets hidden for Image preview on very small screen considering [available design from CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/UI.20redesign.3A.20image.20viewer/near/1624502).
It is set to not display if the container width (not screen width) is less than 100px. For more than 100px its truncated.

| YT Preview                           | Image Preview                        | Video Preview                        |
| ------------------------------------ | ------------------------------------ | ------------------------------------ |
| ![image](https://github.com/user-attachments/assets/77b8fa8a-29af-4996-9a9f-5bf68fc89bec) | ![image](https://github.com/user-attachments/assets/ad4c1491-2178-44fa-a529-1a18d8428b33) | ![image](https://github.com/user-attachments/assets/7b6d5b3b-238b-42bc-8acf-88187a74ea76) |

</details>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
