### PR TITLE
integrations: Update documentation on the Zoom integration.

### DIFF
--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -17,7 +17,7 @@ using the call provider (Jitsi, Zoom, etc.)
 
 {!start-composing.md!}
 
-1. Click the **video camera** (<i class="zulip-icon zulip-icon-video-call"></i>)
+1. Click the **Add video call** (<i class="zulip-icon zulip-icon-video-call"></i>)
    icon at the bottom of the compose box. This will insert a **Join video call.**
    link into your message.
 
@@ -34,9 +34,10 @@ using the call provider (Jitsi, Zoom, etc.)
 
 1. Navigate to a channel, topic, or direct message view.
 
-1. Tap the **video camera**
-   (<img src="/static/images/help/mobile-video-icon.svg" alt="video" class="help-center-icon"/>)
-   button at the bottom of the app. This will insert a **Click to join video call**
+1. Tap the **Add video call**
+   ( <img src="/static/images/help/mobile-video-icon.svg" alt="video"
+   class="help-center-icon"/> )
+   icon at the bottom of the app. This will insert a **Click to join video call**
    link into your message.
 
 1. If you are in a channel view, choose a destination topic by tapping the
@@ -61,9 +62,9 @@ using the call provider (Jitsi, Zoom, etc.)
 
 {!start-composing.md!}
 
-1. Click the **phone** (<i class="zulip-icon zulip-icon-voice-call"></i>) icon
-   at the bottom of the compose box. This will insert a **Join voice call.**
-   link into your message.
+1. Click the **Add voice call** (<i class="zulip-icon
+   zulip-icon-voice-call"></i>) icon at the bottom of the compose box. This
+   will insert a **Join voice call.** link into your message.
 
 1. Send the message.
 
@@ -127,9 +128,28 @@ instance of Jitsi Meet.
 
 {end_tabs}
 
+## Unlink your Zoom account from Zulip
+
+If you linked your Zoom account to Zulip, and no longer want it to be connected,
+you can unlink it.
+
+{start_tabs}
+
+1. Log in to the [Zoom App Marketplace](https://marketplace.zoom.us/), and
+   select **Manage**.
+
+1. Select **Added Apps** and click the **Remove** button next to the Zulip app.
+
+1. Click **Confirm**.
+
+{end_tabs}
+
 [big-blue-button-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#bigbluebutton
 [zoom-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#zoom
 
 ## Related articles
 
+* [Jitsi Meet integration](/integrations/doc/jitsi)
+* [Zoom integration integration](/integrations/doc/zoom)
+* [BigBlueButton integration](/integrations/doc/big-blue-button)
 * [Insert a link](/help/insert-a-link)

--- a/templates/zerver/integrations/zoom.md
+++ b/templates/zerver/integrations/zoom.md
@@ -1,23 +1,46 @@
-Zulip supports using Zoom as its video call provider.
+# Use Zoom as your call provider in Zulip
 
-### Using Zoom
+You can configure Zoom as the call provider for your organization. Users will be
+able to start a Zoom call and invite others using the **add video call** (<i
+class="zulip-icon zulip-icon-video-call"></i>) or **add voice call** (<i
+class="zulip-icon zulip-icon-voice-call"></i>) button [in the compose
+box](/help/start-a-call).
 
-1. Select Zoom as the organization's [video call provider](/help/start-a-call#changing-your-organizations-video-call-provider).
+## Configure Zoom as your call provider
 
-1. Zulip's [call button](/help/start-a-call) will now create meetings
-   using Zoom.
+By default, Zulip integrates with
+[Jitsi Meet](https://jitsi.org/jitsi-meet/), a fully-encrypted, 100% open
+source video conferencing solution. You can configure Zulip to use Zoom as your
+call provider instead.
 
-The first time a user clicks the call button, they will be prompted to
-link their Zoom account with their Zulip account.
+### Configure Zoom on Zulip Cloud
 
-**Note**: If you are self-hosting, you will need to [create a Zoom
-    application](https://zulip.readthedocs.io/en/latest/production/video-calls.html#zoom)
-    in order to use this integration.
+{start_tabs}
 
-### Unlinking your Zoom account
+1. Click on the **gear** (<i class="zulip-icon zulip-icon-gear"></i>) icon in
+   the upper right corner of the web or desktop app.
 
-1. Log in to the [Zoom App Marketplace](https://marketplace.zoom.us/).
+1. Select **Organization settings**.
 
-1. Click **Manage** → **Installed Apps**.
+1. On the left, click **Organization settings**.
 
-1. Click the **Uninstall** button next to the Zulip app.
+1. Under **Other settings**, select Zoom from the **Call provider** dropdown.
+
+1. Click **Save changes**.
+
+{end_tabs}
+
+Users will be prompted to log in to their Zoom account the first time they
+join a call.
+
+## Configure Zoom for a self-hosted organization
+
+If you are self-hosting, you will need to [create a Zoom
+application](https://zulip.readthedocs.io/en/latest/production/video-calls.html#zoom)
+in order to use this integration.
+
+## Related documentation
+
+- [How to start a call](/help/start-a-call)
+- [Jitsi Meet integration](/integrations/doc/jitsi)
+- [BigBlueButton integration](/integrations/doc/big-blue-button)


### PR DESCRIPTION
- Duplicate admin instructions on /integrations (with context).
- Move end user instructions to /help.


**Notes:**
- I think I incorporated all the changes and feedback from #33100 that needed to be preserved.
- The /integrations doc and the help center disagreed on whether you'll be asked to log in when you first *start* a call, or when you first *join* one. I assumed the latter (from the help center) was correct.
- I left the self-hosted documentation as a stub, since we're working on changing how that works.


Current: https://zulip.com/integrations/doc/zoom
<details>
<summary>
Updated
</summary>

![Screenshot 2025-02-04 at 11 19 50](https://github.com/user-attachments/assets/bdf2891a-88ee-4af3-91b3-260240c44476)

</details>

Current: https://zulip.com/help/start-a-call
<details>
<summary>
Updated
</summary>

![Screenshot 2025-02-04 at 11 28 33](https://github.com/user-attachments/assets/ec4bdf58-c8f4-46ea-a385-65980eaf92d9)
![Screenshot 2025-02-04 at 11 33 36](https://github.com/user-attachments/assets/4a4e387a-5ac5-4544-b98d-a265e3316ffd)

![Screenshot 2025-02-04 at 11 30 21](https://github.com/user-attachments/assets/deec1b83-11d6-4c11-913c-e7540776b977)

</details>