### PR TITLE
loading_spinner: Add loading spinner to settings page.

### DIFF
--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -363,7 +363,14 @@ function get_last_active(user: User): string {
         return timerender.render_now(new Date(user.date_joined)).time_str;
     }
     if (!last_active_date) {
-        return $t({defaultMessage: "Loading…"});
+        setTimeout(() => {
+            loading.make_indicator(
+                $(
+                    `.user_row[data-user-id='${CSS.escape(user.user_id.toString())}'] .loading-placeholder`,
+                ),
+            );
+        }, 0);
+        return "";
     }
     return timerender.render_now(last_active_date).time_str;
 }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -353,6 +353,15 @@ select.settings_select {
     word-break: normal;
 }
 
+.last_active {
+    .loading_indicator_spinner {
+        width: 2.7143em; /* 38px at 14px em */
+        display: flex;
+        align-items: center;
+        margin: 0;
+    }
+}
+
 .input-group {
     margin: 0 0 20px;
 

--- a/web/templates/settings/settings_user_list_row.hbs
+++ b/web/templates/settings/settings_user_list_row.hbs
@@ -29,7 +29,11 @@
     </td>
     {{else if display_last_active_column}}
     <td class="last_active">
-        {{ last_active_date }}
+        {{#if last_active_date}}
+            {{last_active_date}}
+        {{else}}
+            <div class="loading-placeholder"></div>
+        {{/if}}
     </td>
     {{/if}}
     {{#if can_modify}}


### PR DESCRIPTION
Remove "Loading..." text from settings page and replace it with a spinner.

<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Loading.20indicator.20in.20the.20settings.2Fusers.20table.2E)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before | After |
|-------|------|
![Before](https://github.com/user-attachments/assets/71815acf-a2a3-445e-8342-50acb75b7cf4) | ![After](https://github.com/user-attachments/assets/b3951e99-439c-44d2-ae3f-418b4fec81b9) | 
![Before](https://github.com/user-attachments/assets/bb639415-8be9-4fc6-b7b0-58e88d296bd1) | ![After](https://github.com/user-attachments/assets/be878c97-7a77-48ad-9a75-8e772957cc6a) | 



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
