### PR TITLE
rendered_markdown: Improve presentation of ordered-list counters.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -92,6 +92,18 @@ export function postprocess_content(html: string): string {
         }
     }
 
+    for (const ol of template.content.querySelectorAll("ol")) {
+        const list_start = Number(ol.getAttribute("start") ?? 1);
+        // We don't count the first item in the list, as it
+        // will be identical to the start value
+        const list_length = ol.children.length - 1;
+        const max_list_counter = list_start + list_length;
+        // We count the characters in the longest list counter,
+        // and use that to offset the list accordingly in CSS
+        const max_list_counter_string_length = max_list_counter.toString().length;
+        ol.classList.add(`counter-length-${max_list_counter_string_length}`);
+    }
+
     for (const inline_img of template.content.querySelectorAll<HTMLImageElement>(
         "div.message_inline_image > a > img",
     )) {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -20,6 +20,31 @@
         margin-inline-start: 3ch;
     }
 
+    /* We set margin according to the length of the longest list counter. */
+    .counter-length-1 {
+        margin-inline-start: 2ch;
+    }
+
+    .counter-length-2 {
+        margin-inline-start: 3ch;
+    }
+
+    .counter-length-3 {
+        margin-inline-start: 4ch;
+    }
+
+    .counter-length-4 {
+        margin-inline-start: 5ch;
+    }
+
+    .counter-length-5 {
+        margin-inline-start: 6ch;
+    }
+
+    .counter-length-6 {
+        margin-inline-start: 7ch;
+    }
+
     & hr {
         border-bottom: 1px solid hsl(0deg 0% 87%);
         border-top: 1px solid hsl(0deg 0% 87%);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -11,24 +11,13 @@
     }
 
     & ul {
-        margin: 0 0 var(--markdown-interelement-space-px) 20px;
-    }
-
-    /* Swap the left and right margins of bullets for Right-To-Left languages */
-    &.rtl ul {
-        margin-right: 20px;
-        margin-left: 0;
+        margin: 0 0 var(--markdown-interelement-space-px) 0;
+        margin-inline-start: 3ch;
     }
 
     & ol {
-        /* 20px at 14px em */
-        margin: 0 0 var(--markdown-interelement-space-px) 1.4285em;
-    }
-
-    /* Swap the left and right margins of ordered list for Right-To-Left languages */
-    &.rtl ol {
-        margin-right: 8px;
-        margin-left: 0;
+        margin: 0 0 var(--markdown-interelement-space-px) 0;
+        margin-inline-start: 3ch;
     }
 
     & hr {

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -38,6 +38,13 @@ run_test("postprocess_content", () => {
     );
 });
 
+run_test("ordered_lists", () => {
+    assert.equal(
+        postprocess_content('<ol start="9"><li>Nine</li><li>Ten</li></ol>'),
+        '<ol start="9" class="counter-length-2"><li>Nine</li><li>Ten</li></ol>',
+    );
+});
+
 run_test("message_inline_animated_image_still", ({override}) => {
     const thumbnail_formats = [
         {


### PR DESCRIPTION
This PR uses some knuckle-draggy JavaScript to calculate the length of the largest counter in a list, and uses `ch`-based offsets to ensure the characters are visible.

This should handle counters up to `999999.`. If we wanted to get fancier, we could use a `.counter-length-max` class and set `list-style-position` to `inside` for counters of `1000000`+, but that seems like a highlighly improbably edge case.

Additionally, [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) is used to replace some previous class-based logic for handling i18n.

[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/large.20numbered.20lists/near/2086330)

Fixes: #33424 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![lists-and-counters-before](https://github.com/user-attachments/assets/63f7182c-2ba3-4937-809a-cfd90605f723) | ![lists-and-counters-after](https://github.com/user-attachments/assets/0bc805f5-0809-45db-8bc8-7778b1b91154) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>