### PR TITLE
tooltips: Group tooltips for smooth transition.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -11,6 +11,7 @@ import * as compose_notifications from "./compose_notifications.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
+import * as compose_tooltips from "./compose_tooltips.ts";
 import * as compose_ui from "./compose_ui.ts";
 import type {ComposeTriggeredOptions} from "./compose_ui.ts";
 import * as compose_validate from "./compose_validate.ts";
@@ -440,6 +441,7 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     // compose-box do not cover the last messages of the current stream
     // while writing a long message.
     resize.reset_compose_message_max_height();
+    compose_tooltips.initialize_compose_tooltips("compose", "#compose .compose_button_tooltip");
 
     complete_starting_tasks(opts);
 

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -14,9 +14,76 @@ import {pick_empty_narrow_banner} from "./narrow_banner.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as popover_menus from "./popover_menus.ts";
 import {realm} from "./state_data.ts";
-import {EXTRA_LONG_HOVER_DELAY, INSTANT_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs.ts";
+import {
+    EXTRA_LONG_HOVER_DELAY,
+    INSTANT_HOVER_DELAY,
+    LONG_HOVER_DELAY,
+    SINGLETON_INSTANT_HOVER_DELAY,
+    SINGLETON_LONG_HOVER_DELAY,
+    get_tooltip_content,
+} from "./tippyjs.ts";
 import {parse_html} from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
+
+type SingletonContext = "compose" | `edit_message:${string}`;
+type SingletonTooltips = {
+    tooltip_instances: tippy.Instance[] | null;
+    singleton_instance: tippy.CreateSingletonInstance | null;
+};
+
+const compose_button_singleton_context_map = new Map<SingletonContext, SingletonTooltips>();
+
+// Ensure proper teardown of singleton instances, especially for "Save/Cancel" actions or when handling edit window time limits.
+// Reference: http://atomiks.github.io/tippyjs/v6/addons/#destroy
+export function clean_up_compose_singleton_tooltip(context: SingletonContext): void {
+    const singleton_tooltips = compose_button_singleton_context_map.get(context);
+    if (singleton_tooltips) {
+        singleton_tooltips.singleton_instance?.destroy();
+        if (singleton_tooltips.tooltip_instances) {
+            for (const tippy_instance of singleton_tooltips.tooltip_instances) {
+                if (!tippy_instance.state.isDestroyed) {
+                    tippy_instance.destroy();
+                }
+            }
+        }
+        compose_button_singleton_context_map.delete(context);
+    }
+}
+
+export function initialize_compose_tooltips(context: SingletonContext, selector: string): void {
+    // Clean up existing instances first
+    clean_up_compose_singleton_tooltip(context);
+
+    const tooltip_instances = tippy.default(selector, {
+        trigger: "mouseenter",
+        appendTo: () => document.body,
+        placement: "top",
+    });
+
+    const singleton_instance = tippy.createSingleton(tooltip_instances, {
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onTrigger(instance, event) {
+            const currentTarget = event.currentTarget;
+            if (currentTarget instanceof HTMLElement) {
+                const content = get_tooltip_content(currentTarget);
+                if (content) {
+                    instance.setContent(content);
+                }
+                if (currentTarget.classList?.contains("disabled-on-hover")) {
+                    instance.setProps({delay: SINGLETON_INSTANT_HOVER_DELAY});
+                } else {
+                    instance.setProps({delay: SINGLETON_LONG_HOVER_DELAY});
+                }
+            }
+        },
+    });
+
+    compose_button_singleton_context_map.set(context, {
+        tooltip_instances,
+        singleton_instance,
+    });
+}
 
 export function initialize(): void {
     tippy.delegate("body", {
@@ -129,40 +196,6 @@ export function initialize(): void {
         },
         onHidden(instance) {
             instance.destroy();
-        },
-    });
-
-    tippy.delegate("body", {
-        // Only display Tippy content on classes accompanied by a `data-` attribute.
-        target: `
-        .compose_control_button[data-tooltip-template-id],
-        .compose_control_button[data-tippy-content],
-        .compose_control_button_container
-        `,
-        // Add some additional delay when they open
-        // so that regular users don't have to see
-        // them unless they want to.
-        delay: LONG_HOVER_DELAY,
-        // By default, tippyjs uses a trigger value of "mouseenter focus",
-        // which means the tooltips can appear either when the element is
-        // hovered over or when it receives focus (e.g. by being clicked).
-        // However, we only want the tooltips to appear on hover, not on click.
-        // Therefore, we need to remove the "focus" trigger from the buttons,
-        // so that the tooltips don't appear when the buttons are clicked.
-        trigger: "mouseenter",
-        // This ensures that the upload files tooltip
-        // doesn't hide behind the left sidebar.
-        appendTo: () => document.body,
-        // If the button is `.disabled-on-hover`, then we want to show the
-        // tooltip instantly, to make it clear to the user that the button
-        // is disabled, and why.
-        onTrigger(instance, event) {
-            assert(event.currentTarget instanceof HTMLElement);
-            if (event.currentTarget.classList.contains("disabled-on-hover")) {
-                instance.setProps({delay: INSTANT_HOVER_DELAY});
-            } else {
-                instance.setProps({delay: LONG_HOVER_DELAY});
-            }
         },
     });
 

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -673,6 +673,10 @@ function edit_message($row: JQuery, raw_content: string): void {
         $message_edit_content.on("keyup", (event) => {
             compose_ui.handle_keyup(event, $message_edit_content);
         });
+        compose_tooltips.initialize_compose_tooltips(
+            `edit_message:${message.id}`,
+            ".message_edit .compose_button_tooltip",
+        );
     }
 
     // Add tooltip and timer
@@ -1104,6 +1108,10 @@ export function end_message_row_edit($row: JQuery): void {
     $row.find(".message_edit").trigger("blur");
     // We should hide the editing typeahead if it is visible
     $row.find("input.message_edit_topic").trigger("blur");
+    // Hide the edit box tooltips
+    compose_tooltips.clean_up_compose_singleton_tooltip(
+        `edit_message:${$row.attr("data-message-id")}`,
+    );
 }
 
 export function end_message_edit(message_id: number): void {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -54,6 +54,14 @@ export const LONG_HOVER_DELAY: [number, number] = [750, 20];
 // keyboard shortcut. For these tooltips, it's very important to avoid
 // distracting users unnecessarily.
 export const EXTRA_LONG_HOVER_DELAY: [number, number] = [1500, 20];
+// These delays are specifically for singleton tooltips. Unlike default tooltips,
+// singleton tooltips can feel disconnected or abrupt when using the default hide delays
+// from INSTANT_HOVER_DELAY or LONG_HOVER_DELAY, due to the very low hide timings we use.
+
+// To address this, we increase the hide delay to 250ms. This ensures smoother transitions
+// and prevents tooltips from disappearing too quickly, improving the overall UX.
+export const SINGLETON_INSTANT_HOVER_DELAY: [number, number] = [100, 250];
+export const SINGLETON_LONG_HOVER_DELAY: [number, number] = [750, 250];
 
 // We override the defaults set by tippy library here,
 // so make sure to check this too after checking tippyjs

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -1,66 +1,66 @@
 <div class="compose-scrollable-buttons compose-control-buttons-container order-1" tabindex="-1">
     <input type="file" class="file_input notvisible" multiple />
-    <div class="compose_control_button_container" data-tooltip-template-id="preview-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container compose_button_tooltip" data-tooltip-template-id="preview-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="markdown_preview compose_control_button zulip-icon zulip-icon-preview" aria-label="{{t 'Preview' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container" data-tippy-content="{{t 'Write' }}">
+    <div class="compose_control_button_container compose_button_tooltip" data-tippy-content="{{t 'Write' }}">
         <a role="button" class="undo_markdown_preview compose_control_button zulip-icon zulip-icon-compose-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;"></a>
     </div>
     {{#if file_upload_enabled }}
-    <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Upload files' }}">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Upload files' }}">
         <a role="button" class="compose_control_button compose_upload_file zulip-icon zulip-icon-attachment" aria-label="{{t 'Upload files' }}" tabindex=0></a>
     </div>
     {{/if}}
-    <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add video call' }}">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add video call' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-video-call video_link" aria-label="{{t 'Add video call' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add voice call' }}">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add voice call' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-voice-call audio_link" aria-label="{{t 'Add voice call' }}" tabindex=0></a>
     </div>
     <div class="divider"></div>
-    <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Add emoji' }}">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add emoji' }}">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-smile-bigger emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container preview_mode_disabled" data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-time time_pick" aria-label="{{t 'Add global time' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}} preview_mode_disabled" data-tippy-content="{{t 'Add GIF' }}">
+    <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}} preview_mode_disabled compose_button_tooltip" data-tippy-content="{{t 'Add GIF' }}">
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
     </div>
     {{#if message_id}}
-    <div class="compose_control_button_container preview_mode_disabled" data-tooltip-template-id="add-saved-snippet-tooltip">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
         <a role="button" class="saved_snippets_widget saved-snippets-message-edit-widget compose_control_button zulip-icon zulip-icon-message-square-text" aria-label="{{t 'Add saved snippet' }}" data-message-id="{{message_id}}" tabindex=0></a>
     </div>
     {{else}}
-    <div class="compose_control_button_container preview_mode_disabled" data-tooltip-template-id="add-saved-snippet-tooltip">
+    <div class="compose_control_button_container preview_mode_disabled compose_button_tooltip" data-tooltip-template-id="add-saved-snippet-tooltip">
         <a role="button" class="saved_snippets_widget saved-snippets-composebox-widget compose_control_button zulip-icon zulip-icon-message-square-text" aria-label="{{t 'Add saved snippet' }}" tabindex=0></a>
     </div>
     {{/if}}
     <div class="divider"></div>
     <div class="compose-control-buttons-container preview_mode_disabled">
-        <a role="button" data-format-type="link" class="compose_control_button zulip-icon zulip-icon-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="link-tooltip" data-tippy-maxWidth="none"></a>
-        <a role="button" data-format-type="bold" class="compose_control_button zulip-icon zulip-icon-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="bold-tooltip" data-tippy-maxWidth="none"></a>
-        <a role="button" data-format-type="italic" class="compose_control_button zulip-icon zulip-icon-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="italic-tooltip" data-tippy-maxWidth="none"></a>
-        <a role="button" data-format-type="strikethrough" class="compose_control_button zulip-icon zulip-icon-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Strikethrough' }}"></a>
+        <a role="button" data-format-type="link" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="link-tooltip" data-tippy-maxWidth="none"></a>
+        <a role="button" data-format-type="bold" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="bold-tooltip" data-tippy-maxWidth="none"></a>
+        <a role="button" data-format-type="italic" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tooltip-template-id="italic-tooltip" data-tippy-maxWidth="none"></a>
+        <a role="button" data-format-type="strikethrough" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-strikethrough formatting_button" aria-label="{{t 'Strikethrough' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Strikethrough' }}"></a>
     </div>
     <div class="divider"></div>
     <div class="compose-control-buttons-container preview_mode_disabled">
-        <a role="button" data-format-type="numbered" class="compose_control_button zulip-icon zulip-icon-ordered-list formatting_button" aria-label="{{t 'Numbered list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Numbered list' }}"></a>
-        <a role="button" data-format-type="bulleted" class="compose_control_button zulip-icon zulip-icon-unordered-list formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
+        <a role="button" data-format-type="numbered" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-ordered-list formatting_button" aria-label="{{t 'Numbered list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Numbered list' }}"></a>
+        <a role="button" data-format-type="bulleted" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-unordered-list formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
         <div class="divider"></div>
-        <a role="button" data-format-type="quote" class="compose_control_button zulip-icon zulip-icon-quote formatting_button" aria-label="{{t 'Quote' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Quote' }}"></a>
-        <a role="button" data-format-type="spoiler" class="compose_control_button zulip-icon zulip-icon-spoiler formatting_button" aria-label="{{t 'Spoiler' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Spoiler' }}"></a>
-        <a role="button" data-format-type="code" class="compose_control_button zulip-icon zulip-icon-code formatting_button" aria-label="{{t 'Code' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Code' }}"></a>
-        <a role="button" data-format-type="latex" class="compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'Math (LaTeX)' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Math (LaTeX)' }}"></a>
+        <a role="button" data-format-type="quote" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-quote formatting_button" aria-label="{{t 'Quote' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Quote' }}"></a>
+        <a role="button" data-format-type="spoiler" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-spoiler formatting_button" aria-label="{{t 'Spoiler' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Spoiler' }}"></a>
+        <a role="button" data-format-type="code" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-code formatting_button" aria-label="{{t 'Code' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Code' }}"></a>
+        <a role="button" data-format-type="latex" class="compose_button_tooltip compose_control_button zulip-icon zulip-icon-math formatting_button" aria-label="{{t 'Math (LaTeX)' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Math (LaTeX)' }}"></a>
     </div>
     <div class="divider"></div>
     {{#unless message_id}}
-    <div class="compose_control_button_container preview_mode_disabled needs-empty-compose" data-tooltip-template-id="add-poll-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container preview_mode_disabled needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-poll-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-poll add-poll" aria-label="{{t 'Add poll' }}" tabindex=0></a>
     </div>
-    <div class="compose_control_button_container preview_mode_disabled needs-empty-compose" data-tooltip-template-id="add-todo-tooltip" data-tippy-maxWidth="none">
+    <div class="compose_control_button_container preview_mode_disabled needs-empty-compose compose_button_tooltip" data-tooltip-template-id="add-todo-tooltip" data-tippy-maxWidth="none">
         <a role="button" class="compose_control_button zulip-icon zulip-icon-todo-list add-todo-list" aria-label="{{t 'Add to-do list' }}" tabindex=0></a>
     </div>
     {{/unless}}
-    <a role="button" class="compose_control_button compose_help_button zulip-icon zulip-icon-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>
+    <a role="button" class="compose_control_button compose_help_button zulip-icon zulip-icon-question compose_button_tooltip" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>
 </div>

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -36,6 +36,7 @@ set_global("requestAnimationFrame", (func) => func());
 const autosize = noop;
 autosize.update = noop;
 mock_esm("autosize", {default: autosize});
+mock_esm("../src/compose_tooltips", {initialize_compose_tooltips: noop});
 
 const channel = mock_esm("../src/channel");
 const compose_fade = mock_esm("../src/compose_fade", {


### PR DESCRIPTION
This PR groups the tooltips for compose box formatting buttons so that the delay only applies to the first button you hover.

This allows two things:
- Smooth transitions of the tippy between many different reference element targets
- Elements with tooltips next to each other that have a delay can be "grouped" so they appear to share a timeout, which greatly improves UX.
- Previously , the tooltips of formatting buttons were treated independently and each of them had their own delays which doesn't feel smooth while hovering.

Fixes: #24825.
Previous PR Reference: #28387.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Status  | Behaviour |
|---------|------------------------------------------------------------------------------------------|
| Before  | ![Before](https://github.com/user-attachments/assets/9a1215bc-226b-4597-9588-bdf3776956ca) |
| After   | ![After](https://github.com/user-attachments/assets/55f1850e-d10d-430b-85c3-fda6127a32c4) |





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
