### PR TITLE
Left sidebar home view unread_count tooltip includes muted messages count.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -200,7 +200,7 @@ export function initialize(): void {
             switch (sidebar_option) {
                 case user_settings.web_home_view:
                     $container.find(".views-tooltip-home-view-note").removeClass("hide");
-                    display_count = unread.get_unread_message_count();
+                    display_count = unread.get_counts().home_unread_messages;
                     $container.find(".views-message-count").text(
                         $t(
                             {


### PR DESCRIPTION
Earlier, unread_count in home view tooltip was set to total unread messages while we normally exclude muted messages from unread_count.

PR changes this by setting it to home_unread_messages count.

Fixes: [czo](https://chat.zulip.org/#narrow/channel/9-issues/topic/New.20left.20sidebar.20tooltips.20bug/near/2065009)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
