### PR TITLE
left_sidebar: Present uniform, gridded filter boxes.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -82,7 +82,7 @@
     font-weight: normal;
 
     .topic_search_section {
-        margin: 3px 0;
+        margin: 3px 0 3px var(--left-sidebar-toggle-width-offset);
     }
 
     & li {
@@ -962,7 +962,7 @@ li.top_left_scheduled_messages {
        definitions have the final say about dimensions and placement. */
     grid-template-areas:
         "starting-offset starting-anchor-element icon-content-gap row-content controls   markers-and-unreads ending-anchor-element ending-offset"
-        ".               .                       filter-box       filter-box  filter-box filter-box          filter-box            .            ";
+        ".               filter-box              filter-box       filter-box  filter-box filter-box          filter-box            .            ";
 }
 
 #views-label-container {
@@ -1113,6 +1113,20 @@ li.top_left_scheduled_messages {
     }
 }
 
+.left-sidebar-filter-row {
+    display: grid;
+    grid-template-columns:
+        [filter-box-start] minmax(0, 1fr)
+        [clear-button-start] var(--line-height-sidebar-row-prominent)
+        [clear-button-end filter-box-end];
+    grid-template-rows: [filter-box-start clear-button-start] auto [clear-button-end filter-box-end];
+    align-content: center;
+
+    .clear_search_button {
+        grid-area: clear-button;
+    }
+}
+
 .topic-box,
 .searching-for-more-topics {
     display: grid;
@@ -1131,12 +1145,6 @@ li.top_left_scheduled_messages {
 .searching-for-more-topics {
     margin-left: var(--left-sidebar-toggle-width-offset);
     height: var(--line-height-sidebar-row-prominent);
-}
-
-.topic_search_section {
-    padding: 8px 10px;
-    display: grid;
-    grid-template: "search-input clear-search" auto / minmax(0, 1fr) 30px;
 }
 
 .topic-box .zero_count {
@@ -1206,14 +1214,18 @@ li.top_left_scheduled_messages {
     }
 }
 
+.direct-messages-list-filter {
+    grid-area: filter-box;
+    padding-right: var(--line-height-sidebar-row-prominent);
+}
+
 .topic-list-filter {
+    grid-area: filter-box;
+    padding-right: var(--line-height-sidebar-row-prominent);
     box-shadow: none;
-    padding-right: 28px;
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
-    grid-column: search-input-start / clear-search-end;
-    grid-row: search-input;
 }
 
 #filter-topic-input:placeholder-shown + #clear_search_topic_button {
@@ -1607,10 +1619,11 @@ li.topic-list-item {
     background-color: var(--color-background);
 
     &.showing-stream-search-section {
-        /* Open up the stream-search rows. The 10px
+        /* Open up the stream-search rows. The 3px gap + 7px
            row maintains space with the streams list
            below. */
-        grid-template-rows: var(--line-height-sidebar-row-prominent) 28px 10px;
+        grid-template-rows: var(--line-height-sidebar-row-prominent) auto 7px;
+        row-gap: 3px;
 
         /* When the search section is showing, switch
            off the hover effects on the row. */
@@ -1690,12 +1703,12 @@ li.topic-list-item {
 
     .stream_search_section {
         grid-area: filter-box;
-        display: flex;
-        justify-content: stretch;
-        /* Set an even line-height for better
-           vertical centering. */
-        line-height: 20px;
         white-space: nowrap;
+    }
+
+    .stream-list-filter {
+        grid-area: filter-box;
+        padding-right: var(--line-height-sidebar-row-prominent);
     }
 
     &.hide_unread_counts {
@@ -1730,29 +1743,6 @@ li.topic-list-item {
 
 .stream_search_section,
 .direct-messages-search-section {
-    .stream-list-filter,
-    .direct-messages-list-filter {
-        box-sizing: border-box;
-        width: 100%;
-        /* Match the input height exactly
-           with the row height for a perfect
-           fit and better vertical alignment. */
-        height: 28px;
-        /* Pad the entire clear-button area,
-           so that input text does not bleed
-           into there. */
-        padding-right: 30px;
-    }
-
-    .clear_search_button {
-        box-sizing: border-box;
-        position: static;
-        display: grid;
-        place-items: center;
-        width: 30px;
-        margin-left: -30px;
-    }
-
     .direct-messages-list-filter:placeholder-shown
         + #clear-direct-messages-search-button {
         display: none;
@@ -1826,6 +1816,7 @@ li.topic-list-item {
     }
 }
 
+.direct-messages-list-filter,
 .stream-list-filter {
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -1894,10 +1885,8 @@ li.topic-list-item {
     }
 
     .direct-messages-search-section {
-        display: flex;
-        grid-column: row-content / markers-and-unreads;
-        margin-top: 5px;
-        margin-bottom: 5px;
+        grid-column: filter-box;
+        margin: 5px 0 5px var(--left-sidebar-toggle-width-offset);
     }
 
     .zoom-in-hide {

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,4 +1,4 @@
-<div class="topic_search_section filter-topics">
+<div class="topic_search_section filter-topics left-sidebar-filter-row">
     <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
     <button type="button" class="clear_search_button" id="clear_search_topic_button">
         <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -163,7 +163,7 @@
         <a class="zoom-out-hide" id="hide-more-direct-messages">
             <span class="hide-more-direct-messages-text"> {{t 'back to channels' }}</span>
         </a>
-        <div class="zoom-out-hide direct-messages-search-section">
+        <div class="zoom-out-hide direct-messages-search-section left-sidebar-filter-row">
             <input class="direct-messages-list-filter filter_text_input home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter direct messages' }}" />
             <button type="button" class="clear_search_button" id="clear-direct-messages-search-button">
                 <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
@@ -192,7 +192,7 @@
                     </span>
                 </div>
 
-                <div class="notdisplayed stream_search_section">
+                <div class="notdisplayed stream_search_section left-sidebar-filter-row">
                     <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter channels' }}" />
                     <button type="button" class="clear_search_button" id="clear_search_stream_button">
                         <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>


### PR DESCRIPTION
This PR presents a proper gridded layout for filter-box inputs and close buttons, correcting some issues introduced by #32638. 

It also ensures that all three left-sidebar filters (DMs, channels, and topics) occupy the same vertical and horizontal space and offsets (note especially how the DM filter now matches the width of the channels and topics filters, and how all filters uniformly align to the left and right of other rows), and present an ellipsis on long filter input when the filter box is unfocused (previously, the DM filter was missing that).

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.E2.9C.94.20extra.20line.20in.20left.20sidebar/near/2035611)

**Screenshots and screen captures:**

_All screenshots show compact mode and 16px and 20px font-size. In addition to before and after comparisons, it can be useful to compare the after shots at, say, 16px._

| DMs, Before | DMs, After |
| --- | --- |
| ![dms-compact-before](https://github.com/user-attachments/assets/56ab570d-fc60-4e50-87cc-677b89b73364) | ![dms-compact-after](https://github.com/user-attachments/assets/491ac000-f524-46ce-ac69-5b89a7e8abfc) |
| ![dms-16-before](https://github.com/user-attachments/assets/bd234893-1a89-4c61-bed9-7c95f98e18bd) | ![dms-16-after](https://github.com/user-attachments/assets/65bedd92-cca1-4f43-96f2-e443579ad9c6) |
| ![dms-20-before](https://github.com/user-attachments/assets/4da5f1f5-03ab-4df1-be71-a7b5e428a5ef) | ![dms-20-after](https://github.com/user-attachments/assets/43cf2881-0163-4518-8943-2975b55d0ce7) |

| Channels, Before | Channels, After |
| --- | --- |
| ![channels-compact-before](https://github.com/user-attachments/assets/7f093cd0-0dcb-4806-a468-fefaed0d012b) | ![channels-compact-after](https://github.com/user-attachments/assets/f1ab2a8d-86cb-4d83-9356-3b71c2ec9c73) |
| ![channels-16-before](https://github.com/user-attachments/assets/d562fd5b-a2f3-4d7b-949d-416fb449e850) | ![channels-16-after](https://github.com/user-attachments/assets/e350b68e-a37c-4671-8ac2-a8e6cec3db8e) |
| ![channels-20-before](https://github.com/user-attachments/assets/f67f76bf-de71-4dca-b57a-5c3a5fe52002) | ![channels-20-after](https://github.com/user-attachments/assets/79f9b79c-c9de-433e-a4e3-dfc560cc1c02) |

| Topics, Before | Topics, After |
| --- | --- |
| ![topics-compact-before](https://github.com/user-attachments/assets/95a1ae02-9717-4dae-ba97-bf036db4cf66) | ![topics-compact-after](https://github.com/user-attachments/assets/ee6ec401-f4f3-4ab9-937a-49c7119365b1) |
| ![topics-16-before](https://github.com/user-attachments/assets/7737e1fa-e043-485c-97f5-b8c205fd870e) | ![topics-16-after](https://github.com/user-attachments/assets/9fbd29d2-1412-4b8d-9c57-2739e7ba5c3d) |
| ![topics-20-before](https://github.com/user-attachments/assets/18797819-e589-4f1b-a9d6-0edd51661aa7) | ![topics-20-after](https://github.com/user-attachments/assets/c61855b2-e75c-4c87-8e05-1203065f56c7) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>