### PR TITLE
edit_message: Remove `cursor:text` from scrollbar thumb.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -919,6 +919,7 @@
     &::-webkit-scrollbar-thumb {
         background-color: hsl(0deg 0% 0% / 30%);
         border-radius: 20px;
+        cursor: auto;
         transition: background-color 0.2s ease;
     }
 


### PR DESCRIPTION
It makes it easy to determine whether you are dragging
the scrollbar or selecting text from the editing area.

Fixes: #33253.

| Before  | After  |
|---------|--------|
| ![before](https://github.com/user-attachments/assets/dcd5cf15-772f-4a5a-8ae2-0f25fbea959a) | ![after](https://github.com/user-attachments/assets/c3cce0be-0705-4c69-ae53-e0614620fe23)


