### PR TITLE
Fix 500 errors on user trying to access selfhosting login pages.

### DIFF
--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -23,6 +23,11 @@
                     {% trans %}Please try a different URL, <a href="{{ root_domain_url }}/accounts/find/">get a list of your accounts</a> on this server, or <a href="mailto:{{ support_email }}">contact this Zulip server's administrators</a>.{% endtrans %}
                 {% endif %}
             </p>
+            {% if is_selfhosting_management_error_page %}
+            <p>
+                {% trans %}<a href="{{ current_url }}/serverlogin/">Click here</a> to access plan management for your Zulip server.{% endtrans %}
+            </p>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -35,7 +35,10 @@
                 {% include 'zerver/portico-header-dropdown.html' %}
             {% else %}
                 {% if not only_sso %}
+                {% if is_self_hosting_management_page %}
+                {% else %}
                 <a href="{{login_url}}">{{ _('Log in') }}</a>
+                {% endif %}
                 {% endif %}
             {% endif %}
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -418,6 +418,11 @@ class AuthBackendTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "http://zulip.testserver/")
 
+    def test_invalid_login_on_self_hosting_management_subdomain(self) -> None:
+        result = self.client_get("/login/", subdomain="selfhosting")
+        self.assertEqual(result.status_code, 404)
+        self.assert_in_response("No organization found", result)
+
     @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipDummyBackend",))
     def test_no_backend_enabled(self) -> None:
         result = self.client_get("/login/")

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -889,8 +889,16 @@ def login_page(
     next: str = "/",
     **kwargs: Any,
 ) -> HttpResponse:
-    if get_subdomain(request) == settings.SOCIAL_AUTH_SUBDOMAIN:
+    subdomain = get_subdomain(request)
+    if subdomain == settings.SOCIAL_AUTH_SUBDOMAIN:
         return social_auth_subdomain_login_page(request)
+
+    if subdomain == settings.SELF_HOSTING_MANAGEMENT_SUBDOMAIN:
+        context = {
+            "current_url": request.get_host(),
+            "is_selfhosting_management_error_page": True,
+        }
+        return render(request, "zerver/invalid_realm.html", status=404, context=context)
 
     # To support previewing the Zulip login pages, we have a special option
     # that disables the default behavior of redirecting logged-in users to the


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![Screenshot from 2025-02-07 10-45-02](https://github.com/user-attachments/assets/e758d246-e85a-412e-9986-f7250bbf07c2) | ![image](https://github.com/user-attachments/assets/8cda51ef-696a-4571-898b-e55f8dbde275) |


On visiting the login page:

![image](https://github.com/user-attachments/assets/b3c96355-7d98-4eb9-843f-6ebfd5e7c870)

I added the last line for `selfhosting` subdomain in the above screenshot.

I think the first commit is enough to fix the issue. We could add similar check for password reset or other pages but now that we have removed the login button in the first commit, user is unlikely to get to other pages.
