### PR TITLE
compose: Scale send button with font size.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1173,8 +1173,8 @@ textarea.new_message_textarea {
 
     .zulip-icon-send {
         display: block;
-        font-size: 17px;
-        line-height: 16px;
+        font-size: 1.2143em; /* 17px at 14px/em */
+        line-height: 0.9412; /* 16px at 17px/em */
     }
 
     .loader {


### PR DESCRIPTION
12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-18 at 16 02 48](https://github.com/user-attachments/assets/907df0d3-dd22-488f-a70b-f3edc52f1108) | ![Screen Shot 2025-02-20 at 12 41 48](https://github.com/user-attachments/assets/db6ed302-691a-4d44-8077-8daceaf136c7) |
| ![Screen Shot 2025-02-18 at 16 02 55](https://github.com/user-attachments/assets/f46abdb6-9a59-4418-9d0f-7dc0c5b1f4c8) | ![Screen Shot 2025-02-20 at 12 41 59](https://github.com/user-attachments/assets/13c4cedd-a236-41a8-b8ad-2adcfe34a489) |
| ![Screen Shot 2025-02-18 at 16 03 00](https://github.com/user-attachments/assets/a2beac42-bcb1-483c-bb3d-f413dda11fe9) | ![Screen Shot 2025-02-20 at 12 42 07](https://github.com/user-attachments/assets/565ae58e-d3b1-4979-ab4b-eb035363f482) |
| ![Screen Shot 2025-02-18 at 16 03 11](https://github.com/user-attachments/assets/365f3480-1c5b-4e3d-bcad-4da9e1fcde30) | ![Screen Shot 2025-02-20 at 12 42 27](https://github.com/user-attachments/assets/890e4da9-a6f7-4afc-9aa0-9628d4aa159e) |
