### PR TITLE
right_sidebar: Use em for triple dot menu size.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -80,7 +80,8 @@
         border-radius: 3px;
 
         & i {
-            font-size: 17px;
+            /* 17px at 16px em */
+            font-size: 1.0625em;
             /* Ensure the icon takes the same baseline
                as the rest of the row, for perfect
                vertical alignment with the username and


### PR DESCRIPTION
before and after at 12px, 14px, 16px, 20px

| before | after |
| -- | -- |
| <img width="263" alt="image" src="https://github.com/user-attachments/assets/f17bc5e3-75d9-4c7a-9981-c22bf9279b60" /> | <img width="264" alt="image" src="https://github.com/user-attachments/assets/79e040e6-a3d3-4cd4-8e60-1ebffc63316c" /> |
| <img width="253" alt="image" src="https://github.com/user-attachments/assets/bf8bfd07-c049-481e-ae93-87d221dbaf31" /> | <img width="264" alt="image" src="https://github.com/user-attachments/assets/f78d001b-7943-4cf5-b61c-a2ed7d2689bd" /> |
| <img width="253" alt="image" src="https://github.com/user-attachments/assets/d9d6e445-5b97-4be0-9c89-71c797dfde01" /> | <img width="253" alt="image" src="https://github.com/user-attachments/assets/2f929666-8d88-45ec-8f71-3d1e6ee55693" /> |
| <img width="253" alt="image" src="https://github.com/user-attachments/assets/d62f0386-7111-43e4-a66a-d84d26c9dff9" /> | <img width="255" alt="image" src="https://github.com/user-attachments/assets/ad2765b5-8b8c-4136-a86a-d69378cb32f3" /> |
