### PR TITLE
topic_link_util: Accept channel name instead of syntax text.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1200,13 +1200,15 @@ export function content_typeahead_selected(
             // will cause encoding issues.
             // "beginning" contains all the text before the cursor, so we use lastIndexOf to
             // avoid any other stream+topic mentions in the message.
-            const syntax_start_index = beginning.lastIndexOf("#**");
+            const syntax = "#**";
+            const syntax_start_index = beginning.lastIndexOf(syntax);
+            const stream_name = beginning.slice(
+                syntax_start_index + syntax.length,
+                beginning.lastIndexOf(">"),
+            );
             beginning =
                 beginning.slice(0, syntax_start_index) +
-                topic_link_util.get_stream_topic_link_syntax(
-                    beginning.slice(syntax_start_index),
-                    item.topic,
-                ) +
+                topic_link_util.get_stream_topic_link_syntax(stream_name, item.topic) +
                 " ";
             break;
         }

--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -10,12 +10,6 @@ export function will_produce_broken_stream_topic_link(word: string): boolean {
     return invalid_stream_topic_regex.test(word);
 }
 
-function get_stream_name_from_topic_link_syntax(syntax: string): string {
-    const start = syntax.indexOf("#**");
-    const end = syntax.lastIndexOf(">");
-    return syntax.slice(start + 3, end);
-}
-
 export function escape_invalid_stream_topic_characters(text: string): string {
     switch (text) {
         case "`":
@@ -60,11 +54,7 @@ export function get_fallback_markdown_link(
     return `[#${escape(stream_name)}](${internal_url.by_stream_url(stream_id, () => stream_name)})`;
 }
 
-export function get_stream_topic_link_syntax(
-    typed_syntax_text: string,
-    topic_name: string,
-): string {
-    const stream_name = get_stream_name_from_topic_link_syntax(typed_syntax_text);
+export function get_stream_topic_link_syntax(stream_name: string, topic_name: string): string {
     // If the topic name is such that it will generate an invalid #**stream>topic** syntax,
     // we revert to generating the normal markdown syntax for a link.
     if (

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -38,39 +38,35 @@ stream_data.add_sub(dollar_stream);
 
 run_test("stream_topic_link_syntax_test", () => {
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>", "topic"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "topic"),
         "#**Sweden>topic**",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>to", "topic"),
-        "#**Sweden>topic**",
-    );
-    assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "test `test` test"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "test `test` test"),
         "[#Sweden > test &#96;test&#96; test](#narrow/channel/1-Sweden/topic/test.20.60test.60.20test)",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Denmark>t", "test `test` test`s"),
+        topic_link_util.get_stream_topic_link_syntax("Denmark", "test `test` test`s"),
         "[#Denmark > test &#96;test&#96; test&#96;s](#narrow/channel/2-Denmark/topic/test.20.60test.60.20test.60s)",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>typeah", "error due to *"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "error due to *"),
         "[#Sweden > error due to &#42;](#narrow/channel/1-Sweden/topic/error.20due.20to.20*)",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "*asterisk"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "*asterisk"),
         "[#Sweden > &#42;asterisk](#narrow/channel/1-Sweden/topic/*asterisk)",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>gibberish", "greaterthan>"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "greaterthan>"),
         "[#Sweden > greaterthan&gt;](#narrow/channel/1-Sweden/topic/greaterthan.3E)",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**$$MONEY$$>t", "dollar"),
+        topic_link_util.get_stream_topic_link_syntax("$$MONEY$$", "dollar"),
         "[#&#36;&#36;MONEY&#36;&#36; > dollar](#narrow/channel/6-.24.24MONEY.24.24/topic/dollar)",
     );
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>t", "swe$$dish"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "swe$$dish"),
         "[#Sweden > swe&#36;&#36;dish](#narrow/channel/1-Sweden/topic/swe.24.24dish)",
     );
     assert.equal(
@@ -84,7 +80,7 @@ run_test("stream_topic_link_syntax_test", () => {
     );
 
     assert.equal(
-        topic_link_util.get_stream_topic_link_syntax("#**Sweden>&ab", "&ab"),
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "&ab"),
         "[#Sweden > &amp;ab](#narrow/channel/1-Sweden/topic/.26ab)",
     );
 


### PR DESCRIPTION
In the function `get_stream_topic_link_syntax`,
we used the typed syntax text to make out
the channel name and then use it to
generate the appropriate link syntax.
We change that to directly accepting the
channel name.

This is in preparation for #31420

Extracted from #31669.