### PR TITLE
banners: Explicitly reference container name in queries.

### DIFF
--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -71,7 +71,7 @@
     justify-content: center;
 }
 
-@container (width >= 44em) and (width < 63em) {
+@container banner (width >= 44em) and (width < 63em) {
     .navbar-alert-banner[data-process="desktop-notifications"] {
         grid-template: var(--banner-grid-template-rows-md) / var(
                 --banner-grid-template-columns-md
@@ -81,7 +81,7 @@
     }
 }
 
-@container (width < 44em) {
+@container banner (width < 44em) {
     .banner {
         grid-template: var(--banner-grid-template-rows-md) / var(
                 --banner-grid-template-columns-md
@@ -99,7 +99,7 @@
     }
 }
 
-@container (width < 25em) {
+@container banner (width < 25em) {
     .banner {
         grid-template-areas: var(--banner-grid-template-areas-sm);
     }


### PR DESCRIPTION
As I just noted in another PR that's using container queries, #32685, we should always be explicitly referencing the container name in `@container` queries. This adds `banner` to the three here (no others in the codebase yet exist, and we should keep it that way).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

