### PR TITLE
reaction: Add `user` object back in reaction events.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 339**
+
+* [`GET /events`](/api/get-events): Added `user` field back in
+  `reaction` events, reverting part of the [feature level 328
+  changes](#feature-level-328). Note that this field was only restored
+  in the events API, and remains deprecated, pending core clients
+  fully migrating away from accessing it.
+
 **Feature level 338**
 
 * [`POST /register`](/api/register-queue): Added `password_max_length`

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 338  # Last bumped for adding password_max_length.
+API_FEATURE_LEVEL = 339  # Last bumped for reaction events.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -238,6 +238,11 @@ exports.fixtures = {
         emoji_name: "airplane",
         emoji_code: "2708",
         user_id: test_user.user_id,
+        user: {
+            email: test_user.email,
+            full_name: test_user.full_name,
+            user_id: test_user.user_id,
+        },
     },
 
     reaction__remove: {
@@ -248,6 +253,11 @@ exports.fixtures = {
         emoji_name: "8ball",
         emoji_code: "1f3b1",
         user_id: test_user.user_id,
+        user: {
+            email: test_user.email,
+            full_name: test_user.full_name,
+            user_id: test_user.user_id,
+        },
     },
 
     realm__deactivated: {

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -20,10 +20,20 @@ from zerver.tornado.django_api import send_event_on_commit
 def notify_reaction_update(
     user_profile: UserProfile, message: Message, reaction: Reaction, op: str
 ) -> None:
+    user_dict = {
+        "user_id": user_profile.id,
+        "email": user_profile.email,
+        "full_name": user_profile.full_name,
+    }
+
     event: dict[str, Any] = {
         "type": "reaction",
         "op": op,
         "user_id": user_profile.id,
+        # TODO: We plan to remove this redundant user_dict object once
+        # clients are updated to support accessing use user_id.  See
+        # https://github.com/zulip/zulip/pull/14711 for details.
+        "user": user_dict,
         "message_id": message.id,
         "emoji_name": reaction.emoji_name,
         "emoji_code": reaction.emoji_code,

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -288,6 +288,15 @@ class EventPresence(EventPresenceCore):
     email: str | None = None
 
 
+# Type for the legacy user field; the `user_id` field is intended to
+# replace this and we expect to remove this once clients have migrated
+# to support the modern API.
+class ReactionLegacyUserType(BaseModel):
+    email: str
+    full_name: str
+    user_id: int
+
+
 class EventReactionAdd(BaseModel):
     type: Literal["reaction"]
     op: Literal["add"]
@@ -296,6 +305,7 @@ class EventReactionAdd(BaseModel):
     emoji_code: str
     reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
     user_id: int
+    user: ReactionLegacyUserType
     id: int
 
 
@@ -307,6 +317,7 @@ class EventReactionRemove(BaseModel):
     emoji_code: str
     reaction_type: Literal["realm_emoji", "unicode_emoji", "zulip_extra_emoji"]
     user_id: int
+    user: ReactionLegacyUserType
     id: int
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1564,11 +1564,18 @@ paths:
                                     emoji_name: {}
                                     reaction_type: {}
                                     user_id: {}
+                                    user: {}
                                   example:
                                     {
                                       "type": "reaction",
                                       "op": "add",
                                       "user_id": 10,
+                                      "user":
+                                        {
+                                          "user_id": 10,
+                                          "email": "user10@zulip.testserver",
+                                          "full_name": "King Hamlet",
+                                        },
                                       "message_id": 32,
                                       "emoji_name": "tada",
                                       "emoji_code": "1f389",
@@ -1603,11 +1610,18 @@ paths:
                                     emoji_name: {}
                                     reaction_type: {}
                                     user_id: {}
+                                    user: {}
                                   example:
                                     {
                                       "type": "reaction",
                                       "op": "remove",
                                       "user_id": 10,
+                                      "user":
+                                        {
+                                          "user_id": 10,
+                                          "email": "user10@zulip.testserver",
+                                          "full_name": "King Hamlet",
+                                        },
                                       "message_id": 52,
                                       "emoji_name": "tada",
                                       "emoji_code": "1f389",
@@ -23415,10 +23429,43 @@ components:
 
                 **Changes**: New in Zulip 3.0 (feature level 2). The `user`
                 object is deprecated and will be removed in the future.
+            user:
+              type: object
+              additionalProperties: false
+              deprecated: true
+              description: |
+                Dictionary with data on the user who added the
+                reaction, including the user ID as the `user_id`
+                field.
 
-                In Zulip 10.0 (feature level 328), the deprecated `user` object
-                was removed which contained the following properties: `user_id`,
-                `email`, `full_name` and `is_mirror_dummy`.
+                **Changes**: This field was re-added in Zulip 10.0 (feature
+                level 339) after having been removed in Zulip 10.0 (feature
+                level 328). It remains deprecated; it was re-added because the
+                React Native mobile app was still using it.
+
+                Deprecated and to be removed in a future release once core
+                clients have migrated to use the adjacent `user_id` field, which
+                was introduced in Zulip 3.0 (feature level 2).  Clients
+                supporting older Zulip server versions should use the user ID
+                mentioned in the description above as they would the `user_id`
+                field.
+              properties:
+                user_id:
+                  type: integer
+                  description: |
+                    ID of the user.
+                email:
+                  type: string
+                  description: |
+                    Zulip API email of the user.
+                full_name:
+                  type: string
+                  description: |
+                    Full name of the user.
+                is_mirror_dummy:
+                  type: boolean
+                  description: |
+                    Whether the user is a mirror dummy.
     MessagesEvent:
       allOf:
         - $ref: "#/components/schemas/MessagesBase"

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -441,6 +441,7 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event["user"]["email"], reaction_sender.email)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "add")
         self.assertEqual(event["emoji_name"], "smile")
@@ -1060,6 +1061,9 @@ class ReactionAPIEventTest(EmojiReactionBase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event["user"]["user_id"], reaction_sender.id)
+        self.assertEqual(event["user"]["email"], reaction_sender.email)
+        self.assertEqual(event["user"]["full_name"], reaction_sender.full_name)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "add")
         self.assertEqual(event["message_id"], pm_id)
@@ -1102,6 +1106,9 @@ class ReactionAPIEventTest(EmojiReactionBase):
         event_user_ids = set(events[0]["users"])
 
         self.assertEqual(expected_recipient_ids, event_user_ids)
+        self.assertEqual(event["user"]["user_id"], reaction_sender.id)
+        self.assertEqual(event["user"]["email"], reaction_sender.email)
+        self.assertEqual(event["user"]["full_name"], reaction_sender.full_name)
         self.assertEqual(event["type"], "reaction")
         self.assertEqual(event["op"], "remove")
         self.assertEqual(event["message_id"], pm_id)


### PR DESCRIPTION
The deprecated `user` object was removed from message objects and reaction events in #32701. This commit restores the `user` object in reaction events to maintain compatibility with mobile clients.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
