### PR TITLE
compose: Handle *general chat* in topic box.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -349,7 +349,7 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         compose_state.set_stream_id("");
         compose_recipient.toggle_compose_recipient_dropdown();
     }
-    compose_state.topic(opts.topic);
+    compose_recipient.update_topic_displayed_text(opts.topic);
 
     // Set the recipients with a space after each comma, so it looks nice.
     compose_state.private_message_recipient(
@@ -528,7 +528,7 @@ export let on_topic_narrow = (): void => {
     // we should update the compose topic to match the new narrow.
     // See #3300 for context--a couple users specifically asked for
     // this convenience.
-    compose_state.topic(narrow_state.topic());
+    compose_recipient.update_topic_displayed_text(narrow_state.topic());
     compose_validate.warn_if_topic_resolved(true);
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -190,7 +190,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
     maybe_scroll_up_selected_message(opts);
     compose_fade.start_compose(opts.message_type);
     $(document).trigger(new $.Event("compose_started.zulip", opts));
-    compose_recipient.update_placeholder_text();
+    compose_recipient.update_compose_area_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
     // We explicitly call this function here apart from compose_setup.js
     // as this helps to show banner when responding in an interleaved view.

--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -25,6 +25,7 @@ import * as popovers from "./popovers.ts";
 import * as reload_state from "./reload_state.ts";
 import * as resize from "./resize.ts";
 import * as spectators from "./spectators.ts";
+import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 
 // Opts sent to `compose_actions.start`.
@@ -509,7 +510,8 @@ export let on_topic_narrow = (): void => {
     }
 
     if (
-        (compose_state.topic() && compose_state.has_novel_message_content()) ||
+        ((compose_state.topic() || !realm.realm_mandatory_topics) &&
+            compose_state.has_message_content()) ||
         compose_state.is_recipient_edited_manually()
     ) {
         // If the user has written something to a different topic or edited it,

--- a/web/src/compose_fade_helper.ts
+++ b/web/src/compose_fade_helper.ts
@@ -1,4 +1,5 @@
 import type {Message} from "./message_store.ts";
+import {realm} from "./state_data.ts";
 import * as sub_store from "./sub_store.ts";
 import type {Recipient} from "./util.ts";
 import * as util from "./util.ts";
@@ -31,11 +32,8 @@ export function want_normal_display(): boolean {
             return true;
         }
 
-        // This is kind of debatable.  If the topic is empty, it could be that
-        // the user simply hasn't started typing it yet, but disabling fading here
-        // means the feature doesn't help realms where topics aren't mandatory
-        // (which is most realms as of this writing).
-        if (focused_recipient.topic === "") {
+        // If the topic is empty, and the realm requires topics, then we want a normal display.
+        if (focused_recipient.topic === "" && realm.realm_mandatory_topics) {
             return true;
         }
     }

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -175,7 +175,7 @@ function switch_message_type(message_type: MessageType): void {
         private_message_recipient: compose_state.private_message_recipient(),
     };
     update_compose_for_message_type(opts);
-    update_placeholder_text();
+    update_compose_area_placeholder_text();
     compose_ui.set_focus(opts);
 }
 
@@ -348,7 +348,7 @@ export function initialize(): void {
     $("#private_message_recipient").on("input", restore_placeholder_in_firefox_for_no_input);
 }
 
-export let update_placeholder_text = (): void => {
+export let update_compose_area_placeholder_text = (): void => {
     const $textarea: JQuery<HTMLTextAreaElement> = $("textarea#compose-textarea");
     // Change compose placeholder text only if compose box is open.
     if (!$textarea.is(":visible")) {
@@ -375,8 +375,10 @@ export let update_placeholder_text = (): void => {
     compose_ui.autosize_textarea($textarea);
 };
 
-export function rewire_update_placeholder_text(value: typeof update_placeholder_text): void {
-    update_placeholder_text = value;
+export function rewire_update_compose_area_placeholder_text(
+    value: typeof update_compose_area_placeholder_text,
+): void {
+    update_compose_area_placeholder_text = value;
 }
 
 // This function addresses the issue of the placeholder not reappearing in Firefox

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -348,7 +348,7 @@ export function initialize(): void {
     $("#private_message_recipient").on("input", restore_placeholder_in_firefox_for_no_input);
 }
 
-export let update_compose_area_placeholder_text = (): void => {
+export let update_compose_area_placeholder_text = (empty_topic_display = true): void => {
     const $textarea: JQuery<HTMLTextAreaElement> = $("textarea#compose-textarea");
     // Change compose placeholder text only if compose box is open.
     if (!$textarea.is(":visible")) {
@@ -359,10 +359,14 @@ export let update_compose_area_placeholder_text = (): void => {
     let placeholder = compose_ui.DEFAULT_COMPOSE_PLACEHOLDER;
     if (message_type === "stream") {
         const stream_id = compose_state.stream_id();
+        let topic = compose_state.topic();
+        if (empty_topic_display && !realm.realm_mandatory_topics) {
+            topic = util.get_final_topic_display_name(topic);
+        }
         placeholder = compose_ui.compute_placeholder_text({
             message_type,
             stream_id,
-            topic: compose_state.topic(),
+            topic,
         });
     } else if (message_type === "private") {
         placeholder = compose_ui.compute_placeholder_text({

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -348,6 +348,33 @@ export function initialize(): void {
     $("#private_message_recipient").on("input", restore_placeholder_in_firefox_for_no_input);
 }
 
+export function update_topic_displayed_text(topic_name: string | undefined): void {
+    if (topic_name === undefined) {
+        topic_name = "";
+    }
+    // When topics are mandatory, we just call topic() as usual.
+    if (realm.realm_mandatory_topics) {
+        compose_state.topic(topic_name);
+        return;
+    }
+    // Otherwise, we have some adjustments to make to display the
+    // general topic as a stylized placeholder
+    const $input = $("input#stream_message_recipient_topic");
+    const is_empty_stream_topic = topic_name === "";
+    let topic_placeholder_text = $t({defaultMessage: "Topic"});
+
+    // Remove any stale references to the empty topic display
+    $input.removeClass("empty-topic-display");
+
+    if (is_empty_stream_topic) {
+        topic_placeholder_text = util.get_final_topic_display_name("");
+        $input.addClass("empty-topic-display");
+    }
+
+    $input.attr("placeholder", topic_placeholder_text);
+    compose_state.topic(topic_name);
+}
+
 export let update_compose_area_placeholder_text = (empty_topic_display = true): void => {
     const $textarea: JQuery<HTMLTextAreaElement> = $("textarea#compose-textarea");
     // Change compose placeholder text only if compose box is open.

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -365,11 +365,13 @@ export function update_topic_displayed_text(
     const $input = $("input#stream_message_recipient_topic");
     const is_empty_stream_topic = topic_name === "";
     let topic_placeholder_text = $t({defaultMessage: "Topic"});
+    const recipient_widget_hidden =
+        $(".compose_select_recipient-dropdown-list-container").length === 0;
 
     // Remove any stale references to the empty topic display
     $input.removeClass("empty-topic-display");
 
-    if (is_empty_stream_topic && !has_topic_focus) {
+    if (is_empty_stream_topic && !has_topic_focus && recipient_widget_hidden) {
         topic_placeholder_text = util.get_final_topic_display_name("");
         $input.addClass("empty-topic-display");
     }

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -348,7 +348,10 @@ export function initialize(): void {
     $("#private_message_recipient").on("input", restore_placeholder_in_firefox_for_no_input);
 }
 
-export function update_topic_displayed_text(topic_name: string | undefined): void {
+export function update_topic_displayed_text(
+    topic_name: string | undefined,
+    has_topic_focus = false,
+): void {
     if (topic_name === undefined) {
         topic_name = "";
     }
@@ -366,7 +369,7 @@ export function update_topic_displayed_text(topic_name: string | undefined): voi
     // Remove any stale references to the empty topic display
     $input.removeClass("empty-topic-display");
 
-    if (is_empty_stream_topic) {
+    if (is_empty_stream_topic && !has_topic_focus) {
         topic_placeholder_text = util.get_final_topic_display_name("");
         $input.addClass("empty-topic-display");
     }

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -501,7 +501,7 @@ export function initialize() {
     });
 
     $("textarea#compose-textarea").on("focus", () => {
-        compose_recipient.update_placeholder_text();
+        compose_recipient.update_compose_area_placeholder_text();
         if (narrow_state.narrowed_by_reply()) {
             compose_notifications.maybe_show_one_time_non_interleaved_view_messages_fading_banner();
         } else {
@@ -523,11 +523,11 @@ export function initialize() {
     });
 
     $("input#stream_message_recipient_topic").on("focus", () => {
-        compose_recipient.update_placeholder_text();
+        compose_recipient.update_compose_area_placeholder_text();
     });
 
     $("input#stream_message_recipient_topic").on("input", () => {
-        compose_recipient.update_placeholder_text();
+        compose_recipient.update_compose_area_placeholder_text();
     });
 
     $("body").on("click", ".formatting_button", function (e) {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -523,11 +523,18 @@ export function initialize() {
     });
 
     $("input#stream_message_recipient_topic").on("focus", () => {
-        compose_recipient.update_compose_area_placeholder_text();
+        const $input = $("input#stream_message_recipient_topic");
+        compose_recipient.update_topic_displayed_text($input.val(), true);
+        compose_recipient.update_compose_area_placeholder_text(false);
+
+        $("input#stream_message_recipient_topic").one("blur", () => {
+            compose_recipient.update_topic_displayed_text($input.val());
+            compose_recipient.update_compose_area_placeholder_text();
+        });
     });
 
     $("input#stream_message_recipient_topic").on("input", () => {
-        compose_recipient.update_compose_area_placeholder_text();
+        compose_recipient.update_compose_area_placeholder_text(false);
     });
 
     $("body").on("click", ".formatting_button", function (e) {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -3,6 +3,7 @@ import $ from "jquery";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import {$t} from "./i18n.ts";
 import * as people from "./people.ts";
+import {realm} from "./state_data.ts";
 import * as sub_store from "./sub_store.ts";
 
 let message_type: "stream" | "private" | undefined;
@@ -236,7 +237,8 @@ export function has_savable_message_content(): boolean {
 
 export function has_full_recipient(): boolean {
     if (message_type === "stream") {
-        return stream_id() !== undefined && topic() !== "";
+        const has_topic = topic() !== "" || !realm.realm_mandatory_topics;
+        return stream_id() !== undefined && has_topic;
     }
     return private_message_recipient() !== "";
 }

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -25,7 +25,7 @@ import * as people from "./people.ts";
 import {postprocess_content} from "./postprocess_content.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
 import * as rtl from "./rtl.ts";
-import {current_user} from "./state_data.ts";
+import {current_user, realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import * as user_status from "./user_status.ts";
 import * as util from "./util.ts";
@@ -202,7 +202,12 @@ export function maybe_show_scrolling_formatting_buttons(container_selector: stri
 function get_focus_area(opts: ComposeTriggeredOptions): string {
     // Set focus to "Topic" when narrowed to a stream+topic
     // and "Start new conversation" button clicked.
-    if (opts.message_type === "stream" && opts.stream_id && !opts.topic) {
+    if (
+        opts.message_type === "stream" &&
+        opts.stream_id &&
+        !opts.topic &&
+        realm.realm_mandatory_topics
+    ) {
         return "input#stream_message_recipient_topic";
     } else if (
         (opts.message_type === "stream" && opts.stream_id !== undefined) ||

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1433,6 +1433,7 @@ export function initialize({
         source(): string[] {
             return topics_seen_for(compose_state.stream_id());
         },
+        helpOnEmptyStrings: $("#compose-recipient").hasClass("permit-empty-topic"),
         items: max_num_items,
         highlighter_html(item: string): string {
             return typeahead_helper.render_typeahead_item({primary: item});

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -14,6 +14,7 @@ import * as messages_overlay_ui from "./messages_overlay_ui.ts";
 import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
 import * as rendered_markdown from "./rendered_markdown.ts";
+import {realm} from "./state_data.ts";
 import * as user_card_popover from "./user_card_popover.ts";
 import * as user_group_popover from "./user_group_popover.ts";
 
@@ -26,7 +27,10 @@ function restore_draft(draft_id: string): void {
     const compose_args = {...drafts.restore_message(draft), draft_id};
 
     if (compose_args.type === "stream") {
-        if (compose_args.stream_id !== undefined && compose_args.topic !== "") {
+        if (
+            compose_args.stream_id !== undefined &&
+            (compose_args.topic !== "" || !realm.realm_mandatory_topics)
+        ) {
             message_view.show(
                 [
                     {

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1373,7 +1373,7 @@ export function to_compose_target(): void {
         // grey-out the message view instead of narrowing to an empty view.
         const terms = [{operator: "channel", operand: stream_id.toString()}];
         const topic = compose_state.topic();
-        if (topic !== "") {
+        if (topic !== "" || !realm.realm_mandatory_topics) {
             terms.push({operator: "topic", operand: topic});
         }
         show(terms, opts);

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -1035,7 +1035,7 @@ export function dispatch_normal_event(event) {
 
                 // Update the status text in compose box placeholder when opened to self.
                 if (compose_pm_pill.get_user_ids().includes(event.user_id)) {
-                    compose_recipient.update_placeholder_text();
+                    compose_recipient.update_compose_area_placeholder_text();
                 }
             }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -576,7 +576,7 @@ export function initialize_everything(state_data) {
     compose_recipient.initialize();
     compose_pm_pill.initialize({
         on_pill_create_or_remove() {
-            compose_recipient.update_placeholder_text();
+            compose_recipient.update_compose_area_placeholder_text();
             compose_recipient.check_posting_policy_for_compose_box();
         },
     });

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -187,6 +187,7 @@ function initialize_compose_box() {
                 giphy_enabled: giphy_state.is_giphy_enabled(),
                 max_stream_name_length: realm.max_stream_name_length,
                 max_topic_length: realm.max_topic_length,
+                realm_mandatory_topics: realm.realm_mandatory_topics,
             }),
         ),
     );

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1058,6 +1058,10 @@ textarea.new_message_textarea {
         padding: 4px 6px;
         /* Reset height to let `align-items: stretch` on the grid parent handle this. */
         height: auto;
+
+        &.empty-topic-display::placeholder {
+            color: var(--color-compose-recipient-box-text-color);
+        }
     }
 
     /* Styles for new conversation button in the recipient_box */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1047,6 +1047,7 @@ textarea.new_message_textarea {
 
     /* Styles for input in the recipient_box */
     #stream_message_recipient_topic {
+        color: var(--color-compose-recipient-box-text-color);
         /* Override grid's effective `max-content` min-width */
         overflow: hidden;
         text-overflow: ellipsis;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1088,7 +1088,7 @@ textarea.new_message_textarea {
         }
     }
 
-    #stream_message_recipient_topic:placeholder-shown
+    #stream_message_recipient_topic:not(.empty-topic-display):placeholder-shown
         + #recipient_box_clear_topic_button {
         visibility: hidden;
     }

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -49,7 +49,7 @@
             <form id="send_message_form" action="/json/messages" method="post">
                 <div class="compose_table">
                     <div id="compose_top">
-                        <div id="compose-recipient">
+                        <div id="compose-recipient" {{#unless realm_mandatory_topics}}class="permit-empty-topic"{{/unless}}>
                             {{> dropdown_widget_wrapper
                               widget_name="compose_select_recipient"}}
                             <div class="topic-marker-container">

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -814,7 +814,7 @@ test_ui("on_events", ({override, override_rewire}) => {
     (function test_undo_markdown_preview_clicked() {
         fake_compose_box.show_message_preview();
 
-        override_rewire(compose_recipient, "update_placeholder_text", noop);
+        override_rewire(compose_recipient, "update_compose_area_placeholder_text", noop);
         override(narrow_state, "narrowed_by_reply", () => true);
         override(
             compose_notifications,

--- a/web/tests/compose_fade.test.cjs
+++ b/web/tests/compose_fade.test.cjs
@@ -25,6 +25,10 @@ const people = zrequire("people");
 const compose_fade = zrequire("compose_fade");
 const compose_fade_helper = zrequire("compose_fade_helper");
 const compose_state = zrequire("compose_state");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
 
 const me = {
     email: "me@example.com",
@@ -77,7 +81,7 @@ run_test("set_focused_recipient", () => {
     assert.ok(compose_fade_helper.should_fade_message(bad_msg));
 });
 
-run_test("want_normal_display", () => {
+run_test("want_normal_display", ({override}) => {
     const stream_id = 110;
     const sub = {
         stream_id,
@@ -100,8 +104,16 @@ run_test("want_normal_display", () => {
     assert.ok(compose_fade_helper.want_normal_display());
 
     // Focused recipient is a valid stream with no topic set
+    // when topics are mandatory
+    override(realm, "realm_mandatory_topics", true);
     stream_data.add_sub(sub);
     assert.ok(compose_fade_helper.want_normal_display());
+
+    // However, focused recipient is a valid stream with a
+    // topic set when topics are not mandatory
+    override(realm, "realm_mandatory_topics", false);
+    stream_data.add_sub(sub);
+    assert.ok(!compose_fade_helper.want_normal_display());
 
     // If we're focused to a topic, then we do want to fade.
     compose_fade_helper.set_focused_recipient({

--- a/web/tests/compose_state.test.cjs
+++ b/web/tests/compose_state.test.cjs
@@ -10,6 +10,10 @@ const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 
 const compose_state = zrequire("compose_state");
 const stream_data = zrequire("stream_data");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
 
 run_test("private_message_recipient", ({override}) => {
     let emails;

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -1280,7 +1280,7 @@ run_test("right-to-left", () => {
 });
 
 const get_focus_area = compose_ui._get_focus_area;
-run_test("get_focus_area", () => {
+run_test("get_focus_area", ({override}) => {
     assert.equal(get_focus_area({message_type: "private"}), "#private_message_recipient");
     assert.equal(
         get_focus_area({
@@ -1293,9 +1293,15 @@ run_test("get_focus_area", () => {
         get_focus_area({message_type: "stream"}),
         "#compose_select_recipient_widget_wrapper",
     );
+    override(realm, "realm_mandatory_topics", true);
     assert.equal(
         get_focus_area({message_type: "stream", stream_name: "fun", stream_id: 4}),
         "input#stream_message_recipient_topic",
+    );
+    override(realm, "realm_mandatory_topics", false);
+    assert.equal(
+        get_focus_area({message_type: "stream", stream_name: "fun", stream_id: 4}),
+        "textarea#compose-textarea",
     );
     assert.equal(
         get_focus_area({message_type: "stream", stream_name: "fun", stream_id: 4, topic: "more"}),

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -145,7 +145,7 @@ function initialize_pm_pill(mock_template) {
     $("#private_message_recipient").before = noop;
 
     compose_pm_pill.initialize({
-        on_pill_create_or_remove: compose_recipient.update_placeholder_text,
+        on_pill_create_or_remove: compose_recipient.update_compose_area_placeholder_text,
     });
 
     $("#zephyr-mirror-error").is = noop;

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -975,7 +975,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         },
     }));
     compose_pm_pill.initialize({
-        on_pill_create_or_remove: compose_recipient.update_placeholder_text,
+        on_pill_create_or_remove: compose_recipient.update_compose_area_placeholder_text,
     });
 
     let expected_value;

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -756,7 +756,7 @@ run_test("narrow_to_compose_target errors", ({disallow_rewire}) => {
     message_view.to_compose_target();
 });
 
-run_test("narrow_to_compose_target streams", ({override_rewire}) => {
+run_test("narrow_to_compose_target streams", ({override, override_rewire}) => {
     const args = {called: false};
     override_rewire(message_view, "show", (terms, opts) => {
         args.terms = terms;
@@ -790,19 +790,43 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
         {operator: "topic", operand: "four"},
     ]);
 
-    // Test with blank topic
+    // Test with blank topic, with realm_mandatory_topics
+    override(realm, "realm_mandatory_topics", true);
     compose_state.topic("");
     args.called = false;
     message_view.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [{operator: "channel", operand: rome_id.toString()}]);
 
-    // Test with no topic
+    // Test with blank topic, without realm_mandatory_topics
+    override(realm, "realm_mandatory_topics", false);
+    compose_state.topic("");
+    args.called = false;
+    message_view.to_compose_target();
+    assert.equal(args.called, true);
+    assert.deepEqual(args.terms, [
+        {operator: "channel", operand: rome_id.toString()},
+        {operator: "topic", operand: ""},
+    ]);
+
+    // Test with no topic, with realm mandatory topics
+    override(realm, "realm_mandatory_topics", true);
     compose_state.topic(undefined);
     args.called = false;
     message_view.to_compose_target();
     assert.equal(args.called, true);
     assert.deepEqual(args.terms, [{operator: "channel", operand: rome_id.toString()}]);
+
+    // Test with no topic, without realm mandatory topics
+    override(realm, "realm_mandatory_topics", false);
+    compose_state.topic(undefined);
+    args.called = false;
+    message_view.to_compose_target();
+    assert.equal(args.called, true);
+    assert.deepEqual(args.terms, [
+        {operator: "channel", operand: rome_id.toString()},
+        {operator: "topic", operand: ""},
+    ]);
 });
 
 run_test("narrow_to_compose_target direct messages", ({override, override_rewire}) => {


### PR DESCRIPTION
This PR reworks the logic for displaying *general chat* in the topic box and compose textarea placeholder text, as well as implementing the correct fading logic on *general chat*.

As specified by @alya, when empty topics are permitted, the typeahead should display immediately in the Topic box.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>