### PR TITLE
banners: Use em for font size.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -532,7 +532,8 @@ input.settings_text_input {
     border: 1px solid var(--color-border-tip);
     border-radius: 4px;
     padding: 10px;
-    font-size: 1rem;
+    /* previously 1rem = 16px at 14px em = 1.1428em */
+    font-size: 1.1428em;
     line-height: 1.5;
     color: hsl(0deg 0% 40%);
 


### PR DESCRIPTION
I didn't put in much effort to find all the other relevant banners for this style:

```
.upgrade-tip,
.upgrade-or-sponsorship-tip,
.tip,
.invite-stream-notice
```

There are a lot of them, especially for `tip`, so if we want to be more careful then I can make this PR change just for the settings modal, and update other ones as we see them. But I just saw a `tip` in "Default user settings" that definitely benefits from this PR.

---

before and after at 12px, 14px, 16px, 20px:

| before | after |
| --- | ---- |
| ![Screen Shot 2025-02-11 at 20 16 12](https://github.com/user-attachments/assets/27ae61e5-c737-40c0-a87a-244287e43fb7) | ![Screen Shot 2025-02-11 at 20 14 38](https://github.com/user-attachments/assets/053fa034-6d8f-4c4c-91a4-d1f333f2cbc4) | 
| ![Screen Shot 2025-02-11 at 20 16 21](https://github.com/user-attachments/assets/c382a327-676a-4d4c-9d41-13faffa8431b) | ![Screen Shot 2025-02-11 at 20 14 30](https://github.com/user-attachments/assets/1361ccb1-6fe2-4a1a-8d47-abbeb1df9aa4) |
| ![Screen Shot 2025-02-11 at 20 17 16](https://github.com/user-attachments/assets/ba335c40-fae3-4462-a2e0-e4c9c0bd3464) | ![Screen Shot 2025-02-11 at 20 14 24](https://github.com/user-attachments/assets/071de50e-ca25-4f35-aa38-1dda71d2c6a6) |
| ![Screen Shot 2025-02-11 at 20 17 36](https://github.com/user-attachments/assets/cfd92ef3-1d24-43c8-a20e-a0c38cc2d084) | ![Screen Shot 2025-02-11 at 20 13 03](https://github.com/user-attachments/assets/57b62f63-95fb-4c86-8bb9-7bebd4a47d7b) |

