### PR TITLE
recent_view: Show topic menu instead of topic visibility popover.

### DIFF
--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -206,7 +206,6 @@ export function initialize(): void {
 
     tippy.delegate("body", {
         target: [
-            "#recent_view .recipient_bar_icon",
             "#inbox-view .recipient_bar_icon",
             "#left-sidebar-container .visibility-policy-icon",
         ].join(","),

--- a/web/src/topic_popover.ts
+++ b/web/src/topic_popover.ts
@@ -47,7 +47,7 @@ function get_conversation(instance: tippy.Instance): {
 
 export function initialize(): void {
     popover_menus.register_popover_menu(
-        "#stream_filters .topic-sidebar-menu-icon, .inbox-row .inbox-topic-menu, .recipient-row-topic-menu",
+        "#stream_filters .topic-sidebar-menu-icon, .inbox-row .inbox-topic-menu, .recipient-row-topic-menu, .recent_view_focusable .visibility-status-icon",
         {
             ...popover_menus.left_sidebar_tippy_options,
             onShow(instance) {
@@ -73,6 +73,11 @@ export function initialize(): void {
                 const is_topic_empty = context.is_topic_empty;
                 const topic_display_name = context.topic_display_name;
                 const is_empty_string_topic = context.is_empty_string_topic;
+
+                const $elt = $(instance.reference).closest(".recent_view_focusable");
+                if ($elt.length === 1) {
+                    $elt.addClass("topic-popover-visible");
+                }
 
                 if (!stream_id) {
                     popover_menus.hide_current_popover_if_visible(instance);
@@ -201,6 +206,10 @@ export function initialize(): void {
                 );
             },
             onHidden(instance) {
+                const $elt = $(instance.reference).closest(".recent_view_focusable");
+                if ($elt.length === 1) {
+                    $elt.removeClass("topic-popover-visible");
+                }
                 instance.destroy();
                 popover_menus.popover_instances.topics_menu = null;
                 ui_util.hide_left_sidebar_menu_icon();

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -54,14 +54,24 @@
             box-shadow: 0 3px 0 var(--color-outline-focus);
         }
 
-        &.change_visibility_policy.visibility-policy-popover-visible {
-            .zulip-icon-inherit {
+        &.change_visibility_policy.topic-popover-visible {
+            .visibility-status-icon {
                 opacity: 0.4;
             }
         }
 
-        &.change_visibility_policy .zulip-icon-inherit {
+        &.change_visibility_policy .visibility-status-icon:hover::before {
+            /* Show vertical ellipsis when user hovers over visibility indicator icon. */
+            content: "\f155";
+        }
+
+        &.change_visibility_policy .recent-view-row-topic-menu {
             opacity: 0;
+            cursor: pointer;
+
+            &:not(.visibility-status-icon) {
+                display: none;
+            }
 
             &:focus {
                 opacity: 0.2;
@@ -348,7 +358,7 @@
         &:hover {
             background-color: var(--color-background-recent-view-row-hover);
 
-            .change_visibility_policy .zulip-icon-inherit {
+            .change_visibility_policy .recent-view-row-topic-menu {
                 opacity: 0.4;
             }
         }

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -64,17 +64,13 @@
                     <div class="hidden-for-spectators">
                         <span class="recent_view_focusable change_visibility_policy hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-col-index="{{ column_indexes.mute }}">
                             {{#if (eq visibility_policy all_visibility_policies.FOLLOWED)}}
-                                <i class="zulip-icon zulip-icon-follow recipient_bar_icon" data-tippy-content="{{t 'You follow this topic.'}}"
-                                  role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You follow this topic.' }}"></i>
+                                <i class="zulip-icon zulip-icon-follow recipient_bar_icon visibility-status-icon" tabindex="0" aria-label="{{t 'Topic actions menu' }}" aria-haspopup="true" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-topic-url="{{topic_url}}" data-tippy-content="{{t 'You follow this topic.'}}" role="button"></i>
                             {{else if (eq visibility_policy all_visibility_policies.UNMUTED)}}
-                                <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon" data-tippy-content="{{t 'You have unmuted this topic.'}}"
-                                  role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have unmuted this topic.' }}"></i>
+                                <i class="zulip-icon zulip-icon-unmute-new recipient_bar_icon visibility-status-icon" tabindex="0" aria-label="{{t 'Topic actions menu' }}" aria-haspopup="true" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-topic-url="{{topic_url}}" data-tippy-content="{{t 'You have unmuted this topic.'}}" role="button"></i>
                             {{else if (eq visibility_policy all_visibility_policies.MUTED)}}
-                                <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon" data-tippy-content="{{t 'You have muted this topic.'}}"
-                                  role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'You have muted this topic.' }}"></i>
+                                <i class="zulip-icon zulip-icon-mute-new recipient_bar_icon visibility-status-icon" tabindex="0" aria-label="{{t 'Topic actions menu' }}" aria-haspopup="true" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-topic-url="{{topic_url}}" data-tippy-content="{{t 'You have muted this topic.'}}" role="button"></i>
                             {{else}}
-                                <i class="zulip-icon zulip-icon-inherit recipient_bar_icon"
-                                  role="button" tabindex="0" aria-haspopup="true" aria-label="{{t 'Notifications are based on your configuration for this channel.' }}"></i>
+                                <i class="zulip-icon zulip-icon-more-vertical recent-view-row-topic-menu visibility-status-icon" tabindex="0" aria-label="{{t 'Topic actions menu' }}" aria-haspopup="true" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-topic-url="{{topic_url}}" role="button"></i>
                             {{/if}}
                         </span>
                     </div>


### PR DESCRIPTION
This helps us include topic summary feature in recent view.

![image](https://github.com/user-attachments/assets/14dfdb8a-aeff-4cdd-b047-259a7519b088)

[Screencast from 2025-02-07 19-53-15.webm](https://github.com/user-attachments/assets/3f53cd8d-231b-44fb-846d-392c8f1c0a74)


Things tested:
* Enter keypress/ click  to open popover works
* Topic visibility icon changes to vertical ellipsis on hover
* Focus is correctly propageted when using via keyboard to different popovers and modals.
* All the options in the topic popover work as expected