### PR TITLE
message_edit: Fix "(deleted)" not showing for empty edited DMs.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1262,16 +1262,6 @@ def build_message_edit_request(
     topic_name: str | None = None,
     content: str | None = None,
 ) -> StreamMessageEditRequest | DirectMessageEditRequest:
-    if not message.is_stream_message():
-        # We have already validated the code to have content
-        # as not None.
-        assert content is not None
-        return DirectMessageEditRequest(
-            content=content,
-            orig_content=message.content,
-            is_content_edited=True,
-        )
-
     is_content_edited = False
     new_content = message.content
     if content is not None:
@@ -1279,6 +1269,15 @@ def build_message_edit_request(
         if content.rstrip() == "":
             content = "(deleted)"
         new_content = normalize_body(content)
+
+    if not message.is_stream_message():
+        # We have already validated that at least one of content, topic, or stream
+        # must be modified, and for DMs, only the content can be edited.
+        return DirectMessageEditRequest(
+            content=new_content,
+            orig_content=message.content,
+            is_content_edited=True,
+        )
 
     is_topic_edited = False
     topic_resolved = False

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -396,8 +396,23 @@ class EditMessageTest(ZulipTestCase):
 
     def test_edit_message_no_content(self) -> None:
         self.login("hamlet")
+        # Check message edit in stream for no content.
         msg_id = self.send_stream_message(
             self.example_user("hamlet"), "Denmark", topic_name="editing", content="before edit"
+        )
+        result = self.client_patch(
+            f"/json/messages/{msg_id}",
+            {
+                "content": " ",
+            },
+        )
+        self.assert_json_success(result)
+        content = Message.objects.filter(id=msg_id).values_list("content", flat=True)[0]
+        self.assertEqual(content, "(deleted)")
+
+        # Check message edit in DMs for no content.
+        msg_id = self.send_personal_message(
+            from_user=self.example_user("hamlet"), to_user=self.example_user("cordelia")
         )
         result = self.client_patch(
             f"/json/messages/{msg_id}",


### PR DESCRIPTION
This PR fixes a bug introduced in commit [37f2c5bc788](https://github.com/zulip/zulip/commit/37f2c5bc788d613e0b65f25341ea2704d9325097), where a message in DM is not updated to "(deleted)" when left empty after editing.

## Before

![image](https://github.com/user-attachments/assets/db29cbec-3389-4057-a663-61735c15c2fe)


## After

![image](https://github.com/user-attachments/assets/4bd242b1-2f29-4d36-b8e0-952e159e1f18)


Fixes: #33305

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
