### PR TITLE
read reciepts: Use em for row height and modal width.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -219,7 +219,7 @@
 
 #read_receipts_modal {
     .modal__container {
-        width: 360px;
+        width: 25.7142em; /* 360px at 14px em */
 
         .modal__content {
             /* When showing read receipts, we use simplebar
@@ -267,8 +267,8 @@
         & li {
             .read_receipts_user_avatar {
                 display: inline-block;
-                height: 20px;
-                width: 20px;
+                height: 1.25em; /* 20px at 16px font-size at 14px em */
+                width: 1.25em; /* 20px at 16px font-size at 14px em */
                 position: relative;
                 right: 8px;
                 border-radius: 4px;
@@ -281,7 +281,7 @@
             white-space: nowrap;
             text-overflow: ellipsis;
             cursor: pointer;
-            line-height: 26px;
+            line-height: 1.625em; /* 26px at 16px font-size at 14px em */
 
             &:hover {
                 background-color: hsl(0deg 0% 0% / 5%);


### PR DESCRIPTION
before and after at 12px, 14px, 16px, 20px

| before | after |
| --- | ---- |
| ![Screen Shot 2025-02-05 at 12 51 34](https://github.com/user-attachments/assets/dd75ab44-f41b-45de-bebf-543b8a372673) | ![Screen Shot 2025-02-05 at 12 47 15](https://github.com/user-attachments/assets/49abdfd3-b1df-4bb9-b00b-6dae352a624a) |
| ![Screen Shot 2025-02-05 at 12 51 15](https://github.com/user-attachments/assets/ff473e37-9f5a-4763-b13f-7844a3400b58) | ![Screen Shot 2025-02-05 at 12 47 52](https://github.com/user-attachments/assets/90a30230-42d2-46d2-bfa9-d2911324be2e) |
| ![Screen Shot 2025-02-05 at 12 50 53](https://github.com/user-attachments/assets/b0505117-595d-48a8-a028-43984e6f22b5) | ![Screen Shot 2025-02-05 at 12 46 44](https://github.com/user-attachments/assets/2b748c4c-823d-4b36-8f34-2f62148524fb) |
| ![Screen Shot 2025-02-05 at 12 50 32](https://github.com/user-attachments/assets/fcb363d3-8afc-4938-af10-deb96be2fe6d) | ![Screen Shot 2025-02-05 at 12 46 14](https://github.com/user-attachments/assets/377f0ef4-1312-40d9-b198-ccdf7a1da1da) |