### PR TITLE
compose: Add notice to confirmation banner.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -368,7 +368,11 @@ function schedule_message_to_custom_date() {
         clear_compose_box();
         const new_row_html = render_success_message_scheduled_banner({
             scheduled_message_id: data.scheduled_message_id,
+            minimum_scheduled_message_delay_minutes:
+                scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60,
             deliver_at,
+            minimum_scheduled_message_delay_minutes_note:
+                scheduled_messages.show_minimum_scheduled_message_delay_minutes_note,
         });
         compose_banner.clear_message_sent_banners();
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);

--- a/web/src/compose_send_menu_popover.js
+++ b/web/src/compose_send_menu_popover.js
@@ -74,9 +74,20 @@ export function open_send_later_menu() {
                             current_time.getTime() +
                                 scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS * 1000,
                         ),
-                        onClose() {
+                        onClose(selectedDates, _dateStr, instance) {
                             // Return to normal state.
                             $send_later_modal_content.css("pointer-events", "all");
+                            const selected_date = selectedDates[0];
+
+                            if (selected_date && selected_date < instance.config.minDate) {
+                                scheduled_messages.set_minimum_scheduled_message_delay_minutes_note(
+                                    true,
+                                );
+                            } else {
+                                scheduled_messages.set_minimum_scheduled_message_delay_minutes_note(
+                                    false,
+                                );
+                            }
                         },
                     },
                 );

--- a/web/src/scheduled_messages.ts
+++ b/web/src/scheduled_messages.ts
@@ -23,6 +23,11 @@ export const scheduled_messages_data = new Map<number, ScheduledMessage>();
 
 let selected_send_later_timestamp: number | undefined;
 
+// show_minimum_scheduled_message_delay_minutes_note is a flag to show the user a note in the
+// confirmation banner if the message is scheduled for the minimal 5 minutes ahead time,
+// regardless of whether the user tried to schedule it for sooner or not.
+export let show_minimum_scheduled_message_delay_minutes_note = false;
+
 function compute_send_times(now = new Date()): Record<TimeKey, number> {
     const send_times: Record<string, number> = {};
 
@@ -214,4 +219,8 @@ export function reset_selected_schedule_timestamp(): void {
 
 export function initialize(scheduled_messages_params: StateData["scheduled_messages"]): void {
     add_scheduled_messages(scheduled_messages_params.scheduled_messages);
+}
+
+export function set_minimum_scheduled_message_delay_minutes_note(flag: boolean): void {
+    show_minimum_scheduled_message_delay_minutes_note = flag;
 }

--- a/web/templates/compose_banner/success_message_scheduled_banner.hbs
+++ b/web/templates/compose_banner/success_message_scheduled_banner.hbs
@@ -2,8 +2,12 @@
   class="main-view-banner success message_scheduled_success_compose_banner"
   data-scheduled-message-id="{{scheduled_message_id}}">
     <div class="main-view-banner-elements-wrapper">
-        <p class="banner_content">{{t 'Your message has been scheduled for {deliver_at}.' }}
-            <a href="#scheduled">{{t "View scheduled messages" }}</a>
+        <p class="banner_content">
+            {{#if minimum_scheduled_message_delay_minutes_note}}
+                {{t 'Messages must be scheduled at least {minimum_scheduled_message_delay_minutes} minutes in the future.'}}
+            {{/if}}
+            {{t 'Your message has been scheduled for {deliver_at}.'}}
+            <a href="#scheduled">{{t "View scheduled messages"}}</a>
         </p>
         <button class="main-view-banner-action-button undo_scheduled_message" >{{t "Undo"}}</button>
     </div>


### PR DESCRIPTION
This commit adds a note to the confirmation banner if the message is scheduled for the minimal 5 minutes ahead time,
regardless of whether the user tried to schedule it for sooner or not.

However this PR still doesn't solve the bug of that 1 minute delay that occurs in some cases as no reason for that lag has been identified yet.

Related [CZO Discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/Offset.20in.20scheduled.20messages).
If you don't want to read the entire thread, please read below mentioned messages as they are important to know about that 1 minute lag.
- [Message 1](https://chat.zulip.org/#narrow/channel/9-issues/topic/Offset.20in.20scheduled.20messages/near/2064263)
- [Message 2](https://chat.zulip.org/#narrow/channel/9-issues/topic/Offset.20in.20scheduled.20messages/near/2065994)

Co-authored-by:  @AnkurPrabhu 

<!-- Describe your pull request here.-->

Fixes: #28503.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/f9b66026-f7c8-4489-b49f-56eb791c84b5) | ![After](https://github.com/user-attachments/assets/51ae07f0-3027-44ad-8648-254c704479f5) |
| ![Before](https://github.com/user-attachments/assets/53300ae6-dbab-459c-94a8-47b7309d4bb5) | ![After](https://github.com/user-attachments/assets/4bc1b71c-34a3-4aa1-91f3-ec467dbfbfcd) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
