### PR TITLE
message_row: Refine grid for better-fitting action icons.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -104,9 +104,7 @@
         in the column. */
     grid-template:
         var(--message-box-sender-line-height) repeat(3, auto) /
-        var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
-            3 * var(--message-box-icon-width)
-        )
+        var(--message-box-avatar-column-width) minmax(0, 1fr) max-content
         8px minmax(var(--message-box-timestamp-column-width), max-content);
     /* Named grid areas provide flexibility for positioning grid items
        reliably, even if the row or column definitions of the grid change. */
@@ -126,14 +124,6 @@
                 var(--message-box-timestamp-column-width),
                 max-content
             );
-    }
-
-    @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
-        grid-template-columns:
-            var(--message-box-avatar-column-width) minmax(0, 1fr) calc(
-                2 * var(--message-box-icon-width)
-            )
-            8px minmax(var(--message-box-timestamp-column-width), max-content);
     }
 
     .message_edit_notice {
@@ -542,10 +532,10 @@
 
     .edit_content {
         /* Icons for editing content are determined on message hover;
-           we set an empty `.edit_content` to have 0 height in order to
-           preserve the layout of the other icons prior to any hovering. */
+           we set an empty `.edit_content` to take the eventual width
+           of whatever icon is displayed, so as to avoid a grid shift. */
         &:empty {
-            height: 0;
+            width: var(--message-box-icon-width);
         }
 
         &:hover {


### PR DESCRIPTION
This creates a more flexible action-button area in the message grid, and reduces some unnecessary complexity that was introduced previously by the fact that the edit icon, when present, isn't known until hover. That has been fixed here by just reserving the em-based equivalent width for the button, allowing other instances of the action button grid (especially in archived channels and narrow viewports) to not need a special grid definition.

(The previous CSS comment about height and the height property have not mattered since the gridded rewrite of the message box, but the selector came in handy here.)

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/spacing.20around.20message.20action.20buttons.20in.20archived.20channels/near/2068327)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Archived, before | Archived, After |
| --- | --- |
| ![archived-before](https://github.com/user-attachments/assets/91668767-6621-4fc6-93df-13919cd46a6a) | ![archived-after](https://github.com/user-attachments/assets/6f7dc579-d357-4e09-a53d-717fd0dfdbf1) |

| Can edit, before | Can edit, after (no change) |
| --- | --- |
| ![can-edit-before](https://github.com/user-attachments/assets/3d127b09-74e9-47df-b434-c212f13b2e1d) | ![can-edit-after](https://github.com/user-attachments/assets/8895e83e-33fa-4891-a09a-ab1b4d63708a) |

| Narrow viewport, before | Narrow viewport, after (no change) |
| --- | --- |
| ![very-narrow-before](https://github.com/user-attachments/assets/15e07bcb-bfd6-427f-9107-5af212b4f38f) | ![very-narrow-after](https://github.com/user-attachments/assets/e6512b55-42c2-4741-91e7-6317769b2d46) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
