### PR TITLE
integrations: Add `interfaced_setting` framework.

### DIFF
--- a/api_docs/unmerged.d/ZF-325305
+++ b/api_docs/unmerged.d/ZF-325305
@@ -1,0 +1,3 @@
+* [`POST /register`](/api/register-queue): Updated
+  `realm_incoming_webhook_bots` with a new `interfaced_settings` key,
+  it defines what interfaced settings each integration uses.

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -1,7 +1,7 @@
 import ClipboardJS from "clipboard";
 import $ from "jquery";
 import type * as tippy from "tippy.js";
-import {z} from "zod";
+import type {z} from "zod";
 
 import render_generate_integration_url_config_checkbox_modal from "../templates/settings/generate_integration_url_config_checkbox_modal.hbs";
 import render_generate_integration_url_config_text_modal from "../templates/settings/generate_integration_url_config_text_modal.hbs";
@@ -14,24 +14,13 @@ import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import type {DropdownWidget, Option} from "./dropdown_widget.ts";
 import {$t_html} from "./i18n.ts";
+import type {integration_config_option_schema} from "./state_data.ts";
 import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import {place_caret_at_end} from "./ui_util.ts";
 import * as util from "./util.ts";
 
-type ConfigOption = {
-    key: string;
-    label: string;
-    validator: string;
-};
-
-const config_option_schema = z.object({
-    key: z.string(),
-    label: z.string(),
-    validator: z.string(),
-});
-
-const config_options_schema = z.array(config_option_schema);
+type ConfigOption = z.infer<typeof integration_config_option_schema>;
 
 export function show_generate_integration_url_modal(api_key: string): void {
     const default_url_message = $t_html({defaultMessage: "Integration URL will appear here."});
@@ -78,10 +67,9 @@ export function show_generate_integration_url_modal(api_key: string): void {
         });
 
         function render_config(config: ConfigOption[]): void {
-            const validated_config = config_options_schema.parse(config);
             $config_container.empty();
 
-            for (const option of validated_config) {
+            for (const option of config) {
                 let $config_element: JQuery;
 
                 if (option.key === "branches") {

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -34,6 +34,7 @@ class IntegrationData {
     config_options: ConfigOption[] | undefined = undefined;
     all_event_types: EventType[] | null = null;
     interfaced_settings: InterfacedSetting | undefined = undefined;
+    integration_logo_url = "";
 
     constructor(selected_integration: string) {
         const selected_integration_data = realm.realm_incoming_webhook_bots.find(
@@ -46,6 +47,9 @@ class IntegrationData {
         }
         if (selected_integration_data?.interfaced_settings) {
             this.interfaced_settings = selected_integration_data.interfaced_settings;
+        }
+        if (selected_integration_data) {
+            this.integration_logo_url = `/static/images/integrations/logos/${selected_integration}.svg`;
         }
     }
 }
@@ -65,6 +69,8 @@ export function show_generate_integration_url_modal(api_key: string): void {
     const map_to_channels_option = {
         name: $t_html({defaultMessage: "Map to Zulip channels"}),
         unique_id: -2,
+        integration_logo_url: "",
+        is_interfaced_setting: true,
     };
     const html_body = render_generate_integration_url_modal({
         default_url_message,
@@ -327,6 +333,8 @@ export function show_generate_integration_url_modal(api_key: string): void {
                 selected_integration_data?.interfaced_settings?.MapToChannelsT;
             const additional_options: Option[] = [];
             if (map_to_channel_setting) {
+                map_to_channels_option.integration_logo_url =
+                    selected_integration_data.integration_logo_url;
                 additional_options.push(map_to_channels_option);
             }
             return additional_options;

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -268,6 +268,12 @@ export const integrations_interfaced_settings_schema = z.object({
     MapToChannelsT: z.nullable(interfaced_settings_context_schema),
 });
 
+export const integration_config_option_schema = z.object({
+    key: z.string(),
+    label: z.string(),
+    validator: z.string(),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 export const realm_schema = z.object({
     custom_profile_fields: z.array(custom_profile_field_schema),
@@ -365,15 +371,7 @@ export const realm_schema = z.object({
             display_name: z.string(),
             name: z.string(),
             all_event_types: z.nullable(z.array(z.string())),
-            config_options: z
-                .array(
-                    z.object({
-                        key: z.string(),
-                        label: z.string(),
-                        validator: z.string(),
-                    }),
-                )
-                .optional(),
+            config_options: z.array(integration_config_option_schema).optional(),
             interfaced_settings: integrations_interfaced_settings_schema,
         }),
     ),

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -257,6 +257,17 @@ export const realm_linkifier_schema = z.object({
     id: z.number(),
 });
 
+// Sync this with zerver.lib.webhooks.interfaced_setting.SettingContext
+export const interfaced_settings_context_schema = z.object({
+    parameter_name: z.string(),
+    unique_query: z.string(),
+});
+
+// Sync this with zerver.lib.webhooks.interfaced_setting.SUPPORTED_INTERFACED_SETTINGS
+export const integrations_interfaced_settings_schema = z.object({
+    MapToChannelsT: z.nullable(interfaced_settings_context_schema),
+});
+
 // Sync this with zerver.lib.events.do_events_register.
 export const realm_schema = z.object({
     custom_profile_fields: z.array(custom_profile_field_schema),
@@ -363,6 +374,7 @@ export const realm_schema = z.object({
                     }),
                 )
                 .optional(),
+            interfaced_settings: integrations_interfaced_settings_schema,
         }),
     ),
     realm_inline_image_preview: z.boolean(),

--- a/web/templates/dropdown_list.hbs
+++ b/web/templates/dropdown_list.hbs
@@ -22,6 +22,8 @@
                 {{> inline_decorated_stream_name stream=stream show_colored_icon=true}}
             {{else if is_direct_message}}
                 <i class="zulip-icon zulip-icon-users stream-privacy-type-icon"></i> {{name}}
+            {{else if is_interfaced_setting}}
+                <img class="zulip-icon zulip-icon-users stream-privacy-type-icon" src="{{integration_logo_url}}"/> {{name}}
             {{else if is_setting_disabled}}
                 <span class="setting-disabled-option"><i class="setting-disabled-option-icon fa fa-ban" aria-hidden="true"></i>{{t "Disable" }}</span>
             {{else}}

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -77,6 +77,7 @@ from zerver.lib.users import (
     max_message_id_for_user,
 )
 from zerver.lib.utils import optional_bytes_to_mib
+from zerver.lib.webhooks.interfaced_settings import get_interfaced_settings_for
 from zerver.models import (
     Client,
     CustomProfileField,
@@ -710,6 +711,7 @@ def fetch_initial_state_data(
                 ]
                 if integration.config_options
                 else [],
+                "interfaced_settings": get_interfaced_settings_for(integration),
             }
             for integration in WEBHOOK_INTEGRATIONS
             if integration.legacy is False

--- a/zerver/lib/webhooks/interfaced_settings.py
+++ b/zerver/lib/webhooks/interfaced_settings.py
@@ -1,0 +1,74 @@
+from dataclasses import asdict, dataclass
+from inspect import signature
+from typing import Annotated, Any, TypeAlias, get_args
+
+from zerver.lib.integrations import WebhookIntegration
+from zerver.lib.typed_endpoint import ApiParamConfig
+
+SettingContextT: TypeAlias = dict[str, Any]
+InterfacedSettingT: TypeAlias = dict[str, SettingContextT | None]
+
+# Encoding to make sure the queries for the interfaced
+# settings are unique.
+INTERFACED_SETTING_ENCODING = "Z_{param}"
+
+MapToChannelsT: TypeAlias = Annotated[
+    bool,
+    ApiParamConfig(INTERFACED_SETTING_ENCODING.format(param="map_to_channels")),
+]
+
+# Keep this in sync with `state_data.integrations_interfaced_settings_schema`
+# this dict is not a dataclass because Type aliases inside dataclass definitions
+# are not supported at runtime.
+SUPPORTED_INTERFACED_SETTINGS: dict[str, TypeAlias] = {
+    "MapToChannelsT": MapToChannelsT,
+}
+
+
+@dataclass
+class SettingContext:
+    parameter_name: str
+    unique_query: str
+
+    def __init__(self, arg_name: str, arg_type: Any) -> None:
+        self.parameter_name = arg_name
+        api_param_config = get_args(arg_type)[1]
+        assert isinstance(api_param_config, ApiParamConfig)
+        whence = api_param_config.whence
+        assert whence is not None
+        self.unique_query = whence
+
+
+def get_settings_context(arg_name: str, arg_type: Any) -> SettingContextT | None:
+    settings_context = None
+    if arg_type == SUPPORTED_INTERFACED_SETTINGS["MapToChannelsT"]:
+        settings_context = SettingContext(arg_name, arg_type)
+
+    if settings_context is not None:
+        return asdict(settings_context)
+    raise AssertionError(f"Please define a SettingContext for this setting: {arg_name}")
+
+
+def get_interfaced_settings_for(
+    integration: WebhookIntegration,
+) -> InterfacedSettingT:
+    integration_name = integration.name
+    endpoint = integration.get_function()
+    parameters = signature(endpoint).parameters
+
+    known_settings: dict[Any, str] = {}
+    integrations_settings: InterfacedSettingT = {}
+    for name, type in SUPPORTED_INTERFACED_SETTINGS.items():
+        known_settings[type] = name
+        integrations_settings[name] = None
+
+    for arg_name, arg in parameters.items():
+        arg_type = arg.annotation
+        if setting_name := known_settings.get(arg_type):
+            if integrations_settings[setting_name] is not None:
+                raise AssertionError(
+                    f"Using multiple interfaced setting of the same kind is not supported. integration: {integration_name}, setting: {setting_name}"
+                )
+            integrations_settings[setting_name] = get_settings_context(arg_name, arg_type)
+
+    return integrations_settings

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15284,6 +15284,8 @@ paths:
                                 **Changes**: New in Zulip 8.0 (feature level 207).
                             config_options:
                               $ref: "#/components/schemas/WebhookConfigOption"
+                            interfaced_settings:
+                              $ref: "#/components/schemas/WebhookInterfacedSetting"
                       recent_private_conversations:
                         description: |
                           Present if `recent_private_conversations` is present in `fetch_event_types`.
@@ -23067,6 +23069,63 @@ components:
               The name of the validator function for the configuration
               option. Currently generated values are `check_bool` and
               `check_string`.
+    WebhookInterfacedSetting:
+      type: object
+      additionalProperties: false
+      description: |
+        Dictionary containing the integration's interfaced settings metadata.
+
+        **Interfaced settings** are pre-built API endpoint parameter types that
+        comes with a UI or custom behavior in the frontend.
+
+        Clients are responsible for implementing the custom behavior that each
+        setting promises.
+
+        By default, all interfaced settings are included as keys. Clients can
+        check if a setting is used by examining its value. The value will be
+        `null` if the setting is not used. Otherwise, it will be a dictionary
+        containing context such as the parameter name declared in the endpoint
+        and the setting's unique query variable.
+
+        This is an unstable API expected to be used only by the Zulip web
+        apps. Please discuss in chat.zulip.org before using it.
+
+        **Changes**: New in Zulip 10.0 (feature level ZF-325305).
+      properties:
+        MapToChannelsT:
+          type: object
+          nullable: true
+          additionalProperties: false
+          description: |
+            The `MapToChannelsT` setting is a boolean parameter designed for
+            third-party chat app integrations. It provides a UI for the option
+            to send messages to Zulip channels with the same name as the
+            incoming message's original channel.
+
+            If the option is selected, a `{unique_query}=true` query will be
+            added to the integrations URL. Where the value of `unique_query` is,
+            as the name suggests, the unique query of each interfaced setting.
+
+            In the Zulip web app, this options is added in the "Where to send
+            notifications" dropdown field in the **Generate integration URL
+            modal** as "Map to Zulip channels". If selected, the "Send all
+            notifications to a single topic" checkbox will also be disabled.
+          properties:
+            parameter_name:
+              type: string
+              description: |
+                The parameter name declared in the integrations endpoint using
+                this interfaced setting as its type.
+
+                Clients can use this as additional context to enforce the custom
+                behaviour each setting promises.
+            unique_query:
+              type: string
+              description: |
+                The unique query variable of each interfaced setting. It is used
+                as the query name when encoding the users input for a specific
+                interfaced setting in the integration URL.
+
     CustomProfileField:
       type: object
       additionalProperties: false

--- a/zerver/webhooks/slack/view.py
+++ b/zerver/webhooks/slack/view.py
@@ -182,6 +182,7 @@ Feel free to reach out to the [Zulip development community]
 (https://chat.zulip.org/#narrow/channel/127-integrations) if you need
 further help!
 """
+from zerver.lib.webhooks.interfaced_settings import MapToChannelsT
 
 
 @webhook_view("Slack", notify_bot_owner_on_invalid_json=False)
@@ -192,6 +193,7 @@ def api_slack_webhook(
     *,
     slack_app_token: str = "",
     channels_map_to_topics: str | None = None,
+    map_to_channel: MapToChannelsT = False,
 ) -> HttpResponse:
     if request.content_type != "application/json":
         # Handle Slack's legacy Outgoing Webhook Service payload.


### PR DESCRIPTION
Overview
---
This adds **Interfaced settings**, those are pre-built API endpoint parameter types that come with a custom UI in the frontend. To use an interfaced setting, an integration would just have to add queries typed with the interfaced setting (for now its only `MapToChannelsT`).

### The `MapToChannelsT` interfaced setting.
The UI that comes with `MapToChannelT`  is the "Map to Zulip Channels" option in the "Where to send notifications" field in the Generate integration URL modal. This is planned to replace Slack integrations `channels_map_to_topics` setting, but it is applicable for other third-party chat integrations too.

**How to use it:**
Use the supported interfaced settings in the endpoint query type.
```python

from zerver.lib.webhooks.interfaced_settings import MapToChannelsT
...

@webhook_view("Slack", notify_bot_owner_on_invalid_json=False)
@typed_endpoint
def api_slack_webhook(
    request: HttpRequest,
    user_profile: UserProfile,
    *,
    slack_app_token: str = "",
    channels_mapping: MapToChannelT = False, # <-- This here!

```
**Result:**

| Lightbox | Dark |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bd68a442-e0a4-4a3f-a49f-ba68b40b9be4) | ![image](https://github.com/user-attachments/assets/84fc48d5-2c87-4dd4-a4fa-0389105cf071) | 

**Just to prove the point that any integration could use this setting (where applicable):**

| Example 1 | Example 2 |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c6a99d19-fd75-4898-b29e-0ee42d7b617f) | ![image](https://github.com/user-attachments/assets/609b255a-443b-4495-a91a-8dc0f94dec91) |

**Behaviours**
If selected:
- The  "Send all notifications to a single topic" field is disabled
- The setting's specific query is also added to the integration URL
Video of manual test:

[Screencast from 2025-02-12 13-24-32.webm](https://github.com/user-attachments/assets/eb85fafc-00ec-417d-b1ec-d69b0db0be2d)

---
| API doc update |
|--------|
| ![image](https://github.com/user-attachments/assets/b316ed00-5e8a-482c-8f31-8d4008b43300) `/api/register-queue`| 

Refactor on `config_options` and `all_event_types`
---
This PR also refactors some frontend logic and `state_data.ts` schema for `config_options` and `all_event_types`.  

<details>

<summary>
Here are some screenshots as proof that there are no regressions to these features:  
</summary>

| feature | screenshot |
|--------|--------|
| `config_options`  | ![image](https://github.com/user-attachments/assets/577aa167-f9a3-4815-9f63-a7d4ecabb8ca)|
| `all_event_types` | ![image](https://github.com/user-attachments/assets/2f02f60d-3242-47a4-a348-ea5c1f719ee0) |

</details>

Concerns
---
- The `integration_url_modal.ts` doesn't have any node test file, I wonder what the priority of adding that is. Having to support 3 or so different frameworks (`all_event_types`, `config_options` & `interfaced_settings`) on top of its main functions I think it'd be great if we could have a test suite for it.

Issue discussion that leads to this solution: [CZO](https://chat.zulip.org/#narrow/channel/127-integrations/topic/Slack's.20channels_map_to_topics.20setting.2E/with/2072236)
Design discussion: CZO


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
