### PR TITLE
billing: Fix deleting next fixed-price plan via support.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -7730,7 +7730,7 @@ class TestRemoteRealmBillingFlow(StripeTestCase, RemoteRealmBillingTestCase):
             support_type=SupportType.delete_fixed_price_next_plan,
         )
         success_message = billing_session.process_support_view_request(support_request)
-        self.assertEqual(success_message, "Fixed price offer deleted")
+        self.assertEqual(success_message, "Fixed-price plan offer deleted")
         result = self.client_get("/activity/remote/support", {"q": "example.com"})
         self.assert_not_in_success_response(["Next plan information:"], result)
         self.assert_in_success_response(

--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -1647,7 +1647,7 @@ class TestSupportEndpoint(ZulipTestCase):
             },
         )
         self.assert_in_success_response(
-            ["Fixed price offer deleted"],
+            ["Fixed-price plan offer deleted"],
             result,
         )
         customer.refresh_from_db()
@@ -1795,6 +1795,21 @@ class TestSupportEndpoint(ZulipTestCase):
         self.assertEqual(next_plan.billing_cycle_anchor, plan.end_date)
         self.assertEqual(next_plan.charge_automatically, plan.charge_automatically)
         self.assertTrue(next_plan.automanage_licenses)
+
+        # Test deleting the fixed-price next plan via support.
+        result = self.client_post(
+            "/activity/support",
+            {
+                "realm_id": f"{lear_realm.id}",
+                "delete_fixed_price_next_plan": "true",
+            },
+        )
+        self.assert_in_success_response(
+            ["Fixed-price scheduled plan deleted"],
+            result,
+        )
+        next_plan = billing_session.get_next_plan(plan)
+        self.assertIsNone(next_plan)
 
     def test_approve_sponsorship_deactivated_realm(self) -> None:
         support_admin = self.example_user("iago")


### PR DESCRIPTION
If the customer has a current fixed-price plan and a support admin configures a fixed-price plan for the upcoming billing year, then a `CustomerPlan` object is created and not a `CustomerPlanOffer`.

Fixes the support action for deleting a configured fixed-price next plan. Currently trying to delete the scheduled next fixed-price plan returns an error.

Updates the success strings for these actions to be specify if the deleted object was a plan offer or a scheduled plan.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
