### PR TITLE
zulip_updates: Handle race in `send_zulip_update_announcements_to_realm`.

### DIFF
--- a/zerver/lib/zulip_update_announcements.py
+++ b/zerver/lib/zulip_update_announcements.py
@@ -425,10 +425,15 @@ def send_zulip_update_announcements_to_realm(
     # ourself.
     realm.refresh_from_db()
     realm_zulip_update_announcements_level = realm.zulip_update_announcements_level
-    assert (
-        realm_zulip_update_announcements_level is None
-        or realm_zulip_update_announcements_level < latest_zulip_update_announcements_level
-    )
+    if (
+        realm_zulip_update_announcements_level is not None
+        and realm_zulip_update_announcements_level == latest_zulip_update_announcements_level
+    ):
+        # This is possible due to a race of some form.
+        logging.warning(  # nocoverage
+            "Skipping realm {realm}: already at level {latest_zulip_update_announcements_level}."
+        )
+        return  # nocoverage
 
     sender = get_system_bot(settings.NOTIFICATION_BOT, realm.id)
 


### PR DESCRIPTION
Earlier, in `send_zulip_update_announcements_to_realm` we had an assert statement:
```py
assert (
    realm_zulip_update_announcements_level is None
    or realm_zulip_update_announcements_level < latest_zulip_update_announcements_level
)
```

This led to an assertion error due to a race of some form.

This commit replaces the assert with a return statement to gracefully abort in such a case.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
