### PR TITLE
message_edit: Disallow empty topic when mandatory topic is true.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -121,6 +121,9 @@ def validate_message_edit_payload(
     if propagate_mode != "change_one" and topic_name is None and stream_id is None:
         raise JsonableError(_("Invalid propagate_mode without topic edit"))
 
+    if message.realm.mandatory_topics and topic_name in ("(no topic)", ""):
+        raise JsonableError(_("Topics are required in this organization."))
+
     if topic_name in {
         RESOLVED_TOPIC_PREFIX.strip(),
         f"{RESOLVED_TOPIC_PREFIX}{Message.EMPTY_TOPIC_FALLBACK_NAME}",


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/32532#issuecomment-2613417916
> The first 2 commits need to be reworked for the empty topic work; @prakhar1144 maybe you can do a PR extracting and updating those, and then this PR can be integrated soon after with just the frontend commit?


* Second commit is not required.
* In the first commit, updated the logic to raise error when topic_name is empty string or "(no topic)" with `mandatory_topic=true`
* Cleaned up tests a bit and added comments.

---

**Screenshots and screen captures:**

<img width="426" alt="Screenshot 2025-01-27 at 7 34 20 PM" src="https://github.com/user-attachments/assets/1e42089a-169e-4569-9d0b-bb1a20bae2c2" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
