### PR TITLE
saved snippets: Use em for width, font-size, padding.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1627,10 +1627,10 @@ textarea.new_message_textarea {
 }
 
 .saved_snippets-dropdown-list-container {
-    width: 250px;
+    width: 17.8571em; /* 250px at 14px/em */
 
     .dropdown-list .dropdown-list-item-common-styles {
-        padding: 5px 10px;
+        padding: 0.3571em 0.7143em; /* 5px 10px at 14px/em */
         display: flex;
         flex-direction: column;
 
@@ -1641,7 +1641,7 @@ textarea.new_message_textarea {
         .dropdown-list-item-description {
             white-space: nowrap;
             font-weight: 400;
-            font-size: 13px;
+            font-size: 0.9283em; /* 13px at 14px/em */
             opacity: 0.8;
             padding: 0;
             text-overflow: ellipsis;


### PR DESCRIPTION
at 12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-18 at 15 03 49](https://github.com/user-attachments/assets/4e73eb3e-63b7-4941-9f3f-23e1d44e82c1) | ![Screen Shot 2025-02-18 at 15 02 48](https://github.com/user-attachments/assets/4173c10e-13af-44aa-bca5-3ce0175b828b) |
| ![Screen Shot 2025-02-18 at 15 03 58](https://github.com/user-attachments/assets/5ac3b0e4-93e3-4029-a704-be5da7f0d5b1) | ![Screen Shot 2025-02-18 at 15 02 32](https://github.com/user-attachments/assets/a3d68086-0a54-4c10-87b9-06f53e2ff207) |
| ![Screen Shot 2025-02-18 at 15 04 06](https://github.com/user-attachments/assets/3b424810-f559-4511-945f-552516883c12) | ![Screen Shot 2025-02-18 at 15 02 20](https://github.com/user-attachments/assets/cd34c554-50c7-46c7-87cf-aa356f1a3e77) |
| ![Screen Shot 2025-02-18 at 15 04 17](https://github.com/user-attachments/assets/e09da8bd-d3f5-4067-8242-1d13f22a7250) | ![Screen Shot 2025-02-18 at 15 02 07](https://github.com/user-attachments/assets/b8d0640f-ba4d-4c51-8c4a-a59c79021ad1) |
