### PR TITLE
subscriptions: Scale copy email icon with font size.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -505,6 +505,7 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
         post_render: generate_email_modal_post_render,
         on_click: generate_email_address,
         close_on_submit: false,
+        always_visible_scrollbar: true,
     });
     $("#show-sender").prop("checked", true);
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -26,7 +26,7 @@
     align-items: center;
     font-family: "Source Code Pro", monospace;
     padding: 10px;
-    font-size: 0.85rem;
+    font-size: 0.85em; /* 13.6px at 16px/em (previously 0.85rem) */
     background-color: hsl(0deg 0% 98%);
     border: 1px solid hsl(0deg 0% 87%);
     border-radius: 4px;
@@ -40,8 +40,8 @@
     white-space: normal;
 }
 
-.copy-email-address {
-    font-size: 16px;
+.stream-email .copy-email-address {
+    font-size: 1.1765em; /* 16px at 13.6px/em */
 }
 
 .sub_setting_checkbox {


### PR DESCRIPTION
Built off of #33538 (which is the first commit here) -- the before images are from that PR and the after images are after this PR is layered on top of that.

At 20px it scrolls in this screenshot, but on most screens it wouldn't scroll, the screenshot screen height is just short. Though I am wondering if it makes sense to make the email text smaller so it's less likely to overflow at larger font-sizes.


| before | after | 
| --- | --- |
| ![Screen Shot 2025-02-18 at 18 08 05](https://github.com/user-attachments/assets/515260ea-e619-4806-b7d7-beba811f6d9c) | ![Screen Shot 2025-02-20 at 12 54 20](https://github.com/user-attachments/assets/56bb9ca7-91e3-4513-90d5-6d2b08c3e75b) |
| ![Screen Shot 2025-02-18 at 18 08 24](https://github.com/user-attachments/assets/e79e2069-6d23-45a5-ae5f-ab06760a7465) | ![Screen Shot 2025-02-20 at 12 54 29](https://github.com/user-attachments/assets/0b73fb3d-7b38-4f1f-b21a-f95f4d582919) |
| ![Screen Shot 2025-02-18 at 18 08 37](https://github.com/user-attachments/assets/bd7e312f-40de-4fa0-89ed-54d354aff2bd) | ![Screen Shot 2025-02-20 at 12 54 37](https://github.com/user-attachments/assets/e7c48b3a-6d47-4772-9445-35b1e6ae6412) |
| ![Screen Shot 2025-02-18 at 18 08 55](https://github.com/user-attachments/assets/a16eeb3d-2c0e-4097-9060-c7393de1c1fb) | ![Screen Shot 2025-02-20 at 12 54 56](https://github.com/user-attachments/assets/c11c9fec-b5a1-4452-a186-8e79447dded7) |

