### PR TITLE
message_header: Specify font-size and line height on content div.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -6,13 +6,13 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     font-weight: 600;
-    font-size: calc(15em / 14);
-    line-height: 120%;
     position: relative;
     z-index: 0;
     background-color: var(--color-background);
 
     .message-header-contents {
+        font-size: 1.0714em; /* 15px at 14px em */
+        line-height: 1.2;
         display: flex;
         align-items: center;
         justify-content: space-between;


### PR DESCRIPTION
Pulled from #32928. It became necessary for this PR because `top: var(--navbar-fixed-height);` on the sticky header needs to use the app's font size, and having a different font size on that div was messing that up.

----

This is helpful for info density, because `em` values change depending on the font-size of the HTML element, and we want to be able to reference `em` sizes for the placement of the message header container when it's sticky.

**This commit should have no functional changes** because `message-header-contents` is the only child of `message_header` and doesn't itself use font size or line height.

This commit also changes the line height to unitless https://chat.zulip.org/#narrow/channel/6-frontend/topic/navbar.20sticky.20header.20with.20em/near/2054561

----

Screen videos of headers working as usual:

12px

![Kapture 2025-01-24 at 12 53 58](https://github.com/user-attachments/assets/5ca740e2-6ed6-4d9a-85c4-c9539528e7b5)


16px

![Kapture 2025-01-24 at 12 51 42](https://github.com/user-attachments/assets/44dc68a8-f163-4ebf-ab64-dcace1f9358b)


20px

![Kapture 2025-01-24 at 12 56 45](https://github.com/user-attachments/assets/53acf507-4d20-415b-8f1b-caec7e5b8c70)


