### PR TITLE
subscriptions: Use em to center permissions radio buttons.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1114,7 +1114,11 @@ div.settings-radio-input-parent {
         float: left;
         width: auto;
         cursor: pointer;
-        margin: 3.5px 0 1px;
+        /* Scale the height with font-size, 14px at 1em */
+        height: 1em;
+        /* This value came from fiddling to find what looked
+           vertically centered at 12px-20px font sizes. */
+        margin-top: 0.15em;
 
         &:focus {
             outline: 1px dotted hsl(0deg 0% 20%);


### PR DESCRIPTION
before and after at 12px, 14px, 16px, 20px:

| before | after |
| ---- | --- |
| ![Screen Shot 2025-02-05 at 21 23 24](https://github.com/user-attachments/assets/3fa81ff6-7ebf-4b6b-8501-0224a3a697e5) | ![Screen Shot 2025-02-05 at 21 22 43](https://github.com/user-attachments/assets/565e2f7f-0d54-4438-9719-ad2bd29bb6d3) |
| ![Screen Shot 2025-02-05 at 21 23 33](https://github.com/user-attachments/assets/47b7bcf8-9542-43e0-bad5-db00143d8323) | ![Screen Shot 2025-02-05 at 21 22 27](https://github.com/user-attachments/assets/76dd8335-5858-42b2-848e-96f383e409c3) |
| ![Screen Shot 2025-02-05 at 21 23 40](https://github.com/user-attachments/assets/5efaebc9-7099-4089-9a7c-62ee6472f454) | ![Screen Shot 2025-02-05 at 21 22 20](https://github.com/user-attachments/assets/60dd91a8-9e51-4f5f-ab76-230ca912aa81) |
| ![Screen Shot 2025-02-05 at 21 23 52](https://github.com/user-attachments/assets/851a1ad6-162b-4b14-8aae-dede07a7f1be) | ![Screen Shot 2025-02-05 at 21 21 51](https://github.com/user-attachments/assets/a4f948be-13b1-4ff6-94ae-0eff9265569c) |

