### PR TITLE
Add placeholders to login and register input fields

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -59,7 +59,7 @@ page can be easily identified in it's respective JavaScript file -->
                                 {{ csrf_input }}
 
                                 <div class="input-box no-validate">
-                                    <input type="email" id="email" class="email" name="email" value="" autofocus required />
+                                    <input type="email" id="email" class="email" name="email" value="" autofocus required placeholder="Enter your email"/>
                                     <label for="email">{{ _('Email') }}</label>
                                     <div class="alert alert-error email-frontend-error"></div>
                                     {% if form.email.errors %}

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -59,7 +59,7 @@ page can be easily identified in it's respective JavaScript file -->
                                 {{ csrf_input }}
 
                                 <div class="input-box no-validate">
-                                    <input type="email" id="email" class="email" name="email" value="" autofocus required placeholder="Enter your email"/>
+                                    <input type="email" id="email" class="email" name="email" value="" autofocus required placeholder="{{ _('Enter your email') }}" />
                                     <label for="email">{{ _('Email') }}</label>
                                     <div class="alert alert-error email-frontend-error"></div>
                                     {% if form.email.errors %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -91,7 +91,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                 <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
                                   name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
                                   {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
-                                  maxlength="72" required />
+                                  maxlength="72" required placeholder="Enter your email"/>
                                 <label for="id_username">
                                     {% if not require_email_format_usernames and email_auth_enabled %}
                                     {{ _('Email or username') }}
@@ -106,7 +106,7 @@ page can be easily identified in it's respective JavaScript file. -->
                             <div class="input-box password-div">
                                 <input id="id_password" name="password" class="required" type="password" autocomplete="off"
                                   {% if email %} autofocus {% endif %}
-                                  required />
+                                  required placeholder="Enter your password" />
                                 <label for="id_password">{{ _('Password') }}</label>
                                 <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0"></i>
                             </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -108,7 +108,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                   {% if email %} autofocus {% endif %}
                                   required placeholder="Enter your password" />
                                 <label for="id_password">{{ _('Password') }}</label>
-                                <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0"></i>
+                                <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0" style="cursor: pointer;"></i>
                             </div>
                             {% else %}
                             {% include "two_factor/_wizard_forms.html" %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -91,7 +91,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                 <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
                                   name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
                                   {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
-                                  maxlength="72" required placeholder="Enter your email"/>
+                                  maxlength="72" required placeholder="{{ _('Enter your email') }}"/>
                                 <label for="id_username">
                                     {% if not require_email_format_usernames and email_auth_enabled %}
                                     {{ _('Email or username') }}
@@ -106,7 +106,7 @@ page can be easily identified in it's respective JavaScript file. -->
                             <div class="input-box password-div">
                                 <input id="id_password" name="password" class="required" type="password" autocomplete="off"
                                   {% if email %} autofocus {% endif %}
-                                  required placeholder="Enter your password" />
+                                  required placeholder="{{ _('Enter your password') }}" />
                                 <label for="id_password">{{ _('Password') }}</label>
                                 <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0" style="cursor: pointer;"></i>
                             </div>


### PR DESCRIPTION
## Add placeholders to login input fields

### Issue(s) Resolved
Fixes: #33484

### Summary of Changes
This PR improves the login & registration page by adding placeholders to the username/email and password input fields. These placeholders help users understand what information is expected, improving form usability.

### Testing Plan
- Restarted the Zulip development server.
- Navigated to [http://localhost:9991/login/](http://localhost:9991/login/) and verified that placeholders appear correctly.
- - Navigated to [http://localhost:9991/register/](http://localhost:9991/register/) and verified that placeholders appear correctly.
- Tested the following login configurations:
  - **Email-based authentication**
  - **Username authentication**
  - **Two-factor authentication enabled/disabled**
- Ensured that placeholders do not interfere with existing form validation.

### Screenshots/GIFs (if applicable)
**Before** :
![image](https://github.com/user-attachments/assets/37d40d65-9073-4ec8-ba66-24ffcb5458a5)
**After** :
![image](https://github.com/user-attachments/assets/49143f25-aae0-4357-936e-761ce5f794f1)


### Additional Information
- This change does not impact authentication logic.
- No new dependencies or database migrations required.
