### PR TITLE
portico: Replace "Find accounts" link with "Log in".

### DIFF
--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -15,6 +15,7 @@
                 <li class="extra_margin"><a href="/apps/">{{ _("Desktop & mobile apps") }}</a></li>
                 <li><a href="/new/">{{ _("New organization") }}</a></li>
                 <li><a href="/accounts/go/">{{ _("Log in") }}</a></li>
+                <li><a href="/accounts/find/">{{ _("Find accounts") }}</a></li>
             </ul>
         </div>
         <div class="footer__section">

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -166,18 +166,11 @@
                 </div>
             </div>
             {% else %}
-            {% if login_link_disabled %}
-            {% else %}
             <a class='top-menu-item' href="/login/">Log in</a>
-            {% endif %}
             {% if register_link_disabled %}
             {% else %}
             <a class='top-menu-item' href="/register/">Sign up</a>
             {% endif %}
-            {% endif %}
-            {% if find_team_link_disabled %}
-            {% else %}
-            <a class='top-menu-item' href="/accounts/find/">Find accounts</a>
             {% endif %}
         </div>
     </div>
@@ -321,18 +314,11 @@
             </div>
         </details>
         {% else %}
-        {% if login_link_disabled %}
-        {% else %}
         <div class='top-menu-mobile-item'><a href="/login/">Log in</a></div>
-        {% endif %}
         {% if register_link_disabled %}
         {% else %}
         <div class='top-menu-mobile-item'><a href="/register/">Sign up</a></div>
         {% endif %}
-        {% endif %}
-        {% if find_team_link_disabled %}
-        {% else %}
-        <div class='top-menu-mobile-item'><a href="/accounts/find/">Find accounts</a></div>
         {% endif %}
     </div>
 </details>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -34,8 +34,7 @@
             {% if user_is_authenticated %}
                 {% include 'zerver/portico-header-dropdown.html' %}
             {% else %}
-                {% if login_link_disabled %}
-                {% elif not only_sso %}
+                {% if not only_sso %}
                 <a href="{{login_url}}">{{ _('Log in') }}</a>
                 {% endif %}
             {% endif %}
@@ -50,8 +49,7 @@
                 {% endif %}
             {% endif %}
 
-            {% if not is_self_hosting_management_page and not find_team_link_disabled %}
-            <a class= "find-accounts-link" href="{{ root_domain_url }}/accounts/find/">{{ _('Find accounts') }}</a>
+            {% if not is_self_hosting_management_page and non_realm_specific_page %}
             <a href="{{ root_domain_url }}/new/">{{ _('New organization') }}</a>
             {% endif %}
         </div>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -130,23 +130,20 @@ def zulip_default_context(request: HttpRequest) -> dict[str, Any]:
 
     skip_footer = False
     register_link_disabled = settings.REGISTER_LINK_DISABLED
-    login_link_disabled = settings.LOGIN_LINK_DISABLED
-    find_team_link_disabled = settings.FIND_TEAM_LINK_DISABLED
     allow_search_engine_indexing = False
+    non_realm_specific_page = False
 
     if (
         settings.ROOT_DOMAIN_LANDING_PAGE
         and get_subdomain(request) == Realm.SUBDOMAIN_FOR_ROOT_DOMAIN
     ):
         register_link_disabled = True
-        login_link_disabled = True
-        find_team_link_disabled = False
         allow_search_engine_indexing = True
+        non_realm_specific_page = True
     elif realm is None:
         register_link_disabled = True
-        login_link_disabled = True
-        find_team_link_disabled = False
         skip_footer = True
+        non_realm_specific_page = True
 
     apps_page_web = settings.ROOT_DOMAIN_URI + "/accounts/go/"
 
@@ -177,7 +174,6 @@ def zulip_default_context(request: HttpRequest) -> dict[str, Any]:
         "root_domain_landing_page": settings.ROOT_DOMAIN_LANDING_PAGE,
         "custom_logo_url": settings.CUSTOM_LOGO_URL,
         "register_link_disabled": register_link_disabled,
-        "login_link_disabled": login_link_disabled,
         "terms_of_service": settings.TERMS_OF_SERVICE_VERSION is not None,
         "login_url": settings.HOME_NOT_LOGGED_IN,
         "only_sso": settings.ONLY_SSO,
@@ -193,7 +189,6 @@ def zulip_default_context(request: HttpRequest) -> dict[str, Any]:
         "development_environment": settings.DEVELOPMENT,
         "support_email": support_email,
         "support_email_html_tag": support_email_html_tag,
-        "find_team_link_disabled": find_team_link_disabled,
         "password_min_length": settings.PASSWORD_MIN_LENGTH,
         "password_max_length": settings.PASSWORD_MAX_LENGTH,
         "password_min_guesses": settings.PASSWORD_MIN_GUESSES,
@@ -209,6 +204,7 @@ def zulip_default_context(request: HttpRequest) -> dict[str, Any]:
         "skip_footer": skip_footer,
         "default_page_params": default_page_params,
         "corporate_enabled": corporate_enabled,
+        "non_realm_specific_page": non_realm_specific_page,
     }
 
     if settings.SENTRY_FRONTEND_DSN is not None:

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -477,8 +477,6 @@ INVITES_NEW_REALM_DAYS = 7
 
 # Controls for which links are published in portico footers/headers/etc.
 REGISTER_LINK_DISABLED: bool | None = None
-LOGIN_LINK_DISABLED = False
-FIND_TEAM_LINK_DISABLED = True
 
 # What domains to treat like the root domain
 ROOT_SUBDOMAIN_ALIASES = ["www"]


### PR DESCRIPTION
Fixes #32199

We only need a log in button since that will take users to "/accounts/go" if we are on a non-realm specific URL.

"/accounts/go" already has link to go to "Find accounts" page.


Home page:

| before | after |
| --- | --- |
| ![Screenshot from 2025-01-14 16-13-18](https://github.com/user-attachments/assets/ad884508-c090-410a-8c1a-d96489c6f4b7) | ![image](https://github.com/user-attachments/assets/db59e625-47fe-42c1-98e0-64a8bcd2cbd6) |

Other pages:

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/768a2115-0181-4597-8248-bec717876250) | ![image](https://github.com/user-attachments/assets/e636486f-696a-421b-a4ff-5412731b2ebd) |

I check help pages, login pages and landing page. I used `zulipdev.com:9991` and `localhost:9991` for testing.

discussion: https://chat.zulip.org/#narrow/channel/101-design/topic/Improve.20website.20navigation.20for.20getting.20started.20.2332112