### PR TITLE
bots: Fix email already in use error message.

### DIFF
--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -251,7 +251,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             short_name="hambot",
         )
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_error(result, "Username already in use")
+        self.assert_json_error(result, "Email 'hambot-bot@zulip.testserver' already in use")
 
         dup_full_name = "The Bot of Hamlet"
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -603,7 +603,7 @@ def add_bot_backend(
         raise JsonableError(_("Bad name or username"))
     try:
         get_user_by_delivery_email(email, user_profile.realm)
-        raise JsonableError(_("Username already in use"))
+        raise JsonableError(_("Email '{email}' already in use").format(email=email))
     except UserProfile.DoesNotExist:
         pass
 


### PR DESCRIPTION
Currently, when trying to create a new bot with a used username, the error message is "Username already in use" which is misleading. This fixes the error message to be correct and consistent with the same error message for the same check in `create_user_backend`.

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/e6b4cfb8-42d5-451e-993b-4022cc0ddddf)| ![image](https://github.com/user-attachments/assets/d8b20b1b-0589-4d3c-a36e-0f35c0e5addc) | 

<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/Misleading.20error.20popup.20when.20creating.20bot.2E/with/2096190)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
