### PR TITLE
help: Document group permissions panel.

### DIFF
--- a/help/manage-user-groups.md
+++ b/help/manage-user-groups.md
@@ -117,6 +117,27 @@
 
 {end_tabs}
 
+## Review and remove permissions assigned to a group
+
+You can review which permissions are assigned to a group, and remove permissions
+as needed.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|group|all}
+
+1. Select a user group.
+
+1. Select the **Permissions** tab on the right.
+
+1. Toggle the checkboxes next to any permissions you'd like to remove.
+
+1. Click **Save changes**.
+
+{end_tabs}
+
 ## Deactivate a user group
 
 {start_tabs}


### PR DESCRIPTION
Current page: https://zulip.com/help/manage-user-groups

Note that I'm aiming to clearly label this heading vs. https://zulip.com/help/manage-user-groups#configure-group-permissions .

![Screenshot 2025-01-27 at 16 17 39@2x](https://github.com/user-attachments/assets/ae95adce-7149-414e-a83e-5a72291ba428)
