### PR TITLE
composebox_typeahead: Avoid opening on multiline stream/topic names.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -920,7 +920,7 @@ export function get_candidates(
         }
 
         // Matches '#**stream name>some text' at the end of a split.
-        const stream_topic_regex = /#\*\*([^*>]+)>([^*]*)$/;
+        const stream_topic_regex = /#\*\*([^*>]+)>([^*\n]*)$/;
         const should_begin_typeahead = stream_topic_regex.test(split[0]);
         if (should_begin_typeahead) {
             completing = "topic_list";

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1862,6 +1862,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     }
     assert_typeahead_equals("#**Sweden>more ice", typed_topics(["more ice", "even more ice"]));
     assert_typeahead_equals("#**Sweden>totally new topic", typed_topics(["totally new topic"]));
+    assert_typeahead_equals("#**Sweden>\n\nmore ice", typed_topics([]));
 
     // time_jump
     const time_jump = [


### PR DESCRIPTION
Since Zulip channel and topic names cannot
contain newlines, we should not show channel
or topic suggestions if the `#**stream>topic`
syntax is spread across multiple lines.

So we tweak the regexes to not match topics having `\n`.

We do not need to change the regexes in `marked.js` or `markdown/__init.py__` since the message text is already split at newlines
before being matched against those regexes,
so a newline will never be present during matching, both in the frontend and the backend.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|-------|------|
| ![image](https://github.com/user-attachments/assets/84bc3b69-deea-4e39-8053-94211902ad0a) | ![image](https://github.com/user-attachments/assets/cb72273e-91aa-4723-969d-e1e23d3eae5c) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
