### PR TITLE
Allow changing description and settings for deactivated groups.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 340**
+
+[`PATCH /user_groups/{user_group_id}`](/api/update-user-group): All
+the permission settings and description can now be updated for
+deactivated groups.
+
 **Feature level 339**
 
 * [`GET /events`](/api/get-events): Added `user` field back in

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 339  # Last bumped for reaction events.
+API_FEATURE_LEVEL = 340  # Last bumped for updating settings for deactivated groups.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21061,7 +21061,8 @@ paths:
       summary: Update a user group
       tags: ["users"]
       description: |
-        Update the name or description of a [user group](/help/user-groups).
+        Update the name, description or any of the permission settings
+        of a [user group](/help/user-groups).
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
       requestBody:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21063,6 +21063,15 @@ paths:
       description: |
         Update the name, description or any of the permission settings
         of a [user group](/help/user-groups).
+
+        Note that while permissions settings of deactivated groups can
+        be edited by this API endpoint, and those permissions settings
+        do affect the ability to modify the deactivated group and its
+        membership, the deactivated group itself cannot be mentioned
+        or used in the value of any permission without first being reactivated.
+
+        **Changes**: Prior to Zulip 10.0 (feature level 340), only the name field
+        of deactivated groups could be modified.
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
       requestBody:

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -861,7 +861,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
         do_deactivate_user_group(user_group, acting_user=None)
         params = {"description": "Troubleshooting and support team"}
         result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
-        self.assert_json_error(result, "You can only change name of deactivated user groups")
+        self.assert_json_success(result)
+        user_group = NamedUserGroup.objects.get(id=user_group.id)
+        self.assertEqual(user_group.description, "Troubleshooting and support team")
 
         params = {"name": "Support team"}
         result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
@@ -1028,9 +1030,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_patch(f"/json/user_groups/{support_group.id}", info=params)
         self.assert_json_error(result, "User group is deactivated.")
 
-        params[setting_name] = orjson.dumps({"new": moderators_group.id}).decode()
+        params[setting_name] = orjson.dumps({"new": marketing_group.id}).decode()
         result = self.client_patch(f"/json/user_groups/{leadership_group.id}", info=params)
-        self.assert_json_error(result, "You can only change name of deactivated user groups")
+        self.assert_json_success(result)
+        leadership_group = NamedUserGroup.objects.get(realm=hamlet.realm, name="leadership")
+        self.assertEqual(getattr(leadership_group, setting_name).id, marketing_group.id)
 
         leadership_group.deactivated = False
         leadership_group.save()

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -153,17 +153,6 @@ def edit_user_group(
         user_group_id, user_profile, permission_setting="can_manage_group", allow_deactivated=True
     )
 
-    if user_group.deactivated and (
-        description is not None
-        or can_add_members_group is not None
-        or can_join_group is not None
-        or can_leave_group is not None
-        or can_mention_group is not None
-        or can_manage_group is not None
-        or can_remove_members_group is not None
-    ):
-        raise JsonableError(_("You can only change name of deactivated user groups"))
-
     if name is not None and name != user_group.name:
         name = check_user_group_name(name)
         do_update_user_group_name(user_group, name, acting_user=user_profile)


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR updates code to allow changing description and permission settings of deactivated
groups.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/channel/101-design/topic/updating.20deactivated.20streams.20and.20groups/near/2037327

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
