### PR TITLE
left_sidebar: Avoid closing sidebar in narrow views when interacting with popovers.

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -210,6 +210,13 @@ export function initialize(): void {
 
             if (
                 left_sidebar_expanded_as_overlay &&
+                $elt.closest(".auto-hide-left-sidebar-overlay").length > 0
+            ) {
+                hide_streamlist_sidebar();
+            }
+
+            if (
+                left_sidebar_expanded_as_overlay &&
                 $elt.closest(".no-auto-hide-left-sidebar-overlay").length === 0
             ) {
                 const $left_column = $(".app-main .column-left");

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -153,7 +153,7 @@
             <a id="show-all-direct-messages" class="tippy-left-sidebar-tooltip-no-label-delay" href="#narrow/is/dm" data-tooltip-template-id="show-all-direct-messages-template">
                 <i class="zulip-icon zulip-icon-all-messages" aria-label="{{t 'Direct message feed' }}"></i>
             </a>
-            <span id="compose-new-direct-message" class="tippy-left-sidebar-tooltip-no-label-delay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
+            <span id="compose-new-direct-message" class="tippy-left-sidebar-tooltip-no-label-delay auto-hide-left-sidebar-overlay" data-tooltip-template-id="new_direct_message_button_tooltip_template">
                 <i class="left-sidebar-new-direct-message-icon zulip-icon zulip-icon-square-plus" aria-label="{{t 'New direct message' }}"></i>
             </span>
         </div>

--- a/web/templates/popovers/color_picker_popover.hbs
+++ b/web/templates/popovers/color_picker_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu color-picker-popover" data-simplebar data-simplebar-tab-index="-1">
+<div class="popover-menu color-picker-popover no-auto-hide-left-sidebar-overlay" data-simplebar data-simplebar-tab-index="-1">
     <div class="message_header message_header_stream" data-stream-id="{{stream_id}}">
         <div class="message-header-contents" style="background: {{recipient_bar_color}};">
             <div class="message_label_clickable stream_label">

--- a/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs
@@ -8,7 +8,7 @@
             </a>
         </li>
         {{else}}
-        <li role="none" class="link-item popover-menu-list-item">
+        <li role="none" class="link-item popover-menu-list-item no-auto-hide-left-sidebar-overlay">
             <a role="menuitem" class="set-home-view popover-menu-link" data-view-code="{{view_code}}" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-house" aria-hidden="true"></i>
                 <span class="popover-menu-label">

--- a/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_inbox_popover.hbs
@@ -8,7 +8,7 @@
             </a>
         </li>
         {{else}}
-        <li role="none" class="link-item popover-menu-list-item">
+        <li role="none" class="link-item popover-menu-list-item no-auto-hide-left-sidebar-overlay">
             <a role="menuitem" class="set-home-view popover-menu-link" data-view-code="{{view_code}}" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-house" aria-hidden="true"></i>
                 <span class="popover-menu-label">

--- a/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_recent_view_popover.hbs
@@ -8,7 +8,7 @@
             </a>
         </li>
         {{else}}
-        <li role="none" class="link-item popover-menu-list-item">
+        <li role="none" class="link-item popover-menu-list-item no-auto-hide-left-sidebar-overlay">
             <a role="menuitem" class="set-home-view popover-menu-link" data-view-code="{{view_code}}" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-house" aria-hidden="true"></i>
                 <span class="popover-menu-label">

--- a/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_starred_messages_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
+<div class="popover-menu no-auto-hide-left-sidebar-overlay" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         {{#if show_unstar_all_button}}
         <li role="none" class="link-item popover-menu-list-item">

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="stream-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
+<div class="popover-menu no-auto-hide-left-sidebar-overlay" id="stream-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
         <li role="none" class="popover-stream-header text-item popover-menu-list-item">
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
@@ -65,7 +65,7 @@
             </a>
         </li>
         <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
-        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators no-auto-hide-left-sidebar-overlay">
+        <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="choose_stream_color popover-menu-link" data-stream-id="{{ stream.stream_id }}" tabindex="0">
                 <i class="popover-menu-icon zulip-icon zulip-icon-pipette" aria-hidden="true"></i>
                 <span class="popover-menu-label">{{t "Change color"}}</span>

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -1,4 +1,4 @@
-<div class="popover-menu" id="topic-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
+<div class="popover-menu no-auto-hide-left-sidebar-overlay" id="topic-actions-menu-popover" data-simplebar data-simplebar-tab-index="-1">
     <ul role="menu" class="popover-menu-list">
         <li role="none" class="popover-topic-header text-item popover-menu-list-item">
             <span class="popover-topic-name {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -12,7 +12,7 @@
 
             <div class="left-sidebar-controls">
                 {{#if can_post_messages}}
-                <div class="channel-new-topic-button tippy-zulip-tooltip hidden-for-spectators" data-tippy-content="{{t 'New topic'}}" data-stream-id="{{id}}">
+                <div class="channel-new-topic-button tippy-zulip-tooltip hidden-for-spectators auto-hide-left-sidebar-overlay" data-tippy-content="{{t 'New topic'}}" data-stream-id="{{id}}">
                     <i class="channel-new-topic-icon zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                 </div>
                 {{/if}}


### PR DESCRIPTION
Fixes: #27625 

[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/narrow.20left.20sidebar.20closing/near/1678316)

Clicking on left_sidebar popovers on smaller screens, where the left_sidebar is hidden by default, caused the left_sidebar to close automatically. This required users to repeatedly reopen the sidebar if they wanted to perform multiple actions on the popover.

The first commit of this PR resolves this issue by adding the `no-auto-hide-left-sidebar-overlay` class to the left_sidebar popovers.
This class was previously used only on the "Change color" option but not on whole popover or the color picker popover itself.

<details>
<summary>Before</summary>

[issue_left_sidebar.webm](https://github.com/user-attachments/assets/a030ab87-91ab-4b6e-85c6-16b71f605751)
</details>

<details>
<summary>After</summary>

[fix_left_sidebar.webm](https://github.com/user-attachments/assets/0d52c182-1be5-4f83-a6d8-88c9972b7d7a)
</details>

Note: This PR prevents auto-hiding of left sidebar only when clicking on popovers but not modals.

I also noticed that clicking the `New topic` and `New direct message` buttons did not close the left_sidebar because these buttons are located within the left_sidebar. Clicking these buttons made the cursor to focus over the compose but the compose remained half hidden by the left_sidebar.

The second commit of this PR solves this issue by adding `auto-hide-left-sidebar-overlay` class on these buttons.

<details>
<summary>Before</summary>

[issue_left_sidebar_2.webm](https://github.com/user-attachments/assets/a6410b08-a4d7-4cba-be50-19375d40ab9d)
</details>

<details>
<summary>After</summary>

[fix_left_sidebar_2.webm](https://github.com/user-attachments/assets/31feec44-5aa7-4157-8d0b-8dbfc1db429d)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
