### PR TITLE
user_profile: invalidate user group state after closing the user modal.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -510,6 +510,7 @@ export function hide_user_profile(): void {
 
 function on_user_profile_hide(): void {
     user_streams_list_widget = undefined;
+    user_groups_list_widget = undefined;
     user_profile_subscribe_widget = undefined;
     const base = get_current_hash_category();
     // After closing the user profile, if the hash consists of `#user`


### PR DESCRIPTION
I believe this regression was introduced by #33075, where some additional logic was added to not render the content of user profile tabs more times than necessary.

<!-- Describe your pull request here.-->

Fixes: The `user_groups_list_widget` is populated once the user profile modal is first opened, but not cleared when closed. This caused user group membership to not be rendered when opening the user profile modal again.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Before

User groups disappear after opening and closing the dialog once:

https://github.com/user-attachments/assets/fcea912e-2d1d-46ba-abf3-3f172a4be3c9

### After

User groups are shown consistently after closing and reopening the modal:

https://github.com/user-attachments/assets/eaf71b85-08e2-4840-96c7-3501062b99fa

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
