### PR TITLE
fixed the negative count displayed issue

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -79,6 +79,7 @@ type BuddyListRenderData = {
     other_users_count: number;
     hide_headers: boolean;
     get_all_participant_ids: () => Set<number>;
+    unsubscribed_posters_count: number;
 };
 
 function get_render_data(): BuddyListRenderData {
@@ -90,6 +91,16 @@ function get_render_data(): BuddyListRenderData {
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
     const get_all_participant_ids = buddy_data.get_conversation_participants_callback();
 
+    let unsubscribed_posters_count = 0;
+    if (current_sub) {
+        const all_participant_ids = get_all_participant_ids();
+        all_participant_ids.forEach((user_id) => {
+            if (!stream_data.is_user_subscribed(current_sub.stream_id, user_id)) {
+                unsubscribed_posters_count++;
+            }
+        });
+    }
+
     return {
         current_sub,
         pm_ids_set,
@@ -97,6 +108,7 @@ function get_render_data(): BuddyListRenderData {
         other_users_count,
         hide_headers,
         get_all_participant_ids,
+        unsubscribed_posters_count,
     };
 }
 
@@ -208,6 +220,15 @@ export class BuddyList extends BuddyListConf {
                             $("#buddy-list-participants-section-heading").attr("data-user-count")!,
                             10,
                         );
+                        const all_participant_ids = buddy_data.get_conversation_participants_callback()();
+                        let unsubscribed_posters_count = 0;
+                        if (current_sub) {
+                            all_participant_ids.forEach((user_id) => {
+                                if (!stream_data.is_user_subscribed(current_sub.stream_id, user_id)) {
+                                    unsubscribed_posters_count++;
+                                }
+                            });
+                        }
                         const elem_id = $elem.attr("id");
                         if (elem_id === "buddy-list-participants-section-heading") {
                             tooltip_text = $t(
@@ -224,7 +245,7 @@ export class BuddyList extends BuddyListConf {
                                         defaultMessage:
                                             "{N, plural, one {# other subscriber} other {# other subscribers}}",
                                     },
-                                    {N: total_human_subscribers_count - participant_count},
+                                    {N: total_human_subscribers_count - participant_count + unsubscribed_posters_count},
                                 );
                             } else if (current_sub) {
                                 tooltip_text = $t(
@@ -395,8 +416,14 @@ export class BuddyList extends BuddyListConf {
     update_section_header_counts(): void {
         const {total_human_subscribers_count, other_users_count} = this.render_data;
         const all_participant_ids = this.render_data.get_all_participant_ids();
+        let unsubscribed_posters_count = 0;
+        all_participant_ids.forEach((user_id) => {
+            if (this.render_data.current_sub && !stream_data.is_user_subscribed(this.render_data.current_sub.stream_id, user_id)) {
+                unsubscribed_posters_count++;
+            }
+        });
         const subscriber_section_user_count =
-            total_human_subscribers_count - all_participant_ids.size;
+            total_human_subscribers_count - all_participant_ids.size + unsubscribed_posters_count
 
         const formatted_participants_count = get_formatted_sub_count(all_participant_ids.size);
         const formatted_sub_users_count = get_formatted_sub_count(subscriber_section_user_count);
@@ -439,7 +466,7 @@ export class BuddyList extends BuddyListConf {
         }
         this.current_filter = narrow_state.filter();
 
-        const {current_sub, total_human_subscribers_count, other_users_count} = this.render_data;
+        const {current_sub, total_human_subscribers_count, other_users_count, unsubscribed_posters_count} = this.render_data;
         $(".buddy-list-subsection-header").empty();
         $(".buddy-list-subsection-header").toggleClass("no-display", hide_headers);
         if (hide_headers) {
@@ -465,7 +492,7 @@ export class BuddyList extends BuddyListConf {
                         ? $t({defaultMessage: "THIS CHANNEL"})
                         : $t({defaultMessage: "THIS CONVERSATION"}),
                     user_count: get_formatted_sub_count(
-                        total_human_subscribers_count - all_participant_ids.size,
+                        total_human_subscribers_count - all_participant_ids.size + unsubscribed_posters_count,
                     ),
                     is_collapsed: this.users_matching_view_is_collapsed,
                 }),

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -90,15 +90,13 @@ function get_render_data(): BuddyListRenderData {
     const other_users_count = people.get_active_human_count() - total_human_subscribers_count;
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
     const get_all_participant_ids = buddy_data.get_conversation_participants_callback();
-
     let unsubscribed_posters_count = 0;
     if (current_sub) {
-        const all_participant_ids = get_all_participant_ids();
-        all_participant_ids.forEach((user_id) => {
+        for (const user_id of get_all_participant_ids()) {
             if (!stream_data.is_user_subscribed(current_sub.stream_id, user_id)) {
-                unsubscribed_posters_count++;
+                unsubscribed_posters_count += 1;
             }
-        });
+        }
     }
 
     return {
@@ -223,11 +221,11 @@ export class BuddyList extends BuddyListConf {
                         const all_participant_ids = buddy_data.get_conversation_participants_callback()();
                         let unsubscribed_posters_count = 0;
                         if (current_sub) {
-                            all_participant_ids.forEach((user_id) => {
+                            for (const user_id of all_participant_ids) {
                                 if (!stream_data.is_user_subscribed(current_sub.stream_id, user_id)) {
-                                    unsubscribed_posters_count++;
+                                    unsubscribed_posters_count += 1;
                                 }
-                            });
+                            }
                         }
                         const elem_id = $elem.attr("id");
                         if (elem_id === "buddy-list-participants-section-heading") {
@@ -417,11 +415,11 @@ export class BuddyList extends BuddyListConf {
         const {total_human_subscribers_count, other_users_count} = this.render_data;
         const all_participant_ids = this.render_data.get_all_participant_ids();
         let unsubscribed_posters_count = 0;
-        all_participant_ids.forEach((user_id) => {
+        for (const user_id of all_participant_ids) {
             if (this.render_data.current_sub && !stream_data.is_user_subscribed(this.render_data.current_sub.stream_id, user_id)) {
-                unsubscribed_posters_count++;
+                unsubscribed_posters_count += 1;
             }
-        });
+        }
         const subscriber_section_user_count =
             total_human_subscribers_count - all_participant_ids.size + unsubscribed_posters_count
 


### PR DESCRIPTION
Fixes: #33452 
### Description
This pull request fixes an issue where the buddy list was displaying a negative count for unsubscribed posters. The problem occurred because the count of unsubscribed posters was not being correctly factored into the total subscribers count. The change introduces a new variable, unsubscribed_posters_count, that is calculated by iterating over all conversation participant IDs and incrementing whenever a user is not subscribed to the current stream. This count is then added to the overall subscriber count, ensuring that the displayed value is accurate and never negative.

### Changes Made
1. Added unsubscribed_posters_count in the render data generation function (get_render_data).
2. Updated the logic in the update_section_header_counts function to include unsubscribed_posters_count in the tooltip display and subscriber count calculations.
3. Adjusted the tooltip text to accurately reflect the total subscriber count, including the unsubscribed posters.


### Screenshots
### Before 
<img width="601" alt="Screenshot 2025-02-12 at 20 00 54" src="https://github.com/user-attachments/assets/81d524c3-1811-4e8e-9167-fd3bb4afac43" />


### After
<img width="539" alt="Screenshot 2025-02-12 at 19 57 30" src="https://github.com/user-attachments/assets/923ebd36-eccc-4969-8d11-387c3e4a2c0d" />



### Self-Review Checklist
I have self-reviewed the changes for clarity and maintainability.
I have explained the differences from previous implementations and highlighted technical choices.
I have completed manual testing for visual appearance, responsiveness, and end-to-end functionality.