### PR TITLE
left sidebar (display): Restyle log-in link to match browse channels.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -396,7 +396,8 @@
     }
 }
 
-#subscribe-to-more-streams {
+#subscribe-to-more-streams,
+#login-to-more-streams {
     /* --left-sidebar-bottom-scrolling-buffer is to prevent the row from
        being cut off, and --sidebar-bottom-spacing is extra padding. */
     margin: 5px var(--left-sidebar-right-margin)
@@ -417,13 +418,16 @@
     .subscribe-more-link {
         display: grid;
         grid-template:
-            "plus-icon . row-text" var(--line-height-sidebar-row-prominent)
+            "plus-icon . row-text" minmax(
+                var(--line-height-sidebar-row-prominent),
+                auto
+            )
             / var(--left-sidebar-icon-column-width) var(
                 --left-sidebar-icon-content-gap
             )
             minmax(0, 1fr);
         align-items: center;
-        line-height: var(--line-height-sidebar-row-prominent);
+        line-height: 1;
         color: var(--color-text-sidebar-action-heading);
         text-decoration: none;
     }
@@ -442,6 +446,7 @@
            because mathematical centering and the perception of center don't
            always match. */
         margin-top: -0.12em;
+        padding: 3px 0;
         font-size: var(--font-size-sidebar-action-heading);
         font-weight: var(--font-weight-sidebar-action-heading);
         font-variant: var(--font-variant-sidebar-action-heading);
@@ -458,27 +463,9 @@
     }
 }
 
-#login-link-container,
-#subscribe-to-more-streams {
+#subscribe-to-more-streams,
+#login-to-mmore-streams {
     text-decoration: none;
-}
-
-#login-link-container {
-    color: var(--color-text-url);
-    display: flex;
-    align-items: center;
-    margin: 5px auto var(--left-sidebar-bottom-scrolling-buffer)
-        var(--left-sidebar-toggle-width-offset);
-
-    &:hover {
-        cursor: pointer;
-        color: var(--color-text-url-hover);
-
-        &.login_button .login-text {
-            color: var(--color-text-url-hover);
-            text-decoration: underline;
-        }
-    }
 }
 
 ul.filters {
@@ -1831,6 +1818,7 @@ li.topic-list-item {
 
     #streams_header,
     #subscribe-to-more-streams,
+    #login-to-more-streams,
     .show-more-topics {
         display: none;
     }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -207,14 +207,11 @@
                 {{#unless is_guest }}
                     <div id="subscribe-to-more-streams"></div>
                 {{/unless}}
-                <div class="only-visible-for-spectators">
-                    <div id="login-link-container" class="login_button">
-                        <i class="zulip-icon zulip-icon-log-in" aria-hidden="true"></i>
-                        {{~!-- squash whitespace --~}}
-                        <a class="login-text">
-                            {{t 'Log in to browse more channels'}}
-                        </a>
-                    </div>
+                <div id="login-to-more-streams" class="only-visible-for-spectators login_button">
+                    <a class="subscribe-more-link">
+                        <i class="subscribe-more-icon zulip-icon zulip-icon-log-in" aria-hidden="true" ></i>
+                        <span class="subscribe-more-label">{{~t "LOG IN TO BROWSE MORE" ~}}</span>
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit updates the styling of "Log in to browse more channels" link in the left sidebar for logged out users to match "BROWSE N MORE CHANNELS" link. If the text exceeds the width of container, it'll be wrapped to the next line.

<!-- Describe your pull request here.-->

Fixes: #33108

The icon looks a bit of the vertical alignment, this problem is being addressed by [#32969](https://github.com/zulip/zulip/issues/32969)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|            |Light Theme|Dark Theme|
|----------|------------------|------------------|
|**B<br>E<br>F<br>O<br>R<br>E**|![image](https://github.com/user-attachments/assets/27d17b20-69dc-4da1-bda0-bb7de8195153)|![image](https://github.com/user-attachments/assets/2087fdf2-057a-4d71-83ed-57f41bf0b6ca)|
|**A<br>F<br>T<br>E<br>R**|![image](https://github.com/user-attachments/assets/966156a1-d169-4578-b8cf-4f3292e84f9e)|![image](https://github.com/user-attachments/assets/65a0a124-9069-407f-92b0-850c0b7675db)|

In case the text gets wrapped:

|Light Theme|Dark Theme|
|------------------|------------------|
|![image](https://github.com/user-attachments/assets/d286f4d3-3365-4137-8a70-a91609a2862c)|![image](https://github.com/user-attachments/assets/b7be47b5-7f92-46ee-9349-07be8549a2cc)|

(Note that the current text in PR is `LOG IN TO BROWSE MORE` only.)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
