### PR TITLE
Let channel and realm admins change permissions without subscribing to a private channel.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -28,6 +28,11 @@ format used by the Zulip server that they are interacting with.
   `can_remove_subscribers_group`. Realm administrators are now
   allowed to unsubscribe other users from a private channel even if
   they are not subscribed to that channel.
+* [`PATCH /streams/{stream_id}`](/api/update-stream),
+  [`DELETE /streams/{stream_id}`](/api/archive-stream): Channel and
+  organization administrators can modify all the settings of a private
+  channel without having access to it. They cannot add subscribers to
+  the channel without having access to it.
 
 **Feature level 343**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -33,6 +33,10 @@ format used by the Zulip server that they are interacting with.
   organization administrators can modify all the settings of a private
   channel without having access to it. They cannot add subscribers to
   the channel without having access to it.
+* [`GET /events`](/api/get-events): If a user is a channel
+  administrator for a private channel they are not subscribed to. That
+  channel will now appear either in the `unsubscribed` or
+  `never_subscribed` list in subscription info.
 
 **Feature level 343**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 344**
+
+* [`DELETE /users/me/subscriptions`](/api/get-subscriptions): Channel
+  administrators can now unsubscribe other users even if they are not
+  an organization administrator or part of
+  `can_remove_subscribers_group`. Realm administrators are now
+  allowed to unsubscribe other users from a private channel even if
+  they are not subscribed to that channel.
+
 **Feature level 343**
 
 * [`GET /events`](/api/get-events): Added a new field `stream_ids` to replace

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 343  # Last bumped for `stream_ids` field in stream deletion events.
+API_FEATURE_LEVEL = 344  # Last bumped for allowing channel admins to unsubscribe users.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -535,7 +535,11 @@ export function can_edit_description(sub: StreamSubscription): boolean {
 
 export function can_view_subscribers(sub: StreamSubscription): boolean {
     // Guest users can't access subscribers of any(public or private) non-subscribed streams.
-    return current_user.is_admin || sub.subscribed || (!current_user.is_guest && !sub.invite_only);
+    return (
+        sub.subscribed ||
+        (!current_user.is_guest && !sub.invite_only) ||
+        can_change_permissions(sub)
+    );
 }
 
 export function can_subscribe_others(sub: StreamSubscription): boolean {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -507,13 +507,10 @@ export function can_preview(sub: StreamSubscription): boolean {
 export function can_change_permissions(sub: StreamSubscription): boolean {
     // Whether the current user has permission to administer this stream.
     // Organisation admins have this permission regardless of whether
-    // they are part of can_administer_channel_group. Non-subscribers with
-    // these permission can edit name and description of a private channel
-    // without being subscribed to it.
-
-    if (sub.invite_only && !sub.subscribed) {
-        return false;
-    }
+    // they are part of can_administer_channel_group. Non-subscribers
+    // with these permission can modify the properties of a private
+    // channel without being subscribed to it except adding subscribers
+    // to a private channel they are not subscribed to.
 
     if (current_user.is_admin) {
         return true;

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -17,6 +17,7 @@ const peer_data = zrequire("peer_data");
 const people = zrequire("people");
 const {set_current_user} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
+const user_groups = zrequire("user_groups");
 
 set_current_user({});
 
@@ -52,6 +53,14 @@ const bot_botson = {
     role: 300,
 };
 
+const nobody_group = {
+    name: "Nobody",
+    id: 1,
+    members: new Set([]),
+    is_system_group: true,
+    direct_subgroup_ids: new Set([]),
+};
+
 function contains_sub(subs, sub) {
     return subs.some((s) => s.name === sub.name);
 }
@@ -64,6 +73,10 @@ function test(label, f) {
         people.init();
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
+
+        user_groups.initialize({
+            realm_user_groups: [nobody_group],
+        });
 
         f({override});
     });
@@ -96,7 +109,12 @@ test("unsubscribe", () => {
 });
 
 test("subscribers", () => {
-    const sub = {name: "Rome", subscribed: true, stream_id: 1001};
+    const sub = {
+        name: "Rome",
+        subscribed: true,
+        stream_id: 1001,
+        can_administer_channel_group: nobody_group.id,
+    };
     stream_data.add_sub(sub);
 
     people.add_active_user(fred);

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -489,17 +489,11 @@ test("admin_options", ({override}) => {
     assert.ok(is_realm_admin(sub));
     assert.ok(can_change_stream_permissions(sub));
 
-    // admins can only make private streams become public
-    // if they are subscribed
+    // admins can make private streams become public
+    // even if they are not subscribed
     sub = make_sub(nobody_group.id);
     sub.invite_only = true;
     sub.subscribed = false;
-    assert.ok(is_realm_admin(sub));
-    assert.ok(!can_change_stream_permissions(sub));
-
-    sub = make_sub(nobody_group.id);
-    sub.invite_only = true;
-    sub.subscribed = true;
     assert.ok(is_realm_admin(sub));
     assert.ok(can_change_stream_permissions(sub));
 
@@ -515,17 +509,11 @@ test("admin_options", ({override}) => {
     assert.ok(!is_realm_admin(sub));
     assert.ok(can_change_stream_permissions(sub));
 
-    // Users in setting group can only make private streams become
-    // public if they are subscribed
+    // Users in setting group can make private streams become
+    // public even if they are not subscribed
     sub = make_sub(moderators_group.id);
     sub.invite_only = true;
     sub.subscribed = false;
-    assert.ok(!is_realm_admin(sub));
-    assert.ok(!can_change_stream_permissions(sub));
-
-    sub = make_sub(moderators_group.id);
-    sub.invite_only = true;
-    sub.subscribed = true;
     assert.ok(!is_realm_admin(sub));
     assert.ok(can_change_stream_permissions(sub));
 });

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -878,7 +878,7 @@ def send_subscription_remove_events(
                 stream
                 for stream in streams_by_user[user_profile.id]
                 if not check_basic_stream_access(
-                    user_profile, stream, sub=None, allow_realm_admin=True
+                    user_profile, stream, False, allow_realm_admin=True
                 )
             ]
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -436,9 +436,6 @@ def check_stream_access_for_delete_or_update(
     if user_profile.is_realm_admin:
         return
 
-    if sub is None and stream.invite_only:
-        raise JsonableError(error)
-
     if can_administer_accessible_channel(stream, user_profile):
         return
 

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -33,6 +33,7 @@ from zerver.lib.types import (
     SubscriptionInfo,
     SubscriptionStreamDict,
 )
+from zerver.lib.user_groups import get_recursive_membership_groups
 from zerver.models import Realm, Stream, Subscription, UserProfile
 from zerver.models.streams import get_all_streams
 
@@ -336,16 +337,30 @@ def validate_user_access_to_subscribers(user_profile: UserProfile | None, stream
     * The stream is invite only, requesting_user is passed, and that user
       does not subscribe to the stream.
     """
+    user_recursive_group_ids: set[int] = set()
+    # Optimization for the organization administrator code path. We
+    # don't explicitly grant realm admins this permission, but admins
+    # implicitly have the can_administer_channel_group permission for
+    # all channels. user_recursive_group_ids is used to check the
+    # membership of the current user in can_administer_channel_group
+    # which we don't need to calculate in case of a realm admin.
+    if user_profile and not user_profile.is_realm_admin:
+        user_recursive_group_ids = set(
+            get_recursive_membership_groups(user_profile).values_list("id", flat=True)
+        )
+
     validate_user_access_to_subscribers_helper(
         user_profile,
         {
             "realm_id": stream.realm_id,
             "is_web_public": stream.is_web_public,
             "invite_only": stream.invite_only,
+            "can_administer_channel_group_id": stream.can_administer_channel_group_id,
         },
         # We use a lambda here so that we only compute whether the
         # user is subscribed if we have to
         lambda user_profile: subscribed_to_stream(user_profile, stream.id),
+        user_recursive_group_ids,
     )
 
 
@@ -353,6 +368,7 @@ def validate_user_access_to_subscribers_helper(
     user_profile: UserProfile | None,
     stream_dict: Mapping[str, Any],
     check_user_subscribed: Callable[[UserProfile], bool],
+    user_recursive_group_ids: set[int],
 ) -> None:
     """Helper for validate_user_access_to_subscribers that doesn't require
     a full stream object.  This function is a bit hard to read,
@@ -398,7 +414,10 @@ def validate_user_access_to_subscribers_helper(
         raise JsonableError(_("Subscriber data is not available for this channel"))
 
     # Organization administrators can view subscribers for all streams.
-    if user_profile.is_realm_admin:
+    if (
+        user_profile.is_realm_admin
+        or stream_dict["can_administer_channel_group_id"] in user_recursive_group_ids
+    ):
         return
 
     if stream_dict["invite_only"] and not check_user_subscribed(user_profile):
@@ -415,6 +434,17 @@ def bulk_get_subscriber_user_ids(
     is_subscribed: bool
     check_user_subscribed = lambda user_profile: is_subscribed
 
+    user_recursive_group_ids = set()
+    # Optimization for the organization administrator code path. We
+    # don't explicitly grant realm admins this permission, but admins
+    # implicitly have the can_administer_channel_group permission for
+    # all channels. user_recursive_group_ids is used to check the
+    # membership of the current user in can_administer_channel_group
+    # which we don't need to calculate in case of a realm admin.
+    if not user_profile.is_realm_admin:
+        user_recursive_group_ids = set(
+            get_recursive_membership_groups(user_profile).values_list("id", flat=True)
+        )
     for stream_dict in stream_dicts:
         stream_id = stream_dict["id"]
         is_subscribed = stream_id in subscribed_stream_ids
@@ -424,6 +454,7 @@ def bulk_get_subscriber_user_ids(
                 user_profile,
                 stream_dict,
                 check_user_subscribed,
+                user_recursive_group_ids,
             )
         except JsonableError:
             continue
@@ -493,7 +524,10 @@ def get_subscribers_query(
 
 
 def has_metadata_access_to_previously_subscribed_stream(
-    user_profile: UserProfile, stream_dict: SubscriptionStreamDict
+    user_profile: UserProfile,
+    stream_dict: SubscriptionStreamDict,
+    user_recursive_group_ids: set[int],
+    can_administer_channel_group_id: int,
 ) -> bool:
     if stream_dict["is_web_public"]:
         return True
@@ -502,7 +536,10 @@ def has_metadata_access_to_previously_subscribed_stream(
         return False
 
     if stream_dict["invite_only"]:
-        return user_profile.is_realm_admin
+        return (
+            user_profile.is_realm_admin
+            or can_administer_channel_group_id in user_recursive_group_ids
+        )
 
     return True
 
@@ -576,6 +613,17 @@ def gather_subscriptions_helper(
     unsubscribed: list[SubscriptionStreamDict] = []
     never_subscribed: list[NeverSubscribedStreamDict] = []
 
+    user_recursive_group_ids = set()
+    # Optimization for the organization administrator code path. We
+    # don't explicitly grant realm admins this permission, but admins
+    # implicitly have the can_administer_channel_group permission for
+    # all channels. user_recursive_group_ids is used to check the
+    # membership of the current user in can_administer_channel_group
+    # which we don't need to calculate in case of a realm admin.
+    if not user_profile.is_realm_admin:
+        user_recursive_group_ids = set(
+            get_recursive_membership_groups(user_profile).values_list("id", flat=True)
+        )
     sub_unsub_stream_ids = set()
     for sub_dict in sub_dicts:
         stream_id = get_stream_id(sub_dict)
@@ -595,7 +643,10 @@ def gather_subscriptions_helper(
         if is_active:
             subscribed.append(stream_dict)
         else:
-            if has_metadata_access_to_previously_subscribed_stream(user_profile, stream_dict):
+            can_administer_channel_group_id = raw_stream_dict["can_administer_channel_group_id"]
+            if has_metadata_access_to_previously_subscribed_stream(
+                user_profile, stream_dict, user_recursive_group_ids, can_administer_channel_group_id
+            ):
                 """
                 User who are no longer subscribed to a stream that they don't have
                 metadata access to will not receive metadata related to this stream
@@ -621,7 +672,9 @@ def gather_subscriptions_helper(
 
     for raw_stream_dict in never_subscribed_streams:
         is_public = not raw_stream_dict["invite_only"]
-        if is_public or user_profile.is_realm_admin:
+        can_administer_channel_group_id = raw_stream_dict["can_administer_channel_group_id"]
+        is_channel_admin = can_administer_channel_group_id in user_recursive_group_ids
+        if is_public or user_profile.is_realm_admin or is_channel_admin:
             slim_stream_dict = build_stream_dict_for_never_sub(
                 raw_stream_dict=raw_stream_dict,
                 recent_traffic=recent_traffic,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15066,7 +15066,12 @@ paths:
                           Unlike `never_subscribed`, the user might have messages in their personal
                           message history that were sent to these channels.
 
-                          **Changes**: Removed `email_address` field from the dictionary
+                          **Changes**: Prior to Zulip 10.0 (feature level 344), if a user was
+                          administrator of a channel that they had unsubscribed from, but not
+                          an organization administrator, the channel in question would not be
+                          part of this array.
+
+                          Removed `email_address` field from the dictionary
                           in Zulip 8.0 (feature level 226).
 
                           Removed `role` field from the dictionary
@@ -15131,6 +15136,11 @@ paths:
 
                           Important for clients containing UI where one can browse channels to subscribe
                           to.
+
+                          **Changes**: Prior to Zulip 10.0 (feature level 344), if a user was
+                          administrator of a channel that they never subscribed to, but not
+                          an organization administrator, the channel in question would not be
+                          part of this array.
                       unread_msgs:
                         type: object
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20371,10 +20371,17 @@ paths:
                         Administrators can always unsubscribe others from a channel.
 
                         Note that a user must also [have access](/help/channel-permissions) to a
-                        channel in order to modify it.
+                        channel in order to modify it. Organization administrators and channel
+                        administrators are an exception to this.
 
-                        **Changes**: Prior to Zulip 10.0 (feature level 320), this value was
-                        always the integer ID of a system group.
+                        **Changes**: Prior to Zulip 10.0 (feature level 344), channel administrators
+                        could not unsubscribe other users if they were not an orgnaziation
+                        administrator or part of `can_remove_subscribers_group`. Realm administrators
+                        were not allowed to unsubscribe other users from a private channel if they
+                        were not subscribed to that channel.
+
+                        Prior to Zulip 10.0 (feature level 320), this value was always the integer
+                        ID of a system group.
 
                         Before Zulip 8.0 (feature level 197), the `can_remove_subscribers_group`
                         setting was named `can_remove_subscribers_group_id`.
@@ -25079,10 +25086,17 @@ components:
             Administrators can always unsubscribe others from a channel.
 
             Note that a user must also [have access](/help/channel-permissions) to a
-            channel in order to modify it.
+            channel in order to modify it. Organization administrators and channel
+            administrators are an exception to this.
 
-            **Changes**: Prior to Zulip 10.0 (feature level 320), this value was
-            always the integer ID of a system group.
+            **Changes**: Prior to Zulip 10.0 (feature level 344), channel administrators
+            could not unsubscribe other users if they were not an orgnaziation
+            administrator or part of `can_remove_subscribers_group`. Realm administrators
+            were not allowed to unsubscribe other users from a private channel if they
+            were not subscribed to that channel.
+
+            Prior to Zulip 10.0 (feature level 320), this value was always the integer
+            ID of a system group.
 
             Before Zulip 8.0 (feature level 197), the `can_remove_subscribers_group`
             setting was named `can_remove_subscribers_group_id`.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -20404,12 +20404,15 @@ paths:
 
                         Administrators can always administer a channel.
 
-                        Note that a user must also [have access](/help/channel-permissions) to a
-                        channel in order to modify it. The exception to this rule is that
-                        organization administrators can edit channel names and descriptions
-                        without having full access to the channel.
+                        Note that a user must [have access](/help/channel-permissions) to a
+                        channel in order to add other subscribers to the channel.
 
-                        **Changes**: New in Zulip 10.0 (feature level 325). Prior to this
+                        **Changes**: Prior to Zulip 10.0 (feature level 344) a user needed to
+                        have access to a channel in order to modify it. The exception to this
+                        rule was that organization administrators can edit channel names and
+                        descriptions without having full access to the channel.
+
+                        New in Zulip 10.0 (feature level 325). Prior to this
                         change, the permission to administer channels was limited to realm
                         administrators.
                       example:
@@ -25113,16 +25116,15 @@ components:
 
             Administrators can always administer a channel.
 
-            Note that a user must also [have access](/help/channel-permissions) to a
-            channel in order to modify it.
+            Note that a user must [have access](/help/channel-permissions) to a
+            channel in order to add other subscribers to the channel.
 
-            Users can edit channel name and description without subscribing to the
-            channel, but they need to be subscribed to edit channel permissions and
-            add users. The exception to this rule is that organization administrators
-            can edit channel names and descriptions without having full access to
-            the channel.
+            **Changes**: Prior to Zulip 10.0 (feature level 344) a user needed to
+            have access to a channel in order to modify it. The exception to this
+            rule was that organization administrators can edit channel names and
+            descriptions without having full access to the channel.
 
-            **Changes**: New in Zulip 10.0 (feature level 325). Prior to this
+            New in Zulip 10.0 (feature level 325). Prior to this
             change, the permission to administer channels was limited to realm
             administrators.
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1218,7 +1218,7 @@ class FetchQueriesTest(ZulipTestCase):
         realm = get_realm_with_settings(realm_id=user.realm_id)
 
         with (
-            self.assert_database_query_count(45),
+            self.assert_database_query_count(47),
             mock.patch("zerver.lib.events.always_want") as want_mock,
         ):
             fetch_initial_state_data(user, realm=realm)
@@ -1252,7 +1252,7 @@ class FetchQueriesTest(ZulipTestCase):
             starred_messages=1,
             stream=5,
             stop_words=0,
-            subscription=7,
+            subscription=9,
             update_display_settings=0,
             update_global_notifications=0,
             update_message_flags=5,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -275,7 +275,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(54),
+            self.assert_database_query_count(56),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -612,7 +612,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(49):
+        with self.assert_database_query_count(51):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1017,7 +1017,7 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(85),
+            self.assert_database_query_count(89),
             self.assert_memcached_count(19),
             self.capture_send_event_calls(expected_num_events=10) as events,
         ):

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -407,9 +407,6 @@ def update_stream_backend(
         if validate_group_setting_value_change(
             current_setting_api_value, new_setting_value, expected_current_setting_value
         ):
-            if sub is None and stream.invite_only:
-                # Admins cannot change this setting for unsubscribed private streams.
-                raise JsonableError(_("Invalid channel ID"))
             with transaction.atomic(durable=True):
                 user_group = access_user_group_for_setting(
                     new_setting_value,


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://chat.zulip.org/#narrow/channel/101-design/topic/permissions.20for.20admin.20to.20unsubscribe.20others/near/2060197

* Channel administrators can now unsubscribe other users even if they are not an organization administrator or part of `can_remove_subscribers_group`.Realm administrators are now allowed to unsubscribe other users from a private channel even if they are not subscribed to that channel.
* Channel and organization administrators can modify all the settings of a private channel without having access to it. They cannot add subscribers to the channel without having access to it.
* If a user is a channel administrator for a private channel they are not subscribed to. That channel will now appear either in the `unsubscribed` or `never_subscribed` list in subscription info.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

I don't think screenshots would do a whole lot of justice here, but here are some screenshots of channel settings for a normal user aaron who is an admin of a channel he is not part of. This PR might benefit from some good testing and playing around.

![Screenshot 2025-01-29 at 2 59 01 AM](https://github.com/user-attachments/assets/2fa688db-7911-4e0f-acb1-388452c07b6d)
![Screenshot 2025-01-29 at 2 59 12 AM](https://github.com/user-attachments/assets/51a9d6fd-5051-4548-b04a-7c8b8e394cac)
![Screenshot 2025-01-29 at 2 59 27 AM](https://github.com/user-attachments/assets/ec432195-a6c8-4658-8cd2-6d4fed841927)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
