### PR TITLE
topic_list: Show empty string topic when narrowed to empty topic.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -181,7 +181,7 @@ export function get_list_info(
 
     if (
         stream_id === narrow_state.stream_id() &&
-        narrowed_topic &&
+        narrowed_topic !== undefined &&
         !contains_topic(topic_names, narrowed_topic)
     ) {
         topic_names.unshift(narrowed_topic);


### PR DESCRIPTION
[CZO bug report](https://chat.zulip.org/#narrow/channel/9-issues/topic/general.20chat.20topic.20not.20shown.20in.20left.20sidebar.20when.20empty/near/2082985):

> Normally, when you go to an empty topic (with no messages yet), we show it in the left sidebar. This doesn't seem to work for test general chat yet.

**Screenshots and screen captures:**

Before | After |
|-------|------|
<img width="1276" alt="Screenshot 2025-02-11 at 6 11 40 PM" src="https://github.com/user-attachments/assets/92351723-25ff-4747-9356-8e3ad41efe8f" /> | <img width="1271" alt="Screenshot 2025-02-11 at 5 59 53 PM" src="https://github.com/user-attachments/assets/42385f3e-3e6a-458c-8133-4ff942532844" />


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
