### PR TITLE
app_layout: Introduce container queries, more flexible right sidebar.

### DIFF
--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -6,7 +6,7 @@ import postcssPrefixWrap from "postcss-prefixwrap";
 import postcssPresetEnv from "postcss-preset-env";
 import postcssSimpleVars from "postcss-simple-vars";
 
-import {media_breakpoints} from "./src/css_variables.ts";
+import {container_breakpoints, media_breakpoints} from "./src/css_variables.ts";
 
 const config = ({file}) => ({
     plugins: [
@@ -18,7 +18,7 @@ const config = ({file}) => ({
                 plugins: [postcssPrefixWrap("%dark-theme")],
             }),
         postcssExtendRule,
-        postcssSimpleVars({variables: media_breakpoints}),
+        postcssSimpleVars({variables: {...container_breakpoints, ...media_breakpoints}}),
         postcssPresetEnv({
             features: {
                 "nesting-rules": true,

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -12,7 +12,6 @@ import render_presence_rows from "../templates/presence_rows.hbs";
 import * as blueslip from "./blueslip.ts";
 import * as buddy_data from "./buddy_data.ts";
 import type {BuddyUserInfo} from "./buddy_data.ts";
-import {media_breakpoints_num} from "./css_variables.ts";
 import type {Filter} from "./filter.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
@@ -26,6 +25,7 @@ import {current_user} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import {INTERACTIVE_HOVER_DELAY} from "./tippyjs.ts";
+import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
@@ -174,7 +174,7 @@ export class BuddyList extends BuddyListConf {
                 e.stopPropagation();
                 const $elem = $(this);
                 let placement: "left" | "auto" = "left";
-                if (window.innerWidth < media_breakpoints_num.md) {
+                if (ui_util.matches_viewport_state("lt_md_min")) {
                     // On small devices display tooltips based on available space.
                     // This will default to "bottom" placement for this tooltip.
                     placement = "auto";

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -13,7 +13,6 @@ import * as buddy_data from "./buddy_data.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_reply from "./compose_reply.ts";
 import * as compose_state from "./compose_state.ts";
-import {media_breakpoints_num} from "./css_variables.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
@@ -484,7 +483,7 @@ export function initialize(): void {
     ): void {
         let placement: tippy.Placement = "left";
         let observer: MutationObserver;
-        if (window.innerWidth < media_breakpoints_num.md) {
+        if (ui_util.matches_viewport_state("lt_md_min")) {
             // On small devices display tooltips based on available space.
             // This will default to "bottom" placement for this tooltip.
             placement = "auto";

--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -13,14 +13,6 @@ const ms = 320; // Mobile small
 // Breakpoints for middle column
 const mc = 849; // Middle column as wide as it appears after the `sm` breakpoint
 
-// Breakpoints for showing and hiding compose buttons which do not always fit in
-// a single row below the compose box
-const cb1 = 1314;
-const cb2 = 1072;
-const cb3 = 860;
-const cb4 = 750;
-const cb5 = 504;
-
 export const media_breakpoints = {
     xs_min: xs + "px",
     sm_min: sm + "px",
@@ -31,11 +23,6 @@ export const media_breakpoints = {
     ml_min: ml + "px",
     mm_min: mm + "px",
     ms_min: ms + "px",
-    cb1_min: cb1 + "px",
-    cb2_min: cb2 + "px",
-    cb3_min: cb3 + "px",
-    cb4_min: cb4 + "px",
-    cb5_min: cb5 + "px",
     short_navbar_cutoff_height: "600px",
     // Used for main settings overlay and stream/subscription settings overlay
     // measured as the width of the overlay itself, not the width of the full

--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -13,6 +13,9 @@ const ms = 320; // Mobile small
 // Breakpoints for middle column
 const mc = 849; // Middle column as wide as it appears after the `sm` breakpoint
 
+// Base em unit for container_breakpoints conversion
+const base_em_px = 16;
+
 export const media_breakpoints = {
     xs_min: xs + "px",
     sm_min: sm + "px",
@@ -29,6 +32,12 @@ export const media_breakpoints = {
     // screen. 800px is the breakpoint at the 14px legacy font size, scaled with
     // em to user-chosen font-size.
     settings_overlay_sidebar_collapse_breakpoint: 800 / 14 + "em",
+};
+
+export const container_breakpoints = {
+    cq_xl_min: xl / base_em_px + "em",
+    cq_md_min: md / base_em_px + "em",
+    cq_mm_min: mm / base_em_px + "em",
 };
 
 export const media_breakpoints_num = {

--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -143,9 +143,31 @@ export function calculate_timestamp_widths(): void {
     $temp_time_div.remove();
 }
 
+function determine_container_query_support(): void {
+    const body = document.querySelector("body");
+    const test_container = document.createElement("div");
+    const test_child = document.createElement("div");
+    test_container.classList.add("container-query-test");
+    test_child.classList.add("container-query-test-child");
+    test_container.append(test_child);
+
+    body?.append(test_container);
+
+    if (test_child?.getClientRects()[0]?.y === 0) {
+        /* Conforming browsers will place the child element
+           at the very top of the viewport. */
+        body?.classList.add("with-container-query-support");
+    } else {
+        body?.classList.add("without-container-query-support");
+    }
+
+    test_container?.remove();
+}
+
 export function initialize(): void {
     set_base_typography_css_variables();
     // We calculate the widths of a candidate set of timestamps,
     // and use the largest to set `--message-box-timestamp-column-width`
     calculate_timestamp_widths();
+    determine_container_query_support();
 }

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -6,11 +6,11 @@ import $ from "jquery";
 import * as tippy from "tippy.js";
 
 import * as blueslip from "./blueslip.ts";
-import {media_breakpoints_num} from "./css_variables.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as modals from "./modals.ts";
 import * as overlays from "./overlays.ts";
 import * as popovers from "./popovers.ts";
+import * as ui_util from "./ui_util.ts";
 import * as util from "./util.ts";
 
 type PopoverName =
@@ -418,7 +418,7 @@ export function toggle_popover_menu(
     // popover centered on the screen as an overlay.
     let show_as_overlay =
         (options?.show_as_overlay_on_mobile === true &&
-            window.innerWidth <= media_breakpoints_num.md) ||
+            ui_util.matches_viewport_state("lt_md_min")) ||
         options?.show_as_overlay_always === true;
     // Show the popover as over if the reference element is hidden.
     if (!show_as_overlay && options?.show_as_overlay_if_reference_hidden_at_trigger) {

--- a/web/src/realm_icon.ts
+++ b/web/src/realm_icon.ts
@@ -36,10 +36,7 @@ export function build_realm_icon_widget(upload_function: UploadFunction): void {
 }
 
 export function rerender(): void {
-    $("#realm-icon-upload-widget .image-block, #realm-navbar-icon-logo").attr(
-        "src",
-        realm.realm_icon_url,
-    );
+    $("#realm-icon-upload-widget .image-block").attr("src", realm.realm_icon_url);
     if (realm.realm_icon_source === "U") {
         $("#realm-icon-upload-widget .image-delete-button").show();
     } else {

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -7,7 +7,6 @@ import render_right_sidebar from "../templates/right_sidebar.hbs";
 import {buddy_list} from "./buddy_list.ts";
 import * as channel from "./channel.ts";
 import * as compose_ui from "./compose_ui.ts";
-import {media_breakpoints_num} from "./css_variables.ts";
 import {reorder_left_sidebar_navigation_list} from "./left_sidebar_navigation_area.ts";
 import {localstorage} from "./localstorage.ts";
 import * as message_lists from "./message_lists.ts";
@@ -56,7 +55,7 @@ export function show_userlist_sidebar(): void {
         return;
     }
 
-    if (window.innerWidth >= media_breakpoints_num.xl) {
+    if (ui_util.matches_viewport_state("gte_xl_min")) {
         $("body").removeClass("hide-right-sidebar");
         fix_invite_user_button_flicker();
         return;
@@ -146,7 +145,7 @@ export function initialize(): void {
         e.preventDefault();
         e.stopPropagation();
 
-        if (window.innerWidth >= media_breakpoints_num.xl) {
+        if (ui_util.matches_viewport_state("gte_xl_min")) {
             $("body").toggleClass("hide-right-sidebar");
             if (!$("body").hasClass("hide-right-sidebar")) {
                 fix_invite_user_button_flicker();
@@ -172,11 +171,11 @@ export function initialize(): void {
         e.preventDefault();
         e.stopPropagation();
 
-        if (window.innerWidth >= media_breakpoints_num.md) {
+        if (ui_util.matches_viewport_state("gte_md_min")) {
             $("body").toggleClass("hide-left-sidebar");
             if (
                 message_lists.current !== undefined &&
-                window.innerWidth <= media_breakpoints_num.xl
+                !ui_util.matches_viewport_state("gte_xl_min")
             ) {
                 // We expand the middle column width between md and xl breakpoints when the
                 // left sidebar is hidden. This can cause the pointer to move out of view.

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -258,3 +258,16 @@ export function show_left_sidebar_menu_icon(element: Element): void {
 export function hide_left_sidebar_menu_icon(): void {
     $(".left_sidebar_menu_icon_visible").removeClass("left_sidebar_menu_icon_visible");
 }
+
+export function matches_viewport_state(state_string: string): boolean {
+    const app_main = document.querySelector(".app-main");
+    if (app_main instanceof HTMLElement) {
+        const app_main_after_content = getComputedStyle(app_main, ":after").content ?? "";
+        /* The .content property includes the quotation marks, so we
+           strip them before splitting on the empty space. */
+        const app_main_after_content_array = app_main_after_content.replaceAll('"', "").split(" ");
+
+        return app_main_after_content_array.includes(state_string);
+    }
+    return false;
+}

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -260,8 +260,6 @@
        that rely on this value, but not necessarily as
        applied to `width:` or `max-width:`. */
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
-    /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
-    --left-sidebar-width-with-realm-icon-logo: 75px;
     /* 50px per icon * 4 icons + 3px space (legacy) = 203px at 20px/1em */
     --right-column-collapsed-sidebar-width: 10.15em;
     /* 288px at 14px/1em */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -262,7 +262,8 @@
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
-    --right-sidebar-width: 250px;
+    --right-column-width: 250px;
+    --right-sidebar-width: calc(var(--right-column-width) - 10px);
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to
        not touch the row outline. */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -262,6 +262,8 @@
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
+    /* 50px per icon * 4 icons + 3px space (legacy) = 203px at 20px/1em */
+    --right-column-collapsed-sidebar-width: 10.15em;
     /* 288px at 14px/1em */
     --right-column-max-width: 20.57em;
     --right-column-width: clamp(10em, 50%, var(--right-column-max-width));

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -262,7 +262,9 @@
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
     /* 40px (toggle icon) + 5px (gap) + 20px logo + 10px right margin */
     --left-sidebar-width-with-realm-icon-logo: 75px;
-    --right-column-width: 250px;
+    /* 288px at 14px/1em */
+    --right-column-max-width: 20.57em;
+    --right-column-width: clamp(10em, 50%, var(--right-column-max-width));
     --right-sidebar-width: calc(var(--right-column-width) - 10px);
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -7,6 +7,10 @@
         border-radius: 5px;
         position: absolute;
         overflow: hidden;
+        /* We bump the z-index to keep the search box
+           clickable despite position-based layout
+           adjustments. */
+        z-index: 1;
     }
 
     .search_icon {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1594,11 +1594,13 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         @extend %hide-right-sidebar;
     }
 
-    &.fluid_layout_width {
-        #compose-content,
-        .app-main .column-middle {
-            margin-right: 7px;
-        }
+    #navbar-middle {
+        margin-right: var(--right-column-collapsed-sidebar-width);
+    }
+
+    #compose-content,
+    .app-main .column-middle {
+        margin-right: 7px;
     }
 }
 
@@ -1715,7 +1717,7 @@ body:not(.hide-left-sidebar) {
 @container header-container (width < $cq_xl_min) {
     #navbar-middle {
         /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
-        margin-right: calc(var(--header-height) * 4 + 3px);
+        margin-right: var(--right-column-collapsed-sidebar-width);
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -495,6 +495,15 @@ body.has-overlay-scrollbar {
     height: 100%;
     min-height: 100%;
 
+    &::after {
+        /* We use `content` values to determine
+           viewport state from JavaScript; this
+           hides the values without disrupting
+           the document flow. */
+        position: absolute;
+        display: none;
+    }
+
     .column-left .left-sidebar,
     .column-right .right-sidebar {
         position: fixed;
@@ -1860,6 +1869,55 @@ body:not(.hide-left-sidebar) {
 }
 
 /* End fallback media queries. */
+
+/* Begin viewport state queries. */
+
+/* We sometimes need the state of the viewport in JavaScript;
+   by setting values on `content:`, we can query instead for
+   those, independent of whether it's a container or media query
+   responsible for layout. See for example `sidebar_ui.ts`.
+
+   These queries for greater than or equal to should be ordered
+   smallest to largest. */
+
+/* Adjustments for smaller viewports are critical
+   regardless of info-density settings, so we
+   don't include a container-query check here. */
+@media (width < $md_min) {
+    .app-main::after {
+        content: "lt_md_min";
+    }
+}
+
+@container app (width >= $cq_md_min) {
+    .app-main::after {
+        content: "gte_md_min";
+    }
+}
+
+@media (width >= $md_min) {
+    .without-container-query-support {
+        .app-main::after {
+            content: "gte_md_min";
+        }
+    }
+}
+
+@container app (width >= $cq_xl_min) {
+    .app-main::after {
+        content: "gte_md_min gte_xl_min";
+    }
+}
+
+@media (width >= $xl_min) {
+    .without-container-query-support {
+        .app-main::after {
+            content: "gte_md_min gte_xl_min";
+        }
+    }
+}
+
+/* End viewport state queries. */
 
 @media (height < $short_navbar_cutoff_height) {
     .app-main .column-right.expanded .right-sidebar,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -234,6 +234,12 @@ p.n-margin {
     box-shadow: 0 0 30px hsl(0deg 0% 0% / 25%);
     z-index: 110;
 
+    @container app (width < $cq_md_min) {
+        width: calc(90% - 30px);
+        left: 5%;
+        top: 5%;
+    }
+
     &.show-feedback-container {
         display: block;
         animation: feedback-slide-in 0.6s forwards;
@@ -1651,42 +1657,8 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
             margin-left: 7px;
         }
     }
-}
 
-body:not(.hide-left-sidebar) {
-    /* User can clearly see the unread count in the left sidebar. So,
-       we don't need an indicator here as it will only serve as a disctraction. */
-    #header-container .column-left .left-sidebar-toggle-unreadcount {
-        display: none !important;
-    }
-}
-
-@media (width < $xl_min) {
-    .app-main {
-        @extend %hide-right-sidebar;
-    }
-
-    .app-main .column-middle {
-        margin-right: 7px;
-    }
-
-    #navbar-middle {
-        /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
-        margin-right: calc(var(--header-height) * 4 + 3px);
-    }
-
-    #typing_notifications,
-    #scheduled_message_indicator,
-    #compose-content {
-        margin-right: 7px;
-    }
-
-    .hide-left-sidebar {
-        #compose-content,
-        .app-main .column-middle {
-            margin-left: 7px;
-        }
-
+    @container header-container (width < $cq_xl_min) {
         #realm-navbar-icon-logo {
             display: inline-block;
         }
@@ -1703,29 +1675,64 @@ body:not(.hide-left-sidebar) {
             margin-left: var(--left-sidebar-width-with-realm-icon-logo);
         }
     }
+
+    @container app (width < $cq_xl_min) {
+        #compose-content,
+        .app-main .column-middle {
+            margin-left: 7px;
+        }
+    }
 }
 
-@media (width < $md_min) {
+body:not(.hide-left-sidebar) {
+    /* User can clearly see the unread count in the left sidebar. So,
+       we don't need an indicator here as it will only serve as a disctraction. */
+    #header-container .column-left .left-sidebar-toggle-unreadcount {
+        display: none !important;
+    }
+}
+
+/* We have some regrettable but temporarily necessary code duplication
+   in the queries that follow.
+
+   In browsers that support spec-aligned, em-aware container queries,
+   we query on the app-main container. That enables breakpoints that
+   look best at a chose base font size.
+
+   However, in browsers that lag the spec, we fall back to the original
+   media queries. The layout will not look as good as it could, but
+   essential scrolling behavior will be maintained. */
+
+@container header-container (width < $cq_xl_min) {
+    #navbar-middle {
+        /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
+        margin-right: calc(var(--header-height) * 4 + 3px);
+    }
+}
+
+@container app (width < $cq_xl_min) {
     .app-main {
-        @extend %hide-left-sidebar;
+        @extend %hide-right-sidebar;
+
+        .column-middle {
+            margin-right: 7px;
+        }
     }
 
+    #typing_notifications,
+    #scheduled_message_indicator,
+    #compose-content {
+        margin-right: 7px;
+    }
+}
+
+@container header-container (width < $cq_md_min) {
     .header-main .column-left {
         display: none;
     }
 
-    .app-main .column-middle {
-        margin-left: 7px;
-        margin-right: 7px;
-    }
-
     #navbar-middle {
         margin-left: 0;
-    }
-
-    .app-main .column-middle .column-middle-inner {
-        margin-left: 0;
-        margin-right: 0;
     }
 
     #streamlist-toggle {
@@ -1735,11 +1742,21 @@ body:not(.hide-left-sidebar) {
     .top-navbar-container {
         margin-left: 40px;
     }
+}
 
-    #feedback_container {
-        width: calc(90% - 30px);
-        left: 5%;
-        top: 5%;
+@container app (width < $cq_md_min) {
+    .app-main {
+        @extend %hide-left-sidebar;
+
+        .column-middle {
+            margin-left: 7px;
+            margin-right: 7px;
+        }
+
+        .column-middle .column-middle-inner {
+            margin-left: 0;
+            margin-right: 0;
+        }
     }
 
     #typing_notifications,
@@ -1748,6 +1765,101 @@ body:not(.hide-left-sidebar) {
         margin-left: 7px;
     }
 }
+
+/* Begin fallback media queries. */
+@media (width < $xl_min) {
+    .without-container-query-support {
+        .app-main {
+            @extend %hide-right-sidebar;
+
+            .column-middle {
+                margin-right: 7px;
+            }
+        }
+
+        #navbar-middle {
+            /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
+            margin-right: calc(var(--header-height) * 4 + 3px);
+        }
+
+        #typing_notifications,
+        #scheduled_message_indicator,
+        #compose-content {
+            margin-right: 7px;
+        }
+
+        .hide-left-sidebar {
+            #compose-content,
+            .app-main .column-middle {
+                margin-left: 7px;
+            }
+
+            #realm-navbar-icon-logo {
+                display: inline-block;
+            }
+
+            #realm-navbar-wide-logo {
+                display: none;
+            }
+
+            #top_navbar .column-left {
+                width: auto;
+            }
+
+            #navbar-middle {
+                margin-left: var(--left-sidebar-width-with-realm-icon-logo);
+            }
+        }
+    }
+}
+
+@media (width < $md_min) {
+    .without-container-query-support {
+        .app-main {
+            @extend %hide-left-sidebar;
+
+            .column-middle {
+                margin-left: 7px;
+                margin-right: 7px;
+            }
+
+            .column-middle .column-middle-inner {
+                margin-left: 0;
+                margin-right: 0;
+            }
+        }
+
+        .header-main .column-left {
+            display: none;
+        }
+
+        #navbar-middle {
+            margin-left: 0;
+        }
+
+        #streamlist-toggle {
+            display: block;
+        }
+
+        .top-navbar-container {
+            margin-left: 40px;
+        }
+
+        #feedback_container {
+            width: calc(90% - 30px);
+            left: 5%;
+            top: 5%;
+        }
+
+        #typing_notifications,
+        #scheduled_message_indicator,
+        #compose-content {
+            margin-left: 7px;
+        }
+    }
+}
+
+/* End fallback media queries. */
 
 @media (height < $short_navbar_cutoff_height) {
     .app-main .column-right.expanded .right-sidebar,
@@ -1810,6 +1922,9 @@ body:not(.hide-left-sidebar) {
     }
 }
 
+/* As these adjustments are properly the province of
+   the viewport, we do not present these mm_min queries
+   in a corresponding container query block. */
 @media (width < $mm_min) {
     html {
         overflow-x: hidden;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -534,6 +534,26 @@ body.has-overlay-scrollbar {
     }
 }
 
+.with-container-query-support {
+    /* With spec-aligned container support, we
+       can establish em-aware containers to
+       query as needed.
+       Note that container queries can only
+       act on children of the container, so
+       at least for now, we include separate
+       queries for #header-container in the
+       navbar as well as .app-main in capable
+       browsers.
+    */
+    #header-container {
+        container: header-container / inline-size;
+    }
+
+    .app {
+        container: app / inline-size;
+    }
+}
+
 .column-middle,
 #compose-content {
     margin-right: var(--right-column-width);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -368,6 +368,8 @@ body.has-overlay-scrollbar {
            the same height and their boxes sit on the
            same invisible line. */
         margin-top: -1px;
+        /* Prevent collisions with the search box. */
+        margin-left: 15px;
 
         & a {
             font-size: calc(16em / 14);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -511,6 +511,29 @@ body.has-overlay-scrollbar {
     }
 }
 
+/* We test for spec-aligned container query support
+   using these styles. */
+.container-query-test {
+    /* Keep the test div from rendering. */
+    visibility: hidden;
+    /* Establish a container. */
+    container: test-container / inline-size;
+    /* Establish a positioning context that
+       conforming browsers will ignore. */
+    position: relative;
+    top: 100px;
+
+    .container-query-test-child {
+        /* Non-spec aligned browsers will keep
+           this element to the top of the containing
+           <div>; spec-aligned browsers move it to the
+           top of the viewport. We check for this in
+           information_density.ts */
+        position: fixed;
+        top: 0;
+    }
+}
+
 .column-middle,
 #compose-content {
     margin-right: var(--right-column-width);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1585,12 +1585,6 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
-#realm-navbar-icon-logo {
-    display: none;
-    width: 20px;
-    height: 20px;
-}
-
 .hide-right-sidebar {
     .app-main {
         @extend %hide-right-sidebar;
@@ -1672,20 +1666,8 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 
     @container header-container (width < $cq_xl_min) {
-        #realm-navbar-icon-logo {
-            display: inline-block;
-        }
-
-        #realm-navbar-wide-logo {
-            display: none;
-        }
-
         #top_navbar .column-left {
             width: auto;
-        }
-
-        #navbar-middle {
-            margin-left: var(--left-sidebar-width-with-realm-icon-logo);
         }
     }
 
@@ -1807,20 +1789,8 @@ body:not(.hide-left-sidebar) {
                 margin-left: 7px;
             }
 
-            #realm-navbar-icon-logo {
-                display: inline-block;
-            }
-
-            #realm-navbar-wide-logo {
-                display: none;
-            }
-
             #top_navbar .column-left {
                 width: auto;
-            }
-
-            #navbar-middle {
-                margin-left: var(--left-sidebar-width-with-realm-icon-logo);
             }
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -337,8 +337,8 @@ body.has-overlay-scrollbar {
 
 /* This applies to column-left both in navbar and app. */
 .column-right {
-    width: var(--right-sidebar-width);
-    max-width: var(--right-sidebar-width);
+    width: var(--right-column-width);
+    max-width: var(--right-column-width);
     position: absolute;
     right: 0;
     top: 0;
@@ -502,7 +502,7 @@ body.has-overlay-scrollbar {
 
     .column-right .right-sidebar {
         padding-left: 5px;
-        width: 240px;
+        width: var(--right-sidebar-width);
     }
 
     .column-middle {
@@ -513,7 +513,7 @@ body.has-overlay-scrollbar {
 
 .column-middle,
 #compose-content {
-    margin-right: var(--right-sidebar-width);
+    margin-right: var(--right-column-width);
     margin-left: calc(
         var(--left-sidebar-width) + var(--left-sidebar-padding-left)
     );

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -338,7 +338,7 @@ body.has-overlay-scrollbar {
 /* This applies to column-left both in navbar and app. */
 .column-right {
     width: var(--right-column-width);
-    max-width: var(--right-column-width);
+    max-width: var(--right-column-max-width);
     position: absolute;
     right: 0;
     top: 0;

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -8,7 +8,6 @@
             </a>
             <a href="" class="brand no-style">
                 <img id="realm-navbar-wide-logo" src="" alt="" class="nav-logo no-drag"/>
-                <img id="realm-navbar-icon-logo" alt="" src="{{ realm_icon_url }}" class="nav-logo no-drag"/>
             </a>
         </div>
         <div class="column-middle" id="navbar-middle">


### PR DESCRIPTION
This PR introduces a container, `app-main`, for app-wide use in container queries. The benefit of this over media queries is that we can query for em-values on the container's size, meaning that adjustable font-size values will be taken into account.

**Updated, 2025-02-21:** The PR now includes a different mechanism for determining viewport state from within JavaScript. Rather than replicating media queries in JavaScript and then also trying to replicate container queries, there is a new stack of media and container queries that set the `content` attribute on `.app-main` for easier querying from JavaScript.

Additionally with the larger, more flexibly sized right sidebar, even above the `xl_min` query, manually hiding the right sidebar allows the middle column to occupy the entire space--even without selecting the "Use full width on wide screens" setting. (This was an issue @gnprice [noted on CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/Right.20sidebar.20width/near/2070525).) The top navbar adjusts as well, keeping the righthand edge of the search box closer to the icons in the upper right. (See screenshots below).

**Update, 2025-02-14:** This PR now introduces a small little test to determine spec-aligned browser support for container queries. That allows us to deliver the benefits of em-aware container queries to browsers that support them, but fall back to the legacy media queries for browsers that do not. The nice thing here is that this test will begin to pass as soon as browsers become spec aligned (note that that is the case in the screenshots below for Safari Technology Preview, versus mainline Safari).

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/Right.20sidebar.20width/near/2006968)

A few design things to note:

* The `xl` and `md` values are derived from Bootstrap. This might be, or invite in the near future, an occasion to better express breakpoints that are bespoke to Zulip's layout. It would be easiest to make those determinations with the `font-size` set to 16px, as that is the value I've used to calculate the pixel-to-em conversions.
* Use of the responsive design mode in the web browser would be helpful here, as well as noting the font-size in play, when discussing remaining pain-points in the overall layout.

A few technical things to note and possibly discuss further here:

* I've added a new object literal, `container_breakpoints`, to `css_variables.ts`. I'm not at all certain that I'm referencing that optimally in `postcss.config.js`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Manually hiding the right sidebar when otherwise displayed (2025-02-21):_

| Before | After |
| --- | --- |
| ![1250-right-sidebar-showing-before](https://github.com/user-attachments/assets/5408f472-5219-406d-9c85-ef5f060b490b) | ![1250-right-sidebar-showing-after](https://github.com/user-attachments/assets/42a9587e-d1a5-41bd-80ac-5e0943a930ac) |
| ![1250-right-sidebar-hidden-before](https://github.com/user-attachments/assets/27c1941b-5306-48f2-b650-1b0d72ac1772) | ![1250-right-sidebar-hidden-after](https://github.com/user-attachments/assets/b526bff6-0419-4708-aea9-ee981ad3b75b) |


_With new spec-aligned container-query detection (2025-02-14), all showing a 20px font-size value:_

| Firefox, before | Firefox, after (spec aligned) |
| --- | --- |
| ![firefox-20px-before](https://github.com/user-attachments/assets/f06de64b-609c-4b07-b135-ad00de1d521d) | ![firefox-20px-after](https://github.com/user-attachments/assets/745f595c-dfa1-4e0a-85dc-f0bf760cb9e7) |

| Chrome, before | Chrome, after (spec aligned) |
| --- | --- |
| ![chrome-20px-before](https://github.com/user-attachments/assets/e67c4bba-774d-498e-ab0d-0e782871ded8) | ![chrome-20px-after](https://github.com/user-attachments/assets/e7d2a4e6-4238-4e91-b3f6-f5aabfec342d) |

| Mainline Safari, before | Mainline Safari, after (not spec aligned) |
| --- | --- |
| ![safari-20px-before](https://github.com/user-attachments/assets/fe440e9b-b632-4ed6-b895-d0e9ab17969e) | ![safari-20px-after](https://github.com/user-attachments/assets/d50b6b70-e06b-4566-b238-c0de9c3352ae) |

| Safari Technology Preview, before | Safari Technology Preview, after (spec aligned) |
| --- | --- |
| ![safari-technology-preview-20px-before](https://github.com/user-attachments/assets/b4364199-39c8-4157-8943-40edde8c9a47) | ![safari-technology-preview-20px-after](https://github.com/user-attachments/assets/89565dc1-e44e-4512-99bf-72339569e03a) |





_Previous screenshots:_

| App layout, before (16px @1470px wide viewport) | App layout, after (note wider right sidebar) |
| --- | --- |
| ![app-layout-before-16px-1470w](https://github.com/user-attachments/assets/9d056b9d-0569-4719-a45d-ccab6cc8b7c5) | ![app-layout-after-16px-1470w](https://github.com/user-attachments/assets/42f57f28-905e-44fb-ba14-cf0f2445b379) |

| 14px viewports (672px, 1199px) | 16px viewports |
| --- | --- |
| ![viewport-672-14px](https://github.com/user-attachments/assets/b970da27-323d-4c38-b020-399dc9803410) | ![viewport-672-16px](https://github.com/user-attachments/assets/eefdd683-2fd6-4395-a597-2653493a8d54) |
| ![viewport-1199-14px](https://github.com/user-attachments/assets/037e7609-3910-4d8b-8231-14493ae92cfd) | ![viewport-1199-16px](https://github.com/user-attachments/assets/b3a3f210-868d-4059-8741-3b440e7a1d7a) |

_Layouts now shift at different viewport sizes, as expected:_

| 14px/672px viewport | 16px/768px viewport | 20px/920px viewport |
| --- | --- | --- |
| ![viewport-comporison-672-14px](https://github.com/user-attachments/assets/80fbbd9a-1ac5-4d0b-bd9a-7340d9cdd4da) | ![viewport-comparison-768-16px](https://github.com/user-attachments/assets/abc9e003-f42f-4337-a470-535e8fd3b847) | ![viewport-comparison-920-20px](https://github.com/user-attachments/assets/a519f1e1-40ba-4a46-9fa2-fd31063fffe7) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>