### PR TITLE
message_feed: Add subscribe option and refine subscription status.

### DIFF
--- a/web/templates/bookend.hbs
+++ b/web/templates/bookend.hbs
@@ -1,31 +1,34 @@
 {{! Client-side Handlebars template for rendering the trailing bookend. }}
-<div class="{{#if is_trailing_bookend}}trailing_bookend {{/if}}bookend sub-unsub-message">
-    {{#if is_spectator}}
-        <span class="recent-topics-link">
-            <a href="#recent">{{t "Browse recent conversations" }}</a>
-        </span>
-    {{else}}
-        <span class="stream-status">
-            {{#if deactivated}}
-                {{t "This channel has been archived." }}
-            {{else if subscribed }}
-                {{#tr}}
-                    You subscribed to <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
-                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
-                    {{#*inline "channel-settings-link"}} <a href="#channels/{{stream_id}}/{{stream_name}}/personal">{{t 'Manage channel settings'}}</a>{{/inline}}
-                {{/tr}}
-            {{else if just_unsubscribed }}
-                {{#tr}}
-                    You unsubscribed from <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
-                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
-                    {{#*inline "channel-settings-link"}} <a href="#channels/{{stream_id}}/{{stream_name}}/general">{{t 'View in channel settings'}}</a>{{/inline}}
-                {{/tr}}
-            {{else}}
-                {{#tr}}
-                    You are not subscribed to <z-stream-name></z-stream-name>.
-                    {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
-                {{/tr}}
-            {{/if}}
-        </span>
-    {{/if}}
-</div>
+{{#if is_trailing_bookend}}
+    <div class="trailing_bookend bookend sub-unsub-message">
+        {{#if is_spectator}}
+            <span class="recent-topics-link">
+                <a href="#recent">{{t "Browse recent conversations" }}</a>
+            </span>
+        {{else}}
+            <span class="stream-status">
+                {{#if deactivated}}
+                    {{t "This channel has been archived." }}
+                {{else if subscribed }}
+                    {{#tr}}
+                        You subscribed to <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
+                        {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
+                        {{#*inline "channel-settings-link"}} <a href="#channels/{{stream_id}}/{{stream_name}}/personal">{{t 'Manage channel settings'}}</a>{{/inline}}
+                    {{/tr}}
+                {{else if just_unsubscribed }}
+                    {{#tr}}
+                        You unsubscribed from <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
+                        {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
+                        {{#*inline "channel-settings-link"}} <a href="#channels/{{stream_id}}/{{stream_name}}/general">{{t 'View in channel settings'}}</a>{{/inline}}
+                    {{/tr}}
+                {{else}}
+                    {{#tr}}
+                        You are not subscribed to <z-stream-name></z-stream-name>. <channel-settings-link></channel-settings-link>
+                        {{#*inline "z-stream-name"}}{{> stream_privacy . }} {{stream_name}}{{/inline}}
+                        {{#*inline "channel-settings-link"}}  <a class="stream_sub_unsub_button"> {{t 'Subscribe' }}</a>{{/inline}}
+                    {{/tr}}
+                {{/if}}
+            </span>
+        {{/if}}
+    </div>
+{{/if}}


### PR DESCRIPTION
This commit adds a Subscribe option, allowing users to join a channel with a single click. It also removes redundant subscription status information, improving user experience and interface clarity.

Fixes: #33060

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

 - [x] Add a "Subscribe" link at the end of the "You are not subscribed to {channel}." divider, that subscribes the user to the current channel.
 - [x] Only show links on the last channel subscription status divider, not on all of them.

## Screenshots for the Subscribe Link Option:


|  Before  |  After  |
|  ---  |  ---  |
| ![before_subscribeLink](https://github.com/user-attachments/assets/9d24b2c4-9832-4206-a2dd-d56256222c31) | ![After Subscribe Link](https://github.com/user-attachments/assets/9c7ae697-7d7e-4c96-855e-644050d5aa75) |

## Screenshots for Redundant Subscription Status:

|  Before  |  After  |
|  ---  |  ---  |
| ![Before](https://github.com/user-attachments/assets/52114e67-01d3-41b2-b150-f1ec29a061c7) | ![After](https://github.com/user-attachments/assets/80f73e70-2de4-4d2c-8d38-05f177ec6845) |
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Demo video for the Subscribe Link Option</summary>

#### Before Subscribe Option

 https://github.com/user-attachments/assets/d525b906-146d-4da7-aa40-34a8a44c14fe  


#### After Subscribe Option

https://github.com/user-attachments/assets/80ea4d35-0a4e-480f-ab16-8ee32a007847 

</details>

<details>
<summary>Demo video for the Redundant Subscription Status</summary>


#### Before: 

https://github.com/user-attachments/assets/790a4c9c-ebde-4214-bf0b-2a7eca675a7e

#### After: 

https://github.com/user-attachments/assets/ae0fff6c-d61f-41e8-b5e6-448e93dd695a

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
