### PR TITLE
color_picker: Enable vertical keyboard navigation at channel settings.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -806,6 +806,13 @@ export function process_hotkey(e, hotkey) {
         return false;
     }
 
+    // We don't treat the color picker like our menu popovers, since it
+    // supports sideways navigation (left and right arrow).
+    if (color_picker_hotkeys.has(event_name) && popover_menus.is_color_picker_popover_displayed()) {
+        color_picker_popover.handle_keyboard(event_name);
+        return true;
+    }
+
     if ((event_name === "up_arrow" || event_name === "down_arrow") && overlays.streams_open()) {
         return stream_settings_ui.switch_rows(event_name);
     }
@@ -843,13 +850,6 @@ export function process_hotkey(e, hotkey) {
             }
             return true;
         }
-    }
-
-    // We don't treat the color picker like our menu popovers, since it
-    // supports sideways navigation (left and right arrow).
-    if (color_picker_hotkeys.has(event_name) && popover_menus.is_color_picker_popover_displayed()) {
-        color_picker_popover.handle_keyboard(event_name);
-        return true;
     }
 
     // Handle our normal popovers that are basically vertical lists of menu items.


### PR DESCRIPTION
[CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/keyboard.20navigation.20in.20color.20picker)

At Channel settings overlay, vertical keyboard navigation on color picker was obstructed by `stream_settings_ui.switch_rows`.
This commit fixes the issue by using `color_picker_popover.handle_keyboard` prior to `stream_settings_ui.switch_rows`

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
