### PR TITLE
compose_banner: Show `realm_empty_topic_display_name` for topic="".

### DIFF
--- a/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
+++ b/web/templates/compose_banner/automatic_new_visibility_policy_banner.hbs
@@ -2,13 +2,25 @@
     <p class="banner_message">
         {{#if followed}}
             {{#tr}}
-                Now following <z-link>{channel_topic}</z-link>.
-                {{#*inline "z-link"}}<a class="above_compose_banner_action_link white-space-preserve-wrap" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
+                Now following <z-link></z-link>.
+                {{#*inline "z-link"~}}
+                    <a class="above_compose_banner_action_link white-space-preserve-wrap" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">
+                        {{~!-- squash whitespace --~}}
+                        #{{channel_name}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>
+                        {{~!-- squash whitespace --~}}
+                    </a>
+                {{~/inline}}
             {{/tr}}
         {{else}}
             {{#tr}}
-                Unmuted <z-link>{channel_topic}</z-link>.
-                {{#*inline "z-link"}}<a class="above_compose_banner_action_link white-space-preserve-wrap" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">{{> @partial-block}}</a>{{/inline}}
+                Unmuted <z-link></z-link>.
+                {{#*inline "z-link"~}}
+                    <a class="above_compose_banner_action_link white-space-preserve-wrap" href="{{narrow_url}}" data-message-id="{{link_msg_id}}">
+                        {{~!-- squash whitespace --~}}
+                        #{{channel_name}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>
+                        {{~!-- squash whitespace --~}}
+                    </a>
+                {{~/inline}}
             {{/tr}}
         {{/if}}
     </p>

--- a/web/templates/compose_banner/message_sent_banner.hbs
+++ b/web/templates/compose_banner/message_sent_banner.hbs
@@ -1,7 +1,22 @@
 <div class="above_compose_banner main-view-banner success {{classname}}">
     <p class="banner_content">
         {{banner_text}}
-        {{#if link_text}} <a class="above_compose_banner_action_link" {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
+        <a class="above_compose_banner_action_link" {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} data-message-id="{{link_msg_id}}">
+            {{#if message_recipient}}
+                {{#with message_recipient}}
+                {{#if (eq message_type "channel")}}
+                    {{#tr}}
+                        Go to #{channel_name} &gt; <z-topic-display-name></z-topic-display-name>
+                        {{#*inline "z-topic-display-name"}}<span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{topic_display_name}}</span>{{/inline}}
+                    {{/tr}}
+                {{else}}
+                    {{t 'Go to {recipient_text}' }}
+                {{/if}}
+                {{/with}}
+            {{else}}
+                {{link_text}}
+            {{/if}}
+        </a>
     </p>
     <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
 </div>


### PR DESCRIPTION
Fixes the following checkbox of #32996:
- [x] Show realm_empty_topic_display_name for empty string as topic name in banners

#### Screenshots

<details><summary>Now following banner</summary>
<img width="939" alt="Screenshot 2025-01-16 at 6 49 44 PM" src="https://github.com/user-attachments/assets/77b3e4ed-d965-40c4-8c12-960a729d9a83" />
</details> 

<details><summary>Unmuted banner</summary>
<img width="836" alt="Screenshot 2025-01-16 at 6 56 07 PM" src="https://github.com/user-attachments/assets/d4b5a0fa-b0e1-498c-89b9-9b87baef199d" />
</details> 

<details><summary>Go to stream > topic</summary>
<img width="842" alt="Screenshot 2025-01-16 at 6 55 21 PM" src="https://github.com/user-attachments/assets/1d94f6c2-a548-447e-8e7c-ba133119b32b" />
</details> 

<details><summary>Narrow to stream > topic</summary>
<img width="931" alt="Screenshot 2025-01-16 at 6 57 32 PM" src="https://github.com/user-attachments/assets/6972521e-ecfb-4cb9-9dfc-acc191e0256d" />
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
