### PR TITLE
api: Allow admins to update user status.

### DIFF
--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -90,6 +90,7 @@
 * [Reactivate a user](/api/reactivate-user)
 * [Get a user's status](/api/get-user-status)
 * [Update your status](/api/update-status)
+* [Update user status](/api/update-status-for-user)
 * [Set "typing" status](/api/set-typing-status)
 * [Set "typing" status for message editing](/api/set-typing-status-for-message-edit)
 * [Get a user's presence](/api/get-user-presence)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10476,6 +10476,152 @@ paths:
           $ref: "#/components/responses/SimpleSuccess"
 
   /users/{user_id}/status:
+    post:
+      operationId: update-status-for-user
+      summary: Update user status
+      tags: ["users"]
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      description: |
+        Administrator endpoint for changing the [status](/help/status-and-availability) of
+        another user.
+      x-requires-administrator: true
+      requestBody:
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                status_text:
+                  type: string
+                  description: |
+                    The text content of the status message. Sending the empty string
+                    will clear the user's status.
+
+                    **Note**: The limit on the size of the message is 60 characters.
+                  example: on vacation
+                emoji_name:
+                  type: string
+                  description: |
+                    The name for the emoji to associate with this status.
+
+                    **Changes**: New in Zulip 5.0 (feature level 86).
+                  example: car
+                emoji_code:
+                  type: string
+                  description: |
+                    A unique identifier, defining the specific emoji codepoint requested,
+                    within the namespace of the `reaction_type`.
+
+                    **Changes**: New in Zulip 5.0 (feature level 86).
+                  example: 1f697
+                reaction_type:
+                  type: string
+                  description: |
+                    A string indicating the type of emoji. Each emoji `reaction_type`
+                    has an independent namespace for values of `emoji_code`.
+
+                    Must be one of the following values:
+
+                    - `unicode_emoji` : In this namespace, `emoji_code` will be a
+                      dash-separated hex encoding of the sequence of Unicode codepoints
+                      that define this emoji in the Unicode specification.
+
+                    - `realm_emoji` : In this namespace, `emoji_code` will be the ID of
+                      the uploaded [custom emoji](/help/custom-emoji).
+
+                    - `zulip_extra_emoji` : These are special emoji included with Zulip.
+                      In this namespace, `emoji_code` will be the name of the emoji (e.g.
+                      "zulip").
+
+                    **Changes**: New in Zulip 5.0 (feature level 86).
+                  example: unicode_emoji
+            encoding:
+              away:
+                contentType: application/json
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Insufficient permission",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response user making request does not have permission to update other user's status.:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Client did not pass any new values.",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response when no changes were requested:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "status_text is too long (limit: 60 characters)",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response when the
+                          `status_text` message exceeds the limit of
+                          60 characters:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Client must pass emoji_name if they pass either emoji_code or reaction_type.",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response when `emoji_name` is not specified
+                          but `emoji_code` or `reaction_type` is specified:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Emoji 'invalid' does not exist",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response when the emoji name does not exist:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Invalid emoji name.",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response when the emoji name is invalid:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "result": "error",
+                            "msg": "Invalid custom emoji.",
+                            "code": "BAD_REQUEST",
+                          }
+                        description: |
+                          An example JSON error response when the custom emoji is invalid:
     get:
       operationId: get-user-status
       summary: Get a user's status

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -104,6 +104,7 @@ from zerver.views.presence import (
     get_status_backend,
     get_statuses_for_realm,
     update_active_status_backend,
+    update_user_status_admin,
     update_user_status_backend,
 )
 from zerver.views.push_notifications import (
@@ -467,7 +468,7 @@ v1_api_and_json_patterns = [
     rest_path("users/<user_id_or_email>/presence", GET=get_presence_backend),
     rest_path("realm/presence", GET=get_statuses_for_realm),
     rest_path("users/me/status", POST=update_user_status_backend),
-    rest_path("users/<int:user_id>/status", GET=get_status_backend),
+    rest_path("users/<int:user_id>/status", POST=update_user_status_admin, GET=get_status_backend),
     # user_groups -> zerver.views.user_groups
     rest_path("user_groups", GET=get_user_groups),
     rest_path("user_groups/create", POST=add_user_group),


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR creates API new endpoint that allow admin to update the user status. It also contain the documentation and test case.
Fixes:  #33139 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
