### PR TITLE
user_profile: Use em to scale height of name heading with font size.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -93,7 +93,7 @@
     align-items: center;
     gap: 10px;
     /* This line-height is to increase the vertical clickable areas on the icons. */
-    line-height: 28px;
+    line-height: 1.2727em; /* 28px at 22px font-size at 14px em */
 
     .user-profile-name {
         white-space: nowrap;


### PR DESCRIPTION
This fixes a bug with names with descenders at large font sizes.

Screenshots before and after at 12px, 14px, 16px, 20px. Note how King Hamlet was cut off on the bottom before this change.

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-01 at 16 53 19](https://github.com/user-attachments/assets/1a30f2a6-a3e4-41a1-bdec-77f4354390e8) | ![Screen Shot 2025-02-01 at 16 59 55](https://github.com/user-attachments/assets/3a0c292e-07de-4c14-9cdd-c1e19864743c) |
| ![Screen Shot 2025-02-01 at 16 53 04](https://github.com/user-attachments/assets/f7500258-74d6-4ce7-8fa0-71ee20ec47ea) | ![Screen Shot 2025-02-01 at 16 57 46](https://github.com/user-attachments/assets/76c7c9d1-1e17-43cb-aac7-4684004f0d26) |
| ![Screen Shot 2025-02-01 at 16 52 52](https://github.com/user-attachments/assets/351bbf35-55a6-4092-acd9-285ace580ef1) | ![Screen Shot 2025-02-01 at 16 59 09](https://github.com/user-attachments/assets/8a1c9d79-b04e-42e5-b46a-89538c5fd119) |
| ![Screen Shot 2025-02-01 at 16 52 38](https://github.com/user-attachments/assets/c1714e8c-df47-4392-aff0-0d0bccd8b025) | ![Screen Shot 2025-02-01 at 16 59 32](https://github.com/user-attachments/assets/77271817-609e-4d39-87e3-1f5ac6035c1e) |
