### PR TITLE
top notice: Update notice at the top of search results, add one for the combined feed

### DIFF
--- a/web/src/message_feed_top_notices.ts
+++ b/web/src/message_feed_top_notices.ts
@@ -36,6 +36,14 @@ function show_end_of_results_notice(): void {
     $(".all-messages-search-caution a.search-shared-history").attr("href", update_hash);
 }
 
+function show_end_of_combined_feed_notice(): void {
+    $(".end-of-combined-feed").show();
+}
+
+function hide_end_of_combined_feed_notice(): void {
+    $(".end-of-combined-feed").hide();
+}
+
 export function update_top_of_narrow_notices(msg_list: MessageList): void {
     // Assumes that the current state is all notices hidden (i.e. this
     // will not hide a notice that should not be there)
@@ -64,6 +72,11 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
         ) {
             show_end_of_results_notice();
         }
+
+        // Display the notice for combined feed view
+        if (filter?.is_in_home()) {
+            show_end_of_combined_feed_notice();
+        }
     }
 
     if (msg_list.data.fetch_status.history_limited()) {
@@ -74,4 +87,5 @@ export function update_top_of_narrow_notices(msg_list: MessageList): void {
 export function hide_top_of_narrow_notices(): void {
     hide_end_of_results_notice();
     hide_history_limit_notice();
+    hide_end_of_combined_feed_notice();
 }

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -42,6 +42,12 @@
     display: flex;
     gap: 8px;
     margin-left: 10px;
+
+    & a {
+        &:hover {
+            text-decoration: none;
+        }
+    }
 }
 
 .banner-close-button {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -662,8 +662,7 @@
         opacity: 0.7;
     }
 
-    .history-limited-box,
-    .all-messages-search-caution {
+    .history-limited-box {
         background-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -191,6 +191,7 @@ p.n-margin {
 .all-messages-search-caution,
 .end-of-combined-feed {
     display: none;
+    font-size: var(--base-font-size-px);
     margin: 0 auto 12px;
     padding: 5px;
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -187,21 +187,12 @@ p.n-margin {
     box-shadow: 0 0 2px hsl(16deg 60% 45%);
 }
 
-.all-messages-search-caution {
-    border: 1px solid hsl(192deg 19% 75% / 20%);
-    box-shadow: 0 0 2px hsl(192deg 19% 75% / 20%);
-}
-
 .history-limited-box,
-.all-messages-search-caution {
-    border-radius: 4px;
+.all-messages-search-caution,
+.end-of-combined-feed {
     display: none;
     margin: 0 auto 12px;
     padding: 5px;
-    /* Difference should be 16px to accommodate the icon. */
-    /* This emulates hanging indent. */
-    padding-left: 26px;
-    text-indent: -10px;
 
     .all-messages-search-caution-icon {
         margin: 0 3px 0 1px;

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -9,29 +9,59 @@
         {{/tr}}
     </p>
 </div>
-<div class="all-messages-search-caution hidden-for-spectators" hidden>
-    <p>
-        <i class="all-messages-search-caution-icon fa fa-exclamation-circle" aria-hidden="true"></i>
-        {{#tr}}
-        End of results from your
-        <z-link>history</z-link>.
-        {{#*inline "z-link"}}<a href="/help/search-for-messages#searching-shared-history"
-          target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-        {{/tr}}
-        &nbsp;
-        <span>
+<div class="all-messages-search-caution banner-wrapper hidden-for-spectators" hidden>
+    <div class="banner banner-neutral">
+        <span class="banner-label">
+            {{#tr}}
+            End of results from
+            <z-link>your message history</z-link>.
+            {{#*inline "z-link"}}<a href="/help/search-for-messages#searching-shared-history"
+            target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+            &nbsp;
+        </span>
+        <span class="banner-action-buttons">
             {{#if is_guest}}
-                {{#tr}}
-                    Consider <z-link>searching all public channels that you can view</z-link>.
-                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
-                {{/tr}}
+            <a class="search-shared-history" href="">
+                <button class="action-button action-button-quiet-neutral">
+                    <span class="action-button-label">
+                        {{#tr}}Search all public channels that you can view{{/tr}}
+                    </span>
+                </button>
+            </a>
             {{else}}
-                {{#tr}}
-                    Consider <z-link>searching all public channels</z-link>.
-                    {{#*inline "z-link"}}<a class="search-shared-history" href="">{{> @partial-block}}</a>{{/inline}}
-                {{/tr}}
+            <a class="search-shared-history" href="">
+                <button class="action-button action-button-quiet-neutral">
+                    <span class="action-button-label">
+                        {{#tr}}Search all public channels{{/tr}}
+                    </span>
+                </button>
+            </a>
             {{/if}}
         </span>
-    </p>
+    </div>
+</div>
+
+<div class="end-of-combined-feed banner-wrapper hidden-for-spectators" hidden>
+    <div class="banner banner-neutral">
+        <span class="banner-label">
+            {{#tr}}
+            End of messages in your
+            <z-link>combined feed</z-link>.
+            {{#*inline "z-link"}}<a href="/help/combined-feed"
+            target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+            &nbsp;
+        </span>
+        <span class="banner-action-buttons">
+            <a href="/#narrow/channels/public">
+                <button class="action-button action-button-quiet-neutral">
+                    <span class="action-button-label">
+                        {{#tr}}View all messages in public channels{{/tr}}
+                    </span>
+                </button>
+            </a>
+        </span>
+    </div>
 </div>
 <div class="empty_feed_notice_main"></div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR adds a top-of-feed notice in the combined feed and improves the one at the top of the search results.

Fixes: #33287 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Below are screenshots for light and dark theme configured in different font sizes.

Light Theme:
12px: <img width="468" alt="image" src="https://github.com/user-attachments/assets/6c0a5836-fd9b-4678-9376-715df3a9c8ac" />

16px: <img width="468" alt="image" src="https://github.com/user-attachments/assets/e9c2e322-0224-4031-a65e-0fe1b1976500" />

20px: <img width="468" alt="image" src="https://github.com/user-attachments/assets/f8cff21c-a681-48e8-b6f3-a468c64335e5" />

Dark Theme: 
12px: <img width="468" alt="image" src="https://github.com/user-attachments/assets/e9f90f28-be13-4a8b-bbc1-1e945146a521" />

16px: <img width="468" alt="image" src="https://github.com/user-attachments/assets/393e7351-6f49-45b0-b89f-49ebaecbf55b" />

20px: <img width="468" alt="image" src="https://github.com/user-attachments/assets/d9fc7dc8-4359-4dc7-b257-356f3eaaccb3" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
