### PR TITLE
compose: Use em for message-limit-indicator font size.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -592,7 +592,7 @@
 }
 
 .message-limit-indicator:not(:empty) {
-    font-size: 12px;
+    font-size: 0.8571em; /* 12px at 14px/em */
     color: var(--color-limit-indicator);
     width: max-content;
 


### PR DESCRIPTION
12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-18 at 15 57 27](https://github.com/user-attachments/assets/9f9bcd22-9bc3-4c9c-8727-19a067fb3f1c) | ![Screen Shot 2025-02-18 at 15 56 51](https://github.com/user-attachments/assets/def4d56a-90a2-469a-930f-ca66eca19c49) |
| ![Screen Shot 2025-02-18 at 15 57 33](https://github.com/user-attachments/assets/7789984b-51ac-41ea-bcfa-291023d54b4c) | ![Screen Shot 2025-02-18 at 15 56 41](https://github.com/user-attachments/assets/8244b493-cb09-42ed-9ad5-43881a5400ba) |
| ![Screen Shot 2025-02-18 at 15 57 39](https://github.com/user-attachments/assets/4017f319-1e5d-4c3c-9615-0a7d99dc10df) | ![Screen Shot 2025-02-18 at 15 56 33](https://github.com/user-attachments/assets/cc1af486-2825-4fad-bf0d-d744c70b2613) |
| ![Screen Shot 2025-02-18 at 15 57 47](https://github.com/user-attachments/assets/fc08e8b5-29f4-4795-968b-818b6f7924af) | ![Screen Shot 2025-02-18 at 15 56 16](https://github.com/user-attachments/assets/e67a4b61-2dfb-46d1-92d2-f59311a62385) |
