### PR TITLE
stream_data: Use user_has_permission_for_group_setting.

### DIFF
--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -22,7 +22,6 @@ import type {
     StreamSpecificNotificationSettings,
     StreamSubscription,
 } from "./sub_store.ts";
-import * as user_groups from "./user_groups.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
@@ -506,13 +505,10 @@ export function has_metadata_access(sub: StreamSubscription): boolean {
         return true;
     }
 
-    // Users that can add other subscribers to a private channel
-    // have content access to that channel. Having content access
-    // should give them metadata access to that private channel even
-    // when unsubscribed.
-    const can_add_subscribers = user_groups.is_user_in_setting_group(
+    const can_add_subscribers = settings_data.user_has_permission_for_group_setting(
         sub.can_add_subscribers_group,
-        people.my_current_user_id(),
+        "can_add_subscribers_group",
+        "stream",
     );
     if (can_add_subscribers) {
         return true;
@@ -543,12 +539,10 @@ export function has_content_access(sub: StreamSubscription): boolean {
         return false;
     }
 
-    // This is after the is_guest check, because this setting has
-    // allow_everyone_group=false.  TODO: Consider adding a
-    // is_user_in_setting_group wrapper abstraction that handles this detail automatically.
-    const can_add_subscribers = user_groups.is_user_in_setting_group(
+    const can_add_subscribers = settings_data.user_has_permission_for_group_setting(
         sub.can_add_subscribers_group,
-        people.my_current_user_id(),
+        "can_add_subscribers_group",
+        "stream",
     );
     if (can_add_subscribers) {
         return true;
@@ -574,9 +568,10 @@ function can_administer_channel(sub: StreamSubscription): boolean {
         return true;
     }
 
-    return user_groups.is_user_in_setting_group(
+    return settings_data.user_has_permission_for_group_setting(
         sub.can_administer_channel_group,
-        people.my_current_user_id(),
+        "can_administer_channel_group",
+        "stream",
     );
 }
 
@@ -660,9 +655,10 @@ export function can_subscribe_others(sub: StreamSubscription): boolean {
         return true;
     }
 
-    return user_groups.is_user_in_setting_group(
+    return settings_data.user_has_permission_for_group_setting(
         sub.can_add_subscribers_group,
-        people.my_current_user_id(),
+        "can_add_subscribers_group",
+        "stream",
     );
 }
 
@@ -698,9 +694,10 @@ export function can_unsubscribe_others(sub: StreamSubscription): boolean {
         return true;
     }
 
-    return user_groups.is_user_in_setting_group(
+    return settings_data.user_has_permission_for_group_setting(
         sub.can_remove_subscribers_group,
-        people.my_current_user_id(),
+        "can_remove_subscribers_group",
+        "stream",
     );
 }
 

--- a/web/tests/lib/example_settings.cjs
+++ b/web/tests/lib/example_settings.cjs
@@ -2,6 +2,14 @@
 
 exports.server_supported_permission_settings = {
     stream: {
+        can_add_subscribers_group: {
+            require_system_group: false,
+            allow_internet_group: false,
+            allow_nobody_group: true,
+            allow_everyone_group: false,
+            default_group_name: "role:nobody",
+            allowed_system_groups: [],
+        },
         can_administer_channel_group: {
             require_system_group: true,
             allow_internet_group: false,

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -8,6 +8,7 @@
 
 const assert = require("node:assert/strict");
 
+const example_settings = require("./lib/example_settings.cjs");
 const {zrequire} = require("./lib/namespace.cjs");
 const {run_test} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
@@ -15,11 +16,13 @@ const {page_params} = require("./lib/zpage_params.cjs");
 
 const peer_data = zrequire("peer_data");
 const people = zrequire("people");
-const {set_current_user} = zrequire("state_data");
+const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
 const user_groups = zrequire("user_groups");
 
 set_current_user({});
+const realm = {};
+set_realm(realm);
 
 page_params.realm_users = [];
 const me = {
@@ -73,6 +76,11 @@ function test(label, f) {
         user_groups.initialize({
             realm_user_groups: [nobody_group],
         });
+        override(
+            realm,
+            "server_supported_permission_settings",
+            example_settings.server_supported_permission_settings,
+        );
 
         f({override});
     });


### PR DESCRIPTION
Before this, we were using `is_user_in_setting_group` which does not do the extra checks around a guest user's permissions (and in future, some other checks).
We introduced `initialize_and_override_current_user` in stream_data test to make it easier to set current_user.user_id.



<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
