### PR TITLE
filter: Add support for filtering archive channels.

### DIFF
--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -77,6 +77,8 @@ Zulip offers the following filters based on the location of the message.
   channels](/help/change-the-privacy-of-a-channel) in the organization, including
   channels you are not subscribed to; see details
   [below](#searching-shared-history).
+* `channels:archived`: Search the history of [archived
+  channels](/help/archive-a-channel#archive-a-channel_1) in the organization.
 
 ### Search by sender
 

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -562,7 +562,7 @@ export class Filter {
                 return stream_data.get_sub_by_id_string(term.operand) !== undefined;
             case "channels":
             case "streams":
-                return term.operand === "public";
+                return term.operand === "public" || term.operand === "archived";
             case "topic":
                 return true;
             case "sender":
@@ -631,6 +631,7 @@ export class Filter {
         const levels = [
             "in",
             "channels-public",
+            "channels-archived",
             "channel",
             "topic",
             "dm",
@@ -1084,6 +1085,8 @@ export class Filter {
             "not-channels-public",
             "channels-web-public",
             "not-channels-web-public",
+            "channels-archived",
+            "not-channels-archived",
             "near",
             "with",
         ]);
@@ -1184,6 +1187,9 @@ export class Filter {
         if (_.isEqual(term_types, ["channels-public"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["channels-archived"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["sender"])) {
             return true;
         }
@@ -1253,6 +1259,8 @@ export class Filter {
                     return "/#narrow/is/mentioned";
                 case "channels-public":
                     return "/#narrow/channels/public";
+                case "channels-archived":
+                    return "/#narrow/channels/archived";
                 case "dm":
                     return "/#narrow/dm/" + people.emails_to_slug(this.operands("dm").join(","));
                 case "is-resolved":
@@ -1404,6 +1412,8 @@ export class Filter {
                     return $t({defaultMessage: "All messages including muted channels"});
                 case "channels-public":
                     return $t({defaultMessage: "Messages in all public channels"});
+                case "channels-archived":
+                    return $t({defaultMessage: "Messages in all archived channels"});
                 case "is-starred":
                     return $t({defaultMessage: "Starred messages"});
                 case "is-mentioned":
@@ -1518,7 +1528,11 @@ export class Filter {
 
         // TODO: It's not clear why `channels:` filters would not be
         // applicable locally.
-        if (this.has_operator("channels") || this.has_negated_operand("channels", "public")) {
+        if (
+            this.has_operator("channels") ||
+            this.has_negated_operand("channels", "public") ||
+            this.has_negated_operand("channels", "archived")
+        ) {
             return false;
         }
 
@@ -1772,6 +1786,8 @@ export class Filter {
             "not-is-resolved",
             "channels-public",
             "not-channels-public",
+            "channels-archived",
+            "not-channels-archived",
             "is-muted",
             "not-is-muted",
             "in-home",

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -622,7 +622,10 @@ function get_special_filter_suggestions(
     return filtered_suggestions;
 }
 
-function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
+function get_public_channels_filter_suggestions(
+    last: NarrowTerm,
+    terms: NarrowTerm[],
+): Suggestion[] {
     let search_string = "channels:public";
     // show "channels:public" option for users who
     // have "streams" in their muscle memory
@@ -652,6 +655,30 @@ function get_channels_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]):
     ];
     return get_special_filter_suggestions(last, terms, suggestions);
 }
+
+function get_archived_channels_filter_suggestions(
+    last: NarrowTerm,
+    terms: NarrowTerm[],
+): Suggestion[] {
+    const archived_description_html = "Archived channels";
+    const suggestions: SuggestionAndIncompatiblePatterns[] = [
+        {
+            search_string: "channels:archived",
+            description_html: archived_description_html,
+            is_people: false,
+            incompatible_patterns: [
+                {operator: "is", operand: "dm"},
+                {operator: "channel"},
+                {operator: "dm-including"},
+                {operator: "dm"},
+                {operator: "in"},
+                {operator: "channels"},
+            ],
+        },
+    ];
+    return get_special_filter_suggestions(last, terms, suggestions);
+}
+
 function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestion[] {
     const suggestions: SuggestionAndIncompatiblePatterns[] = [
         {
@@ -1061,9 +1088,10 @@ export function get_search_result(
         // name, and if there's already has a DM pill then the
         // searching user probably is looking to make a group DM.
         get_group_suggestions,
-        get_channels_filter_suggestions,
+        get_public_channels_filter_suggestions,
         get_is_filter_suggestions,
         get_sent_by_me_suggestions,
+        get_archived_channels_filter_suggestions,
         get_channel_suggestions,
         get_people("dm"),
         get_people("sender"),

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -71,6 +71,16 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">channels:archived</td>
+                        <td class="definition">
+                            {{#if can_access_all_public_channels }}
+                            {{t 'Search all archived channels.'}}
+                            {{else}}
+                            {{t 'Search all archived channels that you can view.'}}
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">sender:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -378,6 +378,7 @@ test("empty_query_suggestions", () => {
         "is:unread",
         "is:resolved",
         "sender:myself@zulip.com",
+        "channels:archived",
         `channel:${devel_id}`,
         `channel:${office_id}`,
         "has:link",
@@ -999,7 +1000,7 @@ test("operator_suggestions", ({override, mock_template}) => {
 
     query = "ch";
     suggestions = get_suggestions(query);
-    expected = ["ch", "channels:public", "channel:"];
+    expected = ["ch", "channels:public", "channels:archived", "channel:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-s";

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -45,6 +45,7 @@ from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import (
     can_access_stream_history_by_id,
     can_access_stream_history_by_name,
+    get_archived_streams_queryset,
     get_public_streams_queryset,
     get_stream_by_narrow_operand_access_unchecked,
     get_web_public_streams_queryset,
@@ -494,6 +495,8 @@ class NarrowBuilder:
             # Get all both subscribed and non-subscribed public channels
             # but exclude any private subscribed channels.
             recipient_queryset = get_public_streams_queryset(self.realm)
+        elif operand == "archived":
+            recipient_queryset = get_archived_streams_queryset(self.realm)
         elif operand == "web-public":
             recipient_queryset = get_web_public_streams_queryset(self.realm)
         else:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -582,6 +582,12 @@ def get_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     return Stream.objects.filter(realm=realm, invite_only=False, history_public_to_subscribers=True)
 
 
+def get_archived_streams_queryset(realm: Realm) -> QuerySet[Stream]:
+    return Stream.objects.filter(
+        deactivated=True,
+    )
+
+
 def get_web_public_streams_queryset(realm: Realm) -> QuerySet[Stream]:
     # This should match the include_web_public code path in do_get_streams.
     return Stream.objects.filter(


### PR DESCRIPTION
<!-- Describe your pull request here.-->
* Added the functionality of filtering archived channels messages using the search bar.
*  Updated the documentation.
*  Updated the test for filtering.


[czo](https://chat.zulip.org/#narrow/channel/101-design/topic/typeahead.20suggestions.20.2332506) thread for the typehead suggestions.

Fixes: <!-- Issue link, or clear description.--> #32506

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

*Screenshots and screen captures:*
![image](https://github.com/user-attachments/assets/81e74573-98a9-454c-bbea-64ad6d1cf2d0)
![image](https://github.com/user-attachments/assets/447a4fa3-b89b-41f7-9ef7-9aad591635ae)
![image](https://github.com/user-attachments/assets/65c1e867-a278-47aa-8e89-8c422183b9d2)
![image](https://github.com/user-attachments/assets/66691edc-2c22-478e-b9eb-bcb97f3f8c79)


https://github.com/user-attachments/assets/0e332c52-58c4-41e2-b7f4-60395205577d




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>