### PR TITLE
get_user_upload_previews: Rename to generate_user_upload_previews.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -67,7 +67,7 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.streams import access_stream_for_send_message, ensure_stream, subscribed_to_stream
 from zerver.lib.string_validation import check_stream_name
-from zerver.lib.thumbnail import get_user_upload_previews, rewrite_thumbnailed_images
+from zerver.lib.thumbnail import generate_user_upload_previews, rewrite_thumbnailed_images
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import participants_for_topic
 from zerver.lib.url_preview.types import UrlEmbedData
@@ -880,7 +880,7 @@ def do_send_messages(
             # does not support this yet: (https://code.djangoproject.com/ticket/10088)
             assert send_request.message.rendered_content is not None
             if send_request.rendering_result.thumbnail_spinners:
-                previews = get_user_upload_previews(
+                previews = generate_user_upload_previews(
                     send_request.message.realm_id,
                     send_request.message.content,
                     lock=True,

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -50,7 +50,7 @@ from zerver.lib.streams import (
 from zerver.lib.thumbnail import (
     THUMBNAIL_ACCEPT_IMAGE_TYPES,
     BadImageError,
-    get_user_upload_previews,
+    generate_user_upload_previews,
     maybe_thumbnail,
 )
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -445,7 +445,7 @@ def fix_message_rendered_content(
                 message[rendered_content_key] = str(soup)
 
             # Trigger thumbnailing of all thumbnails in the message
-            get_user_upload_previews(realm.id, message[content_key], lock=True)
+            generate_user_upload_previews(realm.id, message[content_key], lock=True)
 
             continue
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -58,7 +58,7 @@ from zerver.lib.subdomains import is_static_or_current_realm_url
 from zerver.lib.tex import render_tex
 from zerver.lib.thumbnail import (
     MarkdownImageMetadata,
-    get_user_upload_previews,
+    generate_user_upload_previews,
     rewrite_thumbnailed_images,
 )
 from zerver.lib.timeout import unsafe_timeout
@@ -2755,7 +2755,7 @@ def do_convert(
         else:
             active_realm_emoji = {}
 
-        user_upload_previews = get_user_upload_previews(message_realm.id, content)
+        user_upload_previews = generate_user_upload_previews(message_realm.id, content)
         _md_engine.zulip_db_data = DbData(
             realm_alert_words_automaton=realm_alert_words_automaton,
             mention_data=mention_data,

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -411,7 +411,7 @@ class MarkdownImageMetadata:
     transcoded_image: StoredThumbnailFormat | None = None
 
 
-def get_user_upload_previews(
+def generate_user_upload_previews(
     realm_id: int,
     content: str,
     lock: bool = False,


### PR DESCRIPTION
This better reflects what the function does - it's not just a fetch, it actively causes the generation of previews.

