### PR TITLE
CSS: Updated 'Remove' and 'Unsubscribe' buttons in profile modal

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -647,9 +647,12 @@ ul.popover-group-menu-member-list {
                         padding-right: 10px;
                     }
 
-                    &.remove_subscription,
+                    &.remove_subscription {
+                        float: right;
+                    }
+
                     &.remove_member {
-                        text-align: right;
+                        float: right;
                     }
                 }
             }

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -10,7 +10,7 @@
     <td class="remove_member">
         <div class="group_list_remove">
             <span {{#unless is_direct_member}}class="tippy-zulip-tooltip" data-tippy-content="{{#if is_me}}{{t 'You are a member of {name} because you are a member of a subgroup ({subgroups_name}).'}} {{else}}{{t 'This user is a member of {name} because they are a member of a subgroup ({subgroups_name}).'}}{{/if}}"{{/unless}}>
-                <button type="button" name="remove" class="remove-member-button button small rounded button-danger" {{#unless is_direct_member}}disabled="disabled"{{/unless}} >
+                <button type="button" name="remove" class="action-button action-button-quiet-danger" {{#unless is_direct_member}}disabled="disabled"{{/unless}} >
                     {{t 'Remove' }}
                 </button>
             </span>

--- a/web/templates/user_stream_list_item.hbs
+++ b/web/templates/user_stream_list_item.hbs
@@ -8,7 +8,7 @@
     {{#if show_unsubscribe_button}}
     <td class="remove_subscription">
         <div class="subscription_list_remove">
-            <button type="button" name="unsubscribe" class="remove-subscription-button button small rounded button-danger {{#if (or show_private_stream_unsub_tooltip show_last_user_in_private_stream_unsub_tooltip)}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{#if show_private_stream_unsub_tooltip}}{{t "Use channel settings to unsubscribe from private channels."}}{{else}}{{t "Use channel settings to unsubscribe the last user from a private channel."}}{{/if}}'>
+            <button type="button" name="unsubscribe" class="action-button action-button-quiet-danger {{#if (or show_private_stream_unsub_tooltip show_last_user_in_private_stream_unsub_tooltip)}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{#if show_private_stream_unsub_tooltip}}{{t "Use channel settings to unsubscribe from private channels."}}{{else}}{{t "Use channel settings to unsubscribe the last user from a private channel."}}{{/if}}'>
                 {{t 'Unsubscribe' }}
             </button>
         </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Changed the Unsubscribe and Remove button with action-button medium emphasis and danger color schemes
both buttons was present in the channels and user groups panel in view profile modal respectively

Changes: This PR is subpart of this issue https://github.com/zulip/zulip/issues/33027


| **Category**        | **Before**                                                                                                                                                  | **After**                                                                                                                                                   |
|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **Channels Panel**   | ![Before Channels Panel](https://github.com/user-attachments/assets/241d21c0-3d36-46bf-9155-543a4a1a89be)                                                 | ![After Channels Panel](https://github.com/user-attachments/assets/04f3ceb1-cb49-42d6-ac84-e1bff493a763)                                                   |
| **User Groups Panel**| ![Before User Group Panel](https://github.com/user-attachments/assets/7210f27e-8621-4732-be99-68bb8a3a25c6)                                                | ![After User Group Panel](https://github.com/user-attachments/assets/00da95be-f899-42d9-9a89-e0dea365b4f9)                                                 |


Light Theme Screenshots (16px)
![image](https://github.com/user-attachments/assets/2169340b-5fd2-4fdf-ad12-ca02545f1194)
![image](https://github.com/user-attachments/assets/ea332f87-c027-4e5e-af05-c862dcf48166)

12px Screenshots
![image](https://github.com/user-attachments/assets/379bd162-7a50-45fc-89d7-6a72a849f900)
![image](https://github.com/user-attachments/assets/3014ad22-42d2-4066-88b3-41e63a94297e)


20px screenshots
![image](https://github.com/user-attachments/assets/672af620-eec8-47b3-863f-f2120838d0cd)
![image](https://github.com/user-attachments/assets/d22b685d-f128-48a8-b27b-ccc893de82c0)












<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>