### PR TITLE
settings modal: Fix a few info density related issues

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -883,13 +883,12 @@ input.settings_text_input {
     .save-discard-widget-button {
         border-radius: 5px;
         border: 1px solid hsl(0deg 0% 80%);
-        padding: 0.2143em 1em 0.2857em 0.7857em; /* 3px 14px 4px 11px at 14px/em */
         text-decoration: none;
         color: hsl(0deg 0% 47%);
-        min-width: 80px;
-        /* Limit the height of the button */
-        line-height: 1.2;
-        vertical-align: text-bottom;
+        min-width: 5.7142em; /* 80px at 14px/em */
+        display: flex;
+        align-items: center;
+        height: 1.8429em; /* 25.8px at 14px/em */
 
         &:hover,
         &:focus {
@@ -945,7 +944,7 @@ input.settings_text_input {
         .save-discard-widget-button-icon {
             vertical-align: middle;
             margin-right: 3px;
-            font-size: 15px;
+            font-size: 1.0714em; /* 15px at 14px/em */
             font-weight: 400;
         }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -882,8 +882,9 @@ input.settings_text_input {
 #stream_settings .save-button-controls,
 #settings_page .save-button-controls,
 #user_group_settings .save-button-controls {
-    display: inline;
-    margin: 4px 8px;
+    display: flex;
+    margin: 0.2857em 0.5714em; /* 4px 8px at 14px/em */
+    align-items: center;
 
     &.hide {
         display: none;
@@ -951,15 +952,11 @@ input.settings_text_input {
         }
 
         .save-discard-widget-button-icon {
-            vertical-align: middle;
             margin-right: 3px;
             font-size: 1.0714em; /* 15px at 14px/em */
             font-weight: 400;
-        }
-
-        .save-discard-widget-button-text {
-            vertical-align: middle;
-            line-height: 1;
+            display: flex;
+            align-items: center;
         }
     }
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -870,11 +870,20 @@ input.settings_text_input {
     }
 }
 
+#stream_settings,
+#settings_page,
+#user_group_settings {
+    .subsection-header {
+        display: flex;
+        flex-wrap: wrap;
+    }
+}
+
 #stream_settings .save-button-controls,
 #settings_page .save-button-controls,
 #user_group_settings .save-button-controls {
     display: inline;
-    margin-left: 15px;
+    margin: 4px 8px;
 
     &.hide {
         display: none;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -507,6 +507,7 @@ input[type="checkbox"] {
         display: flex;
         align-items: center;
         cursor: pointer;
+        flex-wrap: wrap;
 
         .stream_setting_subsection_title {
             margin: 4px 8px;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -343,8 +343,12 @@ h4.user_group_setting_subsection_title {
    breakpoint that collapses the left pane, but still narrow
    enough that the sort buttons need a second row to be visible
    without overlapping other UI. Note that for 16px and larger
-   font sizes, we always show two rows of buttons. */
-@container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) {
+   font sizes, we always show two rows of buttons.
+
+   We also show two rows of buttons on particularly narrow
+   screens where the full overlay doesn't have enough space
+   for all the buttons. */
+@container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) or (width <= 36em) {
     @container subscriptions (width < calc(80em + 80px)) {
         #subscription_overlay .subscriptions-container {
             .left {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -346,47 +346,48 @@ h4.user_group_setting_subsection_title {
    font sizes, we always show two rows of buttons.
 
    We also show two rows of buttons on particularly narrow
-   screens where the full overlay doesn't have enough space
-   for all the buttons. */
-@container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) or (width <= 36em) {
-    @container subscriptions (width < calc(80em + 80px)) {
-        #subscription_overlay .subscriptions-container {
-            .left {
-                .list-toggler-container {
-                    height: 5em;
-                    justify-content: end;
-                    flex-wrap: wrap;
-                }
-
-                .tab-switcher {
-                    margin-right: 0;
-                }
-
-                .tab-switcher:first-child {
-                    /* This forces the other buttons to the next row */
-                    width: 100%;
-                    display: flex;
-                    justify-content: end;
-                }
-            }
-
-            .right .display-type {
+   screens where there's only one panel and the overlay doesn't
+   have enough space for all the buttons. */
+@container settings-overlay (
+    ((width >= $settings_overlay_sidebar_collapse_breakpoint) and (width < calc(80em + 80px)))
+    or ((width < $settings_overlay_sidebar_collapse_breakpoint) and (width <= 36em))
+) {
+    #subscription_overlay .subscriptions-container {
+        .left {
+            .list-toggler-container {
                 height: 5em;
+                justify-content: end;
+                flex-wrap: wrap;
             }
 
-            .streams-list {
-                /* Calculated from several heights and padding/margin measurements
-                in .list-toggler-container and .stream_filter, with some added
-                fiddling to see what worked best at 12px - 20px font sizes.
-                Notably this height is shorter than the similar calculation
-                below because the toggler is taller.
-                When we redesign this area we should make this less brittle. */
-                height: calc(100% - 5.4em - 40px);
+            .tab-switcher {
+                margin-right: 0;
             }
 
-            #stream_settings {
-                height: calc(100% - 5em);
+            .tab-switcher:first-child {
+                /* This forces the other buttons to the next row */
+                width: 100%;
+                display: flex;
+                justify-content: end;
             }
+        }
+
+        .right .display-type {
+            height: 5em;
+        }
+
+        .streams-list {
+            /* Calculated from several heights and padding/margin measurements
+            in .list-toggler-container and .stream_filter, with some added
+            fiddling to see what worked best at 12px - 20px font sizes.
+            Notably this height is shorter than the similar calculation
+            below because the toggler is taller.
+            When we redesign this area we should make this less brittle. */
+            height: calc(100% - 5.4em - 40px);
+        }
+
+        #stream_settings {
+            height: calc(100% - 5em);
         }
     }
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -339,11 +339,12 @@ h4.user_group_setting_subsection_title {
 }
 
 /* There's an awkward width of modal that is wider than the
-   @media breakpoint that collapses the left pane, but still
-   narrow enough (965px at 14px em) that the sort buttons need
-   a second row to be visible without overlapping other UI. */
+   breakpoint that collapses the left pane, but still narrow
+   enough that the sort buttons need a second row to be visible
+   without overlapping other UI. Note that for 16px and larger
+   font sizes, we always show two rows of buttons. */
 @container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) {
-    @container subscriptions (width < calc(60em + 70px)) {
+    @container subscriptions (width < calc(80em + 80px)) {
         #subscription_overlay .subscriptions-container {
             .left {
                 .list-toggler-container {
@@ -375,47 +376,6 @@ h4.user_group_setting_subsection_title {
                 Notably this height is shorter than the similar calculation
                 below because the toggler is taller.
                 When we redesign this area we should make this less brittle. */
-                height: calc(100% - 5.4em - 40px);
-            }
-
-            #stream_settings {
-                height: calc(100% - 5em);
-            }
-        }
-    }
-}
-
-/* Copy all the above styles for the breakpoint where the overlay
-   becomes 40% left pane and 60% right pane, since that automatically
-   qualifies the modal for collapsing the buttons into two rows, and
-   especially for smaller font-sizes this will happen before the
-   breakpoint for the subscriptions container width. */
-@media (width < $lg_min) {
-    @container settings-overlay (width >= $settings_overlay_sidebar_collapse_breakpoint) {
-        #subscription_overlay .subscriptions-container {
-            .left {
-                .list-toggler-container {
-                    height: 5em;
-                    justify-content: end;
-                    flex-wrap: wrap;
-                }
-
-                .tab-switcher {
-                    margin-right: 0;
-                }
-
-                .tab-switcher:first-child {
-                    width: 100%;
-                    display: flex;
-                    justify-content: end;
-                }
-            }
-
-            .right .display-type {
-                height: 5em;
-            }
-
-            .streams-list {
                 height: calc(100% - 5.4em - 40px);
             }
 
@@ -481,7 +441,7 @@ h4.user_group_setting_subsection_title {
         position: relative;
         display: inline-block;
         vertical-align: top;
-        width: 50%;
+        width: 40%;
         height: calc(100% - var(--settings-overlay-header-height));
         margin: 0 -2px;
     }
@@ -552,7 +512,7 @@ h4.user_group_setting_subsection_title {
     }
 
     .right {
-        width: calc(50% + 1px);
+        width: calc(60% + 1px);
 
         .nothing-selected .create_stream_button,
         .nothing-selected .create_user_group_button {
@@ -1445,17 +1405,6 @@ div.settings-radio-input-parent {
     .user-groups-container,
     .subscriptions-container {
         max-width: 95%;
-    }
-
-    #groups_overlay,
-    #subscription_overlay {
-        .left {
-            width: 40%;
-        }
-
-        .right {
-            width: calc(60% - 1px);
-        }
     }
 }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1065,7 +1065,7 @@ h4.user_group_setting_subsection_title {
 
             .ind-tab {
                 padding: 0 4px;
-                min-width: 80px;
+                min-width: 5.7142em; /* 80px at 14px/em */
                 width: auto;
                 display: flex;
             }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -122,6 +122,7 @@ h3.user_group_setting_subsection_title {
     font-size: 1.5em;
     font-weight: normal;
     line-height: 1.5;
+    margin: 4px 15px 4px 0;
 }
 
 h4.stream_setting_subsection_title {


### PR DESCRIPTION
Changes:

* Scale width of "general/personal/subscriber" tabs with font size (and similar for user groups)
* Scale X button on the discard button with font size
* Left pane is always 40% width and right pane is always 60% width (previously it was 50/50 at wider screen sizes). This simplifies some CSS and also ensures there's enough space at larger font-sizes for the save/discard buttons to appear beside setting section headings without overflowing onto the next line (which was happening when the X icon got bigger)

**screenshots of subscriptions at 12/14/16/20 px**

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-20 at 15 13 53](https://github.com/user-attachments/assets/7cd8d9b3-a344-466e-8182-a7aba113bc86) | ![Screen Shot 2025-02-20 at 15 21 29](https://github.com/user-attachments/assets/65f6224d-8221-44f3-9caa-2f97559c1496) |
| ![Screen Shot 2025-02-20 at 15 13 40](https://github.com/user-attachments/assets/7c4c6fd4-1651-438d-8cdf-74f497080e6d) | ![Screen Shot 2025-02-20 at 15 21 15](https://github.com/user-attachments/assets/a7141c19-d5c9-4ceb-994d-5ddc56db41a3) |
| ![Screen Shot 2025-02-20 at 15 13 20](https://github.com/user-attachments/assets/10c2639f-fad5-4192-ae04-144299d5c6e9) | ![Screen Shot 2025-02-20 at 15 21 00](https://github.com/user-attachments/assets/10d89b1d-35cc-4dec-a741-c08881c2bede) |
| ![Screen Shot 2025-02-20 at 15 13 07](https://github.com/user-attachments/assets/c00978d6-b72c-4ece-8599-ea76a0bdf04a) | ![Screen Shot 2025-02-20 at 15 20 45](https://github.com/user-attachments/assets/f1697e71-a2a6-4283-8982-b90c0edf07f7) |

**screenshots of usergroups at 12/14/16/20 px**

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-20 at 15 26 09](https://github.com/user-attachments/assets/679fa4e3-35c7-4787-9d7e-e5f706b9d757) | ![Screen Shot 2025-02-20 at 15 23 27](https://github.com/user-attachments/assets/94aeef96-9d7d-4403-bdba-80cd1feabe2f) |
| ![Screen Shot 2025-02-20 at 15 25 51](https://github.com/user-attachments/assets/c0a72a5e-1463-423d-8c3a-6813914503d3) | ![Screen Shot 2025-02-20 at 15 24 04](https://github.com/user-attachments/assets/f8c032fc-e9f2-4d2c-8c00-f4aff5866412) |
| ![Screen Shot 2025-02-20 at 15 25 35](https://github.com/user-attachments/assets/196cde7a-d419-4676-b38b-57838990eefe) | ![Screen Shot 2025-02-20 at 15 24 14](https://github.com/user-attachments/assets/3cc6870a-afbc-44dd-8f91-106d2fb39a41) |
| ![Screen Shot 2025-02-20 at 15 25 14](https://github.com/user-attachments/assets/d448a72d-0d62-4516-800b-9aec039ed3eb) | ![Screen Shot 2025-02-20 at 15 24 31](https://github.com/user-attachments/assets/6c0714ff-a5db-4d67-a770-dadf9e778de8) |
