### PR TITLE
integration: Revise Slack's `channels_map_to_topics` setting documentation.

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -21,15 +21,10 @@ See also the [Zulip Slack incoming webhook integration][1].
 1. {!create-an-incoming-webhook.md!}
 
 1. {!generate-webhook-url-basic.md!}
-
-    To map each Slack channel to a Zulip topic, make sure that the
-    **Send all notifications to a single topic** option is disabled
-    when generating the URL. Add `&channels_map_to_topics=1` to the
-    generated URL.
-
-    Otherwise, add `&channels_map_to_topics=0` to the generated URL.
-    Note that any Zulip channel you specified when generating the URL
-    will be ignored in this case.
+   By default, all incoming Slack messages are sent to the specified
+   Zulip channel under the topic **"Message from Slack"**. For options
+   to configure Slack channel mapping, see [configuration options](#
+   configuration-options).
 
 1. Create a new [Slack app][4], and open it. Navigate to the **OAuth
    & Permissions** menu, and scroll down to the **Scopes** section.
@@ -63,6 +58,15 @@ See also the [Zulip Slack incoming webhook integration][1].
 {!congrats.md!}
 
 ![](/static/images/integrations/slack/001.png)
+
+### Configuration Options
+
+- To map each Slack channel to a Zulip topic, add `&channels_map_to
+  _topics=1` to the generated URL.
+
+- To map each Slack channel to a Zulip channel, add `&channels_map_
+  to_topics=0` to the generated URL. Note that any Zulip channel you
+  specified when generating the URL will be ignored in this case.
 
 ### Related documentation
 


### PR DESCRIPTION
Currently, in `handle_slack_webhook_message`, the `channels_map_to_topic` setting has 3 states:

- `channels_map_to_topics=0` to map each Slack channel to a Zulip channel with the same name as the Slack channel.
  e.g, Slack: #general -> Zulip: #general>Messages from Slack

- `channels_map_to_topics=1` to map each Slack channel to a Zulip topic named after the Slack channel.
  e.g, Slack: #general -> Zulip: #slack integration>channel: general

- The default, `channels_map_to_topics=None` will map incoming Slack messages to a single Zulip topic or DM if the channel is not specified.
  e.g, Slack: #general -> Zulip: #slack integration>Messages from Slack

However, the documentation doesn't communicate these states clearly enough, especially about the default behaviour if the user doesn't specify a `channles_map_to_topics` in the integration URL.

This clarifies the Slack integration documentation on each Slack channel mapping behaviour, especially about the default setup.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/user-attachments/assets/79cda0a8-5e5d-491d-80c5-0793dfafd822)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
