### PR TITLE
modal: Scale channel email widget and email header with font size.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -385,6 +385,10 @@
     opacity: 0.7;
 }
 
+#sender_channel_email_address_widget {
+    width: 12.875em; /* 206px at 16px/em */
+}
+
 #copy_email_address_modal {
     width: 800px;
 
@@ -397,7 +401,7 @@
     }
 
     .stream-email-header {
-        font-size: 18px;
+        font-size: 1.125em; /* 18px at 16px/em */
     }
 }
 


### PR DESCRIPTION
This commit changes the width of the dropdown and also the text above the email.

12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-18 at 18 12 34](https://github.com/user-attachments/assets/09358d06-302a-481e-9059-e1c803f22c7d) | ![Screen Shot 2025-02-18 at 18 08 05](https://github.com/user-attachments/assets/515260ea-e619-4806-b7d7-beba811f6d9c) |
| ![Screen Shot 2025-02-18 at 18 12 14](https://github.com/user-attachments/assets/ebee8e7d-a173-4495-94a6-69a693eba047) | ![Screen Shot 2025-02-18 at 18 08 24](https://github.com/user-attachments/assets/e79e2069-6d23-45a5-ae5f-ab06760a7465) |
| ![Screen Shot 2025-02-18 at 18 11 55](https://github.com/user-attachments/assets/e9636ba0-0c4b-449b-8351-a8f992008cff) | ![Screen Shot 2025-02-18 at 18 08 37](https://github.com/user-attachments/assets/bd7e312f-40de-4fa0-89ed-54d354aff2bd) |
| ![Screen Shot 2025-02-18 at 18 11 28](https://github.com/user-attachments/assets/1ebc2b96-bd85-48f9-a263-ec2555b84449) | ![Screen Shot 2025-02-18 at 18 08 55](https://github.com/user-attachments/assets/a16eeb3d-2c0e-4097-9060-c7393de1c1fb) |
