### PR TITLE
presence_data: Fix last_active_time for users with invisible mode on.

### DIFF
--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -8,6 +8,7 @@ from django.db import connection
 from django.utils.timezone import now as timezone_now
 from typing_extensions import override
 
+from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.users import do_deactivate_user
 from zerver.lib.presence import format_legacy_presence_dict, get_presence_dict_by_realm
 from zerver.lib.test_classes import ZulipTestCase
@@ -1010,6 +1011,88 @@ class GetRealmStatusesTest(ZulipTestCase):
         self.assertEqual(
             set(json["presences"].keys()), {hamlet.email, polonius.email, othello.email}
         )
+
+    def test_do_change_user_setting_presence_enabled(self) -> None:
+        """
+        Tests the logic for backdating user's presence
+        """
+        hamlet = self.example_user("hamlet")
+        UserPresence.objects.filter(user_profile=hamlet).delete()
+        now = timezone_now()
+
+        # If the user has no presence at all, disabling presence_enabled should not change that state.
+        with time_machine.travel(now, tick=False), self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(hamlet, "presence_enabled", False, acting_user=hamlet)
+        self.assertFalse(UserPresence.objects.filter(user_profile=hamlet).exists())
+
+        # Enabling presence_enabled creates a new, current presence record.
+        with time_machine.travel(now, tick=False), self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(hamlet, "presence_enabled", True, acting_user=hamlet)
+
+        presence = UserPresence.objects.get(user_profile=hamlet)
+        self.assertEqual(presence.last_connected_time, now)
+        self.assertEqual(presence.last_active_time, now)
+
+        # Disabling presence_enabled with a very recent presence record will cause it to get backdated
+        # by some minutes to make the user immediately appear offline.
+        with time_machine.travel(now, tick=False), self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(hamlet, "presence_enabled", False, acting_user=hamlet)
+        presence = UserPresence.objects.get(user_profile=hamlet)
+        self.assertEqual(
+            presence.last_connected_time,
+            now
+            - timedelta(
+                seconds=settings.OFFLINE_THRESHOLD_SECS
+                + settings.PRESENCE_UPDATE_MIN_FREQ_SECONDS
+                + 10
+            ),
+        )
+        self.assertEqual(
+            presence.last_active_time,
+            now
+            - timedelta(
+                seconds=settings.OFFLINE_THRESHOLD_SECS
+                + settings.PRESENCE_UPDATE_MIN_FREQ_SECONDS
+                + 10
+            ),
+        )
+
+        # Now we set up a very old presence record.
+        hamlet.presence_enabled = True
+        hamlet.save()
+        presence.last_connected_time = now - timedelta(days=100)
+        presence.last_active_time = now - timedelta(days=100)
+        presence.save()
+
+        # With a very old presence record, disabling presence_enabled should not change that.
+        with time_machine.travel(now, tick=False), self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(hamlet, "presence_enabled", False, acting_user=hamlet)
+        presence = UserPresence.objects.get(user_profile=hamlet)
+        self.assertEqual(presence.last_connected_time, now - timedelta(days=100))
+        self.assertEqual(presence.last_active_time, now - timedelta(days=100))
+
+        hamlet.presence_enabled = True
+        hamlet.save()
+        # Now set up the final edge case - a very old last_active_time and a recent last_connected_time.
+        # In this case, last_connected_time should get backdated (to ensure the user appears offline),
+        # without pushing last_active_time forward.
+        presence.last_active_time = now - timedelta(days=100)
+        presence.last_connected_time = now - timedelta(seconds=1)
+        presence.save()
+
+        with time_machine.travel(now, tick=False), self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(hamlet, "presence_enabled", False, acting_user=hamlet)
+        presence = UserPresence.objects.get(user_profile=hamlet)
+        self.assertEqual(
+            presence.last_connected_time,
+            now
+            - timedelta(
+                seconds=settings.OFFLINE_THRESHOLD_SECS
+                + settings.PRESENCE_UPDATE_MIN_FREQ_SECONDS
+                + 10
+            ),
+        )
+        self.assertEqual(presence.last_active_time, now - timedelta(days=100))
 
     def test_presence_disabled(self) -> None:
         # Disable presence status and test whether the presence


### PR DESCRIPTION
This pull request introduces a change to the `status_from_raw` function in the `web/src/presence.ts` file to account for users who have turned on 'Go invisible' mode. 

## Changes

* Modified the `status_from_raw` function to accept an additional `user_id` parameter.
* Added logic to handle the 'Go invisible' mode by comparing the user's `date_joined` with `last_active` and setting the `last_active` to `idle_timestamp` if the user is considered invisible.
* Added a new test case to verify the 'Go invisible' mode functionality.

<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20last.20active.20time/near/2011826).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
