### PR TITLE
stream_edit: allow channel name field to expand if needed

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -630,6 +630,16 @@ export function initialize(): void {
         dialog_widget.submit_api_request(channel.patch, url, data);
     }
 
+    $(document).on("input", "input#change_stream_name", function () {
+        if (!(this instanceof HTMLInputElement)) {
+            return;
+        }
+
+        const text: string = this.value;
+        const newWidth: string = (text.length || 1) + "ch";
+        $(this).css("width", newWidth);
+    });
+
     $("#channels_overlay_container").on(
         "click",
         ".copy_email_button",

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -449,7 +449,7 @@
         box-shadow linear 0.2s;
     margin-bottom: 10px;
     /* subtract padding (6px each side) and border (1px each side) */
-    width: calc(var(--modal-input-width) - 14px);
+    min-width: calc(var(--modal-input-width) - 14px);
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);


### PR DESCRIPTION
---------------------------------------------------------------------------------
<!-- Describe your pull request here.-->

This PR updates the channel name input field in the stream edit modal so that it dynamically expands as needed. With these changes, the input field's width adjusts inline based on its content, ensuring that longer channel names are fully visible.

**Changes include:**

- **In `stream_edit.ts`:**
  - Added a delegated jQuery event listener for the `input` event on `input#change_stream_name`.
  - Dynamically set the input field's width using `ch` units, computed as `(text.length || 1) + "ch"`, which directly applies an inline style.

- **In `web/styles/modal.css`:**
  - Replaced the fixed width rule (`width: calc(var(--modal-input-width) - 14px);`) with a minimum width rule (`min-width: calc(var(--modal-input-width) - 14px);`).
  - This change allows the inline width style set by JavaScript to take effect without being overridden.

**Screenshots and screen captures:**
![screenshot_14022025_155659](https://github.com/user-attachments/assets/65136387-d232-4592-9b0e-f9df6bbd1123)
![screenshot_14022025_155635](https://github.com/user-attachments/assets/2ceb790d-f3ee-43a4-a8e4-d87249d466bf)

