### PR TITLE
message_header: Fix em height calculation given larger font-size.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -16,7 +16,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        height: 2em; /* 28px at 14px em */
+        height: 1.8666em; /* 28px at 15px em */
         border: 1px solid var(--color-message-header-contents-border);
         border-bottom-color: var(--color-message-header-contents-border-bottom);
         border-radius: 7px 7px 0 0;


### PR DESCRIPTION
Followup to https://github.com/zulip/zulip/pull/32933#discussion_r1910137015

Discussion here:
https://chat.zulip.org/#narrow/channel/6-frontend/topic/info.20density.20with.20em.20font.20size/near/2037799

Previously this value was 28px, and I accidentally converted it to 2em because I assumed 14px font size. But the font size is actually 15px and the em value should be reflected accordingly.

---

12px before and after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d7e29433-225b-4845-883e-93017818377e" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/dd5f9c6a-63bd-47c2-a0e1-f4cb0702f1e7" />


20px before and after

<img width="400" alt="image" src="https://github.com/user-attachments/assets/67bcafae-3712-4c7d-a12c-d082e556d837" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/19f1a822-31a7-4734-a4f8-b8c18ea6ff4c" />
