### PR TITLE
search: Exclude `with` operator terms from search terms.

### DIFF
--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -18,11 +18,15 @@ export function filter(): Filter | undefined {
 export function search_terms(current_filter: Filter | undefined = filter()): NarrowTerm[] {
     if (current_filter === undefined) {
         if (page_params.narrow !== undefined) {
-            return new Filter(page_params.narrow).terms();
+            current_filter = new Filter(page_params.narrow);
+        } else {
+            current_filter = new Filter([]);
         }
-        return new Filter([]).terms();
     }
-    return current_filter.terms();
+
+    const non_search_operators = new Set(["with"]);
+
+    return current_filter.terms().filter((term) => !non_search_operators.has(term.operator));
 }
 
 export function is_search_view(current_filter: Filter | undefined = filter()): boolean {

--- a/web/tests/narrow_state.test.cjs
+++ b/web/tests/narrow_state.test.cjs
@@ -151,6 +151,17 @@ test("terms", () => {
     assert.equal(result.length, 1);
     assert.equal(result[0].operator, "channel");
     assert.equal(result[0].operand, foo_stream_id.toString());
+
+    // `with` terms are excluded from search terms.
+    page_params.narrow = [
+        {operator: "stream", operand: foo_stream_id.toString()},
+        {operator: "topic", operand: "Bar"},
+        {operator: "with", operand: "12"},
+    ];
+    result = narrow_state.search_terms();
+    assert.equal(result.length, 2);
+    assert.equal(result[0].operator, "channel");
+    assert.equal(result[1].operator, "topic");
 });
 
 test("excludes_muted_topics", () => {


### PR DESCRIPTION
This commit excludes terms containing the `with` operator from the search terms, since `with` operator is not a search operator.

<!-- Describe your pull request here.-->

This commit contains cherry-picked changes from https://github.com/zulip/zulip/pull/31152#discussion_r1945775063

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
