### PR TITLE
saved_snippets: Fix Enter click on "Create a new saved snippet" button.

### DIFF
--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -391,7 +391,12 @@ export class DropdownWidget {
 
                     switch (e.key) {
                         case "Enter":
-                            if (e.target === $search_input.get(0)) {
+                            if (
+                                list_items.length === 0 ||
+                                e.target === $sticky_bottom_option.get(0)
+                            ) {
+                                $sticky_bottom_option.trigger("click");
+                            } else if (e.target === $search_input.get(0)) {
                                 // Select first item if in search input.
                                 first_item().trigger("click");
                             } else if (list_items.length > 0) {


### PR DESCRIPTION
Using "Enter" key to click on "Create a new saved snippet" button does not work when the dropdown list is empty. This commit fixes that bug.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
