### PR TITLE
buddy_list: Fix incorrect user count in the right sidebar

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -62,6 +62,17 @@ function get_total_human_subscriber_count(
     return 0;
 }
 
+function get_non_participant_subscribers_count(
+    current_sub: StreamSubscription | undefined,
+): number {
+    if (!current_sub) {
+        return 0;
+    }
+    const total_human_subscribers_count = get_total_human_subscriber_count(current_sub, new Set());
+    const subscribed_participant_ids = buddy_list.subscribed_participant_ids();
+    return total_human_subscribers_count - subscribed_participant_ids.length;
+}
+
 function should_hide_headers(
     current_sub: StreamSubscription | undefined,
     pm_ids_set: Set<number>,
@@ -79,6 +90,7 @@ type BuddyListRenderData = {
     other_users_count: number;
     hide_headers: boolean;
     get_all_participant_ids: () => Set<number>;
+    non_participant_subscribers_count: number;
 };
 
 function get_render_data(): BuddyListRenderData {
@@ -89,6 +101,7 @@ function get_render_data(): BuddyListRenderData {
     const other_users_count = people.get_active_human_count() - total_human_subscribers_count;
     const hide_headers = should_hide_headers(current_sub, pm_ids_set);
     const get_all_participant_ids = buddy_data.get_conversation_participants_callback();
+    const non_participant_subscribers_count = get_non_participant_subscribers_count(current_sub);
 
     return {
         current_sub,
@@ -97,6 +110,7 @@ function get_render_data(): BuddyListRenderData {
         other_users_count,
         hide_headers,
         get_all_participant_ids,
+        non_participant_subscribers_count,
     };
 }
 
@@ -204,6 +218,8 @@ export class BuddyList extends BuddyListConf {
                             current_sub,
                             pm_ids_set,
                         );
+                        const non_participant_subscribers_count =
+                            get_non_participant_subscribers_count(current_sub);
                         const participant_count = Number.parseInt(
                             $("#buddy-list-participants-section-heading").attr("data-user-count")!,
                             10,
@@ -218,31 +234,13 @@ export class BuddyList extends BuddyListConf {
                                 {N: participant_count},
                             );
                         } else if (elem_id === "buddy-list-users-matching-view-section-heading") {
-                            if (participant_count) {
-                                tooltip_text = $t(
-                                    {
-                                        defaultMessage:
-                                            "{N, plural, one {# other subscriber} other {# other subscribers}}",
-                                    },
-                                    {N: total_human_subscribers_count - participant_count},
-                                );
-                            } else if (current_sub) {
-                                tooltip_text = $t(
-                                    {
-                                        defaultMessage:
-                                            "{N, plural, one {# subscriber} other {# subscribers}}",
-                                    },
-                                    {N: total_human_subscribers_count},
-                                );
-                            } else {
-                                tooltip_text = $t(
-                                    {
-                                        defaultMessage:
-                                            "{N, plural, one {# participant} other {# participants}}",
-                                    },
-                                    {N: total_human_subscribers_count},
-                                );
-                            }
+                            tooltip_text = $t(
+                                {
+                                    defaultMessage:
+                                        "{N, plural, one {# other subscriber} other {# other subscribers}}",
+                                },
+                                {N: non_participant_subscribers_count},
+                            );
                         } else {
                             const other_users_count =
                                 people.get_active_human_count() - total_human_subscribers_count;
@@ -263,6 +261,17 @@ export class BuddyList extends BuddyListConf {
                 });
             },
         );
+    }
+
+    subscribed_participant_ids(): number[] {
+        const {current_sub, pm_ids_set, get_all_participant_ids} = this.render_data;
+        const participant_ids_list = [...get_all_participant_ids()];
+        return participant_ids_list.filter((user_id) => {
+            if (current_sub) {
+                return peer_data.is_user_subscribed(current_sub.stream_id, user_id);
+            }
+            return pm_ids_set.has(user_id);
+        });
     }
 
     populate(opts: {all_user_ids: number[]}): void {
@@ -393,13 +402,13 @@ export class BuddyList extends BuddyListConf {
     }
 
     update_section_header_counts(): void {
-        const {total_human_subscribers_count, other_users_count} = this.render_data;
+        const {other_users_count, non_participant_subscribers_count} = this.render_data;
         const all_participant_ids = this.render_data.get_all_participant_ids();
-        const subscriber_section_user_count =
-            total_human_subscribers_count - all_participant_ids.size;
 
         const formatted_participants_count = get_formatted_sub_count(all_participant_ids.size);
-        const formatted_sub_users_count = get_formatted_sub_count(subscriber_section_user_count);
+        const formatted_sub_users_count = get_formatted_sub_count(
+            non_participant_subscribers_count,
+        );
         const formatted_other_users_count = get_formatted_sub_count(other_users_count);
 
         $("#buddy-list-participants-container .buddy-list-heading-user-count").text(
@@ -418,7 +427,7 @@ export class BuddyList extends BuddyListConf {
         );
         $("#buddy-list-users-matching-view-section-heading").attr(
             "data-user-count",
-            subscriber_section_user_count,
+            non_participant_subscribers_count,
         );
         $("#buddy-list-users-other-users-section-heading").attr(
             "data-user-count",
@@ -439,7 +448,8 @@ export class BuddyList extends BuddyListConf {
         }
         this.current_filter = narrow_state.filter();
 
-        const {current_sub, total_human_subscribers_count, other_users_count} = this.render_data;
+        const {current_sub, other_users_count, non_participant_subscribers_count} =
+            this.render_data;
         $(".buddy-list-subsection-header").empty();
         $(".buddy-list-subsection-header").toggleClass("no-display", hide_headers);
         if (hide_headers) {
@@ -464,9 +474,7 @@ export class BuddyList extends BuddyListConf {
                     header_text: current_sub
                         ? $t({defaultMessage: "THIS CHANNEL"})
                         : $t({defaultMessage: "THIS CONVERSATION"}),
-                    user_count: get_formatted_sub_count(
-                        total_human_subscribers_count - all_participant_ids.size,
-                    ),
+                    user_count: get_formatted_sub_count(non_participant_subscribers_count),
                     is_collapsed: this.users_matching_view_is_collapsed,
                 }),
             ),


### PR DESCRIPTION
My main changes are in one file: buddy_list.ts.

The issue occurs because of the following calculation:

1. `{N: total_human_subscribers_count - participant_count}`in `initialize_tooltips`
2. `const subscriber_section_user_count = total_human_subscribers_count - all_participant_ids.size;` in `update_section_header_count`
3. `user_count: get_formatted_sub_count(total_human_subscribers_count - all_participant_ids.size,)` in `render_section_headers`

When a conversation participant unsubscribes (e.g., user ID 6), but that user has previously posted something in the channel, they remain in all_participant_ids (i.e., {6}) because they are still considered a participant. However, since they have unsubscribed, they are no longer included in total_human_subscribers_count. As a result, the calculation produces an incorrect value, such as 0 - 1 = -1

### Solution Approach
To fix this issue, I followed the suggested approach of calculating subscribed_non_participant_count using the set-subtracts method. This avoids iterating over IDs directly, which could lead to performance issues.

1. Helper Function

I introduced the following helper function to compute the number of subscribed users who are not participants:
`function get_non_participant_subscribers_count`

The purpose of this helper function is to calculate the count once in get_render_data, and subscriber_section_user_count can be used in `render_section_headers`, and do not have to calculate again.

2. New Calculation for subscriber_section_user_count

Instead of relying on a subtraction approach that mixes different categories of users, I implemented a separate calculation:
`const non_participant_subscribers_count = get_non_participant_subscribers_count(
            this.render_data.current_sub,
            this.render_data.get_all_participant_ids,
        );`

This ensures that non_participant_subscribers_count is calculated independently without mixing the counts of unsubscribed users and participants.

Changes Applied in Three Places

1. initialize_tooltips – Updates the count when hovering over “THIS CHANNEL”.
![image](https://github.com/user-attachments/assets/a47db46a-5205-4687-bd41-ac3e28f844a2)
2. update_section_header_count – Updates the displayed number of users in “THIS CHANNEL”.
![image](https://github.com/user-attachments/assets/0c95af45-ffde-49ce-8b97-733e3c79a8a7)
3. render_section_headers – Ensures the correct count is displayed when the section is collapsed.
![image](https://github.com/user-attachments/assets/aaf6902d-4a59-406b-8550-183e06fe63a0)

Fixes: https://github.com/zulip/zulip/issues/33452

<details>
<summary>Self-review checklist</summary>
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>