### PR TITLE
help: Refresh email notifications help page.

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -1285,7 +1285,7 @@ _Released 2023-01-23_
 - Use internationalized form of “at” in message timestamps.
 - Updated translations.
 - Fixed the “custom” value for the
-  “[delay before sending message notification emails](https://zulip.com/help/email-notifications#delay-before-sending-emails)”
+  “[delay before sending message notification emails](https://zulip.com/help/email-notifications)”
   setting.
 - Fixed an error which prevented users from changing
   [stream-specific notification settings](https://zulip.com/help/channel-notifications#configure-notifications-for-a-single-channel).

--- a/help/delete-a-message.md
+++ b/help/delete-a-message.md
@@ -91,7 +91,7 @@ the `ARCHIVED_DATA_VACUUMING_DELAY_DAYS` setting.
 ## Message notifications
 
 If you delete a message soon after sending it, any [pending email
-notifications](/help/email-notifications#delay-before-sending-emails)
+notifications](/help/email-notifications#configure-delay-for-message-notification-emails)
 for that message will be canceled, and
 [visual desktop notifications](/help/desktop-notifications) will be removed,
 including [mentions and alerts](/help/dm-mention-alert-notifications).

--- a/help/edit-a-message.md
+++ b/help/edit-a-message.md
@@ -55,7 +55,7 @@ the newly mentioned users will receive notifications just as if they had been
 mentioned in the original message.
 
 If you edit a message soon after sending it, the edit will be reflected in any
-[email notifications that have not yet been sent](/help/email-notifications#delay-before-sending-emails).
+[email notifications that have not yet been sent](/help/email-notifications#configure-delay-for-message-notification-emails).
 This includes canceling notifications for users whose
 [mention](/help/format-your-message-using-markdown#mention-a-user-or-group) was
 removed or changed from a regular mention to a

--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -2,53 +2,37 @@
 
 ## Message notification emails
 
-Zulip can be configured to send message notification emails for [DMs
-and mentions](/help/dm-mention-alert-notifications), as well as
-[channel messages](/help/channel-notifications).
+Zulip can be configured to send message notification emails for [DMs mentions,
+and alerts](/help/dm-mention-alert-notifications), as well as [channel
+messages](/help/channel-notifications) and [followed
+topics](/help/follow-a-topic#configure-notifications-for-followed-topics).
+
+You will receive email notifications only for messages sent when you were not
+[active](/help/status-and-availability#availability) on Zulip. Messages sent to
+the same conversation within a [configurable time
+period](#configure-delay-for-message-notification-emails) (e.g., a few minutes)
+will be combined into a single email.
+
+You can reply to Zulip messages by replying to message notification emails.
+
+!!! warn ""
+
+    To enable replies via email on a self-hosted server, the [incoming email
+    gateway][incoming-email-gateway] must be configured by the system
+    administrator.
+
+### Configure triggers for message notification emails
 
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Toggle the checkboxes for **Channels** and **DMs, mentions, and alerts**
-   in the **Email** column of the **Notification triggers** table.
+1. Toggle the checkboxes in the **Email** column of the **Notification
+   triggers** table.
 
 {end_tabs}
-
-You can [respond to Zulip messages directly][reply-from-email] by
-replying to message notification emails, unless you are connecting to
-a self-hosted Zulip server whose system administrator has not
-configured the [incoming email gateway][incoming-email-gateway].
 
 [incoming-email-gateway]: https://zulip.readthedocs.io/en/stable/production/email-gateway.html
-
-### Delay before sending emails
-
-To reduce the number of emails you receive, Zulip
-delays sending message notification emails for a configurable period
-of time (default: 2 minutes).  The delay
-helps in a few ways:
-
-* No email is sent if you return to Zulip and read the message before
-  the email would go out.
-* Edits made by the sender soon after sending a message will be
-  reflected in the email.
-* Multiple messages in the same Zulip [conversation](/help/reading-conversations)
-  are combined into a single email. (Different conversations will always be in
-  separate emails, so that you can [respond directly from your
-  email](/help/using-zulip-via-email)).
-
-To configure the delay for message notification emails:
-
-{start_tabs}
-
-{settings_tab|notifications}
-
-1. Under **Email message notifications**, select the desired time period from the
-   **Delay before sending message notification emails** dropdown.
-
-{end_tabs}
-
 
 ### Include organization name in subject line
 
@@ -68,10 +52,34 @@ Zulip Cloud organizations, or in multiple organizations on the same Zulip server
 
 {end_tabs}
 
+### Configure delay for message notification emails
+
+To reduce the number of emails you receive, Zulip
+delays sending message notification emails for a configurable period
+of time. The delay helps in a few ways:
+
+* No email is sent if you return to Zulip and read the message before
+  the email would go out.
+* Edits made by the sender soon after sending a message will be
+  reflected in the email.
+* Multiple messages in the same Zulip [conversation](/help/reading-conversations)
+  are combined into a single email. Different conversations will always be in
+  separate emails, so that you can respond directly from your
+  email.
+
+{start_tabs}
+
+{settings_tab|notifications}
+
+1. Under **Email message notifications**, select the desired time period from the
+   **Delay before sending message notification emails** dropdown.
+
+{end_tabs}
+
 ### Hide message content
 
 For security or compliance reasons, you may want to hide the content of your
-Zulip messages from your email. Organization admins can do this at an
+Zulip messages from your email. Organization administrators can do this at an
 [organization-wide level](/help/hide-message-content-in-emails), but you can
 also do this just for the messages you receive.
 
@@ -115,6 +123,8 @@ feel excessive.
 
 ## Low-traffic newsletter
 
+{!cloud-only.md!}
+
 Zulip sends out a low-traffic newsletter (expect 2-4 emails a year)
 to Zulip Cloud users announcing major changes in Zulip.
 
@@ -135,5 +145,7 @@ to Zulip Cloud users announcing major changes in Zulip.
 
 * [Using Zulip via email](/help/using-zulip-via-email)
 * [Message a channel by email](/help/message-a-channel-by-email)
+* [DMs mentions, and alerts](/help/dm-mention-alert-notifications)
 * [Channel notifications](/help/channel-notifications)
+* [Follow a topic](/help/follow-a-topic)
 * [Hide message content in emails (for organizations)](/help/hide-message-content-in-emails)

--- a/help/include/cloud-only.md
+++ b/help/include/cloud-only.md
@@ -1,0 +1,3 @@
+!!! warn ""
+
+    This feature is only available on Zulip Cloud.


### PR DESCRIPTION
Document more clearly when notifications are triggered.

Current: https://zulip.com/help/email-notifications
<details>
<summary>
Updated
</summary>

![Screenshot 2025-01-09 at 09 51 27](https://github.com/user-attachments/assets/19891212-714b-449c-95a7-ae41079a53e2)
![Screenshot 2025-01-09 at 09 51 36](https://github.com/user-attachments/assets/e8ae26c8-b62e-4583-a2e4-d9ff0dffd90a)
![Screenshot 2025-01-09 at 09 51 41](https://github.com/user-attachments/assets/804052d0-b6e0-4fc4-a57e-1f84f30c6a66)

</details>