### PR TITLE
compose_css: Fix responsiveness for long channel names.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1027,6 +1027,8 @@ textarea.new_message_textarea {
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: stretch;
     flex: 1 1 0;
+    /* 128px at 16px/1em */
+    min-width: 8em;
     border: 1px solid var(--color-compose-recipient-box-border-color);
     border-radius: 4px;
     transition: border-color 0.2s ease;
@@ -1094,7 +1096,9 @@ textarea.new_message_textarea {
 }
 
 #compose_select_recipient_widget {
-    width: auto;
+    width: 100%;
+    /* 256px at 16px/1em */
+    max-width: 16em;
     outline: none;
     /* We override the component-level colors to
        ensure concord with the topic box. */
@@ -1440,6 +1444,8 @@ textarea.new_message_textarea {
 #compose_select_recipient_widget_wrapper {
     display: flex;
     justify-content: flex-start;
+    /* absolute min-width is needed to truncate text */
+    min-width: 0;
     height: var(--compose-recipient-box-min-height);
 
     &:focus-visible {
@@ -1452,6 +1458,7 @@ textarea.new_message_textarea {
 
     .dropdown_widget_value {
         flex-grow: 1;
+        overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
         color: var(--color-text-default);


### PR DESCRIPTION
When channel names were long enough, the compose_recipient container started overflowing for smaller screens. This PR fixes this issue by truncating the overflowing channel name. `min-width` and `max-width` has been set to properly display the inputs across different screen sizes.


| Before                               | After                                |
| ------------------------------------ | ------------------------------------ |
| ![image](https://github.com/user-attachments/assets/c74e4445-e6b0-4a7d-b0d9-645a58c59c54) | ![image](https://github.com/user-attachments/assets/3a6dcc56-fe12-4892-bd58-b09d949aa3cf) |
| ![image](https://github.com/user-attachments/assets/70df3279-c395-4eb9-991d-fdf704717be0) | ![image](https://github.com/user-attachments/assets/5689fcb1-f887-47f6-90ef-f89869e72154) |
| ![image](https://github.com/user-attachments/assets/630eaf0f-678f-4b22-a06b-76ec67f79b31) | ![image](https://github.com/user-attachments/assets/edd3e1d2-cedb-47b1-9492-c439a17c9a72) |
| ![image](https://github.com/user-attachments/assets/1e5b13b3-58c7-4b8b-b08d-a04db619b9e6) | ![image](https://github.com/user-attachments/assets/b265665a-adf3-4507-8b92-7f7dcf0983a6) |
| ![image](https://github.com/user-attachments/assets/8efe9260-7b5b-48de-a159-90ac28aff759) | ![image](https://github.com/user-attachments/assets/53b73340-07c8-47a9-9035-5a86c1dad0ea) |



Screen Recordings-
<details>
<summary>Before</summary>
Notice the overflow in compose-

[Screencast from 01-17-25 17:13:52.webm](https://github.com/user-attachments/assets/4ea3b67c-777a-4e28-ae19-fb6358b22648)
</details>

<details>
<summary>After</summary>

[Screencast from 01-17-25 17:14:53.webm](https://github.com/user-attachments/assets/4865c17f-144a-44e8-bc60-9ffa138e74f2)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
