### PR TITLE
drafts: Add confirmation banner and undo option for drafts deletion.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -146,7 +146,7 @@ export function send_message_success(request, data) {
     }
 
     echo.reify_message_id(request.local_id, data.id);
-    drafts.draft_model.deleteDraft(request.draft_id);
+    drafts.draft_model.deleteDrafts([request.draft_id]);
 
     if (request.type === "stream") {
         if (data.automatic_new_visibility_policy) {
@@ -369,7 +369,7 @@ function schedule_message_to_custom_date() {
 
     const $banner_container = $("#compose_banners");
     const success = function (data) {
-        drafts.draft_model.deleteDraft(draft_id);
+        drafts.draft_model.deleteDrafts([draft_id]);
         clear_compose_box();
         const new_row_html = render_success_message_scheduled_banner({
             scheduled_message_id: data.scheduled_message_id,

--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -220,12 +220,14 @@ export const draft_model = (function () {
         return changed;
     }
 
-    function deleteDraft(id: string): void {
+    function deleteDrafts(ids: string[]): void {
         const drafts = get();
 
-        // TODO(typescript) rework this to store the draft data in a map.
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete drafts[id];
+        for (const id of ids) {
+            // TODO(typescript) rework this to store the draft data in a map.
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete drafts[id];
+        }
         save(drafts);
     }
 
@@ -235,7 +237,7 @@ export const draft_model = (function () {
         getDraftCount,
         addDraft,
         editDraft,
-        deleteDraft,
+        deleteDrafts,
     };
 })();
 
@@ -273,7 +275,7 @@ export function rewire_sync_count(value: typeof sync_count): void {
 export function delete_all_drafts(): void {
     const drafts = draft_model.get();
     for (const [id] of Object.entries(drafts)) {
-        draft_model.deleteDraft(id);
+        draft_model.deleteDrafts([id]);
     }
 }
 
@@ -436,7 +438,7 @@ export let update_draft = (opts: UpdateDraftOptions = {}): string | undefined =>
         // there is nothing to save here but delete the
         // draft if exists.
         if (draft_id) {
-            draft_model.deleteDraft(draft_id);
+            draft_model.deleteDrafts([draft_id]);
         }
         return undefined;
     }
@@ -614,7 +616,7 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         // drafts overlay can be opened without any errors.
         // We also report the exception to the server so that
         // the bug can be fixed.
-        draft_model.deleteDraft(id);
+        draft_model.deleteDrafts([id]);
         blueslip.error(
             "Error in rendering draft.",
             {

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -4,6 +4,7 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import render_draft_table_body from "../templates/draft_table_body.hbs";
+import render_drafts_list from "../templates/drafts_list.hbs";
 
 import * as browser_history from "./browser_history.ts";
 import * as compose_actions from "./compose_actions.ts";
@@ -190,15 +191,24 @@ function render_widgets(
     other_drafts: FormattedDraft[],
     narrow_drafts_header: string,
 ): void {
-    $("#drafts_table").empty();
-
-    const rendered = render_draft_table_body({
-        narrow_drafts_header,
-        narrow_drafts,
-        other_drafts,
-    });
     const $drafts_table = $("#drafts_table");
-    $drafts_table.append($(rendered));
+    if ($(".drafts-list").length === 0) {
+        const rendered = render_draft_table_body({
+            context: {
+                narrow_drafts_header,
+                narrow_drafts,
+                other_drafts,
+            },
+        });
+        $drafts_table.append($(rendered));
+    } else {
+        const rendered = render_drafts_list({
+            narrow_drafts_header,
+            narrow_drafts,
+            other_drafts,
+        });
+        $(".drafts-list").replaceWith($(rendered));
+    }
     if ($("#drafts_table .overlay-message-row").length > 0) {
         $("#drafts_table .no-drafts").hide();
         // Update possible dynamic elements.
@@ -297,6 +307,7 @@ function setup_bulk_actions_handlers(): void {
 export function launch(): void {
     const {narrow_drafts, other_drafts, narrow_drafts_header} = get_formatted_drafts_data();
 
+    $("#drafts_table").empty();
     render_widgets(narrow_drafts, other_drafts, narrow_drafts_header);
 
     // We need to force a style calculation on the newly created

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -249,7 +249,9 @@ function setup_event_handlers(): void {
             show_check_icon: true,
         });
     });
+}
 
+function setup_bulk_actions_handlers(): void {
     $(".select-drafts-button").on("click", (e) => {
         e.preventDefault();
         const $unchecked_checkboxes = $(".draft-selection-checkbox").filter(function () {
@@ -293,6 +295,7 @@ export function launch(): void {
     const first_element_id = [...formatted_narrow_drafts, ...formatted_other_drafts][0]?.draft_id;
     messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
     setup_event_handlers();
+    setup_bulk_actions_handlers();
     messages_overlay_ui.initialize_restore_overlay_message_tooltip();
 }
 

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -117,7 +117,7 @@ function remove_draft($draft_row: JQuery): void {
     const draft_id = $draft_row.attr("data-draft-id")!;
 
     const draft = drafts.draft_model.getDraft(draft_id);
-    drafts.draft_model.deleteDraft(draft_id);
+    drafts.draft_model.deleteDrafts([draft_id]);
 
     if (draft) {
         draft_undo_delete_list.push(draft);

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -1,4 +1,8 @@
 .drafts-container {
+    .banner-container {
+        margin: 0 25px 5px;
+    }
+
     .header-body {
         display: flex;
         align-items: center;

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -23,24 +23,7 @@
                     </div>
                 </div>
             </div>
-            <div class="drafts-list overlay-messages-list">
-                <div class="no-drafts no-overlay-messages">
-                    {{t 'No drafts.'}}
-                </div>
-
-                <div id="drafts-from-conversation">
-                    <h2>{{narrow_drafts_header}}</h2>
-                    {{#each narrow_drafts}}
-                        {{> draft .}}
-                    {{/each}}
-                </div>
-                <div id="other-drafts">
-                    <h2 id="other-drafts-header">{{t "Other drafts" }}</h2>
-                    {{#each other_drafts}}
-                        {{> draft .}}
-                    {{/each}}
-                </div>
-            </div>
+            {{> drafts_list context }}
         </div>
     </div>
 </div>

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -6,6 +6,7 @@
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
+                <div id="draft_overlay_banner_container" class="banner-container"></div>
                 <div class="header-body">
                     <div class="drafts-header-note">
                         {{t "Drafts are not synced to other devices and browsers." }}

--- a/web/templates/drafts_list.hbs
+++ b/web/templates/drafts_list.hbs
@@ -1,0 +1,18 @@
+<div class="drafts-list overlay-messages-list">
+    <div class="no-drafts no-overlay-messages">
+        {{t 'No drafts.'}}
+    </div>
+
+    <div id="drafts-from-conversation">
+        <h2>{{narrow_drafts_header}}</h2>
+        {{#each narrow_drafts}}
+            {{> draft .}}
+        {{/each}}
+    </div>
+    <div id="other-drafts">
+        <h2 id="other-drafts-header">{{t "Other drafts" }}</h2>
+        {{#each other_drafts}}
+            {{> draft .}}
+        {{/each}}
+    </div>
+</div>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -194,8 +194,8 @@ test_ui("send_message_success", ({override, override_rewire}) => {
     reset();
 
     const draft_model = drafts.draft_model;
-    override(draft_model, "deleteDraft", (draft_id) => {
-        assert.equal(draft_id, 100);
+    override(draft_model, "deleteDrafts", (draft_ids) => {
+        assert.deepEqual(draft_ids, [100]);
         draft_deleted = true;
     });
     override_rewire(echo, "reify_message_id", (local_id, message_id) => {

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -249,7 +249,7 @@ test("draft_model delete", ({override_rewire}) => {
     const id = draft_model.addDraft(draft_1);
     assert.deepEqual(draft_model.getDraft(id), draft_1);
 
-    draft_model.deleteDraft(id);
+    draft_model.deleteDrafts([id]);
     assert.deepEqual(draft_model.getDraft(id), false);
 });
 

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -646,8 +646,8 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
 
     mock_template("draft_table_body.hbs", false, (data) => {
         // Tests formatting and time-sorting of drafts
-        assert.deepEqual(data.narrow_drafts, []);
-        assert.deepEqual(data.other_drafts, expected);
+        assert.deepEqual(data.context.narrow_drafts, []);
+        assert.deepEqual(data.context.other_drafts, expected);
         assert.ok(data);
         return "<draft table stub>";
     });
@@ -657,6 +657,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
     const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
+    $.create(".drafts-list", {children: []});
     $.create("#drafts_table .overlay-message-row", {children: []});
     $(".draft-selection-checkbox").filter = () => [];
     drafts_overlay_ui.launch();
@@ -800,8 +801,8 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
 
     mock_template("draft_table_body.hbs", false, (data) => {
         // Tests splitting up drafts by current narrow.
-        assert.deepEqual(data.narrow_drafts, expected_pm_drafts);
-        assert.deepEqual(data.other_drafts, expected_other_drafts);
+        assert.deepEqual(data.context.narrow_drafts, expected_pm_drafts);
+        assert.deepEqual(data.context.other_drafts, expected_other_drafts);
         return "<draft table stub>";
     });
 
@@ -813,6 +814,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
     override(user_pill, "get_user_ids", () => [aaron.user_id]);
     compose_state.set_message_type("private");
 
+    $.create(".drafts-list", {children: []});
     $.create("#drafts_table .overlay-message-row", {children: []});
     $(".draft-selection-checkbox").filter = () => [];
     drafts_overlay_ui.launch();


### PR DESCRIPTION
Previously, deleting drafts was too easy, which could result in
accidentally losing important information.

This commit adds a green confirmation banner showing "N drafts were
deleted" and "Undo" button to restore deleted drafts.

Fixes: #32995.


**Screenshots and screen captures:**
| Screenshot                                    |
|---------------------------------------------|
| ![draft](https://github.com/user-attachments/assets/41b80342-5fb1-400c-96c3-51074da0f7d6) |

Recording of Interaction: [Link](https://github.com/user-attachments/assets/6058337a-c96c-4d8d-b327-a3025ac9f802)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
