### PR TITLE
topic_summaries: Ensure modal takes rendered_markdown class.

### DIFF
--- a/web/src/message_summary.ts
+++ b/web/src/message_summary.ts
@@ -62,6 +62,7 @@ export function get_narrow_summary(channel_id: number, topic_name: string): void
                         const summary_html = render_topic_summary({
                             summary_markdown,
                         });
+                        $("#topic-summary-modal .modal__content").addClass("rendered_markdown");
                         $("#topic-summary-modal .modal__content").html(summary_html);
                         rendered_markdown.update_elements(
                             $("#topic-summary-modal .modal__content"),


### PR DESCRIPTION
As we are rendering markdown in topic summaries, this adds the `.rendered_markdown` class to the summary modal to gain the benefits of the rendered-markdown CSS, including especially the thumbnailed treatment of images.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![llm-modal-before](https://github.com/user-attachments/assets/12a7cd77-a784-4585-afdd-016744d421fa) | ![llm-modal-after](https://github.com/user-attachments/assets/6d67fc50-e4fb-4fa0-b1c3-5c8536810769) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>