### PR TITLE
message_viewport: Fix msg selection not updated on scroll.

### DIFF
--- a/web/src/message_viewport.ts
+++ b/web/src/message_viewport.ts
@@ -153,6 +153,16 @@ export function set_message_position(
 
     const new_scroll_top = message_top - message_offset;
 
+    // Ensure we will scroll before we disable updating selection.
+    // This avoids a bug where message selection doesn't change on user scroll.
+    if (
+        // Can't scroll up if we are already at top.
+        (new_scroll_top <= 0 && window.scrollY === 0) ||
+        // Can't scroll down if we are already at bottom.
+        (new_scroll_top >= height() && window.scrollY === height())
+    ) {
+        return;
+    }
     message_scroll_state.set_update_selection_on_next_scroll(false);
     scrollTop(new_scroll_top);
 }


### PR DESCRIPTION
Reproducer:
* Mark all messages in a topic as unread.
* Go to recent view.
* Click on topic.
* Scroll
* Message selection is not updated.

To fix this, we don't disable updating message selection unless we are sure we are going to trigger a scroll event.

Tested using the avove reproducer.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Message.20selection.20not.20updated.20on.20scroll