### PR TITLE
message_edit: Rename get_message_edit_request_object.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1243,7 +1243,7 @@ def check_time_limit_for_change_all_propagate_mode(
     )
 
 
-def get_message_edit_request_object(
+def build_message_edit_request(
     *,
     message: Message,
     user_profile: UserProfile,
@@ -1360,7 +1360,7 @@ def check_update_message(
 
     validate_message_edit_payload(message, stream_id, topic_name, propagate_mode, content)
 
-    message_edit_request = get_message_edit_request_object(
+    message_edit_request = build_message_edit_request(
         message=message,
         user_profile=user_profile,
         propagate_mode=propagate_mode,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -52,9 +52,9 @@ from zerver.actions.invites import (
 )
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_edit import (
+    build_message_edit_request,
     do_update_embedded_data,
     do_update_message,
-    get_message_edit_request_object,
 )
 from zerver.actions.message_flags import do_update_message_flags
 from zerver.actions.muted_users import do_mute_user, do_unmute_user
@@ -606,7 +606,7 @@ class NormalActionsTest(BaseAction):
             message_sender=self.example_user("cordelia"),
         )
 
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=pm,
             user_profile=self.user_profile,
             propagate_mode="change_one",
@@ -915,7 +915,7 @@ class NormalActionsTest(BaseAction):
             message_sender=iago,
         )
 
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=message,
             user_profile=self.user_profile,
             propagate_mode="change_one",
@@ -948,7 +948,7 @@ class NormalActionsTest(BaseAction):
         topic_name = "new_topic"
         propagate_mode = "change_all"
 
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=message,
             user_profile=self.user_profile,
             propagate_mode=propagate_mode,
@@ -1003,7 +1003,7 @@ class NormalActionsTest(BaseAction):
         propagate_mode = "change_all"
         prior_mention_user_ids = set()
 
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=message,
             user_profile=self.user_profile,
             propagate_mode=propagate_mode,
@@ -1047,7 +1047,7 @@ class NormalActionsTest(BaseAction):
         propagate_mode = "change_all"
         prior_mention_user_ids = set()
 
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=message,
             user_profile=self.user_profile,
             propagate_mode="change_one",

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -14,7 +14,7 @@ from typing_extensions import override
 
 from analytics.lib.counts import COUNT_STATS
 from analytics.models import RealmCount
-from zerver.actions.message_edit import do_update_message, get_message_edit_request_object
+from zerver.actions.message_edit import build_message_edit_request, do_update_message
 from zerver.actions.reactions import check_add_reaction
 from zerver.actions.realm_settings import do_set_realm_property
 from zerver.actions.uploads import do_claim_attachments
@@ -4988,7 +4988,7 @@ class MessageHasKeywordsTest(ZulipTestCase):
         rendering_result = render_message_markdown(msg, content)
         mention_backend = MentionBackend(realm_id)
         mention_data = MentionData(mention_backend, content, msg.sender)
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=msg,
             user_profile=hamlet,
             propagate_mode="change_one",

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -9,9 +9,9 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_edit import (
+    build_message_edit_request,
     check_update_message,
     do_update_message,
-    get_message_edit_request_object,
     maybe_send_resolve_topic_notifications,
 )
 from zerver.actions.reactions import do_add_reaction
@@ -142,7 +142,7 @@ class MessageMoveTopicTest(ZulipTestCase):
             topic_name: str,
             users_to_be_notified: list[dict[str, Any]],
         ) -> None:
-            message_edit_request = get_message_edit_request_object(
+            message_edit_request = build_message_edit_request(
                 message=message,
                 user_profile=user_profile,
                 propagate_mode="change_later",
@@ -1749,7 +1749,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         assert stream.recipient_id is not None
         changed_messages = messages_for_topic(stream.realm_id, stream.recipient_id, original_topic)
         resolve_topic = RESOLVED_TOPIC_PREFIX + original_topic
-        message_edit_request = get_message_edit_request_object(
+        message_edit_request = build_message_edit_request(
             message=message,
             user_profile=admin_user,
             propagate_mode="change_all",


### PR DESCRIPTION
"build_message_edit_request" is a better name for the function.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
