### PR TITLE
message_length_toggle: Fix tooltip not hidden on narrow change.

### DIFF
--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -400,4 +400,11 @@ export function initialize(): void {
             instance.destroy();
         },
     });
+
+    message_list_tooltip(".message_expander, .message_condenser", {
+        delay: LONG_HOVER_DELAY,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
 }

--- a/web/templates/message_length_toggle.hbs
+++ b/web/templates/message_length_toggle.hbs
@@ -1,5 +1,5 @@
 {{#if (eq toggle_type "expander")}}
-    <button type="button" class="message_expander message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
+    <button type="button" class="message_expander message_length_toggle" data-tooltip-template-id="message-expander-tooltip-template">{{t "Show more" }}</button>
 {{else if (eq toggle_type "condenser")}}
-    <button type="button" class="message_condenser message_length_toggle tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
+    <button type="button" class="message_condenser message_length_toggle" data-tooltip-template-id="message-condenser-tooltip-template">{{t "Show less" }}</button>
 {{/if}}


### PR DESCRIPTION
We fix tooltip being still visible once collapse / expand tooltip is visible and user changes narrow by destroying the tooltip when reference is hidden.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.22Show.20more.22.20tooltip.20doesn't.20disappear/with/2099867