### PR TITLE
user_status: Remove fixed px height of status input.

### DIFF
--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -11,7 +11,6 @@
         border: 1px solid;
         border-color: hsl(0deg 0% 0% / 60%);
         border-radius: 5px;
-        height: 35px;
 
         & input.user-status {
             grid-area: search-input;


### PR DESCRIPTION
It looks fine without the height explicitly set, and the fixed height only works at 14px info density.

I tested that it doesn't overflow onto a second line or anything with long status messages.

Before and after at 12px, 14px, 16px, and 20px:

| before | after |
| ---- | ---- |
| ![Screen Shot 2025-02-05 at 12 33 52](https://github.com/user-attachments/assets/825280e5-1341-453a-be18-0c3f5d2f8e7f) | ![Screen Shot 2025-02-05 at 12 31 35](https://github.com/user-attachments/assets/5b8312dd-ab91-4e9f-b955-427a9ef081e2) |
| ![Screen Shot 2025-02-05 at 12 34 05](https://github.com/user-attachments/assets/1ba8386f-3502-4ae5-b5ca-65367b269631) | ![Screen Shot 2025-02-05 at 12 30 56](https://github.com/user-attachments/assets/d9ea80de-c4a8-4a09-8aef-ea68aa098661) |
| ![Screen Shot 2025-02-05 at 12 34 20](https://github.com/user-attachments/assets/b12ed348-e68b-4764-990a-4e18bd49cf1c) | ![Screen Shot 2025-02-05 at 12 30 14](https://github.com/user-attachments/assets/94c7a7b0-c3f3-4413-98c1-ba93c88a80b1) |
| ![Screen Shot 2025-02-05 at 12 34 46](https://github.com/user-attachments/assets/353e3b57-1d72-4eda-a64e-f79be91d92ee) | ![Screen Shot 2025-02-05 at 12 29 45](https://github.com/user-attachments/assets/0cc269fe-2200-4463-9a4e-655a38cd7217) |