### PR TITLE
typeahead: Prioritize exact matches over fuzzy matches.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -647,8 +647,6 @@ export function get_person_suggestions(
     query: string,
     opts: PersonSuggestionOpts,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
-    query = typeahead.clean_query_lowercase(query);
-
     function filter_persons(all_persons: User[]): UserOrMentionPillData[] {
         let persons;
 

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -254,9 +254,11 @@ export function compare_by_pms(user_a: User, user_b: User): number {
 
     // We use alpha sort as a tiebreaker, which might be helpful for
     // new users.
-    if (user_a.full_name < user_b.full_name) {
+    const a_name_without_diacritics = typeahead.remove_diacritics(user_a.full_name);
+    const b_name_without_diacritics = typeahead.remove_diacritics(user_b.full_name);
+    if (a_name_without_diacritics < b_name_without_diacritics) {
         return -1;
-    } else if (user_a === user_b) {
+    } else if (a_name_without_diacritics === b_name_without_diacritics) {
         return 0;
     }
     return 1;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR prioritizes exact matching over fuzzy matching in the typeahead and addresses issues related to filtering letters with diacritics.

Changes and Justifications:

- Previously, in the compose box typeahead, typing `Ą` did not return any names containing `Ą.` This issue has been fixed using the `normalize_for_exact_match` function.
- When a user types `A`, results will also include matches with diacritics. This design choice ensures that users who may not know how to type Polish letters or other diacritic characters can still find relevant results. This approach is supported by @timabbott, as discussed in the [CZO thread](https://chat.zulip.org/#narrow/channel/2-general/topic/.E2.9C.94.20Support.20for.20letters.20with.20diacritics/near/1995735).
- In the current system when a small letter is typed its gives priority to capitalized letters first and my PR does not change that even with diacritics. 
- Sorting is done in a way that `a` and `ą` are grouped together and then it sorts the name by removing the diacritics and then sorting it normally how strings are sorted (according to prefix). 

Fixes: #32634 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0d4a23f8-c865-49b4-9b23-03a1684bbf0d" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/26087cab-524d-4830-b278-0bcf9d4f5796" width="400"></td>
  </tr>
</table>


https://github.com/user-attachments/assets/d00e0417-fff9-4e22-94c1-bea80d2856fe


**Additional Screenshots after the feedback:**

with `Ą`
![Screenshot from 2025-02-26 21-11-42](https://github.com/user-attachments/assets/42ead563-3236-459e-906e-759af5c5adf4)
with `ą`
![Screenshot from 2025-02-26 21-46-03](https://github.com/user-attachments/assets/87b48999-8097-47c2-9091-9976d3886be6)
with `A`
![Screenshot from 2025-02-26 21-12-15](https://github.com/user-attachments/assets/87da9310-7596-47e8-8db3-bcfa5704ff40)
with `a`
![Screenshot from 2025-02-26 21-44-51](https://github.com/user-attachments/assets/09e5da10-4cc5-4c2d-b730-379f999de78a)







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

