### PR TITLE
search: Add is-muted search operator. 

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 366**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  Added a new [search/narrow filter](/api/construct-narrow),
+  `is:muted`, matching messages in topics and channels that the user
+  has [muted](/help/mute-a-topic).
+
 **Feature level 365**
 
 * [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -58,6 +58,10 @@ as an empty string.
 
 ## Changes
 
+* In Zulip 10.0 (feature level ZF-f80735), support was added for a new
+  `is:muted` operator combination, matching messages in topics and
+  channels that the user has [muted](/help/mute-a-topic).
+
 * Before Zulip 10.0 (feature level 334), empty string was not a valid
   topic name for channel messages.
 

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -117,6 +117,10 @@ Zulip offers the following filters based on the location of the message.
 * `is:resolved`: Search messages in [resolved topics](/help/resolve-a-topic).
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
 * `is:unread`: Search your unread messages.
+* `is:muted`: Search messages in [muted topics](/help/mute-a-topic) or
+  [muted channels](/help/mute-a-channel).
+* `-is:muted`: Search messages outside [muted topics](/help/mute-a-topic) and
+  [muted channels](/help/mute-a-channel).
 * `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
 
 ### Search by message ID

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 365
+API_FEATURE_LEVEL = 366
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -120,16 +120,15 @@ function zephyr_topic_name_match(message: Message & {type: "stream"}, operand: s
 
 function message_in_home(message: Message): boolean {
     // The home view contains messages not sent to muted channels,
-    // with additional logic for unmuted topics, mentions, and
+    // with additional logic for unmuted topics and
     // single-channel windows.
     if (message.type === "private") {
         return true;
     }
     const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     if (
-        message.mentioned ||
-        (page_params.narrow_stream !== undefined &&
-            stream_name.toLowerCase() === page_params.narrow_stream.toLowerCase())
+        page_params.narrow_stream !== undefined &&
+        stream_name.toLowerCase() === page_params.narrow_stream.toLowerCase()
     ) {
         return true;
     }
@@ -1763,7 +1762,9 @@ export class Filter {
             // not narrowed to dms
             !(this.has_operator("dm") || this.has_operand("is", "dm")) &&
             // not narrowed to starred messages
-            !this.has_operand("is", "starred")
+            !this.has_operand("is", "starred") &&
+            // not narrowed to negated home messages
+            !this.has_negated_operand("in", "home")
         );
     }
 

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -287,6 +287,13 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                     return {
                         title: $t({defaultMessage: "You aren't following any topics."}),
                     };
+
+                case "muted":
+                    return {
+                        title: $t({
+                            defaultMessage: "You have no messages in muted topics and channels.",
+                        }),
+                    };
             }
             // fallthrough to default case if no match is found
             break;

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -747,6 +747,15 @@ function get_is_filter_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Sugge
                 incompatible_patterns: [{operator: "is", operand: "unread"}],
             },
             {
+                search_string: "is:muted",
+                description_html: "muted messages",
+                is_people: false,
+                incompatible_patterns: [
+                    {operator: "is", operand: "muted"},
+                    {operator: "in", operand: "home"},
+                ],
+            },
+            {
                 search_string: "is:resolved",
                 description_html: "resolved topics",
                 is_people: false,

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -50,6 +50,10 @@
             {{~!-- squash whitespace --~}}
             {{this.verb}}followed topics
             {{~!-- squash whitespace --~}}
+        {{else if (eq this.operand "muted")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}muted messages
+            {{~!-- squash whitespace --~}}
         {{else if (eq this.operand "unresolved")}}
             {{~!-- squash whitespace --~}}
             {{this.verb}}unresolved topics

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -152,6 +152,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">is:muted</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages in muted topics or channels.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">near:<span class="operator_value">id</span></td>
                         <td class="definition">
                             {{#tr}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -2699,6 +2699,26 @@ run_test("is_in_home", () => {
     assert.ok(!filter3.is_in_home());
 });
 
+run_test("excludes_muted_topics", () => {
+    let filter = new Filter([{operator: "is", operand: "starred"}]);
+    assert.ok(!filter.excludes_muted_topics());
+
+    filter = new Filter([{operator: "in", operand: "home", negated: true}]);
+    assert.ok(!filter.excludes_muted_topics());
+
+    filter = new Filter([{operator: "search", operand: "pizza"}]);
+    assert.ok(!filter.excludes_muted_topics());
+
+    filter = new Filter([
+        {operator: "channel", operand: foo_stream_id.toString()},
+        {operator: "topic", operand: "bar"},
+    ]);
+    assert.ok(!filter.excludes_muted_topics());
+
+    filter = new Filter([{operator: "is", operand: "dm"}]);
+    assert.ok(!filter.excludes_muted_topics());
+});
+
 run_test("equals", () => {
     let terms = [{operator: "channel", operand: foo_stream_id.toString()}];
     let filter = new Filter(terms);

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -370,6 +370,12 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         empty_narrow_html("translated: You aren't following any topics."),
     );
 
+    current_filter = set_filter([["is", "muted"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: You have no messages in muted topics and channels."),
+    );
     // organization has disabled sending direct messages
     override(realm, "realm_direct_message_permission_group", nobody.id);
 

--- a/web/tests/search_suggestion.test.cjs
+++ b/web/tests/search_suggestion.test.cjs
@@ -378,6 +378,7 @@ test("empty_query_suggestions", () => {
         "is:followed",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "is:resolved",
         "-is:resolved",
         "sender:myself@zulip.com",
@@ -482,6 +483,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:followed",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "is:resolved",
         "dm:alice@zulip.com",
         "sender:alice@zulip.com",
@@ -501,6 +503,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("is:unread"), "Unread messages");
     assert.equal(describe("is:resolved"), "Resolved topics");
     assert.equal(describe("is:followed"), "Followed topics");
+    assert.equal(describe("is:muted"), "Muted messages");
 
     query = "-i";
     suggestions = get_suggestions(query);
@@ -512,6 +515,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "-is:followed",
         "-is:alerted",
         "-is:unread",
+        "-is:muted",
         "-is:resolved",
     ];
     assert.deepEqual(suggestions.strings, expected);
@@ -523,6 +527,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
     assert.equal(describe("-is:unread"), "Exclude unread messages");
     assert.equal(describe("-is:resolved"), "Unresolved topics");
     assert.equal(describe("-is:followed"), "Exclude followed topics");
+    assert.equal(describe("-is:muted"), "Exclude muted messages");
 
     // operand suggestions follow.
 
@@ -535,6 +540,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
         "is:followed",
         "is:alerted",
         "is:unread",
+        "is:muted",
         "is:resolved",
     ];
     assert.deepEqual(suggestions.strings, expected);

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -26,6 +26,7 @@ from sqlalchemy.sql import (
     or_,
     select,
     table,
+    true,
     union_all,
 )
 from sqlalchemy.sql.selectable import SelectBase
@@ -386,7 +387,7 @@ class NarrowBuilder:
             )
             if conditions:
                 return query.where(maybe_negate(and_(*conditions)))
-            return query  # nocoverage
+            return query.where(maybe_negate(true()))
         elif operand == "all":
             return query
 

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -432,6 +432,19 @@ class NarrowBuilder:
         elif operand == "followed":
             cond = get_followed_topic_condition_sa(self.user_profile.id)
             return query.where(maybe_negate(cond))
+        elif operand == "muted":
+            # TODO: If we also have a channel operator, this could be
+            # a lot more efficient if limited to only those muting
+            # rules that appear in such channels.
+            conditions = exclude_muting_conditions(
+                self.user_profile, [NarrowParameter(operator="is", operand="muted")]
+            )
+            if conditions:
+                return query.where(maybe_negate(not_(and_(*conditions))))
+
+            # This is the case where no channels or topics were muted.
+            return query.where(maybe_negate(false()))
+
         raise BadNarrowOperatorError("unknown 'is' operand " + operand)
 
     _alphanum = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")


### PR DESCRIPTION
1st commit fixes the issues existing with `-in:home` search operator.
Previously, mentions from muted channels were incorrectly excluded when narrowed down to `-in:home`. Additionally, messages from all muted topics were missing in the results.
This commit solves the above listed issues.

2nd commit adds `-is:muted` as an alias of `in:home`.

Referenced PR: #31077.
Fixes: #16943.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Search suggestions
![image](https://github.com/user-attachments/assets/cb134de0-2f97-419a-ada1-c5c1ed2d4282)

Help menu
![image](https://github.com/user-attachments/assets/1e34af1c-693a-488a-80e6-aa2b28d1414a)

![image](https://github.com/user-attachments/assets/907a1f56-af84-40fb-8792-c56cec9f879b)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
