### PR TITLE
settings: Scale plus button in stream and user group setting UI.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -534,6 +534,7 @@
     /* .display-type and .list-toggler-container
        in subscriptions and user group settings overlays */
     --settings-overlay-subheader-height: 3.1428em; /* 44px at 14px/em */
+    --settings-overlay-header-button-height: 2em;
     /* .settings-sticky-footer */
     --subscriptions-overlay-sticky-footer-height: 60px;
     /* Informational overlay */

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -59,26 +59,34 @@
     margin-right: 10px;
 }
 
+#add_new_user_group {
+    height: var(--settings-overlay-header-button-height);
+}
+
 .create_user_group_plus_button,
 .create_stream_plus_button {
-    font-size: 24px;
     font-weight: 400;
     position: relative;
-    top: 2px;
     border: 1px solid hsl(0deg 0% 80%);
     border-radius: 5px;
     background-color: hsl(0deg 0% 100%);
     color: hsl(0deg 0% 0%);
     margin: 0 0 0 5px;
-    height: 27px;
+    height: 100%;
+    width: var(--settings-overlay-header-button-height);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     &:hover {
         border: 1px solid hsl(0deg 0% 47%);
     }
 
     .create_button_plus_sign {
-        position: relative;
-        top: -5px;
+        line-height: 1em;
+        display: block;
+        font-size: 1.2em;
+        opacity: 0.8;
     }
 
     &:disabled {
@@ -422,6 +430,12 @@ h4.user_group_setting_subsection_title {
 
     .list-toggler-container .tab-switcher .ind-tab {
         width: auto;
+        display: flex;
+        padding: 0 10px;
+
+        .fa {
+            font-size: 1em;
+        }
     }
 
     .user-groups-header,
@@ -523,8 +537,7 @@ h4.user_group_setting_subsection_title {
             height: var(--settings-overlay-subheader-height);
 
             #add_new_subscription {
-                position: relative;
-                top: -2px;
+                height: var(--settings-overlay-header-button-height);
             }
         }
     }
@@ -874,6 +887,7 @@ h4.user_group_setting_subsection_title {
     .tab-switcher {
         display: flex;
         flex-wrap: nowrap;
+        height: var(--settings-overlay-header-button-height);
     }
 
     #user-group-creation,
@@ -989,6 +1003,7 @@ h4.user_group_setting_subsection_title {
                 padding: 3px 4px;
                 min-width: 80px;
                 width: auto;
+                display: flex;
             }
         }
 

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -13,7 +13,7 @@
                     <div id="add_new_subscription">
                         {{#if can_create_streams}}
                         <button class="create_stream_button create_stream_plus_button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
-                            <span class="create_button_plus_sign">+</span>
+                            <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                         </button>
                         {{/if}}
                         <div class="float-clear"></div>

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -13,7 +13,7 @@
                     <div id="add_new_user_group">
                         {{#if can_create_user_groups}}
                         <button class="create_user_group_button create_user_group_plus_button" {{#if (not zulip_plan_is_not_limited)}}disabled{{/if}}>
-                            <span class="create_button_plus_sign">+</span>
+                            <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                         </button>
                         {{/if}}
                         <div class="float-clear"></div>


### PR DESCRIPTION


<details>
<summary>screenshots for stream setting UI</summary>

before and after at 12px, 14px, 16px, and 20px

| before | after |
| ---- | ---- |
| ![Screen Shot 2025-01-29 at 15 58 06](https://github.com/user-attachments/assets/68c2354a-261e-42ab-800d-baa79dc8424e) | ![Screen Shot 2025-01-29 at 15 56 42](https://github.com/user-attachments/assets/142d1c2f-f739-4fc0-802d-1ee34eb67910) |
| ![Screen Shot 2025-01-29 at 15 58 15](https://github.com/user-attachments/assets/98bd1377-2e6f-4019-b6cd-5bcb281a468d) | ![Screen Shot 2025-01-29 at 15 56 15](https://github.com/user-attachments/assets/c3db9c05-7cdf-4341-8602-985950ba94fc) |
| ![Screen Shot 2025-01-29 at 15 58 29](https://github.com/user-attachments/assets/de0d6428-8540-474f-a83f-65a52d2f6b0e) | ![Screen Shot 2025-01-29 at 15 56 00](https://github.com/user-attachments/assets/d4e3e3ba-610c-474d-a6cf-8afef9639c3a) |
| ![Screen Shot 2025-01-29 at 15 58 47](https://github.com/user-attachments/assets/1286892a-c780-4cfb-9761-bd8acbc6a55e) | ![Screen Shot 2025-01-29 at 15 55 30](https://github.com/user-attachments/assets/9b3ffbda-6ae7-45af-8f61-430f15676f7b) |

dark mode (20px)

![Screen Shot 2025-01-29 at 16 00 31](https://github.com/user-attachments/assets/1bb1fdd7-8530-4bf1-8079-5da9b4b86110)


</details>

<details>
<summary>screenshots for user group settings</summary>


before and after at 12px, 14px, 16px, and 20px

| before | after |
| ---- | ---- |
| ![Screen Shot 2025-01-29 at 16 03 21](https://github.com/user-attachments/assets/d70b4c0f-f97c-4c69-91f8-bd657e4fc1f9) | ![Screen Shot 2025-01-29 at 16 02 26](https://github.com/user-attachments/assets/917b9064-684b-4186-8595-741f3b9874a5) |
| ![Screen Shot 2025-01-29 at 16 03 30](https://github.com/user-attachments/assets/6b701076-0bec-4252-92b4-8e196ed7ed23) | ![Screen Shot 2025-01-29 at 16 02 10](https://github.com/user-attachments/assets/c6d4d134-3df8-432d-ae7a-b8a2a9469f2d) |
| ![Screen Shot 2025-01-29 at 16 03 38](https://github.com/user-attachments/assets/d06839b0-078e-4fb8-be46-6705767f7800) | ![Screen Shot 2025-01-29 at 16 02 02](https://github.com/user-attachments/assets/e37ba9d0-6714-4403-b757-9c644d1be96e) |
| ![Screen Shot 2025-01-29 at 16 03 49](https://github.com/user-attachments/assets/17804d1d-f08f-4e6c-ab5d-6d775e27a682) | ![Screen Shot 2025-01-29 at 16 01 30](https://github.com/user-attachments/assets/576e1a2b-160d-4735-a84e-3429ef828e1f) |


</details>
