### PR TITLE
postprocess: Fix animated images automatically playing on Firefox.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -108,7 +108,15 @@ export function postprocess_content(html: string): string {
         "div.message_inline_image > a > img",
     )) {
         inline_img.setAttribute("loading", "lazy");
-        if (inline_img.src.startsWith("/user_uploads/thumbnail/")) {
+        // We can't just check whether `inline_image.src` starts with
+        // `/user_uploads/thumbnail`, even though that's what the
+        // server writes in the markup, because Firefox will have
+        // already prepended the origin to the source of an image.
+        const image_url = new URL(inline_img.src, window.location.origin);
+        if (
+            image_url.origin === window.location.origin &&
+            image_url.pathname.startsWith("/user_uploads/thumbnail/")
+        ) {
             let thumbnail_name = thumbnail.preferred_format.name;
             if (inline_img.dataset.animated === "true") {
                 if (


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR fixes a bug where animated images automatically play on Firefox because the image source didn't output the same URL across different browsers. Currently, the image source is normalized to ensure consistent URLs across different browsers.

Fixes: #33248

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| --- | --- |
| [Before.webm](https://github.com/user-attachments/assets/a13fa845-8bfc-4b87-97f9-8039f8ebab78) | [After.webm](https://github.com/user-attachments/assets/b22a7069-2f60-4b4a-8c4b-5bfea4b3b3d7)| 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
