### PR TITLE
settings: Show desktop notifications warning when permissions needed.

### DIFF
--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -107,6 +107,8 @@
             {{> settings_save_discard_widget section_name="desktop-message-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
+        <div class="desktop-notification-settings-banners"></div>
+
         {{#unless for_realm_settings}}
         <p><a class="send_test_notification">{{t "Send a test notification" }}</a></p>
         {{/unless}}


### PR DESCRIPTION
Display a yellow warning banner in the desktop notifications settings when browser permissions are not granted (default/denied states).
Hide the "Send a test notification" button when permission state is "default" or "denied".
<!-- Describe your pull request here.-->

Fixes: [Link](https://github.com/zulip/zulip/issues/33222)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Dark Theme:
![image](https://github.com/user-attachments/assets/b32930d7-0df6-4e89-ace7-6996008e2dcf)
Light Theme:
![image](https://github.com/user-attachments/assets/e020d5d4-13bb-4b56-8115-b4856f48ea30)
When clicked on Enable Permissions button:
![image](https://github.com/user-attachments/assets/30eba14c-ae9d-4106-94c9-99ac94f0ff78)
When Notifications allowed Send a Test Notification button is made visible:
![image](https://github.com/user-attachments/assets/b29402e3-eeca-47bd-beeb-5a5f18896ead)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
