### PR TITLE
copy_and_paste: Fix regression caused by quoting math.

### DIFF
--- a/web/src/copy_and_paste.ts
+++ b/web/src/copy_and_paste.ts
@@ -454,6 +454,21 @@ export function paste_handler_converter(
 
             This is done because filter() function only processes HTMLElements
         */
+        let katex_node_count = 0;
+        for (const child of children) {
+            if (
+                child instanceof HTMLElement &&
+                (child.classList.contains("katex") || child.classList.contains("katex-display"))
+            ) {
+                katex_node_count += 1;
+            }
+        }
+        // We do the text node to span conversions only if
+        // the children are sandwiched between katex nodes.
+        if (katex_node_count < 2) {
+            continue;
+        }
+
         for (const child of children) {
             if (child.nodeType === Node.TEXT_NODE) {
                 const span = document.createElement("span");

--- a/web/tests/copy_and_paste.test.cjs
+++ b/web/tests/copy_and_paste.test.cjs
@@ -272,4 +272,13 @@ run_test("paste_handler_converter", () => {
             inline_math_expression_test.expected_output,
         );
     }
+
+    // Span conversion check
+    for (const span_conversion_test of katex_tests.text_node_to_span_conversion_tests) {
+        input = span_conversion_test.input;
+        assert.equal(
+            copy_and_paste.paste_handler_converter(input),
+            span_conversion_test.expected_output,
+        );
+    }
 });

--- a/zerver/tests/fixtures/katex_test_cases.json
+++ b/zerver/tests/fixtures/katex_test_cases.json
@@ -45,5 +45,13 @@
             "expected_output":"I *think* $$e^{i\\pi} = -1$$ is the **coolest** thing I've seen since $$x^2 + y^2 = z^2$$ blew my mind."
 
         }
+    ],
+    "text_node_to_span_conversion_tests":[
+        {
+        "original_markup":"A paragraph with some `code` and a [link](https://example.com/).",
+        "description":"Check conversion of intermediate text nodes and ensure it doesn't distubt pasting/quoting",
+        "input":"<p>A paragraph with some <code>code</code> and a <a href=\"https://example.com/\">link</a>.</p>",
+        "expected_output":"A paragraph with some `code` and a [link](https://example.com/)."
+        }
     ]
 }


### PR DESCRIPTION
We now do a more precise check to decide whether
to perform the span conversion for intermediate
text nodes.

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/HTML.20paragraphs.20misconverted.20by.20copy.20and.20paste.

Tested it manually on some other inline and math blocks.