### PR TITLE
help: Document "general chat" topic.

### DIFF
--- a/help/general-chat-topic.md
+++ b/help/general-chat-topic.md
@@ -1,0 +1,52 @@
+# “*General chat*” topic
+
+Zulip's [topics](/help/introduction-to-topics) help you keep conversations
+organized, but you may sometimes want to send a message without a topic. For
+example, this could be appropriate for social chatter, or for a one-off request
+(e.g., “Is anyone around to help me out?”).
+
+{!general-chat-intro.md!}
+
+The “*general chat*” topic can be used only if [allowed](/help/require-topics)
+by your organization's administrators.
+
+## Sending a message to the “*general chat*” topic
+
+You can [reply](/help/replying-to-messages) to a message in the “*general chat*”
+topic, or follow the instructions below.
+
+{start_tabs}
+
+{tab|via-left-sidebar}
+
+1. Click the **plus** (<i class="zulip-icon zulip-icon-square-plus"></i>) button next
+   to the name of the channel where you'd like to send a message.
+
+{!compose-and-send-message.md!}
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>C</kbd> keyboard shortcut to send a message to
+    the channel you're viewing.
+
+{tab|via-compose-box}
+
+1. Click the **Start new conversation** button at the bottom of the app.
+
+1. _(optional)_ You can change the destination channel for your message using
+   the dropdown in the top left of the compose box. Start typing to filter
+   channels.
+
+{!compose-and-send-message.md!}
+
+!!! keyboard_tip ""
+
+    You can also use the <kbd>C</kbd> keyboard shortcut to send a message to
+    the channel you're viewing.
+
+{end_tabs}
+
+## Related articles
+
+- [Introduction to topics](/help/introduction-to-topics)
+- [Require topics in channel messages](/help/require-topics)

--- a/help/include/general-chat-intro.md
+++ b/help/include/general-chat-intro.md
@@ -1,0 +1,3 @@
+Messages sent without a topic go to the special “*general chat*” topic. The name
+of this topic is shown in italics, and is translated into [your
+language](/help/change-your-language).

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -150,6 +150,7 @@
 * [Rename a topic](/help/rename-a-topic)
 * [Resolve a topic](/help/resolve-a-topic)
 * [Move content to another topic](/help/move-content-to-another-topic)
+* [“*General chat*” topic](/help/general-chat-topic)
 * [Delete a topic](/help/delete-a-topic)
 
 ## Notifications

--- a/help/require-topics.md
+++ b/help/require-topics.md
@@ -1,8 +1,9 @@
 # Require topics in channel messages
 
-If a user sends a message without a topic, the message's topic is displayed as
-**(no topic)**. Administrators can configure whether channel messages must have a
-specified topic.
+{!general-chat-intro.md!}
+
+Administrators can require topics in channel messages to disable the “*general
+chat*” topic.
 
 ## Require topics in channel messages
 
@@ -21,3 +22,4 @@ specified topic.
 ## Related articles
 
 * [Introduction to topics](/help/introduction-to-topics)
+* [“*General chat*” topic](/help/general-chat-topic)


### PR DESCRIPTION
## Notes
- The italics in the heading end up in the tab name. Would be better if they didn't, I think, but it's not terrible.
![Screenshot 2025-02-19 at 15 32 43@2x](https://github.com/user-attachments/assets/e978da4f-ff9e-4790-9c88-5a5e32b8a690)
- I didn't change any of the intro to topics documentation. Possible follow-up.
- Not worried about making `/help/require-topics` perfect, since it'll likely get rewritten with #33549.

## Screenshots

<details>
<summary>
New "_general chat_" help page
</summary>

![Screenshot 2025-02-19 at 15 37 37@2x](https://github.com/user-attachments/assets/30fb7277-2365-44e6-89b9-d81995316fc8)

---
![Screenshot 2025-02-19 at 15 37 14@2x](https://github.com/user-attachments/assets/7d0cf9b7-bec5-42b7-a4e9-f80b97f6e542)
---
![Screenshot 2025-02-19 at 15 37 19@2x](https://github.com/user-attachments/assets/b2500247-803b-45e2-b48c-3864a47f5371)

</details>

<details>
<summary>
Updated version of required topics page
</summary>

https://zulip.com/help/require-topics

![Screenshot 2025-02-19 at 15 38 20@2x](https://github.com/user-attachments/assets/41cb9b5e-5ba1-4a27-a7f5-7fdc544d5ef5)

</details>