### PR TITLE
docs: Change /doc-permalinks/ redirects to point to /stable/ RTD.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -758,7 +758,7 @@ else
             # to not allow future bugs to cause ToS acceptance to be skipped.
             SKIP_TOS_AGREEMENT_OPTION=""
         else
-            SKIP_TOS_AGREEMENT_OPTION="--agree_to_terms_of_service"
+            SKIP_TOS_AGREEMENT_OPTION="--agree-to-terms-of-service"
         fi
         set +x
         echo "Services enabled, attempting to register server..."

--- a/zerver/management/commands/register_server.py
+++ b/zerver/management/commands/register_server.py
@@ -30,7 +30,7 @@ class Command(ZulipBaseCommand):
     @override
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
-            "--agree_to_terms_of_service",
+            "--agree-to-terms-of-service",
             action="store_true",
             help="Agree to the Zulipchat Terms of Service: https://zulip.com/policies/terms.",
         )

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -1498,21 +1498,21 @@ class TestDocRedirectView(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(
             result["Location"],
-            "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-usage-statistics",
+            "https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#uploading-usage-statistics",
         )
 
         result = self.client_get("/doc-permalinks/basic-metadata")
         self.assertEqual(result.status_code, 302)
         self.assertEqual(
             result["Location"],
-            "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata",
+            "https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#uploading-basic-metadata",
         )
 
         result = self.client_get("/doc-permalinks/why-service")
         self.assertEqual(result.status_code, 302)
         self.assertEqual(
             result["Location"],
-            "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#why-a-push-notification-service-is-necessary",
+            "https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#why-a-push-notification-service-is-necessary",
         )
 
         result = self.client_get("/doc-permalinks/registration-transfer")

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -270,9 +270,9 @@ def desktop_home(request: HttpRequest) -> HttpResponse:
 
 def doc_permalinks_view(request: HttpRequest, doc_id: str) -> HttpResponse:
     DOC_PERMALINK_MAP: dict[str, str] = {
-        "usage-statistics": "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-usage-statistics",
-        "basic-metadata": "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#uploading-basic-metadata",
-        "why-service": "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#why-a-push-notification-service-is-necessary",
+        "usage-statistics": "https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#uploading-usage-statistics",
+        "basic-metadata": "https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#uploading-basic-metadata",
+        "why-service": "https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html#why-a-push-notification-service-is-necessary",
         "registration-transfer": "https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html#moving-your-registration-to-a-new-server",
     }
 


### PR DESCRIPTION
With the exception of /registration-transfer, the /stable/ docs have the relevant sections - so that's the better choice to link to.
