### PR TITLE
url_decoding: Add the `Filter` class.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -616,6 +616,8 @@ export class Filter {
     }
 
     static sorted_term_types(term_types: string[]): string[] {
+        // Keep this algorithm in sync with the `sorted_terms` static method in
+        // `url_decoding.Filter` in the backend.
         const levels = [
             "in",
             "channels-public",

--- a/zerver/lib/narrow_helpers.py
+++ b/zerver/lib/narrow_helpers.py
@@ -21,14 +21,17 @@ from users:
 import os
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
+from typing import TypeAlias
 
 from django.conf import settings
+
+NarrowTermOperandT: TypeAlias = str | int | list[int]
 
 
 @dataclass
 class NarrowTerm:
     operator: str
-    operand: str | int | list[int]
+    operand: NarrowTermOperandT
     negated: bool
 
 

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -8,7 +8,7 @@ from urllib.parse import unquote, urlsplit
 from django.conf import settings
 
 from zerver.lib.narrow import BadNarrowOperatorError
-from zerver.lib.narrow_helpers import NarrowTerm
+from zerver.lib.narrow_helpers import NarrowTerm, NarrowTermOperandT
 from zerver.lib.topic import DB_TOPIC_NAME
 from zerver.models.messages import Message
 
@@ -286,3 +286,8 @@ class Filter:
 
     def terms(self) -> list[NarrowTerm]:
         return self._terms
+
+    def operands(self, operator: str) -> list[NarrowTermOperandT]:
+        return [
+            term.operand for term in self.terms() if term.operator == operator and not term.negated
+        ]

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -291,3 +291,6 @@ class Filter:
         return [
             term.operand for term in self.terms() if term.operator == operator and not term.negated
         ]
+
+    def get_terms(self, operator: str) -> list[NarrowTerm]:
+        return [term for term in self.terms() if term.operator == operator]

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -257,11 +257,28 @@ class Filter:
 
         return NarrowTerm(operator, operand, term.negated)
 
+    @staticmethod
+    def term_type(term: NarrowTerm) -> str:
+        result = "not-" if term.negated else ""
+        result += term.operator
+
+        if term.operator in ["is", "has", "in", "channels"]:
+            result += "-" + str(term.operand)
+
+        return result
+
     def _canonicalize_terms(self, terms_mixed_case: Sequence[NarrowTerm]) -> list[NarrowTerm]:
         return [Filter.canonicalize_term(term) for term in terms_mixed_case]
 
+    def _fix_redundant_is_private(self, terms: Sequence[NarrowTerm]) -> list[NarrowTerm]:
+        # Every DM is a DM, so drop `is:dm` if on a DM conversation.
+        if not any(Filter.term_type(term) == "dm" for term in terms):
+            return list(terms)
+        return [term for term in terms if Filter.term_type(term) != "is-dm"]
+
     def _fix_terms(self, terms: Sequence[NarrowTerm]) -> list[NarrowTerm]:
         terms = self._canonicalize_terms(terms)
+        terms = self._fix_redundant_is_private(terms)
         return terms
 
     def _setup_filter(self, terms: Sequence[NarrowTerm]) -> None:

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -1,11 +1,16 @@
 # See the Zulip URL spec at https://zulip.com/api/zulip-urls
 
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any
 from urllib.parse import unquote, urlsplit
 
 from django.conf import settings
 
+from zerver.lib.narrow import BadNarrowOperatorError
 from zerver.lib.narrow_helpers import NarrowTerm
 from zerver.lib.topic import DB_TOPIC_NAME
+from zerver.models.messages import Message
 
 
 def is_same_server_message_link(url: str) -> bool:
@@ -143,3 +148,124 @@ def parse_narrow_url(
 
         terms.append(NarrowTerm(operator, operand, negated))
     return terms
+
+
+class Filter:
+    def __init__(self, terms: Sequence[NarrowTerm]) -> None:
+        self._terms: list[NarrowTerm] = list(terms)
+        self._setup_filter(terms)
+
+    @staticmethod
+    def reformat_channel_operand(operand: str | int) -> str | int:
+        match operand:
+            case int():
+                return operand
+            case str():
+                if operand.strip() == "":
+                    raise BadNarrowOperatorError("Invalid 'channel' operand")
+                if operand.isdigit():
+                    return int(operand)
+                if result := parse_recipient_slug(operand.lower()):
+                    assert isinstance(result[0], int)
+                    return result[0]
+                # if it's not a channel ID nor encoded channel slug, it's
+                # probably a channel name.
+                return operand
+
+    @staticmethod
+    def reformat_dm_operand(operand: str | int | Iterable[Any]) -> str | list[int]:
+        match operand:
+            case int():
+                return [operand]
+            case str():
+                if operand.isdigit():
+                    return [int(operand)]
+                if operand.strip() == "":
+                    raise BadNarrowOperatorError("Invalid user ID")
+                return operand.lower()
+            case Iterable():
+                try:
+                    user_ids = [int(id) for id in operand]
+                    assert user_ids != []
+                    return user_ids
+                except (ValueError, AssertionError):
+                    raise BadNarrowOperatorError("Invalid user ID")
+
+    @staticmethod
+    def canonicalize_term(term: NarrowTerm) -> NarrowTerm:
+        operator = canonicalize_operator_synonyms(term.operator)
+        operand = term.operand
+        match operator:
+            case "channel" if isinstance(operand, str | int):
+                operand = Filter.reformat_channel_operand(operand)
+
+            case "channels" if str(operand) in {"public", "web-public"}:
+                pass
+
+            case "dm":
+                operand = Filter.reformat_dm_operand(operand)
+
+            case "dm-including" | "sender" if isinstance(operand, str | int):
+                operand = int(operand) if str(operand).isdigit() else str(operand).lower()
+                if str(operand).strip() == "":
+                    raise BadNarrowOperatorError("Invalid user ID")
+            case "has":
+                # images -> image, etc.
+                operand = re.sub(r"s$", "", str(operand))
+                if operand not in {
+                    "attachment",
+                    "image",
+                    "link",
+                    "reaction",
+                }:
+                    raise BadNarrowOperatorError(f"unknown '{operator}' operand {operand!s}")
+
+            case "id" | "near" | "with" if isinstance(operand, int | str):
+                if not str(operand).isdigit() or int(operand) > Message.MAX_POSSIBLE_MESSAGE_ID:
+                    raise BadNarrowOperatorError("Invalid message ID")
+                operand = int(operand)
+
+            case "is" if isinstance(operand, str):
+                operand = operand.lower()
+                if operand == "private":
+                    # "is:private" was renamed to "is:dm"
+                    operand = "dm"
+                if operand not in {
+                    "dm",
+                    "starred",
+                    "unread",
+                    "mentioned",
+                    "alerted",
+                    "resolved",
+                    "followed",
+                }:
+                    raise BadNarrowOperatorError(f"unknown '{operator}' operand {operand!s}")
+
+            case "search":
+                # The mac app automatically substitutes regular quotes with curly
+                # quotes when typing in the search bar.  Curly quotes don't trigger our
+                # phrase search behavior, however.  So, we replace all instances of
+                # curly quotes with regular quotes when doing a search.  This is
+                # unlikely to cause any problems and is probably what the user wants.
+                operand = re.sub(r"[\u201C\u201D]", '"', str(operand).lower())
+
+            case "topic" if isinstance(operand, str):
+                pass
+
+            case _:
+                raise BadNarrowOperatorError(f"unknown '{operator}' operand {operand!s}")
+
+        return NarrowTerm(operator, operand, term.negated)
+
+    def _canonicalize_terms(self, terms_mixed_case: Sequence[NarrowTerm]) -> list[NarrowTerm]:
+        return [Filter.canonicalize_term(term) for term in terms_mixed_case]
+
+    def _fix_terms(self, terms: Sequence[NarrowTerm]) -> list[NarrowTerm]:
+        terms = self._canonicalize_terms(terms)
+        return terms
+
+    def _setup_filter(self, terms: Sequence[NarrowTerm]) -> None:
+        self._terms = self._fix_terms(terms)
+
+    def terms(self) -> list[NarrowTerm]:
+        return self._terms

--- a/zerver/lib/url_decoding.py
+++ b/zerver/lib/url_decoding.py
@@ -336,3 +336,13 @@ class Filter:
 
     def get_terms(self, operator: str) -> list[NarrowTerm]:
         return [term for term in self.terms() if term.operator == operator]
+
+    def update_term(self, existing_term: NarrowTerm, new_term: NarrowTerm) -> None:
+        current_terms = self.terms()
+        try:
+            term_index = current_terms.index(existing_term)
+        except ValueError:
+            raise AssertionError("Invalid term to update")
+        new_terms = self.terms()
+        new_terms[term_index] = new_term
+        self._setup_filter(new_terms)

--- a/zerver/tests/fixtures/narrow_term_fixture.json
+++ b/zerver/tests/fixtures/narrow_term_fixture.json
@@ -1,0 +1,195 @@
+{
+    "channel_operator_validations": {
+        "valid_terms": [
+            { "operator": "stream", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": "13", "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": "Denmark", "negated": false },
+            { "operator": "channel", "operand": "13-Denmark", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false },
+            { "operator": "channel", "operand": "Denmark", "negated": false },
+            { "operator": "channel", "operand": 13, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "channel", "operand": [1, 2, 3], "negated": false },
+            { "operator": "channel", "operand": " ", "negated": false }
+        ]
+    },
+    "channels_operator_validations": {
+        "valid_terms": [
+            { "operator": "streams", "operand": "public", "negated": false },
+            { "operator": "channels", "operand": "web-public", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "channels", "operand": "public", "negated": false },
+            { "operator": "channels", "operand": "web-public", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "channels", "operand": [1, 2, 3], "negated": false },
+            { "operator": "channels", "operand": "unkown-channels-operand", "negated": false },
+            { "operator": "channels", "operand": "Denmark", "negated": false }
+        ]
+    },
+    "topic_operator_validation": {
+        "valid_terms": [
+            { "operator": "subject", "operand": "Topic Name", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "topic", "operand": "Topic Name", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "topic", "operand": [1, 2, 3], "negated": false }
+        ]
+    },
+    "dm_operator_validations": {
+        "valid_terms": [
+            { "operator": "pm-with", "operand": 1, "negated": false },
+            { "operator": "dm", "operand": "1", "negated": false },
+            { "operator": "dm", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm", "operand": ["1", "2", "3"], "negated": false },
+            { "operator": "dm", "operand": "porco@zulip.com", "negated": false },
+            { "operator": "dm", "operand": "PoRcO@ZUlIp.Com", "negated": false },
+            { "operator": "dm", "operand": "totoro@zulip.com, nausicaa@zulip.com, ponyo@zulip.com", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "dm", "operand": [1], "negated": false },
+            { "operator": "dm", "operand": [1], "negated": false },
+            { "operator": "dm", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm", "operand": "porco@zulip.com", "negated": false },
+            { "operator": "dm", "operand": "porco@zulip.com", "negated": false },
+            { "operator": "dm", "operand": "totoro@zulip.com, nausicaa@zulip.com, ponyo@zulip.com", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "dm", "operand": ["totoro@zulip.com", "2", "3"], "negated": false },
+            { "operator": "dm", "operand": [], "negated": false },
+            { "operator": "dm", "operand": " ", "negated": false },
+            { "operator": "dm", "operand": ["totoro@zulip.com", "nausicaa@zulip.com", "ponyo@zulip.com"], "negated": false }
+        ]
+    },
+    "dm_including_operator_validations": {
+        "valid_terms": [
+            { "operator": "group-pm-with", "operand": "1", "negated": false },
+            { "operator": "dm-including", "operand": 1, "negated": false },
+            { "operator": "dm-including", "operand": "sophie@zulip.com", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "dm-including", "operand": 1, "negated": false },
+            { "operator": "dm-including", "operand": 1, "negated": false },
+            { "operator": "dm-including", "operand": "sophie@zulip.com", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "dm-including", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm-including", "operand": " ", "negated": false }
+        ]
+    },
+    "sender_operator_validations": {
+        "valid_terms": [
+            { "operator": "from", "operand": "1", "negated": false },
+            { "operator": "sender", "operand": 1, "negated": false },
+            { "operator": "sender", "operand": "kiki@zulip.com", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "sender", "operand": 1, "negated": false },
+            { "operator": "sender", "operand": 1, "negated": false },
+            { "operator": "sender", "operand": "kiki@zulip.com", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "dm-including", "operand": [1, 2, 3], "negated": false },
+            { "operator": "dm-including", "operand": " ", "negated": false }
+        ]
+    },
+    "is_operator_validations": {
+        "valid_terms": [
+            { "operator": "is", "operand": "private", "negated": false },
+            { "operator": "is", "operand": "starred", "negated": false },
+            { "operator": "is", "operand": "MENTIONED", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "is", "operand": "dm", "negated": false },
+            { "operator": "is", "operand": "starred", "negated": false },
+            { "operator": "is", "operand": "mentioned", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "is", "operand": "unknown_operand", "negated": false }
+        ]
+    },
+    "has_operator_validation": {
+        "valid_terms": [
+            { "operator": "has", "operand": "images", "negated": false },
+            { "operator": "has", "operand": "links", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "has", "operand": "image", "negated": false },
+            { "operator": "has", "operand": "link", "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "has", "operand": "unknown", "negated": false }
+        ]
+    },
+    "search_operator_validation": {
+        "valid_terms": [
+            { "operator": "search", "operand": "Hello \u201cWorld\u201d", "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "search", "operand": "hello \"world\"", "negated": false }
+        ],
+        "invalid_terms": []
+    },
+    "near_operator_validation": {
+        "valid_terms": [
+            { "operator": "near", "operand": "1", "negated": false },
+            { "operator": "near", "operand": 1, "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "near", "operand": 1, "negated": false },
+            { "operator": "near", "operand": 1, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "near", "operand": "abc", "negated": false },
+            { "operator": "near", "operand": [1,2,3], "negated": false },
+            { "operator": "near", "operand": " ", "negated": false }
+        ]
+    },
+    "with_operator_validation": {
+        "valid_terms": [
+            { "operator": "with", "operand": "1", "negated": false },
+            { "operator": "with", "operand": 1, "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "with", "operand": 1, "negated": false },
+            { "operator": "with", "operand": 1, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "with", "operand": "abc", "negated": false },
+            { "operator": "with", "operand": [1,2,3], "negated": false },
+            { "operator": "with", "operand": " ", "negated": false }
+        ]
+    },
+    "id_operator_validation":{
+        "valid_terms": [
+            { "operator": "id", "operand": "1", "negated": false },
+            { "operator": "id", "operand": 1, "negated": false }
+        ],
+        "expected_output": [
+            { "operator": "id", "operand": 1, "negated": false },
+            { "operator": "id", "operand": 1, "negated": false }
+        ],
+        "invalid_terms": [
+            { "operator": "id", "operand": "abc", "negated": false },
+            { "operator": "id", "operand": [1,2,3], "negated": false },
+            { "operator": "id", "operand": " ", "negated": false }
+        ]
+    },
+    "unknown_operator": {
+        "valid_terms": [],
+        "expected_output": [],
+        "invalid_terms": [
+            { "operator": "unknown_operator", "operand": "someoperand", "negated": false }
+        ]
+    }
+}

--- a/zerver/tests/fixtures/narrow_term_fixture.json
+++ b/zerver/tests/fixtures/narrow_term_fixture.json
@@ -191,5 +191,19 @@
         "invalid_terms": [
             { "operator": "unknown_operator", "operand": "someoperand", "negated": false }
         ]
+    },
+    "redundant_is_private": {
+        "valid_terms": [
+            { "operator": "is", "operand": "private", "negated": false },
+            { "operator": "dm", "operand": "someone@example.com", "negated": false },
+            { "operator": "near", "operand": "2", "negated": false },
+            { "operator": "is", "operand": "dm", "negated": true }
+        ],
+        "expected_output": [
+            { "operator": "dm", "operand": "someone@example.com", "negated": false },
+            { "operator": "near", "operand": 2, "negated": false },
+            { "operator": "is", "operand": "dm", "negated": true }
+        ],
+        "invalid_terms": []
     }
 }

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -147,3 +147,23 @@ class NarrowTermFilterTest(ZulipTestCase):
         ]
         sorted_terms = Filter.sorted_terms(terms)
         self.assertEqual(sorted_terms[-1], unknown_term)
+
+    def test_update_term(self) -> None:
+        base_terms = [
+            NarrowTerm(negated=False, operator="near", operand=1),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+        ]
+
+        old_term = NarrowTerm(negated=False, operator="channel", operand=13)
+        old_terms = [*base_terms, old_term]
+        filter = Filter(old_terms)
+
+        new_term = NarrowTerm(negated=False, operator="channel", operand=12)
+        new_terms = [*base_terms, new_term]
+        filter.update_term(old_term, new_term)
+
+        self.assertEqual(filter.terms(), new_terms)
+
+        filter = Filter(base_terms)
+        with self.assertRaisesRegex(AssertionError, "Invalid term to update"):
+            filter.update_term(old_term, new_term)

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -72,3 +72,46 @@ class NarrowTermFilterTest(ZulipTestCase):
         self.assertEqual(filter.operands("topic"), ["testing", "testing2"])
         self.assertEqual(filter.operands("near"), [1, 2])
         self.assertEqual(filter.operands("stream"), [])
+
+    def test_get_terms(self) -> None:
+        fixture_terms = [
+            NarrowTerm(negated=False, operator="channel", operand="13"),
+            NarrowTerm(negated=False, operator="channel", operand="2"),
+            NarrowTerm(negated=True, operator="channel", operand="88"),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="topic", operand="testing2"),
+            NarrowTerm(negated=True, operator="dm", operand="90"),
+            NarrowTerm(negated=False, operator="near", operand="1"),
+            NarrowTerm(negated=False, operator="near", operand="2"),
+            NarrowTerm(negated=False, operator="with", operand="3"),
+        ]
+        filter = Filter(fixture_terms)
+
+        self.assertEqual(
+            filter.get_terms("channel"),
+            [
+                NarrowTerm(negated=False, operator="channel", operand=13),
+                NarrowTerm(negated=False, operator="channel", operand=2),
+                NarrowTerm(negated=True, operator="channel", operand=88),
+            ],
+        )
+        self.assertEqual(
+            filter.get_terms("topic"),
+            [
+                NarrowTerm(negated=False, operator="topic", operand="testing"),
+                NarrowTerm(negated=False, operator="topic", operand="testing2"),
+            ],
+        )
+        self.assertEqual(
+            filter.get_terms("with"),
+            [
+                NarrowTerm(negated=False, operator="with", operand=3),
+            ],
+        )
+        self.assertEqual(
+            filter.get_terms("dm"),
+            [
+                NarrowTerm(negated=True, operator="dm", operand=[90]),
+            ],
+        )
+        self.assertEqual(filter.get_terms("stream"), [])

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -55,3 +55,20 @@ class NarrowTermFilterTest(ZulipTestCase):
                 for invalid_term in test_case["invalid_terms"]:
                     with self.assertRaises(BadNarrowOperatorError):
                         Filter([NarrowTerm(**invalid_term)])
+
+    def test_get_operands(self) -> None:
+        fixture_terms = [
+            NarrowTerm(negated=False, operator="channel", operand="13"),
+            NarrowTerm(negated=False, operator="channel", operand="2"),
+            NarrowTerm(negated=True, operator="channel", operand="88"),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="topic", operand="testing2"),
+            NarrowTerm(negated=False, operator="near", operand="1"),
+            NarrowTerm(negated=False, operator="near", operand="2"),
+        ]
+        filter = Filter(fixture_terms)
+
+        self.assertEqual(filter.operands("channel"), [13, 2])
+        self.assertEqual(filter.operands("topic"), ["testing", "testing2"])
+        self.assertEqual(filter.operands("near"), [1, 2])
+        self.assertEqual(filter.operands("stream"), [])

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -1,8 +1,13 @@
+from typing import Any, TypeAlias
+
 import orjson
 
+from zerver.lib.narrow import BadNarrowOperatorError
 from zerver.lib.narrow_helpers import NarrowTerm
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.url_decoding import is_same_server_message_link, parse_narrow_url
+from zerver.lib.url_decoding import Filter, is_same_server_message_link, parse_narrow_url
+
+NarrowTermFixtureT: TypeAlias = dict[str, dict[str, list[dict[str, Any]]]]
 
 
 class URLDecodeTest(ZulipTestCase):
@@ -31,3 +36,22 @@ class NarrowURLDecodeTest(ZulipTestCase):
                         NarrowTerm(**term) for term in expected_output
                     ]
                     self.assertListEqual(parsed_terms, expected_narrow_terms)
+
+
+class NarrowTermFilterTest(ZulipTestCase):
+    def test_initialize_narrow_terms(self) -> None:
+        tests: NarrowTermFixtureT = orjson.loads(self.fixture_data("narrow_term_fixture.json"))
+        for test_name, test_case in tests.items():
+            narrow_terms_input = [NarrowTerm(**term) for term in test_case["valid_terms"]]
+            filter_instance = Filter(narrow_terms_input)
+            actual_output = filter_instance.terms()
+
+            with self.subTest(name=test_name):
+                expected_output: list[NarrowTerm] = [
+                    NarrowTerm(**term) for term in test_case["expected_output"]
+                ]
+                self.assertListEqual(actual_output, expected_output)
+
+                for invalid_term in test_case["invalid_terms"]:
+                    with self.assertRaises(BadNarrowOperatorError):
+                        Filter([NarrowTerm(**invalid_term)])

--- a/zerver/tests/test_url_decoding.py
+++ b/zerver/tests/test_url_decoding.py
@@ -115,3 +115,35 @@ class NarrowTermFilterTest(ZulipTestCase):
             ],
         )
         self.assertEqual(filter.get_terms("stream"), [])
+
+    def test_sorted_terms(self) -> None:
+        expected_order = [
+            NarrowTerm(negated=False, operator="channel", operand=13),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="near", operand=1),
+        ]
+
+        inverted_order = [
+            NarrowTerm(negated=False, operator="near", operand=1),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="channel", operand=13),
+        ]
+        sorted_terms = Filter.sorted_terms(inverted_order)
+        self.assertEqual(sorted_terms, expected_order)
+
+        correct_order = [
+            NarrowTerm(negated=False, operator="channel", operand=13),
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="near", operand=1),
+        ]
+        sorted_terms = Filter.sorted_terms(correct_order)
+        self.assertEqual(sorted_terms, expected_order)
+
+        unknown_term = NarrowTerm(negated=False, operator="unknownterm", operand=13)
+        terms = [
+            unknown_term,
+            NarrowTerm(negated=False, operator="topic", operand="testing"),
+            NarrowTerm(negated=False, operator="near", operand=1),
+        ]
+        sorted_terms = Filter.sorted_terms(terms)
+        self.assertEqual(sorted_terms[-1], unknown_term)


### PR DESCRIPTION
Prep PR to fix: #31100. It adds  `class Filter` which is the lighter Python copy of `filter.Filter` in the frontend. The functions that we want out of this class are:
- canonicalization & validation logic to clean up narrow terms
- the `update_terms` method
- the `sorted_terms` method

PR that depends on these changes: #32272
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [] Visual appearance of the changes.
- [] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
