### PR TITLE
markdown: Handle prettified links in URL placeholder.

### DIFF
--- a/web/third/marked/lib/marked.cjs
+++ b/web/third/marked/lib/marked.cjs
@@ -545,9 +545,16 @@ inline.zulip = merge({}, inline.breaks, {
   unicodeemoji: possible_emoji_regex,
   usermention: /^@(_?)(?:\*\*([^\*]+)\*\*)/, // Match potentially multi-word string between @** **
   groupmention: /^@(_?)(?:\*([^\*]+)\*)/, // Match multi-word string between @* *
+  
+  // These patterns don't handle the case where a prettified link appears
+  // in a markdown link's URL placeholder (e.g. [text](#**stream>topic**)).
+  // While the backend supports this, implementing it in the frontend would add
+  // significant complexity for an extremely rare case that only affects local
+  // echo for a brief moment.
   stream_topic_message: /^#\*\*([^\*>]+)>([^\*]*)@(\d+)\*\*/,
   stream_topic: /^#\*\*([^\*>]+)>([^\*]*)\*\*/,
   stream: /^#\*\*([^\*]+)\*\*/,
+
   tex: /^(\$\$([^\n_$](\\\$|[^\n$])*)\$\$(?!\$))\B/,
   timestamp: /^<time:([^>]+)>/,
   text: replace(inline.breaks.text)

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3357,6 +3357,52 @@ class MarkdownStreamTopicMentionTests(ZulipTestCase):
         )
         self.assertEqual(rendering_result.mentions_user_ids, set())
 
+    def test_stream_in_url(self) -> None:
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "[denmark stream](#**Denmark**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a href="/#narrow/channel/{denmark.id}-Denmark">denmark stream</a></p>',
+        )
+
+    def test_stream_topic_in_url(self) -> None:
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "[topic 1]( #**Denmark>some topic**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            f'<p><a href="/#narrow/channel/{denmark.id}-Denmark/topic/some.20topic">topic 1</a></p>',
+        )
+
+    def test_stream_topic_message_in_url(self) -> None:
+        denmark = get_stream("Denmark", get_realm("zulip"))
+        sender_user_profile = self.example_user("othello")
+        msg = Message(
+            sender=sender_user_profile,
+            sending_client=get_client("test"),
+            realm=sender_user_profile.realm,
+        )
+        content = "As mentioned in [this message](#**Denmark>danish@123**)"
+        self.assertEqual(
+            render_message_markdown(msg, content).rendered_content,
+            "<p>As mentioned in "
+            f"<a "
+            f'href="/#narrow/channel/{denmark.id}-{denmark.name}/topic/danish/near/123">'
+            f"this message</a>"
+            "</p>",
+        )
+
     def test_image_preview_title(self) -> None:
         msg = "[My favorite image](https://example.com/testimage.png)"
         converted = markdown_convert_wrapper(msg)


### PR DESCRIPTION
Handles the stream/topic/message link when a prettified link is pasted in the URL part of a hyperlink text, such as: [text](#**channel**).

This implementation extracts prettified links prefixed with '](' and replaces them with plain text links, which are then processed by the native LinkInlineProcessor.

<!-- Describe your pull request here.-->

Fixes: #31985

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before| After |
|---------|---------|
|![Screenshot_20250119_040301](https://github.com/user-attachments/assets/5dd213fc-d6bd-459b-8c5a-cf4f013b8d0c)|![Screenshot_20250119_040421](https://github.com/user-attachments/assets/c573c618-2139-4489-b927-da72e9a04afa)|

[Screencast_20250119_031537.webm](https://github.com/user-attachments/assets/b6cc8973-e967-430f-b2a3-d12fecfe5825)

I'm not very sure of the functions and variables I've named here. Any suggestion for improvement would be great.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
