### PR TITLE
settings: Improve spacing for info density (exit button and left panel icons)

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1455,7 +1455,7 @@ label.preferences-radio-choice-label {
         .exit {
             font-weight: 600;
             position: absolute;
-            right: 10px;
+            right: 0.7142em; /* 10px at 14px em */
             color: hsl(0deg 0% 67%);
             cursor: pointer;
         }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1361,8 +1361,9 @@ label.preferences-radio-choice-label {
         .sidebar-item {
             display: grid;
             /* 3.5714em is 50px at 14px/1em -- the legacy height of these rows. */
+            /* 2.8571em is 40px at 14px/1em */
             grid-template:
-                "starting-anchor-element row-content ending-anchor-element" 3.5714em / 40px minmax(
+                "starting-anchor-element row-content ending-anchor-element" 3.5714em / 2.8571em minmax(
                     0,
                     1fr
                 )


### PR DESCRIPTION
before and after, at 12px 14px 16px 20px

| before | after |
| ---  | --- |
| ![Screen Shot 2025-02-11 at 20 47 14](https://github.com/user-attachments/assets/e9a66354-1c33-496a-8615-6bceb48c16f5) | ![Screen Shot 2025-02-11 at 20 45 50](https://github.com/user-attachments/assets/31d16ecd-9fd5-485e-9559-735964cd5a87) |
| ![Screen Shot 2025-02-11 at 20 47 19](https://github.com/user-attachments/assets/d3e80f4e-8879-4087-a9ce-74225289b350) | ![Screen Shot 2025-02-11 at 20 45 43](https://github.com/user-attachments/assets/a47eeca7-6265-483a-a8c4-933cb61d6ca0) |
| ![Screen Shot 2025-02-11 at 20 47 29](https://github.com/user-attachments/assets/591da3a1-4b70-469d-8192-c4d83af07202) | ![Screen Shot 2025-02-11 at 20 45 37](https://github.com/user-attachments/assets/2ffecb82-9628-4931-9d01-3662d68327c9) |
| ![Screen Shot 2025-02-11 at 20 47 36](https://github.com/user-attachments/assets/f299a1c9-4b53-4af8-a112-89c5759540c5) | ![Screen Shot 2025-02-11 at 20 45 20](https://github.com/user-attachments/assets/fa6fec9e-1cc7-46e1-a738-25e5e43a0102) |
