### PR TITLE
polls: Do not use pixel height for poll title.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -105,8 +105,9 @@
 
 .todo-widget,
 .poll-widget {
-    & h4 {
-        font-size: 18px;
+    .poll-question-header,
+    .todo-task-list-title-header {
+        font-size: 1.1em;
         font-weight: 600;
     }
 


### PR DESCRIPTION
Poll title was set to 18px which was leading to the title looking smaller than the options in 20px font size. Removing that explicit font-size declaration will make the h4 font-size fall back to 1.1em and thus that title will scale properly to font-size changes. At 16px, the font-size for the title was 18px initially, now it is 17.6px which should not be that big of a change.

NOTE: This PR also applies the same change to TODO lists as well since they share the same css, but I have not uploaded screenshots since it felt redundant to do so.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| 12px | 12px |
| <img width="745" alt="poll_12px_before" src="https://github.com/user-attachments/assets/ec16970b-40ba-4f00-8cba-6ce1d28b530a" /> | <img width="745" alt="poll_12px_after" src="https://github.com/user-attachments/assets/e567ef29-24d2-431a-a0e6-6a5f3b75edde" /> |
| 14px | 14px |
| <img width="877" alt="poll_14px_before" src="https://github.com/user-attachments/assets/5f3776f5-3745-4587-bae9-89d6f1bac78a" /> | <img width="877" alt="poll_14px_after" src="https://github.com/user-attachments/assets/f33c3372-1993-43e8-9125-5011ad703382" /> |
| 16px | 16px |
| <img width="995" alt="poll_16px_before" src="https://github.com/user-attachments/assets/5866a298-0bac-4fd3-a5e2-16b8ce5fa372" /> | <img width="995" alt="poll_16px_after" src="https://github.com/user-attachments/assets/7b86dc5a-583b-4d4e-ab2f-73d1f06c3809" /> |
| 18px | 18px |
| <img width="1097" alt="poll_18px_before" src="https://github.com/user-attachments/assets/575b4865-e7d3-486d-a537-7744020a1a25" /> | <img width="1097" alt="poll_18px_after" src="https://github.com/user-attachments/assets/afd98973-0b30-4a10-bf4f-47e276f9c6f4" /> |
| 20px | 20px |
| <img width="1048" alt="poll_20px_before" src="https://github.com/user-attachments/assets/3b27736c-7878-4ae8-888b-2b65f6f7cb07" /> | <img width="1048" alt="poll_20px_after" src="https://github.com/user-attachments/assets/d56240f1-9711-44ac-9d00-dfede5dd8acb" /> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
