### PR TITLE
banners: Close the timezone update banner after the user selects an option.

### DIFF
--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -512,11 +512,12 @@ export function initialize(): void {
         "click",
         ".accept-update-time-zone",
         function (this: HTMLElement) {
+            const $banner = $(this).closest(".banner");
             void channel.patch({
                 url: "/json/settings",
                 data: {timezone: browser_time_zone},
-                success: () => {
-                    banners.close($(this));
+                success() {
+                    banners.close($banner);
                     feedback_widget.show({
                         title_text: $t({defaultMessage: "Time zone updated"}),
                         populate($container) {
@@ -550,11 +551,12 @@ export function initialize(): void {
         "click",
         ".decline-time-zone-update",
         function (this: HTMLElement) {
+            const $banner = $(this).closest(".banner");
             void channel.patch({
                 url: "/json/settings",
                 data: {web_suggest_update_timezone: false},
-                success: () => {
-                    banners.close($(this));
+                success() {
+                    banners.close($banner);
                     feedback_widget.show({
                         title_text: $t({defaultMessage: "Setting updated"}),
                         populate($container) {


### PR DESCRIPTION
This PR ensures that the timezone update banner is closed after the user either accepts or declines to update the timezone.

<!-- Describe your pull request here.-->

Fixes: [#33313](https://github.com/zulip/zulip/issues/33313).
[CZO thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/time.20zone.20banner.20advancement/near/2073700). 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Accept to update timezone.

| Before | After | 
|--------|-------|
| ![accept before](https://github.com/user-attachments/assets/627cfffa-2764-473a-91e5-7f6afb60cbd2) | ![accept after](https://github.com/user-attachments/assets/fe5595e0-dcad-4c57-8243-26e0b8cad7e7) |

- Decline to update timezone.

| Before | After | 
|--------|-------|
| ![decline before](https://github.com/user-attachments/assets/cabb6646-0999-45dc-a3fe-c94b90e4ed2a) | ![decline after](https://github.com/user-attachments/assets/17702a18-d3a5-4812-b1ef-07f7adcd2e89) |


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
