### PR TITLE
message_header: Center privacy icons.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -223,6 +223,9 @@
         min-width: unset;
         width: 1.1428em; /* 16px at 14px em */
         height: 1.1428em; /* 16px at 14px em */
+        display: flex;
+        justify-content: center;
+        align-items: center;
 
         .hashtag {
             padding-right: 0;


### PR DESCRIPTION
[CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20privacy.20icon.20spacing.20in.20message.20header/near/2057146)[ thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20privacy.20icon.20spacing.20in.20message.20header/near/2057146)

before and after at 12px, 14px, 16px, 20px

| before | after |
| -- | -- |
| ![Screen Shot 2025-02-05 at 21 43 21](https://github.com/user-attachments/assets/4aa5c95a-2d68-45e5-9ff3-077f051fa5fd) | ![Screen Shot 2025-02-05 at 21 43 44](https://github.com/user-attachments/assets/3694c7fc-f4af-44d3-8928-2d8f4d342f86) |
| ![Screen Shot 2025-02-05 at 21 43 01](https://github.com/user-attachments/assets/eec51518-d173-4bc7-a71f-92d3a7023f42) | ![Screen Shot 2025-02-05 at 21 42 44](https://github.com/user-attachments/assets/848f39ad-b8b9-431b-89e5-b4ae3cc23286) |
| ![Screen Shot 2025-02-05 at 21 41 39](https://github.com/user-attachments/assets/90cdde1b-ce3f-4045-8552-b8cd21e6505d) | ![Screen Shot 2025-02-05 at 21 41 58](https://github.com/user-attachments/assets/59f40279-bca8-484c-a7dc-8778a6488adf) |
| ![Screen Shot 2025-02-05 at 21 40 43](https://github.com/user-attachments/assets/e90d6b15-c8d3-4855-9143-95c8cf692415) | ![Screen Shot 2025-02-05 at 21 40 33](https://github.com/user-attachments/assets/070651af-8930-4bd7-ab3e-0cf48448c8eb) |
