### PR TITLE
modal: Scale width with app font size.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -24,7 +24,7 @@
     background-color: var(--color-background-modal);
     max-width: calc(100% - 32px);
     max-height: 96%;
-    width: 32.5rem;
+    width: 37.1428em; /* 520px at 14px em */
     border-radius: 4px;
     box-sizing: border-box;
 }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -600,5 +600,5 @@
 }
 
 #topic-summary-modal {
-    width: 45rem;
+    width: 45em;
 }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -592,3 +592,13 @@
         }
     }
 }
+
+.dialog-widget-footer-minor-text {
+    font-size: smaller;
+    font-style: italic;
+    margin-right: auto;
+}
+
+#topic-summary-modal {
+    width: 45rem;
+}

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2047,13 +2047,3 @@ body:not(.hide-left-sidebar) {
 .empty-topic-display {
     font-style: italic;
 }
-
-.dialog-widget-footer-minor-text {
-    font-size: smaller;
-    font-style: italic;
-    margin-right: auto;
-}
-
-#topic-summary-modal {
-    width: 45rem;
-}


### PR DESCRIPTION
This will become more important with larger font sizes, which we're adding soon. The max-width will prevent the width from becoming too wide.

This affects several modals, but just showing the move message modal for an example of the changes (at 12px, 14px, 16px, 20px)

| before | after |
| ----- | -----|
| ![Screen Shot 2025-02-01 at 15 50 19](https://github.com/user-attachments/assets/f69448f3-72af-411d-87ac-8d2fdc22341d) | ![Screen Shot 2025-02-01 at 15 44 41](https://github.com/user-attachments/assets/d305a3b6-295b-4244-bd6a-b6400df6e185) |
| ![Screen Shot 2025-02-01 at 15 49 55](https://github.com/user-attachments/assets/fe82df37-1528-478a-b2ce-d07929e87ff6) | ![Screen Shot 2025-02-01 at 15 45 12](https://github.com/user-attachments/assets/efbdef99-d1e1-48e9-939b-2464653ebff2) |
| ![Screen Shot 2025-02-01 at 15 48 56](https://github.com/user-attachments/assets/2a1d24a7-4672-42b9-b061-8967e8c09653) | ![Screen Shot 2025-02-01 at 15 45 45](https://github.com/user-attachments/assets/9a0c9eb4-8450-4ce0-936a-7d86be8700b2)  |
| ![Screen Shot 2025-02-01 at 15 48 17](https://github.com/user-attachments/assets/d189a0a6-ede7-4bc7-8e5c-f33b2c9fd6e2) | ![Screen Shot 2025-02-01 at 15 46 38](https://github.com/user-attachments/assets/9815cc58-1587-4256-ad8d-2ea586d5ba1c) |