### PR TITLE
inbox: Allow user to select empty view text.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -152,6 +152,7 @@
             }
 
             .inbox-header {
+                user-select: none;
                 display: block;
                 height: 30px;
 
@@ -259,6 +260,7 @@
             }
 
             .inbox-row {
+                user-select: none;
                 display: block;
                 background-color: var(--color-background-inbox-row);
 

--- a/web/templates/inbox_view/inbox_view.hbs
+++ b/web/templates/inbox_view/inbox_view.hbs
@@ -1,4 +1,4 @@
-<div id="inbox-main" class="no-select">
+<div id="inbox-main">
     <div class="search_group" id="inbox-filters" role="group">
         {{> ../dropdown_widget widget_name="inbox-filter"}}
         <i class="zulip-icon zulip-icon-search-inbox"></i>


### PR DESCRIPTION
We likely added this logic to allow links to be opened in new tab on ctrl + click and not trigger text selection.

We retain this behaviour but allow selection of empty view text.

Verified text selection works on in empty view.

https://chat.zulip.org/#narrow/channel/9-issues/topic/Disallow.20select.20for.20empty.20view.20banner.20texts
![image](https://github.com/user-attachments/assets/fc63340b-5503-4598-8a19-ef617988bd70)
![Screenshot from 2025-02-05 16-45-53](https://github.com/user-attachments/assets/a897442d-c3e9-45b4-8242-e1263bbfd016)
