### PR TITLE
composebox_typeahead: Show topic suggestions for markdown stream links

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -31,6 +31,19 @@ export function html_escape_markdown_syntax_characters(text: string): string {
     return text.replaceAll(invalid_stream_topic_regex, escape_invalid_stream_topic_characters);
 }
 
+const escaped_to_original_mapping: Record<string, string> = {
+    "&#96;": "`",
+    "&gt;": ">",
+    "&#42;": "*",
+    "&amp;": "&",
+    "&#36;&#36;": "$$",
+};
+
+export function unescape_invalid_stream_topic_characters(text: string): string {
+    const unescape_regex = new RegExp(Object.keys(escaped_to_original_mapping).join("|"), "g");
+    return text.replaceAll(unescape_regex, (match) => escaped_to_original_mapping[match] ?? match);
+}
+
 export function get_fallback_markdown_link(
     stream_name: string,
     topic_name?: string,

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -49,6 +49,7 @@ export function get_fallback_markdown_link(
     topic_name?: string,
     message_id?: string,
 ): string {
+    stream_name = unescape_invalid_stream_topic_characters(stream_name);
     const stream = stream_data.get_sub(stream_name);
     const stream_id = stream?.stream_id;
     assert(stream_id !== undefined);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1901,6 +1901,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
         return topics.map((topic) => ({
             type: "topic_list",
             topic,
+            to_markdown_link: false,
         }));
     }
     assert_typeahead_equals("#**Sweden>more ice", typed_topics(["more ice", "even more ice"]));

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -83,7 +83,10 @@ run_test("stream_topic_link_syntax_test", () => {
         topic_link_util.get_stream_topic_link_syntax("Sweden", "&ab"),
         "[#Sweden > &amp;ab](#narrow/channel/1-Sweden/topic/.26ab)",
     );
-
+    assert.equal(
+        topic_link_util.unescape_invalid_stream_topic_characters("&#36;&#36;MONEY&#36;&#36;"),
+        "$$MONEY$$",
+    );
     // Only for full coverage of the module.
     assert.equal(topic_link_util.escape_invalid_stream_topic_characters("Sweden"), "Sweden");
 });


### PR DESCRIPTION
This PR enables topic typeahead suggestions for markdown stream links which are created as fallback if the stream name contains special characters (\`\*\&\>\$\$)

Previously no topic suggestions were shown for such stream links.

Fixes: #32556

<details>
<summary>
After Fix:
</summary>
Linking an existing topic-

[zulip-pr-1.webm](https://github.com/user-attachments/assets/9943c0fb-b3c3-470f-97a9-f926fd258f5f)

Linking a new topic-

[zulip-pr-2.webm](https://github.com/user-attachments/assets/604a701c-49be-4744-96f7-f2ee6f35cfd3)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
