### PR TITLE
app_components: Center-align the shortcut keys in help menu.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -32,8 +32,9 @@ kbd {
     background-color: var(--color-kbd-background);
     color: var(--color-kbd-text);
     margin: 0.25em 0.1em;
-    padding: 0.2em 0.4em;
+    padding: 0.2em 0.4em 0;
     text-shadow: 0 1px 0 hsl(0deg 0% 100%);
+    text-align: center;
     /* Prevent selection */
     user-select: none;
     position: relative;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -39,6 +39,7 @@ kbd {
     position: relative;
     min-height: 1em;
     min-width: 1em;
+    opacity: var(--opacity-hotkey-hint);
 
     .zulip-icon::before {
         position: absolute;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -26,7 +26,7 @@
 kbd {
     display: inline-block;
     border: 1px solid var(--color-kbd-border);
-    border-radius: 4px;
+    border-radius: 3px;
     font-weight: 600;
     white-space: nowrap;
     background-color: var(--color-kbd-background);

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1406,6 +1406,9 @@
     --color-kbd-text: light-dark(hsl(0deg 0% 20%), hsl(236deg 33% 90%));
     --color-kbd-enter-sends: light-dark(hsl(0deg 0% 40%), hsl(236deg 33% 90%));
 
+    /* Hotkey opacity */
+    --opacity-hotkey-hint: 1;
+
     /* Settings */
     --color-realm-enable-spectator-access-link: light-dark(
         hsl(0deg 0% 20%),

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -47,10 +47,7 @@
     #keyboard-shortcuts {
         & kbd {
             border: 1px solid var(--color-hotkey-hint);
-            border-radius: 3px;
             color: var(--color-hotkey-hint);
-            text-align: center;
-            opacity: 0.8;
         }
     }
 

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -73,8 +73,8 @@
 
     .arrow-key {
         font-size: 1.36em;
-        line-height: 1;
-        padding: 0 0.2em 0.2em;
+        line-height: normal;
+        padding: 0 0.2em;
     }
 
     & th {


### PR DESCRIPTION
- Shortcut keys in help menu were not centered in light theme. This PR adds `text-align: center` for the keys in the light theme.
- We had different border-radius defined for light and dark theme. This PR makes the border radius for dark theme equal to that of light theme.

[CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/keys.20not.20centered.20in.20help.20menu/near/2077139)

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<th colspan="2">
Help menu/shortcut keys/The basics
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/b9026777-1716-48e6-abd2-002090bba1a5)

</td>
<td>

![image](https://github.com/user-attachments/assets/c857313e-10a7-4962-b8df-8184050664f6)

</td>
</tr>
<th colspan="2">
Help menu/shortcut keys/Search
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/4b5eb2e5-3dd0-464d-af26-5bb471be409e)

</td>
<td>

![image](https://github.com/user-attachments/assets/1c4bfa3a-e07a-428d-88e4-c3874396aec2)

</td>

</tr>
<th colspan="2">
Help menu/shortcut keys/Navigation
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/6b6df60d-710b-4a4d-9d2a-115f91174ce6)


</td>
<td>

![image](https://github.com/user-attachments/assets/1743d638-b118-42d1-913f-8c38964c0bca)

</td>

</tr>
<th colspan="2">
Help menu/shortcut keys/Composing Messages
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/b32bb6c7-83c9-4fa3-ad39-8fc0da48407d)

</td>
<td>

![image](https://github.com/user-attachments/assets/ffb0e681-d0b1-403b-bb7f-26cddf3e8ae1)

</td>
</tr>
<th colspan="2">
Help menu/shortcut keys/Recent Converations
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/bf5e44a2-6d1e-4299-83b3-143b271a6394)

</td>
<td>

![image](https://github.com/user-attachments/assets/6d4552b7-482d-4ab9-bccc-932bb6473cd4)

</td>
</tr>
<th colspan="2">
Help menu/shortcut keys/Channel Settings
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/e2e42960-a6e5-49a8-a32c-d87ff60d1deb)


</td>
<td>

![image](https://github.com/user-attachments/assets/65a06cb9-b61a-43b0-90a3-14b981eafda0)

</td>

</tr>
<th colspan="2">
Help menu/Message Formatting
</th>
<tr>
<td>

![image](https://github.com/user-attachments/assets/7a3a3fd8-8649-46bf-b4a3-346274b405c9)

</td>
<td>

![image](https://github.com/user-attachments/assets/ee0eb96f-8f99-403f-b5f9-c868eb6f5b2a)

</td>
</tr>
</table>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
