### PR TITLE
subscription settings: Use em for width and height of channel color.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1241,8 +1241,9 @@ div.settings-radio-input-parent {
 }
 
 .stream-settings-color-preview {
-    width: 33px;
-    height: 33px;
+    /* 33px at 12.8 font size (from .button.small) at 14px em */
+    width: 2.5781em;
+    height: 2.5781em;
     margin: -6px 0 -6px -10px;
 }
 


### PR DESCRIPTION
before and after at 12px, 14px, 16px, 20px

| before | after | 
| --- | --- |
| ![Screen Shot 2025-02-09 at 14 56 33](https://github.com/user-attachments/assets/de168e9e-d019-4027-8edd-730eae3c4f10) | ![Screen Shot 2025-02-09 at 14 56 03](https://github.com/user-attachments/assets/cb9cf5f3-fad5-4656-a17b-a63f6c58d98e) | 
| ![Screen Shot 2025-02-09 at 14 56 43](https://github.com/user-attachments/assets/2e367fc5-85b5-4be9-bb5a-fdd09aa01017) | ![Screen Shot 2025-02-09 at 14 56 03](https://github.com/user-attachments/assets/b7c9c260-a1dd-43fc-bef4-12af9d275523) | 
| ![Screen Shot 2025-02-09 at 14 56 51](https://github.com/user-attachments/assets/a58174fe-9511-42ae-bb07-76d2592ea735) | ![Screen Shot 2025-02-09 at 14 56 03](https://github.com/user-attachments/assets/9324bc3f-0b63-43c5-8013-31eb0c363b1c) | 
| ![Screen Shot 2025-02-09 at 14 57 02](https://github.com/user-attachments/assets/d61826ad-f955-4f94-9bc2-d1d985ed3e62) | ![Screen Shot 2025-02-09 at 14 55 19](https://github.com/user-attachments/assets/957d802d-e22d-4113-aede-b70b840965f1) | 
