### PR TITLE
left_sidebar: Sweep for remaining px-based font-size values.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -247,7 +247,8 @@
     --left-sidebar-before-unread-count-padding: 3px;
     /* 15px is the approximate width of a single-digit
        unread marker. */
-    --left-sidebar-single-digit-unread-width: 15px;
+    /* 15px at 16px/1em */
+    --left-sidebar-single-digit-unread-width: 0.9375em;
     --left-sidebar-right-margin: 12px;
     /* 289px at 14px/1em */
     --left-sidebar-max-width: calc(

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -662,12 +662,14 @@ li.active-sub-filter {
         }
 
         &:not(:hover) .unread_count {
-            top: 2px;
-            right: 2px;
-            width: 6px;
-            height: 6px;
-            font-size: 0;
+            /* .unread_count has its based font-size set to 12px at 14px/em. */
+            /* 2px, 6px at 12px/1em */
+            top: 0.1667em;
+            right: 0.1667em;
+            width: 0.5em;
+            height: 0.5em;
             padding: 0;
+            color: transparent;
             background-color: var(--color-background-unread-counter-dot);
         }
 
@@ -697,11 +699,11 @@ li.active-sub-filter {
         display: flex;
         align-items: center;
         justify-content: center;
-        /* TODO: Set this 24px height value as a variable.
-           Keep filter-icon height the full height of the box. */
-        height: 24px;
         /* Enlarge icons slightly in condensed views. */
-        font-size: 15px;
+        /* 15px at 16px/1em */
+        font-size: 0.9375em;
+        /* 24px at 15px/1em */
+        height: 1.6em;
         color: var(--color-left-sidebar-navigation-icon);
     }
 }
@@ -963,7 +965,8 @@ li.top_left_scheduled_messages {
         0 var(--left-sidebar-header-icon-toggle-width) 0 minmax(0, 0.5fr)
         0 minmax(0, 1fr)
         var(--left-sidebar-vdots-width) 0;
-    grid-template-rows: 28px;
+    /* 28px at 16px/1em */
+    grid-template-rows: 1.75em;
     cursor: pointer;
     border-radius: 4px;
 
@@ -1041,10 +1044,12 @@ li.top_left_scheduled_messages {
         /* Horizontally center vdots. */
         justify-self: stretch;
         /* Properly size vdots. */
-        font-size: 17px;
+        /* 17px at 16px/1em */
+        font-size: 1.0625em;
         /* Occupy same clickable height as
            other condensed-view icons */
-        height: 24px;
+        /* 24px at 17px/1em */
+        height: 1.4118em;
         /* Vertically center dots with
            flexbox. */
         display: flex;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -55,7 +55,8 @@
 }
 
 .masked_unread_count {
-    font-size: 8px;
+    /* 8px at 16px/14em */
+    font-size: 0.5em;
     display: none;
     /* Masked unreads display as flex when revealed. */
     align-items: center;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1,14 +1,3 @@
-.hashtag {
-    &:empty {
-        &::after {
-            content: "#";
-            line-height: 0;
-            font-size: 18px;
-            font-weight: 700;
-        }
-    }
-}
-
 .left-sidebar-title {
     color: var(--color-text-sidebar-heading);
     opacity: var(--opacity-sidebar-heading);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1403,20 +1403,6 @@ li.top_left_scheduled_messages {
     }
 }
 
-/*
-    For topic ellipsis-v(vertical 3 dots) we use a slightly smaller
-    font to show they're "lower" in the hierarchy,
-    which also affects it positioning.
-*/
-.topic-sidebar-menu-icon {
-    /* 0.9em, but with a pixel value because the
-       ordinary 17px vdots size is not inherited
-       here, so we can't express an em-value
-       directly. Pixels are easier to reason
-       about with icons, anyway. */
-    font-size: 15.3px;
-}
-
 ul.topic-list {
     line-height: var(--line-height-sidebar-row-prominent);
     list-style-type: none;


### PR DESCRIPTION
This PR removes two unnecessary selectors, but also makes a) masked unread markers and b) the condensed navigation area scale appropriately.

[CZO discussion](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2064636)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before (20px, 12px) | After (20px, 12px) |
| --- | --- |
| ![sidebar-sweep-20-before](https://github.com/user-attachments/assets/2b262959-69de-4839-912c-f2685bb0555d) | ![sidebar-sweep-20-after](https://github.com/user-attachments/assets/12fd4a67-2436-4ea8-93f9-93318b8d3f51) |
| ![sidebar-sweep-12-before](https://github.com/user-attachments/assets/4a0fd427-cf7e-4ca0-9b62-e5c20875f014) | ![sidebar-sweep-12-after](https://github.com/user-attachments/assets/568aebb9-a8b2-483d-994c-c0e5f370b8c1) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>