### PR TITLE
compose: Scale close button with font size.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -642,12 +642,15 @@
     right: 0;
     color: var(--color-compose-send-control-button);
     background: transparent;
-    font-size: 12.5px;
+    /* 12.5px at 14px em */
+    font-size: 0.8928em;
     font-weight: normal;
-    line-height: 20px;
+    /* 3px 7px at 12.5px font size at 14px em */
+    line-height: 1.6em;
     opacity: 0.7;
     border: 0;
-    padding: 3px 7px;
+    /* 3px 7px at 12.5px font size at 14px em */
+    padding: 0.24em 0.56em;
     border-radius: 8px;
     vertical-align: unset;
     text-shadow: none;


### PR DESCRIPTION
before and after at 12px 14px 16px 20px --- screenshots with the hover style on to show the padding

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-13 at 22 24 15](https://github.com/user-attachments/assets/582c7453-3aa3-4f13-92af-4f539e4d1f48) | ![Screen Shot 2025-02-13 at 22 28 49](https://github.com/user-attachments/assets/c7393a2f-eedf-4dca-9b30-17be9c6483f9) |
| ![Screen Shot 2025-02-13 at 22 24 25](https://github.com/user-attachments/assets/05cfa77f-2a3c-449c-9da6-134cbd8d73c4) | ![Screen Shot 2025-02-13 at 22 29 16](https://github.com/user-attachments/assets/acd7148b-bd93-4167-8b72-64a6288f2d93) |
| ![Screen Shot 2025-02-13 at 22 24 34](https://github.com/user-attachments/assets/10566c27-b43e-4439-990d-b785ae3bcb0b) | ![Screen Shot 2025-02-13 at 22 29 23](https://github.com/user-attachments/assets/fe5c853a-bdd6-49d2-9102-8b77cd720f8e) |
| ![Screen Shot 2025-02-13 at 22 25 10](https://github.com/user-attachments/assets/bd854c7f-afac-41bf-b86f-c0d2241e0631) | ![Screen Shot 2025-02-13 at 22 30 34](https://github.com/user-attachments/assets/79747b33-7f87-455e-8356-a1c57fd3dc76) |

