### PR TITLE
searchbox_css: Refactor styles for `clear_search_button`.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -982,7 +982,7 @@ textarea.new_message_textarea {
 
     #stream_message_recipient_topic:placeholder-shown
         + #recipient_box_clear_topic_button {
-        display: none;
+        visibility: hidden;
     }
     /* This will reset the bootstrap margin-bottom: 10px value for the inputs */
     & input {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -92,7 +92,7 @@
         }
 
         #inbox-search:placeholder-shown + #inbox-clear-search {
-            display: none;
+            visibility: hidden;
         }
 
         #inbox-search {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1219,7 +1219,7 @@ li.top_left_scheduled_messages {
 }
 
 #filter-topic-input:placeholder-shown + #clear_search_topic_button {
-    display: none;
+    visibility: hidden;
 }
 
 .searching-for-more-topics img {
@@ -1759,11 +1759,11 @@ li.topic-list-item {
 
     .direct-messages-list-filter:placeholder-shown
         + #clear-direct-messages-search-button {
-        display: none;
+        visibility: hidden;
     }
 
     .stream-list-filter:placeholder-shown + #clear_search_stream_button {
-        display: none;
+        visibility: hidden;
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1211,7 +1211,7 @@ li.top_left_scheduled_messages {
 
 .topic-list-filter {
     box-shadow: none;
-    padding-right: 28px;
+    padding-right: var(--line-height-sidebar-row-prominent);
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
@@ -1744,7 +1744,7 @@ li.topic-list-item {
         /* Pad the entire clear-button area,
            so that input text does not bleed
            into there. */
-        padding-right: 30px;
+        padding-right: var(--line-height-sidebar-row-prominent);
     }
 
     .clear_search_button {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1134,9 +1134,12 @@ li.top_left_scheduled_messages {
 }
 
 .topic_search_section {
-    padding: 8px 10px;
     display: grid;
-    grid-template: "search-input clear-search" auto / minmax(0, 1fr) 30px;
+    grid-template-columns:
+        var(--left-sidebar-toggle-width-offset) 0 0
+        [filter-box-start] minmax(0, 1fr)
+        minmax(0, max-content)
+        [filter-box-end clear-button] 0;
 }
 
 .topic-box .zero_count {
@@ -1212,8 +1215,7 @@ li.top_left_scheduled_messages {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    grid-column: search-input-start / clear-search-end;
-    grid-row: search-input;
+    grid-column: filter-box;
 }
 
 #filter-topic-input:placeholder-shown + #clear_search_topic_button {
@@ -1728,6 +1730,7 @@ li.topic-list-item {
     }
 }
 
+.topic_search_section,
 .stream_search_section,
 .direct-messages-search-section {
     .stream-list-filter,
@@ -1751,6 +1754,7 @@ li.topic-list-item {
         place-items: center;
         width: 30px;
         margin-left: -30px;
+        grid-column: clear-button;
     }
 
     .direct-messages-list-filter:placeholder-shown

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -488,7 +488,7 @@ $user_status_emoji_width: 24px;
         }
 
         .user-list-filter:placeholder-shown + #clear_search_people_button {
-            display: none;
+            visibility: hidden;
         }
     }
 


### PR DESCRIPTION
This PR does following changes:
- use grid-template-columns for topic_search_section
- replaces display: none with visibility: hidden for different search boxes
- reduce padding-right to 28px for search-sections (stream-search, direct-message-search)

[czo](https://chat.zulip.org/#narrow/channel/6-frontend/topic/standardize.20css.20properties.20to.20hide.20elements.2E)

**padding-right changes:**
| 30px | 28px (now) |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/cfa0b9d9-5279-4126-8cf1-aab119e62417) | ![After Image](https://github.com/user-attachments/assets/ece0f546-ffd3-4892-924e-48ede4e8863e) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
