### PR TITLE
Can subscribe others followups

### DIFF
--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -90,7 +90,7 @@ export function user_can_create_multiuse_invite(): boolean {
     );
 }
 
-export function can_subscribe_others_to_all_streams(): boolean {
+export function can_subscribe_others_to_all_accessible_streams(): boolean {
     return user_has_permission_for_group_setting(
         realm.realm_can_add_subscribers_group,
         "can_add_subscribers_group",

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -509,6 +509,19 @@ export function show_new_stream_modal(): void {
         }
     }
 
+    const $add_subscribers_container = $(
+        "#stream_creation_form .subscriber_list_settings",
+    ).expectOne();
+
+    stream_ui_updates.enable_or_disable_add_subscribers_elements(
+        $add_subscribers_container,
+        // User should always be allowed to add subscribers when
+        // creating a new channel regardless of their presence in
+        // realm.can_add_subscribers_group
+        true,
+        true,
+    );
+
     // set default state for "announce stream" and "default stream" option.
     $("#stream_creation_form .default-stream input").prop("checked", false);
     update_announce_stream_state();

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -546,7 +546,7 @@ export function can_subscribe_others(sub: StreamSubscription): boolean {
         return false;
     }
 
-    if (settings_data.can_subscribe_others_to_all_streams()) {
+    if (settings_data.can_subscribe_others_to_all_accessible_streams()) {
         return true;
     }
 

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -434,7 +434,7 @@ export function update_add_subscriptions_elements(sub: SettingsSubscription): vo
 
     if (!allow_user_to_add_subs) {
         let tooltip_message;
-        if (!settings_data.can_subscribe_others_to_all_streams()) {
+        if (!settings_data.can_subscribe_others_to_all_accessible_streams()) {
             tooltip_message = $t({
                 defaultMessage:
                     "You do not have permission to add other users to channels in this organization.",

--- a/web/tests/settings_data.test.cjs
+++ b/web/tests/settings_data.test.cjs
@@ -183,7 +183,7 @@ test_realm_group_settings(
 
 test_realm_group_settings(
     "realm_can_add_subscribers_group",
-    settings_data.can_subscribe_others_to_all_streams,
+    settings_data.can_subscribe_others_to_all_accessible_streams,
 );
 
 test_realm_group_settings(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -789,7 +789,7 @@ def get_streams_to_which_user_cannot_add_subscribers(
     # does not waste database queries re-checking that.
     result: list[Stream] = []
 
-    if user_profile.can_subscribe_others_to_all_streams():
+    if user_profile.can_subscribe_others_to_all_accessible_streams():
         return []
 
     # Optimization for the organization administrator code path. We

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -439,7 +439,7 @@ def check_stream_access_for_delete_or_update(
     if sub is None and stream.invite_only:
         raise JsonableError(error)
 
-    if can_administer_channel(stream, user_profile):
+    if can_administer_accessible_channel(stream, user_profile):
         return
 
     raise CannotAdministerChannelError
@@ -828,7 +828,9 @@ def get_streams_to_which_user_cannot_add_subscribers(
     return result
 
 
-def can_administer_channel(channel: Stream, user_profile: UserProfile) -> bool:
+def can_administer_accessible_channel(channel: Stream, user_profile: UserProfile) -> bool:
+    # IMPORTANT: This function expects its callers to have already
+    # checked that the user can access the provided channel.
     group_allowed_to_administer_channel = channel.can_administer_channel_group
     assert group_allowed_to_administer_channel is not None
     return user_has_permission_for_group_setting(

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1,4 +1,5 @@
 from collections.abc import Collection, Iterable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TypedDict
 
@@ -837,11 +838,22 @@ def can_administer_channel(channel: Stream, user_profile: UserProfile) -> bool:
     )
 
 
+@dataclass
+class StreamsCategorizedByPermissions:
+    authorized_streams: list[Stream]
+    unauthorized_streams: list[Stream]
+    streams_to_which_user_cannot_add_subscribers: list[Stream]
+
+
 def filter_stream_authorization(
     user_profile: UserProfile, streams: Collection[Stream], is_subscribing_other_users: bool = False
-) -> tuple[list[Stream], list[Stream], list[Stream]]:
+) -> StreamsCategorizedByPermissions:
     if len(streams) == 0:
-        return [], [], []
+        return StreamsCategorizedByPermissions(
+            authorized_streams=[],
+            unauthorized_streams=[],
+            streams_to_which_user_cannot_add_subscribers=[],
+        )
 
     recipient_ids = [stream.recipient_id for stream in streams]
     subscribed_recipient_ids = set(
@@ -883,10 +895,10 @@ def filter_stream_authorization(
         if stream.id not in {stream.id for stream in unauthorized_streams}
         and stream.id not in {stream.id for stream in streams_to_which_user_cannot_add_subscribers}
     ]
-    return (
-        authorized_streams,
-        unauthorized_streams,
-        streams_to_which_user_cannot_add_subscribers,
+    return StreamsCategorizedByPermissions(
+        authorized_streams=authorized_streams,
+        unauthorized_streams=unauthorized_streams,
+        streams_to_which_user_cannot_add_subscribers=streams_to_which_user_cannot_add_subscribers,
     )
 
 

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -844,7 +844,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     def can_manage_default_streams(self) -> bool:
         return self.is_realm_admin
 
-    def can_subscribe_others_to_all_streams(self) -> bool:
+    def can_subscribe_others_to_all_accessible_streams(self) -> bool:
         return self.has_permission("can_add_subscribers_group")
 
     def can_invite_users_by_email(self, realm: Optional["Realm"] = None) -> bool:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20370,9 +20370,8 @@ paths:
 
                         Administrators can always unsubscribe others from a channel.
 
-                        Note that a user who is a member of the specified user group must
-                        also [have access](/help/channel-permissions) to the channel in
-                        order to unsubscribe others.
+                        Note that a user must also [have access](/help/channel-permissions) to a
+                        channel in order to modify it.
 
                         **Changes**: Prior to Zulip 10.0 (feature level 320), this value was
                         always the integer ID of a system group.
@@ -20396,16 +20395,12 @@ paths:
 
                         [update-group-setting]: /api/group-setting-values#updating-group-setting-values
 
-                        Note that a user who is a member of the specified user group must
-                        also [have access](/help/channel-permissions) to the channel in
-                        order to administer the channel.
+                        Administrators can always administer a channel.
 
-                        Realm admins are allowed to administer a channel they have access to
-                        regardless of whether they are present in this group.
-
-                        Users in this group can edit channel name and description without
-                        subscribing to the channel, but they need to be subscribed to edit
-                        channel permissions and add users.
+                        Note that a user must also [have access](/help/channel-permissions) to a
+                        channel in order to modify it. The exception to this rule is that
+                        organization administrators can edit channel names and descriptions
+                        without having full access to the channel.
 
                         **Changes**: New in Zulip 10.0 (feature level 325). Prior to this
                         change, the permission to administer channels was limited to realm
@@ -20425,9 +20420,8 @@ paths:
 
                         [update-group-setting]: /api/group-setting-values#updating-group-setting-values
 
-                        Note that a user who is a member of the specified user group must
-                        also [have access](/help/channel-permissions) to the channel in
-                        order to post in the channel.
+                        Note that a user must also [have access](/help/channel-permissions) to a
+                        channel in order to post in the channel.
 
                         **Changes**: New in Zulip 10.0 (feature level 333). Previously
                         `stream_post_policy` field used to control the permission to
@@ -25084,9 +25078,8 @@ components:
 
             Administrators can always unsubscribe others from a channel.
 
-            Note that a user who is a member of the specified user group must
-            also [have access](/help/channel-permissions) to the channel in
-            order to unsubscribe others.
+            Note that a user must also [have access](/help/channel-permissions) to a
+            channel in order to modify it.
 
             **Changes**: Prior to Zulip 10.0 (feature level 320), this value was
             always the integer ID of a system group.
@@ -25104,16 +25097,16 @@ components:
             A [group-setting value][setting-values] defining the set of users
             who have permission to administer this channel.
 
-            Note that a user who is a member of the specified user group must
-            also [have access](/help/channel-permissions) to the channel in
-            order to administer the channel.
+            Administrators can always administer a channel.
 
-            Realm admins are allowed to administer a channel they have access to
-            regardless of whether they are present in this group.
+            Note that a user must also [have access](/help/channel-permissions) to a
+            channel in order to modify it.
 
-            Users in this group can edit channel name and description without
-            subscribing to the channel, but they need to be subscribed to edit
-            channel permissions and add users.
+            Users can edit channel name and description without subscribing to the
+            channel, but they need to be subscribed to edit channel permissions and
+            add users. The exception to this rule is that organization administrators
+            can edit channel names and descriptions without having full access to
+            the channel.
 
             **Changes**: New in Zulip 10.0 (feature level 325). Prior to this
             change, the permission to administer channels was limited to realm
@@ -25127,9 +25120,8 @@ components:
             A [group-setting value][setting-values] defining the set of users
             who have permission to post in this channel.
 
-            Note that a user who is a member of the specified user group must
-            also [have access](/help/channel-permissions) to the channel in
-            order to post in the channel.
+            Note that a user must also [have access](/help/channel-permissions) to a
+            channel in order to post in the channel.
 
             **Changes**: New in Zulip 10.0 (feature level 333). Previously
             `stream_post_policy` field used to control the permission to

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -667,11 +667,16 @@ def add_subscriptions_backend(
         is_default_stream=is_default_stream,
         setting_groups_dict=setting_groups_dict,
     )
-    (
-        authorized_streams,
-        unauthorized_streams,
-        streams_to_which_user_cannot_add_subscribers,
-    ) = filter_stream_authorization(user_profile, existing_streams, is_subscribing_other_users)
+
+    streams_categorized_by_permissions = filter_stream_authorization(
+        user_profile, existing_streams, is_subscribing_other_users
+    )
+    authorized_streams = streams_categorized_by_permissions.authorized_streams
+    unauthorized_streams = streams_categorized_by_permissions.unauthorized_streams
+    streams_to_which_user_cannot_add_subscribers = (
+        streams_categorized_by_permissions.streams_to_which_user_cannot_add_subscribers
+    )
+
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
         raise JsonableError(
             _("Unable to access channel ({channel_name}).").format(


### PR DESCRIPTION
<!-- Describe your pull request here.-->

All the followups mentioned in #33000 have been addressed in this PR. The following lines were not added to any other settings because it does not apply to any other setting from what I checked:

```
  Users who can administer the channel or have the similar
  realm-level permission can add subscribers regardless of the value
  of this setting.
```

It might change once https://github.com/zulip/zulip/pull/33000#discussion_r1927431606 is answered.

https://github.com/zulip/zulip/pull/33000#discussion_r1925950477 is being fixed in #33156.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
