### PR TITLE
web: Add search/filter support for empty topic names.

### DIFF
--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -772,7 +772,8 @@ function filter_should_hide_stream_row({
         return true;
     }
 
-    const text = (sub.name + " " + topic).toLowerCase();
+    const topic_display_name = util.get_final_topic_display_name(topic);
+    const text = (sub.name + " " + topic_display_name).toLowerCase();
 
     if (!row_in_search_results(search_keyword, text)) {
         return true;

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -804,7 +804,8 @@ export function topic_in_search_results(
     if (keyword === "") {
         return true;
     }
-    const text = (stream_name + " " + topic).toLowerCase();
+    const topic_display_name = util.get_final_topic_display_name(topic);
+    const text = (stream_name + " " + topic_display_name).toLowerCase();
     return typeahead.query_matches_string_in_any_order(keyword, text, " ");
 }
 

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -16,6 +16,7 @@ import * as stream_data from "./stream_data.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
 import * as stream_topic_history_util from "./stream_topic_history_util.ts";
 import * as typeahead_helper from "./typeahead_helper.ts";
+import * as util from "./util.ts";
 
 export type UserPillItem = {
     id: number;
@@ -96,9 +97,9 @@ function check_validity(
     return true;
 }
 
-function format_as_suggestion(terms: NarrowTerm[]): Suggestion {
+function format_as_suggestion(terms: NarrowTerm[], is_operator_suggestion = false): Suggestion {
     return {
-        description_html: Filter.search_description_as_html(terms),
+        description_html: Filter.search_description_as_html(terms, is_operator_suggestion),
         search_string: Filter.unparse(terms),
         // TODO: This isn't actually always false. We should
         // treat terms with emails (dm, sender, etc) as `is_people`
@@ -450,7 +451,8 @@ export function get_topic_suggestions_from_candidates({
     // soon as we find enough matches.
     const topics: string[] = [];
     for (const topic of candidate_topics) {
-        if (common.phrase_match(guess, topic)) {
+        const topic_display_name = util.get_final_topic_display_name(topic);
+        if (common.phrase_match(guess, topic_display_name)) {
             topics.push(topic);
             if (topics.length >= max_num_topics) {
                 break;
@@ -828,7 +830,7 @@ function get_operator_suggestions(last: NarrowTerm): Suggestion[] {
             choice = "channel";
         }
         const op = [{operator: choice, operand: "", negated}];
-        return format_as_suggestion(op);
+        return format_as_suggestion(op, true);
     });
 }
 
@@ -851,7 +853,7 @@ function suggestion_search_string(suggestion_line: SuggestionLine): string {
 }
 
 function suggestions_for_current_filter(): SuggestionLine[] {
-    if (narrow_state.stream_id() && narrow_state.topic() !== "") {
+    if (narrow_state.stream_id() && narrow_state.topic() !== undefined) {
         return [
             get_default_suggestion_line([
                 {

--- a/web/src/settings_user_topics.ts
+++ b/web/src/settings_user_topics.ts
@@ -42,7 +42,8 @@ export function populate_list(): void {
         filter: {
             $element: $search_input,
             predicate(item, value) {
-                return item.topic.toLocaleLowerCase().includes(value);
+                const topic_display_name = util.get_final_topic_display_name(item.topic);
+                return topic_display_name.toLocaleLowerCase().includes(value);
             },
             onupdate() {
                 scroll_util.reset_scrollbar(

--- a/web/templates/input_pill.hbs
+++ b/web/templates/input_pill.hbs
@@ -13,7 +13,11 @@
                 <i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon" aria-hidden="true"></i>
                 {{~/if~}}
             {{/if}}
+            {{#if is_empty_string_topic}}
+            {{sign}}topic: <span class="empty-topic-display">{{topic_display_name}}</span>
+            {{else}}
             {{ display_value }}
+            {{/if}}
         </span>
         {{~#if should_add_guest_user_indicator}}&nbsp;<i>({{t 'guest'}})</i>{{~/if~}}
         {{~#if deactivated}}&nbsp;({{t 'deactivated'}}){{~/if~}}

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -3,17 +3,21 @@
     {{#if (eq this.type "plain_text")~}}
         {{~this.content~}}
     {{else if (eq this.type "channel_topic")}}
-        {{~!-- squash whitespace --~}}
-        channel {{this.channel}} > {{this.topic}}
-        {{~!-- squash whitespace --~}}
+        {{~#if is_empty_string_topic~}}
+        channel {{this.channel}} > <span class="empty-topic-display">{{this.topic_display_name}}</span>
+        {{~else~}}
+        channel {{this.channel}} > {{this.topic_display_name}}
+        {{~/if~}}
     {{else if (eq this.type "invalid_has")}}
         {{~!-- squash whitespace --~}}
         invalid {{this.operand}} operand for has operator
         {{~!-- squash whitespace --~}}
     {{else if (eq this.type "prefix_for_operator")}}
-        {{~!-- squash whitespace --~}}
+        {{~#if is_empty_string_topic~}}
+        {{this.prefix_for_operator}} <span class="empty-topic-display">{{this.operand}}</span>
+        {{~ else ~}}
         {{this.prefix_for_operator}} {{this.operand}}{{#if (or (eq this.operand "link") (eq this.operand "image") (eq this.operand "attachment") (eq this.operand "reaction"))}}s{{/if}}
-        {{~!-- squash whitespace --~}}
+        {{~/if~}}
     {{else if (eq this.type "user_pill")}}
         {{~!-- squash whitespace --~}}
         {{this.operator}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1414,8 +1414,17 @@ test("parse", () => {
 
     string = `channel: ${foo_stream_id} topic: "separated with space"`;
     terms = [
-        {operator: "channel", operand: foo_stream_id.toString()},
-        {operator: "topic", operand: "separated with space"},
+        {operator: "channel", operand: ""},
+        {operator: "search", operand: foo_stream_id.toString()},
+        {operator: "topic", operand: ""},
+        {operator: "search", operand: '"separated with space"'},
+    ];
+    _test();
+
+    string = `topic: is:starred`;
+    terms = [
+        {operator: "topic", operand: ""},
+        {operator: "is", operand: "starred"},
     ];
     _test();
 });
@@ -1478,18 +1487,18 @@ test("unparse", () => {
     assert_same_terms(Filter.parse(string), terms);
 });
 
-test("describe", ({mock_template}) => {
+test("describe", ({mock_template, override}) => {
     let narrow;
     let string;
     mock_template("search_description.hbs", true, (_data, html) => html);
 
     narrow = [{operator: "channels", operand: "public"}];
     string = "channels public";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "channels", operand: "public", negated: true}];
     string = "exclude channels public";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     const devel_id = new_stream_id();
     make_sub("devel", devel_id);
@@ -1499,7 +1508,7 @@ test("describe", ({mock_template}) => {
         {operator: "is", operand: "starred"},
     ];
     string = "channel devel, starred messages";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     const river_id = new_stream_id();
     make_sub("river", river_id);
@@ -1508,100 +1517,100 @@ test("describe", ({mock_template}) => {
         {operator: "is", operand: "unread"},
     ];
     string = "channel river, unread messages";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: "JS"},
     ];
     string = "channel devel > JS";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "is", operand: "dm"},
         {operator: "search", operand: "lunch"},
     ];
     string = "direct messages, search for lunch";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "id", operand: 99}];
     string = "message ID 99";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "in", operand: "home"}];
     string = "messages in home";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "mentioned"}];
     string = "@-mentions";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "alerted"}];
     string = "alerted messages";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "resolved"}];
     string = "topics marked as resolved";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "followed"}];
     string = "followed topics";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [{operator: "is", operand: "something_we_do_not_support"}];
     string = "invalid something_we_do_not_support operand for is operator";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     // this should be unreachable, but just in case
     narrow = [{operator: "bogus", operand: "foo"}];
     string = "unknown operator";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "topic", operand: "JS", negated: true},
     ];
     string = "channel devel, exclude topic JS";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "is", operand: "dm"},
         {operator: "search", operand: "lunch", negated: true},
     ];
     string = "direct messages, exclude lunch";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "is", operand: "starred", negated: true},
     ];
     string = "channel devel, exclude starred messages";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "channel", operand: devel_id.toString()},
         {operator: "has", operand: "image", negated: true},
     ];
     string = "channel devel, exclude messages with images";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "has", operand: "abc", negated: true},
         {operator: "channel", operand: devel_id.toString()},
     ];
     string = "invalid abc operand for has operator, channel devel";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [
         {operator: "has", operand: "image", negated: true},
         {operator: "channel", operand: devel_id.toString()},
     ];
     string = "exclude messages with images, channel devel";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     narrow = [];
     string = "combined feed";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
 
     // canonical version of the operator is used in description
     narrow = [
@@ -1609,7 +1618,32 @@ test("describe", ({mock_template}) => {
         {operator: "subject", operand: "JS", negated: true},
     ];
     string = "channel devel, exclude topic JS";
-    assert.equal(Filter.search_description_as_html(narrow), string);
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    // Empty string topic involved.
+    override(realm, "realm_empty_topic_display_name", "general chat");
+    narrow = [
+        {operator: "channel", operand: devel_id.toString()},
+        {operator: "topic", operand: ""},
+    ];
+    string = 'channel devel > <span class="empty-topic-display">translated: general chat</span>';
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [
+        {operator: "topic", operand: ""},
+        {operator: "is", operand: "starred"},
+    ];
+    string =
+        'topic <span class="empty-topic-display">translated: general chat</span>, starred messages';
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "topic", operand: ""}];
+    string = `topic <span class="empty-topic-display">translated: general chat</span>`;
+    assert.equal(Filter.search_description_as_html(narrow, false), string);
+
+    narrow = [{operator: "topic", operand: ""}];
+    string = "topic ";
+    assert.equal(Filter.search_description_as_html(narrow, true), string);
 });
 
 test("can_bucket_by", () => {
@@ -1807,23 +1841,23 @@ test("is_valid_search_term", () => {
     stream_data.add_sub(denmark);
 
     const test_data = [
-        ["has: image", true],
-        ["has: nonsense", false],
-        ["is: unread", true],
-        ["is: nonsense", false],
-        ["in: home", true],
-        ["in: nowhere", false],
-        ["id: 4", true],
-        ["near: home", false],
-        ["channel: " + denmark.stream_id, true],
-        [`channel: ${invalid_sub_id}`, false],
-        ["channels: public", true],
-        ["channels: private", false],
-        ["topic: GhostTown", true],
-        ["dm-including: alice@example.com", true],
-        ["sender: ghost@zulip.com", false],
-        ["dm: alice@example.com,ghost@example.com", false],
-        ["dm: alice@example.com,joe@example.com", true],
+        ["has:image", true],
+        ["has:nonsense", false],
+        ["is:unread", true],
+        ["is:nonsense", false],
+        ["in:home", true],
+        ["in:nowhere", false],
+        ["id:4", true],
+        ["near:home", false],
+        ["channel:" + denmark.stream_id, true],
+        [`channel:${invalid_sub_id}`, false],
+        ["channels:public", true],
+        ["channels:private", false],
+        ["topic:GhostTown", true],
+        ["dm-including:alice@example.com", true],
+        ["sender:ghost@zulip.com", false],
+        ["dm:alice@example.com,ghost@example.com", false],
+        ["dm:alice@example.com,joe@example.com", true],
     ];
     for (const [search_term_string, expected_is_valid] of test_data) {
         assert.equal(

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -1166,5 +1166,6 @@ test("test_search", () => {
     assert.equal(rt.topic_in_search_results("\\", "general", "\\"), true);
     assert.equal(rt.topic_in_search_results("\\", "general", "\\\\"), true);
 
-    // TODO: Add a test for empty topic name after CZO discussion.
+    // Test for empty string topic name.
+    assert.equal(rt.topic_in_search_results("general chat", "Scotland", ""), true);
 });

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -1037,10 +1037,4 @@ test("queries_with_spaces", () => {
     suggestions = get_suggestions(query);
     expected = [`channel:${dev_help_id}`];
     assert.deepEqual(suggestions.strings, expected);
-
-    // test extra space after operator still works
-    query = "channel: offi";
-    suggestions = get_suggestions(query);
-    expected = [`channel:${office_id}`];
-    assert.deepEqual(suggestions.strings, expected);
 });


### PR DESCRIPTION
Completes filter and search part of #32996:

- [ ] Update UX for search, filters, typeahead, and compose box topic to comply with CZO Discussion.


## Screenshots:

### Filters

<details><summary>Recent conversations filter</summary>
<img width="989" alt="Screenshot 2025-01-16 at 3 03 31 PM" src="https://github.com/user-attachments/assets/0ce84565-6920-44ab-a844-bf6e8a1db171" />
</details> 

<details><summary>Inbox view filter</summary>
<img width="698" alt="Screenshot 2025-01-16 at 3 02 26 PM" src="https://github.com/user-attachments/assets/04fa281a-b7c3-47ab-9817-1e296010fca1" />
</details> 

<details><summary>SETTINGS/TOPICS</summary>
<img width="778" alt="Screenshot 2025-01-16 at 3 05 07 PM" src="https://github.com/user-attachments/assets/3ce394b6-0aa3-414b-989e-fc7f01558ace" />
</details> 

### Search

<details><summary><code>channel:Scotland</code></summary>
<img width="961" alt="Screenshot 2025-01-16 at 3 07 38 PM" src="https://github.com/user-attachments/assets/18cc16b8-028e-4441-879a-27682a9ecae7" />
</details> 

<details><summary><code>channel:Scotland topic:</code></summary>
<img width="966" alt="Screenshot 2025-01-16 at 3 08 36 PM" src="https://github.com/user-attachments/assets/277f2bf6-4a99-43bb-a9f9-f82d9f5aa1cb" />
</details>

<details><summary>Pill italics</summary>
<img width="192" alt="Screenshot 2025-01-16 at 3 10 02 PM" src="https://github.com/user-attachments/assets/bec34e88-a8bd-44b7-90c4-bf1597511639" />
</details> 


---
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
