### PR TITLE
docs: highlight need of Punycode for non-ASCII domains

### DIFF
--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -93,7 +93,8 @@ of the failure, you can just rerun the script. For more information, see
 
 - `--hostname=zulip.example.com`: The user-accessible domain name for this Zulip
   server, i.e., what users will type in their web browser. This becomes
-  `EXTERNAL_HOST` in the Zulip [settings][doc-settings].
+  `EXTERNAL_HOST` in the Zulip [settings][doc-settings]. Use Punycode for
+  non-ASCII domains.
 
 - `--certbot`: With this option, the Zulip installer automatically obtains an
   SSL certificate for the server [using Certbot][doc-certbot], and configures a

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -13,6 +13,7 @@ Options:
       The user-accessible domain name for this Zulip server, i.e.,
       what users will type in their web browser.  Required, unless
       --no-init-db or --puppet-classes is set, and --certbot is not.
+      Use Punycode for non-ASCII domains.
 
   --email=zulip-admin@example.com
       The email address of the person or team who should get support


### PR DESCRIPTION
<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

I was playing with installing Zulip, and after a long installation process I got a failure because Certbot does not support Unicode arguments. Given an international audience who might want to use non-ASCII domains, I believe the overhead of including a warning is worthwhile to avoid frustration.