### PR TITLE
saved_snippets: Move initialization directly to ui_init.ts

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -24,6 +24,7 @@ import * as people from "./people.ts";
 import * as popovers from "./popovers.ts";
 import * as reload_state from "./reload_state.ts";
 import * as resize from "./resize.ts";
+import * as saved_snippets_ui from "./saved_snippets_ui.ts";
 import * as spectators from "./spectators.ts";
 import * as stream_data from "./stream_data.ts";
 
@@ -425,6 +426,8 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
     resize.reset_compose_message_max_height();
 
     complete_starting_tasks(opts);
+
+    saved_snippets_ui.setup_saved_snippets_dropdown_widget_if_needed();
 };
 
 export function rewire_start(value: typeof start): void {

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -51,7 +51,7 @@ export type DropdownWidgetOptions = {
     // It is important to not pass `$("body")` here for widgets that would be `setup()`
     // multiple times, so that we don't have duplicate event handlers.
     $events_container: JQuery;
-    on_show_callback?: (instance: tippy.Instance) => void;
+    on_show_callback?: (instance: tippy.Instance, widget: DropdownWidget) => void;
     on_mount_callback?: (instance: tippy.Instance) => void;
     on_hidden_callback?: (instance: tippy.Instance) => void;
     on_exit_with_escape_callback?: () => void;
@@ -88,7 +88,7 @@ export class DropdownWidget {
         is_sticky_bottom_option_clicked: boolean,
     ) => void;
     focus_target_on_hidden: boolean;
-    on_show_callback: (instance: tippy.Instance) => void;
+    on_show_callback: (instance: tippy.Instance, widget: DropdownWidget) => void;
     on_mount_callback: (instance: tippy.Instance) => void;
     on_hidden_callback: (instance: tippy.Instance) => void;
     on_exit_with_escape_callback: () => void;
@@ -473,7 +473,7 @@ export class DropdownWidget {
                     }
                 }, 0);
 
-                this.on_show_callback(instance);
+                this.on_show_callback(instance, this);
                 this.adjust_dropdown_position_post_list_render(instance);
             },
             onMount: (instance: tippy.Instance) => {

--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -13,10 +13,10 @@ import * as dropdown_widget from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as rows from "./rows.ts";
 import * as saved_snippets from "./saved_snippets.ts";
-import type {StateData} from "./state_data.ts";
 
 let saved_snippets_widget: dropdown_widget.DropdownWidget | undefined;
 let saved_snippets_dropdown: tippy.Instance | undefined;
+let composebox_saved_snippets_dropdown_widget = false;
 
 function submit_create_saved_snippet_form(): void {
     const title = $<HTMLInputElement>("#add-new-saved-snippet-modal .saved-snippet-title")
@@ -149,7 +149,9 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
     }).setup();
 }
 
-export const initialize = (params: StateData["saved_snippets"]): void => {
-    saved_snippets.initialize(params);
-    setup_saved_snippets_dropdown_widget(".saved-snippets-composebox-widget");
-};
+export function setup_saved_snippets_dropdown_widget_if_needed(): void {
+    if (!composebox_saved_snippets_dropdown_widget) {
+        composebox_saved_snippets_dropdown_widget = true;
+        setup_saved_snippets_dropdown_widget(".saved-snippets-composebox-widget");
+    }
+}

--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -15,7 +15,8 @@ import * as rows from "./rows.ts";
 import * as saved_snippets from "./saved_snippets.ts";
 import type {StateData} from "./state_data.ts";
 
-let saved_snippet_dropdown_widget: dropdown_widget.DropdownWidget;
+let saved_snippets_widget: dropdown_widget.DropdownWidget | undefined;
+let saved_snippets_dropdown: tippy.Instance | undefined;
 
 function submit_create_saved_snippet_form(): void {
     const title = $<HTMLInputElement>("#add-new-saved-snippet-modal .saved-snippet-title")
@@ -49,8 +50,11 @@ function saved_snippet_modal_post_render(): void {
 }
 
 export function rerender_dropdown_widget(): void {
-    const options = saved_snippets.get_options_for_dropdown_widget();
-    saved_snippet_dropdown_widget.list_widget?.replace_list_data(options);
+    if (saved_snippets_widget && saved_snippets_dropdown) {
+        const options = saved_snippets.get_options_for_dropdown_widget();
+        saved_snippets_widget.list_widget?.replace_list_data(options);
+        saved_snippets_widget.show_empty_if_no_items($(saved_snippets_dropdown.popper));
+    }
 }
 
 function delete_saved_snippet(saved_snippet_id: string): void {
@@ -120,7 +124,7 @@ function item_click_callback(
 }
 
 export function setup_saved_snippets_dropdown_widget(widget_selector: string): void {
-    saved_snippet_dropdown_widget = new dropdown_widget.DropdownWidget({
+    new dropdown_widget.DropdownWidget({
         widget_name: "saved_snippets",
         widget_selector,
         get_options: saved_snippets.get_options_for_dropdown_widget,
@@ -130,6 +134,10 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
         sticky_bottom_option: $t({
             defaultMessage: "Create a new saved snippet",
         }),
+        on_show_callback(dropdown: tippy.Instance, widget: dropdown_widget.DropdownWidget) {
+            saved_snippets_widget = widget;
+            saved_snippets_dropdown = dropdown;
+        },
         focus_target_on_hidden: false,
         prefer_top_start_placement: true,
         tippy_props: {
@@ -138,8 +146,7 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
             // recipient dropdown widget.
             offset: [-100, 5],
         },
-    });
-    saved_snippet_dropdown_widget.setup();
+    }).setup();
 }
 
 export const initialize = (params: StateData["saved_snippets"]): void => {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -98,7 +98,7 @@ import * as realm_user_settings_defaults from "./realm_user_settings_defaults.ts
 import * as recent_view_ui from "./recent_view_ui.ts";
 import * as reload_setup from "./reload_setup.js";
 import * as resize_handler from "./resize_handler.ts";
-import * as saved_snippets_ui from "./saved_snippets_ui.ts";
+import * as saved_snippets from "./saved_snippets.ts";
 import * as scheduled_messages from "./scheduled_messages.ts";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui.ts";
 import * as scheduled_messages_ui from "./scheduled_messages_ui.ts";
@@ -515,7 +515,7 @@ export function initialize_everything(state_data) {
     });
     inbox_ui.initialize();
     alert_words.initialize(state_data.alert_words);
-    saved_snippets_ui.initialize(state_data.saved_snippets);
+    saved_snippets.initialize(state_data.saved_snippets);
     emojisets.initialize();
     scroll_bar.initialize();
     message_viewport.initialize();

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -79,6 +79,9 @@ mock_esm("../src/resize", {
 mock_esm("../src/popovers", {
     hide_all: noop,
 });
+mock_esm("../src/saved_snippets_ui", {
+    setup_saved_snippets_dropdown_widget_if_needed: noop,
+});
 
 const people = zrequire("people");
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
1. Moves initialization of `saved_snippets.ts` directly to ui_init.ts and defers saved snippets dropdown creation until the compose box is opened for better performance.
2. Fix dropdown state sync across browser tabs.

Fixes: #31831<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
