### PR TITLE
api_docs: Improve docs related to empty string topic.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6353,6 +6353,16 @@ paths:
                     Clients should use the `max_topic_length` returned by the
                     [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum topic length.
+
+                    Note: When the value of `realm_empty_topic_display_name` found in
+                    the [POST /register](/api/register-queue) response is used for this
+                    parameter, it is interpreted as an empty string.
+
+                    When [topics are required](/help/require-topics), this parameter can't
+                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+
+                    **Changes**: Before Zulip 10.0 (feature level 334), empty string
+                    was not a valid topic name for channel messages.
                   type: string
                   example: Castle
                 scheduled_delivery_timestamp:
@@ -6517,6 +6527,16 @@ paths:
                     Clients should use the `max_topic_length` returned by the
                     [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum topic length.
+
+                    Note: When the value of `realm_empty_topic_display_name` found in
+                    the [POST /register](/api/register-queue) response is used for this
+                    parameter, it is interpreted as an empty string.
+
+                    When [topics are required](/help/require-topics), this parameter can't
+                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+
+                    **Changes**: Before Zulip 10.0 (feature level 334), empty string
+                    was not a valid topic name for channel messages.
                   type: string
                   example: Castle
                 scheduled_delivery_timestamp:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7220,6 +7220,9 @@ paths:
                     the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
 
+                    When [topics are required](/help/require-topics), this parameter can't
+                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+
                     **Changes**: Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
 
@@ -8560,6 +8563,9 @@ paths:
                     Note: When the value of `realm_empty_topic_display_name` found in
                     the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
+
+                    When [topics are required](/help/require-topics), this parameter can't
+                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
 
                     You can [resolve topics](/help/resolve-a-topic) by editing the topic to
                     `✔ {original_topic}` with the `propagate_mode` parameter set to


### PR DESCRIPTION
* Commit 1: We missed to update docs for scheduled_message while working on feature level 334. 
* Commit 2: [CZO Discussion
](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/.28realm_.29mandatory_topics.20behavior/near/2052822)


Ideally, we should merge this after [/help/require-topics](https://chat.zulip.org/help/require-topics) gets updated -- which would be after we finalize the "general chat" name.

**Screenshots and screen captures:**

 Schedule messages / update scheduled message related:
 
<img width="319" alt="Screenshot 2025-02-05 at 6 51 02 PM" src="https://github.com/user-attachments/assets/f5283ed5-7db4-499c-8f2b-25b690e222a3" />

<img width="304" alt="Screenshot 2025-02-05 at 6 51 17 PM" src="https://github.com/user-attachments/assets/5db0abdf-7d66-43f6-81ab-6c04cd2c727b" />

Message send / edit related:

<img width="309" alt="Screenshot 2025-02-05 at 6 52 07 PM" src="https://github.com/user-attachments/assets/b427b155-221e-47f7-ac4f-5f600d343dec" />

<img width="304" alt="Screenshot 2025-02-05 at 6 51 40 PM" src="https://github.com/user-attachments/assets/b20c1058-e932-417a-8e79-11412554ed7a" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

