### PR TITLE
url_decoding: Add `parse_narrow_url`.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -182,6 +182,9 @@ export function search_public_streams_notice_url(terms: NarrowTerm[]): string {
 }
 
 export function parse_narrow(hash: string[]): NarrowTerm[] | undefined {
+    // There's a Python copy of this function in `zerver/lib/url_decoding.py`
+    // called `parse_narrow_url`, the two should be kept roughly in sync.
+
     // This will throw an exception when passed an invalid hash
     // at the decodeHashComponent call, handle appropriately.
     let i;

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -40,7 +40,7 @@ from zerver.lib.message import (
     remove_message_id_from_unread_mgs,
 )
 from zerver.lib.muted_users import get_user_mutes
-from zerver.lib.narrow_helpers import NarrowTerm, read_stop_words
+from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm, read_stop_words
 from zerver.lib.narrow_predicate import check_narrow_for_events
 from zerver.lib.onboarding_steps import get_next_onboarding_steps
 from zerver.lib.presence import get_presence_for_user, get_presences_for_realm
@@ -1787,7 +1787,7 @@ def do_events_register(
     include_subscribers: bool = True,
     include_streams: bool = True,
     client_capabilities: ClientCapabilities = DEFAULT_CLIENT_CAPABILITIES,
-    narrow: Collection[NarrowTerm] = [],
+    narrow: Collection[NeverNegatedNarrowTerm] = [],
     fetch_event_types: Collection[str] | None = None,
     spectator_requested_language: str | None = None,
     pronouns_field_type_supported: bool = True,

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -14,7 +14,7 @@ from zerver.lib.i18n import (
     get_language_list,
     get_language_translation_data,
 )
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
 from zerver.lib.realm_description import get_realm_rendered_description
 from zerver.lib.request import RequestNotes
 from zerver.models import Message, Realm, Stream, UserProfile
@@ -121,7 +121,7 @@ def build_page_params_for_home_page_load(
     user_profile: UserProfile | None,
     realm: Realm,
     insecure_desktop_app: bool,
-    narrow: list[NarrowTerm],
+    narrow: list[NeverNegatedNarrowTerm],
     narrow_stream: Stream | None,
     narrow_topic_name: str | None,
 ) -> tuple[int, dict[str, object]]:

--- a/zerver/lib/narrow_helpers.py
+++ b/zerver/lib/narrow_helpers.py
@@ -20,24 +20,31 @@ from users:
 
 import os
 from collections.abc import Collection, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from django.conf import settings
 
 
 @dataclass
 class NarrowTerm:
-    # In our current use case we don't yet handle negated narrow terms.
     operator: str
     operand: str
+    negated: bool
 
 
-def narrow_dataclasses_from_tuples(tups: Collection[Sequence[str]]) -> Collection[NarrowTerm]:
+@dataclass
+class NeverNegatedNarrowTerm(NarrowTerm):
+    negated: bool = field(default=False, init=False)
+
+
+def narrow_dataclasses_from_tuples(
+    tups: Collection[Sequence[str]],
+) -> Collection[NeverNegatedNarrowTerm]:
     """
     This method assumes that the callers are in our event-handling codepath, and
     therefore as of summer 2023, they do not yet support the "negated" flag.
     """
-    return [NarrowTerm(operator=tup[0], operand=tup[1]) for tup in tups]
+    return [NeverNegatedNarrowTerm(operator=tup[0], operand=tup[1]) for tup in tups]
 
 
 stop_words_list: list[str] | None = None

--- a/zerver/lib/narrow_helpers.py
+++ b/zerver/lib/narrow_helpers.py
@@ -28,13 +28,14 @@ from django.conf import settings
 @dataclass
 class NarrowTerm:
     operator: str
-    operand: str
+    operand: str | int | list[int]
     negated: bool
 
 
 @dataclass
 class NeverNegatedNarrowTerm(NarrowTerm):
     negated: bool = field(default=False, init=False)
+    operand: str
 
 
 def narrow_dataclasses_from_tuples(

--- a/zerver/lib/narrow_predicate.py
+++ b/zerver/lib/narrow_predicate.py
@@ -4,7 +4,7 @@ from typing import Any, Protocol
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, get_topic_from_message_info
 
 # "stream" is a legacy alias for "channel"
@@ -13,7 +13,7 @@ channel_operators: list[str] = ["channel", "stream"]
 channels_operators: list[str] = ["channels", "streams"]
 
 
-def check_narrow_for_events(narrow: Collection[NarrowTerm]) -> None:
+def check_narrow_for_events(narrow: Collection[NeverNegatedNarrowTerm]) -> None:
     supported_operators = [*channel_operators, "topic", "sender", "is"]
     unsupported_is_operands = ["followed"]
     for narrow_term in narrow:
@@ -31,7 +31,7 @@ class NarrowPredicate(Protocol):
 
 
 def build_narrow_predicate(
-    narrow: Collection[NarrowTerm],
+    narrow: Collection[NeverNegatedNarrowTerm],
 ) -> NarrowPredicate:
     """Changes to this function should come with corresponding changes to
     NarrowLibraryTest."""

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -1,6 +1,9 @@
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 from django.conf import settings
+
+from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.topic import DB_TOPIC_NAME
 
 
 def is_same_server_message_link(url: str) -> bool:
@@ -24,3 +27,117 @@ def is_same_server_message_link(url: str) -> bool:
     ends_with_near_message_id = fragment_parts[-2] == "near" and fragment_parts[-1].isdigit()
 
     return category == "narrow" and section in {"channel", "dm"} and ends_with_near_message_id
+
+
+CHANNEL_SYNONYMS = {"stream": "channel", "streams": "channels"}
+
+OPERATOR_SYNONYMS = {
+    **CHANNEL_SYNONYMS,
+    # "pm-with:" was renamed to "dm:"
+    "pm-with": "dm",
+    # "group-pm-with:" was replaced with "dm-including:"
+    "group-pm-with": "dm-including",
+    "from": "sender",
+    DB_TOPIC_NAME: "topic",
+}
+
+
+def canonicalize_operator_synonyms(text: str) -> str:
+    text = text.lower()
+    if text in OPERATOR_SYNONYMS.values():
+        return text
+    if text in OPERATOR_SYNONYMS:
+        return OPERATOR_SYNONYMS[text]
+    return text
+
+
+def parse_recipient_slug(slug: str) -> tuple[int | list[int], str] | None:
+    """
+    Parses operands formatted in slug containing object ID or IDs.
+    Typical of "channel" or private message operands.
+
+    Doesn't parse the legacy pre-2018 stream slug format, which would
+    require using data for what channels exist for a proper parse.
+        e.g. "stream-name"
+
+    Returns a tuple of parsed ids and the recipient info (channel name,
+    DM'ed users name, etc) or only `None` if the operand is invalid.
+        e.g.
+        - "12,13,14-group" -> ([12, 13, 14], "group")
+        - "89-Markl" -> (89, "Markl")
+        - "stream-name" -> None
+    """
+    try:
+        ids_string, suffix = slug.split("-", maxsplit=1)
+        ids = [int(id) for id in ids_string.split(",")]
+        return (ids if len(ids) > 1 else ids[0], suffix)
+    except ValueError:
+        # We expect this to happen both for invalid URLs and legacy
+        # pre-2018 channel link URLs that don't have a channel ID in
+        # the slug.
+        return None
+
+
+def decode_hash_component(string: str) -> str:
+    # This matches the web app's implementation of decodeHashComponent.
+    return unquote(string.replace(".", "%"))
+
+
+def decode_narrow_operand(operator: str, operand: str) -> str | int | list[int]:
+    # These have the similar slug formatting for their operands which
+    # contain object ID(s).
+    if operator in ["dm-including", "dm", "sender", "channel"]:
+        result = parse_recipient_slug(operand)
+        return result[0] if isinstance(result, tuple) else ""
+
+    if operator == "near":
+        return int(operand) if operand.isdigit() else ""
+
+    operand = decode_hash_component(operand).strip()
+
+    return operand
+
+
+def parse_narrow_url(
+    narrow_url: str,
+) -> list[NarrowTerm] | None:
+    """This server implementation is intended to match the algorithm
+    for the web app's `parse_narrow` in `hash_util.ts`. It largely
+    behaves the same way and has the same purpose: to parse a narrow
+    URL into a list of `NarrowTerm`.
+
+    The key difference from the web app implementation is that this
+    does not validate the referenced objects (users and channels).
+    """
+    split_result = urlsplit(narrow_url)
+    fragment = split_result.fragment
+    fragment_parts = fragment.split("/")
+
+    terms: list[NarrowTerm] = []
+
+    for i in range(1, len(fragment_parts), 2):
+        raw_operator = decode_hash_component(fragment_parts[i]).strip()
+
+        if not raw_operator:
+            return None
+
+        negated = False
+        if raw_operator.startswith("-"):
+            negated = True
+            raw_operator = raw_operator[1:]
+        operator = canonicalize_operator_synonyms(raw_operator)
+
+        try:
+            raw_operand = fragment_parts[i + 1]
+        except IndexError:
+            raw_operand = ""
+        operand = decode_narrow_operand(operator, raw_operand)
+
+        if operand == "" and operator not in ["topic"]:
+            # The empty string is a valid topic (realm_empty_topic_display_name).
+            #
+            # Other empty string operands are invalid.
+            return None
+
+        terms.append(NarrowTerm(operator, operand, negated))
+    return terms

--- a/zerver/tests/fixtures/narrow_url_to_narrow_terms.json
+++ b/zerver/tests/fixtures/narrow_url_to_narrow_terms.json
@@ -1,0 +1,184 @@
+
+[
+    {
+        "name": "channel_link",
+        "near_link": "http://testserver/#narrow/channel/13-Denmark",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "topic_link",
+        "near_link": "http://testserver/#narrow/channel/13-Denmark/topic/desktop",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": false
+            },
+            {
+                "operator": "topic",
+                "operand": "desktop",
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "decoded_topic_link",
+        "near_link": "http://testserver/#narrow/channel/13-Denmark/topic/Broken.20Inline.20giphy.20preview.20.2F.20Messed.20up.20with.20camo",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": false
+            },
+            {
+                "operator": "topic",
+                "operand": "Broken Inline giphy preview / Messed up with camo",
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "missing_topic_operand",
+        "near_link": "http://testserver/#narrow/channel/13-Denmark/topic",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": false
+            },
+            {
+                "operator": "topic",
+                "operand": "",
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "channel_message_link",
+        "near_link": "http://testserver/#narrow/channel/13-Denmark/topic/desktop/near/555",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": false
+            },
+            {
+                "operator": "topic",
+                "operand": "desktop",
+                "negated": false
+            },
+            {
+                "operator": "near",
+                "operand": 555,
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "dm_link",
+        "near_link": "http://testserver/#narrow/dm/95-Calcifer",
+        "expected_output": [
+            {
+                "operator": "dm",
+                "operand": 95,
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "near_dm_link",
+        "near_link": "http://testserver/#narrow/dm/15-John/near/19",
+        "expected_output": [
+            {
+                "operator": "dm",
+                "operand": 15,
+                "negated": false
+            },
+            {
+                "operator": "near",
+                "operand": 19,
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "gdm_link",
+        "near_link": "http://testserver/#narrow/dm/15,12,13-group",
+        "expected_output": [
+            {
+                "operator": "dm",
+                "operand": [15,12,13],
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "near_gdm_link",
+        "near_link": "http://testserver/#narrow/dm/15,12,13-group/near/12",
+        "expected_output": [
+            {
+                "operator": "dm",
+                "operand": [15,12,13],
+                "negated": false
+            },
+            {
+                "operator": "near",
+                "operand": 12,
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "legacy_channel_synonym",
+        "near_link": "http://testserver/#narrow/stream/13-Denmark",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": false
+            }
+        ]
+    },
+    {
+        "name": "hypothetical_negated_link",
+        "near_link": "http://testserver/#narrow/-channel/13-Denmark",
+        "expected_output": [
+            {
+                "operator": "channel",
+                "operand": 13,
+                "negated": true
+            }
+        ]
+    },
+    {
+        "name": "legacy_channel_slug_unsupported",
+        "near_link": "http://testserver/#narrow/channel/test-here",
+        "expected_output": null
+    },
+    {
+        "name": "broken_link_no_channel_operand",
+        "near_link": "http://testserver/#narrow/channel/%20",
+        "expected_output": null
+    },
+    {
+        "name": "broken_link_other_operand",
+        "near_link": "http://testserver/#narrow/near/%20",
+        "expected_output": null
+    },
+    {
+        "name": "broken_link_no_operator",
+        "near_link": "http://testserver/#narrow/%20/test-here",
+        "expected_output": null
+    },
+    {
+        "name": "broken_link_invalid_message_operand",
+        "near_link": "http://testserver/#narrow/near/13-Denmark",
+        "expected_output": null
+    }
+]

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -42,7 +42,7 @@ from zerver.lib.narrow import (
     ok_to_include_history,
     post_process_limited_query,
 )
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
 from zerver.lib.narrow_predicate import build_narrow_predicate
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import StreamDict, create_streams_if_needed, get_public_streams_queryset
@@ -755,7 +755,9 @@ class NarrowBuilderTest(ZulipTestCase):
 
 class NarrowLibraryTest(ZulipTestCase):
     def test_build_narrow_predicate(self) -> None:
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="channel", operand="devel")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="channel", operand="devel")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -779,7 +781,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="topic", operand="bark")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="topic", operand="bark")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -817,8 +821,8 @@ class NarrowLibraryTest(ZulipTestCase):
 
         narrow_predicate = build_narrow_predicate(
             [
-                NarrowTerm(operator="channel", operand="devel"),
-                NarrowTerm(operator="topic", operand="python"),
+                NeverNegatedNarrowTerm(operator="channel", operand="devel"),
+                NeverNegatedNarrowTerm(operator="topic", operand="python"),
             ]
         )
 
@@ -851,7 +855,7 @@ class NarrowLibraryTest(ZulipTestCase):
         ###
 
         narrow_predicate = build_narrow_predicate(
-            [NarrowTerm(operator="sender", operand="hamlet@zulip.com")]
+            [NeverNegatedNarrowTerm(operator="sender", operand="hamlet@zulip.com")]
         )
 
         self.assertTrue(
@@ -870,7 +874,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="dm")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="dm")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -888,7 +894,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="private")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="private")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -906,7 +914,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="starred")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="starred")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -924,7 +934,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="alerted")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="alerted")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -942,7 +954,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="mentioned")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="mentioned")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -960,7 +974,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="unread")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="unread")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -978,7 +994,9 @@ class NarrowLibraryTest(ZulipTestCase):
 
         ###
 
-        narrow_predicate = build_narrow_predicate([NarrowTerm(operator="is", operand="resolved")])
+        narrow_predicate = build_narrow_predicate(
+            [NeverNegatedNarrowTerm(operator="is", operand="resolved")]
+        )
 
         self.assertTrue(
             narrow_predicate(
@@ -1002,9 +1020,11 @@ class NarrowLibraryTest(ZulipTestCase):
 
     def test_build_narrow_predicate_invalid(self) -> None:
         with self.assertRaises(JsonableError):
-            build_narrow_predicate([NarrowTerm(operator="invalid_operator", operand="operand")])
+            build_narrow_predicate(
+                [NeverNegatedNarrowTerm(operator="invalid_operator", operand="operand")]
+            )
         with self.assertRaises(JsonableError):
-            build_narrow_predicate([NarrowTerm(operator="is", operand="followed")])
+            build_narrow_predicate([NeverNegatedNarrowTerm(operator="is", operand="followed")])
 
     def test_is_spectator_compatible(self) -> None:
         self.assertTrue(is_spectator_compatible([]))

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -1,7 +1,8 @@
 import orjson
 
+from zerver.lib.narrow_helpers import NarrowTerm
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.url_decoding import is_same_server_message_link
+from zerver.lib.url_decoding import is_same_server_message_link, parse_narrow_url
 
 
 class URLDecodeTest(ZulipTestCase):
@@ -11,3 +12,22 @@ class URLDecodeTest(ZulipTestCase):
             self.assertEqual(
                 is_same_server_message_link(test["message_link"]), test["expected_output"]
             )
+
+
+class NarrowURLDecodeTest(ZulipTestCase):
+    def test_decode_narrow_url(self) -> None:
+        tests = orjson.loads(self.fixture_data("narrow_url_to_narrow_terms.json"))
+
+        for test_case in tests:
+            with self.subTest(name=test_case["name"]):
+                parsed_terms = parse_narrow_url(test_case["near_link"])
+                expected_output = test_case.get("expected_output")
+
+                if expected_output is None:
+                    self.assertEqual(parsed_terms, expected_output)
+                else:
+                    assert parsed_terms is not None
+                    expected_narrow_terms: list[NarrowTerm] = [
+                        NarrowTerm(**term) for term in expected_output
+                    ]
+                    self.assertListEqual(parsed_terms, expected_narrow_terms)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -13,7 +13,7 @@ from zerver.decorator import web_public_view, zulip_login_required
 from zerver.forms import ToSForm
 from zerver.lib.compatibility import is_outdated_desktop_app, is_unsupported_browser
 from zerver.lib.home import build_page_params_for_home_page_load, get_user_permission_info
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NeverNegatedNarrowTerm
 from zerver.lib.request import RequestNotes
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
@@ -113,13 +113,13 @@ def accounts_accept_terms(request: HttpRequest) -> HttpResponse:
 
 def detect_narrowed_window(
     request: HttpRequest, user_profile: UserProfile | None
-) -> tuple[list[NarrowTerm], Stream | None, str | None]:
+) -> tuple[list[NeverNegatedNarrowTerm], Stream | None, str | None]:
     """This function implements Zulip's support for a mini Zulip window
     that just handles messages from a single narrow"""
     if user_profile is None:
         return [], None, None
 
-    narrow: list[NarrowTerm] = []
+    narrow: list[NeverNegatedNarrowTerm] = []
     narrow_stream = None
     narrow_topic_name = request.GET.get("topic")
 
@@ -129,11 +129,11 @@ def detect_narrowed_window(
             narrow_stream_name = request.GET.get("stream")
             assert narrow_stream_name is not None
             (narrow_stream, ignored_sub) = access_stream_by_name(user_profile, narrow_stream_name)
-            narrow = [NarrowTerm(operator="stream", operand=narrow_stream.name)]
+            narrow = [NeverNegatedNarrowTerm(operator="stream", operand=narrow_stream.name)]
         except Exception:
             logging.warning("Invalid narrow requested, ignoring", extra=dict(request=request))
         if narrow_stream is not None and narrow_topic_name is not None:
-            narrow.append(NarrowTerm(operator="topic", operand=narrow_topic_name))
+            narrow.append(NeverNegatedNarrowTerm(operator="topic", operand=narrow_topic_name))
     return narrow, narrow_stream, narrow_topic_name
 
 


### PR DESCRIPTION
Prep PR to fix: https://github.com/zulip/zulip/issues/31100. It adds `parse_narrow_url` which is the  Python copy of `hash_util.parse_narrow`. 

Additional context and details on the commit descriptions:
- ### narrow_term: Refactor a `NeverNegatedNarrowTerm`.

  <details>
  
  <summary>

  git grep of `NarrowTerm` before  this PR
  </summary>
  
  ```grep
  zerver/lib/events.py:from zerver.lib.narrow_helpers import NarrowTerm, read_stop_words
  zerver/lib/events.py:    narrow: Collection[NarrowTerm] = [],
  zerver/lib/home.py:from zerver.lib.narrow_helpers import NarrowTerm
  zerver/lib/home.py:    narrow: list[NarrowTerm],
  zerver/lib/narrow_helpers.py:class NarrowTerm:
  zerver/lib/narrow_helpers.py:def narrow_dataclasses_from_tuples(tups: Collection[Sequence[str]]) -> Collection[NarrowTerm]:
  zerver/lib/narrow_helpers.py:    return [NarrowTerm(operator=tup[0], operand=tup[1]) for tup in tups]
  zerver/lib/narrow_predicate.py:from zerver.lib.narrow_helpers import NarrowTerm
  zerver/lib/narrow_predicate.py:def check_narrow_for_events(narrow: Collection[NarrowTerm]) -> None:
  zerver/lib/narrow_predicate.py:    narrow: Collection[NarrowTerm],
  zerver/views/home.py:from zerver.lib.narrow_helpers import NarrowTerm
  zerver/views/home.py:) -> tuple[list[NarrowTerm], Stream | None, str | None]:
  zerver/views/home.py:    narrow: list[NarrowTerm] = []
  zerver/views/home.py:            narrow = [NarrowTerm(operator="stream", operand=narrow_stream.name)]
  zerver/views/home.py:            narrow.append(NarrowTerm(operator="topic", operand=narrow_topic_name))
  ```
  </details>
  
- ### narrow_term: Use `Any` as `operand` type.
  In the commit description, I said:
  >Previously, `NarrowTerm` is primarily used in the event-handling system,
  which only supported a limited range of operators (see
  `check_narrow_for_events`).
  
  <details>
  
  <summary>
  
  The `check_narrow_for_events` in `lib/narrow_predicate.py`
  </summary>
  
    ```python
  def check_narrow_for_events(narrow: Collection[NeverNegatedNarrowTerm]) -> None:
        supported_operators = [*channel_operators, "topic", "sender", "is"]
        unsupported_is_operands = ["followed"]
        for narrow_term in narrow:
            operator = narrow_term.operator
            if operator not in supported_operators:
                raise JsonableError(_("Operator {operator} not supported.").format(operator=operator))
            if operator == "is" and narrow_term.operand in unsupported_is_operands:
                raise JsonableError(
                    _("Operand {operand} not supported.").format(operand=narrow_term.operand)
                )
  ```
  </details>

- ### url_decoding: Add `parse_narrow_url`.
  In the commit description, I said:
  >- This doesn't convert a user-id-slug into a list of user emails. It
  will instead parse it into a list of user IDs, as that is the preferred
  form for those kinds of operators. ....
  
  This is based on how `NarrowBuilder` would process it. I wonder if there are any arguments against changing the `NarrowTerm` operand to `Any` from `str`.


**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
