### PR TITLE
Follow-ups for #33316.

### DIFF
--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -238,28 +238,28 @@ export function check_group_permission_settings_data(): void {
     const all_realm_group_settings = z
         .array(realm_group_setting_name_schema)
         .parse(Object.keys(realm.server_supported_permission_settings.realm));
-    const realm_group_settings_with_subsection_data: RealmGroupSettingName[] = [];
+    const realm_group_settings_with_subsection_data = new Set<RealmGroupSettingName>([]);
     for (const subsection_obj of settings_config.realm_group_permission_settings) {
         for (const setting_name of subsection_obj.settings) {
-            realm_group_settings_with_subsection_data.push(setting_name);
+            realm_group_settings_with_subsection_data.add(setting_name);
         }
     }
 
     if (
         !all_realm_group_settings.every((setting_name) =>
-            realm_group_settings_with_subsection_data.includes(setting_name),
+            realm_group_settings_with_subsection_data.has(setting_name),
         )
     ) {
         blueslip.error("Settings missing in 'settings_config.realm_group_permission_settings'");
         return;
     }
 
-    const realm_group_setting_label_object_keys = Object.keys(
-        settings_config.all_group_setting_labels.realm,
+    const realm_group_setting_label_object_keys = new Set(
+        Object.keys(settings_config.all_group_setting_labels.realm),
     );
     if (
         !all_realm_group_settings.every((setting_name) =>
-            realm_group_setting_label_object_keys.includes(setting_name),
+            realm_group_setting_label_object_keys.has(setting_name),
         )
     ) {
         blueslip.error("Settings missing in 'settings_config.all_group_setting_labels.realm'");
@@ -269,21 +269,24 @@ export function check_group_permission_settings_data(): void {
     const all_stream_group_settings = z
         .array(stream_group_setting_name_schema)
         .parse(Object.keys(realm.server_supported_permission_settings.stream));
+    const stream_group_permission_settings = new Set(
+        settings_config.stream_group_permission_settings,
+    );
     if (
         !all_stream_group_settings.every((setting_name) =>
-            settings_config.stream_group_permission_settings.includes(setting_name),
+            stream_group_permission_settings.has(setting_name),
         )
     ) {
         blueslip.error("Settings missing in 'settings_config.stream_group_permission_settings'");
         return;
     }
 
-    const stream_group_setting_label_object_keys = Object.keys(
-        settings_config.all_group_setting_labels.stream,
+    const stream_group_setting_label_object_keys = new Set(
+        Object.keys(settings_config.all_group_setting_labels.stream),
     );
     if (
         !all_stream_group_settings.every((setting_name) =>
-            stream_group_setting_label_object_keys.includes(setting_name),
+            stream_group_setting_label_object_keys.has(setting_name),
         )
     ) {
         blueslip.error("Settings missing in 'settings_config.all_group_setting_labels.stream'");
@@ -291,21 +294,22 @@ export function check_group_permission_settings_data(): void {
     }
 
     const all_group_group_settings = get_group_permission_settings();
+    const group_group_permission_settings = new Set(settings_config.group_permission_settings);
     if (
         !all_group_group_settings.every((setting_name) =>
-            settings_config.group_permission_settings.includes(setting_name),
+            group_group_permission_settings.has(setting_name),
         )
     ) {
         blueslip.error("Settings missing in 'settings_config.group_permission_settings'");
         return;
     }
 
-    const group_group_setting_label_object_keys = Object.keys(
-        settings_config.all_group_setting_labels.group,
+    const group_group_setting_label_object_keys = new Set(
+        Object.keys(settings_config.all_group_setting_labels.group),
     );
     if (
         !all_group_group_settings.every((setting_name) =>
-            group_group_setting_label_object_keys.includes(setting_name),
+            group_group_setting_label_object_keys.has(setting_name),
         )
     ) {
         blueslip.error("Settings missing in 'settings_config.all_group_setting_labels.group'");


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to add test.  https://github.com/zulip/zulip/pull/33316#discussion_r1939986953 
- Second commit is to use set instead of list. https://github.com/zulip/zulip/pull/33316#discussion_r1939990964
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
