### PR TITLE
notifications: Render emoji in desktop notifications.

### DIFF
--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -40,7 +40,7 @@ function get_notification_content(message: Message | TestNotificationMessage): s
     let content;
     // Convert the content to plain text, replacing emoji with their alt text
     const $content = $("<div>").html(message.content);
-    ui_util.replace_emoji_with_text($content);
+    ui_util.convert_unicode_eligible_emoji_to_unicode($content);
     ui_util.change_katex_to_raw_latex($content);
     ui_util.potentially_collapse_quotes($content);
     spoilers.hide_spoilers_in_notification($content);

--- a/web/tests/ui_util.test.cjs
+++ b/web/tests/ui_util.test.cjs
@@ -67,3 +67,15 @@ run_test("potentially_collapse_quotes", ({override_rewire}) => {
         expected_texts,
     );
 });
+
+run_test("replace_emoji_name_with_emoji_unicode", () => {
+    const $emoji = $.create("span").attr("class", "emoji emoji-1f419");
+    $emoji.is = () => false;
+
+    const octopus_emoji = "🐙";
+    assert.equal(octopus_emoji, ui_util.convert_emoji_element_to_unicode($emoji));
+
+    $emoji.attr("class", "emoji emoji-1f468-200d-1f373");
+    const man_cook_emoji = "👨‍🍳";
+    assert.equal(man_cook_emoji, ui_util.convert_emoji_element_to_unicode($emoji));
+});


### PR DESCRIPTION
Through the changes in this PR, in desktop notifications, we no longer display an emoji's status code. Instead, we show the corresponding Unicode emoji to render it properly in desktop notifications. For custom emojis, we continue to display their name.


<!-- Describe your pull request here.-->

Fixes: #30598.
[CZO thread](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Emoji.20in.20windows.20notification/near/1815298).

**Previous PR Reference:**
- This PR continues the work done in the PR [#30653](https://github.com/zulip/zulip/pull/30653) by @tnmkr.
- There also exists a PR [#31949](https://github.com/zulip/zulip/pull/31949) by @tony-nyagah.
- The developments made in this PR are:
  - Better error handling for custom emoji and for the `String.fromCodePoint()` function.
  - Added tests to verify the logic.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Emojis in desktop notifications.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/8a7e90fc-9c7f-4cb7-827b-7356dc46d0bf) | ![image](https://github.com/user-attachments/assets/d57fa804-491c-4b75-bd0e-c75aaf739912) |
| ![image](https://github.com/user-attachments/assets/e7a7e388-b401-4e39-82af-ad038d4ce68c) | ![image](https://github.com/user-attachments/assets/1dccbae7-2a59-47ba-921b-25a05a912b13) |

- Custom emojis in desktop notifications - (_No changes_).

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/f13021c2-06de-4834-823a-06eeea4ea9a2) | ![image](https://github.com/user-attachments/assets/01108f42-0790-4cef-8de0-102374c55c02) |

- Emojis with [ZWJ sequences](https://www.unicode.org/emoji/charts/emoji-zwj-sequences.html).
  
  | Before | After |
  |--------------|-------------|
  | ![image](https://github.com/user-attachments/assets/87713b08-450b-4d4a-adf7-bfbc8833eef4) | ![image](https://github.com/user-attachments/assets/0d887cb3-b123-4194-a4bd-7b139a3a7644) |
---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
