### PR TITLE
message_row: Mock available icons to prevent post-echo reflow.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -912,6 +912,14 @@ of the base style defined for a read-only textarea in dark mode. */
     cursor: default;
 }
 
+/* Placehold the control buttons, unless there's a failure. */
+.locally-echoed
+    .messagebox:hover
+    .message_controls
+    .message_control_button:not(.failed_message_action) {
+    visibility: hidden;
+}
+
 .recipient_row {
     /* See https://stackoverflow.com/questions/2717480/css-selector-for-first-element-with-class/8539107#8539107
        for details on how this works */

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -41,6 +41,8 @@
     {{#if msg/locally_echoed}}
         {{#if msg/failed_request}}
             {{> message_controls_failed_msg}}
+            {{ else }}
+            {{> message_controls .}}
         {{/if}}
     {{else}}
         {{> message_controls .}}


### PR DESCRIPTION
This PR is a follow-up to changes merged from #33447, which caused a readily reproducible regression where message content would reflow after leaving the locally echoed state.

Here the base message-body template includes the same `message_controls.hbs` partial when locally echoed. This appears to avoid any ill side-effects, as `echo.ts` has two functions--`show_message_failed()` and `show_failed_message_success()`--that handle message failure. When messages are sent successfully, the template re-renders with the correct (and visible on hover) buttons placed as expected.

The useful thing about this approach is that there is no need to keep a mock of the buttons in sync with those actually used. A complicated but effective CSS selector also prevents prematurely revealing the action buttons, or their tooltips, on hover.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/messages.20reflowing.20after.20local.20echo/near/2090412)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>