### PR TITLE
help: Document the saved snippets compose box feature.

### DIFF
--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -66,6 +66,7 @@
 * [Quote or forward a message](/help/quote-or-forward-a-message)
 * [Emoji and emoticons](/help/emoji-and-emoticons)
 * [Insert a link](/help/insert-a-link)
+* [Saved snippets](/help/saved-snippets)
 * [Share and upload files](/help/share-and-upload-files)
 * [Animated GIFs](/help/animated-gifs-from-giphy)
 * [Text emphasis](/help/text-emphasis)

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -158,6 +158,9 @@ in the Zulip app to add more to your repertoire as needed.
 * **Insert link**: `[Zulip website](https://zulip.org)` or <kbd>Ctrl</kbd> +
   <kbd>Shift</kbd> + <kbd>L</kbd>
 
+* **Insert or create a [saved snippet](/help/saved-snippets)**:
+  <kbd>Ctrl</kbd> + <kbd>'</kbd>
+
 * **Toggle preview mode**: <kbd>Alt</kbd> + <kbd>P</kbd>
 
 * **Cancel compose and save draft**: <kbd>Esc</kbd> or

--- a/help/saved-snippets.md
+++ b/help/saved-snippets.md
@@ -1,0 +1,82 @@
+# Saved snippets
+
+You can save snippets of message content, and quickly insert them into the
+message you're composing.
+
+## Insert a saved snippet
+
+{start_tabs}
+
+{!start-composing.md!}
+
+1. Click the **Insert saved snippet** (<i class="zulip-icon
+   zulip-icon-message-square-text"></i>) icon at the bottom of the compose box to
+   open the saved snippets menu.
+
+1.  Start typing to filter saved snippets by title. Select a saved snippet to
+    insert it into the compose box.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>'</kbd> to open the saved
+    snippets menu.
+
+{end_tabs}
+
+## Create a saved snippet
+
+{start_tabs}
+
+{!start-composing.md!}
+
+1. *(optional)* Write the text you'd like to use as save as a snippet in the
+   compose box. You can [preview](/help/preview-your-message-before-sending) what
+   it will look like once sent.
+
+1. Click the **Insert saved snippet** (<i class="zulip-icon
+   zulip-icon-message-square-text"></i>) icon at the bottom of the compose box to
+   open the saved snippets menu.
+
+1. Select **Create a new saved snippet**.
+
+1. Enter a **Title** for the saved snippet, which will be used for finding saved
+   snippets.
+
+1. Enter the **Content** you'd like to save as a snippet, or modify the content
+   from the compose box as needed.
+
+1. Click **Save**.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>'</kbd> to open the saved
+    snippets menu.
+
+{end_tabs}
+
+## Delete a saved snippet
+
+{start_tabs}
+
+{!start-composing.md!}
+
+1. Click the **Insert saved snippet** (<i class="zulip-icon
+   zulip-icon-message-square-text"></i>) icon at the bottom of the compose box to
+   open the saved snippets menu.
+
+1. Hover over the saved snippet you'd like to delete, and click the **Delete
+   snippet** (<i class="fa fa-trash-o"></i>) icon on the right.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>'</kbd> to open the saved
+    snippets menu.
+
+{end_tabs}
+
+## Related articles
+
+* [Message formatting](/help/format-your-message-using-markdown)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Mastering the compose box](/help/mastering-the-compose-box)
+* [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -237,6 +237,10 @@
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Use or create a saved snippet' }}</td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>'</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Toggle preview mode' }}</td>
                     <td><span class="hotkey"><kbd>Alt</kbd> + <kbd>P</kbd></span></td>
                 </tr>


### PR DESCRIPTION
First pass at documenting the new saved snippets feature for composing messages.

Fixes #33131.

Blocked on #31892.

---

**Notes**:
- Until #31892 is merged to main, the icon in the compose box used for this feature doesn't exist. So when that's merged, then this needs to be updated to use `class="zulip-icon zulip-icon-message-square-text"` instead of `class="zulip-icon zulip-icon-message-square"` which is used for the current draft.
- Also adds the keyboard shortcut documentation for the changes in the above pull request.
- We could possibly use a shared include file for the instruction to open the saved snippet dropdown and/or the keyboard shortcut tip. But as we probably won't use them anywhere else, it seemed fine to just repeat the text for the three instruction blocks.

---

**Screenshots and screen captures:**

<details>
<summary>First draft of new Saved snippets help center article</summary>

![Screenshot 2025-01-24 at 15 40 44@2x](https://github.com/user-attachments/assets/fbd929ee-10c7-4e8d-b4e7-8d2d5857e5a8)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
