### PR TITLE
polls: Increase height of modal to work at 12px font size.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -468,8 +468,9 @@
 
 #add-poll-modal {
     /* this height allows 3-4 option rows
-    to fit in without need for scrolling */
-    height: 32.1428em; /* 450px / 14px em */
+    to fit in without need for scrolling
+    and works at 12px - 20px font sizes */
+    height: 36em;
     overflow: hidden;
 
     .modal__content {


### PR DESCRIPTION
It was getting cut off at 12px, so I increased the height until the scrollbar disappeared at 12px.

---


at 12px, 14px, 16px, 20px:

| before | after |
| ---  | --- |
| ![Screen Shot 2025-02-13 at 22 54 25](https://github.com/user-attachments/assets/dbc2956d-6c78-4527-95d1-67fb5331915f) | ![Screen Shot 2025-02-13 at 22 49 14](https://github.com/user-attachments/assets/8315bfdf-838d-40aa-b0f7-5baffe6ae95c) |
| ![Screen Shot 2025-02-13 at 22 55 44](https://github.com/user-attachments/assets/1d54b1e1-f758-4e51-929b-cf4a5ef41250) | ![Screen Shot 2025-02-13 at 22 49 27](https://github.com/user-attachments/assets/df03b3c7-e0dc-4bd6-b9a9-5146168f8e58) |
| ![Screen Shot 2025-02-13 at 22 55 50](https://github.com/user-attachments/assets/1cdc8d0e-c90f-4d1b-bda3-b115e552fc64) | ![Screen Shot 2025-02-13 at 22 49 35](https://github.com/user-attachments/assets/681781fd-31da-4253-b777-99d87b70ce8c) |
| ![Screen Shot 2025-02-13 at 22 56 07](https://github.com/user-attachments/assets/171335e8-5d6a-40ce-a391-0bfccee3e98b) | ![Screen Shot 2025-02-13 at 22 49 47](https://github.com/user-attachments/assets/a30abf1d-6960-4326-a94e-4c672a97a22c) |
