### PR TITLE
left_sidebar: Show tooltip only for truncated channel names.

### DIFF
--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -859,14 +859,25 @@ export function initialize_tippy_tooltips(): void {
         target: "#stream_filters li .subscription_block .stream-name",
         delay: LONG_HOVER_DELAY,
         onShow(instance) {
+            // check for "Go to channel feed" tooltip conditions first.
             const stream_id = stream_id_for_elt($(instance.reference).parents("li.narrow-filter"));
             const current_narrow_stream_id = narrow_state.stream_id();
             const current_topic = narrow_state.topic();
-            if (!(current_narrow_stream_id === stream_id && current_topic !== undefined)) {
-                return false;
+            if (current_narrow_stream_id === stream_id && current_topic !== undefined) {
+                instance.setContent(ui_util.parse_html(render_go_to_channel_feed_tooltip()));
+                return undefined;
             }
-            instance.setContent(ui_util.parse_html(render_go_to_channel_feed_tooltip()));
-            return undefined;
+            // Then check for truncation
+            const stream_name_element = instance.reference;
+            assert(stream_name_element instanceof HTMLElement);
+
+            if (stream_name_element.offsetWidth < stream_name_element.scrollWidth) {
+                const stream_name = stream_name_element.textContent ?? "";
+                instance.setContent(stream_name);
+                return undefined;
+            }
+
+            return false;
         },
         appendTo: () => document.body,
     });


### PR DESCRIPTION
This PR show tooltips on channel names in the left sidebar if the channel name is too long.

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/missing.20tooltip.20on.20long.20channel.20names.20in.20left.20sidebar)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After
|-------|---------|
<img width="383" alt="Screenshot 2025-02-13 at 9 14 23 PM" src="https://github.com/user-attachments/assets/25374e53-7fe4-4d61-9d04-a99d9e90750c" /> | <img width="347" alt="Screenshot 2025-02-13 at 10 59 15 PM" src="https://github.com/user-attachments/assets/7cb675aa-5e30-43a2-9dc3-f9140806244e" /> |
 | <img width="363" alt="Screenshot 2025-02-13 at 6 50 02 PM" src="https://github.com/user-attachments/assets/6c17fbd7-ae25-4ea4-a55f-da5efe840d06" /> | <img width="335" alt="Screenshot 2025-02-13 at 9 14 40 PM" src="https://github.com/user-attachments/assets/2100668f-235f-431a-b160-657d4522215f" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
