### PR TITLE
topic_edit: Show "general chat" placeholder when mandatory_topics=false.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -899,6 +899,8 @@ export function start_inline_topic_edit($recipient_row: JQuery): void {
     const $form = $(
         render_topic_edit_form({
             max_topic_length: realm.max_topic_length,
+            realm_mandatory_topics: realm.realm_mandatory_topics,
+            empty_string_topic_display_name: util.get_final_topic_display_name(""),
         }),
     );
     message_lists.current.show_edit_topic_on_recipient_row($recipient_row, $form);
@@ -912,10 +914,6 @@ export function start_inline_topic_edit($recipient_row: JQuery): void {
     const topic = message.topic;
     const $inline_topic_edit_input = $form.find<HTMLInputElement>("input.inline_topic_edit");
     $inline_topic_edit_input.val(topic).trigger("select").trigger("focus");
-    if (topic === "") {
-        const topic_display_name = util.get_final_topic_display_name(topic);
-        $inline_topic_edit_input.attr("placeholder", topic_display_name);
-    }
     const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     composebox_typeahead.initialize_topic_edit_typeahead(
         $inline_topic_edit_input,

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -322,11 +322,12 @@ export async function build_move_topic_to_stream_popover(
     const current_stream_name = sub_store.get(current_stream_id)!.name;
     const stream = sub_store.get(current_stream_id);
     const topic_display_name = util.get_final_topic_display_name(topic_name);
+    const empty_string_topic_display_name = util.get_final_topic_display_name("");
     const is_empty_string_topic = topic_name === "";
     const args: {
         topic_name: string;
-        topic_display_name: string;
-        is_empty_string_topic: boolean;
+        empty_string_topic_display_name: string;
+        realm_mandatory_topics: boolean;
         current_stream_id: number;
         notify_new_thread: boolean;
         notify_old_thread: boolean;
@@ -337,8 +338,8 @@ export async function build_move_topic_to_stream_popover(
         stream: sub_store.StreamSubscription | undefined;
     } = {
         topic_name,
-        topic_display_name,
-        is_empty_string_topic,
+        empty_string_topic_display_name,
+        realm_mandatory_topics: realm.realm_mandatory_topics,
         current_stream_id,
         stream,
         notify_new_thread: message_edit.notify_new_thread_default,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2044,7 +2044,8 @@ body:not(.hide-left-sidebar) {
     }
 }
 
-.empty-topic-display {
+.empty-topic-display,
+.empty-topic-placeholder-display::placeholder {
     font-style: italic;
 }
 

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -8,7 +8,7 @@
         {{/unless}}
         <div class="input-group">
             <label for="move-topic-new-topic-name" class="modal-field-label">New topic</label>
-            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" {{#if is_empty_string_topic}}placeholder="{{topic_display_name}}"{{/if}} value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input {{#unless realm_mandatory_topics}}empty-topic-placeholder-display{{/unless}}" autocomplete="off" {{#unless realm_mandatory_topics}}placeholder="{{empty_string_topic_display_name}}"{{/unless}} value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />

--- a/web/templates/topic_edit_form.hbs
+++ b/web/templates/topic_edit_form.hbs
@@ -1,8 +1,9 @@
 {{! Client-side Handlebars template for rendering the topic edit form. }}
 
 <form id="topic_edit_form">
-    <input type="text" value="" class="inline_topic_edit header-v"
-      autocomplete="off" maxlength="{{ max_topic_length }}" />
+    <input type="text" value="" autocomplete="off" maxlength="{{ max_topic_length }}"
+      class="inline_topic_edit header-v {{#unless realm_mandatory_topics}}empty-topic-placeholder-display{{/unless}}"
+      {{#unless realm_mandatory_topics}}placeholder="{{empty_string_topic_display_name}}"{{/unless}} />
     <button type="button" class="topic_edit_save small_square_button animated-purple-button"><i class="fa fa-check" aria-hidden="true"></i></button>
     <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>
     <div class="alert alert-error edit_error" style="display: none"></div>


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/general.20chat.20.2F.20default.20topic/near/2090500)
> I guess the move topic modal's placeholder doesn't use italics; presumably we can copy the compose box implementation for it.

> When mandatory_topics = false, I think we should always show "test general chat" as the placeholder in the move topic modal.

Also, improved the "inline topic edit form".

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="422" alt="Screenshot 2025-02-14 at 12 53 00 PM" src="https://github.com/user-attachments/assets/478c9af9-d6de-4627-9755-093b749498b1" />

<img width="456" alt="Screenshot 2025-02-14 at 1 28 53 PM" src="https://github.com/user-attachments/assets/7c6d8289-f22b-46ca-bed5-106605e76436" />





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
