### PR TITLE
mention: Optimize query when mentioning several groups.

### DIFF
--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -315,9 +315,8 @@ class MarkdownMiscTest(ZulipTestCase):
             check_add_user_group(realm, group_name, [hamlet, cordelia], acting_user=othello)
             content += f" @*{group_name}*"
 
-        # We should be able to do O(1) queries here.
-        UNFORTUNATE_QUERY_COUNT = 41
-        with self.assert_database_query_count(UNFORTUNATE_QUERY_COUNT):
+        CONSTANT_QUERY_COUNT = 2  # even if it increases in future, make sure it's constant.
+        with self.assert_database_query_count(CONSTANT_QUERY_COUNT):
             MentionData(mention_backend, content, message_sender=None)
 
     def test_invalid_katex_path(self) -> None:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -310,7 +310,7 @@ class MarkdownMiscTest(ZulipTestCase):
         mention_backend = MentionBackend(realm.id)
 
         content = ""
-        for i in range(40):
+        for i in range(5):
             group_name = f"group{i}"
             check_add_user_group(realm, group_name, [hamlet, cordelia], acting_user=othello)
             content += f" @*{group_name}*"


### PR DESCRIPTION
Fixes #32934

## Goal Achieved
Fetching all members (direct & via sub-groups) of groups mentioned in a single message, using a constant number of  queries (only 2 queries) .

## Changes
1. Create `get_root_id_annotated_recursive_subgroups_for_groups` which is the same as `get_recursive_subgroups_for_groups` except the former keeps track of and annotates  `root_id` for each group.

2. Attach `prefetch_related` to the  result of `get_root_id_annotated_recursive_subgroups_for_groups`, to get all the matching **active** members, **fetching only their ids**.

## Performance Testing
Using `CaptureQueriesContext`: 

`get_root_id_annotated_recursive_subgroups_for_groups` executes only **one query**, as opposed to iteratively calling `get_recursive_group_members`  which runs in `O(n)`.

## Manual Functional Testing

I tested the following cases, mentioning them in a single message :

- only groups with direct members (no sub-groups).
- only groups with non-direct members (sub-groups).
- groups with both direct & indirect members.
- a sub-group (e.g. engineering-managers).
- combination of all of the above.

For each case I combared the outcome of my changes to the expected outcome.