### PR TITLE
left_sidebar: Show `Mark all messages as unread` in channel popover.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -34,6 +34,7 @@ import * as stream_settings_ui from "./stream_settings_ui.ts";
 import * as sub_store from "./sub_store.ts";
 import * as ui_report from "./ui_report.ts";
 import * as ui_util from "./ui_util.ts";
+import * as unread from "./unread.ts";
 import * as unread_ops from "./unread_ops.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
@@ -100,11 +101,15 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
     const show_go_to_channel_feed =
         user_settings.web_channel_default_view !==
         web_channel_default_view_values.channel_feed.code;
+    const stream_unread = unread.unread_count_info_for_stream(stream_id);
+    const stream_unread_count = stream_unread.unmuted_count + stream_unread.muted_count;
+    const has_unread_messages = stream_unread_count > 0;
     const content = render_left_sidebar_stream_actions_popover({
         stream: {
             ...sub_store.get(stream_id),
             url: browser_history.get_full_url(stream_hash),
         },
+        has_unread_messages,
         show_go_to_channel_feed,
     });
 
@@ -170,6 +175,14 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
                 const sub = stream_popover_sub(e);
                 hide_stream_popover(instance);
                 unread_ops.mark_stream_as_read(sub.stream_id);
+                e.stopPropagation();
+            });
+
+            // Mark all messages in stream as unread
+            $popper.on("click", ".mark_stream_as_unread", (e) => {
+                const sub = stream_popover_sub(e);
+                hide_stream_popover(instance);
+                unread_ops.mark_stream_as_unread(sub.stream_id);
                 e.stopPropagation();
             });
 

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -613,6 +613,13 @@ export function mark_stream_as_read(stream_id: number): void {
     );
 }
 
+export function mark_stream_as_unread(stream_id: number): void {
+    bulk_update_read_flags_for_narrow(
+        [{operator: "channel", operand: stream_id.toString()}],
+        "remove",
+    );
+}
+
 export function mark_topic_as_read(stream_id: number, topic: string): void {
     bulk_update_read_flags_for_narrow(
         [

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -9,12 +9,21 @@
             <span class="popover-stream-name">{{stream.name}}</span>
         </li>
         <li role="separator" class="popover-menu-separator"></li>
+        {{#if has_unread_messages}}
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="mark_stream_as_read popover-menu-link" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-read" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Mark all messages as read"}}</span>
             </a>
         </li>
+        {{else}}
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
+            <a role="menuitem" class="mark_stream_as_unread popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-mark-as-unread" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Mark all messages as unread"}}</span>
+            </a>
+        </li>
+        {{/if}}
         {{#if show_go_to_channel_feed}}
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" class="stream-popover-go-to-channel-feed popover-menu-link" tabindex="0">


### PR DESCRIPTION
This commit adds an option to show `Mark all messages as unread` when all unmuted messages in the channel are read.

fixes #33067.

**Screenshots**

| read | unread |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/c85393c2-7fd5-4dd4-bc4a-8f1a7f867c37) | ![After Image](https://github.com/user-attachments/assets/93b142cf-9f64-4b4c-b24a-e255d55664dd) |

<details>
<summary>demo</summary>



https://github.com/user-attachments/assets/428ab269-3c9f-4571-94a5-134594763e77



</details> 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
