### PR TITLE
tests: Consume more streaming responses

### DIFF
--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -113,6 +113,7 @@ class ThumbnailRedirectEndpointTest(ZulipTestCase):
             self.logout()
             response = self.client_get("/thumbnail", {"url": url.removeprefix("/"), "size": "full"})
             self.assertEqual(response.status_code, 200)
+            consume_response(response)
 
         # Deny file access since rate limited
         with ratelimit_rule(86400, 0, domain="spectator_attachment_access_by_file"):

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -187,6 +187,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         result = self.client_get(url)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result["Content-Type"], "application/octet-stream")
+        consume_response(result)
 
         uploaded_file = SimpleUploadedFile("somefile.txt", b"zulip!", content_type="")
         result = self.api_post(
@@ -199,6 +200,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         result = self.client_get(url)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result["Content-Type"], "text/plain")
+        consume_response(result)
 
     def test_preserve_provided_content_type(self) -> None:
         uploaded_file = SimpleUploadedFile("somefile.txt", b"zulip!", content_type="image/png")
@@ -212,6 +214,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         result = self.client_get(url)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result["Content-Type"], "image/png")
+        consume_response(result)
 
     # This test will go through the code path for uploading files onto LOCAL storage
     # when Zulip is in DEVELOPMENT mode.


### PR DESCRIPTION
Fixes warnings like `ResourceWarning: unclosed file <_io.FileIO name='/srv/zulip/var/4fc6d348-ccfe-43fa-8a2e-5b4ff5a15a66/test-backend/run_2304691/worker_7/test_uploads/files/2/d9/KYUsAKJ_g45NA7CojVbRW0C4/zulip.jpeg' mode='rb' closefd=True>` with warnings enabled.

- New instances since #30994
- Cc @alexmv