### PR TITLE
buddy list: Adjust horizontal spacing of list elements.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -652,6 +652,15 @@ export class BuddyList extends BuddyListConf {
             this.users_matching_view_ids.length + this.participant_user_ids.length;
         const has_inactive_other_users = other_users_count > this.other_user_ids.length;
 
+        // This is a bit hacky. Ideally we'd be able to figure this out with looking
+        // at the first user's data, but right now this is the only way the server
+        // sends this information to the client.
+        let is_avatar_view = false;
+        if (this.all_user_ids.length > 0) {
+            const data = this.get_data_from_user_ids([this.all_user_ids[0]!]);
+            is_avatar_view = data[0]!.user_list_style.WITH_AVATAR;
+        }
+
         // For stream views, we show a link at the bottom of the list of subscribed users that
         // lets a user find the full list of subscribed users and information about them.
         if (
@@ -667,6 +676,7 @@ export class BuddyList extends BuddyListConf {
                 $(
                     render_view_all_subscribers({
                         stream_edit_hash,
+                        is_avatar_view,
                     }),
                 ),
             );
@@ -675,7 +685,9 @@ export class BuddyList extends BuddyListConf {
         // We give a link to view the list of all users to help reduce confusion about
         // there being hidden (inactive) "other" users.
         // if (has_inactive_other_users) {
-        $("#buddy-list-other-users-container").append($(render_view_all_users()));
+        $("#buddy-list-other-users-container").append(
+            $(render_view_all_users({is_avatar_view})),
+        );
         // }
 
         // Note that we don't show a link for the participants list because we expect

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -656,8 +656,8 @@ export class BuddyList extends BuddyListConf {
         // lets a user find the full list of subscribed users and information about them.
         if (
             current_sub &&
-            stream_data.can_view_subscribers(current_sub) &&
-            has_inactive_users_matching_view
+            stream_data.can_view_subscribers(current_sub) // &&
+            // has_inactive_users_matching_view
         ) {
             const stream_edit_hash = hash_util.channels_settings_edit_url(
                 current_sub,
@@ -674,9 +674,9 @@ export class BuddyList extends BuddyListConf {
 
         // We give a link to view the list of all users to help reduce confusion about
         // there being hidden (inactive) "other" users.
-        if (has_inactive_other_users) {
-            $("#buddy-list-other-users-container").append($(render_view_all_users()));
-        }
+        // if (has_inactive_other_users) {
+        $("#buddy-list-other-users-container").append($(render_view_all_users()));
+        // }
 
         // Note that we don't show a link for the participants list because we expect
         // all participants to be shown (except bots or deactivated users).

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -308,7 +308,6 @@ export class BuddyList extends BuddyListConf {
             this.render_data.hide_headers ? false : this.other_users_is_collapsed,
         );
 
-        this.update_empty_list_placeholders();
         this.fill_screen_with_content();
 
         // This must happen after `fill_screen_with_content`
@@ -317,6 +316,8 @@ export class BuddyList extends BuddyListConf {
         if (!buddy_data.get_is_searching_users()) {
             this.render_view_user_list_links();
         }
+        // This must happen after view user links are rendered
+        this.update_empty_list_placeholders();
         this.display_or_hide_sections();
 
         // `populate` always rerenders all user rows, so we need new load handlers.
@@ -362,32 +363,46 @@ export class BuddyList extends BuddyListConf {
             }
         }
 
-        function add_or_update_empty_list_placeholder(selector: string, message: string): void {
+        function add_or_update_empty_list_placeholder(
+            message: string,
+            list_selector: string,
+            view_all_link_selector?: string,
+        ): void {
+            // If we determined there are inactive users in this list, that aren't
+            // shown but could be visible through a "view more" link, then don't
+            // show the empty list message.
+            if (view_all_link_selector && $(view_all_link_selector).length > 0) {
+                $(`${list_selector} .empty-list-message`).remove();
+                return;
+            }
+
             if (
-                $(selector).children().length === 0 ||
-                $(`${selector} .empty-list-message`).length > 0
+                $(list_selector).children().length === 0 ||
+                $(`${list_selector} .empty-list-message`).length > 0
             ) {
                 const empty_list_widget_html = render_empty_list_widget_for_list({
                     empty_list_message: message,
                 });
-                $(selector).html(empty_list_widget_html);
+                $(list_selector).html(empty_list_widget_html);
             }
         }
 
         add_or_update_empty_list_placeholder(
-            "#buddy-list-users-matching-view",
             matching_view_empty_list_message,
+            "#buddy-list-users-matching-view",
+            ".view-all-subscribers-link",
         );
 
         add_or_update_empty_list_placeholder(
-            "#buddy-list-other-users",
             other_users_empty_list_message,
+            "#buddy-list-other-users",
+            ".view-all-users-link",
         );
 
         if (participants_empty_list_message) {
             add_or_update_empty_list_placeholder(
-                "#buddy-list-participants",
                 participants_empty_list_message,
+                "#buddy-list-participants",
             );
         }
     }

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -536,55 +536,60 @@ export function initialize(): void {
     }
 
     // BUDDY LIST TOOLTIPS (not displayed on touch devices)
-    $(".buddy-list-section").on("mouseenter", ".selectable_sidebar_block", (e) => {
-        e.stopPropagation();
-        const user_id_string = $(e.currentTarget)
-            .closest(".user_sidebar_entry")
-            .attr("data-user-id")!;
-        const title_data = buddy_data.get_title_data(user_id_string, false);
+    $(".buddy-list-section").on(
+        "mouseenter",
+        ".user_sidebar_entry",
+        function (this: HTMLElement, e) {
+            e.stopPropagation();
+            const user_id_string = $(e.currentTarget).attr("data-user-id")!;
+            const title_data = buddy_data.get_title_data(user_id_string, false);
 
-        // `target_node` is the `ul` element since it stays in DOM even after updates.
-        function get_target_node(): HTMLElement {
-            return util.the($(e.target).parents(".buddy-list-section"));
-        }
-
-        function check_reference_removed(
-            mutation: MutationRecord,
-            instance: tippy.Instance,
-        ): boolean {
-            return Array.prototype.includes.call(
-                mutation.removedNodes,
-                instance.reference.parentElement,
-            );
-        }
-
-        const $elem = $(e.currentTarget)
-            .closest(".user_sidebar_entry")
-            .find(".selectable_sidebar_block");
-        do_render_buddy_list_tooltip($elem, title_data, get_target_node, check_reference_removed);
-
-        /*
-           The following implements a little tooltip giving the name for status emoji
-           when hovering them in the right sidebar. This requires special logic, to avoid
-           conflicting with the main tooltip or showing duplicate tooltips.
-        */
-        $(".user_sidebar_entry .status-emoji-name").off("mouseenter").off("mouseleave");
-        $(".user_sidebar_entry .status-emoji-name").on("mouseenter", () => {
-            const element: tippy.ReferenceElement = util.the($elem);
-            const instance = element._tippy;
-            if (instance?.state.isVisible) {
-                instance.destroy();
+            // `target_node` is the `ul` element since it stays in DOM even after updates.
+            function get_target_node(): HTMLElement {
+                return util.the($(e.target).parents(".buddy-list-section"));
             }
-        });
-        $(".user_sidebar_entry .status-emoji-name").on("mouseleave", () => {
+
+            function check_reference_removed(
+                mutation: MutationRecord,
+                instance: tippy.Instance,
+            ): boolean {
+                return Array.prototype.includes.call(
+                    mutation.removedNodes,
+                    instance.reference.parentElement,
+                );
+            }
+
+            const $elem = $(this);
             do_render_buddy_list_tooltip(
                 $elem,
                 title_data,
                 get_target_node,
                 check_reference_removed,
             );
-        });
-    });
+
+            /*
+            The following implements a little tooltip giving the name for status emoji
+            when hovering them in the right sidebar. This requires special logic, to avoid
+            conflicting with the main tooltip or showing duplicate tooltips.
+            */
+            $(".user_sidebar_entry .status-emoji-name").off("mouseenter").off("mouseleave");
+            $(".user_sidebar_entry .status-emoji-name").on("mouseenter", () => {
+                const element: tippy.ReferenceElement = util.the($elem);
+                const instance = element._tippy;
+                if (instance?.state.isVisible) {
+                    instance.destroy();
+                }
+            });
+            $(".user_sidebar_entry .status-emoji-name").on("mouseleave", () => {
+                do_render_buddy_list_tooltip(
+                    $elem,
+                    title_data,
+                    get_target_node,
+                    check_reference_removed,
+                );
+            });
+        },
+    );
 
     // DIRECT MESSAGE LIST TOOLTIPS (not displayed on touch devices)
     $("body").on("mouseenter", ".dm-user-status", function (this: HTMLElement, e) {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -308,6 +308,7 @@
     --right-sidebar-heading-left-spacing: 5px;
     --right-sidebar-avatar-width: 2em;
     --right-sidebar-avatar-height: var(--right-sidebar-avatar-width);
+    --right-sidebar-avatar-right-margin: 4px;
     --right-sidebar-presence-circle-width: 20px;
 
     /* Tippy popover related values */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -308,6 +308,7 @@
     --right-sidebar-heading-left-spacing: 5px;
     --right-sidebar-avatar-width: 2em;
     --right-sidebar-avatar-height: var(--right-sidebar-avatar-width);
+    --right-sidebar-presence-circle-width: 20px;
 
     /* Tippy popover related values */
     --navbar-popover-menu-min-width: 230px;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -570,6 +570,7 @@ $user_status_emoji_width: 24px;
     padding-left: 0;
 
     .invite-user-link {
+        padding-left: 17px;
         grid-template-columns:
             var(--right-sidebar-header-icon-toggle-width)
             minmax(0, 1fr);

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -301,7 +301,7 @@ $user_status_emoji_width: 24px;
 
     .selectable_sidebar_block {
         margin: 4px;
-        margin-left: var(--right-sidebar-header-icon-toggle-width);
+        margin-left: calc(var(--right-sidebar-header-icon-toggle-width) / 2);
     }
 
     .avatar-preload-background {
@@ -561,8 +561,19 @@ $user_status_emoji_width: 24px;
     }
 }
 
+.buddy-list-user-link .right-sidebar-wrappable-text-container.is_avatar_view {
+    margin-left: calc(
+        var(--right-sidebar-header-icon-toggle-width) / 2 +
+            var(--right-sidebar-avatar-width) +
+            var(--right-sidebar-avatar-right-margin)
+    );
+}
+
 .buddy-list-user-link .right-sidebar-wrappable-text-container {
-    margin-left: var(--right-sidebar-header-icon-toggle-width);
+    margin-left: calc(
+        var(--right-sidebar-toggle-width-offset) - 2px +
+            var(--right-sidebar-presence-circle-width)
+    );
 }
 
 .invite-user-shortcut {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -286,7 +286,10 @@ $user_status_emoji_width: 24px;
         "starting-anchor-element row-content markers-and-controls" var(
             --line-height-sidebar-row
         )
-        ".                       row-content ." auto / 20px minmax(0, 1fr)
+        ".                       row-content ." auto / var(
+            --right-sidebar-presence-circle-width
+        )
+        minmax(0, 1fr)
         minmax(0, auto);
     align-items: baseline;
 }
@@ -526,7 +529,6 @@ $user_status_emoji_width: 24px;
 .buddy-list-user-link,
 .invite-user-shortcut {
     margin-right: var(--width-simplebar-scroll-hover);
-    padding-left: var(--right-sidebar-left-spacing);
     border-radius: 4px;
 
     &:hover {
@@ -559,8 +561,8 @@ $user_status_emoji_width: 24px;
     }
 }
 
-.buddy-list-user-link {
-    margin-left: var(--right-sidebar-toggle-width-offset);
+.buddy-list-user-link .right-sidebar-wrappable-text-container {
+    margin-left: var(--right-sidebar-header-icon-toggle-width);
 }
 
 .invite-user-shortcut {
@@ -570,7 +572,6 @@ $user_status_emoji_width: 24px;
        from the legacy value. */
     margin-top: calc(25px - (var(--legacy-body-line-height-unitless) * 1em));
     margin-bottom: var(--sidebar-bottom-spacing);
-    padding-left: 0;
 
     .invite-user-link {
         padding-left: 17px;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -298,6 +298,7 @@ $user_status_emoji_width: 24px;
 
     .selectable_sidebar_block {
         margin: 4px;
+        margin-left: var(--right-sidebar-header-icon-toggle-width);
     }
 
     .avatar-preload-background {
@@ -389,13 +390,15 @@ $user_status_emoji_width: 24px;
         "row-content ." auto / minmax(0, 1fr) 26px;
     align-content: baseline;
     margin-right: var(--width-simplebar-scroll-hover);
-    margin-left: var(--right-sidebar-toggle-width-offset);
     /* When both the left circle and three dot menu are present, we want
        the space to the left of the circle to be more similar to the space
        to the right of the three dot menu. */
     &:not(.with_avatar) {
-        padding-left: 2px;
-        margin-left: calc(var(--right-sidebar-toggle-width-offset) - 2px);
+        padding-left: calc(var(--right-sidebar-toggle-width-offset) - 2px);
+    }
+
+    &:hover {
+        cursor: pointer;
     }
 
     .user-name-and-status-emoji {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1020,7 +1020,7 @@ div.focused-message-list {
 .user_sidebar_entry.with_avatar .user-profile-picture {
     width: var(--right-sidebar-avatar-width);
     height: var(--right-sidebar-avatar-height);
-    margin-right: 11px;
+    margin-right: var(--right-sidebar-avatar-right-margin);
 }
 
 .home-error-bar {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1002,7 +1002,6 @@ div.focused-message-list {
        this preserves the dimensions and rounded corners
        on the image itself. */
     line-height: 1;
-    margin-right: 11px;
     vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
@@ -1021,6 +1020,7 @@ div.focused-message-list {
 .user_sidebar_entry.with_avatar .user-profile-picture {
     width: var(--right-sidebar-avatar-width);
     height: var(--right-sidebar-avatar-height);
+    margin-right: 11px;
 }
 
 .home-error-bar {

--- a/web/templates/buddy_list/view_all_subscribers.hbs
+++ b/web/templates/buddy_list/view_all_subscribers.hbs
@@ -1,5 +1,5 @@
 <div class="buddy-list-user-link view-all-subscribers-link">
-    <a class="right-sidebar-wrappable-text-container" href="{{stream_edit_hash}}">
+    <a class="right-sidebar-wrappable-text-container{{#if is_avatar_view}} is_avatar_view{{/if}}" href="{{stream_edit_hash}}">
         <span class="right-sidebar-wrappable-text-inner">
             {{t "View all subscribers" }}
         </span>

--- a/web/templates/buddy_list/view_all_users.hbs
+++ b/web/templates/buddy_list/view_all_users.hbs
@@ -1,5 +1,5 @@
 <div class="buddy-list-user-link view-all-users-link">
-    <a class="right-sidebar-wrappable-text-container" href="#organization/users">
+    <a class="right-sidebar-wrappable-text-container{{#if is_avatar_view}} is_avatar_view{{/if}}" href="#organization/users">
         <span class="right-sidebar-wrappable-text-inner">
             {{t "View all users" }}
         </span>

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -788,7 +788,6 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         buddy_list.$other_users_list = $("#buddy-list-other-users");
         buddy_list.$other_users_list.append = noop;
         stub_buddy_list_elements();
-        mock_template("empty_list_widget_for_list.hbs", false, () => "<empty-list-stub>");
         clear_buddy_list(buddy_list);
         page_params.presences = {};
     }

--- a/web/tests/lib/buddy_list.cjs
+++ b/web/tests/lib/buddy_list.cjs
@@ -44,4 +44,6 @@ exports.stub_buddy_list_elements = () => {
     $("#buddy-list-other-users-container .view-all-users-link").length = 0;
     $("#buddy-list-users-matching-view-container .view-all-subscribers-link").remove = noop;
     $("#buddy-list-other-users-container .view-all-users-link").remove = noop;
+    $("#buddy-list-other-users .empty-list-message").remove = noop;
+    $("#buddy-list-users-matching-view .empty-list-message").remove = noop;
 };


### PR DESCRIPTION
This is a handful of changes based on conversation on CZO starting here: https://chat.zulip.org/#narrow/channel/101-design/topic/invite.20users.20link.20in.20right.20sidebar.20.20.2332332/near/2013731

still to be finalized:
* [ ] spacing between avatar and user name
* [ ] alignment of invite link

----

<details>
<summary>screen captures</summary>

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ee815f7f-df67-4614-a885-bad2e09f518d" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/7373b8bc-0ca2-4056-8227-e1f70ec60ed7" />
</details>

<details>
<summary>diff to get "view all" link showing locally</summary>

```diff
diff --git a/web/src/buddy_list.ts b/web/src/buddy_list.ts
index f03f66c6aa..f6782f3f88 100644
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -665,8 +665,8 @@ export class BuddyList extends BuddyListConf {
         // lets a user find the full list of subscribed users and information about them.
         if (
             current_sub &&
-            stream_data.can_view_subscribers(current_sub) &&
-            has_inactive_users_matching_view
+            stream_data.can_view_subscribers(current_sub)// &&
+            // has_inactive_users_matching_view
         ) {
             const stream_edit_hash = hash_util.channels_settings_edit_url(
                 current_sub,
@@ -684,11 +684,11 @@ export class BuddyList extends BuddyListConf {
 
         // We give a link to view the list of all users to help reduce confusion about
         // there being hidden (inactive) "other" users.
-        if (has_inactive_other_users) {
+        // if (has_inactive_other_users) {
             $("#buddy-list-other-users-container").append(
                 $(render_view_all_users({is_avatar_view})),
             );
-        }
+        // }
 
         // Note that we don't show a link for the participants list because we expect
         // all participants to be shown (except bots or deactivated users).

```

</details>