### PR TITLE
apt-repos: Install groonga-apt-source only on Debian

### DIFF
--- a/scripts/setup/apt-repos/zulip/custom.sh
+++ b/scripts/setup/apt-repos/zulip/custom.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
+os_info="$(
+    . /etc/os-release
+    printf '%s\n' "$ID"
+)"
+read -r os_id <<<"$os_info"
+
+if [ "$os_id" = debian ] && ! [ -e /usr/share/doc/groonga-apt-source/copyright ]; then
     pgroonga_apt_sign_key=$(readlink -f "$LIST_PATH/pgroonga-packages.groonga.org.asc")
 
     remove_pgroonga_apt_tmp_dir() {


### PR DESCRIPTION
On Ubuntu, we use the groonga PPA, as documented. Although there is an Ubuntu repository at packages.groonga.org, it’s incomplete (missing libarrow) and uses lower version numbers than the PPA.

https://groonga.org/docs/install/debian.html
https://groonga.org/docs/install/ubuntu.html