### PR TITLE
css: Fix misalignment when editing custom profile field with multiple options and adjust padding for input fields.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -436,7 +436,7 @@
 .modal_password_input,
 .modal_url_input,
 .modal_text_input {
-    padding: 4px 6px;
+    padding: 6px 7px;
     color: hsl(0deg 0% 33%);
     border-radius: 4px;
     border: 1px solid hsl(0deg 0% 80%);
@@ -444,7 +444,6 @@
     transition:
         border-color linear 0.2s,
         box-shadow linear 0.2s;
-    margin-bottom: 10px;
     width: 206px;
 
     &:focus {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1683,7 +1683,11 @@ label.preferences-radio-choice-label {
     }
 
     .choice-row {
+        display: grid;
+        grid-template-columns: 20px 210px 40px;
         margin-top: 8px;
+        column-gap: 6px;
+        align-items: center;
 
         & input {
             width: 190px;


### PR DESCRIPTION
This request fixes misalignment issue that occurs when edit customer profile field with multiple options. These changes make sure that all elements in the profile field options align correctly improving layout and consistency.

# Issue Link:
Fixes: #33261.

Screenshot of the fix:
<img width="1072" alt="Screenshot 2025-02-03 at 12 14 04 AM" src="https://github.com/user-attachments/assets/3a6bd728-ad77-4427-985c-c3c5d8034672" />

# Additional Changes:
I also did minimal changes to the padding of .modal_password_input, .modal_url_input, and .modal_text_input, increasing it from 4px 6px to 6px 7px to improve consistency across input fields.