### PR TITLE
web: Add support for empty topic names.

### DIFF
--- a/web/src/compose_call_ui.ts
+++ b/web/src/compose_call_ui.ts
@@ -120,7 +120,7 @@ export function generate_and_insert_audio_or_video_call_link(
         available_providers.big_blue_button &&
         realm.realm_video_chat_provider === available_providers.big_blue_button.id
     ) {
-        const meeting_name = get_recipient_label() + " meeting";
+        const meeting_name = `${get_recipient_label()?.label_text ?? ""} meeting`;
         const request = {
             meeting_name,
             voice_only: is_audio_call,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1011,8 +1011,14 @@ export function content_highlighter_html(item: TypeaheadSuggestion): string | un
             return typeahead_helper.render_typeahead_item({primary: item.language});
         case "topic_jump":
             return typeahead_helper.render_typeahead_item({primary: item.message});
-        case "topic_list":
-            return typeahead_helper.render_typeahead_item({primary: item.topic});
+        case "topic_list": {
+            const topic_display_name = util.get_final_topic_display_name(item.topic);
+            const is_empty_string_topic = item.topic === "";
+            return typeahead_helper.render_typeahead_item({
+                primary: topic_display_name,
+                is_empty_string_topic,
+            });
+        }
         case "time_jump":
             return typeahead_helper.render_typeahead_item({primary: item.message});
         default:

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -981,7 +981,8 @@ export function try_save_inline_topic_edit($row: JQuery): void {
         confirm_dialog.launch({
             html_heading: $t_html({defaultMessage: "Merge with another topic?"}),
             html_body: render_confirm_merge_topics_with_rename({
-                topic_name: new_topic,
+                topic_display_name: util.get_final_topic_display_name(new_topic),
+                is_empty_string_topic: new_topic === "",
             }),
             on_click() {
                 do_save_inline_topic_edit($row, message, new_topic);

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -965,7 +965,7 @@ export function try_save_inline_topic_edit($row: JQuery): void {
     const old_topic = message.topic;
     const new_topic = $row.find<HTMLInputElement>("input.inline_topic_edit").val()?.trim();
     assert(new_topic !== undefined);
-    const topic_changed = new_topic !== old_topic && new_topic !== "";
+    const topic_changed = new_topic !== old_topic;
 
     if (!topic_changed) {
         // this means the inline_topic_edit was opened and submitted without

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -963,9 +963,9 @@ export function try_save_inline_topic_edit($row: JQuery): void {
     const message = message_lists.current.get(message_id);
     assert(message?.type === "stream");
     const old_topic = message.topic;
-    const new_topic = $row.find<HTMLInputElement>("input.inline_topic_edit").val();
+    const new_topic = $row.find<HTMLInputElement>("input.inline_topic_edit").val()?.trim();
     assert(new_topic !== undefined);
-    const topic_changed = new_topic !== old_topic && new_topic.trim() !== "";
+    const topic_changed = new_topic !== old_topic && new_topic !== "";
 
     if (!topic_changed) {
         // this means the inline_topic_edit was opened and submitted without

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -22,7 +22,6 @@ import * as channel from "./channel.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as compose_call from "./compose_call.ts";
-import * as compose_state from "./compose_state.ts";
 import * as compose_tooltips from "./compose_tooltips.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
@@ -893,12 +892,13 @@ export function start_inline_topic_edit($recipient_row: JQuery): void {
     const msg_id = rows.id_for_recipient_row($recipient_row);
     const message = message_lists.current.get(msg_id);
     assert(message?.type === "stream");
-    let topic = message.topic;
-    if (topic === compose_state.empty_topic_placeholder()) {
-        topic = "";
-    }
+    const topic = message.topic;
     const $inline_topic_edit_input = $form.find<HTMLInputElement>("input.inline_topic_edit");
     $inline_topic_edit_input.val(topic).trigger("select").trigger("focus");
+    if (topic === "") {
+        const topic_display_name = util.get_final_topic_display_name(topic);
+        $inline_topic_edit_input.attr("placeholder", topic_display_name);
+    }
     const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     composebox_typeahead.initialize_topic_edit_typeahead(
         $inline_topic_edit_input,

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -319,8 +319,12 @@ export async function build_move_topic_to_stream_popover(
 ): Promise<void> {
     const current_stream_name = sub_store.get(current_stream_id)!.name;
     const stream = sub_store.get(current_stream_id);
+    const topic_display_name = util.get_final_topic_display_name(topic_name);
+    const is_empty_string_topic = topic_name === "";
     const args: {
         topic_name: string;
+        topic_display_name: string;
+        is_empty_string_topic: boolean;
         current_stream_id: number;
         notify_new_thread: boolean;
         notify_old_thread: boolean;
@@ -331,6 +335,8 @@ export async function build_move_topic_to_stream_popover(
         stream: sub_store.StreamSubscription | undefined;
     } = {
         topic_name,
+        topic_display_name,
+        is_empty_string_topic,
         current_stream_id,
         stream,
         notify_new_thread: message_edit.notify_new_thread_default,
@@ -355,7 +361,8 @@ export async function build_move_topic_to_stream_popover(
             {
                 "z-stream-or-topic": () =>
                     render_inline_stream_or_topic_reference({
-                        topic_name,
+                        topic_display_name,
+                        is_empty_string_topic,
                         stream,
                         show_colored_icon: true,
                     }),
@@ -367,7 +374,8 @@ export async function build_move_topic_to_stream_popover(
             {
                 "z-stream-or-topic": () =>
                     render_inline_stream_or_topic_reference({
-                        topic_name,
+                        topic_display_name,
+                        is_empty_string_topic,
                         stream,
                         show_colored_icon: true,
                     }),
@@ -382,7 +390,8 @@ export async function build_move_topic_to_stream_popover(
                 "z-stream-or-topic": () =>
                     render_inline_stream_or_topic_reference({
                         stream,
-                        topic_name,
+                        topic_display_name,
+                        is_empty_string_topic,
                         show_colored_icon: true,
                     }),
             },

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -104,6 +104,7 @@ export let render_typeahead_item = (args: {
     is_user_group?: boolean;
     stream?: StreamData;
     emoji_code?: string | undefined;
+    is_empty_string_topic?: boolean;
 }): string => {
     const has_image = args.img_src !== undefined;
     const has_status = args.status_emoji_info !== undefined;

--- a/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
+++ b/web/templates/confirm_dialog/confirm_merge_topics_with_rename.hbs
@@ -1,7 +1,7 @@
 <p>
     {{#tr}}
-    The topic <z-topic-name>{topic_name}</z-topic-name> already exists in this channel.
+    The topic <z-topic-name>{topic_display_name}</z-topic-name> already exists in this channel.
     Are you sure you want to combine messages from these topics? This cannot be undone.
-    {{#*inline "z-topic-name"}}<strong class="white-space-preserve-wrap">{{> @partial-block}}</strong>{{/inline}}
+    {{#*inline "z-topic-name"}}<strong class="white-space-preserve-wrap {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{> @partial-block}}</strong>{{/inline}}
     {{/tr}}
 </p>

--- a/web/templates/inline_stream_or_topic_reference.hbs
+++ b/web/templates/inline_stream_or_topic_reference.hbs
@@ -1,7 +1,7 @@
 <span class="stream-or-topic-reference">
     {{~#if stream~}}
         {{> inline_decorated_stream_name stream=stream show_colored_icon=show_colored_icon}}
-        {{#if topic_name~}} &gt; {{/if}}
+        {{#if topic_display_name~}} &gt; {{/if}}
     {{~/if~}}
-    {{~ topic_name ~}}
+    <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{~ topic_display_name ~}}</span>
 </span>

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -8,7 +8,7 @@
         {{/unless}}
         <div class="input-group">
             <label for="move-topic-new-topic-name" class="modal-field-label">New topic</label>
-            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" {{#if is_empty_string_topic}}placeholder="{{topic_display_name}}"{{/if}} value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -18,7 +18,7 @@
 {{/if}}
 {{!-- Separate container to ensure overflowing text remains in this container. --}}
 <div class="typeahead-text-container{{#if has_secondary_html}} has_secondary_html{{/if}}">
-    <strong class="typeahead-strong-section">
+    <strong class="typeahead-strong-section{{#if is_empty_string_topic}} empty-topic-display{{/if}}">
         {{~#if stream~}}
             {{~> inline_decorated_stream_name stream=stream ~}}
             {{~else~}}

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -31,6 +31,10 @@ const compose_closed_ui = zrequire("compose_closed_ui");
 const {Filter} = zrequire("filter");
 const {MessageList} = zrequire("message_list");
 const {MessageListData} = zrequire("message_list_data");
+const {set_realm} = zrequire("state_data");
+
+const REALM_EMPTY_TOPIC_DISPLAY_NAME = "general chat";
+set_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME});
 
 // Helper test function
 function test_reply_label(expected_label) {
@@ -96,6 +100,11 @@ run_test("reply_label", () => {
                 id: 5,
                 display_reply_to: "some user, other user",
             },
+            {
+                id: 6,
+                stream_id: stream_two.stream_id,
+                topic: "",
+            },
         ],
         {},
         true,
@@ -124,6 +133,14 @@ run_test("reply_label", () => {
         }
         test_reply_label(expected_label);
     }
+
+    // Separately test for empty string topic as the topic is specially decorated here.
+    list.select_id(list.next());
+    const label_html = $("#left_bar_compose_reply_button_big").html();
+    assert.equal(
+        `translated HTML: Message #second_stream > <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
+        label_html,
+    );
 });
 
 run_test("test_custom_message_input", () => {

--- a/web/tests/compose_video.test.cjs
+++ b/web/tests/compose_video.test.cjs
@@ -245,7 +245,7 @@ test("videos", ({override}) => {
             realm_available_video_chat_providers.big_blue_button.id,
         );
 
-        override(compose_closed_ui, "get_recipient_label", () => "a");
+        override(compose_closed_ui, "get_recipient_label", () => ({label_text: "a"}));
 
         channel.get = (options) => {
             assert.equal(options.url, "/json/calls/bigbluebutton/create");


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes the followings checkboxes from #32996

- [x] Show `realm_empty_topic_display_name` for empty strings as topic name in Move messages modal
- [x] [Show the `realm_empty_topic_display_name` topic name as a placeholder in the message header topic edit input box](https://github.com/zulip/zulip/pull/32963#issuecomment-2581124851)
- [x] [Topic edit to make it empty isn't getting saved](https://github.com/zulip/zulip/pull/32963#issuecomment-2581123387)
- [x] Show `realm_empty_topic_display_name` for empty string as topic name in "confirm merge topics" modal.
- [x] [Fix the incorrect reply button text](https://github.com/zulip/zulip/pull/32963#issuecomment-2578675233)
- [x] [Show`realm_empty_topic_display_name` in the channel/topic typeahead](https://github.com/zulip/zulip/pull/32963#issuecomment-2581129186)

Other Fixes:

- #**stream_name>topic_name** syntax to work properly for empty string topic.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

**Screenshots and screen captures:**

<details><summary>Move messages modal</summary>
<img width="532" alt="Screenshot 2025-01-10 at 6 57 24 PM" src="https://github.com/user-attachments/assets/fa3fea87-31be-4831-8870-894e9af88cf1" />
</details> 

<details><summary>Inline topic edit</summary>
<img width="443" alt="Screenshot 2025-01-10 at 7 45 11 PM" src="https://github.com/user-attachments/assets/e734bda5-e525-4de2-8b56-b3de81a215fb" />
</details> 

<details><summary>Confirm merge topics modal</summary>
<img width="580" alt="Screenshot 2025-01-13 at 12 44 42 PM" src="https://github.com/user-attachments/assets/f23c9bb9-2e50-4476-b5c4-04d78cb6a960" />
</details> 

<details><summary>Reply button text</summary>
<img width="984" alt="Screenshot 2025-01-13 at 3 38 50 PM" src="https://github.com/user-attachments/assets/af820fdb-f413-484a-8080-40dbddad8099" />
</details> 

<details><summary>Compose box textarea topic list typeahead</summary>
<img width="422" alt="Screenshot 2025-01-13 at 10 06 47 PM" src="https://github.com/user-attachments/assets/685077f8-faa6-48a6-859e-034a0d3dd0f6" />
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
