### PR TITLE
left_sidebar: Remove bottom border from 'topic_search_section'.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1137,7 +1137,6 @@ li.top_left_scheduled_messages {
     padding: 8px 10px;
     display: grid;
     grid-template: "search-input clear-search" auto / minmax(0, 1fr) 30px;
-    border-bottom: 1px solid var(--color-border-modal-bar);
 }
 
 .topic-box .zero_count {


### PR DESCRIPTION
This commit removes the mistakenly added bottom border from topic search section.


**Screenshots and screen captures:**
before:
![image](https://github.com/user-attachments/assets/a140932f-80a4-4878-89cc-a18fdf2649b4)

after:
<img width="325" alt="Screenshot 2025-01-11 at 4 27 19 AM" src="https://github.com/user-attachments/assets/09358074-24b8-4fc8-9e32-7c7153c0a2ff" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
