### PR TITLE
topic_link_util: Add `[` and `]` as characters to escape.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -4,7 +4,7 @@ import * as internal_url from "../shared/src/internal_url.ts";
 
 import * as stream_data from "./stream_data.ts";
 
-const invalid_stream_topic_regex = /[`>*&]|(\$\$)/g;
+const invalid_stream_topic_regex = /[`>*&[\]]|(\$\$)/g;
 
 export function will_produce_broken_stream_topic_link(word: string): boolean {
     return invalid_stream_topic_regex.test(word);
@@ -22,6 +22,10 @@ export function escape_invalid_stream_topic_characters(text: string): string {
             return "&amp;";
         case "$$":
             return "&#36;&#36;";
+        case "[":
+            return "&#91;";
+        case "]":
+            return "&#93;";
         default:
             return text;
     }

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -32,9 +32,18 @@ const dollar_stream = {
     type: "stream",
 };
 
+const markdown_stream = {
+    name: "Markdown [md]",
+    description: "markdown",
+    stream_id: 7,
+    subscribed: true,
+    type: "stream",
+};
+
 stream_data.add_sub(sweden_stream);
 stream_data.add_sub(denmark_stream);
 stream_data.add_sub(dollar_stream);
+stream_data.add_sub(markdown_stream);
 
 run_test("stream_topic_link_syntax_test", () => {
     assert.equal(
@@ -78,10 +87,23 @@ run_test("stream_topic_link_syntax_test", () => {
         topic_link_util.get_fallback_markdown_link("$$MONEY$$"),
         "[#&#36;&#36;MONEY&#36;&#36;](#narrow/channel/6-.24.24MONEY.24.24)",
     );
+    assert.equal(
+        topic_link_util.get_fallback_markdown_link("Markdown [md]"),
+        "[#Markdown &#91;md&#93;](#narrow/channel/7-Markdown-.5Bmd.5D)",
+    );
 
     assert.equal(
         topic_link_util.get_stream_topic_link_syntax("Sweden", "&ab"),
         "[#Sweden > &amp;ab](#narrow/channel/1-Sweden/topic/.26ab)",
+    );
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "&ab]"),
+        "[#Sweden > &amp;ab&#93;](#narrow/channel/1-Sweden/topic/.26ab.5D)",
+    );
+
+    assert.equal(
+        topic_link_util.get_stream_topic_link_syntax("Sweden", "&a[b"),
+        "[#Sweden > &amp;a&#91;b](#narrow/channel/1-Sweden/topic/.26a.5Bb)",
     );
 
     // Only for full coverage of the module.


### PR DESCRIPTION
These characters cause the fallback markdown
links produced (https://github.com/zulip/zulip/pull/30071) to be broken.

Broken links are not produced when these are present
in `#**channel>topic**` syntax. It is only a problem
with the fallback markdown links.

<!-- Describe your pull request here.-->


| Before | After|
|-------|------|
| <img width="671" alt="Screenshot 2025-01-25 at 17 43 17" src="https://github.com/user-attachments/assets/04ce7e5c-897b-4038-8933-bb83ea750d6f" />   | <img width="671" alt="Screenshot 2025-01-25 at 17 43 43" src="https://github.com/user-attachments/assets/0978c570-f3e0-470b-8b35-6e4b74563bbe" /> |

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
