### PR TITLE
move_topic_modal: Fix overflow issues.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -843,7 +843,8 @@ ul.popover-group-menu-member-list {
 
     #move_topic_to_stream_widget_wrapper {
         display: flex;
-        width: 50%;
+        /* 230px at 16px/1em */
+        max-width: 14.375em;
 
         .dropdown-widget-button {
             outline: none;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -894,10 +894,6 @@ ul.popover-group-menu-member-list {
     }
 
     .topic_stream_edit_header {
-        display: flex;
-        flex-flow: column wrap;
-        justify-content: flex-start;
-
         #select_stream_id {
             border-left: 0;
             padding-left: 0;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -909,6 +909,31 @@ ul.popover-group-menu-member-list {
             left: 40px;
         }
     }
+
+    .topic_move_breadcrumb_messages {
+        margin: 0 5px 5px 0;
+        align-self: center;
+        width: 100%;
+
+        & label.checkbox {
+            /* Place the checkboxes on their own lines. */
+            display: block;
+
+            & input {
+                margin: 0;
+                vertical-align: baseline;
+            }
+
+            & + label.checkbox {
+                margin-top: 10px;
+            }
+        }
+
+        & label {
+            display: inline-block;
+            margin-right: 10px;
+        }
+    }
 }
 
 #language_selection_modal {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -940,31 +940,6 @@ div.focused-message-list.is-conversation-view .recipient_row {
     outline: none;
 }
 
-.topic_move_breadcrumb_messages {
-    margin: 0 5px 5px 0;
-    align-self: center;
-    width: 100%;
-
-    & label.checkbox {
-        /* Place the checkboxes on their own lines. */
-        display: block;
-
-        & input {
-            margin: 0;
-            vertical-align: baseline;
-        }
-
-        & + label.checkbox {
-            margin-top: 10px;
-        }
-    }
-
-    & label {
-        display: inline-block;
-        margin-right: 10px;
-    }
-}
-
 .message_length_controller {
     .message_length_toggle {
         width: 100%;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -944,7 +944,6 @@ div.focused-message-list.is-conversation-view .recipient_row {
     margin: 0 5px 5px 0;
     align-self: center;
     width: 100%;
-    white-space: nowrap;
 
     & label.checkbox {
         /* Place the checkboxes on their own lines. */


### PR DESCRIPTION
This PR fixes overflow issues in the move_topic_modal by removing the unneeded flex display and allowing the text in checklists to wrap on small screens. It also improves the width of the dropdown across different screen sizes.

<details>
<summary>Quick Overview</summary>

| Before | After |
| --------- | ------ |
| When a channel name is big enough (~60 characters), there is overflow visible in "New topic" input. | Removing flex display helps avoiding this overflow without affecting the existing layout. |
| ![image](https://github.com/user-attachments/assets/1f42e803-4cc2-4440-9648-8cd7253d0795) | ![image](https://github.com/user-attachments/assets/85dd59d6-9cf7-4161-acf6-636a52123ae0)|
| The overflow is slightly noticeable even for shorter channel names. | This issue also gets fixed. |
| ![image](https://github.com/user-attachments/assets/cdb54785-b29e-4ac5-b91b-d9322aec8bd4) | ![image](https://github.com/user-attachments/assets/d98a10e5-edc9-4f48-abc6-480592c27364) |
| For screen width 320px, the text for checklist overflow.<br>The dropdown shrinks because of `width: 50%`. | Removing the `nowrap` fixed the issue for checklist. Setting `max-width:230px` ensures that the dropdown maintains a good length for large screen while taking available space for small screen. |
| ![image](https://github.com/user-attachments/assets/1b18a0bf-a4a4-46db-9adf-251f9cece15b) | ![image](https://github.com/user-attachments/assets/dad67069-7433-4945-a739-954dfebbc8fb) |

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
