### PR TITLE
mentions: Warn on non-silent group mentions with unsubscribed members.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -42,6 +42,7 @@ export const CLASSNAMES = {
     // warnings
     topic_resolved: "topic_resolved",
     recipient_not_subscribed: "recipient_not_subscribed",
+    group_entirely_not_subscribed: "group_entirely_not_subscribed",
     wildcard_warning: "wildcard_warning",
     private_stream_warning: "private_stream_warning",
     guest_in_dm_recipient_warning: "guest_in_dm_recipient_warning",

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1181,6 +1181,11 @@ export function content_typeahead_selected(
                 let user_group_mention_text = is_silent ? "@_*" : "@*";
                 user_group_mention_text += item.name + "* ";
                 beginning += user_group_mention_text;
+                compose_validate.warn_if_mentioning_unsubscribed_group(
+                    item,
+                    $textbox,
+                    is_silent ?? false,
+                );
                 // We could theoretically warn folks if they are
                 // mentioning a user group that literally has zero
                 // members where we are posting to, but we don't have

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -34,6 +34,7 @@ import * as compose_send_menu_popover from "./compose_send_menu_popover.js";
 import * as compose_setup from "./compose_setup.js";
 import * as compose_textarea from "./compose_textarea.ts";
 import * as compose_tooltips from "./compose_tooltips.ts";
+import * as compose_validate from "./compose_validate.ts";
 import * as composebox_typeahead from "./composebox_typeahead.ts";
 import * as condense from "./condense.ts";
 import * as desktop_integration from "./desktop_integration.ts";
@@ -603,6 +604,7 @@ export function initialize_everything(state_data) {
     composebox_typeahead.initialize({
         on_enter_send: compose.finish,
     });
+    compose_validate.initialize();
     compose_textarea.initialize();
     upload.initialize();
     search.initialize({

--- a/web/templates/compose_banner/compose_mention_group_warning.hbs
+++ b/web/templates/compose_banner/compose_mention_group_warning.hbs
@@ -1,0 +1,16 @@
+{{#> compose_banner . }}
+    <p class="banner_message">
+        {{#tr}}
+            None of the members of <z-group-pill></z-group-pill> are subscribed to this channel.
+            {{#*inline "z-group-pill"}}
+                <span class="display_only_group_pill">
+                    <a data-user-group-id="{{group_id}}" class="view_user_group_mention" tabindex="0">
+                        <span class="pill-label">
+                            <span>{{group_name}}</span>
+                        </span>
+                    </a>
+                </span>
+            {{/inline}}
+        {{/tr}}
+    </p>
+{{/compose_banner}}

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -26,6 +26,8 @@ const compose_validate = mock_esm("../src/compose_validate", {
     validate_message_length: () => true,
     warn_if_topic_resolved: noop,
     stream_wildcard_mention_allowed: () => true,
+    warn_if_mentioning_unsubscribed_group: noop,
+    initialize: noop,
 });
 const input_pill = mock_esm("../src/input_pill");
 const message_user_ids = mock_esm("../src/message_user_ids", {


### PR DESCRIPTION
Added a warning banner when a user mentions a group (non-silent) where none of the members are subscribed to the current stream. The banner informs the user that the mention won't notify anyone.
Further on clicking on the group name opens up group card.

Fixes #33545.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

![image](https://github.com/user-attachments/assets/c26e538a-67aa-4912-a22e-5b3bb46972e9)
![image](https://github.com/user-attachments/assets/79fbc0ed-db70-423e-87f3-4670154f11bb)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
