### PR TITLE
left_sidebar: Allow vdots icon to scale.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1361,7 +1361,8 @@ li.top_left_scheduled_messages {
     padding-left: 1px;
     /* Set the icon size, which will be inherited
        by .zulip-icon */
-    font-size: 17px;
+    /* 17px at 16px/1em */
+    font-size: 1.0625em;
 
     /*
         If you hover directly over the ellipsis itself,


### PR DESCRIPTION
This replaces a hard-coded 17px font-size on the left sidebar vdots.

[CZO discussion](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2063089)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_All screenshots were captured at 122 line-height, at 20px, 16px, and 12px font-size._

| Navigation, before | Navigation, after |
| --- | --- |
| ![nav-vdots-20-before](https://github.com/user-attachments/assets/a13523df-2480-4c0b-8b54-e9167da195c1) | ![nav-vdots-20-after](https://github.com/user-attachments/assets/4e8f43e3-dcd4-40c9-8c39-650a57bf0b94) |
| ![nav-vdots-16-before](https://github.com/user-attachments/assets/1fc6eb12-1150-4c88-aad4-6491d4b3f1b7) | ![nav-vdots-16-after](https://github.com/user-attachments/assets/d6a23192-a805-47a5-b0b0-052b77018805) |
| ![nav-vdots-12-before](https://github.com/user-attachments/assets/766b77bf-2a3b-4da5-ba05-df097956f68b) | ![nav-vdots-12-after](https://github.com/user-attachments/assets/c65f57e2-301f-4e0c-b7f2-2087dee4e3e8) |

| Channels, before | Channels, after |
| --- | --- |
| ![channel-vdots-20-before](https://github.com/user-attachments/assets/dbd27a2b-5d7a-4af0-8986-59782a70850f) | ![channel-vdots-20-after](https://github.com/user-attachments/assets/a266af5d-eb4f-4fd0-85bb-dedd0a254828) |
| ![channel-vdots-16-before](https://github.com/user-attachments/assets/778b0fe9-2ea2-4957-b355-60a947ed5a59) | ![channel-vdots-16-after](https://github.com/user-attachments/assets/040682fc-a15a-44fd-8d0b-52c36eb548f9) |
| ![channel-vdots-12-before](https://github.com/user-attachments/assets/6f9a39a8-e98b-4ed3-8035-efc1beea9bbb) | ![channel-vdots-12-after](https://github.com/user-attachments/assets/5b206d4f-650a-452d-9f72-bc445e284986) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
