### PR TITLE
settings: Hide upgrade links and storage stats for guests. 

### DIFF
--- a/web/src/attachments_ui.ts
+++ b/web/src/attachments_ui.ts
@@ -13,7 +13,7 @@ import {$t, $t_html} from "./i18n.ts";
 import * as ListWidget from "./list_widget.ts";
 import * as loading from "./loading.ts";
 import * as scroll_util from "./scroll_util.ts";
-import {realm} from "./state_data.ts";
+import {current_user, realm} from "./state_data.ts";
 import * as timerender from "./timerender.ts";
 import * as ui_report from "./ui_report.ts";
 
@@ -66,6 +66,9 @@ export function percentage_used_space(uploads_size: number): string | null {
 
 function set_upload_space_stats(): void {
     if (realm.realm_upload_quota_mib === null) {
+        return;
+    }
+    if (current_user.is_guest) {
         return;
     }
     const args = {

--- a/web/templates/settings/upgrade_tip_widget.hbs
+++ b/web/templates/settings/upgrade_tip_widget.hbs
@@ -1,17 +1,19 @@
 <div>
-    {{#unless zulip_plan_is_not_limited}}
-    {{#if is_business_type_org}}
-        <a href="/upgrade/" class="upgrade-tip" target="_blank" rel="noopener noreferrer">
-            {{upgrade_text_for_wide_organization_logo}}
-        </a>
-    {{else}}
-        <div class="upgrade-or-sponsorship-tip">
-            {{#tr}}
-                Available on Zulip Cloud Standard. <z-link-upgrade>Upgrade</z-link-upgrade> or <z-link-sponsorship>request sponsorship</z-link-sponsorship> to access.
-                {{#*inline "z-link-upgrade"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-                {{#*inline "z-link-sponsorship"}}<a href="/sponsorship/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-            {{/tr}}
-        </div>
-    {{/if}}
+    {{#unless is_guest}}
+        {{#unless zulip_plan_is_not_limited}}
+        {{#if is_business_type_org}}
+            <a href="/upgrade/" class="upgrade-tip" target="_blank" rel="noopener noreferrer">
+                {{upgrade_text_for_wide_organization_logo}}
+            </a>
+        {{else}}
+            <div class="upgrade-or-sponsorship-tip">
+                {{#tr}}
+                    Available on Zulip Cloud Standard. <z-link-upgrade>Upgrade</z-link-upgrade> or <z-link-sponsorship>request sponsorship</z-link-sponsorship> to access.
+                    {{#*inline "z-link-upgrade"}}<a href="/upgrade/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                    {{#*inline "z-link-sponsorship"}}<a href="/sponsorship/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{/tr}}
+            </div>
+        {{/if}}
+        {{/unless}}
     {{/unless}}
 </div>


### PR DESCRIPTION
## Description  

This pull request addresses issue #20630 by:  

- Hiding upgrade-related links and storage stats for **guest users** to prevent unnecessary UI elements and potential 404 errors.  
- Removing the upgrade link code from `organization_profile_admin`, `organization_settings`, and `organization_permission_admin`, ensuring guests do not see upgrade options.  
- Removing the `% used` banner for uploaded files, which previously routed to `/upgrade/`, to prevent guests from encountering upgrade-related navigation.  
- Updating `admin.ts` to include `realm_plan_type` for better handling of organization settings, ensuring the UI correctly reflects user roles, including guests.  

### Testing  
- Verified that **guest users** no longer see upgrade-related links in the organization settings.  
- Checked that the `upgrade` storage banner is no longer displayed for guests.  
- Ensured that organization settings load correctly without upgrade-related elements for guest users.  


## Before and After Comparison

| Area | Before | After |
|------|--------|-------|
| Personal Settings Uploaded Files | ![Screenshot 2025-01-25 215744](https://github.com/user-attachments/assets/ada6b3c1-c942-447b-815c-01d3423a48e2) | ![After - Organization Settings General](https://github.com/user-attachments/assets/a9367d06-ae7c-46e7-9939-4dd70b5358cb) |
| Organization Profile | ![Before - Upgrade Banner](https://github.com/user-attachments/assets/7303aab7-9425-4c4c-82c3-52bbd6b2f910) |![Screenshot 2025-01-21 040959](https://github.com/user-attachments/assets/c05e4eb6-b79e-4b23-8434-a1a63775c3dd)
| Organization Settings | ![Screenshot 2025-01-25 215322](https://github.com/user-attachments/assets/8bd9e80a-7290-4c5e-bd57-0b2afb7b2b8a) | ![After - Removed Upgrade Prompts](https://github.com/user-attachments/assets/69447066-9b1e-49d7-b809-a9f6bcdf6bf8) |
| Organization Permissions | ![Screenshot 2025-01-25 215509](https://github.com/user-attachments/assets/f35d1cdd-7486-4380-82eb-c7e76688e31f) |![Screenshot 2025-01-25 215701](https://github.com/user-attachments/assets/58ccecd5-34f4-471b-b648-f81cb285caa6)|

## Fixes
Closes https://github.com/zulip/zulip/issues/20630#issuecomment-1006140041




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
