### PR TITLE
Corrected a missing word in this sentence for clarity.

### DIFF
--- a/docs/outreach/mentoring.md
+++ b/docs/outreach/mentoring.md
@@ -116,7 +116,7 @@ administrators as early as possible. Situations you should bring up include:
 - Any significant questions or concerns raised by your mentee that you cannot
   resolve, which for some reason your mentee cannot raise directly.
 
-- If it turns out that cannot dedicate sufficient time to support your mentee
+- If it turns out that you cannot dedicate sufficient time to support your mentee
   for all or part of the remaining duration of the program. As long as Zulip's
   program administrators are informed, we can make sure someone else covers for
   you.


### PR DESCRIPTION
While reading the documentation, I noticed that the word 'you' had been omitted from a sentence. This causes the sentence to be unclear and grammatically incorrect. I have manually edited in the word to improve the documentation. 