### PR TITLE
resize_observer: Prevent loop using requestAnimationFrame.

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -108,7 +108,11 @@ export function initialize() {
 
     // Updates compose max-height and scroll to bottom button position when
     // there is a change in compose height like when a compose banner is displayed.
-    const update_compose_max_height = new ResizeObserver(resize.reset_compose_message_max_height);
+    const update_compose_max_height = new ResizeObserver((_entries) => {
+        requestAnimationFrame(() => {
+            resize.reset_compose_message_max_height();
+        });
+    });
     update_compose_max_height.observe(document.querySelector("#compose"));
 
     function get_input_info(event) {


### PR DESCRIPTION
This commit solves the issue where the ResizeObserver loop completes with undelivered notifications. By using requestAnimationFrame, the resize event is deferred until after the paint cycle, preventing an infinite loop caused by consecutive resize triggers before repaint.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
