### PR TITLE
compose: Use grid for enter sends choices to align radio buttons.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1185,10 +1185,14 @@ textarea.new_message_textarea {
     color: var(--color-text-popover-menu);
 
     .enter_sends_choice {
-        display: flex;
-        gap: 8px;
         padding: 4px 10px;
-        align-items: flex-start;
+        gap: 0 8px;
+        display: grid;
+        /* 1em and 1.5em were chosen from playing around with different values
+           and picking some that looked reasonable. */
+        grid-template:
+            "radio-button instructions" 1.5em
+            ".            instructions" auto / 1em auto;
 
         &:hover {
             background: var(--color-background-hover-popover-menu);
@@ -1209,8 +1213,12 @@ textarea.new_message_textarea {
         & .enter_sends_choice_radio {
             width: auto;
             cursor: pointer;
-            margin: 4px 0 0;
+            /* Radio buttons scale with height, and here we're just
+               matching that to the active font-size. */
+            height: 1em;
             accent-color: hsl(217deg 100% 60%);
+            grid-area: radio-button;
+            align-self: center;
 
             &:focus {
                 outline: 1px dotted hsl(0deg 0% 20%);
@@ -1233,6 +1241,7 @@ textarea.new_message_textarea {
         flex-shrink: 0;
         gap: 3px;
         white-space: nowrap;
+        grid-area: instructions;
     }
 
     .enter_sends_choice_text {


### PR DESCRIPTION
Fixes issue with radio button sitting too high at larger font sizes:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/608116a2-2432-46e7-98b2-b380ac875234" />


----

Here are screenshots after this fix. I turned on grid lines to show how the grid is set up, but just for the first option and the second option works the same but is visible without the grid lines.

12px:

<img width="256" alt="image" src="https://github.com/user-attachments/assets/b41d3872-a68f-4968-bc4a-7e94bb64da5d" />

14px:

<img width="259" alt="image" src="https://github.com/user-attachments/assets/48381e79-a569-42d5-9462-2f2b3cc0a700" />


16px:

<img width="269" alt="image" src="https://github.com/user-attachments/assets/5d33f5db-0e45-45cf-bb5a-ec4fa0dc9271" />


20px:

<img width="322" alt="image" src="https://github.com/user-attachments/assets/892cbe01-1cee-49d8-abc4-e8d3a0c7a6fe" />

