### PR TITLE
settings: Collapse header into two rows at narrower screens.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -325,6 +325,90 @@ h4.user_group_setting_subsection_title {
     }
 }
 
+.subscriptions-container {
+    container: subscriptions / inline-size;
+}
+
+/* There's an awkward width of modal that is wider than the
+   @media breakpoint that collapses the left pane, but still
+   narrow enough (965px at 14px em) that the sort buttons need
+   a second row to be visible without overlapping other UI. */
+@container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) {
+    @container subscriptions (width < calc(60em + 70px)) {
+        #subscription_overlay .subscriptions-container {
+            .left {
+                .list-toggler-container {
+                    height: 5em;
+                    justify-content: end;
+                    flex-wrap: wrap;
+                }
+
+                .tab-switcher {
+                    margin-right: 0;
+                }
+
+                .tab-switcher:first-child {
+                    /* This forces the other buttons to the next row */
+                    width: 100%;
+                    display: flex;
+                    justify-content: end;
+                }
+            }
+
+            .right .display-type {
+                height: 5em;
+            }
+
+            .streams-list {
+                /* Calculated from several heights and padding/margin measurements
+                in .list-toggler-container and .stream_filter, with some added
+                fiddling to see what worked best at 12px - 20px font sizes.
+                Notably this height is shorter than the similar calculation
+                below because the toggler is taller.
+                When we redesign this area we should make this less brittle. */
+                height: calc(100% - 5.4em - 40px);
+            }
+        }
+    }
+}
+
+/* Copy all the above styles for the breakpoint where the overlay
+   becomes 40% left pane and 60% right pane, since that automatically
+   qualifies the modal for collapsing the buttons into two rows, and
+   especially for smaller font-sizes this will happen before the
+   breakpoint for the subscriptions container width. */
+@media (width < $lg_min) {
+    @container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) {
+        #subscription_overlay .subscriptions-container {
+            .left {
+                .list-toggler-container {
+                    height: 5em;
+                    justify-content: end;
+                    flex-wrap: wrap;
+                }
+
+                .tab-switcher {
+                    margin-right: 0;
+                }
+
+                .tab-switcher:first-child {
+                    width: 100%;
+                    display: flex;
+                    justify-content: end;
+                }
+            }
+
+            .right .display-type {
+                height: 5em;
+            }
+
+            .streams-list {
+                height: calc(100% - 5.4em - 40px);
+            }
+        }
+    }
+}
+
 .user-groups-container,
 .subscriptions-container {
     position: relative;
@@ -547,7 +631,11 @@ h4.user_group_setting_subsection_title {
     position: relative;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    height: calc(100% - 6.0714em); /* 85px at 14px em */
+    /* Calculated from several heights and padding/margin measurements
+    in .list-toggler-container and .stream_filter, with some added
+    fiddling to see what worked best at 12px - 20px font sizes.
+    When we redesign this area we should make this less brittle. */
+    height: calc(100% - 3.4em - 40px);
     width: 100%;
 }
 


### PR DESCRIPTION
Fixes #29514 by having separate styling for narrower screens where the buttons don't all fit, and adjusting the height of the stream list based on which state (one row header or two row header) is being displayed.

<details>
<summary>breakpoint screenshots</summary>

12px:
![Kapture 2025-02-04 at 17 18 37](https://github.com/user-attachments/assets/8c6af50d-b2d8-4ca3-8e6b-0f7613e17fe3)

14px
![Kapture 2025-02-04 at 17 21 55](https://github.com/user-attachments/assets/d9933f55-efcf-4ae9-aea1-5bdc6facd3f1)

16px
![Kapture 2025-02-04 at 17 25 56](https://github.com/user-attachments/assets/19b84bd6-a6f7-4d60-90c5-1beedb0feee3)

20px (only has the two-row header)

![Kapture 2025-02-04 at 17 27 51](https://github.com/user-attachments/assets/662ebe27-d61a-41ba-a943-0efe11620335)
</details>

<details>
<summary>screenshots of stream list scrolled to the bottom</summary>

12px

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3e0be193-dc47-4eee-af0e-c81f2ad6c967" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d25be122-6598-4d1d-84c4-fe4ebcf3ccff" />


14px

<img width="400" alt="image" src="https://github.com/user-attachments/assets/cc20ddff-0683-4bf2-9d0b-84fca14535c3" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8fd5ab0a-8bde-4d32-90ad-5939fdb6c096" />


16px

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8310c129-3a00-4baf-83cb-ee4c6990ce07" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0af800fb-5001-4f93-b23a-600419f40a31" />


20px (only has the two-row header)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/59e4b35f-7dba-4a2b-9a0a-639405546353" />
</details>