### PR TITLE
Remove emoji container when reaction count is 0.

### DIFF
--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -468,9 +468,11 @@ export let remove_reaction_from_view = (
     }
 
     if (reaction_count === 0) {
-        // If this user was the only one reacting for this emoji, we simply
-        // remove the reaction and exit.
-        $reaction.remove();
+        // If this user was the only one reacting for this emoji, we
+        // remove the entire `message_reaction` template outer
+        // container, and then update vote text in case we now have
+        // few enough reactions to display names again.
+        $reaction.parent(".message_reaction_container").remove();
         update_vote_text_on_message(message);
         return;
     }

--- a/web/tests/reactions.test.cjs
+++ b/web/tests/reactions.test.cjs
@@ -1259,15 +1259,13 @@ test("remove_reaction_from_view (last person to react)", ({override_rewire}) => 
     };
     const message_id = 507;
 
+    const $reaction_container = $.create("stub-reaction-container");
+
     const $our_reaction = stub_reaction(message_id, "unicode_emoji,1f3b1");
-    override_rewire(reactions, "find_reaction", (message_id_param, local_id) => {
-        assert.equal(message_id_param, message_id);
-        assert.equal(local_id, "unicode_emoji,1f3b1");
-        return $our_reaction;
-    });
+    $our_reaction.parent = () => $reaction_container;
 
     let removed;
-    $our_reaction.remove = () => {
+    $our_reaction.parent().remove = () => {
         removed = true;
     };
 


### PR DESCRIPTION
While adding a new reaction, we create a new JQuery element called "message_reaction_container" and append it to the view to display the emoji.

Previously, when the reaction count became zero for an emoji, we used to just remove the emoji but not the JQuery element mentioned above, requiring a reload to remove it. This inconsistency introduced a bug in the UI. causing unwanted spaces between emojies as this element used to get accumulated.

This PR resolves the bug by introducing logic to remove reaction containers with no reactions. To achieve this, we assign a unique class to each container,
".emoji-container-emoji_code", where "emoji_code" is a variable unique to each emoji. This enables us to specifically identify and remove the containers.

**Before**

[Screencast from 2025-01-14 02-32-32.webm](https://github.com/user-attachments/assets/90dc8ec7-0bb2-46c9-869e-5615710068eb)


**After**

[Screencast from 2025-01-14 02-31-09.webm](https://github.com/user-attachments/assets/c10741a7-8a46-4174-b509-8f6c3df4fbbe)


Fixes: #32983

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
