### PR TITLE
edited_notice: Fix missing "Moved" notice.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -147,13 +147,13 @@ export function fetch_and_render_message_history(message: Message): void {
                 if (index === 0) {
                     edited_by_notice = $t({defaultMessage: "Posted by {full_name}"}, {full_name});
                     body_to_render = msg.rendered_content;
-                } else if (msg.prev_topic && msg.prev_content) {
+                } else if (msg.prev_topic !== undefined && msg.prev_content) {
                     edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
                     body_to_render = msg.content_html_diff;
                     topic_edited = true;
                     prev_topic = msg.prev_topic;
                     new_topic = msg.topic;
-                } else if (msg.prev_topic && msg.prev_stream) {
+                } else if (msg.prev_topic !== undefined && msg.prev_stream) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     topic_edited = true;
                     prev_topic = msg.prev_topic;
@@ -164,7 +164,7 @@ export function fetch_and_render_message_history(message: Message): void {
                     if (prev_stream_item !== null) {
                         prev_stream_item.new_stream = get_display_stream_name(msg.prev_stream);
                     }
-                } else if (msg.prev_topic) {
+                } else if (msg.prev_topic !== undefined) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     topic_edited = true;
                     prev_topic = msg.prev_topic;

--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -192,7 +192,7 @@ function analyze_edit_history(
                 moved = true;
             }
 
-            if (edit_history_event.prev_topic) {
+            if (edit_history_event.prev_topic !== undefined) {
                 // TODO: Possibly this assert could be removed if we tightened the type
                 // on edit history elements such that a `prev_topic` being present means a
                 // `topic` element is.


### PR DESCRIPTION
Commit 1: When a message was moved from an empty string topic to another topic, the "Moved" notice beside sender name in the message body was missing.

Before | After |
|-------|------|
<img width="931" alt="Screenshot 2025-02-14 at 4 39 17 PM" src="https://github.com/user-attachments/assets/894f043f-2d52-43bf-90bd-7f9e3578bfd0" /> | <img width="936" alt="Screenshot 2025-02-14 at 4 43 57 PM" src="https://github.com/user-attachments/assets/6431c0ec-265b-4118-8d3b-6005a4f63cb6" /> | 

Commit 2: Buggy message edit history rendered.

Before | After |
|-------|------|
<img width="871" alt="Screenshot 2025-02-14 at 5 14 05 PM" src="https://github.com/user-attachments/assets/db5a2a0b-dcd8-4b36-9441-7ab0076bfdae" /> |  <img width="875" alt="Screenshot 2025-02-14 at 5 15 05 PM" src="https://github.com/user-attachments/assets/c0d062b7-cae6-4c2b-b2bf-26d9343c0258" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
