### PR TITLE
compose: Fix placeholder disappearance bug.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -343,6 +343,8 @@ export function initialize(): void {
         update_on_recipient_change();
         compose_state.set_recipient_edited_manually(true);
     });
+
+    $("#private_message_recipient").on("input", restore_placeholder_in_firefox_for_no_input);
 }
 
 export let update_placeholder_text = (): void => {
@@ -374,4 +376,16 @@ export let update_placeholder_text = (): void => {
 
 export function rewire_update_placeholder_text(value: typeof update_placeholder_text): void {
     update_placeholder_text = value;
+}
+
+// This function addresses the issue of the placeholder not reappearing in Firefox
+// when the user types into an input field and then deletes the content.
+// The problem arises due to the `contenteditable` attribute, which in some browsers
+// (like Firefox) inserts a <br> tag when the input is emptied. This <br> tag prevents
+// the placeholder from showing up again. The function checks if the input is empty
+// and contains a <br> tag, then removes it to restore the placeholder functionality.
+export function restore_placeholder_in_firefox_for_no_input(): void {
+    if ($("#private_message_recipient").text().trim() === "") {
+        $("#private_message_recipient").empty();
+    }
 }


### PR DESCRIPTION
This pr fixes the bug where the placeholder in message compose disappears after something is typed and the removed.
Just added a function which removes the br tag that gets added because of the `contenteditable` attribute in which the browser automatically adds a br tag when text is removed due to which the placeholder is not shown.

This bug still needs to be fixed for :
- Invite User Modal -> Channels they should join field
- Invite User Modal -> User groups they should join field
- Add Members to a Group Form -> Choose members field
 
Fixes: #32912

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![brave_screenshot_localhost (5)](https://github.com/user-attachments/assets/c71b9867-a064-4761-9397-b70809aefa16)
![brave_screenshot_localhost (6)](https://github.com/user-attachments/assets/6b62601a-4e8c-44f9-b161-3e885e0f77eb)
![brave_screenshot_localhost (7)](https://github.com/user-attachments/assets/7bd75fdb-0df0-4351-970d-1035b9932b51)

https://github.com/user-attachments/assets/d402d735-abee-4f6d-af8e-320551fed5fa



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
