### PR TITLE
compose: Allow left arrow to scroll buttons.

### DIFF
--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -148,6 +148,15 @@ function cursor_at_start_of_whitespace_in_compose(): boolean {
     return message_content() === "" && cursor_position === 0;
 }
 
+export function focus_in_formatting_buttons(): boolean {
+    const is_focused_formatting_button =
+        document.activeElement?.classList.contains("compose_control_button");
+    if (is_focused_formatting_button) {
+        return true;
+    }
+    return false;
+}
+
 export function focus_in_empty_compose(
     consider_start_of_whitespace_message_empty = false,
 ): boolean {

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -936,6 +936,9 @@ export function process_hotkey(e, hotkey) {
         } else if (overlays.streams_open()) {
             stream_settings_ui.toggle_view(event_name);
             return true;
+        } else if (compose_state.focus_in_formatting_buttons()) {
+            // Allow left arrow to scroll the formatting buttons backward
+            return false;
         }
 
         message_edit.edit_last_sent_message();


### PR DESCRIPTION
This PR permits the left arrow key to scroll the formatting buttons when keyboard focus is in the buttons area, making it so both the right and left arrows can control the scroll.

Additional work is being discussed [on CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/arrow.20keys.20on.20scrolling.20formatting.20buttons/near/2043652), but will not be addressed until [after the 10.0 release](https://chat.zulip.org/#narrow/channel/101-design/topic/arrow.20keys.20on.20scrolling.20formatting.20buttons/near/2043779).

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/arrow.20keys.20on.20scrolling.20formatting.20buttons/near/2043652)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![arrow-key-scrolling](https://github.com/user-attachments/assets/12f913c7-f21c-48ac-9736-4e0ae2d913a4)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>