### PR TITLE
message_fetch: Update trailing bookend for empty message lists

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -127,6 +127,7 @@ export function fetch_more_if_required_for_current_msg_list(
         // Even after loading more messages, we have
         // no messages to display in this narrow.
         narrow_banner.show_empty_narrow_message(message_lists.current.data.filter);
+        message_lists.current.update_trailing_bookend();
         compose_closed_ui.update_buttons_for_private();
         compose_recipient.check_posting_policy_for_compose_box();
     }

--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -469,7 +469,7 @@ export class MessageList {
         const is_web_public = sub?.is_web_public;
         if (sub === undefined || sub.is_archived) {
             deactivated = true;
-        } else if (!subscribed && !this.last_message_historical) {
+        } else if (!subscribed && !this.last_message_historical && !this.empty()) {
             just_unsubscribed = true;
         }
 

--- a/web/tests/message_list.test.cjs
+++ b/web/tests/message_list.test.cjs
@@ -403,6 +403,29 @@ run_test("bookend", ({override}) => {
         assert.equal(bookend.stream_name, "IceCream");
         assert.equal(bookend.subscribed, false);
         assert.equal(bookend.deactivated, false);
+        assert.equal(bookend.just_unsubscribed, false);
+    }
+
+    list.last_message_historical = false;
+    is_subscribed = false;
+    list.empty = () => false;
+
+    {
+        const stub = make_stub();
+        list.view.render_trailing_bookend = stub.f;
+        list.update_trailing_bookend();
+        assert.equal(stub.num_calls, 1);
+        const bookend = stub.get_args(
+            "stream_id",
+            "stream_name",
+            "subscribed",
+            "deactivated",
+            "just_unsubscribed",
+        );
+        assert.equal(bookend.stream_id, 5);
+        assert.equal(bookend.stream_name, "IceCream");
+        assert.equal(bookend.subscribed, false);
+        assert.equal(bookend.deactivated, false);
         assert.equal(bookend.just_unsubscribed, true);
     }
 


### PR DESCRIPTION
show ` You are not subscribed to  #xyz. Subscribe` bookend on channel or topic which are not subscribed and have no messages.

fixes #33209

| **before**       | **after**                | 
|--------------------|--------------------------------|
| ![image](https://github.com/user-attachments/assets/a3c7148c-cd82-428f-9238-b2785073bdff)| ![image](https://github.com/user-attachments/assets/ff0e2238-6538-4a88-8650-fa203ec122d7)|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

