### PR TITLE
organization_settings: Restyle many sea-green buttons to action-button-quiet-brand.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -119,6 +119,11 @@ h3,
     min-width: 0;
 }
 
+.change-email {
+    display: flex;
+    gap: 0.5rem;
+}
+
 .admin-realm-description {
     height: 16em;
     width: 100%;

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,6 +1,6 @@
-<button type="button" class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0">
+<button type="button" class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}>
     {{#if icon}}
-    <i class="zulip-icon zulip-icon-{{icon}}"></i>
+    <i class="zulip-icon zulip-icon-{{icon}}" aria-hidden="true"></i>
     {{/if}}
     {{#if label}}
     <span class="action-button-label">{{label}}</span>

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,4 @@
-<button type="button" class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}>
+<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}>
     {{#if icon}}
     <i class="zulip-icon zulip-icon-{{icon}}" aria-hidden="true"></i>
     {{/if}}

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,6 @@
-<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}>
+<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+  {{#if disabled}}disabled{{/if}}
+  >
     {{#if icon}}
     <i class="zulip-icon zulip-icon-{{icon}}" aria-hidden="true"></i>
     {{/if}}

--- a/web/templates/components/icon_button.hbs
+++ b/web/templates/components/icon_button.hbs
@@ -1,3 +1,3 @@
-<button type="button" class="{{#if custom_classes}}{{custom_classes}} {{/if}}icon-button {{#if squared}}icon-button-square {{/if}}icon-button-{{intent}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0">
-    <i class="zulip-icon zulip-icon-{{icon}}"></i>
+<button type="button" class="{{#if custom_classes}}{{custom_classes}} {{/if}}icon-button {{#if squared}}icon-button-square {{/if}}icon-button-{{intent}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}>
+    <i class="zulip-icon zulip-icon-{{icon}}" aria-hidden="true"></i>
 </button>

--- a/web/templates/components/icon_button.hbs
+++ b/web/templates/components/icon_button.hbs
@@ -1,3 +1,5 @@
-<button type="button" class="{{#if custom_classes}}{{custom_classes}} {{/if}}icon-button {{#if squared}}icon-button-square {{/if}}icon-button-{{intent}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}>
+<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}icon-button {{#if squared}}icon-button-square {{/if}}icon-button-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+  {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}}
+  >
     <i class="zulip-icon zulip-icon-{{icon}}" aria-hidden="true"></i>
 </button>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -8,13 +8,20 @@
                 {{#if user_has_email_set}}
                 <div class="input-group">
                     <label class="settings-field-label {{#unless user_can_change_email}}cursor-text{{/unless}}" for="change_email_button">{{t "Email" }}</label>
-                    <div>
+                    <div class="change-email">
                         <div id="email_field_container" class="inline-block {{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                             <input type="email" value="{{current_user.delivery_email}}" class="settings_text_input" disabled="disabled" />
                         </div>
-                        <button id="change_email_button" type="button" class="button rounded tippy-zulip-delayed-tooltip {{#unless user_can_change_email}}hide{{/unless}}" data-tippy-content="{{t 'Change your email' }}" aria-label="{{t 'Change your email' }}">
-                            <i class="fa fa-pencil" aria-hidden="true"></i>
-                        </button>
+                        {{> ../components/icon_button
+                          id="change_email_button"
+                          icon="edit"
+                          intent="brand"
+                          custom_classes="tippy-zulip-delayed-tooltip"
+                          hidden=(not user_can_change_email)
+                          aria-label=(t "Change your email")
+                          aria-hidden="true"
+                          data-tippy-content=(t "Change your email")
+                          }}
                     </div>
                     <div id="email-change-status"></div>
                 </div>
@@ -48,7 +55,12 @@
                 <div>
                     <label class="settings-field-label" for="change_password">{{t "Password" }}</label>
                     <div class="input-group">
-                        <button id="change_password" type="button" class="button rounded" data-dismiss="modal">{{t "Change your password" }}</button>
+                        {{> ../components/action_button
+                          label=(t "Change your password")
+                          type="quiet"
+                          intent="brand"
+                          id="change_password"
+                          }}
                     </div>
                 </div>
                 {{/if}}
@@ -56,10 +68,13 @@
 
             <div class="input-group">
                 <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
-                    <button type="submit" class="button rounded button-danger" id="user_deactivate_account_button"
-                      {{#if user_is_only_organization_owner}}disabled="disabled"{{/if}}>
-                        {{t 'Deactivate account' }}
-                    </button>
+                    {{> ../components/action_button
+                      label=(t "Deactivate account")
+                      type="quiet"
+                      intent="danger"
+                      id="user_deactivate_account_button"
+                      disabled=user_is_only_organization_owner
+                      }}
                 </div>
                 {{#if owner_is_only_user_in_organization}}
                     <button type="submit" class="button rounded button-danger deactivate_realm_button">
@@ -133,9 +148,13 @@
                     {{/tr}}
                 </p>
                 <div id="api_key_button_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
-                    <button class="button rounded" id="api_key_button" {{#unless user_has_email_set}}disabled="disabled"{{/unless}}>
-                        {{t "Manage your API key" }}
-                    </button>
+                    {{> ../components/action_button
+                      label=(t "Manage your API key")
+                      type="quiet"
+                      intent="brand"
+                      id="api_key_button"
+                      disabled=(not user_has_email_set)
+                      }}
                 </div>
             </div>
         </div>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -77,9 +77,12 @@
                       }}
                 </div>
                 {{#if owner_is_only_user_in_organization}}
-                    <button type="submit" class="button rounded button-danger deactivate_realm_button">
-                        {{t 'Deactivate organization' }}
-                    </button>
+                    {{> ../components/action_button
+                      label=(t "Deactivate organization")
+                      type="quiet"
+                      intent="danger"
+                      custom_classes="deactivate_realm_button inline-block"
+                      }}
                 {{/if}}
             </div>
         </div>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -4,9 +4,12 @@
             {{t "Alert words allow you to be notified as if you were @-mentioned when certain words or phrases are used in Zulip. Alert words are not case sensitive."}}
         </p>
     </form>
-    <button class="button rounded sea-green" id="open-add-alert-word-modal" type="button">
-        {{t 'Add alert word'}}
-    </button>
+    {{> ../components/action_button
+      label=(t "Add alert word")
+      type="quiet"
+      intent="brand"
+      id="open-add-alert-word-modal"
+      }}
 
     <div class="settings_panel_list_header">
         <h3>{{t "Alert words"}}</h3>

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -11,7 +11,13 @@
         <div class="bot-settings-tip" id="personal-bot-settings-tip">
         </div>
         <div>
-            <button class="button rounded sea-green add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>
+            {{> ../components/action_button
+              label=(t "Add a new bot")
+              type="quiet"
+              intent="brand"
+              custom_classes="add-a-new-bot"
+              hidden=(not can_create_new_bots)
+              }}
         </div>
         {{/unless}}
 

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -89,9 +89,12 @@
         <div class="deactivate-realm-section">
             <div class="input-group">
                 <div id="deactivate_realm_button_container" class="inline-block {{#unless is_owner}}disabled_setting_tooltip{{/unless}}">
-                    <button class="button rounded button-danger deactivate_realm_button">
-                        {{t 'Deactivate organization' }}
-                    </button>
+                    {{> ../components/action_button
+                      label=(t "Deactivate organization")
+                      type="quiet"
+                      intent="danger"
+                      custom_classes="deactivate_realm_button"
+                      }}
                 </div>
             </div>
         </div>

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -69,10 +69,14 @@
                     <span class="user-details-desc">{{date_joined_text}}</span>
                 </div>
             </div>
-            <button class="button rounded sea-green" id="show_my_user_profile_modal">
-                {{t 'Preview profile' }}
-                <i class="show-user-profile-icon fa fa-external-link" aria-hidden="true"></i>
-            </button>
+            {{> ../components/action_button
+              label=(t "Preview profile")
+              type="quiet"
+              intent="brand"
+              id="show_my_user_profile_modal"
+              icon="external-link"
+              aria-hidden="true"
+              }}
         </div>
     </div>
 </div>


### PR DESCRIPTION
In this PR, I have restyled the button present in Personal settings and a few in Organization Settings.

Commit 1:
> Add a new bot, Add alert word: action-button-quiet-brand

Commit 2:
> "Preview profile": action-button-quiet-brand
> Pencil for email editing: action-button-quiet-brand
Change your password: action-button-quiet-brand
Deactivate account: action-button-quiet-danger
Manage your API key: action-button-quiet-brand

Commit 3:
>Restyle "Deactivate organization" as action-button-quiet-danger

Fixes part of :  #33130.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| **Location**  | **Before** | **After (At 12px)** | **After (At 16px)** | **After (At 20px)** |
|---------------|-----------|--------------------|--------------------|--------------------|
| Preview profile          | <img width="223" alt="Screenshot 2025-01-31 at 6 53 03 PM" src="https://github.com/user-attachments/assets/893240b4-44e3-4b9c-9648-c6e0837e192e" /> | <img width="223" alt="Screenshot 2025-01-31 at 6 45 53 PM" src="https://github.com/user-attachments/assets/15e4286a-791a-4f3b-9ad2-c0c79d766c4f" /> | <img width="210" alt="Screenshot 2025-01-31 at 6 47 55 PM" src="https://github.com/user-attachments/assets/c1262f51-74c8-4972-af4e-852a01807992" /> | <img width="222" alt="Screenshot 2025-01-31 at 6 49 56 PM" src="https://github.com/user-attachments/assets/08662d37-5b22-4727-b388-b638a1528bd9" /> |
| Pencil for email editing     | <img width="114" alt="Screenshot 2025-01-31 at 6 53 27 PM" src="https://github.com/user-attachments/assets/d6048163-9605-41c6-bfbe-f65b8c197fcc" /> | <img width="92" alt="Screenshot 2025-02-02 at 6 58 46 PM" src="https://github.com/user-attachments/assets/cd0dc298-da78-4719-aeb3-711a61a2b62b" /> | <img width="93" alt="Screenshot 2025-02-02 at 6 58 57 PM" src="https://github.com/user-attachments/assets/cbcef318-7319-4ad9-8b50-9878433d2253" /> | <img width="83" alt="Screenshot 2025-02-02 at 6 59 11 PM" src="https://github.com/user-attachments/assets/3875ab41-8a33-4647-ac3a-2b4cf591e7cf" /> |
| Change your password | <img width="215" alt="Screenshot 2025-01-31 at 6 53 31 PM" src="https://github.com/user-attachments/assets/e17327d7-1eef-4199-8bc4-ddf537e013ca" /> | <img width="152" alt="Screenshot 2025-01-31 at 6 46 21 PM" src="https://github.com/user-attachments/assets/0f285c2f-b378-4bdc-825c-b7f8aba19085" /> | <img width="207" alt="Screenshot 2025-01-31 at 6 49 10 PM" src="https://github.com/user-attachments/assets/e99ef44d-92c1-41fb-a67d-be10d04b2c8c" /> | <img width="244" alt="Screenshot 2025-01-31 at 6 50 11 PM" src="https://github.com/user-attachments/assets/94d8973d-d9b6-4484-ab37-16c3f9dd39da" /> |
| Deactivate account    | <img width="195" alt="Screenshot 2025-01-31 at 6 53 34 PM" src="https://github.com/user-attachments/assets/23e02974-260e-466c-be3c-c3e4a987a851" /> | <img width="146" alt="Screenshot 2025-01-31 at 6 46 56 PM" src="https://github.com/user-attachments/assets/cff45aa5-d3af-4cd5-9956-14f2ec5ee4bc" /> | <img width="177" alt="Screenshot 2025-01-31 at 6 49 17 PM" src="https://github.com/user-attachments/assets/971a7085-b5a2-40a8-9f73-1ad1d9044ece" /> | <img width="219" alt="Screenshot 2025-01-31 at 6 50 14 PM" src="https://github.com/user-attachments/assets/f74b7e1d-4d28-4224-b656-3fa0dcb5f54e" /> |
| Manage your API key   | <img width="196" alt="Screenshot 2025-01-31 at 6 53 38 PM" src="https://github.com/user-attachments/assets/f11c94b5-4c1a-4c6a-babc-d91e75ae808a" /> | <img width="144" alt="Screenshot 2025-01-31 at 6 47 04 PM" src="https://github.com/user-attachments/assets/7dcb7153-79f6-45d8-a148-8e51f805a465" /> | <img width="187" alt="Screenshot 2025-01-31 at 6 49 22 PM" src="https://github.com/user-attachments/assets/2f43ff0e-e207-42e2-86a0-2be7c343751a" /> | <img width="230" alt="Screenshot 2025-01-31 at 6 50 18 PM" src="https://github.com/user-attachments/assets/35987329-6bb2-4171-bdf7-2ab8519d4a87" /> |
| Add a new bot  | <img width="152" alt="Screenshot 2025-01-31 at 6 53 55 PM" src="https://github.com/user-attachments/assets/8f0ba225-80b7-4733-a609-2bb13a501672" /> | <img width="106" alt="Screenshot 2025-01-31 at 6 47 14 PM" src="https://github.com/user-attachments/assets/9ee685f0-b34f-4ca9-baf4-7ed5ac68e971" /> | <img width="143" alt="Screenshot 2025-01-31 at 6 49 34 PM" src="https://github.com/user-attachments/assets/422aee18-8f12-46a4-9198-be1c5a32d969" /> | <img width="169" alt="Screenshot 2025-01-31 at 6 50 28 PM" src="https://github.com/user-attachments/assets/f8aad36f-71db-42d5-80dd-4653b8d6bb64" /> |
| Add alert word  | <img width="160" alt="Screenshot 2025-01-31 at 6 54 01 PM" src="https://github.com/user-attachments/assets/0b65b19a-326e-4869-9407-06ec56e570e6" /> | <img width="104" alt="Screenshot 2025-01-31 at 6 47 24 PM" src="https://github.com/user-attachments/assets/9f8c1cf4-8ad5-4012-9025-0a2253375b35" /> | <img width="146" alt="Screenshot 2025-01-31 at 6 49 39 PM" src="https://github.com/user-attachments/assets/84b5bb9f-7050-445a-b0e1-aefd706a8b3b" /> | <img width="170" alt="Screenshot 2025-01-31 at 6 50 34 PM" src="https://github.com/user-attachments/assets/f92f2ce5-370e-4f0e-b605-030fc55fab53" /> |
| Deactivate organization | <img width="214" alt="Screenshot 2025-01-31 at 10 22 45 PM" src="https://github.com/user-attachments/assets/f8988675-ccb5-4a3b-8879-b6424542f3c8" /> | <img width="161" alt="Screenshot 2025-01-31 at 10 13 45 PM" src="https://github.com/user-attachments/assets/4c05e0c5-ab23-4571-9725-6b2eab1edea6" /> | <img width="204" alt="Screenshot 2025-01-31 at 10 13 58 PM" src="https://github.com/user-attachments/assets/2f73e85c-11c2-40c5-825e-8bccf145a2f7" /> | <img width="255" alt="Screenshot 2025-01-31 at 10 14 09 PM" src="https://github.com/user-attachments/assets/75c84dc7-d208-4b12-a8ea-c4b7b2f0f255" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
