### PR TITLE
compose: Size help-button icon to match other formatting buttons.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1315,6 +1315,9 @@ textarea.new_message_textarea {
         height: 1.2727em;
         /* 30px at 22px/1em */
         width: 1.3636em;
+        /* Adhere to the width of formatting buttons,
+           despite flexbox context. */
+        flex: 0 0 auto;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1376,18 +1379,6 @@ textarea.new_message_textarea {
         padding: 0 5px;
         position: relative;
         top: 0.7px;
-    }
-
-    .compose_help_button {
-        /* 20px at 16px/1em */
-        font-size: 1.25em;
-        /* 32px at 20px/1em */
-        height: 1.6em;
-        /* 34.2833 at 20px/1em */
-        width: 1.7142em;
-        /* Adhere to the width of this button,
-           despite flexbox context. */
-        flex: 0 0 auto;
     }
 }
 


### PR DESCRIPTION
As discussed on a call with @alya this week, this PR removes adjustments that made the help icon look diminutive in relation to the others in the formatting bar.

A flex adjustment previously on the help icon is now applied to all compose control buttons,
though no visible changes result from that (it's only the help button that needs it, owing to its place in the DOM relative to other formatting buttons). But because button sizes are controlled precisely in the area, ordinary flex grow/shrink behavior is undesirable.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![formatting-help-before](https://github.com/user-attachments/assets/4034ff4e-9c4a-418d-875a-94c873c6a383) | ![formatting-help-after](https://github.com/user-attachments/assets/ee86da1c-d69d-44dd-af02-0547ab0e352e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>