### PR TITLE
rendered_markdown: Bump margin by half a character on ordered lists.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -12,37 +12,37 @@
 
     & ul {
         margin: 0 0 var(--markdown-interelement-space-px) 0;
-        margin-inline-start: 3ch;
+        margin-inline-start: 3.5ch;
     }
 
     & ol {
         margin: 0 0 var(--markdown-interelement-space-px) 0;
-        margin-inline-start: 3ch;
+        margin-inline-start: 3.5ch;
     }
 
     /* We set margin according to the length of the longest list counter. */
     .counter-length-1 {
-        margin-inline-start: 2ch;
+        margin-inline-start: 2.5ch;
     }
 
     .counter-length-2 {
-        margin-inline-start: 3ch;
+        margin-inline-start: 3.5ch;
     }
 
     .counter-length-3 {
-        margin-inline-start: 4ch;
+        margin-inline-start: 4.5ch;
     }
 
     .counter-length-4 {
-        margin-inline-start: 5ch;
+        margin-inline-start: 5.5ch;
     }
 
     .counter-length-5 {
-        margin-inline-start: 6ch;
+        margin-inline-start: 6.5ch;
     }
 
     .counter-length-6 {
-        margin-inline-start: 7ch;
+        margin-inline-start: 7.5ch;
     }
 
     & hr {


### PR DESCRIPTION
This is a regrettable adjustment, presented as a necessary follow-up to #33438, for how certain browsers (especially Safari on both iOS and macOS) present a larger, non-adjustable gap between the list marker and the list item's text.

Although this solves the immediate, unacceptable problem of counters ending up cut off, I plan to return to this problem after 10.0 to see if a more uniform list presentation is possible (e.g., by setting up a custom counter).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Safari, before | Safari, after |
| --- | --- |
| ![safari-markers-before](https://github.com/user-attachments/assets/50c570f6-aa90-4659-ab4e-db54fd05868c) | ![safari-markers-after](https://github.com/user-attachments/assets/30dbd2a6-0abe-43d7-8362-57a89fa38567) |

| Firefox, before | Firefox, after |
| --- | --- |
| ![firefox-markers-before](https://github.com/user-attachments/assets/24a6bc76-0323-4797-baf9-2fd8cd1adcd8) | ![firefox-markers-after](https://github.com/user-attachments/assets/101597ec-56f8-45d3-8145-8165a7dcf713) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>