### PR TITLE
inbox: Position search clear button with em.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -54,7 +54,7 @@
             }
 
             #inbox-clear-search {
-                border: 1px solid transparent;
+                border: none;
                 background: transparent;
                 display: flex;
                 justify-content: center;
@@ -66,13 +66,12 @@
                 opacity: 0.4;
                 transition: none 140ms;
                 transition-property: background-color, opacity, transform;
-                padding: 5px;
+                /* 5px at 16px font-size at 14px em */
+                padding: 0.3125em;
                 margin: 0;
-                /* = -Width of the button, 28px at 14px em */
-                margin-right: -2em;
                 position: relative;
-                top: 0;
-                right: 30px;
+                /* Width of the button, 27px at 16px font-size at 14px em */
+                right: 1.6875em;
 
                 &:focus {
                     outline: none;


### PR DESCRIPTION
I left the hover styling for now, partially because it's easier to see the space it takes up, but I think it's likely we'll want to remove it.

before and after at 12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-09 at 14 28 30](https://github.com/user-attachments/assets/760003b9-fadc-44b4-90d1-f68dcfd46d05) | ![Screen Shot 2025-02-09 at 14 22 46](https://github.com/user-attachments/assets/2932b3b4-57a9-4a76-a822-3ea1c6f6356e) |
| ![Screen Shot 2025-02-09 at 14 28 14](https://github.com/user-attachments/assets/1b7bee4e-7ebe-4738-9e41-cdbb8e1db1e3) | ![Screen Shot 2025-02-09 at 14 23 04](https://github.com/user-attachments/assets/6174c3f6-f26e-4441-8084-0275f4ae3be1) |
| ![Screen Shot 2025-02-09 at 14 28 02](https://github.com/user-attachments/assets/113bfe76-e3cc-4249-ab1b-168f418992d4) | ![Screen Shot 2025-02-09 at 14 23 16](https://github.com/user-attachments/assets/306b487a-a68d-471a-b6c5-cf5e415ceb86) |
| ![Screen Shot 2025-02-09 at 14 27 15](https://github.com/user-attachments/assets/e081bf7f-0839-48b7-b827-2e76eeddd0b0) | ![Screen Shot 2025-02-09 at 14 24 28](https://github.com/user-attachments/assets/eb725fbe-aa68-48ef-9021-724000c66383) |


