### PR TITLE
file: Automatically convert large pasted text into a .txt file upload.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -574,7 +574,9 @@ export function initialize_everything(state_data) {
     add_stream_options_popover.initialize();
     click_handlers.initialize();
     scheduled_messages_overlay_ui.initialize();
-    compose_paste.initialize();
+    compose_paste.initialize({
+        upload_pasted_file: upload.upload_pasted_file,
+    });
     overlays.initialize();
     invite.initialize();
     message_view_header.initialize();

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -274,6 +274,20 @@ export function rewire_upload_files(value: typeof upload_files): void {
     upload_files = value;
 }
 
+export function upload_pasted_file(pasted_file: File): void {
+    if ($("textarea").hasClass("message_edit_content")) {
+        const row = rows.get_message_id($("textarea").closest(".message_edit_form")[0]!);
+        const edit_uploader = upload_objects_by_message_edit_row.get(row);
+
+        if (edit_uploader) {
+            upload_files(edit_uploader, edit_config(row), [pasted_file]);
+            return;
+        }
+    }
+
+    upload_files(compose_upload_object, compose_config, [pasted_file]);
+}
+
 // Borrowed from tus-js-client code at
 // https://github.com/tus/tus-js-client/blob/ca63ba254ea8766438b9d422f6f94284911f1fa5/lib/index.d.ts#L79
 // The library does not export this type, hence requiring a copy here.


### PR DESCRIPTION
When a user pastes a large amount of text into the compose box, it will now be automatically converted into a .txt file upload named 'pasted.txt'. This ensures that messages do not exceed the length limit.

Specifically, if the pasted text exceeds 1000 characters and would cause the message to surpass the allowed limit (e.g., a 10K character limit), it is converted into a file. For instance, if there are already 6000 characters in the compose box, a new 5000-character paste will be uploaded as a file instead of being added as text.

Fixes #33107.

**Screenshots of the Changes: Pasted character (Uploading) > Uploaded > Changes see in the UI**


<details>
<summary>Pre-existing text in the compose box, then the user paste text that is converted to a text file: </summary>
 <img width="1123" alt="Screenshot 2025-05-01 at 10 34 19 AM" src="https://github.com/user-attachments/assets/c34778d1-e93d-4795-b6e7-1bce1f6bfbdc" />
<img width="1123" alt="Screenshot 2025-05-01 at 10 35 06 AM" src="https://github.com/user-attachments/assets/fb458092-9f33-47aa-a5a7-e7d1cbbbcbc2" />
<img width="1123" alt="Screenshot 2025-05-01 at 10 34 37 AM" src="https://github.com/user-attachments/assets/dd33b6d1-29ac-4c16-a3d0-f4013fd015bf" />
</details>

<details>
<summary>When user directly paste text that is larger than 10,000 character: </summary>
<img width="1123" alt="Screenshot 2025-05-01 at 10 37 53 AM" src="https://github.com/user-attachments/assets/1f853194-6584-443a-816c-d9bd677b83cf" />
<img width="1123" alt="Screenshot 2025-05-01 at 10 38 04 AM" src="https://github.com/user-attachments/assets/f95aa2fc-c039-42f0-861d-3ea2d1b64b4a" />
<img width="1123" alt="Screenshot 2025-05-01 at 10 38 11 AM" src="https://github.com/user-attachments/assets/20cb0dfe-cb9a-4226-95c2-6037628da927" />
</details>



<details>
<summary>When a user is almost around 10,000 characters but ends up pasting only 500 or an amount below the MINIMUM_PASTE_SIZE_FOR_FILE_TREATMENT threshold of 2,000 characters.</summary>
<img width="1123" alt="Screenshot 2025-05-01 at 10 41 46 AM" src="https://github.com/user-attachments/assets/85a322f8-0337-4e29-b4ca-e83b62b8055a" />
<img width="1123" alt="Screenshot 2025-05-01 at 10 42 04 AM" src="https://github.com/user-attachments/assets/557a5ff1-eb1e-40ef-a69a-4b83ba0ce5c5" />
</details>

<details>
<summary>Upload Banner, Upload text in compose, File link in the message Feed and File preview, Edit text area upload and removal</summary>
<img width="832" alt="Screenshot 2025-05-01 at 2 08 34 PM" src="https://github.com/user-attachments/assets/de91fb4e-018d-40aa-befa-915e09fb554e" />
<img width="829" alt="Screenshot 2025-05-01 at 2 09 04 PM" src="https://github.com/user-attachments/assets/9183fe09-baca-4304-8ccb-a7df8a284317" />
<img width="832" alt="Screenshot 2025-05-01 at 2 09 33 PM" src="https://github.com/user-attachments/assets/9bd4287d-7b21-41fe-a968-b3afd7a07bc2" />
<img width="1440" alt="Screenshot 2025-05-01 at 2 11 53 PM" src="https://github.com/user-attachments/assets/f9f8781c-c4f5-49dd-8083-e0858f414ebb" />
<img width="641" alt="Screenshot 2025-05-07 at 8 23 09 PM" src="https://github.com/user-attachments/assets/6bdded28-dbb1-4ab9-81b7-2f0374613427" />
<img width="488" alt="Screenshot 2025-05-07 at 8 23 44 PM" src="https://github.com/user-attachments/assets/b193052c-077d-4236-9912-5113df4ea668" />
</details>



**Pre-existing character in the composition combined with a pasted character.**

https://github.com/user-attachments/assets/bd414608-0d97-4c0b-99a6-f6c60a2436d3



**Directly inserting a lengthy character sequence.**


https://github.com/user-attachments/assets/0ce2b993-9685-4238-aab4-3fd32532e093


**Trying to paste message less than 2000 (MINIMUM_PASTE_SIZE_FOR_FILE_TREATMENT)..**

https://github.com/user-attachments/assets/9b7ac215-9efc-42bd-8582-79147d2f226b







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
