### PR TITLE
markdown: Use em for left-margin of numbered lists.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -21,7 +21,8 @@
     }
 
     & ol {
-        margin: 0 0 var(--markdown-interelement-space-px) 20px;
+        /* 20px at 14px em */
+        margin: 0 0 var(--markdown-interelement-space-px) 1.4285em;
     }
 
     /* Swap the left and right margins of ordered list for Right-To-Left languages */


### PR DESCRIPTION
[CZO conversation](https://chat.zulip.org/#narrow/channel/9-issues/topic/large.20numbered.20lists/near/2086330)

before and after at 12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-11 at 19 32 26](https://github.com/user-attachments/assets/949a4795-31bb-4825-9fb5-53992c3e19be) | ![Screen Shot 2025-02-11 at 19 30 43](https://github.com/user-attachments/assets/8c8ea4cb-3a04-4bd0-877d-10f6d325bdfe) |
| ![Screen Shot 2025-02-11 at 19 31 57](https://github.com/user-attachments/assets/695ea8ce-4e94-4f76-a601-9685a9f4c6ba) | ![Screen Shot 2025-02-11 at 19 30 57](https://github.com/user-attachments/assets/6af0be56-e784-4e33-ac55-1a6775a28430) |
| ![Screen Shot 2025-02-11 at 19 31 50](https://github.com/user-attachments/assets/34a79a78-02a7-4ca6-9a9f-77e98e571025) | ![Screen Shot 2025-02-11 at 19 31 10](https://github.com/user-attachments/assets/a655b2a8-dd11-4d56-8407-e5b4e39b9109) |
| ![Screen Shot 2025-02-11 at 19 31 40](https://github.com/user-attachments/assets/2fa2753c-cf61-4b15-83ce-86064f9c9bdf) | ![Screen Shot 2025-02-11 at 19 31 25](https://github.com/user-attachments/assets/2005eb69-07b4-43e7-b908-5f903ad48898) |
