### PR TITLE
inbox: Use em for more spacing measurements.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -142,7 +142,7 @@
 
             .inbox-focus-border {
                 display: flex;
-                min-height: 30px;
+                min-height: 1.875em; /* 30px at 16px em */
                 border: 2px solid transparent;
                 border-radius: 3px;
                 box-sizing: border-box;
@@ -152,10 +152,10 @@
             .inbox-header {
                 user-select: none;
                 display: block;
-                height: 30px;
+                height: 1.875em; /* 30px at 16px em */
 
                 .inbox-focus-border {
-                    height: 30px;
+                    height: 1.875em; /* 30px at 16px em */
                 }
 
                 .inbox-left-part {
@@ -212,7 +212,6 @@
 
             .zulip-icon-user,
             .stream-privacy.filter-icon {
-                font-size: 16px;
                 margin: 0;
                 margin-right: 1px;
             }
@@ -229,9 +228,8 @@
                 }
 
                 .zulip-icon-arrow-down {
-                    font-size: 16px;
-                    padding: 5px 4px;
-                    margin-right: 9px;
+                    padding: 0.3125em 0.25em; /* 5px 4px at 16px em */
+                    margin-right: 0.5625em; /* 9px at 16px em */
                     opacity: 0.5;
                 }
 
@@ -350,10 +348,9 @@
                 margin-left: 17px;
 
                 .zulip-icon {
-                    line-height: 14px;
-                    font-size: 16px;
-                    height: 16px;
-                    width: 16px;
+                    line-height: 0.875em; /* 14px at 16px em */
+                    height: 1em;
+                    width: 1em;
                 }
             }
 
@@ -385,8 +382,8 @@
 
             #inbox-direct-messages-container .inbox-left-part,
             .inbox-topic-container .inbox-left-part {
-                /* 50px - space occupied by user circle icon */
-                padding-left: 37px;
+                /* 37px (50px - space occupied by user circle icon) at 16px */
+                padding-left: 2.3125em;
             }
 
             .inbox-left-part {
@@ -468,8 +465,7 @@
             }
 
             & i {
-                padding: 5px;
-                font-size: 16px;
+                padding: 0.3125em; /* 5px at 16px em */
                 opacity: 0.3;
                 color: var(--color-vdots-hover);
 


### PR DESCRIPTION
I tried to keep 16px as the default proportions, since it seemed like Inbox View was built with 16px default (it at least looked better to me) -- let me know if I should change to 14px default.

I also wasn't sure how to align the icon and text in the headers. They ended up moving a bit left. I can put in more effort to have it not change at all at 16px but didn't end up getting to that tonight, so let me know if that's preferred or if I should aim for something different.

---

before and 12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-11 at 22 39 41](https://github.com/user-attachments/assets/5a150eb1-7737-4e1e-bbdc-420ff8a10c8f) | ![Screen Shot 2025-02-13 at 00 06 09](https://github.com/user-attachments/assets/eba1f705-1cd1-4ab9-a708-0d09fa665587) |
| ![Screen Shot 2025-02-11 at 22 39 27](https://github.com/user-attachments/assets/ba9b58a6-4d78-4a2f-9ea9-54bfddd71696) | ![Screen Shot 2025-02-13 at 00 05 38](https://github.com/user-attachments/assets/76043c93-6117-47cd-9fb0-20011ff7ce18) |
| ![Screen Shot 2025-02-11 at 22 39 06](https://github.com/user-attachments/assets/71a91f66-40de-4674-b123-c87596112e93) | ![Screen Shot 2025-02-13 at 00 04 55](https://github.com/user-attachments/assets/683c6b00-aa7f-4e69-9b7c-1ab1eab6eb54) |
| ![Screen Shot 2025-02-11 at 22 38 53](https://github.com/user-attachments/assets/cc32cbeb-b167-4abc-95ec-ca93e927fcdb) | ![Screen Shot 2025-02-13 at 00 06 35](https://github.com/user-attachments/assets/941849a2-f416-4055-8859-0bd28d0668c5) |
