### PR TITLE
Update the HubotIntegrations

### DIFF
--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -291,6 +291,7 @@ def get_fixture_and_image_paths(
 
 class HubotIntegration(Integration):
     GIT_URL_TEMPLATE = "https://github.com/hubot-archive/hubot-{}"
+    SECONDARY_LINE_TEXT = "(Hubot script)"
 
     def __init__(
         self,
@@ -309,6 +310,7 @@ class HubotIntegration(Integration):
             name,
             categories,
             logo=logo,
+            secondary_line_text=self.SECONDARY_LINE_TEXT,
             display_name=display_name,
             doc="zerver/integrations/hubot_common.md",
             legacy=legacy,

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -292,6 +292,7 @@ def get_fixture_and_image_paths(
 class HubotIntegration(Integration):
     GIT_URL_TEMPLATE = "https://github.com/hubot-archive/hubot-{}"
     SECONDARY_LINE_TEXT = "(Hubot script)"
+    DOC_PATH = "zerver/integrations/hubot_common.md"
 
     def __init__(
         self,
@@ -312,7 +313,7 @@ class HubotIntegration(Integration):
             logo=logo,
             secondary_line_text=self.SECONDARY_LINE_TEXT,
             display_name=display_name,
-            doc="zerver/integrations/hubot_common.md",
+            doc=self.DOC_PATH,
             legacy=legacy,
         )
 

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -298,14 +298,9 @@ class HubotIntegration(Integration):
         categories: list[str],
         display_name: str | None = None,
         logo: str | None = None,
-        logo_alt: str | None = None,
         git_url: str | None = None,
         legacy: bool = False,
     ) -> None:
-        if logo_alt is None:
-            logo_alt = f"{name.title()} logo"
-        self.logo_alt = logo_alt
-
         if git_url is None:
             git_url = self.GIT_URL_TEMPLATE.format(name)
         self.hubot_docs_url = git_url
@@ -629,14 +624,10 @@ BOT_INTEGRATIONS: list[BotIntegration] = [
 ]
 
 HUBOT_INTEGRATIONS: list[HubotIntegration] = [
-    HubotIntegration(
-        "assembla",
-        ["version-control", "project-management"],
-        logo_alt="Assembla",
-    ),
+    HubotIntegration("assembla", ["version-control", "project-management"]),
     HubotIntegration("bonusly", ["hr"]),
     HubotIntegration("chartbeat", ["marketing"]),
-    HubotIntegration("darksky", ["misc"], display_name="Dark Sky", logo_alt="Dark Sky logo"),
+    HubotIntegration("darksky", ["misc"], display_name="Dark Sky"),
     HubotIntegration(
         "instagram",
         ["misc"],
@@ -644,12 +635,7 @@ HUBOT_INTEGRATIONS: list[HubotIntegration] = [
         logo="images/integrations/logos/instagra_m.svg",
     ),
     HubotIntegration("mailchimp", ["communication", "marketing"]),
-    HubotIntegration(
-        "google-translate",
-        ["misc"],
-        display_name="Google Translate",
-        logo_alt="Google Translate logo",
-    ),
+    HubotIntegration("google-translate", ["misc"], display_name="Google Translate"),
     HubotIntegration(
         "youtube",
         ["misc"],

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -290,7 +290,7 @@ def get_fixture_and_image_paths(
 
 
 class HubotIntegration(Integration):
-    GIT_URL_TEMPLATE = "https://github.com/hubot-scripts/hubot-{}"
+    GIT_URL_TEMPLATE = "https://github.com/hubot-archive/hubot-{}"
 
     def __init__(
         self,


### PR DESCRIPTION
Layered the commits.

Ordered the refactoring commit (DOC_PATH) at the end, because I'm not sure about it, and I didn't want to block the rest of the commits by placing it at the beginning.

Affected integrations: Hubot integrations - Assembla, Bonusly, Chartbeat, Dark Sky, Instagram, Mailchimp, Google Translate, YouTube.

**Screenshots and screen captures:**

Here's how the catalog looks after adding the secondary line text "(Hubot script)"
![image](https://github.com/user-attachments/assets/e5749752-8d52-459d-8cd3-e1527ed66efe)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
