### PR TITLE
search: Fix bug where narrow screen closed search had background color.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -122,6 +122,12 @@
             cursor: text;
         }
 
+        #searchbox-input-container.pill-container {
+            /* Pill container should display the same background
+               color as the search typeahead. */
+            background-color: var(--color-background-search);
+        }
+
         @media (width < $md_min) {
             /* 3px chosen so that the cursor clicks the search button
                and close button from the same position. */
@@ -213,9 +219,7 @@
 
         /* Override styles for .pill-container that aren't relevant for search. */
         &.pill-container {
-            /* Pill container should display the same background
-               color as the search typeahead. */
-            background-color: var(--color-background-search);
+            background: inherit;
             /* Maintain only a column gap. */
             gap: 0 0.3125em; /* 5px at 16px em */
             /* Override padding. */


### PR DESCRIPTION
This was introduced in 325ab83edb78db5fc1609238141f261794b4c670 and should have only been applied to the expanded search bar.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/narrow.20search.20bar.20hover.20behavior/near/2066736)

| before | after |
| --- | --- |
| <img width="595" alt="image" src="https://github.com/user-attachments/assets/4541f45b-61b3-4bbb-bc96-da190798de7c" />| ![Kapture 2025-02-07 at 13 42 39](https://github.com/user-attachments/assets/2d3ae4ad-6176-4be4-881a-6d5d90af2024)|
| no issue in dark mode before | ![Kapture 2025-02-07 at 13 41 14](https://github.com/user-attachments/assets/a595a398-90ea-45b2-9bc8-2dfd488a6123)|
