### PR TITLE
compose: Prevent premature compose mode switch during message send.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -159,6 +159,8 @@ export function send_message_success(request, data) {
             compose_notifications.notify_unmute(muted_narrow, request.stream_id, request.topic);
         }
     }
+
+    do_post_send_tasks();
 }
 
 export let send_message = (request = create_message_object()) => {
@@ -318,7 +320,6 @@ export let finish = (scheduling_message = false) => {
     } else {
         send_message();
     }
-    do_post_send_tasks();
     return true;
 };
 
@@ -372,6 +373,7 @@ function schedule_message_to_custom_date() {
         });
         compose_banner.clear_message_sent_banners();
         compose_banner.append_compose_banner_to_banner_list($(new_row_html), $banner_container);
+        do_post_send_tasks();
     };
 
     const error = function (xhr) {


### PR DESCRIPTION
This commit fixes an issue where the compose box would switch from preview mode to edit mode prematurely while sending a message, especially noticeable under network throttling. The issue occurred because `do_post_send_tasks` was being called immediately after initiating the send operation, rather than after the message was confirmed to be sent.

Now, `do_post_send_tasks` is called only after the message is successfully sent or scheduled, ensuring that the compose box switches to edit mode only once it's empty.

Fixes #33245.

**Before**

https://github.com/user-attachments/assets/f584c48b-2d41-42d9-b55c-8445daf44404


**After**

https://github.com/user-attachments/assets/f93fa2da-6210-4981-92c7-bbbefc7df2f4


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
