### PR TITLE
export/import: Rework how we write `migration_status.json`

### DIFF
--- a/scripts/lib/check-database-compatibility
+++ b/scripts/lib/check-database-compatibility
@@ -25,6 +25,8 @@ import django
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 
+from zerver.lib.migration_status import STALE_MIGRATIONS
+
 django.setup()
 
 django_pg_version = connection.cursor().connection.server_version // 10000
@@ -74,55 +76,7 @@ if django_pg_version < 13:
 loader = MigrationLoader(connection)
 missing = set(loader.applied_migrations)
 
-# Ignore django-guardian, which we installed until 1.7.0~3134
-missing.discard(("guardian", "0001_initial"))
-
-# Ignore django.contrib.sites, which we installed until 2.0.0-rc1~984.
-missing.discard(("sites", "0001_initial"))
-missing.discard(("sites", "0002_alter_domain_unique"))
-
-# These migrations were squashed into 0001, in 6fbddf578a6e through
-# a21f2d771553, 1.7.0~3135.
-missing.difference_update(
-    [
-        ("zerver", "0002_django_1_8"),
-        ("zerver", "0003_custom_indexes"),
-        ("zerver", "0004_userprofile_left_side_userlist"),
-        ("zerver", "0005_auto_20150920_1340"),
-        ("zerver", "0006_zerver_userprofile_email_upper_idx"),
-        ("zerver", "0007_userprofile_is_bot_active_indexes"),
-        ("zerver", "0008_preregistrationuser_upper_email_idx"),
-        ("zerver", "0009_add_missing_migrations"),
-        ("zerver", "0010_delete_streamcolor"),
-        ("zerver", "0011_remove_guardian"),
-        ("zerver", "0012_remove_appledevicetoken"),
-        ("zerver", "0013_realmemoji"),
-        ("zerver", "0014_realm_emoji_url_length"),
-        ("zerver", "0015_attachment"),
-        ("zerver", "0016_realm_create_stream_by_admins_only"),
-        ("zerver", "0017_userprofile_bot_type"),
-        ("zerver", "0018_realm_emoji_message"),
-        ("zerver", "0019_preregistrationuser_realm_creation"),
-        ("zerver", "0020_add_tracking_attachment"),
-        ("zerver", "0021_migrate_attachment_data"),
-        ("zerver", "0022_subscription_pin_to_top"),
-        ("zerver", "0023_userprofile_default_language"),
-        ("zerver", "0024_realm_allow_message_editing"),
-        ("zerver", "0025_realm_message_content_edit_limit"),
-        ("zerver", "0026_delete_mituser"),
-        ("zerver", "0027_realm_default_language"),
-        ("zerver", "0028_userprofile_tos_version"),
-    ]
-)
-
-# This migration was in python-social-auth, and was mistakenly removed
-# from its `replaces` in
-# https://github.com/python-social-auth/social-app-django/pull/25
-missing.discard(("default", "0005_auto_20160727_2333"))
-
-# This was a typo (twofactor for two_factor) corrected in
-# https://github.com/jazzband/django-two-factor-auth/pull/642
-missing.discard(("twofactor", "0001_squashed_0008_delete_phonedevice"))
+missing.difference_update(STALE_MIGRATIONS)
 
 for key, migration in loader.disk_migrations.items():
     missing.discard(key)

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -33,6 +33,7 @@ from analytics.models import RealmCount, StreamCount, UserCount
 from scripts.lib.zulip_tools import overwrite_symlink
 from version import ZULIP_VERSION
 from zerver.lib.avatar_hash import user_avatar_base_path_from_ids
+from zerver.lib.migration_status import AppMigrations, MigrationStatusJson
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.upload.s3 import get_bucket
@@ -98,18 +99,11 @@ SourceFilter: TypeAlias = Callable[[Record], bool]
 
 CustomFetch: TypeAlias = Callable[[TableData, Context], None]
 
-AppMigrations: TypeAlias = dict[str, list[str]]
-
 
 class MessagePartial(TypedDict):
     zerver_message: list[Record]
     zerver_userprofile_ids: list[int]
     realm_id: int
-
-
-class MigrationStatusJson(TypedDict):
-    migrations_by_app: AppMigrations
-    zulip_version: str
 
 
 MESSAGE_BATCH_CHUNK_SIZE = 1000

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -31,7 +31,6 @@ from zerver.lib.bulk_create import bulk_set_users_or_streams_recipient_fields
 from zerver.lib.export import (
     DATE_FIELDS,
     Field,
-    MigrationStatusJson,
     Path,
     Record,
     TableData,
@@ -41,6 +40,7 @@ from zerver.lib.export import (
 from zerver.lib.markdown import markdown_convert
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.message import get_last_message_id
+from zerver.lib.migration_status import MigrationStatusJson
 from zerver.lib.mime_types import guess_type
 from zerver.lib.partial import partial
 from zerver.lib.push_notifications import sends_notifications_directly

--- a/zerver/lib/migration_status.py
+++ b/zerver/lib/migration_status.py
@@ -1,0 +1,41 @@
+import os
+import re
+from importlib import import_module
+from io import StringIO
+from typing import Any
+
+
+def get_migration_status(**options: Any) -> str:
+    from django.apps import apps
+    from django.core.management import call_command
+    from django.db import DEFAULT_DB_ALIAS, connections
+    from django.utils.module_loading import module_has_submodule
+
+    verbosity = options.get("verbosity", 1)
+
+    for app_config in apps.get_app_configs():
+        if module_has_submodule(app_config.module, "management"):
+            import_module(".management", app_config.name)
+
+    app_label = options["app_label"] if options.get("app_label") else None
+    db = options.get("database", DEFAULT_DB_ALIAS)
+    out = StringIO()
+    command_args = ["--list"]
+    if app_label:
+        command_args.append(app_label)
+
+    call_command(
+        "showmigrations",
+        *command_args,
+        database=db,
+        no_color=options.get("no_color", False),
+        settings=options.get("settings", os.environ["DJANGO_SETTINGS_MODULE"]),
+        stdout=out,
+        skip_checks=options.get("skip_checks", True),
+        traceback=options.get("traceback", True),
+        verbosity=verbosity,
+    )
+    connections.close_all()
+    out.seek(0)
+    output = out.read()
+    return re.sub(r"\x1b\[(1|0)m", "", output)

--- a/zerver/lib/migration_status.py
+++ b/zerver/lib/migration_status.py
@@ -4,6 +4,50 @@ from importlib import import_module
 from io import StringIO
 from typing import Any
 
+STALE_MIGRATIONS = [
+    # Ignore django-guardian, which we installed until 1.7.0~3134
+    ("guardian", "0001_initial"),
+    # Ignore django.contrib.sites, which we installed until 2.0.0-rc1~984.
+    ("sites", "0001_initial"),
+    ("sites", "0002_alter_domain_unique"),
+    # These migrations (0002=>0028) were squashed into 0001, in 6fbddf578a6e
+    # through a21f2d771553, 1.7.0~3135.
+    ("zerver", "0002_django_1_8"),
+    ("zerver", "0003_custom_indexes"),
+    ("zerver", "0004_userprofile_left_side_userlist"),
+    ("zerver", "0005_auto_20150920_1340"),
+    ("zerver", "0006_zerver_userprofile_email_upper_idx"),
+    ("zerver", "0007_userprofile_is_bot_active_indexes"),
+    ("zerver", "0008_preregistrationuser_upper_email_idx"),
+    ("zerver", "0009_add_missing_migrations"),
+    ("zerver", "0010_delete_streamcolor"),
+    ("zerver", "0011_remove_guardian"),
+    ("zerver", "0012_remove_appledevicetoken"),
+    ("zerver", "0013_realmemoji"),
+    ("zerver", "0014_realm_emoji_url_length"),
+    ("zerver", "0015_attachment"),
+    ("zerver", "0016_realm_create_stream_by_admins_only"),
+    ("zerver", "0017_userprofile_bot_type"),
+    ("zerver", "0018_realm_emoji_message"),
+    ("zerver", "0019_preregistrationuser_realm_creation"),
+    ("zerver", "0020_add_tracking_attachment"),
+    ("zerver", "0021_migrate_attachment_data"),
+    ("zerver", "0022_subscription_pin_to_top"),
+    ("zerver", "0023_userprofile_default_language"),
+    ("zerver", "0024_realm_allow_message_editing"),
+    ("zerver", "0025_realm_message_content_edit_limit"),
+    ("zerver", "0026_delete_mituser"),
+    ("zerver", "0027_realm_default_language"),
+    ("zerver", "0028_userprofile_tos_version"),
+    # This migration was in python-social-auth, and was mistakenly removed
+    # from its `replaces` in
+    # https://github.com/python-social-auth/social-app-django/pull/25
+    ("default", "0005_auto_20160727_2333"),
+    # This was a typo (twofactor for two_factor) corrected in
+    # https://github.com/jazzband/django-two-factor-auth/pull/642
+    ("twofactor", "0001_squashed_0008_delete_phonedevice"),
+]
+
 
 def get_migration_status(**options: Any) -> str:
     from django.apps import apps

--- a/zerver/lib/migration_status.py
+++ b/zerver/lib/migration_status.py
@@ -37,4 +37,4 @@ def get_migration_status(**options: Any) -> str:
     )
     out.seek(0)
     output = out.read()
-    return re.sub(r"\x1b\[(1|0)m", "", output)
+    return re.sub(r"\x1b\[[0-9;]*m", "", output)

--- a/zerver/lib/migration_status.py
+++ b/zerver/lib/migration_status.py
@@ -8,7 +8,7 @@ from typing import Any
 def get_migration_status(**options: Any) -> str:
     from django.apps import apps
     from django.core.management import call_command
-    from django.db import DEFAULT_DB_ALIAS, connections
+    from django.db import DEFAULT_DB_ALIAS
     from django.utils.module_loading import module_has_submodule
 
     verbosity = options.get("verbosity", 1)
@@ -35,7 +35,6 @@ def get_migration_status(**options: Any) -> str:
         traceback=options.get("traceback", True),
         verbosity=verbosity,
     )
-    connections.close_all()
     out.seek(0)
     output = out.read()
     return re.sub(r"\x1b\[(1|0)m", "", output)

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -123,6 +123,7 @@ class Database:
             previous_migration_status = f.read()
 
         current_migration_status = get_migration_status(settings=settings)
+        connections.close_all()
         all_curr_migrations = extract_migrations_as_list(current_migration_status)
         all_prev_migrations = extract_migrations_as_list(previous_migration_status)
 

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -6,16 +6,10 @@ import shutil
 import subprocess
 import sys
 import time
-from importlib import import_module
-from io import StringIO
-from typing import Any
 
-from django.apps import apps
 from django.conf import settings
-from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, ProgrammingError, connection, connections
 from django.db.utils import OperationalError
-from django.utils.module_loading import module_has_submodule
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from scripts.lib.zulip_tools import (
@@ -117,6 +111,8 @@ class Database:
         )
 
     def what_to_do_with_migrations(self) -> str:
+        from zerver.lib.migration_status import get_migration_status
+
         status_fn = self.migration_status_path
         settings = self.settings
 
@@ -293,37 +289,6 @@ def update_test_databases_if_required(rebuild_test_database: bool = False) -> No
 
     if rebuild_test_database:
         run(["tools/setup/generate-fixtures"])
-
-
-def get_migration_status(**options: Any) -> str:
-    verbosity = options.get("verbosity", 1)
-
-    for app_config in apps.get_app_configs():
-        if module_has_submodule(app_config.module, "management"):
-            import_module(".management", app_config.name)
-
-    app_label = options["app_label"] if options.get("app_label") else None
-    db = options.get("database", DEFAULT_DB_ALIAS)
-    out = StringIO()
-    command_args = ["--list"]
-    if app_label:
-        command_args.append(app_label)
-
-    call_command(
-        "showmigrations",
-        *command_args,
-        database=db,
-        no_color=options.get("no_color", False),
-        settings=options.get("settings", os.environ["DJANGO_SETTINGS_MODULE"]),
-        stdout=out,
-        skip_checks=options.get("skip_checks", True),
-        traceback=options.get("traceback", True),
-        verbosity=verbosity,
-    )
-    connections.close_all()
-    out.seek(0)
-    output = out.read()
-    return re.sub(r"\x1b\[(1|0)m", "", output)
 
 
 def extract_migrations_as_list(migration_status: str) -> list[str]:

--- a/zerver/management/commands/get_migration_status.py
+++ b/zerver/management/commands/get_migration_status.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 
 from scripts.lib.zulip_tools import get_dev_uuid_var_path
 from zerver.lib.management import ZulipBaseCommand
-from zerver.lib.test_fixtures import get_migration_status
+from zerver.lib.migration_status import get_migration_status
 
 
 class Command(ZulipBaseCommand):

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_complete_migrations.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_complete_migrations.json
@@ -1,65 +1,148 @@
 {
-    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
-    "auth": [
-        "0001_initial",
-        "0002_alter_permission_name_max_length",
-        "0003_alter_user_email_max_length",
-        "0004_alter_user_username_opts"
-    ],
-    "zerver": [
-        "0001_initial",
-        "0029_realm_subdomain",
-        "0030_realm_org_type",
-        "0031_remove_system_avatar_source"
-    ],
     "analytics": [
-        "0001_initial",
-        "0002_remove_huddlecount",
-        "0003_fillstate"
+        "[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"
+    ],
+    "auth": [
+        "[X] 0001_initial",
+        "[X] 0002_alter_permission_name_max_length",
+        "[X] 0003_alter_user_email_max_length",
+        "[X] 0004_alter_user_username_opts",
+        "[X] 0005_alter_user_last_login_null",
+        "[X] 0006_require_contenttypes_0002",
+        "[X] 0007_alter_validators_add_error_messages",
+        "[X] 0008_alter_user_username_max_length",
+        "[X] 0009_alter_user_last_name_max_length",
+        "[X] 0010_alter_group_name_max_length",
+        "[X] 0011_update_proxy_permissions",
+        "[X] 0012_alter_user_first_name_max_length"
     ],
     "confirmation": [
-        "0001_initial",
-        "0002_realmcreationkey",
-        "0003_emailchangeconfirmation"
+        "[X] 0001_squashed_0014_confirmation_confirmatio_content_80155a_idx (14 squashed migrations)",
+        "[X] 0015_alter_confirmation_object_id"
+    ],
+    "contenttypes": ["[X] 0001_initial", "[X] 0002_remove_content_type_name"],
+    "corporate": [
+        "[X] 0001_squashed_0044_convert_ids_to_bigints (44 squashed migrations)"
+    ],
+    "otp_static": [
+        "[X] 0001_initial",
+        "[X] 0002_throttling",
+        "[X] 0003_add_timestamps"
+    ],
+    "otp_totp": [
+        "[X] 0001_initial",
+        "[X] 0002_auto_20190420_0723",
+        "[X] 0003_add_timestamps"
+    ],
+    "pgroonga": [
+        "[X] 0001_enable",
+        "[X] 0002_html_escape_subject",
+        "[X] 0003_v2_api_upgrade"
+    ],
+    "phonenumber": ["[X] 0001_squashed_0001_initial (10 squashed migrations)"],
+    "sessions": ["[X] 0001_initial"],
+    "social_django": [
+        "[X] 0001_initial (2 squashed migrations)",
+        "[X] 0002_add_related_name (2 squashed migrations)",
+        "[X] 0003_alter_email_max_length (2 squashed migrations)",
+        "[X] 0004_auto_20160423_0400 (2 squashed migrations)",
+        "[X] 0005_auto_20160727_2333 (1 squashed migrations)",
+        "[X] 0006_partial",
+        "[X] 0007_code_timestamp",
+        "[X] 0008_partial_timestamp",
+        "[X] 0009_auto_20191118_0520",
+        "[X] 0010_uid_db_index",
+        "[X] 0011_alter_id_fields",
+        "[X] 0012_usersocialauth_extra_data_new",
+        "[X] 0013_migrate_extra_data",
+        "[X] 0014_remove_usersocialauth_extra_data",
+        "[X] 0015_rename_extra_data_new_usersocialauth_extra_data",
+        "[X] 0016_alter_usersocialauth_extra_data"
+    ],
+    "two_factor": ["(no migrations)"],
+    "zerver": [
+        "[X] 0001_squashed_0569 (545 squashed migrations)",
+        "[X] 0576_backfill_imageattachment",
+        "[X] 0622_backfill_imageattachment_again",
+        "[X] 0639_zh_hant_tw_rename",
+        "[X] 0570_namedusergroup_can_manage_group",
+        "[X] 0571_set_default_for_can_manage_group",
+        "[X] 0572_alter_usergroup_can_manage_group",
+        "[X] 0573_directmessagegroup_group_size",
+        "[X] 0574_backfill_directmessagegroup_group_size",
+        "[X] 0575_alter_directmessagegroup_group_size",
+        "[X] 0577_merge_20240829_0153",
+        "[X] 0578_namedusergroup_deactivated",
+        "[X] 0579_realm_can_delete_own_message_group",
+        "[X] 0580_set_default_value_for_can_delete_own_message_group",
+        "[X] 0581_alter_realm_can_delete_own_message_group",
+        "[X] 0582_remove_realm_delete_own_message_policy",
+        "[X] 0583_namedusergroup_creator_namedusergroup_date_created",
+        "[X] 0584_namedusergroup_creator_date_created_backfill",
+        "[X] 0585_userprofile_allow_private_data_export_and_more",
+        "[X] 0586_customprofilefield_editable_by_user",
+        "[X] 0587_savedsnippet",
+        "[X] 0588_realm_add_can_create_groups",
+        "[X] 0589_set_can_create_groups",
+        "[X] 0590_alter_realm_can_create_groups",
+        "[X] 0591_realm_add_can_manage_all_groups",
+        "[X] 0592_set_can_manage_all_groups",
+        "[X] 0593_alter_realm_manage_all_groups",
+        "[X] 0594_remove_realm_user_group_edit_policy",
+        "[X] 0595_add_realmexport_table_and_backfill",
+        "[X] 0596_namedusergroup_can_join_group",
+        "[X] 0597_set_default_value_for_can_join_group",
+        "[X] 0598_alter_namedusergroup_can_join_group",
+        "[X] 0599_namedusergroup_add_can_add_members_group",
+        "[X] 0600_set_default_for_can_add_members_group",
+        "[X] 0601_alter_namedusergroup_can_add_members_group",
+        "[X] 0602_remap_can_manage_all_groups",
+        "[X] 0603_realm_can_add_custom_emoji_group",
+        "[X] 0604_set_default_value_for_can_add_custom_emoji_group",
+        "[X] 0605_alter_realm_can_add_custom_emoji_group",
+        "[X] 0606_remove_realm_add_custom_emoji_policy",
+        "[X] 0607_namedusergroup_add_can_leave_group",
+        "[X] 0608_set_default_for_can_leave_group",
+        "[X] 0609_alter_namedusergroup_can_leave_group",
+        "[X] 0610_mark_introduce_resolve_topic_modal_as_read",
+        "[X] 0611_realm_can_move_messages_between_channels_group",
+        "[X] 0612_set_default_value_for_can_move_messages_between_channels_group",
+        "[X] 0613_alter_realm_can_move_messages_between_channels_group",
+        "[X] 0614_remove_realm_move_messages_between_streams_policy",
+        "[X] 0615_system_bot_avatars",
+        "[X] 0616_userprofile_can_change_user_emails",
+        "[X] 0617_remove_prefix_from_archived_streams",
+        "[X] 0618_realm_can_move_messages_between_topics_group",
+        "[X] 0619_set_default_value_for_can_move_messages_between_topics_group",
+        "[X] 0620_alter_realm_can_move_messages_between_topics_group",
+        "[X] 0621_remove_realm_edit_topic_policy",
+        "[X] 0623_merge_20241030_1835",
+        "[X] 0624_alter_realmexport_tarball_size_bytes",
+        "[X] 0625_realm_can_invite_users_group",
+        "[X] 0626_set_default_value_for_can_invite_users_group",
+        "[X] 0627_alter_realm_can_invite_users_group",
+        "[X] 0628_remove_realm_invite_to_realm_policy",
+        "[X] 0629_remove_stream_email_token_backfill_channelemailaddress",
+        "[X] 0630_multiuseinvite_groups_preregistrationuser_groups",
+        "[X] 0631_stream_is_recently_active",
+        "[X] 0632_preregistrationrealm_data_import_metadata",
+        "[X] 0633_namedusergroup_can_remove_members_group",
+        "[X] 0634_set_default_for_can_remove_members_group",
+        "[X] 0635_alter_namedusergroup_can_remove_members_group",
+        "[X] 0636_streams_add_can_administer_channel_group",
+        "[X] 0637_set_default_for_can_administer_channel_group",
+        "[X] 0638_alter_stream_can_administer_channel_group",
+        "[X] 0640_merge_20241211_1953",
+        "[X] 0641_web_suggest_update_time_zone",
+        "[X] 0642_realm_moderation_request_channel",
+        "[X] 0643_realm_scheduled_deletion_date",
+        "[X] 0644_check_update_all_channels_active_status",
+        "[X] 0645_stream_can_send_message_group",
+        "[X] 0646_set_default_for_can_send_message_group",
+        "[X] 0647_alter_stream_can_send_message_group",
+        "[X] 0648_remove_stream_stream_post_policy"
     ],
     "zilencer": [
-        "0001_initial",
-        "0002_remote_zulip_server",
-        "0003_add_default_for_remotezulipserver_last_updated_field"
-    ],
-    "corporate": [
-        "0001_initial",
-        "0002_customer_default_discount",
-        "0003_customerplan"
-    ],
-    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
-    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
-    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
-    "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
-    "two_factor": [
-        "0001_initial",
-        "0002_auto_20150110_0810",
-        "0003_auto_20150817_1733",
-        "0004_auto_20160205_1827"
-    ],
-    "sessions": ["0001_initial"],
-    "default": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400"
-    ],
-    "social_auth": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400",
-        "0005_auto_20160727_2333"
-    ],
-    "social_django": [
-        "0006_partial",
-        "0007_code_timestamp",
-        "0008_partial_timestamp",
-        "0009_auto_20191118_0520"
+        "[X] 0001_squashed_0064_remotezulipserver_last_merge_base (64 squashed migrations)"
     ]
 }

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_missing_apps.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_missing_apps.json
@@ -1,63 +1,146 @@
 {
-    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
-    "auth": [
-        "0001_initial",
-        "0002_alter_permission_name_max_length",
-        "0003_alter_user_email_max_length",
-        "0004_alter_user_username_opts"
-    ],
-    "zerver": [
-        "0001_initial",
-        "0029_realm_subdomain",
-        "0030_realm_org_type",
-        "0031_remove_system_avatar_source"
-    ],
     "analytics": [
-        "0001_initial",
-        "0002_remove_huddlecount",
-        "0003_fillstate"
+        "[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"
+    ],
+    "auth": [
+        "[X] 0001_initial",
+        "[X] 0002_alter_permission_name_max_length",
+        "[X] 0003_alter_user_email_max_length",
+        "[X] 0004_alter_user_username_opts",
+        "[X] 0005_alter_user_last_login_null",
+        "[X] 0006_require_contenttypes_0002",
+        "[X] 0007_alter_validators_add_error_messages",
+        "[X] 0008_alter_user_username_max_length",
+        "[X] 0009_alter_user_last_name_max_length",
+        "[X] 0010_alter_group_name_max_length",
+        "[X] 0011_update_proxy_permissions",
+        "[X] 0012_alter_user_first_name_max_length"
     ],
     "confirmation": [
-        "0001_initial",
-        "0002_realmcreationkey",
-        "0003_emailchangeconfirmation"
+        "[X] 0001_squashed_0014_confirmation_confirmatio_content_80155a_idx (14 squashed migrations)",
+        "[X] 0015_alter_confirmation_object_id"
     ],
-    "zilencer": [
-        "0001_initial",
-        "0002_remote_zulip_server",
-        "0003_add_default_for_remotezulipserver_last_updated_field"
-    ],
+    "contenttypes": ["[X] 0001_initial", "[X] 0002_remove_content_type_name"],
     "corporate": [
-        "0001_initial",
-        "0002_customer_default_discount",
-        "0003_customerplan"
+        "[X] 0001_squashed_0044_convert_ids_to_bigints (44 squashed migrations)"
     ],
-    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
-    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
-    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
-    "two_factor": [
-        "0001_initial",
-        "0002_auto_20150110_0810",
-        "0003_auto_20150817_1733",
-        "0004_auto_20160205_1827"
+    "otp_static": [
+        "[X] 0001_initial",
+        "[X] 0002_throttling",
+        "[X] 0003_add_timestamps"
     ],
-    "default": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400"
+    "otp_totp": [
+        "[X] 0001_initial",
+        "[X] 0002_auto_20190420_0723",
+        "[X] 0003_add_timestamps"
     ],
-    "social_auth": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400",
-        "0005_auto_20160727_2333"
+    "pgroonga": [
+        "[X] 0001_enable",
+        "[X] 0002_html_escape_subject",
+        "[X] 0003_v2_api_upgrade"
     ],
     "social_django": [
-        "0006_partial",
-        "0007_code_timestamp",
-        "0008_partial_timestamp",
-        "0009_auto_20191118_0520"
+        "[X] 0001_initial (2 squashed migrations)",
+        "[X] 0002_add_related_name (2 squashed migrations)",
+        "[X] 0003_alter_email_max_length (2 squashed migrations)",
+        "[X] 0004_auto_20160423_0400 (2 squashed migrations)",
+        "[X] 0005_auto_20160727_2333 (1 squashed migrations)",
+        "[X] 0006_partial",
+        "[X] 0007_code_timestamp",
+        "[X] 0008_partial_timestamp",
+        "[X] 0009_auto_20191118_0520",
+        "[X] 0010_uid_db_index",
+        "[X] 0011_alter_id_fields",
+        "[X] 0012_usersocialauth_extra_data_new",
+        "[X] 0013_migrate_extra_data",
+        "[X] 0014_remove_usersocialauth_extra_data",
+        "[X] 0015_rename_extra_data_new_usersocialauth_extra_data",
+        "[X] 0016_alter_usersocialauth_extra_data"
+    ],
+    "two_factor": ["(no migrations)"],
+    "zerver": [
+        "[X] 0001_squashed_0569 (545 squashed migrations)",
+        "[X] 0576_backfill_imageattachment",
+        "[X] 0622_backfill_imageattachment_again",
+        "[X] 0639_zh_hant_tw_rename",
+        "[X] 0570_namedusergroup_can_manage_group",
+        "[X] 0571_set_default_for_can_manage_group",
+        "[X] 0572_alter_usergroup_can_manage_group",
+        "[X] 0573_directmessagegroup_group_size",
+        "[X] 0574_backfill_directmessagegroup_group_size",
+        "[X] 0575_alter_directmessagegroup_group_size",
+        "[X] 0577_merge_20240829_0153",
+        "[X] 0578_namedusergroup_deactivated",
+        "[X] 0579_realm_can_delete_own_message_group",
+        "[X] 0580_set_default_value_for_can_delete_own_message_group",
+        "[X] 0581_alter_realm_can_delete_own_message_group",
+        "[X] 0582_remove_realm_delete_own_message_policy",
+        "[X] 0583_namedusergroup_creator_namedusergroup_date_created",
+        "[X] 0584_namedusergroup_creator_date_created_backfill",
+        "[X] 0585_userprofile_allow_private_data_export_and_more",
+        "[X] 0586_customprofilefield_editable_by_user",
+        "[X] 0587_savedsnippet",
+        "[X] 0588_realm_add_can_create_groups",
+        "[X] 0589_set_can_create_groups",
+        "[X] 0590_alter_realm_can_create_groups",
+        "[X] 0591_realm_add_can_manage_all_groups",
+        "[X] 0592_set_can_manage_all_groups",
+        "[X] 0593_alter_realm_manage_all_groups",
+        "[X] 0594_remove_realm_user_group_edit_policy",
+        "[X] 0595_add_realmexport_table_and_backfill",
+        "[X] 0596_namedusergroup_can_join_group",
+        "[X] 0597_set_default_value_for_can_join_group",
+        "[X] 0598_alter_namedusergroup_can_join_group",
+        "[X] 0599_namedusergroup_add_can_add_members_group",
+        "[X] 0600_set_default_for_can_add_members_group",
+        "[X] 0601_alter_namedusergroup_can_add_members_group",
+        "[X] 0602_remap_can_manage_all_groups",
+        "[X] 0603_realm_can_add_custom_emoji_group",
+        "[X] 0604_set_default_value_for_can_add_custom_emoji_group",
+        "[X] 0605_alter_realm_can_add_custom_emoji_group",
+        "[X] 0606_remove_realm_add_custom_emoji_policy",
+        "[X] 0607_namedusergroup_add_can_leave_group",
+        "[X] 0608_set_default_for_can_leave_group",
+        "[X] 0609_alter_namedusergroup_can_leave_group",
+        "[X] 0610_mark_introduce_resolve_topic_modal_as_read",
+        "[X] 0611_realm_can_move_messages_between_channels_group",
+        "[X] 0612_set_default_value_for_can_move_messages_between_channels_group",
+        "[X] 0613_alter_realm_can_move_messages_between_channels_group",
+        "[X] 0614_remove_realm_move_messages_between_streams_policy",
+        "[X] 0615_system_bot_avatars",
+        "[X] 0616_userprofile_can_change_user_emails",
+        "[X] 0617_remove_prefix_from_archived_streams",
+        "[X] 0618_realm_can_move_messages_between_topics_group",
+        "[X] 0619_set_default_value_for_can_move_messages_between_topics_group",
+        "[X] 0620_alter_realm_can_move_messages_between_topics_group",
+        "[X] 0621_remove_realm_edit_topic_policy",
+        "[X] 0623_merge_20241030_1835",
+        "[X] 0624_alter_realmexport_tarball_size_bytes",
+        "[X] 0625_realm_can_invite_users_group",
+        "[X] 0626_set_default_value_for_can_invite_users_group",
+        "[X] 0627_alter_realm_can_invite_users_group",
+        "[X] 0628_remove_realm_invite_to_realm_policy",
+        "[X] 0629_remove_stream_email_token_backfill_channelemailaddress",
+        "[X] 0630_multiuseinvite_groups_preregistrationuser_groups",
+        "[X] 0631_stream_is_recently_active",
+        "[X] 0632_preregistrationrealm_data_import_metadata",
+        "[X] 0633_namedusergroup_can_remove_members_group",
+        "[X] 0634_set_default_for_can_remove_members_group",
+        "[X] 0635_alter_namedusergroup_can_remove_members_group",
+        "[X] 0636_streams_add_can_administer_channel_group",
+        "[X] 0637_set_default_for_can_administer_channel_group",
+        "[X] 0638_alter_stream_can_administer_channel_group",
+        "[X] 0640_merge_20241211_1953",
+        "[X] 0641_web_suggest_update_time_zone",
+        "[X] 0642_realm_moderation_request_channel",
+        "[X] 0643_realm_scheduled_deletion_date",
+        "[X] 0644_check_update_all_channels_active_status",
+        "[X] 0645_stream_can_send_message_group",
+        "[X] 0646_set_default_for_can_send_message_group",
+        "[X] 0647_alter_stream_can_send_message_group",
+        "[X] 0648_remove_stream_stream_post_policy"
+    ],
+    "zilencer": [
+        "[X] 0001_squashed_0064_remotezulipserver_last_merge_base (64 squashed migrations)"
     ]
 }

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_unapplied_migrations.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_unapplied_migrations.json
@@ -1,61 +1,148 @@
 {
-    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
-    "auth": [
-        "0001_initial",
-        "0002_alter_permission_name_max_length"
-    ],
-    "zerver": [
-        "0001_initial",
-        "0029_realm_subdomain"
-    ],
     "analytics": [
-        "0001_initial",
-        "0002_remove_huddlecount",
-        "0003_fillstate"
+        "[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"
+    ],
+    "auth": [
+        "[X] 0001_initial",
+        "[X] 0002_alter_permission_name_max_length",
+        "[X] 0003_alter_user_email_max_length",
+        "[X] 0004_alter_user_username_opts",
+        "[X] 0005_alter_user_last_login_null",
+        "[X] 0006_require_contenttypes_0002",
+        "[X] 0007_alter_validators_add_error_messages",
+        "[X] 0008_alter_user_username_max_length",
+        "[X] 0009_alter_user_last_name_max_length",
+        "[X] 0010_alter_group_name_max_length",
+        "[ ] 0011_update_proxy_permissions",
+        "[ ] 0012_alter_user_first_name_max_length"
     ],
     "confirmation": [
-        "0001_initial",
-        "0002_realmcreationkey",
-        "0003_emailchangeconfirmation"
+        "[X] 0001_squashed_0014_confirmation_confirmatio_content_80155a_idx (14 squashed migrations)",
+        "[X] 0015_alter_confirmation_object_id"
+    ],
+    "contenttypes": ["[X] 0001_initial", "[X] 0002_remove_content_type_name"],
+    "corporate": [
+        "[X] 0001_squashed_0044_convert_ids_to_bigints (44 squashed migrations)"
+    ],
+    "otp_static": [
+        "[X] 0001_initial",
+        "[X] 0002_throttling",
+        "[X] 0003_add_timestamps"
+    ],
+    "otp_totp": [
+        "[X] 0001_initial",
+        "[X] 0002_auto_20190420_0723",
+        "[X] 0003_add_timestamps"
+    ],
+    "pgroonga": [
+        "[X] 0001_enable",
+        "[X] 0002_html_escape_subject",
+        "[X] 0003_v2_api_upgrade"
+    ],
+    "phonenumber": ["[X] 0001_squashed_0001_initial (10 squashed migrations)"],
+    "sessions": ["[X] 0001_initial"],
+    "social_django": [
+        "[X] 0001_initial (2 squashed migrations)",
+        "[X] 0002_add_related_name (2 squashed migrations)",
+        "[X] 0003_alter_email_max_length (2 squashed migrations)",
+        "[X] 0004_auto_20160423_0400 (2 squashed migrations)",
+        "[X] 0005_auto_20160727_2333 (1 squashed migrations)",
+        "[X] 0006_partial",
+        "[X] 0007_code_timestamp",
+        "[X] 0008_partial_timestamp",
+        "[X] 0009_auto_20191118_0520",
+        "[X] 0010_uid_db_index",
+        "[X] 0011_alter_id_fields",
+        "[X] 0012_usersocialauth_extra_data_new",
+        "[X] 0013_migrate_extra_data",
+        "[X] 0014_remove_usersocialauth_extra_data",
+        "[X] 0015_rename_extra_data_new_usersocialauth_extra_data",
+        "[X] 0016_alter_usersocialauth_extra_data"
+    ],
+    "two_factor": ["(no migrations)"],
+    "zerver": [
+        "[X] 0001_squashed_0569 (545 squashed migrations)",
+        "[X] 0576_backfill_imageattachment",
+        "[X] 0622_backfill_imageattachment_again",
+        "[X] 0639_zh_hant_tw_rename",
+        "[X] 0570_namedusergroup_can_manage_group",
+        "[X] 0571_set_default_for_can_manage_group",
+        "[X] 0572_alter_usergroup_can_manage_group",
+        "[X] 0573_directmessagegroup_group_size",
+        "[X] 0574_backfill_directmessagegroup_group_size",
+        "[X] 0575_alter_directmessagegroup_group_size",
+        "[X] 0577_merge_20240829_0153",
+        "[X] 0578_namedusergroup_deactivated",
+        "[X] 0579_realm_can_delete_own_message_group",
+        "[X] 0580_set_default_value_for_can_delete_own_message_group",
+        "[X] 0581_alter_realm_can_delete_own_message_group",
+        "[X] 0582_remove_realm_delete_own_message_policy",
+        "[X] 0583_namedusergroup_creator_namedusergroup_date_created",
+        "[X] 0584_namedusergroup_creator_date_created_backfill",
+        "[X] 0585_userprofile_allow_private_data_export_and_more",
+        "[X] 0586_customprofilefield_editable_by_user",
+        "[X] 0587_savedsnippet",
+        "[X] 0588_realm_add_can_create_groups",
+        "[X] 0589_set_can_create_groups",
+        "[X] 0590_alter_realm_can_create_groups",
+        "[X] 0591_realm_add_can_manage_all_groups",
+        "[X] 0592_set_can_manage_all_groups",
+        "[X] 0593_alter_realm_manage_all_groups",
+        "[X] 0594_remove_realm_user_group_edit_policy",
+        "[X] 0595_add_realmexport_table_and_backfill",
+        "[X] 0596_namedusergroup_can_join_group",
+        "[X] 0597_set_default_value_for_can_join_group",
+        "[X] 0598_alter_namedusergroup_can_join_group",
+        "[X] 0599_namedusergroup_add_can_add_members_group",
+        "[X] 0600_set_default_for_can_add_members_group",
+        "[X] 0601_alter_namedusergroup_can_add_members_group",
+        "[X] 0602_remap_can_manage_all_groups",
+        "[X] 0603_realm_can_add_custom_emoji_group",
+        "[X] 0604_set_default_value_for_can_add_custom_emoji_group",
+        "[X] 0605_alter_realm_can_add_custom_emoji_group",
+        "[X] 0606_remove_realm_add_custom_emoji_policy",
+        "[X] 0607_namedusergroup_add_can_leave_group",
+        "[X] 0608_set_default_for_can_leave_group",
+        "[X] 0609_alter_namedusergroup_can_leave_group",
+        "[X] 0610_mark_introduce_resolve_topic_modal_as_read",
+        "[X] 0611_realm_can_move_messages_between_channels_group",
+        "[X] 0612_set_default_value_for_can_move_messages_between_channels_group",
+        "[X] 0613_alter_realm_can_move_messages_between_channels_group",
+        "[X] 0614_remove_realm_move_messages_between_streams_policy",
+        "[X] 0615_system_bot_avatars",
+        "[X] 0616_userprofile_can_change_user_emails",
+        "[X] 0617_remove_prefix_from_archived_streams",
+        "[X] 0618_realm_can_move_messages_between_topics_group",
+        "[X] 0619_set_default_value_for_can_move_messages_between_topics_group",
+        "[X] 0620_alter_realm_can_move_messages_between_topics_group",
+        "[X] 0621_remove_realm_edit_topic_policy",
+        "[X] 0623_merge_20241030_1835",
+        "[X] 0624_alter_realmexport_tarball_size_bytes",
+        "[X] 0625_realm_can_invite_users_group",
+        "[X] 0626_set_default_value_for_can_invite_users_group",
+        "[X] 0627_alter_realm_can_invite_users_group",
+        "[X] 0628_remove_realm_invite_to_realm_policy",
+        "[X] 0629_remove_stream_email_token_backfill_channelemailaddress",
+        "[X] 0630_multiuseinvite_groups_preregistrationuser_groups",
+        "[X] 0631_stream_is_recently_active",
+        "[X] 0632_preregistrationrealm_data_import_metadata",
+        "[X] 0633_namedusergroup_can_remove_members_group",
+        "[X] 0634_set_default_for_can_remove_members_group",
+        "[X] 0635_alter_namedusergroup_can_remove_members_group",
+        "[X] 0636_streams_add_can_administer_channel_group",
+        "[X] 0637_set_default_for_can_administer_channel_group",
+        "[X] 0638_alter_stream_can_administer_channel_group",
+        "[X] 0640_merge_20241211_1953",
+        "[X] 0641_web_suggest_update_time_zone",
+        "[X] 0642_realm_moderation_request_channel",
+        "[X] 0643_realm_scheduled_deletion_date",
+        "[X] 0644_check_update_all_channels_active_status",
+        "[X] 0645_stream_can_send_message_group",
+        "[ ] 0646_set_default_for_can_send_message_group",
+        "[ ] 0647_alter_stream_can_send_message_group",
+        "[ ] 0648_remove_stream_stream_post_policy"
     ],
     "zilencer": [
-        "0001_initial",
-        "0002_remote_zulip_server",
-        "0003_add_default_for_remotezulipserver_last_updated_field"
-    ],
-    "corporate": [
-        "0001_initial",
-        "0002_customer_default_discount",
-        "0003_customerplan"
-    ],
-    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
-    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
-    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
-    "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
-    "two_factor": [
-        "0001_initial",
-        "0002_auto_20150110_0810",
-        "0003_auto_20150817_1733",
-        "0004_auto_20160205_1827"
-    ],
-    "sessions": ["0001_initial"],
-    "default": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400"
-    ],
-    "social_auth": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400",
-        "0005_auto_20160727_2333"
-    ],
-    "social_django": [
-        "0006_partial",
-        "0007_code_timestamp",
-        "0008_partial_timestamp",
-        "0009_auto_20191118_0520"
+        "[X] 0001_squashed_0064_remotezulipserver_last_merge_base (64 squashed migrations)"
     ]
 }

--- a/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_unsorted_migrations_list.json
+++ b/zerver/tests/fixtures/import_fixtures/applied_migrations_fixtures/with_unsorted_migrations_list.json
@@ -1,65 +1,148 @@
 {
-    "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
-    "auth": [
-        "0004_alter_user_username_opts",
-        "0003_alter_user_email_max_length",
-        "0002_alter_permission_name_max_length",
-        "0001_initial"
-    ],
-    "zerver": [
-        "0001_initial",
-        "0029_realm_subdomain",
-        "0030_realm_org_type",
-        "0031_remove_system_avatar_source"
-    ],
     "analytics": [
-        "0001_initial",
-        "0002_remove_huddlecount",
-        "0003_fillstate"
+        "[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"
+    ],
+    "auth": [
+        "[X] 0001_initial",
+        "[X] 0003_alter_user_email_max_length",
+        "[X] 0004_alter_user_username_opts",
+        "[X] 0005_alter_user_last_login_null",
+        "[X] 0006_require_contenttypes_0002",
+        "[X] 0007_alter_validators_add_error_messages",
+        "[X] 0008_alter_user_username_max_length",
+        "[X] 0009_alter_user_last_name_max_length",
+        "[X] 0010_alter_group_name_max_length",
+        "[X] 0002_alter_permission_name_max_length",
+        "[X] 0011_update_proxy_permissions",
+        "[X] 0012_alter_user_first_name_max_length"
     ],
     "confirmation": [
-        "0001_initial",
-        "0002_realmcreationkey",
-        "0003_emailchangeconfirmation"
+        "[X] 0001_squashed_0014_confirmation_confirmatio_content_80155a_idx (14 squashed migrations)",
+        "[X] 0015_alter_confirmation_object_id"
+    ],
+    "contenttypes": ["[X] 0001_initial", "[X] 0002_remove_content_type_name"],
+    "corporate": [
+        "[X] 0001_squashed_0044_convert_ids_to_bigints (44 squashed migrations)"
+    ],
+    "otp_static": [
+        "[X] 0001_initial",
+        "[X] 0002_throttling",
+        "[X] 0003_add_timestamps"
+    ],
+    "otp_totp": [
+        "[X] 0001_initial",
+        "[X] 0002_auto_20190420_0723",
+        "[X] 0003_add_timestamps"
+    ],
+    "pgroonga": [
+        "[X] 0001_enable",
+        "[X] 0002_html_escape_subject",
+        "[X] 0003_v2_api_upgrade"
+    ],
+    "phonenumber": ["[X] 0001_squashed_0001_initial (10 squashed migrations)"],
+    "sessions": ["[X] 0001_initial"],
+    "social_django": [
+        "[X] 0001_initial (2 squashed migrations)",
+        "[X] 0002_add_related_name (2 squashed migrations)",
+        "[X] 0003_alter_email_max_length (2 squashed migrations)",
+        "[X] 0004_auto_20160423_0400 (2 squashed migrations)",
+        "[X] 0005_auto_20160727_2333 (1 squashed migrations)",
+        "[X] 0006_partial",
+        "[X] 0007_code_timestamp",
+        "[X] 0008_partial_timestamp",
+        "[X] 0009_auto_20191118_0520",
+        "[X] 0010_uid_db_index",
+        "[X] 0011_alter_id_fields",
+        "[X] 0012_usersocialauth_extra_data_new",
+        "[X] 0013_migrate_extra_data",
+        "[X] 0014_remove_usersocialauth_extra_data",
+        "[X] 0015_rename_extra_data_new_usersocialauth_extra_data",
+        "[X] 0016_alter_usersocialauth_extra_data"
+    ],
+    "two_factor": ["(no migrations)"],
+    "zerver": [
+        "[X] 0001_squashed_0569 (545 squashed migrations)",
+        "[X] 0625_realm_can_invite_users_group",
+        "[X] 0626_set_default_value_for_can_invite_users_group",
+        "[X] 0627_alter_realm_can_invite_users_group",
+        "[X] 0628_remove_realm_invite_to_realm_policy",
+        "[X] 0629_remove_stream_email_token_backfill_channelemailaddress",
+        "[X] 0630_multiuseinvite_groups_preregistrationuser_groups",
+        "[X] 0631_stream_is_recently_active",
+        "[X] 0632_preregistrationrealm_data_import_metadata",
+        "[X] 0633_namedusergroup_can_remove_members_group",
+        "[X] 0634_set_default_for_can_remove_members_group",
+        "[X] 0635_alter_namedusergroup_can_remove_members_group",
+        "[X] 0636_streams_add_can_administer_channel_group",
+        "[X] 0637_set_default_for_can_administer_channel_group",
+        "[X] 0638_alter_stream_can_administer_channel_group",
+        "[X] 0640_merge_20241211_1953",
+        "[X] 0641_web_suggest_update_time_zone",
+        "[X] 0642_realm_moderation_request_channel",
+        "[X] 0643_realm_scheduled_deletion_date",
+        "[X] 0644_check_update_all_channels_active_status",
+        "[X] 0645_stream_can_send_message_group",
+        "[X] 0646_set_default_for_can_send_message_group",
+        "[X] 0647_alter_stream_can_send_message_group",
+        "[X] 0648_remove_stream_stream_post_policy",
+        "[X] 0576_backfill_imageattachment",
+        "[X] 0622_backfill_imageattachment_again",
+        "[X] 0639_zh_hant_tw_rename",
+        "[X] 0570_namedusergroup_can_manage_group",
+        "[X] 0571_set_default_for_can_manage_group",
+        "[X] 0572_alter_usergroup_can_manage_group",
+        "[X] 0573_directmessagegroup_group_size",
+        "[X] 0574_backfill_directmessagegroup_group_size",
+        "[X] 0575_alter_directmessagegroup_group_size",
+        "[X] 0577_merge_20240829_0153",
+        "[X] 0578_namedusergroup_deactivated",
+        "[X] 0579_realm_can_delete_own_message_group",
+        "[X] 0580_set_default_value_for_can_delete_own_message_group",
+        "[X] 0581_alter_realm_can_delete_own_message_group",
+        "[X] 0582_remove_realm_delete_own_message_policy",
+        "[X] 0583_namedusergroup_creator_namedusergroup_date_created",
+        "[X] 0584_namedusergroup_creator_date_created_backfill",
+        "[X] 0585_userprofile_allow_private_data_export_and_more",
+        "[X] 0586_customprofilefield_editable_by_user",
+        "[X] 0587_savedsnippet",
+        "[X] 0588_realm_add_can_create_groups",
+        "[X] 0589_set_can_create_groups",
+        "[X] 0590_alter_realm_can_create_groups",
+        "[X] 0591_realm_add_can_manage_all_groups",
+        "[X] 0592_set_can_manage_all_groups",
+        "[X] 0593_alter_realm_manage_all_groups",
+        "[X] 0594_remove_realm_user_group_edit_policy",
+        "[X] 0595_add_realmexport_table_and_backfill",
+        "[X] 0596_namedusergroup_can_join_group",
+        "[X] 0597_set_default_value_for_can_join_group",
+        "[X] 0598_alter_namedusergroup_can_join_group",
+        "[X] 0599_namedusergroup_add_can_add_members_group",
+        "[X] 0600_set_default_for_can_add_members_group",
+        "[X] 0601_alter_namedusergroup_can_add_members_group",
+        "[X] 0602_remap_can_manage_all_groups",
+        "[X] 0603_realm_can_add_custom_emoji_group",
+        "[X] 0604_set_default_value_for_can_add_custom_emoji_group",
+        "[X] 0605_alter_realm_can_add_custom_emoji_group",
+        "[X] 0606_remove_realm_add_custom_emoji_policy",
+        "[X] 0607_namedusergroup_add_can_leave_group",
+        "[X] 0608_set_default_for_can_leave_group",
+        "[X] 0609_alter_namedusergroup_can_leave_group",
+        "[X] 0610_mark_introduce_resolve_topic_modal_as_read",
+        "[X] 0611_realm_can_move_messages_between_channels_group",
+        "[X] 0612_set_default_value_for_can_move_messages_between_channels_group",
+        "[X] 0613_alter_realm_can_move_messages_between_channels_group",
+        "[X] 0614_remove_realm_move_messages_between_streams_policy",
+        "[X] 0615_system_bot_avatars",
+        "[X] 0616_userprofile_can_change_user_emails",
+        "[X] 0617_remove_prefix_from_archived_streams",
+        "[X] 0618_realm_can_move_messages_between_topics_group",
+        "[X] 0619_set_default_value_for_can_move_messages_between_topics_group",
+        "[X] 0620_alter_realm_can_move_messages_between_topics_group",
+        "[X] 0621_remove_realm_edit_topic_policy",
+        "[X] 0623_merge_20241030_1835",
+        "[X] 0624_alter_realmexport_tarball_size_bytes"
     ],
     "zilencer": [
-        "0001_initial",
-        "0002_remote_zulip_server",
-        "0003_add_default_for_remotezulipserver_last_updated_field"
-    ],
-    "corporate": [
-        "0001_initial",
-        "0002_customer_default_discount",
-        "0003_customerplan"
-    ],
-    "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
-    "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
-    "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
-    "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
-    "two_factor": [
-        "0001_initial",
-        "0002_auto_20150110_0810",
-        "0003_auto_20150817_1733",
-        "0004_auto_20160205_1827"
-    ],
-    "sessions": ["0001_initial"],
-    "default": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400"
-    ],
-    "social_auth": [
-        "0001_initial",
-        "0002_add_related_name",
-        "0003_alter_email_max_length",
-        "0004_auto_20160423_0400",
-        "0005_auto_20160727_2333"
-    ],
-    "social_django": [
-        "0006_partial",
-        "0007_code_timestamp",
-        "0008_partial_timestamp",
-        "0009_auto_20191118_0520"
+        "[X] 0001_squashed_0064_remotezulipserver_last_merge_base (64 squashed migrations)"
     ]
 }

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/extra_migrations_error.txt
@@ -7,11 +7,21 @@ Printing migrations that differ between the versions:
 --- exported realm
 +++ this server
 'auth' app:
- 0002_alter_permission_name_max_length
--0003_alter_user_email_max_length
--0004_alter_user_username_opts
++[ ] 0011_update_proxy_permissions
++[ ] 0012_alter_user_first_name_max_length
+ [X] 0001_initial
+@@ -10,3 +12 @@
+ [X] 0010_alter_group_name_max_length
+-[X] 0011_update_proxy_permissions
+-[X] 0012_alter_user_first_name_max_length
 
 'zerver' app:
- 0029_realm_subdomain
--0030_realm_org_type
--0031_remove_system_avatar_source
++[ ] 0646_set_default_for_can_send_message_group
++[ ] 0647_alter_stream_can_send_message_group
++[ ] 0648_remove_stream_stream_post_policy
+ [X] 0001_squashed_0569 (545 squashed migrations)
+@@ -77,4 +80 @@
+ [X] 0645_stream_can_send_message_group
+-[X] 0646_set_default_for_can_send_message_group
+-[X] 0647_alter_stream_can_send_message_group
+-[X] 0648_remove_stream_stream_post_policy

--- a/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
+++ b/zerver/tests/fixtures/import_fixtures/check_migrations_errors/unapplied_migrations_error.txt
@@ -7,11 +7,21 @@ Printing migrations that differ between the versions:
 --- exported realm
 +++ this server
 'auth' app:
- 0002_alter_permission_name_max_length
-+0003_alter_user_email_max_length
-+0004_alter_user_username_opts
+-[ ] 0011_update_proxy_permissions
+-[ ] 0012_alter_user_first_name_max_length
+ [X] 0001_initial
+@@ -12 +10,3 @@
+ [X] 0010_alter_group_name_max_length
++[X] 0011_update_proxy_permissions
++[X] 0012_alter_user_first_name_max_length
 
 'zerver' app:
- 0029_realm_subdomain
-+0030_realm_org_type
-+0031_remove_system_avatar_source
+-[ ] 0646_set_default_for_can_send_message_group
+-[ ] 0647_alter_stream_can_send_message_group
+-[ ] 0648_remove_stream_stream_post_policy
+ [X] 0001_squashed_0569 (545 squashed migrations)
+@@ -80 +77,4 @@
+ [X] 0645_stream_can_send_message_group
++[X] 0646_set_default_for_can_send_message_group
++[X] 0647_alter_stream_can_send_message_group
++[X] 0648_remove_stream_stream_post_policy

--- a/zerver/tests/fixtures/import_fixtures/migration_status.json
+++ b/zerver/tests/fixtures/import_fixtures/migration_status.json
@@ -1,68 +1,151 @@
 {
     "migrations_by_app": {
-        "contenttypes": ["0001_initial", "0002_remove_content_type_name"],
-        "auth": [
-            "0001_initial",
-            "0002_alter_permission_name_max_length",
-            "0003_alter_user_email_max_length",
-            "0004_alter_user_username_opts"
-        ],
-        "zerver": [
-            "0001_initial",
-            "0029_realm_subdomain",
-            "0030_realm_org_type",
-            "0031_remove_system_avatar_source"
-        ],
         "analytics": [
-            "0001_initial",
-            "0002_remove_huddlecount",
-            "0003_fillstate"
+            "[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"
+        ],
+        "auth": [
+            "[X] 0001_initial",
+            "[X] 0002_alter_permission_name_max_length",
+            "[X] 0003_alter_user_email_max_length",
+            "[X] 0004_alter_user_username_opts",
+            "[X] 0005_alter_user_last_login_null",
+            "[X] 0006_require_contenttypes_0002",
+            "[X] 0007_alter_validators_add_error_messages",
+            "[X] 0008_alter_user_username_max_length",
+            "[X] 0009_alter_user_last_name_max_length",
+            "[X] 0010_alter_group_name_max_length",
+            "[X] 0011_update_proxy_permissions",
+            "[X] 0012_alter_user_first_name_max_length"
         ],
         "confirmation": [
-            "0001_initial",
-            "0002_realmcreationkey",
-            "0003_emailchangeconfirmation"
+            "[X] 0001_squashed_0014_confirmation_confirmatio_content_80155a_idx (14 squashed migrations)",
+            "[X] 0015_alter_confirmation_object_id"
+        ],
+        "contenttypes": ["[X] 0001_initial", "[X] 0002_remove_content_type_name"],
+        "corporate": [
+            "[X] 0001_squashed_0044_convert_ids_to_bigints (44 squashed migrations)"
+        ],
+        "otp_static": [
+            "[X] 0001_initial",
+            "[X] 0002_throttling",
+            "[X] 0003_add_timestamps"
+        ],
+        "otp_totp": [
+            "[X] 0001_initial",
+            "[X] 0002_auto_20190420_0723",
+            "[X] 0003_add_timestamps"
+        ],
+        "pgroonga": [
+            "[X] 0001_enable",
+            "[X] 0002_html_escape_subject",
+            "[X] 0003_v2_api_upgrade"
+        ],
+        "phonenumber": ["[X] 0001_squashed_0001_initial (10 squashed migrations)"],
+        "sessions": ["[X] 0001_initial"],
+        "social_django": [
+            "[X] 0001_initial (2 squashed migrations)",
+            "[X] 0002_add_related_name (2 squashed migrations)",
+            "[X] 0003_alter_email_max_length (2 squashed migrations)",
+            "[X] 0004_auto_20160423_0400 (2 squashed migrations)",
+            "[X] 0005_auto_20160727_2333 (1 squashed migrations)",
+            "[X] 0006_partial",
+            "[X] 0007_code_timestamp",
+            "[X] 0008_partial_timestamp",
+            "[X] 0009_auto_20191118_0520",
+            "[X] 0010_uid_db_index",
+            "[X] 0011_alter_id_fields",
+            "[X] 0012_usersocialauth_extra_data_new",
+            "[X] 0013_migrate_extra_data",
+            "[X] 0014_remove_usersocialauth_extra_data",
+            "[X] 0015_rename_extra_data_new_usersocialauth_extra_data",
+            "[X] 0016_alter_usersocialauth_extra_data"
+        ],
+        "two_factor": ["(no migrations)"],
+        "zerver": [
+            "[X] 0001_squashed_0569 (545 squashed migrations)",
+            "[X] 0576_backfill_imageattachment",
+            "[X] 0622_backfill_imageattachment_again",
+            "[X] 0639_zh_hant_tw_rename",
+            "[X] 0570_namedusergroup_can_manage_group",
+            "[X] 0571_set_default_for_can_manage_group",
+            "[X] 0572_alter_usergroup_can_manage_group",
+            "[X] 0573_directmessagegroup_group_size",
+            "[X] 0574_backfill_directmessagegroup_group_size",
+            "[X] 0575_alter_directmessagegroup_group_size",
+            "[X] 0577_merge_20240829_0153",
+            "[X] 0578_namedusergroup_deactivated",
+            "[X] 0579_realm_can_delete_own_message_group",
+            "[X] 0580_set_default_value_for_can_delete_own_message_group",
+            "[X] 0581_alter_realm_can_delete_own_message_group",
+            "[X] 0582_remove_realm_delete_own_message_policy",
+            "[X] 0583_namedusergroup_creator_namedusergroup_date_created",
+            "[X] 0584_namedusergroup_creator_date_created_backfill",
+            "[X] 0585_userprofile_allow_private_data_export_and_more",
+            "[X] 0586_customprofilefield_editable_by_user",
+            "[X] 0587_savedsnippet",
+            "[X] 0588_realm_add_can_create_groups",
+            "[X] 0589_set_can_create_groups",
+            "[X] 0590_alter_realm_can_create_groups",
+            "[X] 0591_realm_add_can_manage_all_groups",
+            "[X] 0592_set_can_manage_all_groups",
+            "[X] 0593_alter_realm_manage_all_groups",
+            "[X] 0594_remove_realm_user_group_edit_policy",
+            "[X] 0595_add_realmexport_table_and_backfill",
+            "[X] 0596_namedusergroup_can_join_group",
+            "[X] 0597_set_default_value_for_can_join_group",
+            "[X] 0598_alter_namedusergroup_can_join_group",
+            "[X] 0599_namedusergroup_add_can_add_members_group",
+            "[X] 0600_set_default_for_can_add_members_group",
+            "[X] 0601_alter_namedusergroup_can_add_members_group",
+            "[X] 0602_remap_can_manage_all_groups",
+            "[X] 0603_realm_can_add_custom_emoji_group",
+            "[X] 0604_set_default_value_for_can_add_custom_emoji_group",
+            "[X] 0605_alter_realm_can_add_custom_emoji_group",
+            "[X] 0606_remove_realm_add_custom_emoji_policy",
+            "[X] 0607_namedusergroup_add_can_leave_group",
+            "[X] 0608_set_default_for_can_leave_group",
+            "[X] 0609_alter_namedusergroup_can_leave_group",
+            "[X] 0610_mark_introduce_resolve_topic_modal_as_read",
+            "[X] 0611_realm_can_move_messages_between_channels_group",
+            "[X] 0612_set_default_value_for_can_move_messages_between_channels_group",
+            "[X] 0613_alter_realm_can_move_messages_between_channels_group",
+            "[X] 0614_remove_realm_move_messages_between_streams_policy",
+            "[X] 0615_system_bot_avatars",
+            "[X] 0616_userprofile_can_change_user_emails",
+            "[X] 0617_remove_prefix_from_archived_streams",
+            "[X] 0618_realm_can_move_messages_between_topics_group",
+            "[X] 0619_set_default_value_for_can_move_messages_between_topics_group",
+            "[X] 0620_alter_realm_can_move_messages_between_topics_group",
+            "[X] 0621_remove_realm_edit_topic_policy",
+            "[X] 0623_merge_20241030_1835",
+            "[X] 0624_alter_realmexport_tarball_size_bytes",
+            "[X] 0625_realm_can_invite_users_group",
+            "[X] 0626_set_default_value_for_can_invite_users_group",
+            "[X] 0627_alter_realm_can_invite_users_group",
+            "[X] 0628_remove_realm_invite_to_realm_policy",
+            "[X] 0629_remove_stream_email_token_backfill_channelemailaddress",
+            "[X] 0630_multiuseinvite_groups_preregistrationuser_groups",
+            "[X] 0631_stream_is_recently_active",
+            "[X] 0632_preregistrationrealm_data_import_metadata",
+            "[X] 0633_namedusergroup_can_remove_members_group",
+            "[X] 0634_set_default_for_can_remove_members_group",
+            "[X] 0635_alter_namedusergroup_can_remove_members_group",
+            "[X] 0636_streams_add_can_administer_channel_group",
+            "[X] 0637_set_default_for_can_administer_channel_group",
+            "[X] 0638_alter_stream_can_administer_channel_group",
+            "[X] 0640_merge_20241211_1953",
+            "[X] 0641_web_suggest_update_time_zone",
+            "[X] 0642_realm_moderation_request_channel",
+            "[X] 0643_realm_scheduled_deletion_date",
+            "[X] 0644_check_update_all_channels_active_status",
+            "[X] 0645_stream_can_send_message_group",
+            "[X] 0646_set_default_for_can_send_message_group",
+            "[X] 0647_alter_stream_can_send_message_group",
+            "[X] 0648_remove_stream_stream_post_policy"
         ],
         "zilencer": [
-            "0001_initial",
-            "0002_remote_zulip_server",
-            "0003_add_default_for_remotezulipserver_last_updated_field"
-        ],
-        "corporate": [
-            "0001_initial",
-            "0002_customer_default_discount",
-            "0003_customerplan"
-        ],
-        "otp_static": ["0001_initial", "0002_throttling", "0003_add_timestamps"],
-        "otp_totp": ["0001_initial", "0002_auto_20190420_0723", "0003_add_timestamps"],
-        "pgroonga": ["0001_enable", "0002_html_escape_subject", "0003_v2_api_upgrade"],
-        "phonenumber": ["0001_initial", "0001_squashed_0001_initial"],
-        "two_factor": [
-            "0001_initial",
-            "0002_auto_20150110_0810",
-            "0003_auto_20150817_1733",
-            "0004_auto_20160205_1827"
-        ],
-        "sessions": ["0001_initial"],
-        "default": [
-            "0001_initial",
-            "0002_add_related_name",
-            "0003_alter_email_max_length",
-            "0004_auto_20160423_0400"
-        ],
-        "social_auth": [
-            "0001_initial",
-            "0002_add_related_name",
-            "0003_alter_email_max_length",
-            "0004_auto_20160423_0400",
-            "0005_auto_20160727_2333"
-        ],
-        "social_django": [
-            "0006_partial",
-            "0007_code_timestamp",
-            "0008_partial_timestamp",
-            "0009_auto_20191118_0520"
+            "[X] 0001_squashed_0064_remotezulipserver_last_merge_base (64 squashed migrations)"
         ]
     },
     "zulip_version": "10.0-dev+git"
- }
+}

--- a/zerver/tests/fixtures/import_fixtures/showmigrations_fixtures/with_stale_migrations.txt
+++ b/zerver/tests/fixtures/import_fixtures/showmigrations_fixtures/with_stale_migrations.txt
@@ -1,0 +1,76 @@
+analytics
+ [X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)
+auth
+ [X] 0001_initial
+ [X] 0002_alter_permission_name_max_length
+ [X] 0003_alter_user_email_max_length
+confirmation
+ [X] 0001_squashed_0014_confirmation_confirmatio_content_80155a_idx (14 squashed migrations)
+ [X] 0015_alter_confirmation_object_id
+contenttypes
+ [X] 0001_initial
+ [X] 0002_remove_content_type_name
+corporate
+ [X] 0001_squashed_0044_convert_ids_to_bigints (44 squashed migrations)
+guardian
+ [X] 0001_initial
+otp_static
+ [X] 0001_initial
+ [X] 0002_throttling
+ [X] 0003_add_timestamps
+otp_totp
+ [X] 0001_initial
+ [X] 0002_auto_20190420_0723
+ [X] 0003_add_timestamps
+pgroonga
+ [X] 0001_enable
+ [X] 0002_html_escape_subject
+ [X] 0003_v2_api_upgrade
+phonenumber
+ [X] 0001_squashed_0001_initial (10 squashed migrations)
+sessions
+ [X] 0001_initial
+social_django
+ [X] 0001_initial (2 squashed migrations)
+ [X] 0002_add_related_name (2 squashed migrations)
+ [X] 0003_alter_email_max_length (2 squashed migrations)
+sites
+ [X] 0001_initial
+ [X] 0002_alter_domain_unique
+two_factor
+ [X] 0001_squashed_0008_delete_phonedevice
+zerver
+ [X] 0001_squashed_0569 (545 squashed migrations)
+ [X] 0002_django_1_8
+ [X] 0003_custom_indexes
+ [X] 0004_userprofile_left_side_userlist
+ [X] 0005_auto_20150920_1340
+ [X] 0006_zerver_userprofile_email_upper_idx
+ [X] 0007_userprofile_is_bot_active_indexes
+ [X] 0008_preregistrationuser_upper_email_idx
+ [X] 0009_add_missing_migrations
+ [X] 0010_delete_streamcolor
+ [X] 0011_remove_guardian
+ [X] 0012_remove_appledevicetoken
+ [X] 0013_realmemoji
+ [X] 0014_realm_emoji_url_length
+ [X] 0015_attachment
+ [X] 0016_realm_create_stream_by_admins_only
+ [X] 0017_userprofile_bot_type
+ [X] 0018_realm_emoji_message
+ [X] 0019_preregistrationuser_realm_creation
+ [X] 0020_add_tracking_attachment
+ [X] 0021_migrate_attachment_data
+ [X] 0022_subscription_pin_to_top
+ [X] 0023_userprofile_default_language
+ [X] 0024_realm_allow_message_editing
+ [X] 0025_realm_message_content_edit_limit
+ [X] 0026_delete_mituser
+ [X] 0027_realm_default_language
+ [X] 0028_userprofile_tos_version
+ [X] 0576_backfill_imageattachment
+ [X] 0622_backfill_imageattachment_again
+default
+ [X] 0005_auto_20160727_2333
+zilencer
+ [X] 0001_squashed_0064_remotezulipserver_last_merge_base (64 squashed migrations)

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -2070,8 +2070,8 @@ class RealmImportExportTest(ExportFile):
         with (
             self.assertRaises(Exception) as e,
             self.assertLogs(level="INFO"),
-            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
-            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+            patch("zerver.lib.export.parse_migration_status") as mock_export,
+            patch("zerver.lib.import_realm.parse_migration_status") as mock_import,
         ):
             mock_export.return_value = self.get_applied_migrations_fixture(
                 "with_unapplied_migrations.json"
@@ -2096,8 +2096,8 @@ class RealmImportExportTest(ExportFile):
         with (
             self.assertRaises(Exception) as e,
             self.assertLogs(level="INFO"),
-            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
-            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+            patch("zerver.lib.export.parse_migration_status") as mock_export,
+            patch("zerver.lib.import_realm.parse_migration_status") as mock_import,
         ):
             mock_export.return_value = self.get_applied_migrations_fixture(
                 "with_complete_migrations.json"
@@ -2121,8 +2121,8 @@ class RealmImportExportTest(ExportFile):
         with (
             self.settings(BILLING_ENABLED=False),
             self.assertLogs(level="WARNING") as mock_log,
-            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
-            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+            patch("zerver.lib.export.parse_migration_status") as mock_export,
+            patch("zerver.lib.import_realm.parse_migration_status") as mock_import,
         ):
             mock_export.return_value = self.get_applied_migrations_fixture(
                 "with_complete_migrations.json"
@@ -2148,8 +2148,8 @@ class RealmImportExportTest(ExportFile):
         with (
             self.settings(BILLING_ENABLED=False),
             self.assertLogs(level="WARNING") as mock_log,
-            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
-            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+            patch("zerver.lib.export.parse_migration_status") as mock_export,
+            patch("zerver.lib.import_realm.parse_migration_status") as mock_import,
         ):
             mock_export.return_value = self.get_applied_migrations_fixture("with_missing_apps.json")
             mock_import.return_value = self.get_applied_migrations_fixture(
@@ -2178,8 +2178,8 @@ class RealmImportExportTest(ExportFile):
         with (
             self.settings(BILLING_ENABLED=False),
             self.assertLogs(level="INFO"),
-            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
-            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+            patch("zerver.lib.export.parse_migration_status") as mock_export,
+            patch("zerver.lib.import_realm.parse_migration_status") as mock_import,
         ):
             mock_export.return_value = self.get_applied_migrations_fixture(
                 "with_complete_migrations.json"
@@ -2240,8 +2240,8 @@ class RealmImportExportTest(ExportFile):
         realm = get_realm("zulip")
         with (
             self.assertLogs(level="INFO"),
-            patch("zerver.lib.export.get_migrations_by_app") as mock_export,
-            patch("zerver.lib.import_realm.get_migrations_by_app") as mock_import,
+            patch("zerver.lib.export.parse_migration_status") as mock_export,
+            patch("zerver.lib.import_realm.parse_migration_status") as mock_import,
         ):
             mock_export.return_value = self.get_applied_migrations_fixture(
                 "with_unsorted_migrations_list.json"

--- a/zerver/tests/test_migration_status.py
+++ b/zerver/tests/test_migration_status.py
@@ -1,0 +1,61 @@
+from zerver.lib.migration_status import (
+    STALE_MIGRATIONS,
+    AppMigrations,
+    get_migration_status,
+    parse_migration_status,
+)
+from zerver.lib.test_classes import ZulipTestCase
+
+
+class MigrationStatusTests(ZulipTestCase):
+    def test_parse_migration_status(self) -> None:
+        showmigrations_sample = """
+analytics
+ [X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)
+auth
+ [ ] 0012_alter_user_first_name_max_length
+zerver
+ [-] 0015_alter_confirmation_object_id
+two_factor
+ (no migrations)
+"""
+        app_migrations = parse_migration_status(showmigrations_sample)
+        expected: AppMigrations = {
+            "analytics": ["[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"],
+            "auth": ["[ ] 0012_alter_user_first_name_max_length"],
+            "zerver": ["[-] 0015_alter_confirmation_object_id"],
+            "two_factor": ["(no migrations)"],
+        }
+        self.assertDictEqual(app_migrations, expected)
+
+        # Run one with the real showmigrations. A more thorough tests of these
+        # functions are done in the test_import_export.py as part of the import-
+        # export suite.
+        showmigrations = get_migration_status(app_label="zerver")
+        app_migrations = parse_migration_status(showmigrations)
+        zerver_migrations = app_migrations.get("zerver")
+        self.assertIsNotNone(zerver_migrations)
+        self.assertNotEqual(zerver_migrations, [])
+
+    def test_parse_stale_migration_status(self) -> None:
+        assert ("guardian", "0001_initial") in STALE_MIGRATIONS
+        showmigrations_sample = """
+analytics
+ [X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)
+auth
+ [ ] 0012_alter_user_first_name_max_length
+zerver
+ [-] 0015_alter_confirmation_object_id
+two_factor
+ (no migrations)
+guardian
+ [X] 0001_initial
+"""
+        app_migrations = parse_migration_status(showmigrations_sample)
+        expected: AppMigrations = {
+            "analytics": ["[X] 0001_squashed_0021_alter_fillstate_id (21 squashed migrations)"],
+            "auth": ["[ ] 0012_alter_user_first_name_max_length"],
+            "zerver": ["[-] 0015_alter_confirmation_object_id"],
+            "two_factor": ["(no migrations)"],
+        }
+        self.assertDictEqual(app_migrations, expected)


### PR DESCRIPTION
The current `get_migration_by_app` has a rather naive approach to compiling the migration status of a realm, which has led to issues like #32826. Specifically, those flaws are:
- It does not report the complete state of the migration status of the exporting servers, only the applied migration.
- It shows both the replaced and the squashing migrations. This would be a problem if we decide to delete old migrations we've replaced and import a slightly older realm with those still intact, `check_migration_status` would complain of incompatibility even though those migration files don't matter (they are replaced, after all). 
- It does not clean up ancient/stale applied migrations  (for reference, see how `check-database-compatibility` cleans those) 

This PR attempts to write a better `migration_status.json` by parsing the output of `showmigrations` instead of trying to manually write one like in `get_migration_by_app`. 

This is because Django's `showmigrations`([source](https://github.com/django/django/blob/8c118c0e00846091c261b97dbed9a5b89ceb79bf/django/core/management/commands/showmigrations.py#L113)) has a lot more logic and validations baked into it than previously thought. Ones that we care about are:
- it does validations to make sure app names are valid
- it doesn't list replaced migrations and only squashed one
- it takes into account migrations in disk(`MigrationsLoader`) vs applied migrations (`MigrationsRecorder`)

Which would resolve the first two points highlighted above.

Additionally, this PR also consolidates the list of stale migrations from `check-database-compatibility` to `lib/migration_status.py` and shares it with the migration status-related functions there to resolve the third point above.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
