### PR TITLE
message_row: Refine grids and alignment for scalable action buttons.

### DIFF
--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -540,7 +540,6 @@ export class MessageList {
     show_edit_topic_on_recipient_row($recipient_row: JQuery, $form: JQuery): void {
         $recipient_row.find(".topic_edit_form").append($form);
         $recipient_row.find(".on_hover_topic_edit").hide();
-        $recipient_row.find(".edit_message_button").hide();
         $recipient_row.find(".stream_topic").hide();
         $recipient_row.find(".topic_edit").show();
         $recipient_row.find(".always_visible_topic_edit").hide();
@@ -551,7 +550,6 @@ export class MessageList {
     hide_edit_topic_on_recipient_row($recipient_row: JQuery): void {
         $recipient_row.find(".stream_topic").show();
         $recipient_row.find(".on_hover_topic_edit").show();
-        $recipient_row.find(".edit_message_button").show();
         $recipient_row.find(".topic_edit_form").empty();
         $recipient_row.find(".topic_edit").hide();
         $recipient_row.find(".always_visible_topic_edit").show();

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -399,9 +399,12 @@
     --message-box-markdown-aligned-vertical-space: var(
         --markdown-interelement-space-px
     );
-    /* 22px matches to the width of the padded icon. */
-    --message-box-icon-width: 22px;
-    --message-box-icon-height: 25px;
+    /* 22px matches to the width of the padded icon.
+       22px at 16px/1em
+    */
+    --message-box-icon-width: 1.375em;
+    /* 25px at 16px/1em */
+    --message-box-icon-height: 1.6667em;
     --message-box-height-senderless-single-line-message: calc(
         var(--base-line-height-unitless) * var(--base-font-size-px) +
             calc(var(--markdown-interelement-space-px) * 2)

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -136,18 +136,6 @@
             8px minmax(var(--message-box-timestamp-column-width), max-content);
     }
 
-    .message_controls {
-        grid-area: controls;
-
-        @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
-            /* This is intended to target the first message_controls child
-               when there are 3 displayed. */
-            .message_control_button:nth-last-child(3) {
-                display: none;
-            }
-        }
-    }
-
     .message_edit_notice {
         grid-area: edited;
     }
@@ -420,8 +408,28 @@
 }
 
 .message_controls {
+    grid-area: controls;
+    /* Let the controls occupy the entire height
+       of the row; inner flexboxes handle the
+       centering of the icons. */
+    align-self: stretch;
+    /* But to better set the height to the typical
+       sender-row line height for better centering
+       in all contexts. */
+    height: var(--message-box-sender-line-height);
     display: flex;
-    align-items: baseline;
+    /* The flexbox here matches the height set above. */
+    align-items: stretch;
+    /* Ensure square icons for better centering. */
+    line-height: 1;
+
+    @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
+        /* This is intended to target the first message_controls child
+           when there are 3 displayed. */
+        .message_control_button:nth-last-child(3) {
+            display: none;
+        }
+    }
 
     /* This is a bit tricky; we need to reserve space for the message
        controls even when the message isn't hovered, so that hover
@@ -433,18 +441,31 @@
         visibility: hidden;
         transition: none 0.2s ease;
         transition-property: opacity, visibility;
-        width: var(--message-box-icon-width);
-        height: var(--message-box-icon-height);
-        text-align: center;
+        /* Allow buttons to grow to fill the available space,
+           in concord with the column calculated for the
+           .messagebox-content grid. */
+        flex: 1 0 0;
+        /* Set the height to 100% to effectively flex open
+           on the vertical axis. */
+        height: 100%;
+        /* Control buttons are their own flex containers,
+           to more gracefully center the icons. */
+        display: flex;
+        place-items: center center;
         color: var(--color-message-action-visible);
 
+        .emoji-message-control-button-container {
+            /* This button has an extra div for Tippy purposes,
+               so it becomes its own flex container. */
+            display: flex;
+        }
+
         & .message-controls-icon {
-            vertical-align: middle;
-            /* TODO: Math for these values, possibly with variables.
-               In short, the icon body is 16px square; the current
+            /* The icon body is 16px square at 16px/1em; the clickable
                area for the icon is 26px wide by 25px tall, so these
                values ensure a 26px x 25px clickable area for the icon. */
-            padding: 2.5px 3px;
+            /* 2.5px at 16px/1em; 3px at 16px/1em */
+            padding: 0.1563em 0.1875em;
 
             &::before {
                 /* We specify block display so the

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -257,10 +257,16 @@
 
         &.is-me-message {
             grid-template-areas:
+                ".      .         .        . .   "
                 "avatar sender    controls . time"
                 "avatar sender    .        . .   "
                 ".      more      .        . .   "
                 ".      reactions .        . .   ";
+            grid-template-rows:
+                var(--message-box-vertical-margin) var(
+                    --message-box-avatar-height
+                )
+                minmax(0, auto) repeat(3, auto);
 
             .message-avatar {
                 /* Set the line-height to match the height of the avatar image
@@ -271,6 +277,19 @@
                    single-line me message, this margin preserves the
                    overall height of the message box. */
                 margin-bottom: var(--message-box-vertical-margin);
+
+                .inline_profile_picture {
+                    /* We adjust the vertical space in me messages via
+                       the grid definition above. */
+                    margin-top: 0;
+                }
+            }
+
+            .message_controls {
+                /* Because the controls height is smaller than the
+                   available grid row height on me-messages, we
+                   align to center here. */
+                align-self: center;
             }
 
             .message_sender {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -422,7 +422,7 @@
 .message_controls {
     display: flex;
     align-items: baseline;
-    font-size: 16px;
+
     /* This is a bit tricky; we need to reserve space for the message
        controls even when the message isn't hovered, so that hover
        doesn't disturb the layout.  Usually that would be just

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -316,7 +316,14 @@
             grid-area: avatar;
             /* The picture should not participate in the baseline group. */
             align-self: start;
-            margin-top: var(--message-box-vertical-margin);
+
+            .inline_profile_picture {
+                /* Setting the margin inside this element prevents
+                   unwanted shifts in the placement of especially
+                   sender-line elements on the .messagebox-content
+                   grid. */
+                margin-top: var(--message-box-vertical-margin);
+            }
         }
 
         .status-message {


### PR DESCRIPTION
This PR does a few things:

1. It fixes a bug where going into topic-edit mode would cause a vertical shift in the sender line.
2. It reworks variables and grid definitions to allow the message action buttons to scale along with text, as well as ensuring uniform vertical alignment of the buttons with the timestamp, no matter what kind of message is displayed, with or without a sender line.
3. It improves the grid definitions on me-messages.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures** (The showing-grids captures have been updated since Tim's initial review):

| Topic outside edit mode | Topic while editing, before | Topic while editing, after |
| --- | --- | --- |
| ![topic-pre-edit](https://github.com/user-attachments/assets/a35d7155-6de4-4431-8e59-11834d2c7d9f) | ![topic-edit-before](https://github.com/user-attachments/assets/4f55aca2-04cb-4b88-b72c-ab01aaf1aaf1) | ![topic-edit-after](https://github.com/user-attachments/assets/15b63e55-5f46-4c7a-ad0a-e808455bd4e2) |

| Showing grids, 16px before | Showing grids, 16px after |
| --- | --- |
| ![showing-grid-16px-before-redux](https://github.com/user-attachments/assets/7143bf60-7b74-4631-9328-76ae5b667f07) | ![showing-grid-16px-after-redux](https://github.com/user-attachments/assets/6b686429-acb6-4048-9210-f7977185216c) |

| Showing grids, 20px before | Showing grids, 20px after |
| --- | --- |
| ![showing-grid-20px-before-redux](https://github.com/user-attachments/assets/b9338c31-47c8-4d97-9cdc-98496f8d878e) | ![showing-grid-20px-after-redux](https://github.com/user-attachments/assets/f1acf284-8f43-4768-903c-e93f5cbc6a21) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>