### PR TITLE
settings: Add option to customize channel notifications in Personal settings > Notifications.

### DIFF
--- a/web/src/settings.ts
+++ b/web/src/settings.ts
@@ -117,6 +117,8 @@ export function build_page(): void {
         twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         general_settings: settings_config.all_notifications(user_settings).general_settings,
         notification_settings: settings_config.all_notifications(user_settings).settings,
+        custom_stream_specific_notification_settings:
+            settings_config.get_custom_stream_specific_notifications_table_row_data(),
         email_notifications_batching_period_values:
             settings_config.email_notifications_batching_period_values,
         realm_name_in_email_notifications_policy_values:

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1012,6 +1012,21 @@ export function get_notifications_table_row_data(
     });
 }
 
+export function get_custom_stream_specific_notifications_table_row_data(): NotificationSettingCheckbox[] {
+    // Returns an array of NotificationSettingCheckbox for the special row that
+    // allows adding new configuration for a previously uncustomized channel.
+    return stream_specific_notification_settings.map((setting_name) => {
+        const checkbox = {
+            setting_name,
+            is_disabled: true,
+            is_checked: false,
+            is_mobile_checkbox: setting_name === "push_notifications",
+            push_notifications_disabled: !realm.realm_push_notifications_enabled,
+        };
+        return checkbox;
+    });
+}
+
 export type AllNotifications = {
     general_settings: {
         label: string;

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -973,6 +973,7 @@ type NotificationSettingCheckbox = {
     is_disabled: boolean;
     is_checked: boolean;
     is_mobile_checkbox: boolean;
+    push_notifications_disabled: boolean;
 };
 
 export function get_notifications_table_row_data(
@@ -987,6 +988,7 @@ export function get_notifications_table_row_data(
                 is_disabled: true,
                 is_checked: false,
                 is_mobile_checkbox: false,
+                push_notifications_disabled: false,
             };
         }
 
@@ -1000,6 +1002,7 @@ export function get_notifications_table_row_data(
             is_disabled: false,
             is_checked: checked,
             is_mobile_checkbox: false,
+            push_notifications_disabled: !realm.realm_push_notifications_enabled,
         };
         if (column === "mobile") {
             checkbox.is_disabled = !realm.realm_push_notifications_enabled;

--- a/web/src/settings_notifications.ts
+++ b/web/src/settings_notifications.ts
@@ -75,6 +75,7 @@ function rerender_ui(): void {
                         settings_config.all_notifications(user_settings)
                             .disabled_notification_settings,
                     muted: muted_stream_ids.includes(stream.stream_id),
+                    push_notifications_disabled: !realm.realm_push_notifications_enabled,
                 }),
             ),
         );

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -415,6 +415,26 @@ input[type="checkbox"] {
     }
 }
 
+.decorated-stream-name-dropdown-widget {
+    .dropdown_widget_value {
+        /* The max-width should account for the
+           16px-square box (at 16px/1em) for the
+           chevron icon. */
+        max-width: calc(100% - 1em);
+        display: flex;
+        align-items: baseline;
+        /* Mimic the space from the previous inline
+           layout. */
+        gap: 0.4ch;
+    }
+
+    .decorated-channel-name {
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
 .allow-subdomains,
 .new-realm-domain-allow-subdomains {
     margin: 0 !important;
@@ -834,24 +854,6 @@ input[type="checkbox"] {
 #organization-settings {
     .dropdown-widget-button {
         color: hsl(0deg 0% 33%);
-
-        .dropdown_widget_value {
-            /* The max-width should account for the
-               16px-square box (at 16px/1em) for the
-               chevron icon. */
-            max-width: calc(100% - 1em);
-            display: flex;
-            align-items: baseline;
-            /* Mimic the space from the previous inline
-               layout. */
-            gap: 0.4ch;
-        }
-
-        .decorated-channel-name {
-            overflow-x: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -850,6 +850,7 @@ input[type="checkbox"] {
         .decorated-channel-name {
             overflow-x: hidden;
             text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -509,6 +509,19 @@ input[type="checkbox"] {
     }
 }
 
+#customizable_stream_notifications_table .dropdown-widget-button {
+    /* 225px at 16px/1em */
+    width: 14.0625em;
+
+    &:focus {
+        outline: none;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+    }
+}
+
 .advanced-configurations-container {
     .advance-config-toggle-area {
         cursor: pointer;

--- a/web/templates/dropdown_widget.hbs
+++ b/web/templates/dropdown_widget.hbs
@@ -1,4 +1,4 @@
-<button id="{{widget_name}}_widget" class="dropdown-widget-button" type="button" {{#if is_setting_disabled}}disabled{{/if}} {{#if disable_keyboard_focus}}tabindex="-1"{{/if}} name="{{widget_name}}">
+<button id="{{widget_name}}_widget" class="dropdown-widget-button {{#if custom_classes}}{{custom_classes}}{{/if}}" type="button" {{#if is_setting_disabled}}disabled{{/if}} {{#if disable_keyboard_focus}}tabindex="-1"{{/if}} name="{{widget_name}}">
     <span class="dropdown_widget_value">{{#if default_text}}{{default_text}}{{/if}}</span>
     <i class="zulip-icon zulip-icon-chevron-down"></i>
 </button>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -50,6 +50,22 @@
             {{#unless for_realm_settings}}
             <tbody id="stream-specific-notify-table">
             </tbody>
+            <tbody id="customizable_stream_notifications_table">
+                <tr>
+                    <td>
+                        {{> ../dropdown_widget widget_name="customize_stream_notifications" custom_classes="decorated-stream-name-dropdown-widget"}}
+                    </td>
+                    {{#each custom_stream_specific_notification_settings}}
+                        {{> notification_settings_checkboxes
+                          setting_name=this.setting_name
+                          is_checked=this.is_checked
+                          is_mobile_checkbox=this.is_mobile_checkbox
+                          is_disabled=this.is_disabled
+                          push_notifications_disabled=this.push_notifications_disabled
+                          prefix="customize_stream_" }}
+                    {{/each}}
+                </tr>
+            </tbody>
             {{/unless}}
         </table>
     </div>

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -41,6 +41,7 @@
                               is_checked=this.is_checked
                               is_disabled=this.is_disabled
                               is_mobile_checkbox=this.is_mobile_checkbox
+                              push_notifications_disabled=this.push_notifications_disabled
                               prefix=../../prefix }}
                         {{/each}}
                     </tr>

--- a/web/templates/settings/notification_settings_checkboxes.hbs
+++ b/web/templates/settings/notification_settings_checkboxes.hbs
@@ -1,5 +1,5 @@
 <td>
-    <span {{#if (and is_mobile_checkbox is_disabled)}} class="tippy-zulip-tooltip" data-tooltip-template-id="mobile-push-notification-tooltip-template"{{/if}}>
+    <span {{#if (and is_mobile_checkbox push_notifications_disabled)}} class="tippy-zulip-tooltip" data-tooltip-template-id="mobile-push-notification-tooltip-template"{{/if}}>
         <label class="checkbox">
             <input type="checkbox" name="{{setting_name}}" id="{{prefix}}{{setting_name}}"
               {{#if is_disabled}} disabled {{/if}}

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -19,17 +19,20 @@
                 {{> ../dropdown_widget_with_label
                   widget_name="realm_new_stream_announcements_stream_id"
                   label=admin_settings_label.realm_new_stream_announcements_stream
-                  value_type="number"}}
+                  value_type="number"
+                  custom_classes="decorated-stream-name-dropdown-widget"}}
 
                 {{> ../dropdown_widget_with_label
                   widget_name="realm_signup_announcements_stream_id"
                   label=admin_settings_label.realm_signup_announcements_stream
-                  value_type="number"}}
+                  value_type="number"
+                  custom_classes="decorated-stream-name-dropdown-widget"}}
 
                 {{> ../dropdown_widget_with_label
                   widget_name="realm_zulip_update_announcements_stream_id"
                   label=admin_settings_label.realm_zulip_update_announcements_stream
-                  value_type="number"}}
+                  value_type="number"
+                  custom_classes="decorated-stream-name-dropdown-widget"}}
 
                 {{> settings_checkbox
                   setting_name="realm_message_content_allowed_in_email_notifications"

--- a/web/templates/settings/stream_specific_notification_row.hbs
+++ b/web/templates/settings/stream_specific_notification_row.hbs
@@ -16,6 +16,7 @@
           is_checked=(lookup ../stream this)
           is_disabled=(lookup ../is_disabled this)
           is_mobile_checkbox=(eq this "push_notifications")
+          push_notifications_disabled=../push_notifications_disabled
           }}
     {{/each}}
 </tr>

--- a/web/tests/settings_config.test.cjs
+++ b/web/tests/settings_config.test.cjs
@@ -171,3 +171,46 @@ run_test("all_notifications", ({override}) => {
         },
     ]);
 });
+
+run_test("customize_stream_notifications_table_row_data", () => {
+    const customize_stream_notifications_table_row_data =
+        settings_config.get_custom_stream_specific_notifications_table_row_data();
+
+    assert.deepEqual(customize_stream_notifications_table_row_data, [
+        {
+            is_checked: false,
+            is_disabled: true,
+            is_mobile_checkbox: false,
+            setting_name: "desktop_notifications",
+            push_notifications_disabled: true,
+        },
+        {
+            is_checked: false,
+            is_disabled: true,
+            is_mobile_checkbox: false,
+            setting_name: "audible_notifications",
+            push_notifications_disabled: true,
+        },
+        {
+            is_checked: false,
+            is_disabled: true,
+            is_mobile_checkbox: true,
+            setting_name: "push_notifications",
+            push_notifications_disabled: true,
+        },
+        {
+            is_checked: false,
+            is_disabled: true,
+            is_mobile_checkbox: false,
+            setting_name: "email_notifications",
+            push_notifications_disabled: true,
+        },
+        {
+            is_checked: false,
+            is_disabled: true,
+            is_mobile_checkbox: false,
+            setting_name: "wildcard_mentions_notify",
+            push_notifications_disabled: true,
+        },
+    ]);
+});

--- a/web/tests/settings_config.test.cjs
+++ b/web/tests/settings_config.test.cjs
@@ -9,7 +9,8 @@ const settings_config = zrequire("settings_config");
 const {set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
 
-set_realm({});
+const realm = {realm_push_notifications_enabled: false};
+set_realm(realm);
 const user_settings = {};
 initialize_user_settings({user_settings});
 
@@ -55,30 +56,35 @@ run_test("all_notifications", ({override}) => {
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_stream_desktop_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: true,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_stream_audible_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: true,
                     is_disabled: true,
                     is_mobile_checkbox: true,
                     setting_name: "enable_stream_push_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: false,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_stream_email_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: false,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "wildcard_mentions_notify",
+                    push_notifications_disabled: true,
                 },
             ],
         },
@@ -90,30 +96,35 @@ run_test("all_notifications", ({override}) => {
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_desktop_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: true,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_sounds",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: false,
                     is_disabled: true,
                     is_mobile_checkbox: true,
                     setting_name: "enable_offline_push_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: true,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_offline_email_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: false,
                     is_disabled: true,
                     is_mobile_checkbox: false,
                     setting_name: "",
+                    push_notifications_disabled: false,
                 },
             ],
         },
@@ -126,30 +137,35 @@ run_test("all_notifications", ({override}) => {
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_followed_topic_desktop_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: true,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_followed_topic_audible_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: false,
                     is_disabled: true,
                     is_mobile_checkbox: true,
                     setting_name: "enable_followed_topic_push_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: true,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_followed_topic_email_notifications",
+                    push_notifications_disabled: true,
                 },
                 {
                     is_checked: false,
                     is_disabled: false,
                     is_mobile_checkbox: false,
                     setting_name: "enable_followed_topic_wildcard_mentions_notify",
+                    push_notifications_disabled: true,
                 },
             ],
         },


### PR DESCRIPTION
This PR adds an option to change the notification settings of a channel from default to custom in the Notifications menu of Personal settings.

<!-- Describe your pull request here.-->

**Placeholder behavior of the widget**: If no channel has been added to the notification table (there are no channels for which the user has customized the notifications), the initial placeholder value is "Customize a channel". Once a channel is added to the table, the placeholder is changed to "Customize another channel". - [CZO thread](https://chat.zulip.org/#narrow/channel/101-design/topic/notification.20settings.20for.20muted.20streams/near/2051962).


Fixes: #19849.
[CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/notification.20settings.20for.20muted.20streams/near/1256417).


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Added option to customize channel notifications in Personal settings > Notifications.</summary>

**Light mode:**

- When no channel is added to the Notification table.
![image](https://github.com/user-attachments/assets/2e50c4a8-b66d-413b-bca9-e597e3ccde01)

- When a channel is added to the Notification table.
![image](https://github.com/user-attachments/assets/ee2f5587-b634-4807-97b2-36c95becbcc4)


**Dark mode:**

- When no channel is added to the Notification table.
![image](https://github.com/user-attachments/assets/47ff916f-5080-461d-b36e-f176aea2f7a0)

- When a channel is added to the Notification table.
![image](https://github.com/user-attachments/assets/b0d60f69-f1f1-4128-9944-4f40754827b4)


</details>

<details>
<summary>Behavior of adding a channel to customize notifications.</summary>

**Light mode:**
![light](https://github.com/user-attachments/assets/c59e9da8-b6ad-46ff-9658-c4185e79dac9)

**Dark mode:**
![dark](https://github.com/user-attachments/assets/b5df7fb5-51d4-40cc-a0be-eaf46668d3d8)

</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
