### PR TITLE
Update docs for Slack integrations

### DIFF
--- a/zerver/webhooks/slack/doc.md
+++ b/zerver/webhooks/slack/doc.md
@@ -1,10 +1,19 @@
-# Zulip Slack integration
+# Forward Slack messages into Zulip
 
-Get Zulip notifications for messages on your team's public Slack
-channels! You can choose to map each **Slack channel** either to a
-**Zulip topic** or to a **Zulip channel**.
+Forward messages sent to your Slack workspace's public channels into Zulip!
 
-See also the [Zulip Slack incoming webhook integration][1].
+This integration lets you choose how to organize your Slack messages in Zulip.
+You can:
+
+- Send messages from each Slack channel into a **matching Zulip channel**.
+- Send messages from each Slack channel into a **matching Zulip topic**.
+- Send all Slack messages into a **single Zulip topic**.
+
+If you'd like to forward messages in both directions (Slack to Zulip and Zulip
+to Slack), please see [separate instructions][6] for how to set this up.
+
+If you are looking to quickly move your Slack integrations to Zulip, check out
+[Zulip's Slack-compatible incoming webhook][1].
 
 !!! warn ""
 
@@ -14,22 +23,27 @@ See also the [Zulip Slack incoming webhook integration][1].
 
 {start_tabs}
 
-1. To map each Slack channel to a Zulip topic, [create one channel][2]
-   you'd like to use for Slack notifications. Otherwise, for each public
-   Slack channel, [create a Zulip channel][2] with the same name.
-
 1. {!create-an-incoming-webhook.md!}
 
 1. {!generate-webhook-url-basic.md!}
 
-    To map each Slack channel to a Zulip topic, make sure that the
-    **Send all notifications to a single topic** option is disabled
-    when generating the URL. Add `&channels_map_to_topics=1` to the
-    generated URL.
+    To send messages from each Slack channel into a **matching Zulip channel**,
+    enable the **Send all notifications to a single topic** option, and add
+    `&channels_map_to_topics=0` to the generated URL. For each public channel in
+    your Slack workspace, be sure to [create][2] a Zulip channel with the same
+    name.
 
-    Otherwise, add `&channels_map_to_topics=0` to the generated URL.
-    Note that any Zulip channel you specified when generating the URL
-    will be ignored in this case.
+    To send messages from each Slack channel into a **matching Zulip topic**,
+    disable the **Send all notifications to a single topic** option when
+    generating the URL. Add `&channels_map_to_topics=1` to the generated URL.
+
+    To send all Slack messages into a **single Zulip topic**, enable the **Send
+    all notifications to a single topic** option, with no further modifications.
+
+1. *(optional)* If you're setting up a [Slack bridge][6] to forward Zulip messages
+   into your Slack workspace, replace the value of the `?api_key=` parameter in
+   the **integration URL** you generated with the API key of the **Generic bot**
+   you're using for the Slack bridge.
 
 1. Create a new [Slack app][4], and open it. Navigate to the **OAuth
    & Permissions** menu, and scroll down to the **Scopes** section.
@@ -46,13 +60,11 @@ See also the [Zulip Slack incoming webhook integration][1].
 1. Scroll to the **OAuth Tokens for Your Workspace** section in the
    same menu, and click **Install to Workspace**.
 
-1. The **Bot User OAuth Token** should be available now. Note it down as
-   `BOT_OAUTH_TOKEN`, and add it to the end of the URL you generated
-   above as: `&slack_app_token=BOT_OAUTH_TOKEN`.
+1. Copy the Slack **Bot User OAuth Token**, and add it to the end of your
+   **integration URL** as `&slack_app_token=BOT_OAUTH_TOKEN`.
 
-1. Go to the **Event Subscriptions** menu, toggle **Enable Events**,
-   and enter the URL with the bot user token in the **Request URL**
-   field.
+1. Go to the **Event Subscriptions** menu, toggle **Enable Events**, and enter
+   your updated **integration URL** in the **Request URL** field.
 
 1. In the same menu, scroll down to the **Subscribe to bot events**
    section, and click on **Add Bot User Event**. Select the
@@ -66,9 +78,13 @@ See also the [Zulip Slack incoming webhook integration][1].
 
 ### Related documentation
 
+- [Forward messages Slack <-> Zulip][6] (both directions)
+
 - [Slack Events API documentation][3]
 
 - [Slack Apps][4]
+
+- [Zulip's Slack-compatible incoming webhook][1]
 
 {!webhooks-url-specification.md!}
 
@@ -77,3 +93,4 @@ See also the [Zulip Slack incoming webhook integration][1].
 [3]: https://api.slack.com/apis/events-api
 [4]: https://api.slack.com/apps
 [5]: https://api.slack.com/legacy/custom-integrations/outgoing-webhooks
+[6]: https://github.com/zulip/python-zulip-api/blob/main/zulip/integrations/bridge_with_slack/README.md

--- a/zerver/webhooks/slack_incoming/doc.md
+++ b/zerver/webhooks/slack_incoming/doc.md
@@ -1,4 +1,4 @@
-# Zulip Slack incoming webhook integration
+# Zulip's Slack-compatible incoming webhook
 
 Zulip can process incoming webhook messages written to work with Slack's
 [incoming webhook API][1]. This makes it easy to quickly move your
@@ -25,8 +25,11 @@ integrations when migrating your organization from Slack to Zulip.
 
 - [Slack's incoming webhook documentation][1]
 
-- [Zulip Slack integration](/integrations/doc/slack)
+- [Forward Slack messages into Zulip](/integrations/doc/slack)
+
+- [Forward messages Slack <-> Zulip][2] (both directions)
 
 {!webhooks-url-specification.md!}
 
 [1]: https://api.slack.com/messaging/webhooks
+[2]: https://github.com/zulip/python-zulip-api/blob/main/zulip/integrations/bridge_with_slack/README.md


### PR DESCRIPTION
I didn't test anything. The intent is there are no substantive changes in these instructions.

This PR replaces #32714.

Current: https://zulip.com/integrations/doc/slack
<details>
<summary>
Updated
</summary>

![Screenshot 2025-01-27 at 17 16 26@2x](https://github.com/user-attachments/assets/7b6a79f6-9634-48b9-aa4a-ad5aaa0b0566)
![Screenshot 2025-01-27 at 17 17 14@2x](https://github.com/user-attachments/assets/eec533c0-bd8a-4df4-88a3-500d8aef9cce)

</details>

Current: https://zulip.com/integrations/doc/slack_incoming
<details>
<summary>
Updated
</summary>
![Screenshot 2025-01-27 at 17 15 55@2x](https://github.com/user-attachments/assets/2b319393-679b-492b-b17c-fe078263acfa)

</details>