### PR TITLE
composebox_typeahead: Update order of user typeahead elements.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -197,4 +197,8 @@
     i.zulip-icon-bot {
         align-self: center;
     }
+
+    .status-emoji {
+        margin-left: 0;
+    }
 }

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -41,14 +41,14 @@
     {{~#if is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
     {{/if}}
-    {{~#if has_pronouns}}
-        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
-    {{~/if}}
     {{~#if should_add_guest_user_indicator}}
         <i>({{t 'guest'}})</i>
     {{~/if}}
     {{~#if has_status}}
     {{> status_emoji status_emoji_info}}
+    {{~/if}}
+    {{~#if has_pronouns}}
+        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
     {{~/if}}
     {{~#if has_secondary_html}}
     <span class="autocomplete_secondary rendered_markdown single-line-rendered-markdown">{{rendered_markdown secondary_html}}</span>


### PR DESCRIPTION
Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20extraneous.20comma.20after.20pronouns/with/2088251.

| Before | After |
|--------|-------|
|       ![image](https://github.com/user-attachments/assets/470b8487-02e7-4ff3-b8b1-1e426373b2a9)          |  ![image](https://github.com/user-attachments/assets/a08e27a7-a881-4125-aa3a-a5c23a924a1b)|


| Before | After |
|--------|-------|
 | ![image](https://github.com/user-attachments/assets/6341b084-dff4-4704-bfed-6d11445ed4e4) |![image](https://github.com/user-attachments/assets/86d21715-a360-430b-8c93-4c87cdb79041)
 (stays the same, as expected)

 
 | case1 | case2 | case3 |
|--------|-------|-------|
|![image](https://github.com/user-attachments/assets/d688e55d-cacb-471a-8cc9-5e4bf820c177) | ![image](https://github.com/user-attachments/assets/05d919ba-effb-45d8-bc51-d7cdc0711b31)|![image](https://github.com/user-attachments/assets/05777618-5d6d-442f-8231-04ade39f0c51)





