### PR TITLE
missedmessage_emails: Show EMPTY_TOPIC_FALLBACK_NAME for topic="".

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -31,7 +31,7 @@ from zerver.lib.send_email import FromAddress, send_future_email
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
 from zerver.lib.tex import change_katex_to_raw_latex
 from zerver.lib.timezone import canonicalize_timezone
-from zerver.lib.topic import get_topic_resolution_and_bare_name
+from zerver.lib.topic import get_topic_display_name, get_topic_resolution_and_bare_name
 from zerver.lib.url_encoding import (
     direct_message_group_narrow_url,
     personal_narrow_url,
@@ -541,10 +541,11 @@ def do_send_missedmessage_events_reply_in_zulip(
             topic_name=message.topic_name(),
         )
         context.update(narrow_url=narrow_url)
-        topic_resolved, topic_name = get_topic_resolution_and_bare_name(message.topic_name())
+        topic_resolved, bare_topic_name = get_topic_resolution_and_bare_name(message.topic_name())
+        display_topic_name = get_topic_display_name(bare_topic_name, user_profile.default_language)
         context.update(
             channel_name=stream.name,
-            topic_name=topic_name,
+            topic_name=display_topic_name,
             topic_resolved=topic_resolved,
         )
     else:

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -6,6 +6,8 @@ import orjson
 from django.db import connection
 from django.db.models import F, Func, JSONField, Q, QuerySet, Subquery, TextField, Value
 from django.db.models.functions import Cast
+from django.utils.translation import gettext as _
+from django.utils.translation import override as override_language
 
 from zerver.lib.types import EditHistoryEvent, StreamMessageEditRequest
 from zerver.lib.utils import assert_is_not_none
@@ -347,4 +349,11 @@ def maybe_rename_empty_topic_to_general_chat(
 ) -> str:
     if is_channel_message and topic_name == "" and not allow_empty_topic_name:
         return Message.EMPTY_TOPIC_FALLBACK_NAME
+    return topic_name
+
+
+def get_topic_display_name(topic_name: str, language: str) -> str:
+    if topic_name == "":
+        with override_language(language):
+            return _(Message.EMPTY_TOPIC_FALLBACK_NAME)
     return topic_name


### PR DESCRIPTION
Fixes part of #32996.

Email only

- [ ] Email and mobile push notification implementations of rendering realm_empty_topic_display_name.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="660" alt="Screenshot 2025-01-27 at 3 51 18 PM" src="https://github.com/user-attachments/assets/b336495b-df0f-44b3-90c5-66b7f9ada185" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
