### PR TITLE
css: Use `--color-text-url` variable as color for text links.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -528,7 +528,7 @@
 
 .inbox-container #inbox-pane .inbox-empty-action-link {
     text-decoration: underline;
-    color: hsl(200deg 100% 40%);
+    color: var(--color-text-url);
 }
 
 #inbox-filter_widget {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -353,15 +353,6 @@ ul.popover-group-menu-member-list {
     line-height: 1;
 }
 
-.bot-owner-name {
-    text-decoration: underline;
-
-    &:hover {
-        cursor: pointer;
-        color: hsl(200deg 100% 40%);
-    }
-}
-
 .popover-avatar {
     height: 240px;
     width: 240px;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -72,7 +72,7 @@
         & button.user-status-value:focus {
             /* Important is required for generic night them styling to not
                have precedence over this. */
-            color: hsl(200deg 100% 40%) !important;
+            color: var(--color-text-url) !important;
         }
 
         .user-status-value {


### PR DESCRIPTION
This PR replaces instances of `hsl(200deg 100% 40%)` with CSS variable `--color-text-url` to standardise text link color. Unused style for `.bot-owner-name` is also removed.

fixes: #31520

<details>
<summary>UI Changes</summary>

| Before | After |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/77382499-a5c5-4a08-bb02-9e2d6ce7f1d5) | ![After Image](https://github.com/user-attachments/assets/29d99202-6f60-43d5-be24-0252fbe396ac) |
| ![Before Image](https://github.com/user-attachments/assets/11de5023-310e-4957-9108-024f36508c3c) | ![After Image](https://github.com/user-attachments/assets/8b81bb2b-a1b7-446a-b3bd-c46b0427a0f5) |
| ![Before Image](https://github.com/user-attachments/assets/10c45011-83c8-42b6-b249-c86608a9aca8) | ![After Image](https://github.com/user-attachments/assets/61448129-a110-4199-8bc6-38387c573d1b) |
| ![Before Image](https://github.com/user-attachments/assets/499560ed-9e0e-4649-99af-7eb8c3c91097) | ![After Image](https://github.com/user-attachments/assets/70a18962-3204-406c-b5f3-f3c512049b22) |
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
