### PR TITLE
empty feed: Increase line-height and use em for width.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1259,7 +1259,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 .empty-feed-notice-title {
     font-size: 1.5em;
     font-weight: 400;
-    line-height: 1;
+    line-height: inherit;
     word-wrap: break-word;
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1250,7 +1250,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 }
 
 .empty_feed_notice {
-    max-width: 600px;
+    max-width: 42.8571em;
     margin: 0 auto;
     padding: 3em 1em;
     text-align: center;


### PR DESCRIPTION
There's a jump when the central panel becomes fixed width, which I showed Alya already and we both feel okay about it.

---

12px, 14px, 16px, 20px

(I realized near the end of recording these that exporting to a video might be better so you can pause. Let me know if you want me to rerecord them and to that)

| before | after |
| --- | --- |
|  ![Kapture 2025-02-06 at 13 56 30](https://github.com/user-attachments/assets/3bf81add-a05b-4b1c-b95f-33b69ca6dd71) | ![Kapture 2025-02-06 at 13 49 04](https://github.com/user-attachments/assets/ceb893bc-531d-461b-a4be-b11cc490d8d2) |
| ![Kapture 2025-02-06 at 13 53 49](https://github.com/user-attachments/assets/d0f67ff4-727a-4b3c-8e9a-27d2cefe75ee) | ![Kapture 2025-02-06 at 13 47 16](https://github.com/user-attachments/assets/536c433a-8421-4927-9a1b-579134d17ebc) |
| ![Kapture 2025-02-06 at 13 53 20](https://github.com/user-attachments/assets/b9178c08-10d4-436c-9eca-7cbc81fa3010) | ![Kapture 2025-02-06 at 13 46 11](https://github.com/user-attachments/assets/eac00a7c-c084-4e38-99f2-6a15be61eee2) |
| ![Kapture 2025-02-06 at 13 52 11](https://github.com/user-attachments/assets/c2d51302-5252-45c3-bd1c-139528465680) | ![Kapture 2025-02-06 at 13 50 37](https://github.com/user-attachments/assets/9430ccbf-c23f-40fe-ac38-80a66125f00f) |


