### PR TITLE
requirements: Upgrade asgiref

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -28,3 +28,4 @@ couldn
 ges
 assertIn
 thirdparty
+asend

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -7,7 +7,7 @@
 
 # Django itself
 Django[argon2]==5.0.*
-asgiref<3.8.0  # Breaks with https://github.com/django/asgiref/pull/367
+https://github.com/andersk/asgiref/archive/8a2717c14bce1b8dd37371c675ee3728e66c3fe3.zip#egg=asgiref==3.8.1+git  # https://github.com/django/asgiref/pull/494
 
 # needed for NotRequired, ParamSpec
 typing-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -155,9 +155,8 @@ arrow==1.3.0 \
     --hash=sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80 \
     --hash=sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85
     # via gitlint-core
-asgiref==3.7.2 \
-    --hash=sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e \
-    --hash=sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed
+https://github.com/andersk/asgiref/archive/8a2717c14bce1b8dd37371c675ee3728e66c3fe3.zip#egg=asgiref==3.8.1+git \
+    --hash=sha256:cf6ca7018a0f71c116ddde28c1c68bbfefeb4abdef4e56458811348ae9c10c9b
     # via
     #   -r requirements/common.in
     #   django

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -146,9 +146,8 @@ argon2-cffi-bindings==21.2.0 \
     --hash=sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e \
     --hash=sha256:f9f8b450ed0547e3d473fdc8612083fd08dd2120d6ac8f73828df9b7d45bb351
     # via argon2-cffi
-asgiref==3.7.2 \
-    --hash=sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e \
-    --hash=sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed
+https://github.com/andersk/asgiref/archive/8a2717c14bce1b8dd37371c675ee3728e66c3fe3.zip#egg=asgiref==3.8.1+git \
+    --hash=sha256:cf6ca7018a0f71c116ddde28c1c68bbfefeb4abdef4e56458811348ae9c10c9b
     # via
     #   -r requirements/common.in
     #   django

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 352  # Last bumped for can_mention_many_users_group.
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (311, 0)  # bumped 2024-01-29 to upgrade JavaScript dependencies
+PROVISION_VERSION = (312, 0)  # bumped 2024-02-14 to upgrade asgiref

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -1,14 +1,13 @@
 import asyncio
 import socket
-from collections.abc import Awaitable, Callable, Iterator
-from contextlib import contextmanager
-from functools import wraps
+from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, TypeVar
-from unittest import TestResult, mock
+from unittest import mock
 from urllib.parse import urlencode
 
 import orjson
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core import signals
 from django.db import close_old_connections
@@ -16,7 +15,7 @@ from django.test import override_settings
 from tornado import netutil
 from tornado.httpclient import AsyncHTTPClient, HTTPResponse
 from tornado.httpserver import HTTPServer
-from typing_extensions import ParamSpec, override
+from typing_extensions import override
 
 from zerver.lib.cache import user_profile_narrow_by_id_cache_key
 from zerver.lib.test_classes import ZulipTestCase
@@ -26,16 +25,7 @@ from zerver.tornado import event_queue
 from zerver.tornado.application import create_tornado_application
 from zerver.tornado.event_queue import process_event
 
-P = ParamSpec("P")
 T = TypeVar("T")
-
-
-def async_to_sync_decorator(f: Callable[P, Awaitable[T]]) -> Callable[P, T]:
-    @wraps(f)
-    def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-        return async_to_sync(f)(*args, **kwargs)
-
-    return wrapped
 
 
 async def in_django_thread(f: Callable[[], T]) -> T:
@@ -43,9 +33,8 @@ async def in_django_thread(f: Callable[[], T]) -> T:
 
 
 class TornadoWebTestCase(ZulipTestCase):
-    @async_to_sync_decorator
-    @override
-    async def setUp(self) -> None:
+    @asynccontextmanager
+    async def with_tornado(self) -> AsyncIterator[None]:
         super().setUp()
 
         with override_settings(DEBUG=False):
@@ -57,19 +46,15 @@ class TornadoWebTestCase(ZulipTestCase):
         signals.request_started.disconnect(close_old_connections)
         signals.request_finished.disconnect(close_old_connections)
         self.session_cookie: dict[str, str] | None = None
-
-    @async_to_sync_decorator
-    @override
-    async def tearDown(self) -> None:
-        self.http_client.close()
-        self.http_server.stop()
-        super().tearDown()
-
-    @override
-    def run(self, result: TestResult | None = None) -> TestResult | None:
-        return async_to_sync(
-            sync_to_async(super().run, thread_sensitive=False), force_new_loop=True
-        )(result)
+        try:
+            yield
+        finally:
+            self.http_client.close()
+            self.http_server.stop()
+            await self.http_server.close_all_connections()
+            tasks = set(asyncio.all_tasks()) - {asyncio.current_task()}
+            if tasks:
+                await asyncio.wait(tasks)
 
     async def fetch_async(self, method: str, path: str, **kwargs: Any) -> HTTPResponse:
         self.add_session_cookie(kwargs)
@@ -109,11 +94,11 @@ class TornadoWebTestCase(ZulipTestCase):
 
 
 class EventsTestCase(TornadoWebTestCase):
-    @async_to_sync_decorator
     async def test_create_queue(self) -> None:
-        await in_django_thread(lambda: self.login_user(self.example_user("hamlet")))
-        queue_id = await self.create_queue()
-        self.assertIn(queue_id, event_queue.clients)
+        async with self.with_tornado():
+            await in_django_thread(lambda: self.login_user(self.example_user("hamlet")))
+            queue_id = await self.create_queue()
+            self.assertIn(queue_id, event_queue.clients)
 
     @contextmanager
     def mocked_events(self, user_profile: UserProfile, event: dict[str, object]) -> Iterator[None]:
@@ -129,85 +114,87 @@ class EventsTestCase(TornadoWebTestCase):
         with mock.patch("zerver.tornado.views.fetch_events", side_effect=wrapped_fetch_events):
             yield
 
-    @async_to_sync_decorator
     async def test_events_async(self) -> None:
-        user_profile = await in_django_thread(lambda: self.example_user("hamlet"))
-        await in_django_thread(lambda: self.login_user(user_profile))
-        event_queue_id = await self.create_queue()
-        data = {
-            "queue_id": event_queue_id,
-            "last_event_id": -1,
-        }
+        async with self.with_tornado():
+            user_profile = await in_django_thread(lambda: self.example_user("hamlet"))
+            await in_django_thread(lambda: self.login_user(user_profile))
+            event_queue_id = await self.create_queue()
+            data = {
+                "queue_id": event_queue_id,
+                "last_event_id": -1,
+            }
 
-        path = f"/json/events?{urlencode(data)}"
+            path = f"/json/events?{urlencode(data)}"
 
-        with self.mocked_events(user_profile, {"type": "test", "data": "test data"}):
-            response = await self.fetch_async("GET", path)
+            with self.mocked_events(user_profile, {"type": "test", "data": "test data"}):
+                response = await self.fetch_async("GET", path)
 
-        self.assertEqual(response.headers["Vary"], "Accept-Language, Cookie")
-        data = orjson.loads(response.body)
-        self.assertEqual(
-            data["events"],
-            [
-                {"type": "test", "data": "test data", "id": 0},
-            ],
-        )
-        self.assertEqual(data["result"], "success")
+            self.assertEqual(response.headers["Vary"], "Accept-Language, Cookie")
+            data = orjson.loads(response.body)
+            self.assertEqual(
+                data["events"],
+                [
+                    {"type": "test", "data": "test data", "id": 0},
+                ],
+            )
+            self.assertEqual(data["result"], "success")
 
-    @async_to_sync_decorator
     async def test_events_caching(self) -> None:
-        user_profile = await in_django_thread(lambda: self.example_user("hamlet"))
-        await in_django_thread(lambda: self.login_user(user_profile))
-        event_queue_id = await self.create_queue()
-        data = {
-            "queue_id": event_queue_id,
-            "last_event_id": -1,
-        }
+        async with self.with_tornado():
+            user_profile = await in_django_thread(lambda: self.example_user("hamlet"))
+            await in_django_thread(lambda: self.login_user(user_profile))
+            event_queue_id = await self.create_queue()
+            data = {
+                "queue_id": event_queue_id,
+                "last_event_id": -1,
+            }
 
-        path = f"/json/events?{urlencode(data)}"
+            path = f"/json/events?{urlencode(data)}"
 
-        with (
-            self.mocked_events(user_profile, {"type": "test", "data": "test data"}),
-            cache_tries_captured() as cache_gets,
-            queries_captured() as queries,
-        ):
-            await self.fetch_async("GET", path)
+            with (
+                self.mocked_events(user_profile, {"type": "test", "data": "test data"}),
+                cache_tries_captured() as cache_gets,
+                queries_captured() as queries,
+            ):
+                await self.fetch_async("GET", path)
 
-            # Two cache fetches -- for the user and the client.  In
-            # production, the session would also be a cache access,
-            # but tests don't use cached sessions.
-            self.assert_length(cache_gets, 2)
-            self.assertEqual(
-                cache_gets[0], ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None)
-            )
-            self.assertEqual(cache_gets[1][0], "get")
-            assert isinstance(cache_gets[1][1], str)
-            self.assertTrue(cache_gets[1][1].startswith("get_client:"))
+                # Two cache fetches -- for the user and the client.  In
+                # production, the session would also be a cache access,
+                # but tests don't use cached sessions.
+                self.assert_length(cache_gets, 2)
+                self.assertEqual(
+                    cache_gets[0],
+                    ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None),
+                )
+                self.assertEqual(cache_gets[1][0], "get")
+                assert isinstance(cache_gets[1][1], str)
+                self.assertTrue(cache_gets[1][1].startswith("get_client:"))
 
-            # Three database queries -- session, user, and client.
-            # The user query should remain small; it is currently 470
-            # bytes, but anything under 1k should be Fine.
-            self.assert_length(queries, 3)
-            self.assertIn("django_session", queries[0].sql)
-            self.assertIn("zerver_userprofile", queries[1].sql)
-            self.assertLessEqual(len(queries[1].sql), 1024)
-            self.assertIn("zerver_client", queries[2].sql)
+                # Three database queries -- session, user, and client.
+                # The user query should remain small; it is currently 470
+                # bytes, but anything under 1k should be Fine.
+                self.assert_length(queries, 3)
+                self.assertIn("django_session", queries[0].sql)
+                self.assertIn("zerver_userprofile", queries[1].sql)
+                self.assertLessEqual(len(queries[1].sql), 1024)
+                self.assertIn("zerver_client", queries[2].sql)
 
-        # Perform the same request again, preserving the caches.  We
-        # should only see one database query -- the session.  As noted
-        # above, in production even that would be cached.
-        with (
-            self.mocked_events(user_profile, {"type": "test", "data": "test data"}),
-            cache_tries_captured() as cache_gets,
-            queries_captured(keep_cache_warm=True) as queries,
-        ):
-            await self.fetch_async("GET", path)
-            self.assert_length(cache_gets, 1)
-            self.assertEqual(
-                cache_gets[0], ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None)
-            )
-            # Client is cached in-process-memory, so doesn't even see
-            # a memcached hit
+            # Perform the same request again, preserving the caches.  We
+            # should only see one database query -- the session.  As noted
+            # above, in production even that would be cached.
+            with (
+                self.mocked_events(user_profile, {"type": "test", "data": "test data"}),
+                cache_tries_captured() as cache_gets,
+                queries_captured(keep_cache_warm=True) as queries,
+            ):
+                await self.fetch_async("GET", path)
+                self.assert_length(cache_gets, 1)
+                self.assertEqual(
+                    cache_gets[0],
+                    ("get", user_profile_narrow_by_id_cache_key(user_profile.id), None),
+                )
+                # Client is cached in-process-memory, so doesn't even see
+                # a memcached hit
 
-            self.assert_length(queries, 1)
-            self.assertIn("django_session", queries[0].sql)
+                self.assert_length(queries, 1)
+                self.assertIn("django_session", queries[0].sql)

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -132,10 +132,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler):
         # Django's WSGIHandler.__call__ before the call to
         # `get_response()`.
         set_script_prefix(get_script_name(environ))
-        await sync_to_async(
-            lambda: signals.request_started.send(sender=type(self.django_handler)),
-            thread_sensitive=True,
-        )()
+        await signals.request_started.asend(sender=type(self.django_handler))
         self._request = WSGIRequest(environ)
 
         # We do the import during runtime to avoid cyclic dependency


### PR DESCRIPTION
Required for Django 5.1. I’m not sure how much I trust this. Let’s give it some time to bake on chat.zulip.org.