### PR TITLE
widgets: Add task reordering in todo widget

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -760,6 +760,10 @@
         hsl(0deg 0% 80%),
         hsl(0deg 0% 0% / 60%)
     );
+    --color-background-hover-todo-item: light-dark(
+        hsl(0deg 0% 97%),
+        hsl(0deg 0% 21%)
+    );
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-masked-unread-marker: light-dark(
         hsl(0deg 0% 80%),

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -167,6 +167,12 @@
             );
         }
 
+        &:has(.todo-widget) {
+            /* The reason for this is that we need to show the drag
+               icon on hovering over the task in todo widget. */
+            overflow: visible;
+        }
+
         &:empty {
             display: none;
         }

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -23,6 +23,11 @@
 }
 
 .todo-widget {
+    & li.todo-item-draggable {
+        margin-left: -26px !important;
+        padding-left: 5px;
+    }
+
     .todo-task-list-title-bar {
         flex: 1 1 auto;
         display: flex;
@@ -43,6 +48,41 @@
     .add-task,
     .add-desc {
         font-weight: 400;
+    }
+
+    .todo-item {
+        align-items: center;
+        border-radius: 6px;
+
+        &:hover {
+            background-color: var(--color-background-hover-todo-item);
+
+            div.todo-draggable {
+                opacity: 0.5;
+            }
+        }
+    }
+
+    div.todo-draggable {
+        height: min-content;
+        cursor: grab;
+        opacity: 0;
+
+        i.drag-icon {
+            display: block;
+        }
+    }
+
+    .dragging {
+        user-select: none;
+        background-color: var(--color-background-hover-todo-item);
+        position: relative;
+        z-index: 1;
+
+        div.todo-draggable {
+            opacity: 0.5;
+            cursor: grabbing;
+        }
     }
 
     & label.checkbox {

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -1,5 +1,10 @@
 {{#each all_tasks}}
-    <li>
+    <li class="todo-item {{#if ../showDrag}}todo-item-draggable{{/if}}">
+        {{#if ../showDrag }}
+        <div class="todo-draggable">
+            <i class="zulip-icon zulip-icon-grip-vertical drag-icon"></i>
+        </div>
+        {{/if}}
         <label class="checkbox">
             <div class="todo-checkbox">
                 <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -547,6 +547,17 @@ def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "reorder":
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("from", check_int),
+                ("to", check_int),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -525,6 +525,13 @@ class WidgetContentTestCase(ZulipTestCase):
         assert_error('{"type": "strike"}', "key is missing")
         assert_error('{"type": "strike", "key": 999}', 'data["key"] is not a string')
 
+        assert_error('{"type": "reorder"}', "from key is missing from todo data")
+        assert_error('{"type": "reorder", "from":"1"}', 'todo data["from"] is not an integer')
+        assert_error('{"type": "reorder", "from": 1}', "to key is missing from todo data")
+        assert_error(
+            '{"type": "reorder", "from": 1, "to": "2"}', 'todo data["to"] is not an integer'
+        )
+
         def assert_success(data: dict[str, object]) -> None:
             content = orjson.dumps(data).decode()
             result = post_submessage(content)
@@ -532,6 +539,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         assert_success(dict(type="new_task", key=7, task="eat", desc="", completed=False))
         assert_success(dict(type="strike", key="5,9"))
+        assert_success({"type": "reorder", "from": 1, "to": 2})
 
     def test_get_widget_type(self) -> None:
         sender = self.example_user("cordelia")


### PR DESCRIPTION
This PR aims to handle a part of issue [#20213](https://github.com/zulip/zulip/issues/20213):
> Make it possible to manually reorder tasks, ideally by dragging and dropping them in the message view.

This PR contains 3 commits for each subtask:

**1. Make the backend to accept `reorder` submessage request.**
This commit makes the backend server `submessage` API handle the `type: reorder` requests along with a `from` and `to` indices which represent the initial and final indices of the task and adds it to the `submessage` table.

**2. Render the widget to handle inbound `reorder` submessage.**
The renderer can now handle the submessage with `type: reorder` and reorder the task accordingly. It'll just punt if the reorder doesn't make sense (If `from` or `to` indices` exceed the number of tasks).

**3. Create drag and drop functionality and send outbound `reorder` submessage.**
This is the UI part, which implements drag and drop functionality using the native DOM APIs. 

**Screenshots & Screencaptures:**

| Light Theme | Dark Theme |
|-------------|------------|
| ![image](https://github.com/user-attachments/assets/278044cc-aaf0-48da-ac1e-e49f6b7e62cb) | ![image](https://github.com/user-attachments/assets/0f8be62d-da84-4ed6-8aa5-0d113356ce9c) |
| ![image](https://github.com/user-attachments/assets/e415306f-4848-4548-b041-c2ce9f2b9d43) | ![image](https://github.com/user-attachments/assets/774707bb-9e7b-4c44-81ac-8730f9ee1a4e) |
| [Screencast - Light Theme.webm](https://github.com/user-attachments/assets/9726e5d2-80ea-43d4-bcab-eba6147d8b96) | [Screencast - Dark Theme.webm](https://github.com/user-attachments/assets/082e4342-1add-41de-a6cf-b67a56a80b4c) |

**Additional Notes:**
As per my observertions, the drag icon can't overlap with the "EDITED" or "MOVED" labels. 
<details>
<summary>Take a look at this screenshot for understanding</summary>

![Screenshot_20250123_031808](https://github.com/user-attachments/assets/b7fdf7d8-f66a-4e0c-a1fe-49ca864170dc)

</details>

**CZO Discussion Threads:**
[CZO Thread - backend](https://chat.zulip.org/#narrow/channel/3-backend/topic/Manual.20reordering.20of.20tasks)
[CZO Thread - design](https://chat.zulip.org/#narrow/channel/101-design/topic/Manual.20reordering.20of.20tasks)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
