### PR TITLE
channels: Auto-mark channel archival event messages as read.

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -143,6 +143,7 @@ def do_deactivate_stream(stream: Stream, *, acting_user: UserProfile | None) -> 
             topic_name=str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
             content=_("Channel {channel_name} has been archived.").format(channel_name=stream.name),
             archived_channel_notice=True,
+            limit_unread_user_ids=set(),
         )
 
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1621,7 +1621,7 @@ class StreamAdminTest(ZulipTestCase):
             {hamlet.id, polonius.id}, subscriber_ids_with_stream_history_access(stream4)
         )
 
-    def test_deactivate_stream_backend(self) -> None:
+    def test_deactivate_stream_as_realm_admin(self) -> None:
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         stream = self.make_stream("new_stream_1")
@@ -1639,7 +1639,11 @@ class StreamAdminTest(ZulipTestCase):
         )
         self.assertTrue(subscription_exists)
 
-        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
+    def test_deactivate_stream_via_user_group_permissions(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        stream = self.make_stream("new_stream_1")
+        self.subscribe(user_profile, stream.name)
         user_profile_group = check_add_user_group(
             user_profile.realm, "user_profile_group", [user_profile], acting_user=user_profile
         )


### PR DESCRIPTION
Previously, channel archival unread messages in archived channels could still be accessed from the inbox view.
This commit fixes this issue by auto-marking the channel archival event message as read.


Fixes: #33258.

**Screenshots and screen captures:**
| Before                                                                                      | After                                                                                       |
|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
| ![before](https://github.com/user-attachments/assets/a0c94270-c6bc-4f36-91f3-8765aea91012) | ![after](https://github.com/user-attachments/assets/8d6a0a76-6b93-438d-adcc-bc9c574ad326) |


Screen Recording: [Link](https://github.com/user-attachments/assets/ed97f0b6-1734-4f40-87b8-3681d73fb9ba)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
