### PR TITLE
manage-user: updated style of 'Deactivate user' button to latest designs

### DIFF
--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -42,6 +42,10 @@
     overflow: hidden;
 }
 
+.action-button-padding {
+    padding: 7.85px 14.85px;
+}
+
 /* Action buttons -- Neutral Intent */
 .action-button-primary-neutral {
     color: var(--color-text-neutral-primary-action-button);

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -29,7 +29,7 @@
     <div class="input-group">
         {{#if is_active}}
         <span {{#if owner_is_only_user_in_organization}}class="deactivate_user_button_tooltip"{{/if}}>
-            <button class="button rounded button-danger deactivate_user_button" {{#if owner_is_only_user_in_organization}}disabled="disabled"{{/if}}>
+            <button class="action-button action-button-quiet-danger action-button-padding" {{#if owner_is_only_user_in_organization}}disabled="disabled"{{/if}}>
                 {{t 'Deactivate user' }}
             </button>
         </span>


### PR DESCRIPTION
This PR updates the style of 'Deactivated user' button in the Manage User panel to updated designs, 
and this PR is part of issue: https://github.com/zulip/zulip/issues/33027

<!-- Describe your pull request here.-->
**Screenshots and screen captures:**
Before:
![Screenshot From 2025-01-17 12-44-20](https://github.com/user-attachments/assets/d8bed03a-893f-4fc4-80d2-cd4dd8be1f69)
After: 
![Screenshot From 2025-01-17 12-45-10](https://github.com/user-attachments/assets/e4f257f5-fafc-4e2f-aef0-6bc12e029bb3)

light mode screenshot (16px )
![image](https://github.com/user-attachments/assets/daeba68b-4b63-42e1-85dd-b998893943d5)

12 px screenshots
![image](https://github.com/user-attachments/assets/d5e3787d-60de-4c77-9f52-a10ef01d6821)

20px screenshots
![image](https://github.com/user-attachments/assets/a3733275-6bd6-4746-b433-20bb40ff7777)






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
