### PR TITLE
billing: Update billing page label elements to header elements.

### DIFF
--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -42,8 +42,8 @@
         <div class="white-box">
             <div id="billing-page-details">
                 <div class="input-box billing-page-field">
-                    <label for="org-current-plan">Your plan</label>
-                    <div id="org-current-plan" class="not-editable-realm-field">
+                    <label>Your plan</label>
+                    <div class="not-editable-realm-field">
                         {% if free_trial or downgrade_at_end_of_free_trial %}
                         <a href="{{ billing_base_url }}/plans/">
                             {{ plan_name }} <i>(free trial)</i>
@@ -73,7 +73,7 @@
                   {%if downgrade_at_end_of_cycle %}data-downgrade-eoc="true"{% endif %}
                   {%if switch_to_monthly_at_end_of_cycle %}data-switch-to-monthly-eoc="true"{% endif %}
                   {%if switch_to_annual_at_end_of_cycle %}data-switch-to-annual-eoc="true"{% endif %}>
-                    <label for="org-billing-frequency">Billing frequency</label>
+                    <label >Billing frequency</label>
                     {% if downgrade_at_end_of_free_trial or downgrade_at_end_of_cycle or complimentary_access_plan or fixed_price_plan or (free_trial and not charge_automatically) %}
                     <div class="not-editable-realm-field">
                         {{ billing_frequency }}
@@ -109,7 +109,7 @@
                 {% if complimentary_access_plan or fixed_price_plan %}
                 {% elif automanage_licenses %}
                 <div class="input-box billing-page-field">
-                    <label for="automatic-license-count">
+                    <label>
                         Number of licenses
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -122,7 +122,7 @@
                         {% endif %}
 
                     </label>
-                    <div id="automatic-license-count" class="not-editable-realm-field">
+                    <div class="not-editable-realm-field">
                         {{ licenses }}
                         <br />
                         Licenses are managed
@@ -200,15 +200,15 @@
                 </form>
                 <div id="toggle-license-management-error" class="alert alert-danger"></div>
                 <div class="input-box billing-page-field">
-                    <label for="billing-contact">Billing contact</label>
-                    <div id="billing-contact" class="not-editable-realm-field">
+                    <label>Billing contact</label>
+                    <div class="not-editable-realm-field">
                         <a href="mailto:{{ stripe_email }}">{{ stripe_email }}</a>
                     </div>
                 </div>
                 <div id="cardchange-error" class="alert alert-danger"></div>
                 <div class="input-box billing-page-field">
-                    <label for="customer-payment-method">Payment method</label>
-                    <div id="customer-payment-method" class="not-editable-realm-field">
+                    <label>Payment method</label>
+                    <div class="not-editable-realm-field">
                         {{ payment_method }}
                     </div>
                     {% if charge_automatically %}
@@ -279,7 +279,7 @@
                             {% if free_trial and not charge_automatically %}
                             {% else %}
                             <div class="input-box billing-page-field">
-                                <label for="expected-charge">Expected next charge</label>
+                                <label>Expected next charge</label>
                                 {% if not fixed_price_plan %}
                                 <div class="not-editable-realm-field">
                                     ${{ pre_discount_renewal_cents }} (${{ price_per_license }} x {{ licenses_at_next_renewal }} {{ 'user' if licenses_at_next_renewal == 1 else 'users' }} x

--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -42,8 +42,8 @@
         <div class="white-box">
             <div id="billing-page-details">
                 <div class="input-box billing-page-field">
-                    <label>Your plan</label>
-                    <div class="not-editable-realm-field">
+                    <h2 class="billing-section-title">Your plan</h2>
+                    <div class="billing-section-content">
                         {% if free_trial or downgrade_at_end_of_free_trial %}
                         <a href="{{ billing_base_url }}/plans/">
                             {{ plan_name }} <i>(free trial)</i>
@@ -73,13 +73,13 @@
                   {%if downgrade_at_end_of_cycle %}data-downgrade-eoc="true"{% endif %}
                   {%if switch_to_monthly_at_end_of_cycle %}data-switch-to-monthly-eoc="true"{% endif %}
                   {%if switch_to_annual_at_end_of_cycle %}data-switch-to-annual-eoc="true"{% endif %}>
-                    <label >Billing frequency</label>
+                    <h2 class="billing-section-title">Billing frequency</h2>
                     {% if downgrade_at_end_of_free_trial or downgrade_at_end_of_cycle or complimentary_access_plan or fixed_price_plan or (free_trial and not charge_automatically) %}
-                    <div class="not-editable-realm-field">
+                    <div class="billing-section-content">
                         {{ billing_frequency }}
                     </div>
                     {% elif switch_to_annual_at_end_of_cycle %}
-                    <select name="schedule" id="org-billing-frequency-annual" class="billing-frequency-select">
+                    <select name="schedule" id="org-billing-frequency-annual" class="billing-frequency-select billing-section-content">
                         <option value="Monthly">Monthly</option>
                         <option value="Annual" selected>Annual</option>
                     </select>
@@ -87,7 +87,7 @@
                         Your plan will switch to annual billing on {{ renewal_date }}.
                     </div>
                     {%elif switch_to_monthly_at_end_of_cycle %}
-                    <select name="schedule" id="org-billing-frequency-monthly" class="billing-frequency-select">
+                    <select name="schedule" id="org-billing-frequency-monthly" class="billing-frequency-select billing-section-content">
                         <option value="Monthly" selected>Monthly</option>
                         <option value="Annual">Annual</option>
                     </select>
@@ -95,7 +95,7 @@
                         Your plan will switch to monthly billing on {{ renewal_date }}.
                     </div>
                     {% else %}
-                    <select name="schedule" id="org-billing-frequency-default" class="billing-frequency-select">
+                    <select name="schedule" id="org-billing-frequency-default" class="billing-frequency-select billing-section-content">
                         <option value="Monthly" {% if billing_frequency == "Monthly" %}selected{% endif %}>Monthly</option>
                         <option value="Annual" {% if billing_frequency == "Annual" %}selected{% endif %}>Annual</option>
                     </select>
@@ -109,7 +109,7 @@
                 {% if complimentary_access_plan or fixed_price_plan %}
                 {% elif automanage_licenses %}
                 <div class="input-box billing-page-field">
-                    <label>
+                    <h2 class="billing-section-title">
                         Number of licenses
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -121,8 +121,8 @@
                         </a>
                         {% endif %}
 
-                    </label>
-                    <div class="not-editable-realm-field">
+                    </h2>
+                    <div class="billing-section-content">
                         {{ licenses }}
                         <br />
                         Licenses are managed
@@ -135,7 +135,7 @@
                 {% else %}
                 {% if not (free_trial or downgrade_at_end_of_free_trial) %}
                 <div class="input-box billing-page-field input-box-number">
-                    <label for="current-manual-license-count">
+                    <h2 class="billing-section-title">
                         Number of licenses for current billing period
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -146,10 +146,10 @@
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
                         {% endif %}
-                    </label>
+                    </h2>
                     <div class="number-input-with-label">
                         <form id="current-license-change-form">
-                            <input type="number" name="licenses" autocomplete="off" id="current-manual-license-count" class="short-width-number-input" data-original-value="{{ licenses }}" value="{{ licenses }}" {%if not exempt_from_license_number_check %}min="{{ seat_count }}"{% endif %} required/>
+                            <input type="number" name="licenses" autocomplete="off" id="current-manual-license-count" class="short-width-number-input billing-section-content" data-original-value="{{ licenses }}" value="{{ licenses }}" {%if not exempt_from_license_number_check %}min="{{ seat_count }}"{% endif %} required/>
                         </form>
                         <span class="licence-count-in-use">licenses ({{ seat_count }} in use)</span>
                         <button id="current-manual-license-count-update-button" class="license-count-update-button hide">
@@ -169,7 +169,7 @@
                 {% endif %}
                 {% if not (downgrade_at_end_of_cycle or downgrade_at_end_of_free_trial) %}
                 <div class="input-box billing-page-field input-box-number">
-                    <label for="next-manual-license-count">
+                    <h2 class="billing-section-title">
                         Number of licenses for next billing period
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -180,10 +180,10 @@
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
                         {% endif %}
-                    </label>
+                    </h2>
                     <div class="number-input-with-label">
                         <form id="next-license-change-form">
-                            <input type="number" name="licenses_at_next_renewal" autocomplete="off" id="next-manual-license-count" class="short-width-number-input" data-original-value="{{ licenses_at_next_renewal }}" value="{{ licenses_at_next_renewal }}" {%if not exempt_from_license_number_check %}min="{{ seat_count }}"{% endif %} required/>
+                            <input type="number" name="licenses_at_next_renewal" autocomplete="off" id="next-manual-license-count" class="short-width-number-input billing-section-content" data-original-value="{{ licenses_at_next_renewal }}" value="{{ licenses_at_next_renewal }}" {%if not exempt_from_license_number_check %}min="{{ seat_count }}"{% endif %} required/>
                         </form>
                         <span class="licence-count-in-use">licenses ({{ seat_count }} in use)</span>
                         <button id="next-manual-license-count-update-button" class="license-count-update-button hide">
@@ -200,15 +200,15 @@
                 </form>
                 <div id="toggle-license-management-error" class="alert alert-danger"></div>
                 <div class="input-box billing-page-field">
-                    <label>Billing contact</label>
-                    <div class="not-editable-realm-field">
+                    <h2 class="billing-section-title">Billing contact</h2>
+                    <div class="billing-section-content">
                         <a href="mailto:{{ stripe_email }}">{{ stripe_email }}</a>
                     </div>
                 </div>
                 <div id="cardchange-error" class="alert alert-danger"></div>
                 <div class="input-box billing-page-field">
-                    <label>Payment method</label>
-                    <div class="not-editable-realm-field">
+                    <h2 class="billing-section-title">Payment method</h2>
+                    <div class="billing-section-content">
                         {{ payment_method }}
                     </div>
                     {% if charge_automatically %}
@@ -279,9 +279,9 @@
                             {% if free_trial and not charge_automatically %}
                             {% else %}
                             <div class="input-box billing-page-field">
-                                <label>Expected next charge</label>
+                                <h2 class="billing-section-title">Expected next charge</h2>
                                 {% if not fixed_price_plan %}
-                                <div class="not-editable-realm-field">
+                                <div class="billing-section-content">
                                     ${{ pre_discount_renewal_cents }} (${{ price_per_license }} x {{ licenses_at_next_renewal }} {{ 'user' if licenses_at_next_renewal == 1 else 'users' }} x
                                     {% if switch_to_annual_at_end_of_cycle %}
                                         12 months
@@ -317,8 +317,8 @@
                     </div>
                 </div>
                 <div class="input-box billing-page-field">
-                    <label>Invoices</label>
-                    <div class="not-editable-realm-field">
+                    <h2 class="billing-section-title">Invoices</h2>
+                    <div class="billing-section-content">
                         <a href="{{ billing_base_url }}/invoices/">
                             View past invoices
                         </a>

--- a/templates/corporate/billing/billing.html
+++ b/templates/corporate/billing/billing.html
@@ -42,7 +42,7 @@
         <div class="white-box">
             <div id="billing-page-details">
                 <div class="input-box billing-page-field">
-                    <label for="org-current-plan" class="inline-block label-title">Your plan</label>
+                    <label for="org-current-plan">Your plan</label>
                     <div id="org-current-plan" class="not-editable-realm-field">
                         {% if free_trial or downgrade_at_end_of_free_trial %}
                         <a href="{{ billing_base_url }}/plans/">
@@ -109,7 +109,7 @@
                 {% if complimentary_access_plan or fixed_price_plan %}
                 {% elif automanage_licenses %}
                 <div class="input-box billing-page-field">
-                    <label for="automatic-license-count" class="inline-block label-title">
+                    <label for="automatic-license-count">
                         Number of licenses
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-automatic-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -135,7 +135,7 @@
                 {% else %}
                 {% if not (free_trial or downgrade_at_end_of_free_trial) %}
                 <div class="input-box billing-page-field input-box-number">
-                    <label for="current-manual-license-count" class="inline-block label-title">
+                    <label for="current-manual-license-count">
                         Number of licenses for current billing period
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -169,7 +169,7 @@
                 {% endif %}
                 {% if not (downgrade_at_end_of_cycle or downgrade_at_end_of_free_trial) %}
                 <div class="input-box billing-page-field input-box-number">
-                    <label for="next-manual-license-count" class="inline-block label-title">
+                    <label for="next-manual-license-count">
                         Number of licenses for next billing period
                         {% if is_self_hosted_billing %}
                         <a href="/help/self-hosted-billing#how-does-manual-license-management-work" target="_blank" rel="noopener noreferrer">
@@ -200,14 +200,14 @@
                 </form>
                 <div id="toggle-license-management-error" class="alert alert-danger"></div>
                 <div class="input-box billing-page-field">
-                    <label for="billing-contact" class="inline-block label-title">Billing contact</label>
+                    <label for="billing-contact">Billing contact</label>
                     <div id="billing-contact" class="not-editable-realm-field">
                         <a href="mailto:{{ stripe_email }}">{{ stripe_email }}</a>
                     </div>
                 </div>
                 <div id="cardchange-error" class="alert alert-danger"></div>
                 <div class="input-box billing-page-field">
-                    <label for="customer-payment-method" class="inline-block label-title">Payment method</label>
+                    <label for="customer-payment-method">Payment method</label>
                     <div id="customer-payment-method" class="not-editable-realm-field">
                         {{ payment_method }}
                     </div>
@@ -317,7 +317,7 @@
                     </div>
                 </div>
                 <div class="input-box billing-page-field">
-                    <label class="inline-block label-title">Invoices</label>
+                    <label>Invoices</label>
                     <div class="not-editable-realm-field">
                         <a href="{{ billing_base_url }}/invoices/">
                             View past invoices

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -1168,6 +1168,25 @@ button#register_auth_button_gitlab {
     }
 }
 
+#billing-page-details {
+    .billing-section-title {
+        display: block;
+        margin: 2px;
+        font-size: 1rem;
+        font-weight: 600;
+        color: hsl(0deg 0% 27%);
+        line-height: 20px;
+        text-align: left;
+    }
+
+    .billing-section-content {
+        font-weight: normal;
+        margin: 2px;
+        text-align: left;
+        overflow-wrap: break-word;
+    }
+}
+
 .static.org-url + #subdomain_section {
     margin-top: 0 !important;
 


### PR DESCRIPTION
Updates the billing page HML and CSS to use header elements and classes for styling instead of label elements. Most of the label elements were not associated with any form or input elements, and were serving the role of a section header.

This also fixes an issue with displaying the next charge amount for fixed-price plans that are scheduled; see first screenshot.

*Sidenote: It looks like the CSS rules are still being applied/ordered oddly on these corporate billing pages as the font-family that's being applied (at least in the dev environment) is the one set by bootstrap and not portico.*

---

**Screenshots and screen captures:**

<details>
<summary>Scheduled upgrade to fixed-price plan</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-14 17-56-49](https://github.com/user-attachments/assets/79487fac-43cc-442a-806f-b304e99689e5) | ![Screenshot from 2025-01-14 17-57-07](https://github.com/user-attachments/assets/bcdd1bb4-ca33-4d45-b43e-acf112f8b778) |
</details>

<details>
<summary>Scheduled upgrade with invoice from complimentary access plan</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-14 17-50-29](https://github.com/user-attachments/assets/74b49be2-c080-4e2f-98a7-e28dfc40c332) | ![Screenshot from 2025-01-14 17-50-43](https://github.com/user-attachments/assets/7598a656-f61a-43a5-a90b-03107bfe6f34) |
</details>
<details>
<summary>Current plan with manual license management and pay by card</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-14 17-46-11](https://github.com/user-attachments/assets/0e178e55-b484-451b-ab73-701f38ab9b91) | ![Screenshot from 2025-01-14 17-46-28](https://github.com/user-attachments/assets/aaea7326-4536-4a97-9d3f-da9e7a9f858c) |
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
