### PR TITLE
AI summary modal UI tweaks

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -59,7 +59,8 @@ function current_dialog_widget_selector(): string {
  */
 
 export type DialogWidgetConfig = {
-    html_heading: string;
+    html_heading?: string;
+    text_heading?: string;
     html_body: string;
     on_click: (e: JQuery.ClickEvent) => void;
     html_submit_button?: string;
@@ -136,7 +137,7 @@ export function get_current_values($inputs: JQuery): Record<string, unknown> {
 
 export function launch(conf: DialogWidgetConfig): string {
     // Mandatory fields:
-    // * html_heading
+    // * html_heading | text_heading
     // * html_body
     // * on_click
     // The html_ fields should be safe HTML. If callers
@@ -172,7 +173,8 @@ export function launch(conf: DialogWidgetConfig): string {
     const html_exit_button = conf.html_exit_button ?? $t_html({defaultMessage: "Cancel"});
     const html = render_dialog_widget({
         modal_unique_id,
-        heading_text: conf.html_heading,
+        html_heading: conf.html_heading,
+        text_heading: conf.text_heading,
         link: conf.help_link,
         html_submit_button,
         html_exit_button,

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -79,6 +79,7 @@ export type DialogWidgetConfig = {
     loading_spinner?: boolean;
     update_submit_disabled_state_on_change?: boolean;
     always_visible_scrollbar?: boolean;
+    footer_minor_text?: string;
 };
 
 type RequestOpts = {
@@ -179,6 +180,7 @@ export function launch(conf: DialogWidgetConfig): string {
         id: conf.id,
         single_footer_button: conf.single_footer_button,
         always_visible_scrollbar: conf.always_visible_scrollbar,
+        footer_minor_text: conf.footer_minor_text,
     });
     const $dialog = $(html);
     $("body").append($dialog);

--- a/web/src/message_summary.ts
+++ b/web/src/message_summary.ts
@@ -8,7 +8,8 @@ import * as dialog_widget from "./dialog_widget.ts";
 import {Filter} from "./filter.ts";
 import {$t} from "./i18n.ts";
 import * as message_fetch from "./message_fetch.ts";
-import * as stream_data from "./stream_data.ts";
+import * as unread from "./unread.ts";
+import * as unread_ops from "./unread_ops.ts";
 import * as util from "./util.ts";
 
 export function get_narrow_summary(channel_id: number, topic_name: string): void {
@@ -17,21 +18,36 @@ export function get_narrow_summary(channel_id: number, topic_name: string): void
         {operator: "topic", operand: topic_name},
     ]);
     const data = {narrow: message_fetch.get_narrow_for_message_fetch(filter)};
-    const channel_name = stream_data.get_stream_name_from_id(channel_id);
     const display_topic_name = util.get_final_topic_display_name(topic_name);
-    dialog_widget.launch({
-        html_heading: $t(
-            {defaultMessage: "Summary of #${channel_name} > ${topic_name}:"},
-            {channel_name, topic_name: display_topic_name},
-        ),
-        html_body: "",
-        html_submit_button: "Close",
-        close_on_submit: true,
+    const unread_topic_params = {
+        html_submit_button: $t({defaultMessage: "Mark topic as read"}),
+        html_exit_button: $t({defaultMessage: "Close"}),
+        on_click() {
+            unread_ops.mark_topic_as_read(channel_id, topic_name);
+        },
+        single_footer_button: false,
+    };
+
+    let params = {
+        html_submit_button: $t({defaultMessage: "Close"}),
         on_click() {
             // Just close the modal, there is nothing else to do.
         },
-        id: "topic-summary-modal",
         single_footer_button: true,
+    };
+    if (unread.topic_has_any_unread(channel_id, topic_name)) {
+        params = {
+            ...params,
+            ...unread_topic_params,
+        };
+    }
+    dialog_widget.launch({
+        text_heading: display_topic_name,
+        html_body: "",
+        close_on_submit: true,
+        id: "topic-summary-modal",
+        footer_minor_text: $t({defaultMessage: "AI summaries may have errors."}),
+        ...params,
         post_render() {
             const close_on_success = false;
             dialog_widget.submit_api_request(

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2047,3 +2047,9 @@ body:not(.hide-left-sidebar) {
 .empty-topic-display {
     font-style: italic;
 }
+
+.dialog-widget-footer-minor-text {
+    font-size: smaller;
+    font-style: italic;
+    margin-right: auto;
+}

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2053,3 +2053,7 @@ body:not(.hide-left-sidebar) {
     font-style: italic;
     margin-right: auto;
 }
+
+#topic-summary-modal {
+    width: 45rem;
+}

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -15,6 +15,9 @@
                 {{{ html_body }}}
             </main>
             <footer class="modal__footer">
+                {{#if footer_minor_text }}
+                <div class="dialog-widget-footer-minor-text">{{footer_minor_text}}</div>
+                {{/if}}
                 {{#unless single_footer_button}}
                 <button class="modal__button dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{{ html_exit_button }}}</button>
                 {{/unless}}

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -3,7 +3,11 @@
         <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <header class="modal__header">
                 <h1 class="modal__title dialog_heading">
-                    {{{ heading_text }}}
+                    {{#if html_heading}}
+                        {{{ html_heading }}}
+                    {{else}}
+                        {{ text_heading }}
+                    {{/if}}
                     {{#if link}}
                     {{> help_link_widget . }}
                     {{/if}}


### PR DESCRIPTION
Implemets part of #33230

    * Make it wider.
    * modal title just be the plain topic name
    * add a "Mark topic as read" button if the topic has unreads.
    * Add a footer warning.

Topic without unreads:

![Screenshot from 2025-01-29 21-45-27](https://github.com/user-attachments/assets/05635a4c-bd7b-4017-b672-23b46ab066df)

Topic with unreads:

![Screenshot from 2025-01-29 22-25-26](https://github.com/user-attachments/assets/f9d6a971-b433-429b-90ad-365247047a30)
![Screenshot from 2025-01-29 22-25-25](https://github.com/user-attachments/assets/29e503d5-184a-44c1-b43a-3d6ab80eb272)
