### PR TITLE
list_widget: Fix placeholder for unmatched deactivated user filters.

### DIFF
--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -205,6 +205,15 @@ function add_value_to_filters(
     section.list_widget.hard_redraw();
 }
 
+function are_filters_active(
+    filters: UserSettingsSection["filters"],
+    $search_input: JQuery,
+): boolean {
+    const search_value = String($search_input.val()).trim();
+    const selected_role = filters.role_code;
+    return Boolean(search_value) || selected_role !== 0;
+}
+
 function role_selected_handler(
     event: JQuery.ClickEvent,
     dropdown: tippy.Instance,
@@ -519,6 +528,10 @@ function active_create_table(active_users: number[]): void {
             predicate(person) {
                 return people.predicate_for_user_settings_filters(person, active_section.filters);
             },
+            is_active() {
+                const $search_input = $("#admin-active-users-list .search");
+                return are_filters_active(active_section.filters, $search_input);
+            },
             onupdate: reset_scrollbar($users_table),
         },
         $parent_container: $("#admin-active-users-list").expectOne(),
@@ -568,6 +581,10 @@ function deactivated_create_table(deactivated_users: number[]): void {
                         person,
                         deactivated_section.filters,
                     );
+                },
+                is_active() {
+                    const $search_input = $("#admin-deactivated-users-list .search");
+                    return are_filters_active(deactivated_section.filters, $search_input);
                 },
                 onupdate: reset_scrollbar($deactivated_users_table),
             },

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -31,7 +31,9 @@
                 {{/if}}
             </thead>
             <tbody id="admin_deactivated_users_table" class="admin_user_table"
-              data-empty="{{t 'There are no deactivated users.' }}" data-search-results-empty="{{t 'No users match your filters.' }}"></tbody>
+              data-empty="{{t 'There are no deactivated users.' }}"
+              data-search-results-empty="{{t 'No deactivated users match your filters.' }}">
+            </tbody>
         </table>
     </div>
     <div id="admin_page_deactivated_users_loading_indicator"></div>


### PR DESCRIPTION
Previously, the placeholder text displayed incorrectly after applying filters.

This commit refactors `list_widget` to check if combinations of filters applied, such as role and search filters. It ensures that the correct placeholder message is displayed.

Fixes: #32971.

**Screenshots and screen captures:**

| **Before**                          | **After**                           |
|-------------------------------------|-------------------------------------|
| ![Before Image](https://github.com/user-attachments/assets/834d1444-e764-4d99-9796-7bf52f7bc9a2) | ![After Image](https://github.com/user-attachments/assets/0c4cebb3-d488-4cde-b744-770757d1bfc5)   |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
