### PR TITLE
Improvements for #32803.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -180,7 +180,7 @@
     <source class="notification-sound-source-mp3" type="audio/mpeg" />
 </audio>
 
-<div class="alert-box">
+<div id="popup_banners_wrapper" class="banner-wrapper alert-box">
     <div class="alert alert_sidebar alert-error home-error-bar" id="connection-error">
         <div class="exit"></div>
         <strong class="message">{{ _('Unable to connect to Zulip.') }}</strong>
@@ -222,7 +222,6 @@
         <div class="alert-content"></div>
         <div class="exit"></div>
     </div>
-    <div id="found-missing-unreads"></div>
 </div>
 
 <div id="navbar-fixed-container">

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -222,6 +222,7 @@
         <div class="alert-content"></div>
         <div class="exit"></div>
     </div>
+    <div id="found-missing-unreads"></div>
 </div>
 
 <div id="navbar-fixed-container">

--- a/web/src/alert_popup.ts
+++ b/web/src/alert_popup.ts
@@ -1,5 +1,49 @@
 import $ from "jquery";
 
+import * as banners from "./banners.ts";
+import type {Banner} from "./banners.ts";
+import {$t} from "./i18n.ts";
+
+// Show user a banner with a button to allow user to navigate
+// to the first unread if required.
+const FOUND_MISSING_UNREADS_IN_CURRENT_NARROW: Banner = {
+    intent: "warning",
+    label: $t({
+        defaultMessage: "This conversation also has older unread messages.",
+    }),
+    buttons: [
+        {
+            type: "quiet",
+            label: $t({defaultMessage: "Jump to first unread"}),
+            custom_classes: "found-missing-unreads-jump-to-first-unread",
+        },
+    ],
+    close_button: true,
+    custom_classes: "found-missing-unreads popup-alert-banner",
+};
+
+export function open_found_missing_unreads_banner(on_jump_to_first_unread: () => void): void {
+    banners.append(FOUND_MISSING_UNREADS_IN_CURRENT_NARROW, $("#popup_banners_wrapper"));
+
+    $("#popup_banners_wrapper").on(
+        "click",
+        ".found-missing-unreads-jump-to-first-unread",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const $banner = $(this).closest(".banner");
+            banners.close($banner);
+            on_jump_to_first_unread();
+        },
+    );
+}
+
+export function close_found_missing_unreads_banner(): void {
+    const $banner = $("#popup_banners_wrapper").find(".found-missing-unreads");
+    banners.close($banner);
+}
+
 // this will hide the alerts that you click "x" on.
 $("body").on("click", ".alert-box > div .exit", function () {
     const $alert = $(this).closest(".alert-box > div");

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -30,7 +30,7 @@ import * as stream_list from "./stream_list.ts";
 import * as ui_report from "./ui_report.ts";
 import * as util from "./util.ts";
 
-const response_schema = z.object({
+export const response_schema = z.object({
     anchor: z.number(),
     found_newest: z.boolean(),
     found_oldest: z.boolean(),
@@ -342,7 +342,7 @@ export function get_narrow_for_message_fetch(filter: Filter): string {
     return narrow_param_string;
 }
 
-function get_parameters_for_message_fetch_api(opts: MessageFetchOptions): MessageFetchAPIParams {
+export function get_parameters_for_message_fetch_api(opts: MessageFetchOptions): MessageFetchAPIParams {
     if (typeof opts.anchor === "number") {
         // Messages that have been locally echoed messages have
         // floating point temporary IDs, which is intended to be a.

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -5,6 +5,7 @@ import assert from "minimalistic-assert";
 
 import render_navbar_banners_testing_popover from "../templates/popovers/navbar_banners_testing_popover.hbs";
 
+import * as alert_popup from "./alert_popup.ts";
 import * as banners from "./banners.ts";
 import type {AlertBanner} from "./banners.ts";
 import * as channel from "./channel.ts";
@@ -642,6 +643,13 @@ export function initialize(): void {
                 });
                 $popper.on("click", ".time_zone_update_offer", () => {
                     banners.open(time_zone_update_offer_banner(), $("#navbar_alerts_wrapper"));
+                    popover_menus.hide_current_popover_if_visible(instance);
+                });
+                $popper.on("click", ".found_missing_unreads_banner", () => {
+                    const on_jump_to_first_unread = (): void => {
+                        console.log("testing: jump to first unread called");
+                    };
+                    alert_popup.open_found_missing_unreads_banner(on_jump_to_first_unread);
                     popover_menus.hide_current_popover_if_visible(instance);
                 });
             },

--- a/web/src/ui_report.ts
+++ b/web/src/ui_report.ts
@@ -82,7 +82,12 @@ export function generic_row_button_error(xhr: JQuery.jqXHR, $button: JQuery): vo
     }
 }
 
-export function hide_error($target: JQuery): void {
+export function hide_error($target: JQuery, instantly = false): void {
+    if (instantly) {
+        $target.removeClass("show");
+        return;
+    }
+
     $target.addClass("fade-out");
     setTimeout(() => {
         $target.removeClass("show fade-out");

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -145,3 +145,7 @@
     color: var(--color-text-danger-banner);
     border-color: var(--color-border-danger-banner);
 }
+
+.popup-alert-banner {
+    margin: 5px 0 10px;
+}

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -143,6 +143,15 @@
                     <span class="unread_count quiet-count"></span>
                 </a>
             </li>
+            <li class="top_left_change_navbar_banners top_left_row hidden-for-spectators">
+                <a class="left-sidebar-navigation-label-container">
+                    <span class="filter-icon">
+                        <i class="zulip-icon zulip-icon-spoiler" aria-hidden="true"></i>
+                    </span>
+                    {{~!-- squash whitespace --~}}
+                    <span class="left-sidebar-navigation-label">{{t 'Change navbar banner' }}</span>
+                </a>
+            </li>
         </ul>
     </div>
 

--- a/web/templates/popovers/navbar_banners_testing_popover.hbs
+++ b/web/templates/popovers/navbar_banners_testing_popover.hbs
@@ -54,5 +54,11 @@
                 <span class="popover-menu-label">{{t "Time zone update offer"}}</span>
             </a>
         </li>
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" class="found_missing_unreads_banner popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-edit" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Found missing unreads banner"}}</span>
+            </a>
+        </li>
     </ul>
 </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Related PR:  #32803

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2025-02-07 at 9 49 19 PM](https://github.com/user-attachments/assets/d40e3dea-3c6f-4108-8b6a-7ae1a8d62ddf)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
