### PR TITLE
typeahead: Use em for image placement.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -22,8 +22,9 @@
 
         & > a {
             display: flex;
-            padding: 3px 10px;
-            gap: 5px;
+            align-items: center;
+            padding: 0.2142em 0.7142em; /* 3px 10px at 14px em */
+            gap: 0.3571em; /* 5px at 14px em */
             font-weight: normal;
             /* We want to keep this `max-width` less than 320px. */
             max-width: 292px;
@@ -174,22 +175,22 @@
     }
 }
 
+/* For FontAwesome icons and zulip icons used in place of images for some users. */
 .typeahead-image {
+    font-size: 1.3571em; /* 19px at 14px em */
     display: inline-block;
-    height: 21px;
-    width: 21px;
+    height: 1.1052em; /* 21px at 19px/1em */
+    width: 1.1052em; /* 21px at 19px/1em */
     border-radius: 4px;
 
-    /* For FontAwesome icons and zulip icons used in place of images for some users. */
-    font-size: 19px;
     text-align: center;
 
     &.zulip-icon-triple-users {
-        font-size: 19px;
+        font-size: 1.3571em; /* 19px at 14px em */
     }
 
     &.no-presence-circle {
-        margin-left: 14px;
+        margin-left: 0.7368em; /* 14px at 19px/1em */
     }
 }
 


### PR DESCRIPTION
This is a quicker fix for the sake of info density consistency. Later we'll hopefully convert these styles to grid.

There's still a slight visual issue with the icon and text moving a bit left when the text overflows. This was already an issue at 14px before this PR. I haven't figured this out yet and am not sure if it should be a blocker, since this is a low-visibility area and this PR is definitely an improvement.

Before and after at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-16 at 20 29 38](https://github.com/user-attachments/assets/b1dc6d8d-0eef-4be6-b65e-17d213cd6ffa) | ![Screen Shot 2025-02-16 at 20 30 27](https://github.com/user-attachments/assets/d9c951dd-4869-475f-ae13-718db7fba438) |
| ![Screen Shot 2025-02-16 at 20 29 12](https://github.com/user-attachments/assets/a451c669-14b7-4191-acac-337e359f9e8d) | ![Screen Shot 2025-02-16 at 20 30 44](https://github.com/user-attachments/assets/3a37f1a3-b06d-475e-b5f2-11fc8197d429) |
| ![Screen Shot 2025-02-16 at 20 28 51](https://github.com/user-attachments/assets/1d271417-0d85-4036-8300-2e74dc80c0f2) | ![Screen Shot 2025-02-16 at 20 30 59](https://github.com/user-attachments/assets/01f47e34-4f3c-42d1-b734-a849479604ad) |
| ![Screen Shot 2025-02-16 at 20 26 43](https://github.com/user-attachments/assets/72eab9c8-8295-4a88-9d9e-99676fd9da7c) | ![Screen Shot 2025-02-16 at 20 25 50](https://github.com/user-attachments/assets/a25ac1bb-960b-4c25-84fb-c929d8a465a0) |
