### PR TITLE
typeahead: Scale header text with font size.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -144,7 +144,7 @@
 
     #typeahead-header-text {
         color: var(--color-dropdown-item);
-        font-size: 12px;
+        font-size: 0.8571em; /* 12px at 14px/em */
     }
 
     a strong.typeahead-strong-section {


### PR DESCRIPTION
at 12px, 14px, 16px, 20px:

| before | after |
| --- | -- |
| ![Screen Shot 2025-02-20 at 21 56 08](https://github.com/user-attachments/assets/49337ab8-2d64-4326-8011-25cabba8590f) | ![Screen Shot 2025-02-20 at 21 55 20](https://github.com/user-attachments/assets/256a1fc9-703d-4b4f-9199-9130857278f7) |
| ![Screen Shot 2025-02-20 at 21 56 24](https://github.com/user-attachments/assets/39fb4d4f-9982-4a92-9944-0a872b0e19a8) | ![Screen Shot 2025-02-20 at 21 55 00](https://github.com/user-attachments/assets/a36b0639-c26c-46fc-ac6e-5a381aa5750e) |
| ![Screen Shot 2025-02-20 at 21 56 40](https://github.com/user-attachments/assets/ae01e10f-a1fc-4bb2-9245-f7f1cdeaee84) | ![Screen Shot 2025-02-20 at 21 54 42](https://github.com/user-attachments/assets/322b29b1-729e-446b-9312-8ebbf34c88bd) |
| ![Screen Shot 2025-02-20 at 21 56 56](https://github.com/user-attachments/assets/b3b39ef5-ddfc-4f18-9b01-733cff95570a) | ![Screen Shot 2025-02-20 at 21 54 18](https://github.com/user-attachments/assets/8932b954-f6f1-4e6f-a120-c1b72d3350ae) |

