### PR TITLE
api-docs: Updates documentation for user settings related to time zones.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -301,9 +301,11 @@ deactivated groups.
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),
   [`POST /register`](/api/register-queue), [`PATCH /settings`](/api/update-settings):
-  Added new `web_suggest_update_timezone` option to decide whether the user should be
-  shown an alert offering to update their profile time zone to the time zone of the
-  browser in case they differ.
+  Added new `web_suggest_update_timezone` user setting to indicate whether
+  the user should be shown an alert, offering to update their [profile
+  time zone](/help/change-your-timezone), when the time displayed for the
+  profile time zone differs from the current time displayed by the time
+  zone configured on their device.
 
 **Feature level 328**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -455,7 +455,7 @@ paths:
                                     - type: object
                                       additionalProperties: false
                                       description: |
-                                        When a user changes their time zone setting.
+                                        When a user changes their [profile time zone](/help/change-your-timezone).
                                       properties:
                                         user_id:
                                           type: integer
@@ -472,7 +472,7 @@ paths:
                                         timezone:
                                           type: string
                                           description: |
-                                            The new time zone of the user.
+                                            The IANA identifier of the new profile time zone for the user.
                                     - type: object
                                       additionalProperties: false
                                       description: |
@@ -9657,7 +9657,8 @@ paths:
                       timezone:
                         type: string
                         description: |
-                          The time zone of the requesting user.
+                          The IANA identifier of the requesting user's [profile time zone](/help/change-your-timezone),
+                          which is used primarily to display the user's local time to other users.
 
                           **Changes**: New in Zulip 3.0 (feature level 10).
                         example: ""
@@ -15809,7 +15810,8 @@ paths:
                           timezone:
                             type: string
                             description: |
-                              The IANA identifier of the user's [configured time zone](/help/change-your-timezone).
+                              The IANA identifier of the user's [profile time zone](/help/change-your-timezone),
+                              which is used primarily to display the user's local time to other users.
                           enter_sends:
                             type: boolean
                             description: |
@@ -16721,8 +16723,8 @@ paths:
                           and only for clients that did not include `user_settings_object` in
                           their [`client_capabilities`][capabilities] when registering the event queue.
 
-                          The time zone configured for the user. This is used primarily to display
-                          the user's time zone to other users.
+                          The user's [profile time zone](/help/change-your-timezone), which is
+                          used primarily to display the user's local time to other users.
 
                           See [PATCH /settings](/api/update-settings) for details on
                           the meaning of this setting.
@@ -19721,7 +19723,8 @@ paths:
                     **Changes**: New in Zulip 10.0 (feature level 350).
                 timezone:
                   description: |
-                    The IANA identifier of the user's [configured time zone](/help/change-your-timezone).
+                    The IANA identifier of the user's [profile time zone](/help/change-your-timezone),
+                    which is used primarily to display the user's local time to other users.
 
                     **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
                     the `PATCH /settings/display` endpoint.
@@ -24760,7 +24763,8 @@ components:
         timezone:
           type: string
           description: |
-            The time zone of the user.
+            The IANA identifier of the user's [profile time zone](/help/change-your-timezone),
+            which is used primarily to display the user's local time to other users.
         avatar_url:
           type: string
           nullable: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -12223,8 +12223,10 @@ paths:
                   example: true
                 web_suggest_update_timezone:
                   description: |
-                    Whether the user should be shown an alert offering to update their profile time zone
-                    to the time zone of the browser in case they differ.
+                    Whether the user should be shown an alert, offering to update their
+                    [profile time zone](/help/change-your-timezone), when the time displayed
+                    for the profile time zone differs from the current time displayed by the
+                    time zone configured on their device.
 
                     **Changes**: New in Zulip 10.0 (feature level 329).
                   type: boolean
@@ -15652,8 +15654,10 @@ paths:
                           web_suggest_update_timezone:
                             type: boolean
                             description: |
-                              Whether the user should be shown an alert offering to update their profile time zone
-                              to the time zone of the browser in case they differ.
+                              Whether the user should be shown an alert, offering to update their
+                              [profile time zone](/help/change-your-timezone), when the time displayed
+                              for the profile time zone differs from the current time displayed by the
+                              time zone configured on their device.
 
                               **Changes**: New in Zulip 10.0 (feature level 329).
                           fluid_layout_width:
@@ -16781,13 +16785,6 @@ paths:
 
                           **Changes**: New in Zulip 9.0 (feature level 253). Previously, there were
                           only options to disable sending typing notifications.
-                      web_suggest_update_timezone:
-                        type: boolean
-                        description: |
-                          Whether the user should be shown an alert offering to update their profile time zone
-                          to the time zone of the browser in case they differ.
-
-                          **Changes**: New in Zulip 10.0 (feature level 329).
                       enter_sends:
                         deprecated: true
                         type: boolean
@@ -18318,8 +18315,10 @@ paths:
                           web_suggest_update_timezone:
                             type: boolean
                             description: |
-                              Whether the user should be shown an alert offering to update their profile time zone
-                              to the time zone of the browser in case they differ.
+                              Whether the user should be shown an alert, offering to update their
+                              [profile time zone](/help/change-your-timezone), when the time displayed
+                              for the profile time zone differs from the current time displayed by the
+                              time zone configured on their device.
 
                               **Changes**: New in Zulip 10.0 (feature level 329).
                           fluid_layout_width:
@@ -19487,8 +19486,10 @@ paths:
                 web_suggest_update_timezone:
                   type: boolean
                   description: |
-                    Whether the user should be shown an alert offering to update their profile time zone
-                    to the time zone of the browser in case they differ.
+                    Whether the user should be shown an alert, offering to update their
+                    [profile time zone](/help/change-your-timezone), when the time displayed
+                    for the profile time zone differs from the current time displayed by the
+                    time zone configured on their device.
 
                     **Changes**: New in Zulip 10.0 (feature level 329).
                   example: true


### PR DESCRIPTION
Updates API documentation for changes discussed here on CZO: https://chat.zulip.org/#narrow/channel/378-api-design/topic/Automatically.20detect.20user's.20timezone/near/2054874.

**Notes**:
- Refers to the `timezone` user setting as the "profile time zone" to help clarify that this user setting is used for displaying the user's local time to other users
  - Adds links to the help center article about this user setting: https://zulip.com/help/change-your-timezone.
  - More consistently notes the format of the string that's being returned is an IANA identifer of the time zone.
- For the feature level 329 changes:
  - Clarifies that the alert is shown when the time displayed for the users's "profile time zone" setting differs from the current time displayed by the time zone configured on the user's device.
  - Removes incorrectly having web_suggest_update_timezone as a separate field returned by the POST /register response. It will only be a field in the user_settings and realm_user_settings_defaults objects.


<details>
<summary>API docs diff</summary>

```diff
diff -r -B -u current_api_html/changelog.html new_api_html/changelog.html
--- current_api_html/changelog.html	2025-02-13 20:54:05.729669105 +0100
+++ new_api_html/changelog.html	2025-02-13 20:53:21.072669110 +0100
@@ -619,9 +619,11 @@
 <ul>
 <li><a href="/api/update-realm-user-settings-defaults"><code>PATCH /realm/user_settings_defaults</code></a>,
   <a href="/api/register-queue"><code>POST /register</code></a>, <a href="/api/update-settings"><code>PATCH /settings</code></a>:
-  Added new <code>web_suggest_update_timezone</code> option to decide whether the user should be
-  shown an alert offering to update their profile time zone to the time zone of the
-  browser in case they differ.</li>
+  Added new <code>web_suggest_update_timezone</code> user setting to indicate whether
+  the user should be shown an alert, offering to update their <a href="/help/change-your-timezone">profile
+  time zone</a>, when the time displayed for the
+  profile time zone differs from the current time displayed by the time
+  zone configured on their device.</li>
 </ul>
 <p><strong>Feature level 328</strong></p>
 <ul>
diff -r -B -u current_api_html/get-events.html new_api_html/get-events.html
--- current_api_html/get-events.html	2025-02-13 20:54:24.846669103 +0100
+++ new_api_html/get-events.html	2025-02-13 20:53:41.715669108 +0100
@@ -953,7 +953,7 @@
 </ul>
 </li>
 <li>
-<p>When a user changes their time zone setting.</p>
+<p>When a user changes their <a href="/help/change-your-timezone">profile time zone</a>.</p>
 <ul>
 <li>
 <p><code>user_id</code>: <span class="api-field-type">integer</span></p>
@@ -967,7 +967,7 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The new time zone of the user.</p>
+<p>The IANA identifier of the new profile time zone for the user.</p>
 </li>
 </ul>
 </li>
@@ -2300,7 +2300,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
diff -r -B -u current_api_html/get-own-user.html new_api_html/get-own-user.html
--- current_api_html/get-own-user.html	2025-02-13 20:54:14.715669104 +0100
+++ new_api_html/get-own-user.html	2025-02-13 20:53:30.289669109 +0100
@@ -430,7 +430,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the requesting user.</p>
+<p>The IANA identifier of the requesting user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 <p><strong>Changes</strong>: New in Zulip 3.0 (feature level 10).</p>
 </li>
 <li>
diff -r -B -u current_api_html/get-user-by-email.html new_api_html/get-user-by-email.html
--- current_api_html/get-user-by-email.html	2025-02-13 20:54:14.551669104 +0100
+++ new_api_html/get-user-by-email.html	2025-02-13 20:53:30.118669109 +0100
@@ -521,7 +521,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
diff -r -B -u current_api_html/get-user.html new_api_html/get-user.html
--- current_api_html/get-user.html	2025-02-13 20:54:14.281669104 +0100
+++ new_api_html/get-user.html	2025-02-13 20:53:29.835669109 +0100
@@ -490,7 +490,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
diff -r -B -u current_api_html/get-users.html new_api_html/get-users.html
--- current_api_html/get-users.html	2025-02-13 20:54:14.954669104 +0100
+++ new_api_html/get-users.html	2025-02-13 20:53:30.490669109 +0100
@@ -503,7 +503,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
diff -r -B -u current_api_html/register-queue.html new_api_html/register-queue.html
--- current_api_html/register-queue.html	2025-02-13 20:54:24.114669103 +0100
+++ new_api_html/register-queue.html	2025-02-13 20:53:40.367669108 +0100
@@ -3479,8 +3479,10 @@
 </li>
 <li>
 <p><code>web_suggest_update_timezone</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the user should be shown an alert offering to update their profile time zone
-to the time zone of the browser in case they differ.</p>
+<p>Whether the user should be shown an alert, offering to update their
+<a href="/help/change-your-timezone">profile time zone</a>, when the time displayed
+for the profile time zone differs from the current time displayed by the
+time zone configured on their device.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 329).</p>
 </li>
 <li>
@@ -3627,7 +3629,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The IANA identifier of the user's <a href="/help/change-your-timezone">configured time zone</a>.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>enter_sends</code>: <span class="api-field-type">boolean</span></p>
@@ -4340,8 +4343,8 @@
 <p>Present if <code>update_display_settings</code> is present in <code>fetch_event_types</code>
 and only for clients that did not include <code>user_settings_object</code> in
 their <a href="/api/register-queue#parameter-client_capabilities"><code>client_capabilities</code></a> when registering the event queue.</p>
-<p>The time zone configured for the user. This is used primarily to display
-the user's time zone to other users.</p>
+<p>The user's <a href="/help/change-your-timezone">profile time zone</a>, which is
+used primarily to display the user's local time to other users.</p>
 <p>See <a href="/api/update-settings">PATCH /settings</a> for details on
 the meaning of this setting.</p>
 <p><strong>Changes</strong>: Deprecated in Zulip 5.0 (feature level 89). Clients
@@ -4383,12 +4386,6 @@
 only options to disable sending typing notifications.</p>
 </li>
 <li>
-<p><code>web_suggest_update_timezone</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the user should be shown an alert offering to update their profile time zone
-to the time zone of the browser in case they differ.</p>
-<p><strong>Changes</strong>: New in Zulip 10.0 (feature level 329).</p>
-</li>
-<li>
 <p><code>enter_sends</code>: <span class="api-field-type">boolean</span></p>
 <p>Present if <code>update_display_settings</code> is present in <code>fetch_event_types</code>
 and only for clients that did not include <code>user_settings_object</code> in
@@ -6062,8 +6059,10 @@
 </li>
 <li>
 <p><code>web_suggest_update_timezone</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the user should be shown an alert offering to update their profile time zone
-to the time zone of the browser in case they differ.</p>
+<p>Whether the user should be shown an alert, offering to update their
+<a href="/help/change-your-timezone">profile time zone</a>, when the time displayed
+for the profile time zone differs from the current time displayed by the
+time zone configured on their device.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 329).</p>
 </li>
 <li>
@@ -6566,7 +6565,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
@@ -6721,7 +6721,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
@@ -6999,7 +7000,8 @@
 </li>
 <li>
 <p><code>timezone</code>: <span class="api-field-type">string</span></p>
-<p>The time zone of the user.</p>
+<p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 </li>
 <li>
 <p><code>avatar_url</code>: <span class="api-field-type">string | null</span></p>
diff -r -B -u current_api_html/update-realm-user-settings-defaults.html new_api_html/update-realm-user-settings-defaults.html
--- current_api_html/update-realm-user-settings-defaults.html	2025-02-13 20:54:22.815669103 +0100
+++ new_api_html/update-realm-user-settings-defaults.html	2025-02-13 20:53:38.902669108 +0100
@@ -381,8 +381,10 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Whether the user should be shown an alert offering to update their profile time zone
-to the time zone of the browser in case they differ.</p>
+    <div class="api-description"><p>Whether the user should be shown an alert, offering to update their
+<a href="/help/change-your-timezone">profile time zone</a>, when the time displayed
+for the profile time zone differs from the current time displayed by the
+time zone configured on their device.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 329).</p></div>
     <hr>
 </div>
diff -r -B -u current_api_html/update-settings.html new_api_html/update-settings.html
--- current_api_html/update-settings.html	2025-02-13 20:54:17.421669104 +0100
+++ new_api_html/update-settings.html	2025-02-13 20:53:33.265669109 +0100
@@ -493,8 +493,10 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Whether the user should be shown an alert offering to update their profile time zone
-to the time zone of the browser in case they differ.</p>
+    <div class="api-description"><p>Whether the user should be shown an alert, offering to update their
+<a href="/help/change-your-timezone">profile time zone</a>, when the time displayed
+for the profile time zone differs from the current time displayed by the
+time zone configured on their device.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 329).</p></div>
     <hr>
 </div>
@@ -751,7 +753,8 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>&quot;Asia/Kolkata&quot;</code>
     </div>
-    <div class="api-description"><p>The IANA identifier of the user's <a href="/help/change-your-timezone">configured time zone</a>.</p>
+    <div class="api-description"><p>The IANA identifier of the user's <a href="/help/change-your-timezone">profile time zone</a>,
+which is used primarily to display the user's local time to other users.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/display</code> endpoint.</p>
 <p>Unnecessary JSON-encoding of this parameter was removed in Zulip 4.0 (feature level 64).</p></div>
```

</details>

---

**Screenshots and screen captures:**

*The post register response shows the updated test for a User object that's returned by various other endpoints, see API docs diff above>*

| Doc | Screenshot |
| --- | --- |
| API changelog entry, https://zulip.com/api/changelog | ![Screenshot from 2025-02-13 21-03-12](https://github.com/user-attachments/assets/f2c3fa68-1ac3-4746-ae54-e20acf64cce9) |
| Get events, https://zulip.com/api/get-events | ![Screenshot from 2025-02-13 21-06-48](https://github.com/user-attachments/assets/19097d93-8a9f-4f11-bcd9-6ca280dae74a) ![Screenshot from 2025-02-13 21-06-20](https://github.com/user-attachments/assets/eb8eabf2-159f-4245-9088-31f8332de955) ![Screenshot from 2025-02-13 21-06-04](https://github.com/user-attachments/assets/c342bc7e-8ab8-4b90-84ee-6522c44d5ee8) ![Screenshot from 2025-02-13 21-05-50](https://github.com/user-attachments/assets/ce07cbc4-2987-49a3-af11-c88889dec77b) |
| Post register, https://zulip.com/api/register-queue | ![Screenshot from 2025-02-13 21-08-31](https://github.com/user-attachments/assets/38787e53-c037-419c-9e9e-8ef4d6d26ca3) ![Screenshot from 2025-02-13 21-08-15](https://github.com/user-attachments/assets/0c0ccf65-32eb-472f-a56d-46893332de03) ![Screenshot from 2025-02-13 21-08-00](https://github.com/user-attachments/assets/43dccbbc-4954-4610-9882-da46bb9a30b6) |
| Update new user defaults, https://zulip.com/api/update-realm-user-settings-defaults#parameter-web_suggest_update_timezone | ![Screenshot from 2025-02-13 21-10-43](https://github.com/user-attachments/assets/44d1d1be-3732-4bf5-a816-af81d4f7a921) |
| Update user settings "timezone", https://zulip.com/api/update-settings#parameter-timezone | ![Screenshot from 2025-02-13 21-12-17](https://github.com/user-attachments/assets/29ad791d-29d7-46b5-8e76-37c6b3d057bc) |
| Update user settings "web_suggest...", https://zulip.com/api/update-settings#parameter-web_suggest_update_timezone | ![Screenshot from 2025-02-13 21-13-26](https://github.com/user-attachments/assets/aa4ff1ff-f92c-4053-b15d-564ee4a2c954) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
