### PR TITLE
emoji: Use emoji_code to send first reaction instead of emoji_name.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1210,8 +1210,13 @@ export function process_hotkey(e, hotkey) {
             // '+': reacts with thumbs up emoji on selected message
             // Use canonical name.
             const thumbs_up_emoji_code = "1f44d";
-            const canonical_name = emoji.get_emoji_name(thumbs_up_emoji_code);
-            reactions.toggle_emoji_reaction(msg, canonical_name);
+            const thumbs_up_emoji_name = emoji.get_emoji_name(thumbs_up_emoji_code);
+            reactions.toggle_emoji_reaction(
+                msg,
+                thumbs_up_emoji_name,
+                thumbs_up_emoji_code,
+                "unicode_emoji",
+            );
             return true;
         }
         case "upvote_first_emoji": {
@@ -1228,7 +1233,12 @@ export function process_hotkey(e, hotkey) {
                 return true;
             }
 
-            reactions.toggle_emoji_reaction(msg, first_reaction.emoji_name);
+            reactions.toggle_emoji_reaction(
+                msg,
+                first_reaction.emoji_name,
+                first_reaction.emoji_code,
+                first_reaction.reaction_type,
+            );
             return true;
         }
         case "toggle_topic_visibility_policy":

--- a/web/src/reactions.ts
+++ b/web/src/reactions.ts
@@ -133,14 +133,23 @@ function update_ui_and_send_reaction_ajax(
     }
 }
 
-export function toggle_emoji_reaction(message: Message, emoji_name: string): void {
+export function toggle_emoji_reaction(
+    message: Message,
+    emoji_name: string,
+    emoji_code: string,
+    reaction_type: "zulip_extra_emoji" | "realm_emoji" | "unicode_emoji",
+): void {
     // This codepath doesn't support toggling a deactivated realm emoji.
     // Since a user can interact with a deactivated realm emoji only by
     // clicking on a reaction and that is handled by `process_reaction_click()`
     // method. This codepath is to be used only where there is no chance of an
     // user interacting with a deactivated realm emoji like emoji picker.
 
-    const rendering_details = emoji.get_emoji_details_by_name(emoji_name);
+    const rendering_details = emoji.get_emoji_details_for_rendering({
+        emoji_name,
+        emoji_code,
+        reaction_type,
+    });
     update_ui_and_send_reaction_ajax(message, rendering_details);
 }
 


### PR DESCRIPTION
On any message, pressing '=' to react the first reaction was causing the error "Bad emoji name", the reason being that emoji_name was being passed instead of emoji_code.

This commit handles modifies the 'toggle_emoji_reaction' function to accept emoji_name, emoji_code, reaction_type parameters and the subsequent calls of this function are modified to pass all of these arguments.

Fixes: #33574 

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

[CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/Bad.20emoji.20name.3A.20crying_cat_face/with/2079458)