### PR TITLE
user_groups_setting: Fix the style related bugs in the user groups member settings.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1774,6 +1774,10 @@ label.preferences-radio-choice-label {
         display: none;
     }
 
+    .empty-email-col-for-user-group {
+        display: none;
+    }
+
     .upload-size {
         display: none;
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1778,6 +1778,10 @@ label.preferences-radio-choice-label {
         display: none;
     }
 
+    .hidden-subscriber-email {
+        display: none;
+    }
+
     .upload-size {
         display: none;
     }

--- a/web/templates/user_group_settings/new_user_group_subgroup.hbs
+++ b/web/templates/user_group_settings/new_user_group_subgroup.hbs
@@ -1,7 +1,8 @@
 <tr>
-    <td class="panel_user_list" colspan="2">
+    <td class="panel_user_list">
         {{> ../user_group_display_only_pill . strikethrough=soft_removed}}
     </td>
+    <td class="empty-email-col-for-user-group"></td>
     <td>
         {{#if soft_removed}}
             <button data-group-id="{{group_id}}" class="undo_soft_removed_potential_subgroup button small rounded white">{{t 'Add' }}</button>

--- a/web/templates/user_group_settings/user_group_subgroup_entry.hbs
+++ b/web/templates/user_group_settings/user_group_subgroup_entry.hbs
@@ -1,7 +1,8 @@
 <tr data-subgroup-id="{{group_id}}">
-    <td class="subgroup-name panel_user_list" colspan="2">
+    <td class="subgroup-name panel_user_list">
         {{> ../user_group_display_only_pill .}}
     </td>
+    <td class="empty-email-col-for-user-group"></td>
     {{#if can_remove_members}}
     <td class="remove">
         <div class="subgroup_list_remove">


### PR DESCRIPTION
Commit 1:

- Removed the hard coded `colspan="2"` because of which the bug is encountering as it is always taking space of 2 columns even if the email column is hidden on small screens.
- Added a new table data `empty-email-col-for-user-group` and toggling its display property using media queries to fit on every screen.

Commit 2:

- While fixing the above bug, I found that on small screens, `settings-email-column` is set to `display: none`, while `hidden-subscriber-email` remains visible, breaking compatibility on small screens.  
- In this commit, I added the `display: none` property to `hidden-subscriber-email` when `settings-email-column` is set to `display: none`.

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.9B.A0.EF.B8.8F.20misaligned.20button.20in.20user.20group.20members/near/2077591).
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|------|
<img width="932" alt="Screenshot 2025-02-04 at 11 35 13 PM" src="https://github.com/user-attachments/assets/6ee4964f-3f53-439b-a0c4-76d717b0d1af" /> | <img width="844" alt="Screenshot 2025-02-05 at 1 27 44 PM" src="https://github.com/user-attachments/assets/6dc2dc1a-2e5c-49f6-bdf0-db476f789e24" />  |
<img width="724" alt="Screenshot 2025-02-05 at 10 12 40 AM" src="https://github.com/user-attachments/assets/ddd04543-5665-4b35-8dc3-66e9cd1fa4e6" /> | <img width="577" alt="Screenshot 2025-02-05 at 1 28 38 PM" src="https://github.com/user-attachments/assets/98b316bc-9a1d-4969-b396-5fb21502eb13" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
