### PR TITLE
Avoid rerender of user sidebar when adding or removing messages from message list.

### DIFF
--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -92,12 +92,7 @@ export function redraw_user(user_id: number): void {
         return;
     }
 
-    const info = buddy_data.get_item(user_id);
-
-    buddy_list.insert_or_move({
-        user_id,
-        item: info,
-    });
+    buddy_list.insert_or_move([user_id]);
     update_presence_indicators();
 }
 

--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -10,6 +10,7 @@ import * as buddy_data from "./buddy_data.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as keydown_util from "./keydown_util.ts";
 import {ListCursor} from "./list_cursor.ts";
+import * as narrow_state from "./narrow_state.ts";
 import * as people from "./people.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popovers from "./popovers.ts";
@@ -94,6 +95,14 @@ export function redraw_user(user_id: number): void {
 
     buddy_list.insert_or_move([user_id]);
     update_presence_indicators();
+}
+
+export function rerender_user_sidebar_participants(): void {
+    if (!narrow_state.stream_id() || !narrow_state.topic()) {
+        return;
+    }
+
+    buddy_list.rerender_participants();
 }
 
 export function check_should_redraw_new_user(user_id: number): boolean {

--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -319,11 +319,6 @@ export function get_title_data(user_ids_string: string, is_group: boolean): Titl
     };
 }
 
-export function get_item(user_id: number): BuddyUserInfo {
-    const info = info_for(user_id);
-    return info;
-}
-
 export function get_items_for_users(user_ids: number[]): BuddyUserInfo[] {
     const user_info = user_ids.map((user_id) => info_for(user_id));
     return user_info;

--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -1,8 +1,5 @@
-import _ from "lodash";
 import assert from "minimalistic-assert";
 
-import * as blueslip from "./blueslip.ts";
-import {ConversationParticipants} from "./conversation_participants.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
@@ -452,32 +449,18 @@ function get_filtered_user_id_list(
     return filter_user_ids(user_filter_text, [...user_ids_set]);
 }
 
-export function get_conversation_participants(): Set<number> {
-    const participant_ids_set = new Set<number>();
-    if (!narrow_state.stream_id() || !narrow_state.topic() || !message_lists.current) {
-        return participant_ids_set;
-    }
-    for (const message of message_lists.current.all_messages()) {
-        if (people.is_displayable_conversation_participant(message.sender_id)) {
-            participant_ids_set.add(message.sender_id);
+export function get_conversation_participants_callback(): () => Set<number> {
+    return () => {
+        if (!narrow_state.stream_id() || !narrow_state.topic() || !message_lists.current) {
+            return new Set<number>();
         }
-    }
-    const conversation_participants = new ConversationParticipants(
-        message_lists.current.all_messages(),
-    ).visible();
-    if (!_.isEqual(participant_ids_set, conversation_participants)) {
-        /* istanbul ignore next */
-        blueslip.error("Participants calculations disagree", {
-            participant_ids_set,
-            conversation_participants,
-        });
-    }
-    return participant_ids_set;
+        return message_lists.current.data.participants.visible();
+    };
 }
 
 export function get_filtered_and_sorted_user_ids(user_filter_text: string): number[] {
     let user_ids;
-    const conversation_participants = get_conversation_participants();
+    const conversation_participants = get_conversation_participants_callback()();
     user_ids = get_filtered_user_id_list(user_filter_text, conversation_participants);
     user_ids = maybe_shrink_list(user_ids, user_filter_text, conversation_participants);
     return sort_users(user_ids, conversation_participants);

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -983,6 +983,24 @@ export class BuddyList extends BuddyListConf {
                 is_participant_user: all_participant_ids.has(user_id),
             });
         }
+
+        this.display_or_hide_sections();
+        this.render_section_headers();
+    }
+
+    rerender_participants(): void {
+        const all_participant_ids = this.render_data.get_all_participant_ids();
+        const users_to_remove = this.participant_user_ids.filter(
+            (user_id) => !all_participant_ids.has(user_id),
+        );
+        const users_to_add = [...all_participant_ids].filter(
+            (user_id) => !this.participant_user_ids.includes(user_id),
+        );
+
+        // We are just moving the users around since we still want to show the
+        // user in buddy list regardless of if they are a participant, so we
+        // call `insert_or_move` on both `users_to_remove` and `users_to_add`.
+        this.insert_or_move([...users_to_remove, ...users_to_add]);
     }
 
     fill_screen_with_content(): void {

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -5,15 +5,21 @@ const assert = require("node:assert/strict");
 const _ = require("lodash");
 
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {noop, run_test} = require("./lib/test.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
 mock_esm("../src/settings_data", {
     user_can_access_all_other_users: () => true,
 });
 const timerender = mock_esm("../src/timerender");
+mock_esm("../src/buddy_list", {
+    buddy_list: {
+        rerender_participants: noop,
+    },
+});
 
 const compose_fade_helper = zrequire("compose_fade_helper");
+const activity_ui = zrequire("activity_ui");
 const muted_users = zrequire("muted_users");
 const narrow_state = zrequire("narrow_state");
 const peer_data = zrequire("peer_data");
@@ -435,6 +441,7 @@ test("get_conversation_participants", ({override_rewire}) => {
     override_rewire(narrow_state, "stream_id", () => rome_sub.stream_id);
     override_rewire(narrow_state, "topic", () => "Foo");
 
+    activity_ui.rerender_user_sidebar_participants();
     assert.deepEqual(
         buddy_data.get_conversation_participants_callback()(),
         new Set([selma.user_id]),

--- a/web/tests/buddy_data.test.cjs
+++ b/web/tests/buddy_data.test.cjs
@@ -427,23 +427,18 @@ test("get_conversation_participants", ({override_rewire}) => {
     message_lists.set_current({
         data: {
             filter,
-        },
-        all_messages() {
-            return [
-                {
-                    sender_id: selma.user_id,
-                    id: rome_sub.stream_id,
-                    content: "example content",
-                    topic: "Foo",
-                    type: "stream",
-                },
-            ];
+            participants: {
+                visible: () => new Set([selma.user_id]),
+            },
         },
     });
     override_rewire(narrow_state, "stream_id", () => rome_sub.stream_id);
     override_rewire(narrow_state, "topic", () => "Foo");
 
-    assert.deepEqual(buddy_data.get_conversation_participants(), new Set([selma.user_id]));
+    assert.deepEqual(
+        buddy_data.get_conversation_participants_callback()(),
+        new Set([selma.user_id]),
+    );
 });
 
 test("level", ({override}) => {

--- a/web/tests/conversation_participants.test.cjs
+++ b/web/tests/conversation_participants.test.cjs
@@ -53,4 +53,10 @@ run_test("Add participants", () => {
     const participants = new ConversationParticipants(all_messages);
     assert.ok(_.isEqual(participants.humans, new Set([user1.user_id, user2.user_id])));
     assert.ok(_.isEqual(participants.bots, new Set([bot1.user_id, bot2.user_id])));
+    // None since they were not added as active users.
+    assert.equal(participants.visible().size, 0);
+
+    // Add user1 as active user.
+    people.add_active_user(user1);
+    assert.ok(_.isEqual(participants.visible(), new Set([user1.user_id])));
 });

--- a/web/tests/message_list.test.cjs
+++ b/web/tests/message_list.test.cjs
@@ -52,7 +52,7 @@ const current_user = {};
 set_current_user(current_user);
 
 run_test("basics", ({override}) => {
-    override(activity_ui, "build_user_sidebar", noop);
+    override(activity_ui, "rerender_user_sidebar_participants", noop);
     const filter = new Filter([]);
 
     const list = new MessageList({
@@ -451,7 +451,7 @@ run_test("bookend", ({override}) => {
 });
 
 run_test("add_remove_rerender", ({override}) => {
-    override(activity_ui, "build_user_sidebar", noop);
+    override(activity_ui, "rerender_user_sidebar_participants", noop);
 
     const filter = new Filter([]);
     const list = new MessageList({


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/build_user_sidebar.20called.203x.20when.20changing.20view


Tested by simply sending new messages or removing existing messages. Also tested that other narrows look good.