### PR TITLE
icon_lock: Increase width of the icon in modal title.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -975,6 +975,14 @@ input.settings_text_input {
     margin-top: -0.2188em !important;
 }
 
+.modal__title {
+    /* The lock icon width is slightly less as required
+       for the modal title, so we adjust the width here. */
+    .stream-privacy-type-icon {
+        width: 20px !important;
+    }
+}
+
 .dropdown-list-container
     .dropdown-list
     .dropdown-list-item-common-styles


### PR DESCRIPTION
This pull request adds a new CSS rule to adjust the width of the lock icon within modal titles.

- Previously, the lock icon in the modal had a width of `12px` applied universally. 

- With this commit, the width of the lock icon has been explicitly increased to `20px` specifically for modal titles.

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/channel.20icon.20spacing.20in.20modal.20heading)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Feature           | Before                                                                                         | After                                                                                          |
|-------------------|------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
| **CSS Box Model** | <img width="336" alt="Screenshot 2025-01-23 at 3 04 27 PM" src="https://github.com/user-attachments/assets/669a6169-3549-421e-a48c-27a9e77a27d1" /> | <img width="320" alt="Screenshot 2025-01-23 at 3 04 08 PM" src="https://github.com/user-attachments/assets/1ab9261a-7bdc-4ea2-979b-61ac59acc7ee" /> |
| **Dialog Box**    | <img width="530" alt="Screenshot 2025-01-23 at 3 04 36 PM" src="https://github.com/user-attachments/assets/65123e1e-b3f2-4fb9-8713-38a7fa03c54b" /> | <img width="528" alt="Screenshot 2025-01-23 at 3 03 43 PM" src="https://github.com/user-attachments/assets/9346227e-766f-468d-a766-38ef103f192f" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ x] Corner cases, error conditions, and easily imagined bugs.
</details>
