### PR TITLE
css: Adjust focus outline for New Channel input in Move messages modal.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -843,12 +843,13 @@ ul.popover-group-menu-member-list {
 
     #move_topic_to_stream_widget_wrapper {
         display: flex;
+        width: 50%;
 
         .dropdown-widget-button {
             outline: none;
             /* 24px at 16px/1em */
             line-height: 1.5em;
-            width: 50%;
+            width: 100%;
         }
 
         .dropdown_widget_value {


### PR DESCRIPTION
This PR adjusts the focus outline for the "New channel" input in the Move message(s) and topic modal, preventing it from extending to the entire modal and limiting it to the input element only.

<!-- Describe your pull request here.-->

Fixes: [CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/Focus.20outline.20in.20move.20messages.20modal/near/2042020).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Focus outline on the "New channel" input.</summary>

**Light mode:**
| Before changes | After changes |
|----------------|---------------|
| ![image](https://github.com/user-attachments/assets/8747474e-e9ab-4da4-8603-f93e40217073) | ![image](https://github.com/user-attachments/assets/6f18ac2d-1b1f-49c5-93ec-16c215a77c0c) |

**Dark mode:**
| Before changes | After changes |
|----------------|---------------|
| ![image](https://github.com/user-attachments/assets/e19f83d5-eb89-4e4c-9b10-894cc277c1b6) | ![image](https://github.com/user-attachments/assets/e0781d2e-dbe8-43c4-8487-d8b9d79a5893) |

</details>



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
