### PR TITLE
Fix vertical alignment of icons in integration docs

### DIFF
--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -211,11 +211,6 @@
             }
         }
 
-        & i.zulip-icon {
-            margin: 0 2px 2px;
-            vertical-align: middle;
-        }
-
         & i.icon-collapsed-state {
             transform: rotate(270deg);
         }
@@ -223,6 +218,11 @@
         @media (width <= 500px) {
             padding: 10px;
         }
+    }
+
+    & i.zulip-icon {
+        margin: 0 2px 2px;
+        vertical-align: middle;
     }
 
     & a {


### PR DESCRIPTION
Fixes: [CZO Link](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Alignment.20of.20zulip-icon.20in.20integration.20docs/near/2054942)

The `zulip-icon` `vertical-alignment` discrepancy is caused by a rule that applies only to `.content` children.
While help docs and API docs have a `.content` element, integration docs do not.

So, I've moved that rule outside the `.content` selector, so that it applies to the integration docs and the Team page as well. Not sure if that's the best fix.

### Screenshots

<details>
<summary>Screenshots</summary>

**`/team`**
| Before | After |
|--------|--------|
| ![Pasted image 20250123004253](https://github.com/user-attachments/assets/ebe4cf3d-7402-4a2d-bd0e-f0d3dc5bb50c) | ![Pasted image 20250123004309](https://github.com/user-attachments/assets/1864ca4c-48da-4ece-956a-39e4f78720a6) |

**Integration Docs**
| Before | After |
|--------|--------|
| ![Pasted image 20250123030226](https://github.com/user-attachments/assets/9ea8405e-e964-48bf-a7f8-12b0ec718dac) | ![Pasted image 20250123030235](https://github.com/user-attachments/assets/c787b9ef-5aed-489a-af74-7d973a6c0535) | 

**Help / API docs**
| Before | After (unchanged) |
|--------|--------|
| ![Pasted image 20250123030303](https://github.com/user-attachments/assets/5322e258-5037-4ac0-bcc8-c86bd64265e3) | ![Pasted image 20250123030254](https://github.com/user-attachments/assets/cae44dab-0ace-4a99-9fc6-9edb0ae4b725) |

</details>

### How did I verify that this does not introduce any undesired changes?

<details>
<summary>Details</summary>

The newly added selector: `.markdown i.zulip-icon`

The Markdown class seems to be used only in:
- `templates/corporate`
- `dev_tools.html`
- `documentation_main.html` -> help docs, api docs, policy docs
- `integrations/index.html`

And among these, only the integration docs and `team.html` contain `<i class="zulip-icon`. At least for the moment :upside_down_face:.

</details>

I've never worked on Zulip's styling before, so it would be awesome if the reviewer could verify the changes thoroughly, to help ensure that I'm not introducing any regressions.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
