### PR TITLE
Allow renaming deactivated user groups.

### DIFF
--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -65,9 +65,8 @@ export function should_show_first_stream_created_modal(): boolean {
 }
 
 export function maybe_update_error_message(): void {
-    if ($("#stream_name_error").is(":visible") && $("#archived_stream_rename").is(":visible")) {
-        $("#create_stream_name").trigger("input");
-    }
+    const stream_name = $<HTMLInputElement>("input#create_stream_name").val()!.trim();
+    stream_name_error.pre_validate(stream_name);
 }
 
 const group_setting_widget_map = new Map<string, GroupSettingPillContainer | null>([

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -138,7 +138,9 @@ export function update_stream_name(sub: StreamSubscription, new_name: string): v
     message_view_header.maybe_rerender_title_area_for_stream(sub);
 
     // Update the create stream error if needed
-    stream_create.maybe_update_error_message();
+    if (overlays.streams_open()) {
+        stream_create.maybe_update_error_message();
+    }
 }
 
 export function update_stream_description(

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -658,11 +658,6 @@ export function open_group_edit_panel_for_row(group_row: HTMLElement): void {
     show_group_settings(group);
 }
 
-// Ideally this should be included in page params.
-// Like we have realm.max_stream_name_length` and
-// `realm.max_stream_description_length` for streams.
-export const max_user_group_name_length = 100;
-
 export function set_up_click_handlers(): void {
     $("#groups_overlay").on("click", ".left #clear_search_group_name", (e) => {
         const $input = $("#groups_overlay .left #search_group_name");
@@ -1042,7 +1037,7 @@ export function setup_page(callback: () => void): void {
             upgrade_text_for_wide_organization_logo: realm.upgrade_text_for_wide_organization_logo,
             is_business_type_org:
                 realm.realm_org_type === settings_config.all_org_type_values.business.code,
-            max_user_group_name_length,
+            max_user_group_name_length: user_groups.max_user_group_name_length,
         };
 
         const groups_overlay_html = render_user_group_settings_overlay(template_data);
@@ -1223,7 +1218,7 @@ export function initialize(): void {
             const template_data = {
                 group_name: user_group.name,
                 group_description: user_group.description,
-                max_user_group_name_length,
+                max_user_group_name_length: user_groups.max_user_group_name_length,
             };
             const change_user_group_info_modal = render_change_user_group_info_modal(template_data);
             dialog_widget.launch({

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -791,6 +791,7 @@ export function update_group(event: UserGroupUpdateEvent): void {
     const $group_row = row_for_group_id(group_id);
     if (event.data.name !== undefined) {
         $group_row.find(".group-name").text(group.name);
+        user_group_create.maybe_update_error_message();
     }
 
     if (event.data.description !== undefined) {
@@ -1219,6 +1220,7 @@ export function initialize(): void {
                 group_name: user_group.name,
                 group_description: user_group.description,
                 max_user_group_name_length: user_groups.max_user_group_name_length,
+                allow_editing_description: true,
             };
             const change_user_group_info_modal = render_change_user_group_info_modal(template_data);
             dialog_widget.launch({

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -41,6 +41,11 @@ export function init(): void {
 // WE INITIALIZE DATA STRUCTURES HERE!
 init();
 
+// Ideally this should be included in page params.
+// Like we have realm.max_stream_name_length` and
+// `realm.max_stream_description_length` for streams.
+export const max_user_group_name_length = 100;
+
 export function add(user_group_raw: UserGroupRaw): UserGroup {
     // Reformat the user group members structure to be a set.
     const user_group = {

--- a/web/templates/user_group_settings/change_user_group_info_modal.hbs
+++ b/web/templates/user_group_settings/change_user_group_info_modal.hbs
@@ -4,9 +4,12 @@
     </label>
     <input type="text" id="change_user_group_name" class="modal_text_input" name="user_group_name" value="{{ group_name }}" maxlength="{{max_user_group_name_length}}" />
 </div>
+
+{{#if allow_editing_description}}
 <div>
     <label for="change_user_group_description" class="modal-field-label">
         {{t 'User group description' }}
     </label>
     <textarea id="change_user_group_description" class="settings_textarea" name="user_group_description">{{ group_description }}</textarea>
 </div>
+{{/if}}

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -13,6 +13,7 @@
                         <input type="text" name="user_group_name" id="create_user_group_name" class="settings_text_input"
                           placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="{{ max_user_group_name_length }}"/>
                         <div id="user_group_name_error" class="user_group_creation_error"></div>
+                        <a id="deactivated_group_rename"></a>
                     </section>
                     <section id="user-group-description-container">
                         <label for="create_user_group_description" class="settings-field-label">


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is a preparatory refactor.
- Second commit is to live-update duplicate name error on receving stream rename events.
- Third commit is to allow renaming deactivated groups.

Fixes: <!-- Issue link, or clear description.--> #32876

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Peek 2025-01-10 17-11](https://github.com/user-attachments/assets/11d06e32-66e0-4df4-81c9-32fa740cc957)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
