### PR TITLE
requirements: Upgrade Django from 5.0.10 to 5.1.6

### DIFF
--- a/corporate/migrations/0001_squashed_0044_convert_ids_to_bigints.py
+++ b/corporate/migrations/0001_squashed_0044_convert_ids_to_bigints.py
@@ -366,7 +366,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="customer",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("realm__isnull", False),
                     ("remote_server__isnull", False),
                     ("remote_realm__isnull", False),

--- a/corporate/migrations/0018_customer_cloud_xor_self_hosted.py
+++ b/corporate/migrations/0018_customer_cloud_xor_self_hosted.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="customer",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("realm__isnull", False), ("remote_server__isnull", False), _connector="XOR"
                 ),
                 name="cloud_xor_self_hosted",

--- a/corporate/migrations/0020_add_remote_realm_customers.py
+++ b/corporate/migrations/0020_add_remote_realm_customers.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="customer",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("realm__isnull", False),
                     ("remote_server__isnull", False),
                     ("remote_realm__isnull", False),

--- a/corporate/models.py
+++ b/corporate/models.py
@@ -53,7 +53,7 @@ class Customer(models.Model):
         # Enforce that at least one of these is set.
         constraints = [
             models.CheckConstraint(
-                check=Q(realm__isnull=False)
+                condition=Q(realm__isnull=False)
                 | Q(remote_server__isnull=False)
                 | Q(remote_realm__isnull=False),
                 name="has_associated_model_object",

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -6,7 +6,7 @@
 -r pip.in
 
 # Django itself
-Django[argon2]==5.0.*
+Django[argon2]==5.1.*
 https://github.com/andersk/asgiref/archive/8a2717c14bce1b8dd37371c675ee3728e66c3fe3.zip#egg=asgiref==3.8.1+git  # https://github.com/django/asgiref/pull/494
 
 # needed for NotRequired, ParamSpec

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -639,9 +639,9 @@ distro==1.9.0 \
     # via
     #   openai
     #   zulip
-django[argon2]==5.0.10 \
-    --hash=sha256:0f6cbc56cc298b0451d20a5120c6a8731e9073330fb5d84295c23c151a1eb300 \
-    --hash=sha256:c8fab2c553750933c8e7f5f95e5507e138e6acf6c2b4581cb691e70fe3ed747b
+django[argon2]==5.1.6 \
+    --hash=sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690 \
+    --hash=sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5
     # via
     #   -r requirements/common.in
     #   django-auth-ldap

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -467,9 +467,9 @@ distro==1.9.0 \
     # via
     #   openai
     #   zulip
-django[argon2]==5.0.10 \
-    --hash=sha256:0f6cbc56cc298b0451d20a5120c6a8731e9073330fb5d84295c23c151a1eb300 \
-    --hash=sha256:c8fab2c553750933c8e7f5f95e5507e138e6acf6c2b4581cb691e70fe3ed747b
+django[argon2]==5.1.6 \
+    --hash=sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690 \
+    --hash=sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5
     # via
     #   -r requirements/common.in
     #   django-auth-ldap

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 353  # Last bumped for Zoom server to server video chat opti
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (312, 0)  # bumped 2024-02-14 to upgrade asgiref
+PROVISION_VERSION = (313, 0)  # bumped 2024-02-14 to upgrade Django


### PR DESCRIPTION
- Requires #33299.
- [Django 5.1 release notes](https://docs.djangoproject.com/en/5.1/releases/5.1/).
- We already desupported Python 3.9 in #29458.
- We already desupported PostgreSQL 12 in #32207.