### PR TITLE
settings: Make label for warning when DMing a guest more succinct.

### DIFF
--- a/help/guest-users.md
+++ b/help/guest-users.md
@@ -42,7 +42,11 @@ pricing](/help/zulip-cloud-billing#temporary-users-and-guests) for guest users.
 
 {end_tabs}
 
-## Configure warning for direct messages to guest users
+## Configure warning when composing a DM to a guest
+
+Zulip can display a warning to let users know when recipients for a direct
+message they are composing are guests in your organization. The warning will be
+shown as a banner in the compose box on the web and desktop apps.
 
 {start_tabs}
 
@@ -50,7 +54,7 @@ pricing](/help/zulip-cloud-billing#temporary-users-and-guests) for guest users.
 
 {settings_tab|organization-permissions}
 
-1. Under **Guests**, toggle **Display a warning when composing a direct message with guest user recipients**.
+1. Under **Guests**, toggle **Warn when composing a DM to a guest**.
 
 {!save-changes.md!}
 

--- a/web/src/admin.ts
+++ b/web/src/admin.ts
@@ -74,8 +74,7 @@ const admin_settings_label = {
         defaultMessage: "Display “(guest)” after names of guest users",
     }),
     realm_enable_guest_user_dm_warning: $t({
-        defaultMessage:
-            "Display a warning when composing a direct message with guest user recipients",
+        defaultMessage: "Warn when composing a DM to a guest",
     }),
 };
 


### PR DESCRIPTION
[CZO thread](https://chat.zulip.org/#narrow/channel/378-api-design/topic/guest.20user.20warning.20.2330222/near/2081743)

Also explain what the setting does in the [help center](https://zulip.com/help/guest-users).

![Screenshot 2025-02-06 at 12 34 55@2x](https://github.com/user-attachments/assets/45b2a72c-f793-4bd2-9370-70e90b38516a)

![Screenshot 2025-02-06 at 12 39 45@2x](https://github.com/user-attachments/assets/b98b7960-3506-4e5e-bdb8-46f3857472b1)
