### PR TITLE
compose: Fix Cmd + Return to send messages in preview mode on Mac.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -272,10 +272,10 @@ export function rewire_send_message(value) {
     send_message = value;
 }
 
-export function handle_enter_key_with_preview_open(ctrl_pressed = false) {
+export function handle_enter_key_with_preview_open(cmd_or_ctrl_pressed = false) {
     if (
-        (user_settings.enter_sends && !ctrl_pressed) ||
-        (!user_settings.enter_sends && ctrl_pressed)
+        (user_settings.enter_sends && !cmd_or_ctrl_pressed) ||
+        (!user_settings.enter_sends && cmd_or_ctrl_pressed)
     ) {
         // If this enter should send, we attempt to send the message.
         finish();

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -117,10 +117,10 @@ const keydown_unshift_mappings = {
 
 const keydown_ctrl_mappings = {
     219: {name: "escape", message_view_only: false}, // '['
-    13: {name: "ctrl_enter", message_view_only: true}, // enter
 };
 
 const keydown_cmd_or_ctrl_mappings = {
+    13: {name: "action_with_enter", message_view_only: true}, // 'Enter'
     67: {name: "copy_with_c", message_view_only: false}, // 'C'
     75: {name: "search_with_k", message_view_only: false}, // 'K'
     83: {name: "star_message", message_view_only: true}, // 'S'
@@ -580,10 +580,10 @@ export function process_enter_key(e) {
     return true;
 }
 
-export function process_ctrl_enter_key() {
+export function process_cmd_or_ctrl_enter_key() {
     if ($("#preview_message_area").is(":visible")) {
-        const ctrl_pressed = true;
-        compose.handle_enter_key_with_preview_open(ctrl_pressed);
+        const cmd_or_ctrl_pressed = true;
+        compose.handle_enter_key_with_preview_open(cmd_or_ctrl_pressed);
         return true;
     }
 
@@ -710,8 +710,8 @@ export function process_hotkey(e, hotkey) {
             return process_escape_key(e);
         case "enter":
             return process_enter_key(e);
-        case "ctrl_enter":
-            return process_ctrl_enter_key(e);
+        case "action_with_enter":
+            return process_cmd_or_ctrl_enter_key(e);
         case "tab":
             return process_tab_key();
         case "shift_tab":


### PR DESCRIPTION
Previously, Cmd + Return did not send messages in preview mode when configured by the user.

This commit fixes the logic to allow sending messages in preview mode with Cmd + Return as per user configuration.

<!-- Describe your pull request here.-->

Fixes: #32960

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
