### PR TITLE
reload: Check "/server_settings" before initiating a reload of the web-app.

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -8,7 +8,7 @@ async function navigate_using_left_sidebar(page: Page, stream_name: string): Pro
     console.log("Visiting #" + stream_name);
     const stream_id = await page.evaluate(() => zulip_test.get_sub("Verona")!.stream_id);
     await page.click(`.narrow-filter[data-stream-id="${stream_id}"] .stream-name`);
-    await page.waitForSelector(`#message_feed_container`, {visible: true});
+    await page.waitForSelector("#message_view_header .zulip-icon-hashtag", {visible: true});
 }
 
 async function open_menu(page: Page): Promise<void> {
@@ -96,12 +96,12 @@ async function navigation_tests(page: Page): Promise<void> {
     await navigate_using_left_sidebar(page, "Verona");
 
     await page.click("#left-sidebar-navigation-list .home-link");
-    await page.waitForSelector("#message_feed_container", {visible: true});
+    await page.waitForSelector("#message_view_header .zulip-icon-all-messages", {visible: true});
 
     await navigate_to_subscriptions(page);
 
     await page.click("#left-sidebar-navigation-list .home-link");
-    await page.waitForSelector(`#message_feed_container`, {visible: true});
+    await page.waitForSelector("#message_view_header .zulip-icon-all-messages", {visible: true});
 
     await navigate_to_settings(page);
     await navigate_to_private_messages(page);


### PR DESCRIPTION
In order to avoid races with the user's device connecting to a network after unsuspending, we ping the `/server_settings` endpoint for a success response before initiating the reload of the app.

Fixes #33118.

---

**Notes**:
- I haven't able to reproduce the reported error/screen from the issue / CZO conversation in the dev environment, but I was able to trigger initiating a reload of the web-app in the dev environment.
- Currently, there isn't any `"#connection-error"` show/hide for `ui_report` included in these updates. I wasn't sure if going with something like we have in [`get_events`](https://github.com/zulip/zulip/blob/264e49e7e8ede23be94089b5dd2237f577ad8518/web/src/server_events.js#L148-L156) polling where there is a specific class added to the error message or with something more like [`message_fetch`](https://github.com/zulip/zulip/blob/264e49e7e8ede23be94089b5dd2237f577ad8518/web/src/message_fetch.ts#L384-L435) where there is no class added to the error message container.
- See in-line comments below ...

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
