### PR TITLE
Popover menus: Fix disappearing popover on small screens.

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -335,7 +335,10 @@ function get_props_for_popover_centering(
     return {
         arrow: false,
         getReferenceClientRect: () => new DOMRect(0, 0, 0, 0),
-        placement: "top",
+        // Since we are resetting the reference to (0,0) in DOM the placement here doesn't matter
+        // Using "bottom" placement as it works well with Popper's positioning system
+        // when the popover exceeds window height
+        placement: "bottom",
         popperOptions: {
             modifiers: [
                 {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR fixes the issue  where the popover menus would disappear on very small screen. This is done by changing its property to bottom when viewed on mobile/small screen. This still retains the functionality of popover_menus appearing on top of element for normal screen and handles issue where it would disappear on small screen.

This PR addresses the issue from scratch, independent of the previous assignee's work, as their post-review changes did not fully resolve the problem. My approach differs from the previous one, which inadvertently introduced a new issue—popover menus always appearing at the bottom of an element. I resolved this by ensuring that popovers only behave this way on smaller screens, preserving the intended functionality.

Fixes: #29472


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.



Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<h3>BEFORE</h3>

[before.webm](https://github.com/user-attachments/assets/dae91e5c-0e20-44c7-8cff-f311a7d83b0e)

<h3>AFTER</H3>

[after.webm](https://github.com/user-attachments/assets/f0a60b4b-90d9-4e56-a420-e7f14abe9c3a)


Additional information after review:

[Screencast from 2025-02-28 11-33-11.webm](https://github.com/user-attachments/assets/3f9892a2-2257-44da-b8a1-cbc3c0232dc1)

In the above video it shows that the issue is cause because the `data-placement` attribute of the div with class `tippy-box show-when-reference-hidden`changes from `bottom` to `top` when the screen size is decreased vertically which causes the element to go above the screen and hence disappear.


[Screencast from 2025-02-28 11-34-03.webm](https://github.com/user-attachments/assets/2a8b0e6b-17ed-4da0-8a4e-68930fa9b23b)

This PR makes it so that even if the screen size is decreased the `data-placement` attribute does not change and it behaves as intended for other elements aswell (only remains bottom for very small screen). For other element which use tippyjs this behavior of disappearing should be fixed for them aswell.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
