### PR TITLE
popovers: Make "popover-menu-user-full-name" text selectable.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1021,6 +1021,7 @@ ul.popover-group-menu-member-list {
         line-height: 1.1111em;
         color: var(--color-text-full-name);
         word-break: break-word;
+        user-select: text;
 
         .zulip-icon.zulip-icon-bot {
             vertical-align: middle;


### PR DESCRIPTION
In the profile card that pops up when clicking a user's name, the text of their name was not selectable text previously. This commit makes the text selectable.

## Before

[Screencast from 2025-01-27 22-07-00.webm](https://github.com/user-attachments/assets/d2ea36b5-85ac-4b67-ba18-89e8f310ef16)

## After

[Screencast from 2025-01-27 22-06-16.webm](https://github.com/user-attachments/assets/34f7c56a-3b2c-4e23-946f-b632f1cb0170)

[CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/text.20in.20user.20card.20not.20selectable)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
