### PR TITLE
typeahead: Use null check for user comma insertion and comment for removing margin for status emoji.

### DIFF
--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -114,7 +114,7 @@ export let render_typeahead_item = (args: {
 }): string => {
     const has_image = args.img_src !== undefined;
     const has_status = args.status_emoji_info !== undefined;
-    const has_secondary = args.secondary !== undefined;
+    const has_secondary = args.secondary !== undefined && args.secondary !== null;
     const has_secondary_html = args.secondary_html !== undefined;
     const has_pronouns = args.pronouns !== undefined;
     return render_typeahead_list_item({
@@ -163,7 +163,6 @@ export let render_person = (person: UserPillData | UserOrMentionPillData): strin
         ),
         pronouns,
         secondary: person.user.delivery_email,
-        show_comma: person.user.delivery_email !== null,
     };
 
     return render_typeahead_item(typeahead_arguments);

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -199,6 +199,12 @@
         align-self: center;
     }
 
+    /*
+    Negates the extra 3px left margin from `.status-emoji` in zulip.css, which,
+    combined with .typeahead-text-container's `gap`, created unintended spacing.
+    The typeahead's spacing is now managed only by `gap` in
+    .typeahead-text-container.
+    */
     .status-emoji {
         margin-left: 0;
     }

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -48,7 +48,7 @@
     {{> status_emoji status_emoji_info}}
     {{~/if}}
     {{~#if has_pronouns}}
-        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html show_comma)}},{{/if}}</span>
+        <span class="pronouns">{{pronouns}}{{#if (or has_secondary_html has_secondary)}},{{/if}}</span>
     {{~/if}}
     {{~#if has_secondary_html}}
     <span class="autocomplete_secondary rendered_markdown single-line-rendered-markdown">{{rendered_markdown secondary_html}}</span>


### PR DESCRIPTION
Commit 1:
Use null check for user comma insertion.
As per https://github.com/zulip/zulip/pull/33536#discussion_r1960991985 which seems like a better fix than the
current implementation to include/exclude comma after pronouns.

Commit 2:
Adds a comment explaining the reason for setting left-margin to 0 for status-emoji typeahead item([CZO context](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Removing.20extra.20space.20for.20status.20emoji.20in.20typeahead.2E/near/2095812))

