### PR TITLE
new_topic: Fix the new topic tooltip in the compose box.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -236,6 +236,18 @@ export function update_recipient_text_for_reply_button(
     }
 }
 
+function can_user_reply_to_message(message_id: number): boolean {
+    const selected_message = message_store.get(message_id);
+    if (selected_message === undefined) {
+        return false;
+    }
+    if (selected_message.is_stream) {
+        return !should_disable_compose_reply_button_for_stream();
+    }
+    assert(selected_message.is_private);
+    return message_util.user_can_send_direct_message(selected_message.to_user_ids);
+}
+
 export function initialize(): void {
     // When the message selection changes, change the label on the Reply button.
     $(document).on("message_selected.zulip", () => {
@@ -244,14 +256,9 @@ export function initialize(): void {
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
             update_recipient_text_for_reply_button();
-
-            // Disable compose reply button if the selected message is a stream
-            // message and the user is not allowed to post in the stream the message
-            // belongs to.
-            if (maybe_get_selected_message_stream_id() !== undefined) {
-                update_buttons_for_stream_views();
-                update_buttons_for_non_specific_views();
-            }
+            update_reply_button_state(
+                !can_user_reply_to_message(message_lists.current!.selected_id()),
+            );
         }
     });
 

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -23,7 +23,6 @@ mock_esm("../src/message_list_view", {
     MessageListView,
 });
 mock_esm("../src/settings_data", {
-    user_has_permission_for_group_setting: () => true,
     user_can_access_all_other_users: () => true,
 });
 


### PR DESCRIPTION
This pull request improves the user interface behavior when composing messages by fixing the new topic tooltip in the compose box.

* Removed the call to `update_buttons_for_non_specific_views()` to avoid redundant updates when the selected message stream ID is defined.
* Added a reference to the `$reply_button` and modified the tooltip content logic to check the state of `$reply_button` instead of `$new_conversation_button`.


Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.22Start.20new.20conversation.22.20tooltips.20lagging.3F/near/2040122)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary> Before: </summary>
<img width="815" alt="Screenshot 2025-01-14 at 2 50 55 PM" src="https://github.com/user-attachments/assets/1d8c6416-895f-467e-a869-8eaf59fa0663" />

</details>
<details>
<summary> After: </summary>
<img width="825" alt="Screenshot 2025-01-14 at 2 53 26 PM" src="https://github.com/user-attachments/assets/2d668a34-6cb0-4fc1-ab0f-854d292d9e7c" />

</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
