### PR TITLE
user_status: Scale emoji with user's font-size.

### DIFF
--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -78,7 +78,7 @@
             display: flex;
             align-items: center;
             width: 100%;
-            margin-bottom: 7px;
+            padding: 3.5px 0;
             line-height: 1em;
 
             .status-emoji {

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -43,8 +43,8 @@
             cursor: pointer;
 
             .selected-emoji {
-                width: 20px;
-                height: 20px;
+                width: 1.25em; /* 20px at 16px/em */
+                height: 1.25em; /* 20px at 16px/em */
                 cursor: pointer;
             }
 
@@ -52,7 +52,7 @@
             & img.selected-emoji,
             .smiley-icon {
                 text-align: center;
-                min-width: 20px;
+                min-width: 1.25em; /* 20px at 16px/em */
             }
 
             .smiley-icon {
@@ -84,8 +84,8 @@
             .status-emoji {
                 /* Size and align status emoji to match
                    the top line of the modal. */
-                height: 20px;
-                width: 20px;
+                height: 1.25em; /* 20px at 16px/em */
+                width: 1.25em; /* 20px at 16px/em */
                 margin: 0 7px;
             }
         }


### PR DESCRIPTION
at 12px, 14px, 16px, 20px

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-20 at 18 42 53](https://github.com/user-attachments/assets/be97fe43-57fe-41e1-992f-23cb914e148c) | ![Screen Shot 2025-02-20 at 18 42 19](https://github.com/user-attachments/assets/e4cb28fe-bc1b-4efd-8e32-013700ef573b) |
| ![Screen Shot 2025-02-20 at 18 43 15](https://github.com/user-attachments/assets/bf592933-022c-4827-b2b0-e7cf30598941) | ![Screen Shot 2025-02-20 at 18 42 05](https://github.com/user-attachments/assets/28689776-133e-438c-9114-16eef4f9719e) |
| ![Screen Shot 2025-02-20 at 18 43 25](https://github.com/user-attachments/assets/f92a3934-54d3-4254-abea-c5aa5a0fa526) | ![Screen Shot 2025-02-20 at 18 41 48](https://github.com/user-attachments/assets/d6177e4f-7b77-419a-9952-628d4f4697ca) |
| ![Screen Shot 2025-02-20 at 18 43 43](https://github.com/user-attachments/assets/1c93de7d-afe1-4877-944c-d86a20dabb04) | ![Screen Shot 2025-02-20 at 18 39 47](https://github.com/user-attachments/assets/c5367f90-92fb-4b47-a4e8-132aff5f18c0) |
