### PR TITLE
settings: Correctly handle passing empty anonymous group.

### DIFF
--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -33,6 +33,7 @@ from zerver.lib.user_groups import (
     get_direct_memberships_of_users,
     get_group_setting_value_for_api,
     get_subgroup_ids,
+    get_system_user_group_by_name,
     get_user_group_direct_member_ids,
     get_user_group_member_ids,
     is_user_in_group,
@@ -43,6 +44,7 @@ from zerver.lib.user_groups import (
 )
 from zerver.lib.users import access_user_by_id, user_ids_to_users
 from zerver.models import NamedUserGroup, UserProfile
+from zerver.models.groups import SystemGroups
 from zerver.models.users import get_system_bot
 from zerver.views.streams import compose_views
 
@@ -71,12 +73,15 @@ def add_user_group(
 
     group_settings_map = {}
     request_settings_dict = locals()
+    nobody_group = get_system_user_group_by_name(SystemGroups.NOBODY, user_profile.realm_id)
     for setting_name, permission_config in NamedUserGroup.GROUP_PERMISSION_SETTINGS.items():
         if setting_name not in request_settings_dict:  # nocoverage
             continue
 
         if request_settings_dict[setting_name] is not None:
-            setting_value = parse_group_setting_value(request_settings_dict[setting_name])
+            setting_value = parse_group_setting_value(
+                request_settings_dict[setting_name], nobody_group
+            )
             setting_value_group = access_user_group_for_setting(
                 setting_value,
                 user_profile,
@@ -159,6 +164,7 @@ def edit_user_group(
         do_update_user_group_description(user_group, description, acting_user=user_profile)
 
     request_settings_dict = locals()
+    nobody_group = get_system_user_group_by_name(SystemGroups.NOBODY, user_profile.realm_id)
     for setting_name, permission_config in NamedUserGroup.GROUP_PERMISSION_SETTINGS.items():
         if setting_name not in request_settings_dict:  # nocoverage
             continue
@@ -167,11 +173,13 @@ def edit_user_group(
             continue
 
         setting_value = request_settings_dict[setting_name]
-        new_setting_value = parse_group_setting_value(setting_value.new)
+        new_setting_value = parse_group_setting_value(setting_value.new, nobody_group)
 
         expected_current_setting_value = None
         if setting_value.old is not None:
-            expected_current_setting_value = parse_group_setting_value(setting_value.old)
+            expected_current_setting_value = parse_group_setting_value(
+                setting_value.old, nobody_group
+            )
 
         current_value = getattr(user_group, setting_name)
         current_setting_api_value = get_group_setting_value_for_api(current_value)


### PR DESCRIPTION
If empty anonymous group is passed for a setting value in an API request, the setting is set to "Nobody" group.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
