### PR TITLE
register_server: Add docs_url to HostnameAlreadyInUseBouncerError.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1532,8 +1532,9 @@ class PushNotificationsDisallowedByBouncerError(Exception):
 
 class HostnameAlreadyInUseBouncerError(JsonableError):
     code = ErrorCode.HOSTNAME_ALREADY_IN_USE_BOUNCER_ERROR
+    docs_url = "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#moving-your-registration-to-a-new-server"
 
-    data_fields = ["hostname"]
+    data_fields = ["hostname", "docs_url"]
 
     def __init__(self, hostname: str) -> None:
         self.hostname: str = hostname

--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -237,6 +237,7 @@ that registration and saving the updated secret in
                 "code" in content_dict
                 and content_dict["code"] == "HOSTNAME_ALREADY_IN_USE_BOUNCER_ERROR"
             ):
+                docs_url = content_dict["docs_url"]
                 print(
                     "--------------------------------\n"
                     "The hostname is already in use by another server. If you control the hostname \n"
@@ -246,7 +247,7 @@ that registration and saving the updated secret in
                     "\n"
                     "For more information, see: \n"
                     "\n"
-                    "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#moving-your-registration-to-a-new-server"
+                    f"{docs_url}"
                 )
                 raise CommandError
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -48,6 +48,7 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.push_notifications import (
     APNsContext,
     DeviceToken,
+    HostnameAlreadyInUseBouncerError,
     InvalidRemotePushDeviceTokenError,
     UserPushIdentityCompat,
     b64_to_hex,
@@ -5361,6 +5362,7 @@ class PushBouncerSignupTest(ZulipTestCase):
         result = self.client_post("/api/v1/remotes/server/register", request)
         self.assert_json_error(result, "A server with hostname example.com already exists")
         self.assertEqual(result.json()["code"], "HOSTNAME_ALREADY_IN_USE_BOUNCER_ERROR")
+        self.assertEqual(result.json()["docs_url"], HostnameAlreadyInUseBouncerError.docs_url)
 
     def test_register_contact_email_validation_rules(self) -> None:
         zulip_org_id = str(uuid.uuid4())


### PR DESCRIPTION
Remaining follow-up from https://github.com/zulip/zulip/pull/33233#discussion_r1936356290

This means that the URL is only hard-coded on the bouncer side. That's useful, because now we'll be able to change the URL and only need a bouncer deployment for users to get the new URL when they encounter HostnameAlreadyInUseBouncerError. As opposed to self-hosted servers being stuck with an outdated docs link hardcoded in their register_server.py.


