### PR TITLE
compose_closed_ui: Unify translation strings for reply button label.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -1,7 +1,9 @@
 import $ from "jquery";
 
+import render_reply_recipient_label from "../templates/reply_recipient_label.hbs";
+
 import * as compose_actions from "./compose_actions.ts";
-import {$t, $t_html} from "./i18n.ts";
+import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as message_util from "./message_util.ts";
@@ -172,24 +174,14 @@ export function set_standard_text_for_reply_button(): void {
 export function update_reply_recipient_label(message?: ComposeClosedMessage): void {
     const recipient_label = get_recipient_label(message);
     if (recipient_label !== undefined) {
-        if (!recipient_label.has_empty_string_topic) {
-            const recipient_label_text = recipient_label.label_text;
-            set_reply_button_label(
-                $t({defaultMessage: "Message {recipient_label_text}"}, {recipient_label_text}),
-            );
-        } else {
-            const topic_display_name = util.get_final_topic_display_name("");
-            const recipient_label_html = $t_html(
-                {
-                    defaultMessage: "Message <z-recipient-label></z-recipient-label>",
-                },
-                {
-                    "z-recipient-label": () =>
-                        `#${recipient_label.stream_name} > <span class="empty-topic-display">${topic_display_name}</span>`,
-                },
-            );
-            $("#left_bar_compose_reply_button_big").html(recipient_label_html);
-        }
+        const empty_string_topic_display_name = util.get_final_topic_display_name("");
+        const rendered_recipient_label = render_reply_recipient_label({
+            has_empty_string_topic: recipient_label.has_empty_string_topic,
+            channel_name: recipient_label.stream_name,
+            empty_string_topic_display_name,
+            label_text: recipient_label.label_text,
+        });
+        $("#left_bar_compose_reply_button_big").html(rendered_recipient_label);
     } else {
         set_standard_text_for_reply_button();
     }

--- a/web/templates/reply_recipient_label.hbs
+++ b/web/templates/reply_recipient_label.hbs
@@ -1,0 +1,10 @@
+{{#tr}}
+    Message <z-recipient-label></z-recipient-label>
+    {{#*inline "z-recipient-label"}}
+        {{#if has_empty_string_topic~}}
+        #{{channel_name}} &gt; <span class="empty-topic-display">{{empty_string_topic_display_name}}</span>
+        {{~else~}}
+        {{label_text}}
+        {{~/if}}
+    {{~/inline}}
+{{/tr}}

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -38,8 +38,8 @@ set_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME});
 
 // Helper test function
 function test_reply_label(expected_label) {
-    const label = $("#left_bar_compose_reply_button_big").text();
-    const prepend_text_length = "translated: Message ".length;
+    const label = $("#left_bar_compose_reply_button_big").html();
+    const prepend_text_length = "Message ".length;
     assert.equal(
         label.slice(prepend_text_length),
         expected_label,
@@ -111,10 +111,10 @@ run_test("reply_label", () => {
     );
 
     const expected_labels = [
-        "#first_stream > first_topic",
-        "#first_stream > second_topic",
-        "#second_stream > third_topic",
-        "#second_stream > second_topic",
+        "#first_stream &gt; first_topic",
+        "#first_stream &gt; second_topic",
+        "#second_stream &gt; third_topic",
+        "#second_stream &gt; second_topic",
         "some user",
         "some user, other user",
     ];
@@ -138,7 +138,7 @@ run_test("reply_label", () => {
     list.select_id(list.next());
     const label_html = $("#left_bar_compose_reply_button_big").html();
     assert.equal(
-        `translated HTML: Message #second_stream > <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
+        `Message #second_stream &gt; <span class="empty-topic-display">translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}</span>`,
         label_html,
     );
 });
@@ -154,7 +154,7 @@ run_test("test_custom_message_input", () => {
         stream_id: stream.stream_id,
         topic: "topic test",
     });
-    test_reply_label("#stream test > topic test");
+    test_reply_label("#stream test &gt; topic test");
 });
 
 run_test("empty_narrow", () => {


### PR DESCRIPTION
Addresses https://github.com/zulip/zulip/pull/33020#discussion_r1915463713:

> I think ideally we'd arrange for this translation to match the other Message one just above to save translation effort, which probably means just reworking the recipient_label_text case to use the same string.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
