### PR TITLE
message_flags: Add skipped unsubscribed stream ids in the response.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 355**
+
+* [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /messages/flags`](/api/update-message-flags):
+  Added `ignored_because_not_subscribed_channels` field in the response, which
+  is a list of the channels whose messages were skipped to mark as unread
+  because the user is not subscribed to them.
+
 **Feature level 354**
 
 * [`GET /messages`](/api/get-messages), [`GET

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 354  # Last bumped for accounting groups for has_message_access.
+API_FEATURE_LEVEL = 355  # Last bumped for adding 'ignored_because_not_subscribed_channels'
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7893,8 +7893,26 @@ paths:
                           type: integer
                         description: |
                           An array with the IDs of the modified messages.
+                      ignored_because_not_subscribed_channels:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          Only present if the flag is `read` and the operation is `remove`.
+
+                          Zulip has an invariant that all unread messages must be in channels
+                          the user is subscribed to. This field will contain a list of the
+                          channels whose messages were skipped to mark as unread because the
+                          user is not subscribed to them.
+
+                          **Changes**: New in Zulip 10.0 (feature level 355).
                     example:
-                      {"msg": "", "messages": [4, 18, 15], "result": "success"}
+                      {
+                        "msg": "",
+                        "messages": [4, 18, 15],
+                        "ignored_because_not_subscribed_channels": [12, 13, 9],
+                        "result": "success",
+                      }
   /messages/flags/narrow:
     post:
       operationId: update-message-flags-for-narrow
@@ -8089,6 +8107,19 @@ paths:
                           bulk update to decide whether to issue
                           another request anchored at
                           `last_processed_id`).
+                      ignored_because_not_subscribed_channels:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          Only present if the flag is `read` and the operation is `remove`.
+
+                          Zulip has an invariant that all unread messages must be in channels
+                          the user is subscribed to. This field will contain a list of the
+                          channels whose messages were skipped to mark as unread because the
+                          user is not subscribed to them.
+
+                          **Changes**: New in Zulip 10.0 (feature level 355).
                     example:
                       {
                         "result": "success",
@@ -8099,6 +8130,7 @@ paths:
                         "last_processed_id": 55,
                         "found_oldest": false,
                         "found_newest": true,
+                        "ignored_because_not_subscribed_channels": [12, 13, 9],
                       }
   /messages/render:
     post:

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -53,7 +53,9 @@ def update_message_flags(
     request_notes = RequestNotes.get_notes(request)
     assert request_notes.log_data is not None
 
-    count = do_update_message_flags(user_profile, operation, flag, messages)
+    (count, ignored_because_not_subscribed_channels) = do_update_message_flags(
+        user_profile, operation, flag, messages
+    )
 
     target_count_str = str(len(messages))
     log_data_str = f"[{operation} {flag}/{target_count_str}] actually {count}"
@@ -63,6 +65,7 @@ def update_message_flags(
         request,
         data={
             "messages": messages,  # Useless, but included for backwards compatibility.
+            "ignored_because_not_subscribed_channels": ignored_because_not_subscribed_channels,
         },
     )
 
@@ -110,7 +113,9 @@ def update_message_flags_for_narrow(
     )
 
     messages = [row[0] for row in query_info.rows]
-    updated_count = do_update_message_flags(user_profile, operation, flag, messages)
+    (updated_count, ignored_because_not_subscribed_channels) = do_update_message_flags(
+        user_profile, operation, flag, messages
+    )
 
     return json_success(
         request,
@@ -121,6 +126,7 @@ def update_message_flags_for_narrow(
             "last_processed_id": messages[-1] if messages else None,
             "found_oldest": query_info.found_oldest,
             "found_newest": query_info.found_newest,
+            "ignored_because_not_subscribed_channels": ignored_because_not_subscribed_channels,
         },
     )
 


### PR DESCRIPTION
Added `ignored_because_not_subscribed` field in the response of `/messages/flags/narrow` endpoint.

Fixes a part of #23470.

Extracted from #31535, which still needs some work on the frontend, so we can integrate the API change.