### PR TITLE
stream_settings: Fix height of right pane for two-row header.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -383,6 +383,10 @@ h4.user_group_setting_subsection_title {
                 When we redesign this area we should make this less brittle. */
                 height: calc(100% - 5.4em - 40px);
             }
+
+            #stream_settings {
+                height: calc(100% - 5em);
+            }
         }
     }
 }
@@ -419,6 +423,10 @@ h4.user_group_setting_subsection_title {
 
             .streams-list {
                 height: calc(100% - 5.4em - 40px);
+            }
+
+            #stream_settings {
+                height: calc(100% - 5em);
             }
         }
     }


### PR DESCRIPTION
I double checked things still look okay for the one-row header.

Screenshots for two-row header with right pane scrolled to the bottom, at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-18 at 18 00 28](https://github.com/user-attachments/assets/75488bd7-22a3-45f2-a4e8-2d4a8e0ae505) | ![Screen Shot 2025-02-18 at 18 00 41](https://github.com/user-attachments/assets/9e6bce23-7ff0-49fb-a30e-3c45fe84d259) |
| ![Screen Shot 2025-02-18 at 18 01 34](https://github.com/user-attachments/assets/6e867a1a-9997-4d8b-b288-9dd8d182cdbd) | ![Screen Shot 2025-02-18 at 18 01 43](https://github.com/user-attachments/assets/c3a9789e-0064-4566-b869-aa80e019f110) |
| ![Screen Shot 2025-02-18 at 18 02 36](https://github.com/user-attachments/assets/f47e5609-1809-4944-96e1-c16825d94eaa) | ![Screen Shot 2025-02-18 at 18 02 46](https://github.com/user-attachments/assets/6495141d-f3e8-43e0-987c-50a319f7e753) |
| ![Screen Shot 2025-02-18 at 18 03 13](https://github.com/user-attachments/assets/429fd87a-78f5-4c3e-8ef8-35bcada13343) | ![Screen Shot 2025-02-18 at 18 03 37](https://github.com/user-attachments/assets/31867cf6-a27f-458a-b6a8-56188aa3f15f) |
