### PR TITLE
settings_ui: Refactor the `do_settings_change()` function.

### DIFF
--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -6,6 +6,7 @@ import type {AjaxRequestHandler} from "./channel.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as loading from "./loading.ts";
 import * as ui_report from "./ui_report.ts";
+import * as util from "./util.ts";
 
 export type RequestOpts = {
     success_msg_html?: string | undefined;
@@ -50,15 +51,17 @@ export function do_settings_change(
     loading.make_indicator($spinner, {text: strings.saving});
     const remove_after = sticky ? undefined : 1000;
     const appear_after = 500;
+    const request_start_time = Date.now();
 
     void request_method({
         url,
         data,
         success(response_data) {
+            const remaining_delay = util.get_remaining_time(request_start_time, appear_after);
             setTimeout(() => {
                 ui_report.success(success_msg_html, $spinner, remove_after);
                 display_checkmark($spinner);
-            }, appear_after);
+            }, remaining_delay);
             if (success_continuation !== undefined) {
                 success_continuation(response_data);
             }


### PR DESCRIPTION
This PR refactors the `do_settings_change()` function in the [`web/src/settings_ui.ts`](https://github.com/zulip/zulip/blob/main/web/src/settings_ui.ts#L34) file. It is used to inform users about the changes to the settings UI.

The function uses a `setTimeout` function (introduced in [`381e498`](https://github.com/zulip/zulip/commit/381e49834326bff609b5ff0b69ec27e6fc2e30c2#diff-b41fc8099af8ce546ed80f29155d770eed68bf1141db0b7ef91452d4a13119a1R55)) in its success callback where the value of `appear_after` is `500ms`. It was pointed out if the `setTimeout` function is useful here by `Tim Abbott` over [here](https://github.com/zulip/zulip/pull/32260#discussion_r1906092460).

`Tim Abbott` [said](https://chat.zulip.org/#narrow/channel/6-frontend/topic/setTimeout.20in.20do_settings_change/near/2033590):
> ... there's a better way to write that -- the loading indicator is created before the network call, so if we wanted that, what we'd want to do is wait max(0, 500ms - time elapsed for the request), not 500ms always, even if the request itself was slow.


With the change in this PR, the delay for reporting success is calculated dynamically to account for the time elapsed during the request and report the success accordingly.

<!-- Describe your pull request here.-->



Fixes: [CZO thread](https://chat.zulip.org/#narrow/channel/6-frontend/topic/setTimeout.20in.20do_settings_change/near/2032891).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
_None_

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
