### PR TITLE
style: Center the ⌘ symbol by replacing with icon

### DIFF
--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -58,6 +58,14 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
             const $kbd_elem = $("<kbd>").text(following_key);
             $(this).after($("<span>").text(" + ").contents(), $kbd_elem);
         }
+
+        // The ⌘ symbol isn't vertically centered, so we use an icon.
+        if (key_text === "⌘") {
+            const $icon = $("<i>")
+                .addClass("zulip-icon zulip-icon-mac-command")
+                .attr("aria-label", key_text);
+            $(this).empty().append($icon); // Use .append() to safely add the icon
+        }
     });
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -32,10 +32,20 @@ kbd {
     background-color: var(--color-kbd-background);
     color: var(--color-kbd-text);
     margin: 0.25em 0.1em;
-    padding: 0.1em 0.4em;
+    padding: 0.2em 0.4em;
     text-shadow: 0 1px 0 hsl(0deg 0% 100%);
     /* Prevent selection */
     user-select: none;
+    position: relative;
+    min-height: 1em;
+    min-width: 1em;
+
+    .zulip-icon::before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    }
 }
 
 @media (width < $sm_min) {


### PR DESCRIPTION



This commit updates the keyboard shortcuts UI by replacing the ⌘ symbol with a more visually appealing icon.

Fixes: #32926 

| **before**       | **after**                | 
|--------------------|--------------------------------|
| ![image](https://github.com/user-attachments/assets/3c31351d-265a-41ad-b4a2-a8d4d19c9756) | ![image](https://github.com/user-attachments/assets/65cf8e27-c705-4618-9947-d51710bece0d)    |
| ![image](https://github.com/user-attachments/assets/726c5179-c5ad-4fa0-be02-78053d433fc4)| ![image](https://github.com/user-attachments/assets/45998a94-b875-4cc6-a743-5cd8d5f58390) |



