### PR TITLE
right_sidebar: Use em for empty list message font-size.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -182,7 +182,8 @@ $user_status_emoji_width: 24px;
         font-style: italic;
         color: var(--color-text-empty-list-message);
         /* Overwrite default empty list font size, to look better under the subheaders. */
-        font-size: 14px;
+        /* 14px at 16px/1em */
+        font-size: 0.875em;
         /* Override .empty-list-message !important styling */
         padding: 0 !important;
         margin-left: calc(


### PR DESCRIPTION
<!-- Describe your pull request here.-->

The reason to use 0.875em instead of 1em in part was also that 1em felt a bit too large to show that empty list message. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Haven't uploaded comparison screenshots, since it was not scaling at all before this. Let me know if you need them.

12px:
<img width="261" alt="right_sidebar_empty_12px" src="https://github.com/user-attachments/assets/38848de1-579f-47df-b88e-473b9b397531" />

14px:
<img width="261" alt="right_sidebar_empty_14px" src="https://github.com/user-attachments/assets/14463991-a485-436e-8cdb-21283fbcc24b" />

16px:
<img width="261" alt="right_sidebar_empty_16px" src="https://github.com/user-attachments/assets/765ff164-fe9d-47da-9e63-9740cfc1c927" />

18px:
<img width="261" alt="right_sidebar_empty_18px" src="https://github.com/user-attachments/assets/f156ccf8-ff72-458b-82b5-b081bd0d3e79" />

20px:
<img width="261" alt="right_sidebar_empty_20px" src="https://github.com/user-attachments/assets/b2a306b2-2279-4a8b-a5cc-27532a310432" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
