### PR TITLE
composebox_typeahead: Reduce Escape induced select calls in typeahead.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -245,7 +245,7 @@ export class Typeahead<ItemType extends string | object> {
     mouse_moved_since_typeahead = false;
     shown = false;
     // To trigger updater when Esc is pressed only during the stream topic typeahead in composebox.
-    escape_topic_completion = false;
+    select_on_escape_condition: () => boolean;
     openInputFieldOnKeyUp: (() => void) | undefined;
     closeInputFieldOnHide: (() => void) | undefined;
     helpOnEmptyStrings: boolean;
@@ -296,7 +296,7 @@ export class Typeahead<ItemType extends string | object> {
         // return a string to show in typeahead items or false.
         this.option_label = options.option_label ?? (() => false);
         this.stopAdvance = options.stopAdvance ?? false;
-        this.escape_topic_completion = options.escape_topic_completion ?? false;
+        this.select_on_escape_condition = options.select_on_escape_condition ?? (() => false);
         this.advanceKeys = options.advanceKeys ?? [];
         this.openInputFieldOnKeyUp = options.openInputFieldOnKeyUp;
         this.closeInputFieldOnHide = options.closeInputFieldOnHide;
@@ -754,9 +754,7 @@ export class Typeahead<ItemType extends string | object> {
                 break;
 
             case "Escape":
-                // TODO: escape_topic_completion should be scoped more narrowly.
-                // See https://github.com/zulip/zulip/pull/32217#discussion_r1934905517
-                if (this.escape_topic_completion) {
+                if (this.select_on_escape_condition()) {
                     this.select(e);
                 }
                 if (!this.shown) {
@@ -889,7 +887,7 @@ type TypeaheadOptions<ItemType> = {
     sorter: (items: ItemType[], query: string) => ItemType[];
     stopAdvance?: boolean;
     tabIsEnter?: boolean;
-    escape_topic_completion?: boolean;
+    select_on_escape_condition?: () => boolean;
     trigger_selection?: (event: JQuery.KeyDownEvent) => boolean;
     updater?: (
         item: ItemType,

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1095,21 +1095,6 @@ export function content_typeahead_selected(
         };
     }
 
-    // We only want to consider escape key for the stream+topic typeahead completion case.
-    if (event?.key === "Escape" && item.type !== "topic_list") {
-        setTimeout(() => {
-            // Select any placeholder text configured to be highlighted.
-            if (highlight.start && highlight.end) {
-                $textbox.range(highlight.start, highlight.end);
-            } else {
-                $textbox.caret(beginning.length);
-            }
-            // Also, trigger autosize to check if compose box needs to be resized.
-            compose_ui.autosize_textarea($textbox);
-        }, 0);
-        return beginning + rest;
-    }
-
     switch (item.type) {
         case "emoji":
             // leading and trailing spaces are required for emoji,
@@ -1386,7 +1371,7 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
             },
             updater: content_typeahead_selected,
             stopAdvance: true, // Do not advance to the next field on a Tab or Enter
-            escape_topic_completion: true,
+            select_on_escape_condition: () => completing === "topic_list",
             automated: compose_automated_selection,
             option_label(_matching_items, item): string | false {
                 if (item.type === "topic_list" && item.is_channel_link) {


### PR DESCRIPTION
Fixes : https://github.com/zulip/zulip/pull/32217#discussion_r1934905517.