### PR TITLE
move_topic_to_stream: Limit topic name length in modal.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -336,6 +336,7 @@ export async function build_move_topic_to_stream_popover(
         disable_topic_input?: boolean;
         message_placement?: "first" | "intermediate" | "last";
         stream: sub_store.StreamSubscription | undefined;
+        max_topic_length: number;
     } = {
         topic_name,
         empty_string_topic_display_name,
@@ -346,6 +347,7 @@ export async function build_move_topic_to_stream_popover(
         notify_old_thread: message_edit.notify_old_thread_default,
         from_message_actions_popover: message !== undefined,
         only_topic_edit,
+        max_topic_length: realm.max_topic_length,
     };
 
     // When the modal is opened for moving the whole topic from left sidebar,

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -8,7 +8,7 @@
         {{/unless}}
         <div class="input-group">
             <label for="move-topic-new-topic-name" class="modal-field-label">New topic</label>
-            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input {{#unless realm_mandatory_topics}}empty-topic-placeholder-display{{/unless}}" autocomplete="off" {{#unless realm_mandatory_topics}}placeholder="{{empty_string_topic_display_name}}"{{/unless}} value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input {{#unless realm_mandatory_topics}}empty-topic-placeholder-display{{/unless}}" autocomplete="off" {{#unless realm_mandatory_topics}}placeholder="{{empty_string_topic_display_name}}"{{/unless}} value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} maxlength="{{ max_topic_length }}"/>
         </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />


### PR DESCRIPTION
Fixes:
https://chat.zulip.org/#narrow/channel/9-issues/topic/no.20topic.20length.20limit.20in.20move.20modal/with/2097474.

