### PR TITLE
compose: Use em for sizing and position of stream typeahead icon.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1469,11 +1469,11 @@ textarea.new_message_textarea {
         color: var(--color-text-default);
 
         .stream-privacy-type-icon {
-            font-size: 13px;
-            width: 13px;
-            height: 13px;
+            font-size: 0.9285em; /* 13px at 14px em */
+            width: 1em;
+            height: 1em;
             position: relative;
-            top: 2px;
+            top: 0.1428em; /* 2px at 13px font-size at 14px em */
         }
     }
 


### PR DESCRIPTION
Before and after at 12px, 14px, 16px, 20px. The movement in the background is unrelated to this PR, I just forgot to do a full refresh before taking some of the screenshots. I can retake them if desired.

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-18 at 11 45 07](https://github.com/user-attachments/assets/c3b90ea5-e6f7-454a-99ef-94cb10424752) | ![Screen Shot 2025-02-18 at 11 41 53](https://github.com/user-attachments/assets/1bbf0140-e435-4eb2-8cd5-e205083343b1) |
| ![Screen Shot 2025-02-18 at 11 43 44](https://github.com/user-attachments/assets/74b9381a-46b6-469d-9ef2-435e078acccf) | ![Screen Shot 2025-02-18 at 11 41 40](https://github.com/user-attachments/assets/a68e3ef3-944f-4ff0-a13d-9f3100d91007) |
| ![Screen Shot 2025-02-18 at 11 43 37](https://github.com/user-attachments/assets/e2cab617-9152-450c-93a9-949d4c6a8ff5) | ![Screen Shot 2025-02-18 at 11 41 28](https://github.com/user-attachments/assets/046fd6f2-f7a5-448d-84d2-68de8bca503d) |
| ![Screen Shot 2025-02-18 at 11 43 27](https://github.com/user-attachments/assets/b0d18f11-ca09-4bd6-b7dc-3c54bb70faac) | ![Screen Shot 2025-02-18 at 11 41 04](https://github.com/user-attachments/assets/57884f2a-f602-4b3e-a150-16e208f6f63e) |