### PR TITLE
Don't track unreads in archived channels

### DIFF
--- a/web/src/popover_menus_data.ts
+++ b/web/src/popover_menus_data.ts
@@ -45,6 +45,7 @@ type ActionPopoverContext = {
     should_display_delete_option: boolean;
     should_display_read_receipts_option: boolean;
     should_display_add_reaction_option: boolean;
+    is_stream_archived: boolean;
 };
 
 type TopicPopoverContext = {
@@ -69,6 +70,7 @@ type TopicPopoverContext = {
     all_visibility_policies: AllVisibilityPolicies;
     can_summarize_topics: boolean;
     show_ai_features: boolean;
+    is_stream_archived: boolean;
 };
 
 type VisibilityChangePopoverContext = {
@@ -220,6 +222,8 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         return $message_row.find(".message_controls .reaction_button").is(":visible");
     }
 
+    const is_stream_archived = stream_id !== undefined && stream_data.is_stream_archived(stream_id);
+
     // Since we only display msg actions and star icons on windows smaller than
     // `media_breakpoints.sm_min`, we need to include the reaction button in the
     // popover if it is not displayed.
@@ -227,7 +231,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         !message.is_me_message &&
         !is_add_reaction_icon_visible() &&
         not_spectator &&
-        !(stream_id && stream_data.is_stream_archived(stream_id));
+        !is_stream_archived;
 
     return {
         message_id: message.id,
@@ -244,6 +248,7 @@ export function get_actions_popover_content_context(message_id: number): ActionP
         should_display_delete_option,
         should_display_read_receipts_option,
         should_display_quote_message,
+        is_stream_archived,
     };
 }
 
@@ -270,6 +275,7 @@ export function get_topic_popover_content_context({
     const all_visibility_policies = user_topics.all_visibility_policies;
     const is_spectator = page_params.is_spectator;
     const is_topic_empty = is_topic_definitely_empty(stream_id, topic_name);
+    const is_stream_archived = stream_data.is_stream_archived(stream_id);
     return {
         stream_name: sub.name,
         stream_id: sub.stream_id,
@@ -292,6 +298,7 @@ export function get_topic_popover_content_context({
         all_visibility_policies,
         can_summarize_topics: settings_data.user_can_summarize_topics(),
         show_ai_features: !user_settings.hide_ai_features,
+        is_stream_archived,
     };
 }
 

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -114,6 +114,7 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
     const stream_unread = unread.unread_count_info_for_stream(stream_id);
     const stream_unread_count = stream_unread.unmuted_count + stream_unread.muted_count;
     const has_unread_messages = stream_unread_count > 0;
+    const is_stream_archived = stream_data.is_stream_archived(stream_id);
     const content = render_left_sidebar_stream_actions_popover({
         stream: {
             ...sub_store.get(stream_id),
@@ -123,6 +124,7 @@ function build_stream_popover(opts: {elt: HTMLElement; stream_id: number}): void
         has_unread_messages,
         show_go_to_channel_feed,
         show_go_to_list_of_topics,
+        is_stream_archived,
     });
 
     popover_menus.toggle_popover_menu(elt, {

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -23,11 +23,13 @@ import type {Message} from "./message_store.ts";
 import * as message_store from "./message_store.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as modals from "./modals.ts";
+import * as narrow_state from "./narrow_state.ts";
 import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
 import * as recent_view_ui from "./recent_view_ui.ts";
 import type {MessageDetails} from "./server_event_types.ts";
 import type {NarrowTerm} from "./state_data.ts";
+import * as stream_data from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
 import * as ui_report from "./ui_report.ts";
 import * as unread from "./unread.ts";
@@ -337,6 +339,13 @@ export function mark_as_unread_from_here(message_id: number): void {
     const current_filter = message_lists.current.data.filter;
     const narrow = current_filter.get_stringified_narrow_for_server_query();
     message_lists.current.prevent_reading();
+
+    // We want to prevent messages in archived streams from
+    // being marked as unread using shortcut keys.
+    const stream_id = narrow_state.stream_id();
+    if (stream_id && stream_data.is_stream_archived(stream_id)) {
+        return;
+    }
 
     const has_found_newest = message_lists.current.data.fetch_status.has_found_newest();
     const may_contain_multiple_conversations = current_filter.may_contain_multiple_conversations();

--- a/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs
@@ -9,6 +9,7 @@
             <span class="popover-stream-name">{{stream.name}}</span>
         </li>
         <li role="separator" class="popover-menu-separator"></li>
+        {{#unless is_stream_archived}}
         {{#if has_unread_messages}}
         <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
             <a role="menuitem" class="mark_stream_as_read popover-menu-link" tabindex="0">
@@ -24,6 +25,7 @@
             </a>
         </li>
         {{/if}}
+        {{/unless}}
         {{#if show_go_to_channel_feed}}
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" class="stream-popover-go-to-channel-feed popover-menu-link" tabindex="0">

--- a/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_topic_actions_popover.hbs
@@ -56,6 +56,7 @@
                 </a>
             </li>
             {{/if}}
+            {{#unless is_stream_archived}}
             {{#if has_unread_messages}}
             <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
                 <a role="menuitem" class="sidebar-popover-mark-topic-read popover-menu-link" tabindex="0">
@@ -71,6 +72,7 @@
                 </a>
             </li>
             {{/if}}
+            {{/unless}}
             <li role="none" class="link-item popover-menu-list-item">
                 <a role="menuitem" class="sidebar-popover-copy-link-to-topic popover-menu-link" data-clipboard-text="{{ url }}" tabindex="0">
                     <i class="popover-menu-icon zulip-icon zulip-icon-link-alt" aria-hidden="true"></i>

--- a/web/templates/popovers/message_actions_popover.hbs
+++ b/web/templates/popovers/message_actions_popover.hbs
@@ -62,6 +62,7 @@
         {{#if (or should_display_mark_as_unread should_display_hide_option should_display_collapse should_display_uncollapse)}}
         <li role="separator" class="popover-menu-separator"></li>
         {{/if}}
+        {{#unless is_stream_archived}}
         {{#if should_display_mark_as_unread}}
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" data-message-id="{{message_id}}" class="mark_as_unread popover-menu-link" tabindex="0">
@@ -71,6 +72,7 @@
             </a>
         </li>
         {{/if}}
+        {{/unless}}
         {{#if should_display_hide_option}}
         <li role="none" class="link-item popover-menu-list-item">
             <a role="menuitem" data-message-id="{{message_id}}" class="rehide_muted_user_message popover-menu-link" tabindex="0">


### PR DESCRIPTION
Previously, messages that were unread at the time of stream archiving remained marked as unread indefinitely. Users had to manually mark them as read, which was not ideal.

With this PR, unread markers for messages are removed when the stream in which they are present is archived.

## Tasks Completed

- [x] Hide the mark as read / mark as unread options in all menus for that channel (channel, topic, and message menus).

### Hide Mark as read and unread for archived streams

 <table>
<tr>
<th>

Before

</th>
<th>

After

</th>
</tr>
<tr>
<td>

![image](https://github.com/user-attachments/assets/864af03b-730f-4e5f-b6e5-e535ab5929ec)


</td>
<td>

![image](https://github.com/user-attachments/assets/0f964955-b08b-48f0-87b8-a71b83c62e0c)

</td>
</tr>
<tr>
<td>

![image](https://github.com/user-attachments/assets/dfe22f06-7d5e-402f-8382-afebddcbe141)


</td>
<td>

![image](https://github.com/user-attachments/assets/008f345e-69ae-49a4-89be-d0094454ad5d)

</td>
</tr>
</table>

- [x] Write a database migration to clear unread markers for messages in archived channels. 

FIxes: #33259 

**I would like to thank @Aditya8840 for their help.**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
