### PR TITLE
message_edit: Disallow resolving empty string topic.

### DIFF
--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -86,7 +86,7 @@
                 </a>
             </li>
             {{/if}}
-            {{#if can_rename_topic}}
+            {{#if (and can_rename_topic (not is_empty_string_topic))}}
             <li role="none" class="link-item popover-menu-list-item">
                 <a role="menuitem" class="sidebar-popover-toggle-resolved popover-menu-link" tabindex="0">
                     {{# if topic_is_resolved }}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -54,7 +54,7 @@
                 <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
             {{/if}}
 
-            {{#if user_can_resolve_topic}}
+            {{#if (and user_can_resolve_topic (not is_empty_string_topic))}}
                 {{#if topic_is_resolved}}
                     <i class="fa fa-check on_hover_topic_unresolve recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as unresolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as unresolved' }}"></i>
                 {{else}}

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -121,6 +121,12 @@ def validate_message_edit_payload(
     if propagate_mode != "change_one" and topic_name is None and stream_id is None:
         raise JsonableError(_("Invalid propagate_mode without topic edit"))
 
+    if topic_name in {
+        RESOLVED_TOPIC_PREFIX.strip(),
+        f"{RESOLVED_TOPIC_PREFIX}{Message.EMPTY_TOPIC_FALLBACK_NAME}",
+    }:
+        raise JsonableError(_("General chat cannot be marked as resolved"))
+
     if topic_name is not None:
         check_stream_topic(topic_name)
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8515,6 +8515,10 @@ paths:
                     the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
 
+                    You can [resolve topics](/help/resolve-a-topic) by editing the topic to
+                    `✔ {original_topic}` with the `propagate_mode` parameter set to
+                    `"change_all"`. The empty string topic cannot be marked as resolved.
+
                     **Changes**: Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
 

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -1757,3 +1757,17 @@ class MessageMoveTopicTest(ZulipTestCase):
             topic_messages[0].content,
             f"@_**Iago|{admin_user.id}** has marked this topic as resolved.",
         )
+
+    def test_resolve_empty_string_topic(self) -> None:
+        hamlet = self.example_user("hamlet")
+
+        message_id = self.send_stream_message(hamlet, "Denmark", topic_name="")
+        result = self.resolve_topic_containing_message(hamlet, target_message_id=message_id)
+        self.assert_json_error(result, "General chat cannot be marked as resolved")
+
+        # Verification for old clients that don't support empty string topic.
+        message_id = self.send_stream_message(
+            hamlet, "Denmark", topic_name=Message.EMPTY_TOPIC_FALLBACK_NAME
+        )
+        result = self.resolve_topic_containing_message(hamlet, target_message_id=message_id)
+        self.assert_json_error(result, "General chat cannot be marked as resolved")


### PR DESCRIPTION
FIxes the following checkbox from #32996 

- [x]  Restrict resolving empty string topic.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
---

**Screenshots and screen captures:**

<details><summary>Topic popover</summary>
<img width="277" alt="Screenshot 2025-01-15 at 1 26 53 AM" src="https://github.com/user-attachments/assets/be7a1b0b-3166-4412-ab70-abecd0db0908" />
</details> 

<details><summary>Message header</summary>
<img width="468" alt="Screenshot 2025-01-15 at 1 27 05 AM" src="https://github.com/user-attachments/assets/f3607a0b-437e-4500-acc8-756ae43f5247" />
</details> 

<details><summary><code>/api/update-message</code></summary>
<img width="739" alt="Screenshot 2025-01-15 at 1 29 33 AM" src="https://github.com/user-attachments/assets/d1b0195a-848b-473c-9904-e8f0d31ed5a8" />

</details> 

---
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
