### PR TITLE
 Considered negations of dm and channel narrows before pruning the search

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -302,8 +302,13 @@ class NarrowBuilder:
         self.is_dm_narrow = False
 
     def check_not_both_channel_and_dm_narrow(
-        self, is_dm_narrow: bool = False, is_channel_narrow: bool = False
+        self,
+        maybe_negate: ConditionTransform,
+        is_dm_narrow: bool = False,
+        is_channel_narrow: bool = False,
     ) -> None:
+        if maybe_negate is not_:
+            return
         if is_dm_narrow:
             self.is_dm_narrow = True
         if is_channel_narrow:
@@ -390,7 +395,12 @@ class NarrowBuilder:
 
         if operand in ["dm", "private"]:
             # "is:private" is a legacy alias for "is:dm"
-            self.check_not_both_channel_and_dm_narrow(is_dm_narrow=True)
+            if maybe_negate is not_:
+                self.check_not_both_channel_and_dm_narrow(
+                    maybe_negate=lambda cond: cond, is_channel_narrow=True
+                )
+            else:
+                self.check_not_both_channel_and_dm_narrow(maybe_negate, is_dm_narrow=True)
             cond = column("flags", Integer).op("&")(UserMessage.flags.is_private.mask) != 0
             return query.where(maybe_negate(cond))
         elif operand == "starred":
@@ -443,7 +453,7 @@ class NarrowBuilder:
     def by_channel(
         self, query: Select, operand: str | int, maybe_negate: ConditionTransform
     ) -> Select:
-        self.check_not_both_channel_and_dm_narrow(is_channel_narrow=True)
+        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
 
         try:
             # Because you can see your own message history for
@@ -488,7 +498,7 @@ class NarrowBuilder:
         return query.where(maybe_negate(cond))
 
     def by_channels(self, query: Select, operand: str, maybe_negate: ConditionTransform) -> Select:
-        self.check_not_both_channel_and_dm_narrow(is_channel_narrow=True)
+        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
 
         if operand == "public":
             # Get all both subscribed and non-subscribed public channels
@@ -504,7 +514,7 @@ class NarrowBuilder:
         return query.where(maybe_negate(cond))
 
     def by_topic(self, query: Select, operand: str, maybe_negate: ConditionTransform) -> Select:
-        self.check_not_both_channel_and_dm_narrow(is_channel_narrow=True)
+        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_channel_narrow=True)
 
         if self.realm.is_zephyr_mirror_realm:
             # MIT users expect narrowing to topic "foo" to also show messages to /^foo(.d)*$/
@@ -580,7 +590,7 @@ class NarrowBuilder:
         assert not self.is_web_public_query
         assert self.user_profile is not None
 
-        self.check_not_both_channel_and_dm_narrow(is_dm_narrow=True)
+        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_dm_narrow=True)
 
         try:
             if isinstance(operand, str):
@@ -688,7 +698,7 @@ class NarrowBuilder:
         assert not self.is_web_public_query
         assert self.user_profile is not None
 
-        self.check_not_both_channel_and_dm_narrow(is_dm_narrow=True)
+        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_dm_narrow=True)
 
         try:
             if isinstance(operand, str):
@@ -741,7 +751,7 @@ class NarrowBuilder:
         assert not self.is_web_public_query
         assert self.user_profile is not None
 
-        self.check_not_both_channel_and_dm_narrow(is_dm_narrow=True)
+        self.check_not_both_channel_and_dm_narrow(maybe_negate, is_dm_narrow=True)
 
         try:
             if isinstance(operand, str):


### PR DESCRIPTION
[CZO discussion thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/-is.3Adm.20doesn't.20work.20with.20channels.3Apublic)

Solves the issue of ignoring the dm operators when they are present with channel operator in search even when one of them is negated.
Now the -is:dm filter when applied with channels:public filter gives the same result as channels:public filter. (same goes for -channels:public with is:dm)
For this I have added checks for negated terms which basically compares the address of the maybe_negative function with the not_ function so it has negligible effect on server speed.

Fixes: #33033 -is:dm now works with channels:public filter

**Screenshots:**
![Screenshot 2025-01-18 110800](https://github.com/user-attachments/assets/5b839c19-4eac-4113-b8ae-ca31f07e7c05)

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

As discussed in the thread maybe next steps can be trying to handle channels filter in local as well. 
Please let me know if any changes or optimizations are required in this.

I had opened a pull request earlier but I due to multiple lint errors which I wasn't able to resolve the commit history became a mess, hence I decided to clean my fork and add the code again. 
Also I've added two tests one for `-is:dm channels:public` and other for `-channels:public is:dm`
