### PR TITLE
typehead: Fix the narrow edit box typehead dropdown.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -147,7 +147,7 @@
     }
 
     a strong.typeahead-strong-section {
-        white-space: pre;
+        white-space: normal;
         /* Present as flexbox to better control
            icon alignment and spacing, when icons
            are shown. */


### PR DESCRIPTION
Previously, we were unable to see the complete topic name in the typeahead dropdown if its length exceeded a certain limit. Now, we wrap the text to the next line so that the entire topic name is visible.

## Before

![image](https://github.com/user-attachments/assets/03f92fbb-483a-4175-8a49-d26a70f97c08)

## After

<details>
<summary>Providing screenshot for various possible dimensions</summary>

![image](https://github.com/user-attachments/assets/41e3597a-e07a-499e-8df8-8a04839eff40)


![image](https://github.com/user-attachments/assets/377fa086-2cc3-482e-a29b-f383e0b94ed7)


![image](https://github.com/user-attachments/assets/35a843c0-ecf3-4615-9d8d-88ea74ad8472)


![image](https://github.com/user-attachments/assets/adc5e918-28c3-4f14-a986-bf9abd4bcc91)


![image](https://github.com/user-attachments/assets/343fc34d-85b3-4738-a618-f8a27262b23f)


</details>

Design Discussion: [CZO Thread](https://chat.zulip.org/#narrow/channel/101-design/topic/long.20topics.20in.20typeahead/with/2079333)


Fixes: #33288

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
