### PR TITLE
settings: Fix placement of remove date button.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -697,6 +697,14 @@ input[type="checkbox"] {
     }
 }
 
+.settings-profile-user-field.editable-date-field {
+    display: grid;
+    grid-template-areas: "datepicker close-button";
+    grid-template-columns: minmax(0, 1fr) 1.4285em; /* 20px at 14px em */
+    align-items: center;
+    width: 325px;
+}
+
 .control-label-disabled {
     color: hsl(0deg 0% 50%);
 }
@@ -1569,9 +1577,7 @@ label.preferences-radio-choice-label {
             opacity: 0.5;
             display: none;
             cursor: pointer;
-            position: relative;
-            top: 2px;
-            left: -20px;
+            grid-area: close-button;
 
             &:hover {
                 opacity: 1;
@@ -1580,6 +1586,10 @@ label.preferences-radio-choice-label {
 
         .datepicker {
             cursor: default;
+            padding-right: 1.4285em; /* 20px at 14px em */
+            /* full input width minus right padding and
+               6px left padding from .settings_text_input */
+            max-width: calc(325px - 1.4285em - 6px);
         }
 
         & input[disabled].datepicker {

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -5,7 +5,7 @@
     </span>
     <div class="alert-notification custom-field-status"></div>
     <div class="settings-profile-user-field-hint">{{ field.hint }}</div>
-    <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}} {{#unless editable_by_user}}not-editable-by-user-input-wrapper{{/unless}}">
+    <div class="settings-profile-user-field {{#if is_empty_required_field}}empty-required-field{{/if}} {{#unless editable_by_user}}not-editable-by-user-input-wrapper{{/unless}}{{#if (and is_date_field editable_by_user)}}editable-date-field{{/if}}">
         {{#if is_long_text_field}}
         <textarea id="id_custom_profile_field_input_{{ field.id }}" maxlength="500" class="custom_user_field_value settings_textarea" name="{{ field.id }}" {{#unless editable_by_user}}disabled{{/unless}}>{{ field_value.value }}</textarea>
         {{else if is_select_field}}
@@ -22,7 +22,7 @@
         {{else if is_date_field }}
         <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" name="{{ field.id }}" data-field-id="{{ field.id }}" type="text"
           value="{{ field_value.value }}" {{#unless editable_by_user}}disabled{{/unless}}/>
-        {{#if editable_by_user}}<span class="remove_date"><i class="fa fa-close"></i></span>{{/if}}
+        {{#if editable_by_user}}<span class="remove_date"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></span>{{/if}}
         {{else if is_url_field }}
         <input id="id_custom_profile_field_input_{{ field.id }}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_url_input{{else}}settings_url_input{{/if}}" name="{{ field.id }}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" {{#unless editable_by_user}}disabled{{/unless}}/>
         {{else if is_pronouns_field}}


### PR DESCRIPTION
Ideally this isn't set with relative positioning, but I decided not to refactor that for now and just help what we already have not be buggy.

---

12px before and after

<img width="348" alt="image" src="https://github.com/user-attachments/assets/20776509-0be5-4ec6-bf9a-38a41bd0a72a" />
<img width="338" alt="image" src="https://github.com/user-attachments/assets/d280fccd-85c7-4206-889c-12bdaa41f309" />

14px before and after

<img width="361" alt="image" src="https://github.com/user-attachments/assets/6e0f7dc7-96f9-4760-8a01-3075e7356781" />
<img width="356" alt="image" src="https://github.com/user-attachments/assets/e6226c18-dff1-407d-bb1f-48fcb106634c" />



16px before and after

<img width="353" alt="image" src="https://github.com/user-attachments/assets/2115b7b9-d097-4953-86cc-3d644d447cd7" />
<img width="355" alt="image" src="https://github.com/user-attachments/assets/e4f8151c-f0c9-4d2b-9639-9f6eb8ffaffe" />


20px before and after

<img width="376" alt="image" src="https://github.com/user-attachments/assets/ddfc91c4-88ca-4cf8-bf96-db4594f3f440" />
<img width="358" alt="image" src="https://github.com/user-attachments/assets/b04cdba6-55ee-4b3c-9c3f-1e83b9ba574a" />
