### PR TITLE
searchbox_css: Replace `display: none` with `visibility: hidden`.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1085,7 +1085,7 @@ textarea.new_message_textarea {
 
     #stream_message_recipient_topic:placeholder-shown
         + #recipient_box_clear_topic_button {
-        display: none;
+        visibility: hidden;
     }
     /* This will reset the bootstrap margin-bottom: 10px value for the inputs */
     & input {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -92,7 +92,7 @@
         }
 
         #inbox-search:placeholder-shown + #inbox-clear-search {
-            display: none;
+            visibility: hidden;
         }
 
         #inbox-search {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1217,7 +1217,7 @@ li.top_left_scheduled_messages {
 }
 
 #filter-topic-input:placeholder-shown + #clear_search_topic_button {
-    display: none;
+    visibility: hidden;
 }
 
 .searching-for-more-topics img {
@@ -1755,11 +1755,11 @@ li.topic-list-item {
 
     .direct-messages-list-filter:placeholder-shown
         + #clear-direct-messages-search-button {
-        display: none;
+        visibility: hidden;
     }
 
     .stream-list-filter:placeholder-shown + #clear_search_stream_button {
-        display: none;
+        visibility: hidden;
     }
 }
 

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -488,7 +488,7 @@ $user_status_emoji_width: 24px;
         }
 
         .user-list-filter:placeholder-shown + #clear_search_people_button {
-            display: none;
+            visibility: hidden;
         }
     }
 


### PR DESCRIPTION
This PR standardizes the use of `visibility: hidden` for `clear_search_buttons` in search boxes instead of `display: none`.

related [comment](https://github.com/zulip/zulip/pull/33047#issuecomment-2603110892)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
