### PR TITLE
Frontend validation for custom linkifiers before being sent to the server

### DIFF
--- a/web/src/linkifiers.ts
+++ b/web/src/linkifiers.ts
@@ -16,7 +16,7 @@ export function get_linkifier_map(): LinkifierMap {
     return linkifier_map;
 }
 
-function python_to_js_linkifier(
+export function python_to_js_linkifier(
     pattern: string,
     url: string,
 ): [RegExp | null, url_template_lib.Template, Record<number, string>] {

--- a/web/src/settings_linkifiers.ts
+++ b/web/src/settings_linkifiers.ts
@@ -11,6 +11,7 @@ import * as channel from "./channel.ts";
 import * as confirm_dialog from "./confirm_dialog.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t_html} from "./i18n.ts";
+import * as linkifiers from "./linkifiers.ts";
 import * as ListWidget from "./list_widget.ts";
 import * as scroll_util from "./scroll_util.ts";
 import * as settings_ui from "./settings_ui.ts";
@@ -254,6 +255,21 @@ export function build_page(): void {
             $linkifier_status.hide();
             $pattern_status.hide();
             $template_status.hide();
+
+            const pattern = String($("#linkifier_pattern").val()).trim();
+            const url_template = String($("#linkifier_template").val()).trim();
+
+            try {
+                linkifiers.python_to_js_linkifier(pattern, url_template);
+            } catch {
+                $add_linkifier_button.prop("disabled", false);
+                ui_report.error(
+                    $t_html({defaultMessage: "Failed: Invalid Pattern"}),
+                    undefined,
+                    $pattern_status,
+                );
+                return;
+            }
 
             void channel.post({
                 url: "/json/realm/filters",


### PR DESCRIPTION
[CZO discussion thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20linkifier.20validation.20in.20web.20app)

This PR adds frontend validation for custom linkifiers using `python_to_js_linkifier`. Previously, users could submit a linkifier that would be supported by the server but not by the web-app. This resulted in `BlueslipError: python_to_js_linkifier failure!`

**Changes**:
- Exported `python_to_js_linkifier` from `linkifiers.ts`.
- Added validation in `settings_linkifiers.ts` using a try-catch block.
- Displayed error message when validation fails, preventing invalid submissions.

Fixes #33238: Candidate linkifiers are now being validated locally before being sent to the server

**Screenshots:**
![Error message](https://github.com/user-attachments/assets/826b66b4-6e44-43d3-9597-c3c408b384bf)


<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
