### PR TITLE
compose_reply: Fix the logic to quote a message in an archived stream.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1350,7 +1350,9 @@ def check_update_message(
     and raises a JsonableError if otherwise.
     It returns the number changed.
     """
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(
+        user_profile, message_id, lock_message=True, allow_archived_channel=False
+    )
 
     # If there is a change to the content, check that it hasn't been too long
     # Allow an extra 20 seconds since we potentially allow editing 15 seconds

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -106,7 +106,7 @@ def check_add_reaction(
     reaction_type: str | None,
 ) -> None:
     message, user_message = access_message_and_usermessage(
-        user_profile, message_id, lock_message=True
+        user_profile, message_id, lock_message=True, allow_archived_channel=False
     )
 
     if emoji_code is None or reaction_type is None:

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -965,7 +965,7 @@ def update_narrow_terms_containing_with_operator(
 
     if maybe_user_profile.is_authenticated:
         try:
-            message = access_message(maybe_user_profile, message_id)
+            message = access_message(maybe_user_profile, message_id, allow_archived_channel=False)
         except JsonableError:
             can_user_access_target_message = False
     else:

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1300,7 +1300,7 @@ def handle_push_notification(user_profile_id: int, missed_message: dict[str, Any
     with transaction.atomic(savepoint=False):
         try:
             (message, user_message) = access_message_and_usermessage(
-                user_profile, missed_message["message_id"], lock_message=True
+                user_profile, missed_message["message_id"], lock_message=True, allow_archived_channel=False
             )
         except JsonableError:
             if ArchivedMessage.objects.filter(id=missed_message["message_id"]).exists():

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1208,7 +1208,7 @@ class MessageMoveStreamTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test"
         )
 
-        with self.assert_database_query_count(59), self.assert_memcached_count(14):
+        with self.assert_database_query_count(60), self.assert_memcached_count(14):
             result = self.client_patch(
                 f"/json/messages/{msg_id}",
                 {

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -334,7 +334,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         # state + 1/user with a UserTopic row for the events data)
         # beyond what is typical were there not UserTopic records to
         # update. Ideally, we'd eliminate the per-user component.
-        with self.assert_database_query_count(27):
+        with self.assert_database_query_count(28):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,
@@ -431,7 +431,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(29):
+        with self.assert_database_query_count(30):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -461,7 +461,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         ]
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
-        with self.assert_database_query_count(34):
+        with self.assert_database_query_count(35):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -494,7 +494,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(31):
+        with self.assert_database_query_count(32):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -517,7 +517,7 @@ class MessageMoveTopicTest(ZulipTestCase):
         second_message_id = self.send_stream_message(
             hamlet, stream_name, topic_name="changed topic name", content="Second message"
         )
-        with self.assert_database_query_count(24):
+        with self.assert_database_query_count(25):
             check_update_message(
                 user_profile=desdemona,
                 message_id=second_message_id,
@@ -596,7 +596,7 @@ class MessageMoveTopicTest(ZulipTestCase):
             users_to_be_notified_via_muted_topics_event.append(user_topic.user_profile_id)
 
         change_all_topic_name = "Topic 1 edited"
-        with self.assert_database_query_count(32):
+        with self.assert_database_query_count(33):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -529,7 +529,7 @@ class TypingHappyPathTestStreams(ZulipTestCase):
 
         with self.settings(MAX_STREAM_SIZE_FOR_TYPING_NOTIFICATIONS=5):
             with (
-                self.assert_database_query_count(5),
+                self.assert_database_query_count(6),
                 self.capture_send_event_calls(expected_num_events=0) as events,
             ):
                 result = self.api_post(sender, "/api/v1/message_edit_typing", params)

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -119,7 +119,7 @@ def get_message_edit_history(
         == MessageEditHistoryVisibilityPolicyEnum.none.value
     ):
         raise JsonableError(_("Message edit history is disabled in this organization"))
-    message = access_message(user_profile, message_id)
+    message = access_message(user_profile, message_id, allow_archived_channel=False)
 
     # Extract the message edit history from the message
     if message.edit_history is not None:
@@ -205,7 +205,9 @@ def delete_message_backend(
     # concurrently are serialized properly with deleting the message; this prevents a deadlock
     # that would otherwise happen because of the other transaction holding a lock on the `Message`
     # row.
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(
+        user_profile, message_id, lock_message=True, allow_archived_channel=False
+    )
     validate_can_delete_message(user_profile, message)
     try:
         do_delete_messages(user_profile.realm, [message], acting_user=user_profile)

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -40,7 +40,9 @@ def remove_reaction(
     emoji_code: str | None = None,
     reaction_type: str = "unicode_emoji",
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(
+        user_profile, message_id, lock_message=True, allow_archived_channel=False
+    )
 
     if emoji_code is None:
         if emoji_name is None:

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -26,7 +26,9 @@ def process_submessage(
     msg_type: str,
     content: str,
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(
+        user_profile, message_id, lock_message=True, allow_archived_channel=False
+    )
 
     verify_submessage_sender(
         message_id=message.id,

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -80,7 +80,7 @@ def send_message_edit_notification_backend(
     operator: Annotated[Literal["start", "stop"], ApiParamConfig("op")],
     message_id: Json[int],
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id)
+    message = access_message(user_profile, message_id, allow_archived_channel=False)
     validate_user_can_edit_message(user_profile, message, edit_limit_buffer=0)
     recipient = message.recipient
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previous to this commit we were unable to do following actions in an archived stream:
- quote a message
- forward a message
- view original message 
- view read receipts 

Before | After |
|-------|------|
![Before](https://github.com/user-attachments/assets/838b06df-4ccb-44fb-b521-db49c6c064ad) | ![After](https://github.com/user-attachments/assets/a1fe3d97-5931-44c0-b8c2-f734121b0940) | 



Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.22quote.20message.22.20not.20working.20in.20archived.20channels/near/2088501)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
