### PR TITLE
hashchange: Fix `near` link not working if already narrowed to it.

### DIFF
--- a/web/src/hashchange.ts
+++ b/web/src/hashchange.ts
@@ -562,9 +562,8 @@ export function initialize(): void {
     hashchanged(true);
 
     $("body").on("click", "a", function (this: HTMLAnchorElement, e: JQuery.ClickEvent) {
-        const href = this.href;
-        if (href === window.location.hash && href.includes("/near/")) {
-            // The clicked on a link, perhaps a "said" reference, that
+        if (this.hash === window.location.hash && this.hash.includes("/near/")) {
+            // User clicked on a link, perhaps a "said" reference, that
             // matches the current view. Such a click doesn't trigger
             // a hashchange event, so we manually trigger one in order
             // to ensure the app scrolls to the correct message.


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Clicking.20link.20for.20same.20message.20the.202nd.20time.20doesn't.20work

In 666ce4519d09ac2f5bf53635cc9f422590b21c7b, we switched to use `this.href` instead of `e.currentTarget.getAttribute("href")`.

This bugged the behaviour since `this.href` includes the complete URL including hostname.

Switched to use `this.hash` to fix it.

