### PR TITLE
gravatar: add option to overwrite global settings per realm

### DIFF
--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -114,16 +114,25 @@ def get_avatar_field(
         hash_key = user_avatar_base_path_from_ids(user_id, avatar_version, realm_id)
         return get_avatar_url(hash_key, medium=medium)
 
-    return get_gravatar_url(email=email, avatar_version=avatar_version, medium=medium)
+    return get_gravatar_url(
+        email=email,
+        avatar_version=avatar_version,
+        realm_id=realm_id,
+        medium=medium,
+    )
 
 
-def get_gravatar_url(email: str, avatar_version: int, medium: bool = False) -> str:
-    url = _get_unversioned_gravatar_url(email, medium)
+def get_gravatar_url(email: str, avatar_version: int, realm_id: int, medium: bool = False) -> str:
+    url = _get_unversioned_gravatar_url(email, medium, realm_id)
     return append_url_query_string(url, f"version={avatar_version:d}")
 
 
-def _get_unversioned_gravatar_url(email: str, medium: bool) -> str:
-    if settings.ENABLE_GRAVATAR:
+def _get_unversioned_gravatar_url(email: str, medium: bool, realm_id: int) -> str:
+    use_gravatar = settings.ENABLE_GRAVATAR
+    if realm_id in settings.GRAVATAR_REALM_OVERRIDE:
+        use_gravatar = settings.GRAVATAR_REALM_OVERRIDE[realm_id]
+
+    if use_gravatar:
         gravitar_query_suffix = f"&s={MEDIUM_AVATAR_SIZE}" if medium else ""
         hash_key = gravatar_hash(email)
         return f"https://secure.gravatar.com/avatar/{hash_key}?d=identicon{gravitar_query_suffix}"

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -76,6 +76,7 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
         gravatar_url = get_gravatar_url(
             othello.delivery_email,
             othello.avatar_version,
+            get_realm("zulip").id,
         )
 
         expected_message_data = {

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1203,10 +1203,24 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
             redirect_url = response["Location"]
             self.assertEqual(redirect_url, str(avatar_url(cordelia)) + "&foo=bar")
 
+        with self.settings(
+            ENABLE_GRAVATAR=False, GRAVATAR_REALM_OVERRIDE={get_realm("zulip").id: True}
+        ):
+            response = self.client_get("/avatar/cordelia@zulip.com", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue("gravatar" in redirect_url)
+
         with self.settings(ENABLE_GRAVATAR=False):
             response = self.client_get("/avatar/cordelia@zulip.com", {"foo": "bar"})
             redirect_url = response["Location"]
             self.assertTrue(redirect_url.endswith(str(avatar_url(cordelia)) + "&foo=bar"))
+
+        with self.settings(
+            ENABLE_GRAVATAR=True, GRAVATAR_REALM_OVERRIDE={get_realm("zulip").id: False}
+        ):
+            response = self.client_get("/avatar/cordelia@zulip.com", {"foo": "bar"})
+            redirect_url = response["Location"]
+            self.assertTrue("gravatar" not in redirect_url)
 
     def test_get_settings_avatar(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -386,7 +386,9 @@ class PermissionTest(ZulipTestCase):
         members = self.assert_json_success(result)["members"]
         hamlet = find_dict(members, "user_id", user.id)
         self.assertEqual(hamlet["email"], f"user{user.id}@zulip.testserver")
-        self.assertEqual(hamlet["avatar_url"], get_gravatar_url(user.delivery_email, 1))
+        self.assertEqual(
+            hamlet["avatar_url"], get_gravatar_url(user.delivery_email, 1, get_realm("zulip").id)
+        )
 
         # client_gravatar is still turned off for admins.  In theory,
         # it doesn't need to be, but client-side changes would be
@@ -399,7 +401,9 @@ class PermissionTest(ZulipTestCase):
         members = self.assert_json_success(result)["members"]
         hamlet = find_dict(members, "user_id", user.id)
         self.assertEqual(hamlet["email"], f"user{user.id}@zulip.testserver")
-        self.assertEqual(hamlet["avatar_url"], get_gravatar_url(user.delivery_email, 1))
+        self.assertEqual(
+            hamlet["avatar_url"], get_gravatar_url(user.delivery_email, 1, get_realm("zulip").id)
+        )
         self.assertEqual(hamlet["delivery_email"], self.example_email("hamlet"))
 
     def test_user_cannot_promote_to_admin(self) -> None:

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -406,7 +406,7 @@ def avatar_by_email(
     except UserProfile.DoesNotExist:
         # If there is no such user, treat it as a new gravatar
         avatar_version = 1
-        url = get_gravatar_url(email, avatar_version, medium)
+        url = get_gravatar_url(email, avatar_version, realm.id, medium)
 
     assert url is not None
     if request.META["QUERY_STRING"]:

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -215,6 +215,8 @@ POLICIES_DIRECTORY: str = "zerver/policies_absent"
 # Security
 ENABLE_FILE_LINKS = False
 ENABLE_GRAVATAR = True
+## Overrides the above setting for individual realms, by integer ID.
+GRAVATAR_REALM_OVERRIDE: dict[int, bool] = {}
 INLINE_IMAGE_PREVIEW = True
 INLINE_URL_EMBED_PREVIEW = True
 NAME_CHANGES_DISABLED = False


### PR DESCRIPTION
The functionality of gravatar can break anonymity if the user has had a gravatar account set up previously.

This option allows specifically cloud instances to have gravatar disabled selectively.

Fixes: no specific issue has been created yet

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] ~Visual appearance of the changes.~
- [ ] ~Responsiveness and internationalization.~
- [ ] ~Strings and tooltips.~
- [ ] ~End-to-end functionality of buttons, interactions and flows.~
- [ ] ~Corner cases, error conditions, and easily imagined bugs.~
</details>

The option does have one main issue, it uses `realm.id` instead of the `realm.string_id`. I tried using `string_id` first, but this spawned a whole lot of regression fails due to increased database queries. To mitigate the broken usability of needing to find out the `id`, I added a short description next to the setting.