### PR TITLE
billing: Update plans page for "legacy" name change.

### DIFF
--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -225,7 +225,7 @@
                         <div class="bottom">
                             <div class="text-content">
                                 <div class="standard-price-box">
-                                    {% if (is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BASIC)
+                                    {% if (has_scheduled_upgrade and scheduled_upgrade_plan.tier == scheduled_upgrade_plan.TIER_SELF_HOSTED_BASIC)
                                       or (is_self_hosted_realm and sponsorship_pending and requested_sponsorship_plan == "Basic")
                                       or (is_self_hosted_realm and customer_plan and customer_plan.tier != customer_plan.TIER_SELF_HOSTED_LEGACY)%}
                                     <div class="price"><span class="currency-symbol">$</span>3.50</div>
@@ -246,7 +246,7 @@
                                     </div>
                                     {% endif %}
                                 </div>
-                                {% if is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BASIC %}
+                                {% if has_scheduled_upgrade and scheduled_upgrade_plan.tier == scheduled_upgrade_plan.TIER_SELF_HOSTED_BASIC %}
                                 <a href="{{ billing_base_url }}/billing/" class="button current-plan-button">
                                     Upgrade is scheduled
                                 </a>
@@ -310,7 +310,7 @@
                         <div class="bottom">
                             <div class="text-content">
                                 <div class="standard-price-box">
-                                    {% if (is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BUSINESS)
+                                    {% if (has_scheduled_upgrade and scheduled_upgrade_plan.tier == scheduled_upgrade_plan.TIER_SELF_HOSTED_BUSINESS)
                                       or (is_self_hosted_realm and sponsorship_pending and requested_sponsorship_plan == "Business")
                                       or (is_self_hosted_realm and customer_plan and customer_plan.tier != customer_plan.TIER_SELF_HOSTED_LEGACY)%}
                                     <div class="price"><span class="currency-symbol">$</span>6.67</div>
@@ -333,7 +333,7 @@
                                     </div>
                                     {% endif %}
                                 </div>
-                                {% if is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_BUSINESS %}
+                                {% if has_scheduled_upgrade and scheduled_upgrade_plan.tier == scheduled_upgrade_plan.TIER_SELF_HOSTED_BUSINESS %}
                                 <a href="{{ billing_base_url }}/billing/" class="button current-plan-button">
                                     Upgrade is scheduled
                                 </a>
@@ -389,7 +389,7 @@
                         </div>
                         <div class="bottom">
                             <div class="text-content">
-                                {% if is_legacy_server_with_scheduled_upgrade and legacy_server_new_plan.tier == legacy_server_new_plan.TIER_SELF_HOSTED_ENTERPRISE %}
+                                {% if has_scheduled_upgrade and scheduled_upgrade_plan.tier == scheduled_upgrade_plan.TIER_SELF_HOSTED_ENTERPRISE %}
                                 <a href="{{ billing_base_url }}/billing/" class="button current-plan-button">
                                     Upgrade is scheduled
                                 </a>


### PR DESCRIPTION
Updates the context variables used in the plans page template for the "legacy" plan change to "complimentary access".

**Notes**:
- Fixes the logic for when to show an "Upgrade scheduled" notice on the plans page template. Previously, that note was shown in the case that an annual fixed-price plan had a continuing plan scheduled for the upcoming year.

**Follow-ups**:
- Technically, an annual fixed-price plan could have a downgrade scheduled, e.g., the customer is on the Zulip Business plan currently and the upcoming year they negotiated a fixed-price plan for Zulip Basic. This is the only current case where a downgrade could be "scheduled". Regular plans would just be scheduled to end without a plan tier change. We should probably think about how we'd want this to appear on both the billing and plans page that the customer can access for this billing state (see screenshots below for plans page).

---

**Screenshots and screen captures:**

### Complimentary access plan with upgrade scheduled - NO CHANGE:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-20 17-08-47](https://github.com/user-attachments/assets/3b29c465-4aea-48fa-8182-83037ff89cac) | ![Screenshot from 2025-01-20 17-08-25](https://github.com/user-attachments/assets/efd5e5bb-b635-4f7e-a359-da0233a6028c) |

### Fixed-price annual plan with continuation of plan scheduled:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-20 17-07-33](https://github.com/user-attachments/assets/088e0d6b-c411-4b17-a554-fc7f73770923) | ![Screenshot from 2025-01-20 17-06-29](https://github.com/user-attachments/assets/ba7404b3-a3bd-4428-b51b-eacfc09715b4) |


### Fixed-price annual plan with downgrade scheduled - NO CHANGE:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-01-20 17-21-22](https://github.com/user-attachments/assets/fc5b62eb-75e7-488e-ae5f-d7a0279fa511) |  ![Screenshot from 2025-01-20 17-20-58](https://github.com/user-attachments/assets/44f12367-e3bb-4018-8ca4-7fb0a4dba27c) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
