### PR TITLE
Allow multiple recipients in dm-including pills and improve suggestion behavior

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -245,7 +245,10 @@ function message_matches_search_term(message: Message, operator: string, operand
             if (!user_ids) {
                 return false;
             }
-            return user_ids.includes(operand_user.user_id);
+            const operand_users = operand
+                .split(",")
+                .map((email) => people.get_by_email(email.trim()));
+            return operand_users.every((user) => user && user_ids.includes(user.user_id)); 
         }
     }
 

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -16,6 +16,11 @@ import * as user_pill from "./user_pill.ts";
 import type {UserPillData, UserPillWidget} from "./user_pill.ts";
 
 function person_matcher(query: string, item: UserPillData): boolean {
+    // If the query contains commas, consider only the part after the last comma.
+    if (query.includes(",")) {
+        query = query.split(",").pop()?.trim() ?? "";
+    }
+    query = query.toLowerCase().replaceAll("\u00A0", " ");
     return (
         people.is_known_user_id(item.user.user_id) &&
         typeahead_helper.query_matches_person(query, item)


### PR DESCRIPTION
<!-- Describe your pull request here. -->
This PR improves the behavior of the `dm-including` search operator to support multiple recipients in a single pill, similar to how the `dm` operator works. The changes include:

1. **Multi-user support**:
   - Typing a comma after selecting a user now suggests additional matching users.
   - Starting to type a name provides relevant user suggestions.

2. **Data handling**:
   - The `dm-including` operator now properly handles lists of emails instead of user IDs.
   - Duplicate emails are automatically removed before constructing the narrow query.

3. **Pill behavior**:
   - Duplicate users are prevented from being added.

**Fixes**: <!-- Issue link, or clear description --> issue #33342

| **Before** | **After** |
|------------|----------|
| ![Before](https://github.com/user-attachments/assets/d1386e53-806a-492d-89f5-d1564d044591) | ![After 1](https://github.com/user-attachments/assets/d2d1c0af-d21b-4719-a7cc-b20c41dd428d) |
|            | ![After 2](https://github.com/user-attachments/assets/139846c9-d581-4ae4-b107-41f6fa4cdf90) |


<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
