### PR TITLE
Add Text-to-Speech (TTS) Feature to Message Controls

### DIFF
--- a/web/shared/icons/pause.svg
+++ b/web/shared/icons/pause.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="2" width="3" height="12" fill="black"/>
+  <rect x="9" y="2" width="3" height="12" fill="black"/>
+</svg>

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -282,7 +282,7 @@ export function initialize(): void {
             console.error("Error: Could not find .message_content inside messagebox");
             return;
         }
-    
+        // const text = "This is Akash, creator of skytup.com, testing the Text to Speech feature";
         const text = messageElement.text().trim();
         if (!text) {
             console.error("Error: Message text is empty");

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -3,7 +3,7 @@
 import $ from "jquery";
 import assert from "minimalistic-assert";
 import * as tippy from "tippy.js";
-import { z } from "zod";
+import {z} from "zod";
 
 import render_buddy_list_tooltip_content from "../templates/buddy_list_tooltip_content.hbs";
 
@@ -13,7 +13,7 @@ import * as buddy_data from "./buddy_data.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_reply from "./compose_reply.ts";
 import * as compose_state from "./compose_state.ts";
-import { media_breakpoints_num } from "./css_variables.ts";
+import {media_breakpoints_num} from "./css_variables.ts";
 import * as emoji_picker from "./emoji_picker.ts";
 import * as hash_util from "./hash_util.ts";
 import * as hashchange from "./hashchange.ts";
@@ -23,7 +23,7 @@ import * as message_store from "./message_store.ts";
 import * as message_view from "./message_view.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as navigate from "./navigate.ts";
-import { page_params } from "./page_params.ts";
+import {page_params} from "./page_params.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as reactions from "./reactions.ts";
@@ -39,7 +39,7 @@ import * as stream_list from "./stream_list.ts";
 import * as stream_popover from "./stream_popover.ts";
 import * as topic_list from "./topic_list.ts";
 import * as ui_util from "./ui_util.ts";
-import { parse_html } from "./ui_util.ts";
+import {parse_html} from "./ui_util.ts";
 import * as util from "./util.ts";
 
 export function initialize(): void {
@@ -47,7 +47,7 @@ export function initialize(): void {
 
     function initialize_long_tap(): void {
         const MS_DELAY = 750;
-        const meta: { touchdown: boolean; current_target: number | undefined; invalid?: boolean } = {
+        const meta: {touchdown: boolean; current_target: number | undefined; invalid?: boolean} = {
             touchdown: false,
             current_target: undefined,
         };
@@ -208,7 +208,7 @@ export function initialize(): void {
         if (page_params.is_spectator) {
             return;
         }
-        compose_reply.respond_to_message({ trigger: "message click" });
+        compose_reply.respond_to_message({trigger: "message click"});
         e.stopPropagation();
     };
 
@@ -248,50 +248,50 @@ export function initialize(): void {
         starred_messages_ui.toggle_starred_and_update_server(message);
     });
 
-    function resetButtonState(button: JQuery<HTMLElement>): void {
+    function resetButtonState(button: JQuery): void {
         // Ensure button contains an icon before modifying it
         const icon = button.find("i");
-        if (icon.length) {
+        if (icon.length > 0) {
             icon.removeClass("zulip-icon-pause").addClass("zulip-icon-unmute");
         }
-    
+
         // Reset tooltip safely
         if (document.querySelector("#tts-tooltip-template")) {
             button.attr("data-tooltip-template-id", "tts-tooltip-template");
         }
     }
-    
+
     let currentUtterance: SpeechSynthesisUtterance | null = null; // Store the currently speaking utterance
-    let currentButton: JQuery<HTMLElement> | null = null; // Store the button associated with the current speech
-    
+    let currentButton: JQuery | null = null; // Store the button associated with the current speech
+
     $("#main_div").on("click", ".tts_button", function (e: JQuery.ClickEvent): void {
         e.stopPropagation();
-    
-        const button: JQuery<HTMLElement> = $(this);
-        const messageBox: JQuery<HTMLElement> = button.closest(".messagebox");
-    
+
+        const button: JQuery = $(this);
+        const messageBox: JQuery = button.closest(".messagebox");
+
         if (messageBox.length === 0) {
             return; // Avoid unnecessary errors
         }
-    
-        const messageElement: JQuery<HTMLElement> = messageBox.find(".message_content.rendered_markdown");
-    
+
+        const messageElement: JQuery = messageBox.find(".message_content.rendered_markdown");
+
         if (messageElement.length === 0) {
             return;
         }
-    
+
         const text: string = messageElement.text().trim();
         if (text.length === 0) {
             return;
         }
-    
+
         // If the same button is clicked again, toggle pause/resume
         if (button.is(currentButton) && window.speechSynthesis.speaking) {
             window.speechSynthesis.cancel();
             resetButtonState(button);
             return;
         }
-    
+
         // Stop any currently speaking utterance (if different message)
         if (currentUtterance) {
             window.speechSynthesis.cancel();
@@ -299,25 +299,25 @@ export function initialize(): void {
                 resetButtonState(currentButton);
             }
         }
-    
+
         // Create a new utterance for the new message
         const utterance: SpeechSynthesisUtterance = new SpeechSynthesisUtterance(text);
         currentUtterance = utterance;
         currentButton = button; // Store this button as the currently active one
-    
+
         // Ensure button contains an icon before modifying it
         const icon = button.find("i");
-        if (icon.length) {
+        if (icon.length > 0) {
             icon.removeClass("zulip-icon-unmute").addClass("zulip-icon-pause");
         }
-    
+
         // Update tooltip safely
         if (document.querySelector("#tts-pause-tooltip-template")) {
             button.attr("data-tooltip-template-id", "tts-pause-tooltip-template");
         }
-    
+
         window.speechSynthesis.speak(utterance);
-    
+
         // When speech ends, reset the button
         utterance.onend = (): void => {
             resetButtonState(button);
@@ -325,7 +325,6 @@ export function initialize(): void {
             currentButton = null;
         };
     });
-    
 
     $("#main_div").on("click", ".message_reaction", function (this: HTMLElement, e) {
         e.stopPropagation();
@@ -505,7 +504,7 @@ export function initialize(): void {
             }
             e.preventDefault();
             const row_id = get_row_id_for_narrowing(this);
-            message_view.narrow_by_recipient(row_id, { trigger: "message header" });
+            message_view.narrow_by_recipient(row_id, {trigger: "message header"});
         },
     );
 
@@ -515,7 +514,7 @@ export function initialize(): void {
         }
         e.preventDefault();
         const row_id = get_row_id_for_narrowing(this);
-        message_view.narrow_by_topic(row_id, { trigger: "message header" });
+        message_view.narrow_by_topic(row_id, {trigger: "message header"});
     });
 
     // SIDEBARS
@@ -540,7 +539,7 @@ export function initialize(): void {
 
         const $li = $(e.target).parents("li");
 
-        activity_ui.narrow_for_user({ $li });
+        activity_ui.narrow_for_user({$li});
 
         e.preventDefault();
         e.stopPropagation();
@@ -598,7 +597,7 @@ export function initialize(): void {
                 // it will be removed and we need to attach it on an element which will remain in the DOM.
                 const target_node = get_target_node(instance);
                 // We only need to know if any of the `li` elements were removed.
-                const config = { attributes: false, childList: true, subtree };
+                const config = {attributes: false, childList: true, subtree};
                 const callback: MutationCallback = function (mutationsList) {
                     for (const mutation of mutationsList) {
                         // Hide instance if reference is in the removed node list.

--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -248,58 +248,75 @@ export function initialize(): void {
         starred_messages_ui.toggle_starred_and_update_server(message);
     });
 
+    function resetButtonState(button) {
+        // Reset the button icon and tooltip
+        button.find("i")
+            .removeClass("zulip-icon-pause")
+            .addClass("zulip-icon-unmute");
+        
+        // Reset tooltip
+        const tooltipTemplate = document.querySelector('#tts-tooltip-template');
+        if (tooltipTemplate) {
+            button.attr('data-tooltip-template-id', 'tts-tooltip-template');
+        }
+    }
+    
+    // This code is for Text To Speech Feature for each message
     let currentUtterance = null; // Store the currently speaking utterance
     let currentButton = null; // Store the button associated with the current speech
-
+    
     $("#main_div").on("click", ".tts_button", function (e) {
         e.stopPropagation();
-
+    
         const button = $(this);
         const messageBox = button.closest(".messagebox");
-
+    
         if (!messageBox.length) {
             console.error("Error: Could not find .messagebox for clicked button");
             return;
         }
-
+    
         const messageElement = messageBox.find(".message_content.rendered_markdown");
-
+    
         if (!messageElement.length) {
             console.error("Error: Could not find .message_content inside messagebox");
             return;
         }
-
+    
         const text = messageElement.text().trim();
         if (!text) {
             console.error("Error: Message text is empty");
             return;
         }
-
+    
         // If the same button is clicked again, toggle pause/resume
         if (button.is(currentButton) && window.speechSynthesis.speaking) {
             window.speechSynthesis.cancel();
             resetButtonState(button);
             return;
         }
-
+    
         // Stop any currently speaking utterance (if different message)
         if (currentUtterance) {
             window.speechSynthesis.cancel();
             resetButtonState(currentButton);
         }
-
+    
         // Create a new utterance for the new message
         const utterance = new SpeechSynthesisUtterance(text);
         currentUtterance = utterance;
         currentButton = button; // Store this button as the currently active one
-
-        // Update UI before speaking
-        button.text("Pause").find("i")
-            .removeClass("zulip-icon-volume-up")
+    
+        // Update UI before speaking (change icon and tooltip for "Pause")
+        button.find("i")
+            .removeClass("zulip-icon-unmute")
             .addClass("zulip-icon-pause");
-
+    
+        // Update tooltip to "Pause"
+        button.attr('data-tooltip-template-id', 'tts-pause-tooltip-template');
+    
         window.speechSynthesis.speak(utterance);
-
+    
         // When speech ends, reset the button
         utterance.onend = () => {
             resetButtonState(button);
@@ -307,17 +324,7 @@ export function initialize(): void {
             currentButton = null;
         };
     });
-
-    // Function to reset button UI
-    function resetButtonState(button) {
-        if (button) {
-            button.text("Speak").find("i")
-                .removeClass("zulip-icon-pause")
-                .addClass("zulip-icon-volume-up");
-        }
-    }
-
-
+    
     $("#main_div").on("click", ".message_reaction", function (this: HTMLElement, e) {
         e.stopPropagation();
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -399,6 +399,14 @@
                 margin-left: 5px;
             }
 
+            .zulip-icon-volume-up {
+                background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 4H3V12H5L9 16V0L5 4Z' fill='%23333333'/%3E%3Cpath d='M11 5.5V10.5C11 11.3284 11.6716 12 12.5 12C13.3284 12 14 11.3284 14 10.5V5.5C14 4.67157 13.3284 4 12.5 4C11.6716 4 11 4.67157 11 5.5Z' fill='%23333333'/%3E%3C/svg%3E%0A");
+            }
+            
+            .zulip-icon-pause {
+                background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 4H7V12H5V4Z' fill='%23333333'/%3E%3Cpath d='M9 4H11V12H9V4Z' fill='%23333333'/%3E%3C/svg%3E%0A");
+            }
+            
             .sender_name {
                 display: inline-flex;
                 font-weight: 700;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -398,7 +398,7 @@
                 align-self: center;
                 margin-left: 5px;
             }
-            
+
             .sender_name {
                 display: inline-flex;
                 font-weight: 700;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -398,14 +398,6 @@
                 align-self: center;
                 margin-left: 5px;
             }
-
-            .zulip-icon-volume-up {
-                background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 4H3V12H5L9 16V0L5 4Z' fill='%23333333'/%3E%3Cpath d='M11 5.5V10.5C11 11.3284 11.6716 12 12.5 12C13.3284 12 14 11.3284 14 10.5V5.5C14 4.67157 13.3284 4 12.5 4C11.6716 4 11 4.67157 11 5.5Z' fill='%23333333'/%3E%3C/svg%3E%0A");
-            }
-            
-            .zulip-icon-pause {
-                background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 4H7V12H5V4Z' fill='%23333333'/%3E%3Cpath d='M9 4H11V12H9V4Z' fill='%23333333'/%3E%3C/svg%3E%0A");
-            }
             
             .sender_name {
                 display: inline-flex;

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -1,5 +1,5 @@
 <div class="tts_button message_control_button" data-tooltip-template-id="tts-tooltip-template">
-    <i role="button" tabindex="0" class="message-controls-icon zulip-icon zulip-icon-unmute" aria-label="{{t 'Read Aloud' }}" aria-haspopup="true"></i>
+    <i role="button" tabindex="0" class="message-controls-icon zulip-icon zulip-icon-unmute" aria-label="{{t 'Read aloud' }}" aria-haspopup="true"></i>
 </div>
 
 {{#unless is_archived}}

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -1,3 +1,7 @@
+<div class="tts_button message_control_button" data-tooltip-template-id="tts-tooltip-template">
+    <i role="button" tabindex="0" class="message-controls-icon zulip-icon zulip-icon-unmute" aria-label="Read Aloud" aria-haspopup="true"></i>
+</div>
+
 {{#unless is_archived}}
     {{#if msg/sent_by_me}}
         <div class="edit_content message_control_button"></div>

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -1,5 +1,5 @@
 <div class="tts_button message_control_button" data-tooltip-template-id="tts-tooltip-template">
-    <i role="button" tabindex="0" class="message-controls-icon zulip-icon zulip-icon-unmute" aria-label="Read Aloud" aria-haspopup="true"></i>
+    <i role="button" tabindex="0" class="message-controls-icon zulip-icon zulip-icon-unmute" aria-label="{{t 'Read Aloud' }}" aria-haspopup="true"></i>
 </div>
 
 {{#unless is_archived}}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -200,7 +200,7 @@
     {{tooltip_hotkey_hints ":"}}
 </template>
 <template id="tts-tooltip-template">
-    {{t "Read Aloud" }}
+    {{t "Read aloud" }}
 </template>
 <template id="tts-pause-tooltip-template">
     {{t "Pause" }}

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -199,6 +199,12 @@
     {{t "Add emoji reaction" }}
     {{tooltip_hotkey_hints ":"}}
 </template>
+<template id="tts-tooltip-template">
+    {{t "Read Aloud" }}
+</template>
+<template id="tts-pause-tooltip-template">
+    {{t "Pause" }}
+</template>
 <template id="message-actions-tooltip-template">
     {{t "Message actions" }}
     {{tooltip_hotkey_hints "I"}}


### PR DESCRIPTION
#### Hey it's me Akash Vishwakarma, I would like to add a new feature TTS to messages

#### Summary  
This PR introduces a new feature that adds text-to-speech functionality to Zulip messages.  
- Implemented a speech synthesis function in `click_handlers.ts`.  
- Updated `message_controls.hbs` to include a new button for text-to-speech playback and a pause button.  
- Modified `tooltip_template` to provide appropriate labels for accessibility.  
- Added a `pause.svg` icon.

## Fixes: #33503  

#### Screenshots and Screen Captures  

![Screenshot 2025-02-16 151402](https://github.com/user-attachments/assets/80eeb198-cb67-4bd0-8c41-6ef425a67c0f)
![Screenshot 2025-02-16 151403](https://github.com/user-attachments/assets/3fa1157e-d7c2-49b7-8a0f-25afe906f79c)


https://github.com/user-attachments/assets/648da4fd-b6f4-4a9f-8eaf-97293540a025


<details>  
<summary>Self-review checklist</summary>  

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).  
- [ ] Explains differences from previous plans (e.g., issue description).  
- [ ] Highlights technical choices and bugs encountered.  
- [ ] Calls out remaining decisions and concerns.  
- [x] Automated tests verify logic where appropriate.  

##### Individual commits are ready for review:  
- [ ] Each commit is a coherent idea.  
- [x] Commit message(s) explain reasoning and motivation for changes.  

##### Manual review and testing:  
- [ ] Visual appearance of the changes.  
- [ ] Responsiveness and internationalization.  
- [ ] Strings and tooltips.  
- [ ] End-to-end functionality of buttons, interactions, and flows.  
- [ ] Corner cases, error conditions, and easily imagined bugs.  

</details>
