### PR TITLE
topic_list_data: Add support to filter empty string topic.

### DIFF
--- a/web/src/topic_list_data.ts
+++ b/web/src/topic_list_data.ts
@@ -189,10 +189,11 @@ export function get_list_info(
 
     if (zoomed) {
         const word_separator_regex = /[\s/:_-]/; // Use -, _, :, / as word separators in addition to spaces.
+        const empty_string_topic_display_name = util.get_final_topic_display_name("");
         topic_names = util.filter_by_word_prefix_match(
             topic_names,
             search_term,
-            (topic) => topic,
+            (topic) => (topic === "" ? empty_string_topic_display_name : topic),
             word_separator_regex,
         );
     }

--- a/web/tests/topic_list_data.test.cjs
+++ b/web/tests/topic_list_data.test.cjs
@@ -194,16 +194,23 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     assert.equal(list_info.num_possible_topics, 11);
 
     add_topic_message("After Brooklyn", 1008);
-    add_topic_message("Catering", 1009);
+    add_topic_message("Delhi", 1009);
 
     // When topic search input is not empty, we show topics
     // based on the search term.
-    const search_term = "b,c";
+    let search_term = "b,d";
     list_info = get_list_info(zoomed, search_term);
     assert.equal(list_info.items.length, 2);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 2);
+
+    // Verify empty string topic shows up for "general" search term.
+    search_term = "general";
+    list_info = get_list_info(zoomed, search_term);
+    assert.equal(list_info.items.length, 1);
+    assert.equal(list_info.items[0].topic_name, "");
+    assert.equal(list_info.items[0].topic_display_name, REALM_EMPTY_TOPIC_DISPLAY_NAME);
 });
 
 test("get_list_info unreads", ({override}) => {


### PR DESCRIPTION
This PR makes it possible to search for empty string topic in the left sidebar.

<img width="311" alt="Screenshot 2025-02-21 at 12 09 26 PM" src="https://github.com/user-attachments/assets/60d1e21b-a6d0-41a1-9a72-480ed3ad981d" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
