### PR TITLE
Update display names for `role:members` and `role:everyone` group.

### DIFF
--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1072,12 +1072,12 @@ export const system_user_groups_list = [
     {
         name: "role:everyone",
         dropdown_option_name: $t({defaultMessage: "Admins, moderators, members and guests"}),
-        display_name: $t({defaultMessage: "Everyone"}),
+        display_name: $t({defaultMessage: "Everyone including guests"}),
     },
     {
         name: "role:members",
         dropdown_option_name: $t({defaultMessage: "Admins, moderators and members"}),
-        display_name: $t({defaultMessage: "Members"}),
+        display_name: $t({defaultMessage: "Everyone except guests"}),
     },
     {
         name: "role:fullmembers",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -1106,6 +1106,8 @@ export const system_user_groups_list = [
     },
 ];
 
+export const alternate_members_group_typeahead_matching_name = $t({defaultMessage: "Members"});
+
 export const user_topic_visibility_policy_values = {
     followed: {
         code: 3,

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -20,6 +20,7 @@ import type {PseudoMentionUser, User} from "./people.ts";
 import * as pm_conversations from "./pm_conversations.ts";
 import * as pygments_data from "./pygments_data.ts";
 import * as recent_senders from "./recent_senders.ts";
+import * as settings_config from "./settings_config.ts";
 import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
 import type {StreamPill, StreamPillData} from "./stream_pill.ts";
@@ -486,9 +487,15 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
     ];
     const email_okay_matches = [...email_results.word_boundary_matches];
 
-    const groups_results = typeahead.triage_raw(query, groups, (g) =>
-        user_groups.get_display_group_name(g.name),
-    );
+    const groups_results = typeahead.triage_raw_with_multiple_items(query, groups, (g) => {
+        if (g.name === "role:members") {
+            return [
+                user_groups.get_display_group_name(g.name),
+                settings_config.alternate_members_group_typeahead_matching_name,
+            ];
+        }
+        return [user_groups.get_display_group_name(g.name)];
+    });
     const groups_good_matches = [
         ...groups_results.exact_matches,
         ...groups_results.begins_with_case_sensitive_matches,
@@ -686,9 +693,15 @@ export let sort_group_setting_options = ({
         users_name_results.no_matches,
         (p) => p.user.email,
     );
-    const groups_results = typeahead.triage_raw(query, groups, (g) =>
-        user_groups.get_display_group_name(g.name),
-    );
+    const groups_results = typeahead.triage_raw_with_multiple_items(query, groups, (g) => {
+        if (g.name === "role:members") {
+            return [
+                user_groups.get_display_group_name(g.name),
+                settings_config.alternate_members_group_typeahead_matching_name,
+            ];
+        }
+        return [user_groups.get_display_group_name(g.name)];
+    });
 
     const exact_matches = sort_group_setting_items([
         ...groups_results.exact_matches,
@@ -890,6 +903,20 @@ export function query_matches_stream_name(query: string, stream: StreamPillData)
 }
 
 export function query_matches_group_name(query: string, user_group: UserGroupPillData): boolean {
+    if (user_group.name === "role:members") {
+        return (
+            typeahead.query_matches_string_in_order(
+                query,
+                user_groups.get_display_group_name(user_group.name),
+                "",
+            ) ||
+            typeahead.query_matches_string_in_order(
+                query,
+                settings_config.alternate_members_group_typeahead_matching_name,
+                "",
+            )
+        );
+    }
     return typeahead.query_matches_string_in_order(
         query,
         user_groups.get_display_group_name(user_group.name),

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -486,7 +486,9 @@ export let sort_recipients = <UserType extends UserOrMentionPillData | UserPillD
     ];
     const email_okay_matches = [...email_results.word_boundary_matches];
 
-    const groups_results = typeahead.triage_raw(query, groups, (g) => g.name);
+    const groups_results = typeahead.triage_raw(query, groups, (g) =>
+        user_groups.get_display_group_name(g.name),
+    );
     const groups_good_matches = [
         ...groups_results.exact_matches,
         ...groups_results.begins_with_case_sensitive_matches,

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -190,7 +190,13 @@
     }
 
     &.no-presence-circle {
-        margin-left: 0.7368em; /* 14px at 19px/1em */
+        /* 0.6875 * var(--base-font-size) is the width of presence
+        circle, 2px is right margin of the presence circle and
+        0.3571 * var(--base-font-size-px) is gap between the presence
+        circle and avatar. Cannot directly use 0.6875em or 0.3571em
+        since font-size for triple users icon is different from the
+        font size used to calculate presence circle width and gap. */
+        margin-left: calc((0.6875 + 0.3571) * var(--base-font-size-px) + 2px);
     }
 }
 

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -529,7 +529,7 @@ const admins = user_group_item({
 });
 
 const members = user_group_item({
-    name: "Members",
+    name: "role:members",
     id: 6,
     creator_id: null,
     date_created: 1596710000,
@@ -1659,7 +1659,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     );
     assert_typeahead_equals(
         "test @_**o",
-        mentions_with_silent_marker([othello_item, cordelia_item, admins], true),
+        mentions_with_silent_marker([othello_item, cordelia_item, admins, members], true),
     );
     assert_typeahead_equals(
         "test @*o",
@@ -1762,6 +1762,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 othello_item,
                 hamletcharacters,
                 call_center,
+                members,
             ],
             true,
         ),
@@ -1778,7 +1779,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     );
     assert_typeahead_equals(
         "test @_o",
-        mentions_with_silent_marker([othello_item, cordelia_item, admins], true),
+        mentions_with_silent_marker([othello_item, cordelia_item, admins, members], true),
     );
     assert_typeahead_equals("test @z", []);
     assert_typeahead_equals("test @_z", []);

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -171,8 +171,16 @@ const admins_group = {
 };
 const admins_group_item = user_group_item(admins_group);
 
+const members_group = {
+    id: 5,
+    name: "role:members",
+    description: "",
+    members: new Set([]),
+    is_system_group: true,
+};
+
 user_groups.initialize({
-    realm_user_groups: [bob_system_group, bob_group, second_bob_group, admins_group],
+    realm_user_groups: [bob_system_group, bob_group, second_bob_group, admins_group, members_group],
 });
 
 function test(label, f) {
@@ -1118,6 +1126,7 @@ test("sort_group_setting_options", ({override_rewire}) => {
         b_user_2.full_name,
         b_user_1.full_name,
         b_user_3.full_name,
+        members_group.name,
         admins_group.name,
         a_user.full_name,
         zman.full_name,
@@ -1130,6 +1139,7 @@ test("sort_group_setting_options", ({override_rewire}) => {
         b_user_2.full_name,
         b_user_1.full_name,
         b_user_3.full_name,
+        members_group.name,
         admins_group.name,
         a_user.full_name,
         zman.full_name,
@@ -1140,11 +1150,51 @@ test("sort_group_setting_options", ({override_rewire}) => {
         admins_group.name,
         a_user.full_name,
         bob_system_group.name,
+        members_group.name,
         bob_group.name,
         second_bob_group.name,
         b_user_2.full_name,
         b_user_1.full_name,
         b_user_3.full_name,
+    ]);
+
+    assert.deepEqual(get_group_setting_typeahead_result("me", second_bob_group), [
+        members_group.name,
+        bob_system_group.name,
+        admins_group.name,
+        bob_group.name,
+        second_bob_group.name,
+        b_user_2.full_name,
+        a_user.full_name,
+        b_user_1.full_name,
+        b_user_3.full_name,
+        zman.full_name,
+    ]);
+
+    assert.deepEqual(get_group_setting_typeahead_result("ever", second_bob_group), [
+        members_group.name,
+        bob_system_group.name,
+        admins_group.name,
+        bob_group.name,
+        second_bob_group.name,
+        b_user_2.full_name,
+        a_user.full_name,
+        b_user_1.full_name,
+        b_user_3.full_name,
+        zman.full_name,
+    ]);
+
+    assert.deepEqual(get_group_setting_typeahead_result("translated: members", second_bob_group), [
+        members_group.name,
+        bob_system_group.name,
+        admins_group.name,
+        bob_group.name,
+        second_bob_group.name,
+        b_user_2.full_name,
+        a_user.full_name,
+        b_user_1.full_name,
+        b_user_3.full_name,
+        zman.full_name,
     ]);
 
     override_rewire(bootstrap_typeahead, "MAX_ITEMS", 6);

--- a/web/tests/user_group_pill.test.cjs
+++ b/web/tests/user_group_pill.test.cjs
@@ -112,7 +112,7 @@ run_test("display_value", () => {
     );
     assert.deepEqual(
         user_group_pill.display_pill(everyone),
-        "translated HTML: translated: Everyone: 5 users",
+        "translated HTML: translated: Everyone including guests: 5 users",
     );
 });
 

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -637,7 +637,10 @@ run_test("get_display_group_name", () => {
     });
 
     assert.equal(user_groups.get_display_group_name(admins.name), "translated: Administrators");
-    assert.equal(user_groups.get_display_group_name(all.name), "translated: Everyone");
+    assert.equal(
+        user_groups.get_display_group_name(all.name),
+        "translated: Everyone including guests",
+    );
     assert.equal(user_groups.get_display_group_name(students.name), "Students");
 });
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to use display name when sorting recipients in typeahead.
- Second commit is to update display name for `role:everyone` and `role:members` groups.
- Third commit is to show "role:members" group in typeahead considering both "Members" and "Everyone except guests" names.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/channel/101-design/topic/suggesting.20.22Everyone.22.20for.20permissions.20that.20exclude.20guests.3F
 
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2025-02-18 17-18-34](https://github.com/user-attachments/assets/cd2a27cc-1f26-4fb0-8d94-bda69481cab2)
![Screenshot from 2025-02-18 21-37-57](https://github.com/user-attachments/assets/529da67d-4270-43da-a1e2-8c06b73765d8)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
