### PR TITLE
topic_list_data: Update variable names to avoid confusion.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -55,8 +55,7 @@ function choose_topics(
             stream_id,
             topic_name,
         );
-        const [topic_resolved_prefix, topic_display_name] =
-            resolved_topic.display_parts(topic_name);
+        const [topic_resolved_prefix, topic_bare_name] = resolved_topic.display_parts(topic_name);
         // Important: Topics are lower-case in this set.
         const contains_unread_mention = topic_choice_state.topics_with_unread_mentions.has(
             topic_name.toLowerCase(),
@@ -128,8 +127,8 @@ function choose_topics(
             stream_id,
             topic_name,
             topic_resolved_prefix,
-            topic_display_name: util.get_final_topic_display_name(topic_display_name),
-            is_empty_string_topic: topic_display_name === "",
+            topic_display_name: util.get_final_topic_display_name(topic_bare_name),
+            is_empty_string_topic: topic_bare_name === "",
             unread: num_unread,
             is_zero: num_unread === 0,
             is_muted: is_topic_muted,

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -536,12 +536,12 @@ export function compare_a_b<T>(a: T, b: T): number {
     return -1;
 }
 
-export function get_final_topic_display_name(topic_display_name: string): string {
-    if (topic_display_name === "") {
+export function get_final_topic_display_name(topic_name: string): string {
+    if (topic_name === "") {
         if (realm.realm_empty_topic_display_name === "general chat") {
             return $t({defaultMessage: "general chat"});
         }
         return realm.realm_empty_topic_display_name;
     }
-    return topic_display_name;
+    return topic_name;
 }


### PR DESCRIPTION
Earlier, in `topic_list_data.ts` we were using `topic_display_name` variable to represent part of the topic name without resolved_prefix. This could led to confusion with `util.get_final_topic_display_name()` as both represent different things.

This commit updates the code to use 'topic_bare_name' for a better representation of its meaning.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
