### PR TITLE
api_docs: Improve docs related to mandatory topics.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6366,7 +6366,7 @@ paths:
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
-                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+                    be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
                     **Changes**: Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
@@ -6540,7 +6540,7 @@ paths:
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
-                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+                    be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
                     **Changes**: Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
@@ -7228,7 +7228,7 @@ paths:
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
-                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+                    be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
                     **Changes**: Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
@@ -8572,7 +8572,7 @@ paths:
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
-                    be `"(no topic)"`, an empty string, or `realm_empty_topic_display_name`.
+                    be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
                     You can [resolve topics](/help/resolve-a-topic) by editing the topic to
                     `✔ {original_topic}` with the `propagate_mode` parameter set to


### PR DESCRIPTION
[CZO suggestion by Greg:](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/.28realm_.29mandatory_topics.20behavior/near/2079225)

> I'd say "the value of realm_empty_topic_display_name" (like in the paragraph above it) — otherwise it's a bit ambiguous whether the forbidden value is the string "realm_empty_topic_display_name" itself.

Ideally, we should have made this change in #33355 itself, but it was merged overnight :)

---

<img width="403" alt="Screenshot 2025-02-12 at 2 56 16 PM" src="https://github.com/user-attachments/assets/10ce1e3d-255c-407b-b604-bbb6f696aa30" />

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
