### PR TITLE
Correctly align the bot icon in message area.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -425,6 +425,11 @@
             .zulip-icon.zulip-icon-bot {
                 align-self: center;
                 margin-left: 5px;
+                /* The bot icon is center-aligned but appears
+                slightly misaligned with the bot name text due
+                to its shape. Adding a negative top margin ensures
+                it's proper alignment. */
+                margin-top: -0.12em;
             }
 
             .sender_name {


### PR DESCRIPTION
It was observed that the bot icon in the message area appeared misaligned with the bot name, positioning slightly lower. This PR fixes the UI bug by correctly aligning the bot icon with the bot name.

## Screenshots 

![image](https://github.com/user-attachments/assets/9270c00b-9785-4799-8411-4ef7fe7e51dd)

![image](https://github.com/user-attachments/assets/73fec892-673e-4fce-a35c-16c2ba924b4b)


Fixes: #32992

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
