### PR TITLE
Fix Cmd + Return to send messages in preview mode on Mac.#32979

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -266,10 +266,10 @@ export function rewire_send_message(value) {
     send_message = value;
 }
 
-export function handle_enter_key_with_preview_open(ctrl_pressed = false) {
+export function handle_enter_key_with_preview_open(cmd_or_ctrl_pressed = false) {
     if (
-        (user_settings.enter_sends && !ctrl_pressed) ||
-        (!user_settings.enter_sends && ctrl_pressed)
+        (user_settings.enter_sends && !cmd_or_ctrl_pressed) ||
+        (!user_settings.enter_sends && cmd_or_ctrl_pressed)
     ) {
         // If this enter should send, we attempt to send the message.
         finish();

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -64,6 +64,7 @@ import * as user_card_popover from "./user_card_popover.ts";
 import * as user_group_popover from "./user_group_popover.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_topics_ui from "./user_topics_ui.ts";
+import {transpileModule} from "typescript";
 
 function do_narrow_action(action) {
     if (message_lists.current === undefined) {
@@ -132,6 +133,7 @@ const keydown_ctrl_mappings = {
 };
 
 const keydown_cmd_or_ctrl_mappings = {
+    13: {name: "ctrl_enter", message_view_only: true}, // enter
     67: {name: "copy_with_c", message_view_only: false}, // 'C'
     75: {name: "search_with_k", message_view_only: false}, // 'K'
     83: {name: "star_message", message_view_only: true}, // 'S'
@@ -596,10 +598,11 @@ export function process_enter_key(e) {
     return true;
 }
 
-export function process_ctrl_enter_key() {
+export function process_cmd_or_ctrl_enter_key() {
     if ($("#preview_message_area").is(":visible")) {
-        const ctrl_pressed = true;
-        compose.handle_enter_key_with_preview_open(ctrl_pressed);
+        const cmd_or_ctrl_pressed = true;
+        compose.handle_enter_key_with_preview_open(cmd_or_ctrl_pressed);
+
         return true;
     }
 
@@ -727,7 +730,7 @@ export function process_hotkey(e, hotkey) {
         case "enter":
             return process_enter_key(e);
         case "ctrl_enter":
-            return process_ctrl_enter_key(e);
+            return process_cmd_or_ctrl_enter_key(e);
         case "tab":
             return process_tab_key();
         case "shift_tab":

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1,7 +1,8 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
-import * as activity from "./activity.ts";
+import "./activity.ts";
+
 import * as activity_ui from "./activity_ui.ts";
 import * as browser_history from "./browser_history.ts";
 import * as color_picker_popover from "./color_picker_popover.ts";

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1,8 +1,7 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
-import "./activity.ts";
-
+import * as activity from "./activity.ts";
 import * as activity_ui from "./activity_ui.ts";
 import * as browser_history from "./browser_history.ts";
 import * as color_picker_popover from "./color_picker_popover.ts";
@@ -65,7 +64,6 @@ import * as user_card_popover from "./user_card_popover.ts";
 import * as user_group_popover from "./user_group_popover.ts";
 import {user_settings} from "./user_settings.ts";
 import * as user_topics_ui from "./user_topics_ui.ts";
-import {transpileModule} from "typescript";
 
 function do_narrow_action(action) {
     if (message_lists.current === undefined) {


### PR DESCRIPTION
cmd+ return commands were not working in preview mode. I have made the necessary changes to fix the issue

Fixes: #32979 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshot** 
![image](https://github.com/user-attachments/assets/bea48117-1021-490e-84c7-791fa3492bd1)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
