### PR TITLE
compose: Add banner when topic is moved and recipient is updated.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -37,6 +37,7 @@ export const CLASSNAMES = {
     ...MESSAGE_SENT_CLASSNAMES,
     non_interleaved_view_messages_fading: "non_interleaved_view_messages_fading",
     interleaved_view_messages_fading: "interleaved_view_messages_fading",
+    topic_is_moved: "topic_is_moved",
     // unmute topic notifications are styled like warnings but have distinct behaviour
     unmute_topic_notification: "unmute_topic_notification warning-style",
     // warnings

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -114,6 +114,10 @@ export function update_on_recipient_change(): void {
     drafts.update_compose_draft_count();
     check_posting_policy_for_compose_box();
     compose_validate.validate_and_update_send_button_status();
+
+    // Clear the topic moved banner when the recipient
+    // is changed or compose box is closed.
+    compose_validate.clear_topic_moved_info();
 }
 
 export let check_posting_policy_for_compose_box = (): void => {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -18,6 +18,7 @@ let preview_render_count = 0;
 // the narrow and the user should still be able to see the banner once after
 // performing these actions
 let recipient_viewed_topic_resolved_banner = false;
+let recipient_viewed_topic_moved_banner = false;
 let recipient_guest_ids_for_dm_warning: number[] = [];
 
 export function set_recipient_edited_manually(flag: boolean): void {
@@ -58,6 +59,14 @@ export function set_recipient_viewed_topic_resolved_banner(flag: boolean): void 
 
 export function has_recipient_viewed_topic_resolved_banner(): boolean {
     return recipient_viewed_topic_resolved_banner;
+}
+
+export function set_recipient_viewed_topic_moved_banner(flag: boolean): void {
+    recipient_viewed_topic_moved_banner = flag;
+}
+
+export function has_recipient_viewed_topic_moved_banner(): boolean {
+    return recipient_viewed_topic_moved_banner;
 }
 
 export function set_recipient_guest_ids_for_dm_warning(guest_ids: number[]): void {

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -549,6 +549,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
                 }
 
                 compose_validate.warn_if_topic_resolved(true);
+                compose_validate.inform_if_topic_is_moved(orig_topic, old_stream_id);
                 compose_fade.set_focused_recipient("stream");
             }
 

--- a/web/templates/compose_banner/topic_moved_banner.hbs
+++ b/web/templates/compose_banner/topic_moved_banner.hbs
@@ -1,0 +1,12 @@
+{{#> compose_banner . }}
+    <p class="banner_message">
+        {{#tr}}
+            The topic you were composing to (<z-link></z-link>) was moved, and the destination for your message has been updated to its new location.
+            {{#*inline "z-link"~}}
+                <a class="above_compose_banner_action_link" href="{{narrow_url}}">
+                    {{~> ../inline_topic_link_label channel_name=old_stream topic_display_name=orig_topic is_empty_string_topic=is_empty_string_topic~}}
+                </a>
+            {{~/inline}}
+        {{/tr}}
+    </p>
+{{/compose_banner}}

--- a/web/templates/inline_topic_link_label.hbs
+++ b/web/templates/inline_topic_link_label.hbs
@@ -1,0 +1,13 @@
+{{#if is_empty_string_topic}}
+<span class="stream-topic">
+    {{~!-- squash whitespace --~}}
+    #{{channel_name}} &gt; <em class="empty-topic-display">{{t "general chat"}}</em>
+    {{~!-- squash whitespace --~}}
+</span>
+{{~else}}
+<span class="stream-topic">
+    {{~!-- squash whitespace --~}}
+    #{{channel_name}} &gt; {{topic_display_name}}
+    {{~!-- squash whitespace --~}}
+</span>
+{{~/if}}


### PR DESCRIPTION
This PR adds the INFO compose banner for new channel/topic when the recipient is updated when topic is moved.

banner details:
- Text: The topic you were composing to ([# channel > topic](https://github.com/zulip/zulip/issues/33445)) was moved, and the destination for your message has been updated to its new location.
- Color: blue
- Buttons: just an `x`

fixes: #33445

### Screenshots

|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Dark Theme     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/1849b339-fde4-4f12-bd56-11be3e68f4be)    |
| Light Theme  | ![dm](https://github.com/user-attachments/assets/81a5d987-216a-416e-8860-d8b9ab27a644) |
| Empty Topic  | ![dm](https://github.com/user-attachments/assets/3f504800-8bea-45e7-a31b-5f0102d4cc0a) |

<details>
<summary>videos</summary>

- only topic changed




https://github.com/user-attachments/assets/6988fa39-fb6e-4e3d-8c48-74b04cda1c98



- stream also changed



https://github.com/user-attachments/assets/5e03c8d1-115d-4b55-b6f9-87007ee6cd95





</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
