### PR TITLE
Live update permissions panel when group gains permission.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -83,6 +83,7 @@ import * as stream_ui_updates from "./stream_ui_updates.ts";
 import * as sub_store from "./sub_store.ts";
 import * as submessage from "./submessage.ts";
 import * as theme from "./theme.ts";
+import {group_setting_value_schema} from "./types.ts";
 import * as typing_events from "./typing_events.ts";
 import * as unread_ops from "./unread_ops.ts";
 import * as unread_ui from "./unread_ui.ts";
@@ -300,10 +301,9 @@ export function dispatch_normal_event(event) {
                                         realm.server_supported_permission_settings.realm,
                                     ).includes(key)
                                 ) {
-                                    const $elem = $(`#id_group_permission_${CSS.escape(key)}`);
-                                    user_group_edit.update_setting_in_group_permissions_panel(
-                                        $elem,
-                                        value,
+                                    user_group_edit.update_realm_setting_in_permissions_panel(
+                                        key,
+                                        group_setting_value_schema.parse(value),
                                     );
                                 }
 

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1776,11 +1776,16 @@ export function set_custom_time_inputs_visibility(
 }
 
 export function get_group_assigned_realm_permissions(group: UserGroup): {
+    subsection_key: string;
     subsection_heading: string;
     assigned_permissions: AssignedGroupPermission[];
 }[] {
     const group_assigned_realm_permissions = [];
-    for (const {subsection_heading, settings} of settings_config.realm_group_permission_settings) {
+    for (const {
+        subsection_heading,
+        subsection_key,
+        settings,
+    } of settings_config.realm_group_permission_settings) {
         const assigned_permission_objects = [];
         for (const setting_name of settings) {
             const setting_value = realm[realm_schema.keyof().parse("realm_" + setting_name)];
@@ -1802,6 +1807,7 @@ export function get_group_assigned_realm_permissions(group: UserGroup): {
         }
         group_assigned_realm_permissions.push({
             subsection_heading,
+            subsection_key,
             assigned_permissions: assigned_permission_objects,
         });
     }

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1800,12 +1800,10 @@ export function get_group_assigned_realm_permissions(group: UserGroup): {
                 assigned_permission_objects.push(assigned_permission_object);
             }
         }
-        if (assigned_permission_objects.length > 0) {
-            group_assigned_realm_permissions.push({
-                subsection_heading,
-                assigned_permissions: assigned_permission_objects,
-            });
-        }
+        group_assigned_realm_permissions.push({
+            subsection_heading,
+            assigned_permissions: assigned_permission_objects,
+        });
     }
     return group_assigned_realm_permissions;
 }

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1780,17 +1780,13 @@ export function get_group_assigned_realm_permissions(group: UserGroup): {
     assigned_permissions: AssignedGroupPermission[];
 }[] {
     const group_assigned_realm_permissions = [];
-    const owner_editable_settings = new Set([
-        "can_create_groups",
-        "can_invite_users_group",
-        "can_manage_all_groups",
-        "create_multiuse_invite_group",
-    ]);
     for (const {subsection_heading, settings} of settings_config.realm_group_permission_settings) {
         const assigned_permission_objects = [];
         for (const setting_name of settings) {
             const setting_value = realm[realm_schema.keyof().parse("realm_" + setting_name)];
-            const can_edit = owner_editable_settings.has(setting_name)
+            const can_edit = settings_config.owner_editable_realm_group_permission_settings.has(
+                setting_name,
+            )
                 ? current_user.is_owner
                 : current_user.is_admin;
             const assigned_permission_object =

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -716,14 +716,17 @@ export const all_group_setting_labels = {
 // in group permissions panel.
 export const realm_group_permission_settings: {
     subsection_heading: string;
+    subsection_key: string;
     settings: RealmGroupSettingName[];
 }[] = [
     {
         subsection_heading: $t({defaultMessage: "Joining the organization"}),
+        subsection_key: "org-join-settings",
         settings: ["can_invite_users_group", "create_multiuse_invite_group"],
     },
     {
         subsection_heading: $t({defaultMessage: "Channel permissions"}),
+        subsection_key: "org-stream-permissions",
         settings: [
             "can_create_public_channel_group",
             "can_create_web_public_channel_group",
@@ -733,14 +736,17 @@ export const realm_group_permission_settings: {
     },
     {
         subsection_heading: $t({defaultMessage: "Group permissions"}),
+        subsection_key: "org-group-permissions",
         settings: ["can_manage_all_groups", "can_create_groups"],
     },
     {
         subsection_heading: $t({defaultMessage: "Direct message permissions"}),
+        subsection_key: "org-direct-message-permissions",
         settings: ["direct_message_permission_group", "direct_message_initiator_group"],
     },
     {
         subsection_heading: $t({defaultMessage: "Moving messages"}),
+        subsection_key: "org-moving-msgs",
         settings: [
             "can_move_messages_between_topics_group",
             "can_move_messages_between_channels_group",
@@ -748,14 +754,17 @@ export const realm_group_permission_settings: {
     },
     {
         subsection_heading: $t({defaultMessage: "Message deletion"}),
+        subsection_key: "org-msg-deletion",
         settings: ["can_delete_any_message_group", "can_delete_own_message_group"],
     },
     {
         subsection_heading: $t({defaultMessage: "Guests"}),
+        subsection_key: "org-guests-permissions",
         settings: ["can_access_all_users_group"],
     },
     {
         subsection_heading: $t({defaultMessage: "Other permissions"}),
+        subsection_key: "org-other-permissions",
         settings: [
             "can_create_write_only_bots_group",
             "can_create_bots_group",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -764,6 +764,13 @@ export const realm_group_permission_settings: {
     },
 ];
 
+export const owner_editable_realm_group_permission_settings = new Set([
+    "can_create_groups",
+    "can_invite_users_group",
+    "can_manage_all_groups",
+    "create_multiuse_invite_group",
+]);
+
 // Order of settings is important, as this list is used to
 // render assigned permissions in permissions panel.
 export const stream_group_permission_settings: StreamGroupSettingName[] = [

--- a/web/src/stream_events.ts
+++ b/web/src/stream_events.ts
@@ -104,12 +104,10 @@ export function update_property<P extends keyof UpdatableStreamProperties>(
             sub,
             group_setting_value_schema.parse(value),
         );
-        const $elem = $(
-            `#id_group_permission_${CSS.escape(sub.stream_id.toString())}_${CSS.escape(property)}`,
-        );
-        user_group_edit.update_setting_in_group_permissions_panel(
-            $elem,
+        user_group_edit.update_stream_setting_in_permissions_panel(
+            stream_permission_group_settings_schema.parse(property),
             group_setting_value_schema.parse(value),
+            sub,
         );
         return;
     }

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -672,6 +672,9 @@ export function update_setting_in_group_permissions_panel(
 export function show_settings_for(group: UserGroup): void {
     const group_assigned_realm_permissions =
         settings_components.get_group_assigned_realm_permissions(group);
+    const group_has_no_realm_permissions = group_assigned_realm_permissions.every(
+        (subsection_obj) => subsection_obj.assigned_permissions.length === 0,
+    );
     const group_assigned_stream_permissions =
         settings_components.get_group_assigned_stream_permissions(group);
     const group_assigned_user_group_permissions =
@@ -695,10 +698,11 @@ export function show_settings_for(group: UserGroup): void {
         ...get_membership_status_context(group),
         all_group_setting_labels: settings_config.all_group_setting_labels,
         group_assigned_realm_permissions,
+        group_has_no_realm_permissions,
         group_assigned_stream_permissions,
         group_assigned_user_group_permissions,
         group_has_no_permissions:
-            group_assigned_realm_permissions.length === 0 &&
+            group_has_no_realm_permissions &&
             group_assigned_stream_permissions.length === 0 &&
             group_assigned_user_group_permissions.length === 0,
     });

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -1,5 +1,5 @@
 <div class="group-permissions">
-    <div class="realm-group-permissions group-permissions-section {{#unless group_assigned_realm_permissions.length}}hide{{/unless}}">
+    <div class="realm-group-permissions group-permissions-section {{#if group_has_no_realm_permissions}}hide{{/if}}">
         <h3>{{t "Organization permissions"}}</h3>
 
         {{#each group_assigned_realm_permissions}}
@@ -28,27 +28,12 @@
         <h3>{{t "Channel permissions"}}</h3>
 
         {{#each group_assigned_stream_permissions}}
-            <div class="settings-subsection-parent {{#unless assigned_permissions.length}}hide{{/unless}}" data-stream-id="{{stream.stream_id}}">
-                <div class="subsection-header">
-                    <h3>
-                        {{> ../inline_decorated_stream_name stream=stream }}
-                    </h3>
-                    {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
-                </div>
-
-                <div class="subsection-settings">
-                    {{#each assigned_permissions}}
-                        {{> ../settings/settings_checkbox
-                          setting_name=setting_name
-                          prefix=../id_prefix
-                          is_checked=true
-                          label=(lookup ../../all_group_setting_labels.stream setting_name)
-                          is_disabled=(not can_edit)
-                          tooltip_message=tooltip_message
-                          }}
-                    {{/each}}
-                </div>
-            </div>
+            {{> stream_group_permission_settings
+              stream=stream
+              assigned_permissions=assigned_permissions
+              setting_labels=../all_group_setting_labels.stream
+              id_prefix=id_prefix
+              }}
         {{/each}}
     </div>
 
@@ -56,25 +41,13 @@
         <h3>{{t "User group permissions"}}</h3>
 
         {{#each group_assigned_user_group_permissions}}
-            <div class="settings-subsection-parent {{#unless assigned_permissions.length}}hide{{/unless}}" data-group-id="{{group_id}}">
-                <div class="subsection-header">
-                    <h3>{{group_name}}</h3>
-                    {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
-                </div>
-
-                <div class="subsection-settings">
-                    {{#each assigned_permissions}}
-                        {{> ../settings/settings_checkbox
-                          setting_name=setting_name
-                          prefix=../id_prefix
-                          is_checked=true
-                          label=(lookup ../../all_group_setting_labels.group setting_name)
-                          is_disabled=(not can_edit)
-                          tooltip_message=tooltip_message
-                          }}
-                    {{/each}}
-                </div>
-            </div>
+            {{> user_group_permission_settings
+              group_id=group_id
+              group_name=group_name
+              assigned_permissions=assigned_permissions
+              setting_labels=../all_group_setting_labels.group
+              id_prefix=id_prefix
+              }}
         {{/each}}
     </div>
 </div>

--- a/web/templates/user_group_settings/group_permission_settings.hbs
+++ b/web/templates/user_group_settings/group_permission_settings.hbs
@@ -3,7 +3,7 @@
         <h3>{{t "Organization permissions"}}</h3>
 
         {{#each group_assigned_realm_permissions}}
-            <div class="settings-subsection-parent {{#unless assigned_permissions.length}}hide{{/unless}}">
+            <div class="settings-subsection-parent {{subsection_key}} {{#unless assigned_permissions.length}}hide{{/unless}}">
                 <div class="subsection-header">
                     <h3>{{subsection_heading}}</h3>
                     {{> ../settings/settings_save_discard_widget show_only_indicator=false }}

--- a/web/templates/user_group_settings/stream_group_permission_settings.hbs
+++ b/web/templates/user_group_settings/stream_group_permission_settings.hbs
@@ -1,0 +1,21 @@
+<div class="settings-subsection-parent" data-stream-id="{{stream.stream_id}}">
+    <div class="subsection-header">
+        <h3>
+            {{> ../inline_decorated_stream_name stream=stream }}
+        </h3>
+        {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
+    </div>
+
+    <div class="subsection-settings">
+        {{#each assigned_permissions}}
+            {{> ../settings/settings_checkbox
+              setting_name=setting_name
+              prefix=../id_prefix
+              is_checked=true
+              label=(lookup ../setting_labels setting_name)
+              is_disabled=(not can_edit)
+              tooltip_message=tooltip_message
+              }}
+        {{/each}}
+    </div>
+</div>

--- a/web/templates/user_group_settings/user_group_permission_settings.hbs
+++ b/web/templates/user_group_settings/user_group_permission_settings.hbs
@@ -1,0 +1,19 @@
+<div class="settings-subsection-parent" data-group-id="{{group_id}}">
+    <div class="subsection-header">
+        <h3>{{group_name}}</h3>
+        {{> ../settings/settings_save_discard_widget show_only_indicator=false }}
+    </div>
+
+    <div class="subsection-settings">
+        {{#each assigned_permissions}}
+            {{> ../settings/settings_checkbox
+              setting_name=setting_name
+              prefix=../id_prefix
+              is_checked=true
+              label=(lookup ../setting_labels setting_name)
+              is_disabled=(not can_edit)
+              tooltip_message=tooltip_message
+              }}
+        {{/each}}
+    </div>
+</div>

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -590,7 +590,7 @@ run_test("realm settings", ({override}) => {
         },
     });
     override(settings_org, "populate_auth_methods", noop);
-    override(user_group_edit, "update_setting_in_group_permissions_panel", noop);
+    override(user_group_edit, "update_realm_setting_in_permissions_panel", noop);
     dispatch(event);
     assert_same(realm.realm_create_multiuse_invite_group, 3);
     assert_same(realm.realm_allow_message_editing, true);

--- a/web/tests/stream_events.test.cjs
+++ b/web/tests/stream_events.test.cjs
@@ -118,7 +118,7 @@ test("update_property", ({override}) => {
         "server_supported_permission_settings",
         example_settings.server_supported_permission_settings,
     );
-    override(user_group_edit, "update_setting_in_group_permissions_panel", noop);
+    override(user_group_edit, "update_stream_setting_in_permissions_panel", noop);
     const sub = {...frontend};
     stream_data.add_sub(sub);
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First two commits are refactors.
- Last commit is to live-update permissions panel when group gains permission.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
