### PR TITLE
compose: Remove stale classname: compose_draft_button.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1383,15 +1383,6 @@ textarea.new_message_textarea {
             display: none;
         }
     }
-
-    .compose_draft_button {
-        font-size: 15px;
-        font-weight: 600;
-        font-family: "Source Sans 3 VF", sans-serif;
-        padding: 0 5px;
-        position: relative;
-        top: 0.7px;
-    }
 }
 
 .less-dense-mode {


### PR DESCRIPTION
This was removed in 609106e2d0958903c57761620293782aa5ec1d23 but the CSS was still there, unused.
