### PR TITLE
modals: Standardize width and height of input and dropdowns.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1159,6 +1159,7 @@ input.settings_text_input {
     justify-content: space-between;
     outline: none;
     color: var(--color-text-default);
+    width: 206px;
 
     &:disabled {
         cursor: not-allowed;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -539,6 +539,7 @@
     --subscriptions-overlay-sticky-footer-height: 60px;
     /* Informational overlay */
     --informational-overlay-max-width: 43.75em;
+    --modal-input-width: 23.2142em;
 
     /*
     Maximum height of the compose box when it is not in maximised state. This

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -403,7 +403,7 @@
 
 .modal_select {
     height: 30px;
-    width: 220px;
+    width: var(--modal-input-width);
     padding: 0 25px 0 6px;
     color: hsl(0deg 0% 33%);
     border-radius: 4px;
@@ -429,6 +429,14 @@
     width: fit-content;
 }
 
+.modal__body,
+.overlay-content {
+    .dropdown-widget-button,
+    .dropdown_widget_with_label_wrapper {
+        width: var(--modal-input-width);
+    }
+}
+
 .modal_password_input,
 .modal_url_input,
 .modal_text_input {
@@ -441,7 +449,8 @@
         border-color linear 0.2s,
         box-shadow linear 0.2s;
     margin-bottom: 10px;
-    width: 206px;
+    /* subtract padding (6px each side) and border (1px each side) */
+    width: calc(var(--modal-input-width) - 14px);
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);
@@ -450,6 +459,12 @@
             inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
+}
+
+#create_bot_short_name {
+    /* A shorter dropdown width (~200px at 14px em)
+       to ensure the email all fits on one line. */
+    width: 14em;
 }
 
 #add-poll-modal {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -429,10 +429,6 @@
     width: fit-content;
 }
 
-.dropdown-widget-button {
-    width: 206px;
-}
-
 .modal_password_input,
 .modal_url_input,
 .modal_text_input {

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -402,9 +402,8 @@
 }
 
 .modal_select {
-    height: 30px;
     width: var(--modal-input-width);
-    padding: 0 25px 0 6px;
+    padding: 4px 25px 4px 6px;
     color: hsl(0deg 0% 33%);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -283,13 +283,20 @@ h3,
 
     .settings_select {
         height: 30px;
-        min-width: 325px;
+        width: var(--modal-input-width);
         max-width: 100%;
     }
 
     .account-settings-heading {
         margin-right: 10px;
     }
+}
+
+/* Make this one less wide because it's indented, so that the right
+   edge lines up with other dropdown menus. Usual 33px plus 23px extra
+   margin. */
+#id_realm_jitsi_server_url {
+    width: calc(var(--modal-input-width) - 33px - 23px);
 }
 
 /* list_select is similar to settings_select, but without the height styling. */
@@ -360,20 +367,19 @@ select.settings_select {
     /* Preserve the effective space allotted
        inside the input group.
 
-       Select element: 325px
+       Select element: --modal-input-width
        Button element: ~29px
-       Right margin:     4px
-       TOTAL           358px */
-    max-width: 358px;
+       Right margin:     4px */
+    max-width: calc(var(--modal-input-width) + 29px + 4px);
 
     .settings_select {
-        /* Hold the settings select to its usual 325px;
+        /* Hold the settings select to its usual value;
            a TODO would be to fix up the min- and max-
            width values on the parent class, as the
            min-width always applies, and max-width: 100%
            has no meaning without an actual width:
            declaration. */
-        max-width: 325px;
+        max-width: var(--modal-input-width);
         /* Disregard the min-width from the main
            .settings_select selector. */
         min-width: 0;
@@ -673,11 +679,13 @@ input[type="checkbox"] {
     }
 
     .person_picker {
-        min-width: 319px;
+        /* Subtract 2 * (2px padding) + 2 * (1px border) */
+        min-width: calc(var(--modal-input-width) - 6px);
     }
 
     & textarea {
-        width: 311px;
+        /* Subtract 6px of padding from side */
+        width: calc(var(--modal-input-width) - 12px);
     }
 }
 
@@ -699,7 +707,7 @@ input[type="checkbox"] {
     grid-template-areas: "datepicker close-button";
     grid-template-columns: minmax(0, 1fr) 1.4285em; /* 20px at 14px em */
     align-items: center;
-    width: 325px;
+    width: var(--modal-input-width);
 }
 
 .control-label-disabled {
@@ -816,8 +824,6 @@ input[type="checkbox"] {
 
 #organization-permissions {
     .dropdown-widget-button {
-        min-width: 325px;
-        width: auto;
         color: hsl(0deg 0% 33%);
     }
 }
@@ -829,9 +835,8 @@ input[type="checkbox"] {
 }
 
 .org-permissions-form .pill-container {
-    /* 319px + 2 * (2px padding) + 2 * (1px border) = 325px, which is the total
-    width of dropdown widget buttons */
-    min-width: 319px;
+    /* Subtract 2 * (2px padding) + 2 * (1px border) */
+    min-width: calc(var(--modal-input-width) - 6px);
     background-color: hsl(0deg 0% 100%);
 
     .input {
@@ -1506,7 +1511,7 @@ label.preferences-radio-choice-label {
     }
 
     .preferences-settings-form select {
-        width: 245px;
+        width: var(--modal-input-width);
     }
 }
 
@@ -1566,8 +1571,9 @@ label.preferences-radio-choice-label {
             cursor: default;
             padding-right: 1.4285em; /* 20px at 14px em */
             /* full input width minus right padding and
-               6px left padding from .settings_text_input */
-            max-width: calc(325px - 1.4285em - 6px);
+               6px left padding from .settings_text_input
+               and 1px border on each side */
+            max-width: calc(var(--modal-input-width) - 1.4285em - 8px);
         }
 
         & input[disabled].datepicker {
@@ -1589,12 +1595,13 @@ label.preferences-radio-choice-label {
 
 #edit-user-form {
     .person_picker {
-        min-width: 206px;
+        /* Subtract (1px border and 2px of padding) on each side */
+        min-width: calc(var(--modal-input-width) - 6px);
     }
 
     & textarea {
-        width: max(206px, 25vw);
-        max-width: 320px;
+        /* Subtract (1px border and 6px padding) on each side */
+        width: calc(var(--modal-input-width) - 14px);
     }
 }
 
@@ -2140,9 +2147,8 @@ label.preferences-radio-choice-label {
         box-shadow linear 0.2s;
     margin-bottom: 10px;
 
-    /* 311px + 2 * 6px (padding) + 2 * 1px (border) = 325px (min width of select
-    elements in settings) */
-    width: 311px;
+    /* Subtract 2 * 6px (padding) + 2 * 1px (border) */
+    width: calc(var(--modal-input-width) - 14px);
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -281,10 +281,20 @@ h3,
         color: var(--color-realm-enable-spectator-access-link);
     }
 
+    /* The height and width of this should match input fields in settings
+       menu. We try to keep the padding and height the same, and both without
+       border-box box-sizing.
+
+       These styles should be kept in sync with the styles for .settings_select
+       in subscriptions.css */
     .settings_select {
-        height: 30px;
-        width: var(--modal-input-width);
+        box-sizing: unset;
+        /* Subtract 1px border on each side and 25+6 padding */
+        width: calc(var(--modal-input-width) - 33px);
         max-width: 100%;
+        padding-top: 4px;
+        padding-bottom: 4px;
+        height: 1.4em; /* To match height of input elements */
     }
 
     .account-settings-heading {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1265,10 +1265,14 @@ div.settings-radio-input-parent {
     }
 
     .settings_select {
-        /* Match with select elements in settings page */
-        min-width: var(--modal-input-width);
+        /* Match with select elements in settings page. See there
+           for comments about these values. */
+        box-sizing: unset;
+        width: calc(var(--modal-input-width) - 33px);
         max-width: 100%;
-        height: 30px;
+        padding-top: 4px;
+        padding-bottom: 4px;
+        height: 1.4em;
     }
 
     .dropdown-widget-button {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1266,7 +1266,7 @@ div.settings-radio-input-parent {
 
     .settings_select {
         /* Match with select elements in settings page */
-        min-width: 325px;
+        min-width: var(--modal-input-width);
         max-width: 100%;
         height: 30px;
     }
@@ -1274,7 +1274,7 @@ div.settings-radio-input-parent {
     .dropdown-widget-button {
         /* Match the margin with other input groups around. */
         margin-bottom: 20px;
-        min-width: 325px;
+        min-width: var(--modal-input-width);
         max-width: 100%;
         width: auto;
         height: 30px;
@@ -1292,9 +1292,8 @@ div.settings-radio-input-parent {
 
 .group-permissions .pill-container,
 .stream-permissions .pill-container {
-    /* 319px + 2 * (2px padding) + 2 * (1px border) = 325px, which is the total
-    width of dropdown widget buttons */
-    min-width: 319px;
+    /* Subtract 2 * (2px padding) + 2 * (1px border) */
+    min-width: calc(var(--modal-input-width) - 6px);
     background-color: hsl(0deg 0% 100%);
 
     .input {


### PR DESCRIPTION
This covers a lot of ground and applies to every modal in the app with inputs or dropdowns (which is many of them). It seems like too much to take screenshots of every modal screen at 4 font-sizes before and after, but I do think it would be good to do thorough manual testing. Maybe Alya you can let me know which screenshots would be helpful for you?

Modals I've looked at:
* Personal settings, all tabs
   * "Add bot" modal
   * "Add a new alert word" modal
* Org settings
   * "Add a new emoji"
   * Manage User
   * Manage bot 
   * Add a new custom profile field
   * Add default channels
* Create a channel
* Move messages
* Polls
* User group settings
* Invite Users

Things I want to change:
* [x] Add bot modal needs narrower inputs, even with #33270, or the email will wrap

Things of note:

(1) I made the jitsi indented dropdown less wide to line up on the right. Let me know if you'd prefer it extend further to the right. (Screenshot at 20px)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/42f7a3cc-9539-4fe1-b243-df9743ea989a" />

(2) There are two different kinds of dropdowns with different sized arrows. I didn't try to change that in this PR, but that would be a good followup at some point (or we could wait for a modal redesign)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/504075b6-c5b9-4138-9699-833c1e955bcc" />

(3) Channel create modal has had a longer input field for the channel description (same for creating user groups) and I left it like that for now. Happy to make it narrower if that's preferred.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7ed07dac-d536-4f32-ae60-b756a868c066" />

(4) I kept the channel more narrow in the move messages modal as it was before, but I can extend it to match widths if that's preferred.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2be44360-c980-4129-b168-043b4700fe1e" />

(5) Invite Users also has some input fields that are longer

<img width="400" alt="image" src="https://github.com/user-attachments/assets/67f9d7b3-f083-403a-a63a-3bbd25f8836e" />
