### PR TITLE
subscriptions: Update layout to use inline-flex for improved alignment

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -383,7 +383,8 @@ h4.user_group_setting_subsection_title {
     .left,
     .right {
         position: relative;
-        display: inline-block;
+        display: inline-flex;
+        flex-direction: column;
         vertical-align: top;
         width: 50%;
         height: calc(100% - 45px);
@@ -1305,11 +1306,11 @@ div.settings-radio-input-parent {
     #subscription_overlay .right,
     #settings_page .content-wrapper.right {
         position: absolute;
-        display: block;
+        display: inline-flex;
+        flex-direction: column;
         margin: 0;
         width: 100%;
         height: calc(100% - 45px);
-
         border: none;
     }
 


### PR DESCRIPTION
## Description

This pull request addresses https://github.com/zulip/zulip/issues/29514 by:

- Updating the subscription layout to use inline-flex for better alignment.
- Refactoring the flex container and its children so that the entire list (including the last row) is visible across all breakpoints.

### Testing
- Verified that the subscription list now displays all rows correctly on large, medium, and small screens.
- Confirmed that the updated inline-flex layout maintains proper alignment and spacing in the subscription view.
- Ensured that no other UI components are adversely affected by these CSS changes.

## Before and After Comparison

| Area                           | Before                                                                                   | After                                                                                    |
|--------------------------------|------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
| Channels list (Large)      | ![Screenshot 2025-02-02 020118](https://github.com/user-attachments/assets/aa1574ec-19d1-4586-92c0-3eb27a639cca) | ![Screenshot 2025-02-02 020140](https://github.com/user-attachments/assets/9ed4e8aa-67eb-41fe-ad0b-5e159d754f82) |
| Channels List (Medium)     | ![Screenshot 2025-02-02 015922](https://github.com/user-attachments/assets/ddd553ae-0abf-4771-b673-46de46901097)  | ![Screenshot 2025-02-02 020025](https://github.com/user-attachments/assets/9b44f593-060b-48ef-be58-55fa58a6152b) |
| Channels List (Small)      | ![Screenshot 2025-02-02 015934](https://github.com/user-attachments/assets/6ee00243-25db-44ac-97f1-2e74007e9bd7) | ![Screenshot 2025-02-02 020012](https://github.com/user-attachments/assets/ae29edd1-fb36-47bc-ba06-6b3ebaa934ac) |

## Fixes
Closes https://github.com/zulip/zulip/issues/29514
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
