### PR TITLE
desktop_notification: Add support for empty string topic.

### DIFF
--- a/web/src/message_notifications.ts
+++ b/web/src/message_notifications.ts
@@ -156,7 +156,8 @@ function get_notification_title(
             return title_prefix + " " + title_suffix;
         case "stream": {
             const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
-            title_suffix = " (#" + stream_name + " > " + message.topic + ")";
+            const topic_display_name = util.get_final_topic_display_name(message.topic);
+            title_suffix = " (#" + stream_name + " > " + topic_display_name + ")";
             break;
         }
     }


### PR DESCRIPTION
This PR adds support to display `realm_empty_topic_display_name` value for empty string topic in the desktop notification.

<img width="363" alt="Screenshot 2025-02-19 at 10 43 03 AM" src="https://github.com/user-attachments/assets/57e0bc26-fad6-44cd-8a97-4bff74c15fc7" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
