### PR TITLE
Empty string topic related bugs.

### DIFF
--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -27,6 +27,7 @@ export function notify_unmute(muted_narrow: string, stream_id: number, topic_nam
             muted_narrow,
             stream_id,
             topic_name,
+            is_empty_string_topic: topic_name === "",
             classname: compose_banner.CLASSNAMES.unmute_topic_notification,
             banner_type: "",
             button_text: $t({defaultMessage: "Unmute topic"}),

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -1602,7 +1602,7 @@ export function initialize(): void {
         }
         const stream_id = Number($elt.attr("data-stream-id"));
         const topic = $elt.attr("data-topic-name");
-        if (topic) {
+        if (topic !== undefined) {
             unread_ops.mark_topic_as_read(stream_id, topic);
         } else {
             unread_ops.mark_stream_as_read(stream_id);

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -311,7 +311,7 @@ export function stream_and_topic_exist_in_edit_history(
     }
 
     for (const edit_history_event of message.edit_history) {
-        if (!edit_history_event.prev_stream && !edit_history_event.prev_topic) {
+        if (!edit_history_event.prev_stream && edit_history_event.prev_topic === undefined) {
             // Message was not moved in this edit event.
             continue;
         }
@@ -324,7 +324,7 @@ export function stream_and_topic_exist_in_edit_history(
             message_dict.stream_id = edit_history_event.prev_stream;
         }
 
-        if (edit_history_event.prev_topic) {
+        if (edit_history_event.prev_topic !== undefined) {
             // This edit event changed the topic.  We expect the
             // following to be true due to the invariants of the edit
             // history data structure:

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -82,8 +82,9 @@ function retrieve_search_query_data(): SearchData {
             const stream_name = stream_data.get_valid_sub_by_id_string(stream_id).name;
             search_string_result.stream_query = stream_name;
         }
-        if (topic) {
-            search_string_result.topic_query = topic;
+        if (topic !== undefined) {
+            search_string_result.topic_query = util.get_final_topic_display_name(topic);
+            search_string_result.is_empty_string_topic = topic === "";
         }
     }
 

--- a/web/src/narrow_error.ts
+++ b/web/src/narrow_error.ts
@@ -10,6 +10,7 @@ export type SearchData = {
     has_stop_word: boolean;
     stream_query?: string;
     topic_query?: string;
+    is_empty_string_topic?: boolean;
 };
 
 export type NarrowBannerData = {

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -2,7 +2,7 @@
   class="main-view-banner {{banner_type}} {{classname}}"
   {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
   {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
-  {{#if topic_name}}data-topic-name="{{topic_name}}"{{/if}}>
+  {{#if (or topic_name is_empty_string_topic)}}data-topic-name="{{topic_name}}"{{/if}}>
     <div class="main-view-banner-elements-wrapper">
         {{#if banner_text}}
         <p class="banner_content">{{banner_text}}</p>

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -7,7 +7,11 @@
             <span>channel: {{search_data.stream_query}}</span>
             {{/if}}
             {{#if search_data.topic_query}}
+            {{#if search_data.is_empty_string_topic}}
+            <span>topic: <span class="empty-topic-display">{{search_data.topic_query}}</span></span>
+            {{else}}
             <span>topic: {{search_data.topic_query}}</span>
+            {{/if}}
             {{/if}}
             {{#each search_data.query_words}}
                 {{#if is_stop_word}}


### PR DESCRIPTION
Fixed the following bugs:
* Mark *test general chat* as read was buggy.
* Unmuting *test general chat* via unmute banner was broke.
* Buggy `stream_and_topic_exist_in_edit_history`
* Buggy empty feed notice when *test general chat* involved.


Before | After |
|-------|------|
<img width="956" alt="Screenshot 2025-02-18 at 10 10 16 PM" src="https://github.com/user-attachments/assets/28c96231-29bf-40ce-9720-bbb5ce633b39" /> |  <img width="796" alt="Screenshot 2025-02-18 at 10 11 04 PM" src="https://github.com/user-attachments/assets/0324a4e7-97a5-4374-b378-abee078c961f" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
