### PR TITLE
Improve dropdown select highlighting in inbox/conversation selection menu.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2183,6 +2183,23 @@ body:not(.spectator-view) {
     }
 }
 
+.inbox-filter-dropdown-list-container,
+.recent-view-filter-dropdown-list-container {
+    .list-item {
+        &:focus {
+            border-radius: 4px;
+            outline: 1px solid var(--color-outline-focus) !important;
+            outline-offset: -1px;
+            background-color: transparent;
+        }
+
+        &.active {
+            background-color: var(--background-color-active-dropdown-item);
+            outline: none;
+        }
+    }
+}
+
 .dropdown-list-container .dropdown-list .dropdown-list-item-common-styles {
     position: relative;
     display: flex;

--- a/web/templates/dropdown_list.hbs
+++ b/web/templates/dropdown_list.hbs
@@ -1,5 +1,5 @@
 {{#with item}}
-    <li class="list-item" role="presentation" data-unique-id="{{unique_id}}" data-name="{{name}}" tabindex="0">
+    <li class="list-item {{#if is_item_selected}}active{{/if}}" role="presentation" data-unique-id="{{unique_id}}" data-name="{{name}}" tabindex="0">
         {{#if description}}
         <a class="dropdown-list-item-common-styles">
             <span class="dropdown-list-item-name">


### PR DESCRIPTION
Previously, the dropdown had a bug where the first item was highlighted regardless of the selected option.

This PR fixes the bug, ensuring that the
selected option is now correctly highlighted.

## Tasks completed

- [x] Initially highlight the currently selected option.

- [x] When navigating with the keyboard, show a focus ring, similar to how keyboard selection is indicated in a topic or channel menu.

## Before

[Screencast from 2025-01-19 23-09-02.webm](https://github.com/user-attachments/assets/c381081e-86c3-415a-809c-80a127e59a32)


## After

<table>
<tr>
<th>
Open with keyboard
</th>
<th>
Open with mouse
</th>
</tr>
<tr>
<td>

[Screencast from 2025-01-29 00-26-36.webm](https://github.com/user-attachments/assets/08ce953e-edf2-4000-acf9-eba4d0e1915f)


</td>
<td>

[Screencast from 2025-02-02 01-00-38.webm](https://github.com/user-attachments/assets/b60d43b5-7665-4164-89f9-73b914727bf2)


</td>
</tr>
</table>


Fixes: #33066

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
