### PR TITLE
Prevent participants avatars from overflowing in recent view.

### DIFF
--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -547,6 +547,15 @@ type AvatarsContext = {
 };
 
 function get_avatars_context(all_senders: number[]): AvatarsContext {
+    // Show the all avatars rather than `max_avatars` + 1.
+    const max_space_for_avatars = max_avatars + 1;
+    if (all_senders.length <= max_space_for_avatars) {
+        return {
+            senders: people.sender_info_for_recent_view_row(all_senders),
+            other_sender_names_html: "",
+            other_senders_count: 0,
+        };
+    }
     const senders = all_senders.slice(-max_avatars);
     const extra_sender_ids = all_senders.slice(0, -max_avatars);
     const displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -711,7 +711,6 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         };
     }
 
-    extra_sender_ids = all_senders.slice(0, -max_avatars);
     const displayed_other_names = people.get_display_full_names(displayed_other_senders.reverse());
 
     if (extra_sender_ids.length > MAX_EXTRA_SENDERS) {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -57,7 +57,7 @@ let filters_dropdown_widget: dropdown_widget.DropdownWidget;
 export let is_backfill_in_progress = false;
 // Sets the number of avatars to display.
 // Rest of the avatars, if present, are displayed as {+x}
-const MAX_AVATAR = 4;
+let max_avatars = 4;
 const MAX_EXTRA_SENDERS = 10;
 
 // Use this to set the focused element.
@@ -632,10 +632,10 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         // we provide our handlebars with senders in opposite order.
         // Display in most recent sender first order.
         all_senders = recent_senders.get_topic_recent_senders(stream_id, topic).reverse();
-        senders = all_senders.slice(-MAX_AVATAR);
+        senders = all_senders.slice(-max_avatars);
 
         // Collect extra sender fullname for tooltip
-        extra_sender_ids = all_senders.slice(0, -MAX_AVATAR);
+        extra_sender_ids = all_senders.slice(0, -max_avatars);
         displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
 
         stream_context = {
@@ -695,9 +695,9 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         // styling, but it's important to not destroy the information of "who's actually
         // talked".
         all_senders = recent_senders.get_pm_recent_senders(user_ids_string).participants.reverse();
-        senders = all_senders.slice(-MAX_AVATAR);
+        senders = all_senders.slice(-max_avatars);
         // Collect extra senders fullname for tooltip.
-        extra_sender_ids = all_senders.slice(0, -MAX_AVATAR);
+        extra_sender_ids = all_senders.slice(0, -max_avatars);
         displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
 
         dm_context = {
@@ -711,7 +711,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         };
     }
 
-    extra_sender_ids = all_senders.slice(0, -MAX_AVATAR);
+    extra_sender_ids = all_senders.slice(0, -max_avatars);
     const displayed_other_names = people.get_display_full_names(displayed_other_senders.reverse());
 
     if (extra_sender_ids.length > MAX_EXTRA_SENDERS) {
@@ -737,7 +737,7 @@ function format_conversation(conversation_data: ConversationData): ConversationC
         unread_count,
         last_msg_time,
         senders: people.sender_info_for_recent_view_row(senders),
-        other_senders_count: Math.max(0, all_senders.length - MAX_AVATAR),
+        other_senders_count: Math.max(0, all_senders.length - max_avatars),
         other_sender_names_html: displayed_other_names.map((name) => _.escape(name)).join("<br />"),
         last_msg_url: hash_util.by_conversation_and_time_url(last_msg),
         is_spectator: page_params.is_spectator,
@@ -1296,6 +1296,10 @@ function get_list_data_for_widget(): ConversationData[] {
 export function complete_rerender(): void {
     if (!recent_view_util.is_visible()) {
         return;
+    }
+
+    if (!page_params.is_node_test) {
+        max_avatars = Number.parseInt($("html").css("--recent-view-max-avatars"), 10);
     }
 
     // Show topics list

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -5,6 +5,7 @@ import assert from "minimalistic-assert";
 import * as blueslip from "./blueslip.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
+import {media_breakpoints_num} from "./css_variables.ts";
 import * as message_viewport from "./message_viewport.ts";
 
 function get_bottom_whitespace_height(): number {
@@ -178,9 +179,24 @@ export function resize_sidebars(): void {
     $("#left_sidebar_scroll_container").css("max-height", h.stream_filters_max_height);
 }
 
-export function update_recent_view_filters_height(): void {
-    const recent_view_filters_height = $("#recent_view_filter_buttons").outerHeight(true) ?? 0;
+export function update_recent_view(): void {
+    const $recent_view_filter_container = $("#recent_view_filter_buttons");
+    const recent_view_filters_height = $recent_view_filter_container.outerHeight(true) ?? 0;
     $("html").css("--recent-topics-filters-height", `${recent_view_filters_height}px`);
+
+    // Update max avatars to prevent participant avatars from overflowing.
+    // These numbers are just based on speculation.
+    const recent_view_filters_width = $recent_view_filter_container.outerWidth(true) ?? 0;
+    if (!recent_view_filters_width) {
+        return;
+    }
+    const num_avatars_narrow_window = 2;
+    const num_avatars_max = 4;
+    if (recent_view_filters_width < media_breakpoints_num.md) {
+        $("html").css("--recent-view-max-avatars", num_avatars_narrow_window);
+    } else {
+        $("html").css("--recent-view-max-avatars", num_avatars_max);
+    }
 }
 
 function resize_navbar_alerts(): void {

--- a/web/src/resize_handler.ts
+++ b/web/src/resize_handler.ts
@@ -26,7 +26,7 @@ export function handler(): void {
     }
     resize.resize_page_components();
     compose_ui.autosize_textarea($("textarea#compose-textarea"));
-    resize.update_recent_view_filters_height();
+    resize.update_recent_view();
     scroll_bar.handle_overlay_scrollbars();
 
     // Re-compute and display/remove 'Show more' buttons to messages

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -111,7 +111,7 @@ export function show(opts: {
 
     // Misc.
     if (opts.is_recent_view) {
-        resize.update_recent_view_filters_height();
+        resize.update_recent_view();
     }
 }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -702,6 +702,7 @@
     --color-invalid-input-box-shadow: 0 0 2px hsl(3deg 57% 33%);
 
     /* Recent view */
+    --recent-view-max-avatars: 4;
     --color-border-recent-view-row: hsl(0deg 0% 87%);
     --color-border-recent-view-table: hsl(0deg 0% 0% / 60%);
     --color-background-recent-view-row: hsl(100deg 11% 96%);

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -455,7 +455,6 @@ function stub_out_filter_buttons() {
 
 function test(label, f) {
     run_test(label, (helpers) => {
-        $(".header").css = noop;
         page_params.development_environment = true;
 
         messages = sample_messages.map((message) => ({...message}));

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -187,7 +187,7 @@ mock_esm("../src/unread", {
     topic_has_any_unread_mentions: () => false,
 });
 mock_esm("../src/resize", {
-    update_recent_view_filters_height: noop,
+    update_recent_view: noop,
 });
 const dropdown_widget = mock_esm("../src/dropdown_widget", {
     DataTypes: {NUMBER: "number", STRING: "string"},
@@ -456,7 +456,7 @@ function stub_out_filter_buttons() {
 function test(label, f) {
     run_test(label, (helpers) => {
         page_params.development_environment = true;
-
+        page_params.is_node_test = true;
         messages = sample_messages.map((message) => ({...message}));
         f(helpers);
     });


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/recent.20conversations.3A.20narrow.20window.20column.20misalignment

| just before right sidebar is hidden 4 avatars | with only 2 avatars |
| --- | --- |
| ![Screenshot from 2025-01-12 17-25-15](https://github.com/user-attachments/assets/6de8c6e6-b411-468c-b8bd-6c3813304b12) | ![Screenshot from 2025-01-12 17-25-23](https://github.com/user-attachments/assets/a76a5be9-b7fd-49f3-ba6f-3a0c65ab3c22)  |

| just before left sidebar is hidden 4 avatars | with only 2 avatars |
| --- | --- |
| ![Screenshot from 2025-01-12 17-25-59](https://github.com/user-attachments/assets/1fc4cb05-a2ba-48ed-8663-2b61e0ca2e28) | ![Screenshot from 2025-01-12 17-25-41](https://github.com/user-attachments/assets/04857679-33b8-41d0-9f2c-a84f157f841e) |

