### PR TITLE
right_sidebar: Ensure opaque userlist header.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -467,11 +467,12 @@
     grid-template-rows: var(--line-height-sidebar-row-prominent);
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    margin-bottom: 10px;
-    margin-left: var(--right-sidebar-heading-left-spacing);
+    padding-bottom: 10px;
+    padding-left: var(--right-sidebar-heading-left-spacing);
     /* The scrollbar doesn't extend this high, but we want the three-dot
        menus to line up. */
-    margin-right: var(--width-simplebar-scroll-hover);
+    padding-right: var(--width-simplebar-scroll-hover);
+    background-color: var(--color-background);
 
     #userlist-header-search {
         display: grid;


### PR DESCRIPTION
These fixes replace `margin` with `padding`, and replicate the `--background-color` variable on the userlist header, so as to stave off an edge case where margin offsets might allow usernames from the user list to bleed through. (Note that the subsections were other possible culprits, but they are already offset by padding and have `--background-color` set on the `.buddy-list-subsection-header` selector.)

Though I was unable to replicate [the original issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFusers.20peeking.20through.20above.20heading/near/1989366), including in the desktop app on an external monitor, this fix seems likely to correct the problem.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFusers.20peeking.20through.20above.20heading/near/1989366)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no visible change) |
| --- | --- |
| ![userlist-header-before](https://github.com/user-attachments/assets/10744754-6af1-4bd6-842d-9c67a599033c) | ![userlist-header-after](https://github.com/user-attachments/assets/432549d4-969c-490f-9c22-29d196ae1cc4) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>