### PR TITLE
right-sidebar: Show orange/idle dot for personal presence.

### DIFF
--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -164,6 +164,24 @@ function do_update_users_for_search(): void {
 
 const update_users_for_search = _.throttle(do_update_users_for_search, 50);
 
+export function initialize_activity(): void {
+    $("html").on("mousemove", () => {
+        activity.set_new_user_input(true);
+    });
+
+    $(window).on("focus", () => {
+        activity.mark_client_active(redraw_user);
+    });
+    $(window).idle({
+        idle: activity.DEFAULT_IDLE_TIMEOUT_MS,
+        onIdle: activity.mark_client_idle,
+        onActive() {
+            activity.mark_client_active(redraw_user);
+        },
+        keepTracking: true,
+    });
+}
+
 export function initialize(opts: {narrow_by_email: (email: string) => void}): void {
     narrow_by_email = opts.narrow_by_email;
 

--- a/web/src/presence.ts
+++ b/web/src/presence.ts
@@ -69,8 +69,8 @@ const BIG_REALM_COUNT = 250;
 export function get_status(user_id: number): PresenceStatus["status"] {
     if (people.is_my_user_id(user_id)) {
         if (user_settings.presence_enabled) {
-            // if the current user is sharing presence, they always see themselves as online.
-            return "active";
+            // if the current user is sharing presence, and is not idle, they always see themselves as active.
+            return presence_info.get(user_id)?.status === "idle" ? "idle" : "active";
         }
         // if the current user is not sharing presence, they always see themselves as offline.
         return "offline";

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -639,7 +639,7 @@ export function initialize_everything(state_data) {
     about_zulip.initialize();
 
     initialize_unread_ui();
-    activity.initialize();
+    activity_ui.initialize_activity();
     activity.register_on_new_user_input_hook(() => {
         // Instead of marking new messages as read immediately when bottom
         // of feed is visible, we wait for user input to mark them as read.


### PR DESCRIPTION
This commit ensures that users see their own presence status as orange/idle when applicable matching what other users see. Previously, the system only updated offline status but did not reflect idle status correctly. This change improves consistency in presence indications reducing confusions.

Earlier, the user was seeing himself as active if he's sharing the presence. This commit adds one more condition to check if the user is idle or not. If the user is idle, it'll show idle, otherwise it'll show active.

Fixes: #18846

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot_20250201_035945](https://github.com/user-attachments/assets/980dfc32-208e-421a-b4b7-f9e150d4d8cd)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
