### PR TITLE
Add permissions panel to group management UI.

### DIFF
--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -59,6 +59,12 @@ export const realm_group_setting_name_schema = z.enum([
 ]);
 export type RealmGroupSettingName = z.infer<typeof realm_group_setting_name_schema>;
 
+export type StreamGroupSettingName =
+    | "can_add_subscribers_group"
+    | "can_administer_channel_group"
+    | "can_remove_subscribers_group"
+    | "can_send_message_group";
+
 export function get_realm_user_groups_for_setting(
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
@@ -126,14 +132,14 @@ export function get_realm_user_groups_for_dropdown_list_widget(
 }
 
 export type AssignedGroupPermission = {
-    setting_name: RealmGroupSettingName;
+    setting_name: RealmGroupSettingName | StreamGroupSettingName;
     can_edit: boolean;
     tooltip_message?: string;
 };
 
 export function get_assigned_permission_object(
     setting_value: GroupSettingValue,
-    setting_name: RealmGroupSettingName,
+    setting_name: RealmGroupSettingName | StreamGroupSettingName,
     group_id: number,
     can_edit_settings: boolean,
 ): AssignedGroupPermission | undefined {

--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -132,14 +132,14 @@ export function get_realm_user_groups_for_dropdown_list_widget(
 }
 
 export type AssignedGroupPermission = {
-    setting_name: RealmGroupSettingName | StreamGroupSettingName;
+    setting_name: RealmGroupSettingName | StreamGroupSettingName | GroupSettingName;
     can_edit: boolean;
     tooltip_message?: string;
 };
 
 export function get_assigned_permission_object(
     setting_value: GroupSettingValue,
-    setting_name: RealmGroupSettingName | StreamGroupSettingName,
+    setting_name: RealmGroupSettingName | StreamGroupSettingName | GroupSettingName,
     group_id: number,
     can_edit_settings: boolean,
 ): AssignedGroupPermission | undefined {

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -275,7 +275,7 @@ export function validate_group_settings_hash(hash: string): string {
 
         const group_name = hash_components[2];
         let right_side_tab = hash_components[3];
-        const valid_right_side_tab_values = new Set(["general", "members"]);
+        const valid_right_side_tab_values = new Set(["general", "members", "permissions"]);
         if (
             group.name === group_name &&
             right_side_tab !== undefined &&

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -295,6 +295,18 @@ export function dispatch_normal_event(event) {
                                 }
 
                                 if (
+                                    Object.keys(
+                                        realm.server_supported_permission_settings.realm,
+                                    ).includes(key)
+                                ) {
+                                    const $elem = $(`#id_group_permission_${CSS.escape(key)}`);
+                                    user_group_edit.update_setting_in_group_permissions_panel(
+                                        $elem,
+                                        value,
+                                    );
+                                }
+
+                                if (
                                     key === "create_multiuse_invite_group" ||
                                     key === "can_invite_users_group"
                                 ) {

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -10,7 +10,7 @@ import * as blueslip from "./blueslip.ts";
 import * as compose_banner from "./compose_banner.ts";
 import type {DropdownWidget} from "./dropdown_widget.ts";
 import * as group_permission_settings from "./group_permission_settings.ts";
-import type {GroupSettingName} from "./group_permission_settings.ts";
+import type {AssignedGroupPermission, GroupSettingName} from "./group_permission_settings.ts";
 import * as group_setting_pill from "./group_setting_pill.ts";
 import {$t} from "./i18n.ts";
 import {
@@ -1767,4 +1767,34 @@ export function set_custom_time_inputs_visibility(
     } else {
         $time_select_elem.parent().find(".custom-time-input-container").hide();
     }
+}
+
+export function get_group_assigned_realm_permissions(group: UserGroup): {
+    subsection_heading: string;
+    assigned_permissions: AssignedGroupPermission[];
+}[] {
+    const group_assigned_realm_permissions = [];
+    for (const {subsection_heading, settings} of settings_config.realm_group_permission_settings) {
+        const assigned_permission_objects = [];
+        for (const setting_name of settings) {
+            const setting_value = realm[realm_schema.keyof().parse("realm_" + setting_name)];
+            const assigned_permission_object =
+                group_permission_settings.get_assigned_permission_object(
+                    group_setting_value_schema.parse(setting_value),
+                    setting_name,
+                    group.id,
+                    current_user.is_admin,
+                );
+            if (assigned_permission_object !== undefined) {
+                assigned_permission_objects.push(assigned_permission_object);
+            }
+        }
+        if (assigned_permission_objects.length > 0) {
+            group_assigned_realm_permissions.push({
+                subsection_heading,
+                assigned_permissions: assigned_permission_objects,
+            });
+        }
+    }
+    return group_assigned_realm_permissions;
 }

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1,6 +1,7 @@
 import Handlebars from "handlebars/runtime.js";
 
 import {page_params} from "./base_page_params.ts";
+import type {RealmGroupSettingName} from "./group_permission_settings.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults.ts";
 import {realm} from "./state_data.ts";
@@ -701,6 +702,55 @@ export const group_setting_labels = {
         can_remove_members_group: $t({defaultMessage: "Who can remove members from this group"}),
     },
 };
+
+// Order of subsections and its settings is important here as
+// this object is used for rendering the assigned permissions
+// in group permissions panel.
+export const realm_group_permission_settings: {
+    subsection_heading: string;
+    settings: RealmGroupSettingName[];
+}[] = [
+    {
+        subsection_heading: $t({defaultMessage: "Joining the organization"}),
+        settings: ["can_invite_users_group", "create_multiuse_invite_group"],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Channel permissions"}),
+        settings: [
+            "can_create_public_channel_group",
+            "can_create_web_public_channel_group",
+            "can_create_private_channel_group",
+            "can_add_subscribers_group",
+        ],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Group permissions"}),
+        settings: ["can_manage_all_groups", "can_create_groups"],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Direct message permissions"}),
+        settings: ["direct_message_permission_group", "direct_message_initiator_group"],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Moving messages"}),
+        settings: [
+            "can_move_messages_between_topics_group",
+            "can_move_messages_between_channels_group",
+        ],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Message deletion"}),
+        settings: ["can_delete_any_message_group", "can_delete_own_message_group"],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Guests"}),
+        settings: ["can_access_all_users_group"],
+    },
+    {
+        subsection_heading: $t({defaultMessage: "Other permissions"}),
+        settings: ["can_add_custom_emoji_group"],
+    },
+];
 
 // NOTIFICATIONS
 

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1,7 +1,7 @@
 import Handlebars from "handlebars/runtime.js";
 
 import {page_params} from "./base_page_params.ts";
-import type {RealmGroupSettingName} from "./group_permission_settings.ts";
+import type {RealmGroupSettingName, StreamGroupSettingName} from "./group_permission_settings.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults.ts";
 import {realm} from "./state_data.ts";
@@ -750,6 +750,15 @@ export const realm_group_permission_settings: {
         subsection_heading: $t({defaultMessage: "Other permissions"}),
         settings: ["can_add_custom_emoji_group"],
     },
+];
+
+// Order of settings is important, as this list is used to
+// render assigned permissions in permissions panel.
+export const stream_group_permission_settings: StreamGroupSettingName[] = [
+    "can_send_message_group",
+    "can_administer_channel_group",
+    "can_add_subscribers_group",
+    "can_remove_subscribers_group",
 ];
 
 // NOTIFICATIONS

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1,7 +1,11 @@
 import Handlebars from "handlebars/runtime.js";
 
 import {page_params} from "./base_page_params.ts";
-import type {RealmGroupSettingName, StreamGroupSettingName} from "./group_permission_settings.ts";
+import type {
+    GroupSettingName,
+    RealmGroupSettingName,
+    StreamGroupSettingName,
+} from "./group_permission_settings.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults.ts";
 import {realm} from "./state_data.ts";
@@ -759,6 +763,17 @@ export const stream_group_permission_settings: StreamGroupSettingName[] = [
     "can_administer_channel_group",
     "can_add_subscribers_group",
     "can_remove_subscribers_group",
+];
+
+// Order of settings is important, as this list is used to
+// render assigned permissions in permissions panel.
+export const group_permission_settings: GroupSettingName[] = [
+    "can_manage_group",
+    "can_mention_group",
+    "can_add_members_group",
+    "can_remove_members_group",
+    "can_join_group",
+    "can_leave_group",
 ];
 
 // NOTIFICATIONS

--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -37,6 +37,7 @@ import * as sub_store from "./sub_store.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import {group_setting_value_schema} from "./types.ts";
 import * as unread_ui from "./unread_ui.ts";
+import * as user_group_edit from "./user_group_edit.ts";
 import * as user_profile from "./user_profile.ts";
 
 // In theory, this function should apply the account-level defaults,
@@ -101,6 +102,13 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
         stream_settings_ui.update_stream_permission_group_setting(
             stream_permission_group_settings_schema.parse(property),
             sub,
+            group_setting_value_schema.parse(value),
+        );
+        const $elem = $(
+            `#id_group_permission_${CSS.escape(sub.stream_id.toString())}_${CSS.escape(property)}`,
+        );
+        user_group_edit.update_setting_in_group_permissions_panel(
+            $elem,
             group_setting_value_schema.parse(value),
         );
         return;

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -477,6 +477,25 @@ export function is_user_in_group(
     return false;
 }
 
+export function group_has_permission(setting_value: GroupSettingValue, group_id: number): boolean {
+    if (typeof setting_value === "number") {
+        return setting_value === group_id;
+    }
+
+    const direct_subgroup_ids = setting_value.direct_subgroups;
+    if (direct_subgroup_ids.includes(group_id)) {
+        return true;
+    }
+
+    for (const direct_subgroup_id of direct_subgroup_ids) {
+        if (is_subgroup_of_target_group(direct_subgroup_id, group_id)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export function is_user_in_any_group(
     user_group_ids: number[],
     user_id: number,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -293,6 +293,35 @@ h4.user_group_setting_subsection_title {
     opacity: 1;
 }
 
+.group-assigned-permissions {
+    .subsection-header {
+        display: inline;
+
+        h3 {
+            font-size: 1.5em;
+            font-weight: normal;
+            line-height: 1.5;
+            display: inline;
+        }
+    }
+
+    .subsection-settings {
+        margin-top: 10px;
+
+        .input-group {
+            margin-bottom: 20px;
+        }
+    }
+
+    .no-permissions-for-group-text {
+        font-size: 1.5em;
+    }
+
+    .inline {
+        display: inline;
+    }
+}
+
 .user-groups-container,
 .subscriptions-container {
     position: relative;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -302,6 +302,10 @@ h4.user_group_setting_subsection_title {
             font-weight: normal;
             line-height: 1.5;
             display: inline;
+
+            .stream-privacy-type-icon {
+                margin-right: 4px;
+            }
         }
     }
 

--- a/web/templates/settings/settings_checkbox.hbs
+++ b/web/templates/settings/settings_checkbox.hbs
@@ -1,5 +1,5 @@
 {{#unless (eq render_only false)}}
-<div class="input-group {{#if is_disabled}}control-label-disabled{{/if}}">
+<div class="input-group {{#if is_disabled}}control-label-disabled{{/if}} {{#if tooltip_message}}tippy-zulip-tooltip{{/if}}" {{#if tooltip_message}}data-tippy-content="{{tooltip_message}}"{{/if}}>
     <label class="checkbox">
         <input type="checkbox" class="{{setting_name}} inline-block setting-widget {{#unless skip_prop_element}}prop-element{{/unless}}" name="{{setting_name}}" data-setting-widget-type="boolean"
           id="{{#if prefix}}{{prefix}}{{/if}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} {{#if is_disabled}}disabled{{/if}} />

--- a/web/templates/settings/settings_numeric_input.hbs
+++ b/web/templates/settings/settings_numeric_input.hbs
@@ -8,8 +8,8 @@
         {{#if help_link}}
         {{> ../help_link_widget link=help_link }}
         {{/if}}
-        {{#if tooltip_text}}
-        <i class="tippy-zulip-tooltip fa fa-info-circle settings-info-icon" {{#if hide_tooltip}}style="display: none;"{{/if}} data-tippy-content="{{tooltip_text}}"></i>
+        {{#if help_icon_tooltip_text}}
+        <i class="tippy-zulip-tooltip fa fa-info-circle settings-info-icon" {{#if hide_tooltip}}style="display: none;"{{/if}} data-tippy-content="{{help_icon_tooltip_text}}"></i>
         {{/if}}
     </label>
     <input type="text" inputmode="numeric" pattern="\d*" value="{{setting_value}}" class="{{setting_name}} settings_text_input setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="number"

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -23,4 +23,32 @@
             </div>
         {{/each}}
     </div>
+
+    <div class="channel-group-permissions {{#unless group_assigned_stream_permissions.length}}hide{{/unless}}">
+        <h3>{{t "Channel permissions"}}</h3>
+
+        {{#each group_assigned_stream_permissions}}
+            <div class="settings-subsection-parent {{#unless assigned_permissions.length}}hide{{/unless}}" data-stream-id="{{stream.stream_id}}">
+                <div class="subsection-header">
+                    <h3>
+                        {{> ../inline_decorated_stream_name stream=stream }}
+                    </h3>
+                    {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
+                </div>
+
+                <div class="subsection-settings">
+                    {{#each assigned_permissions}}
+                        {{> ../settings/settings_checkbox
+                          setting_name=setting_name
+                          prefix=../id_prefix
+                          is_checked=true
+                          label=(lookup ../../group_setting_labels.stream setting_name)
+                          is_disabled=(not can_edit)
+                          tooltip_message=tooltip_message
+                          }}
+                    {{/each}}
+                </div>
+            </div>
+        {{/each}}
+    </div>
 </div>

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -51,4 +51,30 @@
             </div>
         {{/each}}
     </div>
+
+    <div class="user-group-permissions {{#unless group_assigned_user_group_permissions.length}}hide{{/unless}}">
+        <h3>{{t "User group permissions"}}</h3>
+
+        {{#each group_assigned_user_group_permissions}}
+            <div class="settings-subsection-parent {{#unless assigned_permissions.length}}hide{{/unless}}" data-group-id="{{group_id}}">
+                <div class="subsection-header">
+                    <h3>{{group_name}}</h3>
+                    {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
+                </div>
+
+                <div class="subsection-settings">
+                    {{#each assigned_permissions}}
+                        {{> ../settings/settings_checkbox
+                          setting_name=setting_name
+                          prefix=../id_prefix
+                          is_checked=true
+                          label=(lookup ../../group_setting_labels.group setting_name)
+                          is_disabled=(not can_edit)
+                          tooltip_message=tooltip_message
+                          }}
+                    {{/each}}
+                </div>
+            </div>
+        {{/each}}
+    </div>
 </div>

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -1,0 +1,26 @@
+<div class="group-permissions">
+    <div class="realm-group-permissions {{#unless group_assigned_realm_permissions.length}}hide{{/unless}}">
+        <h3>{{t "Organization permissions"}}</h3>
+
+        {{#each group_assigned_realm_permissions}}
+            <div class="settings-subsection-parent {{#unless assigned_permissions.length}}hide{{/unless}}">
+                <div class="subsection-header">
+                    <h3>{{subsection_heading}}</h3>
+                    {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
+                </div>
+
+                <div class="subsection-settings">
+                    {{#each assigned_permissions}}
+                        {{> ../settings/settings_checkbox
+                          setting_name=setting_name
+                          prefix="id_group_permission_"
+                          is_checked=true
+                          label=(lookup ../../group_setting_labels.realm setting_name)
+                          is_disabled=(not can_edit)
+                          tooltip_message=tooltip_message}}
+                    {{/each}}
+                </div>
+            </div>
+        {{/each}}
+    </div>
+</div>

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -43,7 +43,7 @@
                     {{> ../settings/settings_save_discard_widget section_name="group-permissions" }}
                 </div>
 
-                {{> group_permissions prefix="id_" group_setting_labels=group_setting_labels}}
+                {{> group_permissions prefix="id_" group_setting_labels=group_setting_labels.group}}
             </div>
 
             <div class="group_detail_box">
@@ -65,6 +65,18 @@
         <div class="group_member_settings group_setting_section" data-group-section="members">
             <div class="edit_members_for_user_group">
                 {{> user_group_members .}}
+            </div>
+        </div>
+
+        <div class="group_setting_section" data-group-section="permissions">
+            <div class="group-assigned-permissions">
+                {{#if group_has_no_permissions}}
+                    <span class="no-permissions-for-group-text">
+                        {{t 'This group has no assigned permissions.'}}
+                    </span>
+                {{else}}
+                    {{> group_permission_settings .}}
+                {{/if}}
             </div>
         </div>
     </div>

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -605,7 +605,13 @@ run_test("realm settings", ({override}) => {
     override(realm, "realm_plan_type", 2);
     override(realm, "realm_upload_quota_mib", 5000);
     override(realm, "max_file_upload_size_mib", 10);
+    override(realm, "server_supported_permission_settings", {
+        realm: {
+            create_multiuse_invite_group: {},
+        },
+    });
     override(settings_org, "populate_auth_methods", noop);
+    override(user_group_edit, "update_setting_in_group_permissions_panel", noop);
     dispatch(event);
     assert_same(realm.realm_create_multiuse_invite_group, 3);
     assert_same(realm.realm_allow_message_editing, true);

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -885,6 +885,7 @@ exports.fixtures = {
         data: {
             name: "Frontend",
             description: "All Frontend people",
+            can_manage_group: 2,
         },
     },
 

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -39,6 +39,8 @@ mock_esm("../src/settings_notifications", {
 mock_esm("../src/overlays", {
     streams_open: () => true,
 });
+
+const user_group_edit = mock_esm("../src/user_group_edit");
 const user_profile = mock_esm("../src/user_profile");
 
 const {Filter} = zrequire("../src/filter");
@@ -77,6 +79,8 @@ const dev_help = {
     stream_id: 2,
     is_muted: true,
     invite_only: false,
+    can_administer_channel_group: 1,
+    can_remove_subscribers_group: 1,
 };
 
 const frontend = {
@@ -86,6 +90,8 @@ const frontend = {
     stream_id: 101,
     is_muted: true,
     invite_only: false,
+    can_administer_channel_group: 1,
+    can_remove_subscribers_group: 1,
 };
 
 function narrow_to_frontend() {
@@ -112,6 +118,7 @@ test("update_property", ({override}) => {
         "server_supported_permission_settings",
         example_settings.server_supported_permission_settings,
     );
+    override(user_group_edit, "update_setting_in_group_permissions_panel", noop);
     const sub = {...frontend};
     stream_data.add_sub(sub);
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is a refactor commit to move type definition.
- Second commit is to improve node tests.
- Third commit is a refactor in live-update code.
- Fourth commit is to define labels in a common object.
- Fifth commit is again a refactor for moving function definitions.
- Sixth commit is a refactor to rename a variable.
- Last three commits are to add realm, stream and group settings in permissions panel.

Fixes part of #28806 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2025-01-24 19-42-56](https://github.com/user-attachments/assets/99a35ac5-943e-488f-9d75-0b75e64e3971)

![Peek 2025-01-24 19-42](https://github.com/user-attachments/assets/604cf41d-cff7-4c6c-aa63-d96efb3a9f45)

![Peek 2025-01-24 19-44](https://github.com/user-attachments/assets/1ae5ea7d-165b-4f05-9097-70a244d888a9)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
