### PR TITLE
Setting filters

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2024,8 +2024,9 @@ label.preferences-radio-choice-label {
         gap: 6px;
 
         & .dropdown-widget-button {
-            height: 30px;
+            height: 1.4em;
             max-width: 160px;
+            box-sizing: content-box;
         }
 
         & input.search {
@@ -2092,7 +2093,7 @@ label.preferences-radio-choice-label {
         .dropdown-widget-button, we need to explicitly set the height here.
         We could set the height inside .user_filters but that would make
         the height a tiny bit inconsistent on pages without .user_filters. */
-        height: 20px;
+        height: 1.4em;
         float: right;
         font-size: 1em;
         max-width: 160px;

--- a/web/templates/settings/active_user_list_admin.hbs
+++ b/web/templates/settings/active_user_list_admin.hbs
@@ -5,7 +5,7 @@
         <div class="alert-notification" id="user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=active_user_list_dropdown_widget_name}}
-            {{> filter_text_input placeholder=(t 'Filter users') aria_label=(t 'Filter users')}}
+            {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter users')}}
         </div>
     </div>
 

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -2,7 +2,7 @@
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
         <h3>{{t "Your uploads"}}</h3>
-        {{> filter_text_input id="upload_file_search" placeholder=(t 'Filter uploaded files') aria_label=(t 'Filter uploads')}}
+        {{> filter_text_input id="upload_file_search" placeholder=(t 'Filter') aria_label=(t 'Filter uploads')}}
     </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -21,7 +21,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>
         <div class="alert-notification" id="bot-field-status"></div>
-        {{> filter_text_input placeholder=(t 'Filter bots') aria_label=(t 'Filter bots')}}
+        {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter bots')}}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -55,7 +55,7 @@
             <h3>{{t "Export permissions"}}</h3>
             <div class="user_filters">
                 {{> ../dropdown_widget widget_name="filter_by_consent"}}
-                {{> filter_text_input placeholder=(t 'Filter users') aria_label=(t 'Filter users')}}
+                {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter users')}}
             </div>
         </div>
 

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -8,7 +8,7 @@
         <div class="alert-notification" id="deactivated-user-field-status"></div>
         <div class="user_filters">
             {{> ../dropdown_widget widget_name=deactivated_user_list_dropdown_widget_name}}
-            {{> filter_text_input placeholder=(t 'Filter deactivated users') aria_label=(t 'Filter deactivated users')}}
+            {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter deactivated users')}}
         </div>
     </div>
 

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -7,7 +7,7 @@
             {{#if is_admin}}
                 <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
             {{/if}}
-            {{> filter_text_input placeholder=(t 'Filter default channels') aria_label=(t 'Filter default channels')}}
+            {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter default channels')}}
         </div>
     </div>
 

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -11,7 +11,7 @@
 
     <div class="settings_panel_list_header">
         <h3>{{t "Custom emoji"}}</h3>
-        {{> filter_text_input placeholder=(t 'Filter emoji') aria_label=(t 'Filter emoji')}}
+        {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter emoji')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table admin_emoji_table">

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -8,7 +8,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Invitations "}}</h3>
         <div class="alert-notification" id="invites-field-status"></div>
-        {{> filter_text_input placeholder=(t 'Filter invitations') aria_label=(t 'Filter invitations')}}
+        {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter invitations')}}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -57,7 +57,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Linkifiers"}}</h3>
         <div class="alert-notification edit-linkifier-status" id="linkifier-field-status"></div>
-        {{> filter_text_input placeholder=(t 'Filter linkifiers') aria_label=(t 'Filter linkifiers')}}
+        {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter linkifiers')}}
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -1,7 +1,7 @@
 <div id="muted-user-settings" class="settings-section" data-name="muted-users">
     <div class="settings_panel_list_header">
         <h3>{{t "Muted users"}}</h3>
-        {{> filter_text_input id="muted_users_search" placeholder=(t 'Filter muted users') aria_label=(t 'Filter muted users')}}
+        {{> filter_text_input id="muted_users_search" placeholder=(t 'Filter') aria_label=(t 'Filter muted users')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -64,7 +64,7 @@
 
         <div class="settings_panel_list_header">
             <h3>{{t "Code playgrounds"}}</h3>
-            {{> filter_text_input placeholder=(t 'Filter code playgrounds') aria_label=(t 'Filter code playgrounds')}}
+            {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter code playgrounds')}}
         </div>
 
         <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -12,7 +12,7 @@
             {{> ../help_link_widget link="/help/topic-notifications" }}
         </h3>
         {{> settings_save_discard_widget section_name="user-topics-settings" show_only_indicator=true }}
-        {{> filter_text_input id="user_topics_search" placeholder=(t 'Filter topics') aria_label=(t 'Filter invitations')}}
+        {{> filter_text_input id="user_topics_search" placeholder=(t 'Filter') aria_label=(t 'Filter invitations')}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -13,7 +13,7 @@
     <div>
         <h4 class="inline-block stream_setting_subsection_title">{{t "Subscribers"}}</h4>
         <span class="subscriber-search float-right">
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter subscribers' }}" />
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
         </span>
     </div>
     <div class="subscriber-list-box">

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -15,7 +15,7 @@
     <div>
         <h4 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h4>
         <span class="member-search float-right">
-            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter members' }}" />
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter' }}" />
         </span>
     </div>
     <div class="member-list-box">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Commit 1:
There are cases where the placeholder text overflows outside of the input box. In the settings panels, all these filter boxes are on the same row as a subheading on the left side. So the x in `Filter x` is usually the subheading title, making it redundant to mention the x part. We have not modified the aria-labels since it might still be helpful for assistive technologies to have the whole `Filter x` part.
[CZO thread](https://chat.zulip.org/#narrow/channel/101-design/topic/setting.20filter.20width)

Commit 2:
By removing an explicit height, we let the font-size, padding and line-height decide the height, which will vary based on font-size. We had to set line-height explicitly to 1.25em = 20px at 16px/1em since dropdown's height within the header was somehow 0.5px more than the filter beside it at line-height: normal, explicitly specifying the line-height fixed it.
[CZO thread](https://chat.zulip.org/#narrow/channel/101-design/topic/setting.20filter.20height)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Height adjustment:
| Before | After |
| --- | --- |
|  <img width="757" alt="Screenshot 2025-01-21 at 2 03 42 PM" src="https://github.com/user-attachments/assets/1d992e88-0dbb-4292-95d5-9394577359f7" /> | ![Screenshot 2025-02-11 at 5 00 16 PM](https://github.com/user-attachments/assets/198810ec-8d81-4bfd-b00c-3e7463c4be31)  |
| <img width="757" alt="Screenshot 2025-01-21 at 2 03 54 PM" src="https://github.com/user-attachments/assets/2bd5ad62-f6e0-4396-a8cf-ec4229a76b69" /> | ![role_filter_16px](https://github.com/user-attachments/assets/efdb890a-0705-4bc4-adef-a04c0d2cbbea) |

New height at different font-sizes:

12px:
![role_filter_12px](https://github.com/user-attachments/assets/cdd7f70d-012c-45e6-a877-70909bbc6b00)

14px:
![role_filter_14px](https://github.com/user-attachments/assets/18546210-3494-433d-a508-54580b5db0fa)

16px:
![role_filter_16px](https://github.com/user-attachments/assets/efdb890a-0705-4bc4-adef-a04c0d2cbbea)

18px:
![role_filter_18px](https://github.com/user-attachments/assets/47154e57-8da0-4d62-be50-3c88ea9fb338)

20px:
![role_filter_20px](https://github.com/user-attachments/assets/00fa57bf-5255-4c74-b6b2-6ace79706689)



Renaming filter string (some examples):
![role_filter_16px](https://github.com/user-attachments/assets/efdb890a-0705-4bc4-adef-a04c0d2cbbea)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
