### PR TITLE
api_docs: Improve topic-permalink docs in `/api/message-formatting`.

### DIFF
--- a/api_docs/message-formatting.md
+++ b/api_docs/message-formatting.md
@@ -42,18 +42,18 @@ Sample HTML formats are as follows:
  #announce &gt; Zulip updates
 </a>
 
+<!-- Syntax: #**announce>Zulip updates**
+     Generated only if topic had no messages or the link was rendered
+     before Zulip 10.0 (feature level 347) -->
+<a class="stream-topic" data-stream-id="9"
+  href="/#narrow/channel/9-announce/topic/Zulip.20updates">
+ #announce &gt; Zulip updates
+</a>
+
 <!-- Syntax: #**announce>Zulip updates@214** -->
 <a class="message-link"
   href="/#narrow/channel/9-announce/topic/Zulip.20updates/near/214">
  #announce &gt; Zulip updates @ 💬
-</a>
-
-<!-- Syntax: #**announce>Zulip updates**
-     Generated only if topic is empty or the link was rendered before
-     Zulip 10.0 (feature level 347) -->
-<a class="stream-topic" data-stream-id="9"
-  href="/#narrow/channel/9-announce/topic/Zulip.20updates">
- #announce &gt; Zulip updates
 </a>
 ```
 
@@ -86,18 +86,18 @@ are as follows:
  #announce &gt; <em>general chat</em>
 </a>
 
+<!-- Syntax: #**announce>**
+     Generated only if topic had no messages or the link was rendered
+     before Zulip 10.0 (feature level 347) -->
+<a class="stream-topic" data-stream-id="9"
+  href="/#narrow/channel/9-announce/topic/">
+ #announce &gt; <em>general chat</em>
+</a>
+
 <!-- Syntax: #**announce>@214** -->
 <a class="message-link"
   href="/#narrow/channel/9-announce/topic//near/214">
  #announce &gt; <em>general chat</em> @ 💬
-</a>
-
-<!-- Syntax: #**announce>**
-     Generated only if topic is empty or the link was rendered before
-     Zulip 10.0 (feature level 347) -->
-<a class="stream-topic" data-stream-id="9"
-  href="/#narrow/channel/9-announce/topic/">
- #announce &gt; <em>general chat</em>
 </a>
 ```
 


### PR DESCRIPTION
This PR updates the wording related to topic-permalink in `/api/message-formatting`:
* Clarify that the condition applies when a topic has no messages, not when the topic name is empty.
* Reorders examples so that similar input formats are grouped together, improving readability.

[CZO Discussion](https://chat.zulip.org/#narrow/channel/378-api-design/topic/topic.20permalinks/near/2076905)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="400" alt="Screenshot 2025-02-05 at 1 48 32 PM" src="https://github.com/user-attachments/assets/2c666abd-bf88-4013-b5c1-ae1262772da2" />

<img width="400" alt="Screenshot 2025-02-05 at 1 48 42 PM" src="https://github.com/user-attachments/assets/0594fd75-6990-45e2-9797-216b80d52b37" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

