### PR TITLE
change_password_modal: Hide the dialog spinner when action fails.

### DIFF
--- a/web/src/password_quality.ts
+++ b/web/src/password_quality.ts
@@ -60,7 +60,7 @@ export function password_warning(password: string, $password_field: JQuery): str
 
     if (password.length < min_length) {
         return $t(
-            {defaultMessage: "Password should be at least {length} characters long"},
+            {defaultMessage: "Password should be at least {length} characters long."},
             {length: min_length},
         );
     } else if (password.length > max_length) {
@@ -71,5 +71,5 @@ export function password_warning(password: string, $password_field: JQuery): str
             {max: max_length},
         );
     }
-    return zxcvbn(password).feedback.warning ?? $t({defaultMessage: "Password is too weak"});
+    return zxcvbn(password).feedback.warning ?? $t({defaultMessage: "Password is too weak."});
 }

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -199,7 +199,8 @@ export function update_send_read_receipts_tooltip(): void {
 }
 
 function settings_change_error(message_html: string, xhr?: JQuery.jqXHR): void {
-    ui_report.error(message_html, xhr, $("#account-settings-status").expectOne());
+    ui_report.error(message_html, xhr, $("#dialog_error"));
+    dialog_widget.hide_dialog_spinner();
 }
 
 function update_custom_profile_field(
@@ -463,7 +464,7 @@ export function set_up(): void {
 
             if (old_password === "") {
                 ui_report.error(
-                    $t_html({defaultMessage: "Please enter your password"}),
+                    $t_html({defaultMessage: "Please enter your password."}),
                     undefined,
                     $("#dialog_error"),
                 );
@@ -472,7 +473,7 @@ export function set_up(): void {
 
             if (new_password === "") {
                 ui_report.error(
-                    $t_html({defaultMessage: "Please choose a new password"}),
+                    $t_html({defaultMessage: "Please choose a new password."}),
                     undefined,
                     $("#dialog_error"),
                 );
@@ -483,7 +484,7 @@ export function set_up(): void {
             if (new_password && new_password.toString().length > max_length) {
                 ui_report.error(
                     $t_html(
-                        {defaultMessage: "Maximum password length: {max_length} characters"},
+                        {defaultMessage: "Maximum password length: {max_length} characters."},
                         {max_length},
                     ),
                     undefined,
@@ -549,7 +550,7 @@ export function set_up(): void {
                 );
                 return;
             } else if (!password_quality(new_pw, undefined, $new_pw_field)) {
-                settings_change_error($t_html({defaultMessage: "New password is too weak"}));
+                settings_change_error($t_html({defaultMessage: "New password is too weak!"}));
                 return;
             }
         }

--- a/web/tests/password.test.cjs
+++ b/web/tests/password.test.cjs
@@ -59,7 +59,7 @@ run_test("basics w/progress bar", () => {
     assert.equal($bar.w, "39.7%");
     assert.equal($bar.added_class, "bar-danger");
     warning = password_warning(password, password_field(10));
-    assert.equal(warning, "translated: Password should be at least 10 characters long");
+    assert.equal(warning, "translated: Password should be at least 10 characters long.");
 
     password = "foo";
     accepted = password_quality(password, $bar, password_field(2, 200, 10));
@@ -67,7 +67,7 @@ run_test("basics w/progress bar", () => {
     assert.equal($bar.w, "10.390277164940581%");
     assert.equal($bar.added_class, "bar-success");
     warning = password_warning(password, password_field(2));
-    assert.equal(warning, "translated: Password is too weak");
+    assert.equal(warning, "translated: Password is too weak.");
 
     password = "aaaaaaaa";
     accepted = password_quality(password, $bar, password_field(6, 1e100));


### PR DESCRIPTION
This commit modify the settings_change_error function to show the error inside the modal, instead of the settings panel behind it.

<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/Modal.20not.20closing.20when.20action.20fails.2E).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After |
|-------|------|
<img width="1419" alt="Screenshot 2025-02-05 at 6 22 23 PM" src="https://github.com/user-attachments/assets/1480e0c6-9d61-448a-9eb1-8fe043e52294" /> | <img width="481" alt="Screenshot 2025-02-06 at 12 47 57 AM" src="https://github.com/user-attachments/assets/7fdf6b0e-b518-4d5a-9b2f-e4caaef87460" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
