### PR TITLE
message_send: Fix how we flag service bots event messages.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -778,6 +778,8 @@ def create_user_messages(
     mark_as_read_user_ids: set[int],
     limit_unread_user_ids: set[int] | None,
     topic_participant_user_ids: set[int],
+    service_bot_tuples: list[tuple[int, int]],
+    triggered_service_bots: set[int],
 ) -> list[UserMessageLite]:
     # These properties on the Message are set via
     # render_message_markdown by code in the Markdown inline patterns
@@ -809,11 +811,22 @@ def create_user_messages(
     #
     # See https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html#soft-deactivation
     # for details on this system.
+    service_bot_ids = dict(service_bot_tuples).keys()
     user_messages = []
     for user_profile_id in um_eligible_user_ids:
         flags = base_flags
-        if user_profile_id in mark_as_read_user_ids or (
-            limit_unread_user_ids is not None and user_profile_id not in limit_unread_user_ids
+        if (
+            user_profile_id in mark_as_read_user_ids
+            or (limit_unread_user_ids is not None and user_profile_id not in limit_unread_user_ids)
+            or (
+                # We track whether a service bot event message has been
+                # processed by checking if it has been read by the bot.
+                #
+                # This makes sure all messages where the service bots are
+                # part of the recipients but their function isn't triggered,
+                # are marked as read by them.
+                user_profile_id in (service_bot_ids - triggered_service_bots)
+            )
         ):
             flags |= UserMessage.flags.read
         if user_profile_id in mentioned_user_ids:
@@ -953,14 +966,24 @@ def do_send_messages(
 
     ums: list[UserMessageLite] = []
     for send_request in send_message_requests:
-        # Service bots (outgoing webhook bots and embedded bots) don't store UserMessage rows;
-        # they will be processed later.
         mentioned_user_ids = send_request.rendering_result.mentions_user_ids
 
         # Extend the set with users who have muted the sender.
         mark_as_read_user_ids = send_request.muted_sender_user_ids
         mark_as_read_user_ids.update(mark_as_read)
 
+        send_request.service_queue_events = get_service_bot_events(
+            sender=send_request.message.sender,
+            service_bot_tuples=send_request.service_bot_tuples,
+            mentioned_user_ids=mentioned_user_ids,
+            active_user_ids=send_request.active_user_ids,
+            recipient_type=send_request.message.recipient.type,
+        )
+        triggered_service_bots = {
+            event["user_profile_id"]
+            for events in send_request.service_queue_events.values()
+            for event in events
+        }
         user_messages = create_user_messages(
             message=send_request.message,
             rendering_result=send_request.rendering_result,
@@ -974,20 +997,14 @@ def do_send_messages(
             mark_as_read_user_ids=mark_as_read_user_ids,
             limit_unread_user_ids=send_request.limit_unread_user_ids,
             topic_participant_user_ids=send_request.topic_participant_user_ids,
+            service_bot_tuples=send_request.service_bot_tuples,
+            triggered_service_bots=triggered_service_bots,
         )
 
         for um in user_messages:
             user_message_flags[send_request.message.id][um.user_profile_id] = um.flags_list()
 
         ums.extend(user_messages)
-
-        send_request.service_queue_events = get_service_bot_events(
-            sender=send_request.message.sender,
-            service_bot_tuples=send_request.service_bot_tuples,
-            mentioned_user_ids=mentioned_user_ids,
-            active_user_ids=send_request.active_user_ids,
-            recipient_type=send_request.message.recipient.type,
-        )
 
     bulk_insert_ums(ums)
 

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -813,7 +813,7 @@ def create_user_messages(
     # for details on this system.
     service_bot_ids = dict(service_bot_tuples).keys()
     user_messages = []
-    for user_profile_id in um_eligible_user_ids:
+    for user_profile_id in um_eligible_user_ids | triggered_service_bots:
         flags = base_flags
         if (
             user_profile_id in mark_as_read_user_ids

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -624,7 +624,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
         message_id = self.send_group_direct_message(
             sender, recipients, content=f"@**{self.bot_profile.full_name}** foo"
         )
-        # message = Message.objects.get(id=message_id, sender=sender)
+
         bot_user_message = UserMessage.objects.get(
             user_profile=self.bot_profile, message=message_id
         )


### PR DESCRIPTION
Changes in this PR:
* Makes service bots able to read event messages from private and unsubscribed channels.
* Makes service bots read all non-event messages where they are part of the recipient.
* Adds a test to make sure unprocessed event messages are unread by the service bots.

Follow up on: #32247

[CZO](https://chat.zulip.org/#narrow/channel/3-backend/topic/.2328869.20UserMessage.20for.20Outgoing.20webhook.20bot.20.26.20embedded.20bots)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
