### PR TITLE
user_group_popover: Reduce member list size, add member page links.

### DIFF
--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -11,7 +11,7 @@
                 {{/if}}
             </div>
         </li>
-        {{#if (or members.length subgroups.length)}}
+        {{#if (or displayed_members.length displayed_subgroups.length)}}
             <li role="none" class="popover-menu-list-item text-item italic">
                 {{#tr}}
                 {members_count, plural, =1 {1 member} other {# members}}
@@ -25,15 +25,15 @@
         {{/if}}
         <li role="separator" class="popover-menu-separator"></li>
         <li role="none" class="popover-menu-list-item">
-            {{#if (or members.length subgroups.length)}}
+            {{#if (or displayed_members.length displayed_subgroups.length)}}
                 <ul class="popover-menu-list popover-group-menu-member-list" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                    {{#each subgroups}}
+                    {{#each displayed_subgroups}}
                         <li class="popover-group-menu-member">
                             <i class="popover-group-member-icon popover-menu-icon zulip-icon zulip-icon-triple-users" aria-hidden="true"></i>
                             <span class="popover-group-menu-member-name">{{name}}</span>
                         </li>
                     {{/each}}
-                    {{#each members}}
+                    {{#each displayed_members}}
                         <li class="popover-group-menu-member">
                             {{#if is_bot}}
                                 <i class="popover-group-member-icon zulip-icon zulip-icon-bot" aria-hidden="true"></i>
@@ -43,6 +43,29 @@
                             <span class="popover-group-menu-member-name">{{full_name}}</span>
                         </li>
                     {{/each}}
+                    {{#unless display_all_subgroups_and_members}}
+                        <li class="popover-group-menu-member">
+                            <span class="popover-group-menu-member-name">
+                                {{#if is_system_group}}
+                                    {{#if has_bots}}
+                                        {{#tr class="popover-group-menu-member"}}
+                                            View all <z-link-users>users</z-link-users> and <z-link-bots>bots</z-link-bots>
+                                            {{#*inline "z-link-users"}}<a href="#organization/users">{{> @partial-block}}</a>{{/inline}}
+                                            {{#*inline "z-link-bots"}}<a href="#organization/bot-list-admin">{{> @partial-block}}</a>{{/inline}}
+                                        {{/tr}}
+                                    {{else}}
+                                        <a href="#organization/users" role="menuitem">
+                                            {{t "View all users"}}
+                                        </a>
+                                    {{/if}}
+                                {{else}}
+                                    <a href="{{group_members_url}}" role="menuitem">
+                                        {{t "View all members"}}
+                                    </a>
+                                {{/if}}
+                            </span>
+                        </li>
+                    {{/unless}}
                 </ul>
             {{else}}
                 <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>


### PR DESCRIPTION
Fixes #31550.

<!-- Describe your pull request here.-->
This PR improves user group popover presentation. Instead of displaying all members, it just shows the first 30 members and includes a link to member management page or organization users page.

Note: I accidentally closed the PR [32917](https://github.com/zulip/zulip/pull/32917), so open this one instead.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

For testing purpose, the gif shows change when cut-off is 10 members. The actual code was implemented with cut-off of 30 members. This value can be modified.
<img width="343" alt="Screenshot 2025-01-06 at 3 51 21 PM" src="https://github.com/user-attachments/assets/7c5a34e4-b011-4d64-b36d-30b0d1a877c7" />
<img width="291" alt="Screenshot 2025-01-06 at 3 51 37 PM" src="https://github.com/user-attachments/assets/2f92191f-5703-4913-988c-ed63f4d713c4" />
<img width="274" alt="Screenshot 2025-01-06 at 3 51 47 PM" src="https://github.com/user-attachments/assets/adea8ab3-42e7-42ec-a537-c18c5979ca42" />


![zulip_popover](https://github.com/user-attachments/assets/35ca632a-df23-40d2-839a-b14ab76a7627)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
