### PR TITLE
composebox_typeahead: Remove extra comma in user mentions.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -163,6 +163,7 @@ export let render_person = (person: UserPillData | UserOrMentionPillData): strin
         ),
         pronouns,
         secondary: person.user.delivery_email,
+        show_comma: person.user.delivery_email !== null,
     };
 
     return render_typeahead_item(typeahead_arguments);

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -48,7 +48,7 @@
     {{> status_emoji status_emoji_info}}
     {{~/if}}
     {{~#if has_pronouns}}
-        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
+        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html show_comma)}},{{/if}}</span>
     {{~/if}}
     {{~#if has_secondary_html}}
     <span class="autocomplete_secondary rendered_markdown single-line-rendered-markdown">{{rendered_markdown secondary_html}}</span>


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
|![image](https://github.com/user-attachments/assets/80cdb72d-e91c-40b0-8f70-d1b73cd1e187)   | ![image](https://github.com/user-attachments/assets/c0f978aa-3880-4036-b9cd-1f303ee15ef0) |

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20extraneous.20comma.20after.20pronouns/with/2088251