### PR TITLE
onboarding: Make new topic instructions point to left sidebar.

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -282,12 +282,13 @@ conversations with unread messages.
 """)
 
     content1_of_start_conversation_topic_name = _("""
-To kick off a new conversation, click **Start new conversation** below.
-The new conversation thread will be labeled with its own topic.
+To kick off a new conversation, pick a channel in the left sidebar, and click
+the `+` button next to its name.
 """)
 
     content2_of_start_conversation_topic_name = _("""
-For a good topic name, think about finishing the sentence: “Hey, can we chat about…?”
+Label your conversation with a topic. Think about finishing the sentence: “Hey,
+can we chat about…?”
 """)
 
     content3_of_start_conversation_topic_name = _("""


### PR DESCRIPTION
The left sidebar `+` is now the primary way to start a new conversation.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/onboarding.20messages.3A.20starting.20a.20topic/with/2099476)

![Screenshot 2025-02-21 at 16 12 57@2x](https://github.com/user-attachments/assets/76b9b490-897b-4afb-b872-928fa6772eb4)
