### PR TITLE
billing: Fix "Payment method" wrapping to next line.

### DIFF
--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -650,7 +650,7 @@ input[name="licenses"] {
 #upgrade-page-details #upgrade-payment-menthod-wrapper {
     margin-left: 0;
     grid-area: payment-info;
-    width: auto;
+    width: 100%;
 }
 
 /* Used class twice to increase specificity */


### PR DESCRIPTION
Likely due to increase in font size payment method is wrapping to next line.

| before | after |
| --- | --- |
|![Screenshot from 2025-01-14 19-41-26](https://github.com/user-attachments/assets/a29d72c3-fcfa-4f02-ade1-1e291d343d2f) | ![Screenshot from 2025-01-14 19-41-12](https://github.com/user-attachments/assets/4ec3647e-0cc2-4ad3-a469-823171cd4f65) | 
