### PR TITLE
outbox: Implement outbox for offline messages.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -25,7 +25,8 @@ async function test_empty_drafts(page: Page): Promise<void> {
 
     await wait_for_drafts_to_appear(page);
     await page.waitForSelector(drafts_overlay, {visible: true});
-    assert.strictEqual(await common.get_text_from_selector(page, ".drafts-list"), "No drafts.");
+    const selector = '[data-tab-content="drafts"] .drafts-list';
+    assert.strictEqual(await common.get_text_from_selector(page, selector), "No drafts.");
 
     await page.click(`${drafts_overlay} .exit`);
     await wait_for_drafts_to_disappear(page);

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -28,6 +28,9 @@ import * as zcommand from "./zcommand.ts";
 
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
 
+export let failed_message_queue = [];
+let retry_failed = false;
+
 export function clear_invites() {
     $(
         `#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
@@ -168,6 +171,67 @@ export function send_message_success(request, data) {
     }
 }
 
+function retry_failed_messages() {
+    if (failed_message_queue.length === 0) {
+        retry_failed = false;
+        return;
+    }
+
+    retry_failed = true;
+    const message = failed_message_queue[0];
+
+    const is_message_deleted = echo.delete_message_container.some(
+        (deleted_message) => deleted_message.local_id === message.local_id,
+    );
+
+    if (is_message_deleted) {
+        failed_message_queue.shift();
+        retry_failed_messages();
+        return;
+    }
+
+    message.resend = true;
+
+    transmit.send_message(
+        message,
+        (data) => {
+            send_message_success(message, data);
+
+            failed_message_queue.shift();
+            retry_failed_messages();
+        },
+        () => {
+            setTimeout(retry_failed_messages, 10000);
+        },
+    );
+}
+
+export function remove_failed_message(message) {
+    if (!message) {
+        return;
+    }
+
+    failed_message_queue = failed_message_queue.filter((msg) => msg.id !== message.id);
+}
+
+export function add_failed_message_back_to_queue(message) {
+    if (!message) {
+        return;
+    }
+
+    // Check if message is already in the queue to avoid duplicates
+    const already_in_queue = failed_message_queue.some((msg) => msg.local_id === message.local_id);
+
+    if (!already_in_queue) {
+        failed_message_queue.push(message);
+
+        // Start retry process if not already running
+        if (!retry_failed) {
+            retry_failed_messages();
+        }
+    }
+}
+
 export let send_message = (request = create_message_object()) => {
     compose_state.set_recipient_edited_manually(false);
     compose_state.set_is_content_unedited_restored_draft(false);
@@ -244,19 +308,29 @@ export let send_message = (request = create_message_object()) => {
             compose_ui.hide_compose_spinner();
             return;
         }
-
-        echo.message_send_error(message.id, response);
-
         // We might not have updated the draft count because we assumed the
         // message would send. Ensure that the displayed count is correct.
         drafts.sync_count();
 
         const draft = drafts.draft_model.getDraft(request.draft_id);
-        draft.is_sending_saving = false;
-        drafts.draft_model.editDraft(request.draft_id, draft);
+
+        if (!draft) {
+            return;
+        }
+
+        message.content = request.content;
+        draft.message = message;
+        echo.message_send_error(message.id, response);
+        drafts.draft_model.editDraft(message.draft_id, draft);
+        failed_message_queue.push(message);
+
+        if (!retry_failed) {
+            retry_failed_messages();
+        }
     }
 
     transmit.send_message(request, success, error);
+
     server_events.assert_get_events_running(
         "Restarting get_events because it was not running during send",
     );

--- a/web/src/drafts_overlay_ui.ts
+++ b/web/src/drafts_overlay_ui.ts
@@ -2,15 +2,20 @@ import ClipboardJS from "clipboard";
 import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
+import type {z} from "zod";
 
 import render_draft_table_body from "../templates/draft_table_body.hbs";
 
 import * as browser_history from "./browser_history.ts";
+import * as components from "./components.ts";
 import * as compose_actions from "./compose_actions.ts";
 import {show_copied_confirmation} from "./copied_tooltip.ts";
 import type {FormattedDraft, LocalStorageDraft} from "./drafts.ts";
 import * as drafts from "./drafts.ts";
+import type {send_message_api_response_schema} from "./echo.ts";
+import {abort_message, resend_message} from "./echo.ts";
 import {$t} from "./i18n.ts";
+import type {Message} from "./message_store.ts";
 import * as message_view from "./message_view.ts";
 import * as messages_overlay_ui from "./messages_overlay_ui.ts";
 import * as overlays from "./overlays.ts";
@@ -67,8 +72,11 @@ function remove_draft($draft_row: JQuery): void {
 
     $draft_row.remove();
 
-    if ($("#drafts_table .overlay-message-row").length === 0) {
+    if ($("#drafts_table .draft-message-row.overlay-message-row").length === 0) {
         $("#drafts_table .no-drafts").show();
+    }
+    if ($("#drafts_table .outbox-messsage-row.overlay-message-row").length === 0) {
+        $("#drafts_table .no-outbox-message").show();
     }
     update_rendered_drafts(
         $("#drafts-from-conversation .overlay-message-row").length > 0,
@@ -123,6 +131,10 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
     },
     items_container_selector: "drafts-container",
     items_list_selector: "drafts-list",
+    get_items_list_selector() {
+        const activeTab = $(".tab-content.active").attr("data-tab-content");
+        return `.tab-content[data-tab-content="${activeTab}"] .drafts-list`;
+    },
     row_item_selector: "draft-message-row",
     box_item_selector: "draft-message-info-box",
     id_attribute_name: "data-draft-id",
@@ -130,6 +142,23 @@ const keyboard_handling_context: messages_overlay_ui.Context = {
 
 export function handle_keyboard_events(event_key: string): void {
     messages_overlay_ui.modals_handle_events(event_key, keyboard_handling_context);
+}
+
+function discard_draft_and_abort_message(draft_id: string, $draftRow: JQuery): void {
+    const draft = drafts.draft_model.getDraft(draft_id);
+
+    if (!draft) {
+        return;
+    }
+
+    const message = draft.message;
+
+    drafts.draft_model.deleteDraft(draft_id);
+    $draftRow.remove();
+
+    if (message) {
+        abort_message(message);
+    }
 }
 
 export function launch(): void {
@@ -167,7 +196,11 @@ export function launch(): void {
         return $t({defaultMessage: "Drafts from {recipient}"}, {recipient});
     }
 
-    function render_widgets(narrow_drafts: FormattedDraft[], other_drafts: FormattedDraft[]): void {
+    function render_widgets(
+        narrow_drafts: FormattedDraft[],
+        other_drafts: FormattedDraft[],
+        outbox_message: FormattedDraft[],
+    ): void {
         $("#drafts_table").empty();
 
         const narrow_drafts_header = get_header_for_narrow_drafts();
@@ -176,9 +209,18 @@ export function launch(): void {
             narrow_drafts_header,
             narrow_drafts,
             other_drafts,
+            outbox_message,
         });
         const $drafts_table = $("#drafts_table");
         $drafts_table.append($(rendered));
+
+        if (narrow_drafts.length === 0) {
+            $("#drafts-from-conversation").hide();
+        }
+        if (other_drafts.length === 0) {
+            $("#other-drafts").hide();
+        }
+
         if ($("#drafts_table .overlay-message-row").length > 0) {
             $("#drafts_table .no-drafts").hide();
             // Update possible dynamic elements.
@@ -188,6 +230,9 @@ export function launch(): void {
             $rendered_drafts.each(function () {
                 rendered_markdown.update_elements($(this));
             });
+        }
+        if ($(".outbox-message-row").length > 0) {
+            $(".no-outbox-message").hide();
         }
         update_rendered_drafts(narrow_drafts.length > 0, other_drafts.length > 0);
         update_bulk_delete_ui();
@@ -205,6 +250,61 @@ export function launch(): void {
             const draft_id = $draft_row.attr("data-draft-id")!;
             restore_draft(draft_id);
         });
+
+        $(".refresh-failed-message").on("click", (e) => {
+            e.preventDefault();
+
+            const $draftRow = $(e.target).closest(".outbox-message-row");
+            const draft_id = $draftRow.attr("data-draft-id");
+
+            if (!draft_id) {
+                return;
+            }
+
+            const draft = drafts.draft_model.getDraft(draft_id);
+
+            if (!draft) {
+                return;
+            }
+
+            resend_message(draft.message!, $draftRow, {
+                send_message,
+                on_send_message_success,
+                remove_failed_message,
+                add_failed_message_back_to_queue,
+            });
+        });
+
+        $(".remove-failed-message").on("click", (e) => {
+            e.preventDefault();
+
+            const $draftRow = $(e.target).closest(".outbox-message-row");
+            const draft_id = $draftRow.attr("data-draft-id");
+
+            if (draft_id === undefined) {
+                return;
+            }
+
+            discard_draft_and_abort_message(draft_id, $draftRow);
+        });
+
+        const opts = {
+            child_wants_focus: true,
+            selected: 0,
+            values: [
+                {label: $t({defaultMessage: "Drafts"}), key: "drafts"},
+                {label: $t({defaultMessage: "Outbox"}), key: "outbox"},
+            ],
+            callback(_name: string | undefined, key: string) {
+                $(".tab-content").removeClass("active");
+                $(`[data-tab-content="${key}"]`).addClass("active");
+            },
+        };
+
+        const toggler = components.toggle(opts);
+        const $elem = toggler.get();
+        $elem.addClass("tab-container");
+        $elem.prependTo("#draft_overlay .overlay-messages-header");
 
         $("#drafts_table .restore-overlay-message").on(
             "click",
@@ -252,76 +352,192 @@ export function launch(): void {
             });
         });
 
+        $("#drafts_table .overlay_message_controls .outbox-selection-checkbox").on("click", (e) => {
+            const is_checked = is_checkbox_icon_checked($(e.target));
+            toggle_checkbox_icon_state($(e.target), !is_checked);
+            update_bulk_delete_ui();
+        });
+
         $(".select-drafts-button").on("click", (e) => {
             e.preventDefault();
-            const $unchecked_checkboxes = $(".draft-selection-checkbox").filter(function () {
+
+            const $drafts_checkboxes = $(`[data-tab-content="drafts"] .draft-selection-checkbox`);
+
+            const $unchecked_checkboxes = $drafts_checkboxes.filter(function () {
                 return !is_checkbox_icon_checked($(this));
             });
             const check_boxes = $unchecked_checkboxes.length > 0;
-            $(".draft-selection-checkbox").each(function () {
+
+            $drafts_checkboxes.each(function () {
                 toggle_checkbox_icon_state($(this), check_boxes);
             });
+
+            toggle_checkbox_icon_state(
+                $(".select-drafts-button .select-state-indicator"),
+                check_boxes,
+                "drafts",
+            );
+
+            update_bulk_delete_ui();
+        });
+
+        $(".select-outbox-button").on("click", (e) => {
+            e.preventDefault();
+
+            const $outbox_checkboxes = $(`[data-tab-content="outbox"] .outbox-selection-checkbox`);
+
+            const $unchecked_checkboxes = $outbox_checkboxes.filter(function () {
+                return !is_checkbox_icon_checked($(this));
+            });
+            const check_boxes = $unchecked_checkboxes.length > 0;
+
+            $outbox_checkboxes.each(function () {
+                toggle_checkbox_icon_state($(this), check_boxes);
+            });
+
+            toggle_checkbox_icon_state(
+                $(".select-outbox-button .select-state-indicator"),
+                check_boxes,
+                "outbox",
+            );
+
             update_bulk_delete_ui();
         });
 
         $(".delete-selected-drafts-button").on("click", () => {
-            $(".drafts-list")
-                .find(".draft-selection-checkbox.fa-check-square")
+            $(`[data-tab-content="drafts"] .draft-selection-checkbox.fa-check-square`)
                 .closest(".overlay-message-row")
                 .each(function () {
                     remove_draft($(this));
                 });
             update_bulk_delete_ui();
         });
+
+        $(".delete-selected-outbox-button").on("click", (e) => {
+            e.preventDefault();
+
+            $(`[data-tab-content="outbox"] .outbox-selection-checkbox.fa-check-square`)
+                .closest(".overlay-message-row")
+                .each(function () {
+                    const $row = $(this);
+                    const draft_id = $row.attr("data-draft-id");
+
+                    if (draft_id !== undefined) {
+                        const draft = drafts.draft_model.getDraft(draft_id);
+
+                        if (!draft) {
+                            return;
+                        }
+
+                        const message = draft.message;
+
+                        if (!message) {
+                            return;
+                        }
+
+                        abort_message(message);
+
+                        drafts.draft_model.deleteDraft(draft_id);
+                    }
+
+                    $row.remove();
+                });
+
+            update_bulk_delete_ui();
+        });
     }
 
     const all_drafts = drafts.draft_model.get();
-    const narrow_drafts = drafts.filter_drafts_by_compose_box_and_recipient(all_drafts);
+
+    const outbox_message = Object.fromEntries(
+        Object.entries(all_drafts).filter(([_, draft]) => draft.is_sending_saving),
+    );
+
+    const drafts_message = Object.fromEntries(
+        Object.entries(all_drafts).filter(([_, draft]) => !draft.is_sending_saving),
+    );
+
+    const narrow_drafts = drafts.filter_drafts_by_compose_box_and_recipient(drafts_message);
     const other_drafts = _.pick(
-        all_drafts,
-        _.difference(Object.keys(all_drafts), Object.keys(narrow_drafts)),
+        drafts_message,
+        _.difference(Object.keys(drafts_message), Object.keys(narrow_drafts)),
     );
     const formatted_narrow_drafts = format_drafts(narrow_drafts);
     const formatted_other_drafts = format_drafts(other_drafts);
+    const formatted_outbox_message = format_drafts(outbox_message);
 
-    render_widgets(formatted_narrow_drafts, formatted_other_drafts);
+    render_widgets(formatted_narrow_drafts, formatted_other_drafts, formatted_outbox_message);
 
     // We need to force a style calculation on the newly created
     // element in order for the CSS transition to take effect.
     $("#draft_overlay").css("opacity");
 
     open_overlay();
-    const first_element_id = [...formatted_narrow_drafts, ...formatted_other_drafts][0]?.draft_id;
+    const first_element_id = [
+        ...formatted_narrow_drafts,
+        ...formatted_other_drafts,
+        ...formatted_outbox_message,
+    ][0]?.draft_id;
     messages_overlay_ui.set_initial_element(first_element_id, keyboard_handling_context);
     setup_event_handlers();
     messages_overlay_ui.initialize_restore_overlay_message_tooltip();
 }
 
 export function update_bulk_delete_ui(): void {
-    const $unchecked_checkboxes = $(".draft-selection-checkbox").filter(function () {
+    const $unchecked_draft_checkboxes = $(".draft-selection-checkbox").filter(function () {
         return !is_checkbox_icon_checked($(this));
     });
-    const $checked_checkboxes = $(".draft-selection-checkbox").filter(function () {
+    const $checked_draft_checkboxes = $(".draft-selection-checkbox").filter(function () {
         return is_checkbox_icon_checked($(this));
     });
+    const $unchecked_outbox_checkboxes = $(".outbox-selection-checkbox").filter(function () {
+        return !is_checkbox_icon_checked($(this));
+    });
+    const $checked_outbox_checkboxes = $(".outbox-selection-checkbox").filter(function () {
+        return is_checkbox_icon_checked($(this));
+    });
+
     const $select_drafts_button = $(".select-drafts-button");
-    const $select_state_indicator = $(".select-drafts-button .select-state-indicator");
+    const $drafts_state_indicator = $(".select-drafts-button .select-state-indicator");
     const $delete_selected_drafts_button = $(".delete-selected-drafts-button");
 
-    if ($checked_checkboxes.length > 0) {
+    const $select_outbox_button = $(".select-outbox-button");
+    const $outbox_state_indicator = $(".select-outbox-button .select-state-indicator");
+    const $delete_selected_outbox_button = $(".delete-selected-outbox-button");
+
+    // Update UI for drafts tab
+    if ($checked_draft_checkboxes.length > 0) {
         $delete_selected_drafts_button.prop("disabled", false);
-        if ($unchecked_checkboxes.length === 0) {
-            toggle_checkbox_icon_state($select_state_indicator, true);
+        if ($unchecked_draft_checkboxes.length === 0) {
+            toggle_checkbox_icon_state($drafts_state_indicator, true, "drafts");
         } else {
-            toggle_checkbox_icon_state($select_state_indicator, false);
+            toggle_checkbox_icon_state($drafts_state_indicator, false, "drafts");
         }
     } else {
-        if ($unchecked_checkboxes.length > 0) {
-            toggle_checkbox_icon_state($select_state_indicator, false);
+        if ($unchecked_draft_checkboxes.length > 0) {
+            toggle_checkbox_icon_state($drafts_state_indicator, false, "drafts");
             $delete_selected_drafts_button.prop("disabled", true);
         } else {
             $select_drafts_button.hide();
             $delete_selected_drafts_button.hide();
+        }
+    }
+
+    // Update UI for outbox tab
+    if ($checked_outbox_checkboxes.length > 0) {
+        $delete_selected_outbox_button.prop("disabled", false);
+        if ($unchecked_outbox_checkboxes.length === 0) {
+            toggle_checkbox_icon_state($outbox_state_indicator, true, "outbox");
+        } else {
+            toggle_checkbox_icon_state($outbox_state_indicator, false, "outbox");
+        }
+    } else {
+        if ($unchecked_outbox_checkboxes.length > 0) {
+            toggle_checkbox_icon_state($outbox_state_indicator, false, "outbox");
+            $delete_selected_outbox_button.prop("disabled", true);
+        } else {
+            $select_outbox_button.hide();
+            $delete_selected_outbox_button.hide();
         }
     }
 }
@@ -342,16 +558,59 @@ export function is_checkbox_icon_checked($checkbox: JQuery): boolean {
     return $checkbox.hasClass("fa-check-square");
 }
 
-export function toggle_checkbox_icon_state($checkbox: JQuery, checked: boolean): void {
-    $checkbox.parent().attr("aria-checked", checked.toString());
-    if (checked) {
-        $checkbox.removeClass("fa-square-o").addClass("fa-check-square");
+export function toggle_checkbox_icon_state(
+    $checkbox: JQuery,
+    checked: boolean,
+    tab?: string,
+): void {
+    const $parent = $checkbox.parent();
+    $parent.attr("aria-checked", checked.toString());
+
+    if (tab) {
+        const buttonClass =
+            tab.toLowerCase() === "drafts" ? "select-drafts-button" : "select-outbox-button";
+        $(`.${buttonClass}`).attr("aria-checked", checked.toString());
+        $(`.${buttonClass} .select-state-indicator`)
+            .toggleClass("fa-square-o", !checked)
+            .toggleClass("fa-check-square", checked);
     } else {
-        $checkbox.removeClass("fa-check-square").addClass("fa-square-o");
+        $checkbox.toggleClass("fa-square-o", !checked).toggleClass("fa-check-square", checked);
     }
 }
 
-export function initialize(): void {
+type PostMessageAPIData = z.output<typeof send_message_api_response_schema>;
+
+let remove_failed_message: (message: Message) => void;
+
+let send_message: (
+    request: Message,
+    on_success: (raw_data: unknown) => void,
+    error: (response: string, _server_error_code: string) => void,
+) => void;
+
+let on_send_message_success: (request: Message, data: PostMessageAPIData) => void;
+
+let add_failed_message_back_to_queue: (message: Message) => void;
+
+export function initialize({
+    on_send_message_success: on_success,
+    send_message: send_message_content,
+    remove_failed_message: remove_failed,
+    add_failed_message_back_to_queue: add_failed_message,
+}: {
+    on_send_message_success: (request: Message, data: PostMessageAPIData) => void;
+    send_message: (
+        request: Message,
+        on_success: (raw_data: unknown) => void,
+        error: (response: string, _server_error_code: string) => void,
+    ) => void;
+    remove_failed_message: (message: Message) => void;
+    add_failed_message_back_to_queue: (message: Message) => void;
+}): void {
+    send_message = send_message_content;
+    on_send_message_success = on_success;
+    remove_failed_message = remove_failed;
+    add_failed_message_back_to_queue = add_failed_message;
     $("body").on("focus", "#drafts_table .overlay-message-info-box", function (this: HTMLElement) {
         messages_overlay_ui.activate_element(this, keyboard_handling_context);
     });

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -12,6 +12,7 @@ export type Context = {
     row_item_selector: string;
     box_item_selector: string;
     id_attribute_name: string;
+    get_items_list_selector?: () => string;
     get_items_ids: () => string[];
     on_enter: () => void;
     on_delete: () => void;
@@ -82,7 +83,10 @@ export function set_initial_element(element_id: string | undefined, context: Con
         const focus_element = current_element.children[0];
         assert(focus_element instanceof HTMLElement);
         activate_element(focus_element, context);
-        util.the($(`.${CSS.escape(context.items_list_selector)}`)).scrollTop = 0;
+        const selector = context.get_items_list_selector
+            ? context.get_items_list_selector()
+            : `.${CSS.escape(context.items_list_selector)}`;
+        util.the($(selector)).scrollTop = 0;
     }
 }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -534,6 +534,8 @@ export function initialize_everything(state_data) {
     echo.initialize({
         on_send_message_success: compose.send_message_success,
         send_message: transmit.send_message,
+        remove_failed_message: compose.remove_failed_message,
+        add_failed_message_back_to_queue: compose.add_failed_message_back_to_queue,
     });
     stream_create.initialize();
     stream_edit.initialize();
@@ -703,7 +705,12 @@ export function initialize_everything(state_data) {
         },
     });
     drafts.initialize_ui();
-    drafts_overlay_ui.initialize();
+    drafts_overlay_ui.initialize({
+        on_send_message_success: compose.send_message_success,
+        send_message: transmit.send_message,
+        remove_failed_message: compose.remove_failed_message,
+        add_failed_message_back_to_queue: compose.add_failed_message_back_to_queue,
+    });
     // This needs to happen after activity_ui.initialize, so that user_filter
     // is defined. Also, must happen after people.initialize()
     onboarding_steps.initialize(

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -984,7 +984,6 @@ input.settings_text_input {
 
     .overlay-messages-list {
         padding: 10px 25px;
-        overflow: auto;
 
         .no-overlay-messages {
             display: block;

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -1,4 +1,6 @@
-.drafts-container {
+.tab-content {
+    display: none;
+
     .header-body {
         display: flex;
         align-items: center;
@@ -27,7 +29,26 @@
                 }
             }
 
+            .delete-selected-outbox-button {
+                &:focus {
+                    background-color: hsl(0deg 0% 93%);
+                }
+            }
+
             .select-drafts-button {
+                display: flex;
+                align-items: center;
+                gap: 5px;
+                margin-right: 25px;
+                padding-left: 15px;
+                padding-right: 15px;
+
+                &:focus {
+                    background-color: hsl(0deg 0% 93%);
+                }
+            }
+
+            .select-outbox-button {
                 display: flex;
                 align-items: center;
                 gap: 5px;
@@ -56,6 +77,10 @@
     }
 
     .drafts-list {
+        overflow: auto;
+        overflow-y: auto;
+        max-height: 75vh;
+
         & h2 {
             font-size: 1.1em;
             line-height: normal;
@@ -71,4 +96,45 @@
            the checkbox icon) will work. */
         width: 15px;
     }
+
+    .outbox-selection-checkbox {
+        margin-top: 5px;
+        /* Required to make sure that the checkbox icon stays inside
+            the grid. Any value greater than 13px (original width of
+            the checkbox icon) will work. */
+        width: 15px;
+    }
+}
+
+.drafts-container {
+    .tab-switcher {
+        display: flex;
+        margin-top: 45px;
+        margin-bottom: 10px;
+    }
+
+    .ind-tab {
+        flex: 1;
+        min-width: 120px;
+        max-width: 100%;
+        text-align: center;
+        padding: 6px 12px;
+        white-space: nowrap;
+    }
+
+    @media (width <= 600px) {
+        .ind-tab {
+            min-width: 120px;
+            font-size: 14px;
+        }
+    }
+}
+
+.tab-container {
+    padding: 0 20px;
+}
+
+.tab-content.active {
+    display: block;
+    overflow: hidden;
 }

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -1,44 +1,77 @@
 <div id="draft_overlay" class="overlay" data-overlay="drafts">
     <div class="flex overlay-content">
         <div class="drafts-container overlay-messages-container overlay-container">
-            <div class="overlay-messages-header">
-                <h1>{{t 'Drafts' }}</h1>
-                <div class="exit">
-                    <span class="exit-sign">&times;</span>
-                </div>
-                <div class="header-body">
-                    <div class="drafts-header-note">
-                        {{t "Drafts are not synced to other devices and browsers." }}
+            <div class="tab-content active" data-tab-content="drafts">
+                <div class="overlay-messages-header">
+                    <div class="exit">
+                        <span class="exit-sign">&times;</span>
                     </div>
-                    <div class="delete-drafts-group">
-                        <div class="delete-selected-drafts-button-container">
-                            <button class="button small rounded delete-selected-drafts-button" type="button" disabled>
-                                <i class="fa fa-trash-o fa-lg" aria-hidden="true"></i>
+                    <div class="header-body">
+                        <div class="drafts-header-note">
+                            {{t "Drafts are not synced to other devices and browsers." }}
+                        </div>
+                        <div class="delete-drafts-group">
+                            <div class="delete-selected-drafts-button-container">
+                                <button class="button small rounded delete-selected-drafts-button" type="button" disabled>
+                                    <i class="fa fa-trash-o fa-lg" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            <button class="button small rounded select-drafts-button" role="checkbox" aria-checked="false">
+                                <span>{{t "Select all drafts" }}</span>
+                                <i class="fa fa-square-o fa-lg select-state-indicator" aria-hidden="true"></i>
                             </button>
                         </div>
-                        <button class="button small rounded select-drafts-button" role="checkbox" aria-checked="false">
-                            <span>{{t "Select all drafts" }}</span>
-                            <i class="fa fa-square-o fa-lg select-state-indicator" aria-hidden="true"></i>
-                        </button>
+                    </div>
+                </div>
+                <div class="drafts-list overlay-messages-list">
+                    <div class="no-drafts no-overlay-messages">
+                        {{t 'No drafts.'}}
+                    </div>
+                    <div id="drafts-from-conversation">
+                        <h2>{{narrow_drafts_header}}</h2>
+                        {{#each narrow_drafts}}
+                            {{> draft .}}
+                        {{/each}}
+                    </div>
+                    <div id="other-drafts">
+                        <h2 id="other-drafts-header">{{t "Other drafts" }}</h2>
+                        {{#each other_drafts}}
+                            {{> draft .}}
+                        {{/each}}
                     </div>
                 </div>
             </div>
-            <div class="drafts-list overlay-messages-list">
-                <div class="no-drafts no-overlay-messages">
-                    {{t 'No drafts.'}}
+            <div class="tab-content" data-tab-content="outbox">
+                <div class="overlay-messages-header">
+                    <div class="exit">
+                        <span class="exit-sign">&times;</span>
+                    </div>
+                    <div class="header-body">
+                        <div class="drafts-header-note">
+                            {{t "Messages waiting to be sent." }}
+                        </div>
+                        <div class="delete-drafts-group">
+                            <div class="delete-selected-outbox-button-container">
+                                <button class="button small rounded delete-selected-outbox-button" type="button" disabled>
+                                    <i class="fa fa-trash-o fa-lg" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            <button class="button small rounded select-outbox-button" role="checkbox" aria-checked="false" id="select-outbox-button">
+                                <span>{{t "Select all outbox" }}</span>
+                                <i class="fa fa-square-o fa-lg select-state-indicator outbox-checkbox" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
                 </div>
-
-                <div id="drafts-from-conversation">
-                    <h2>{{narrow_drafts_header}}</h2>
-                    {{#each narrow_drafts}}
-                        {{> draft .}}
-                    {{/each}}
-                </div>
-                <div id="other-drafts">
-                    <h2 id="other-drafts-header">{{t "Other drafts" }}</h2>
-                    {{#each other_drafts}}
-                        {{> draft .}}
-                    {{/each}}
+                <div class="drafts-list overlay-messages-list">
+                    <div class="no-outbox-message no-overlay-messages">
+                        {{t 'No outbox message.'}}
+                    </div>
+                    <div id="outbox-messages">
+                        {{#each outbox_message}}
+                            {{> outbox .}}
+                        {{/each}}
+                    </div>
                 </div>
             </div>
         </div>

--- a/web/templates/outbox.hbs
+++ b/web/templates/outbox.hbs
@@ -1,0 +1,60 @@
+<div class="outbox-message-row overlay-message-row" data-draft-id="{{draft_id}}">
+    <div class="draft-message-info-box overlay-message-info-box" tabindex="0">
+        {{#if is_stream}}
+        <div class="message_header message_header_stream">
+            <div class="message-header-contents" style="background: {{recipient_bar_color}};">
+                <div class="message_label_clickable stream_label">
+                    <span class="stream-privacy-modified-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_privacy_icon_color}}">
+                        {{> stream_privacy .}}
+                    </span>
+                    {{#if stream_name}}
+                        {{stream_name}}
+                    {{else}}
+                        &nbsp;
+                    {{/if}}
+                </div>
+                <span class="stream_topic_separator"><i class="zulip-icon zulip-icon-chevron-right"></i></span>
+                <span class="stream_topic">
+                    <div class="message_label_clickable narrows_by_topic">
+                        <span class="stream-topic-inner {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
+                    </div>
+                </span>
+                <span class="recipient_bar_controls"></span>
+                <div class="recipient_row_date">{{time_stamp}}</div>
+            </div>
+        </div>
+        {{else}}
+        <div class="message_header message_header_private_message">
+            <div class="message-header-contents">
+                <div class="message_label_clickable stream_label">
+                    <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
+                    <span class="private_message_header_name">{{t "You and {recipients}" recipients=private_message_recipient}}</span>
+                </div>
+                <div class="recipient_row_date">{{time_stamp}}</div>
+            </div>
+        </div>
+        {{/if}}
+        <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
+            <div class="messagebox">
+                <div class="messagebox-content">
+                    <div class="message_top_line">
+                        <div class="overlay_message_controls">
+                            <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
+                                <i class="message-controls-icon fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
+                            </div>
+                            <div class="message_control_button failed_message_action" data-tooltip-template-id="dismiss-failed-send-button-tooltip-template">
+                                <i class="message-controls-icon fa fa-times-circle remove-failed-message" aria-label="{{t 'Dismiss' }}" role="button" tabindex="0"></i>
+                            </div>
+                            <div class="outbox-selection-tooltip">
+                                <i class="fa fa-square-o fa-lg outbox-selection-checkbox" aria-hidden="true"></i>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="message_content rendered_markdown restore-overlay-message tippy-zulip-delayed-tooltip" data-tooltip-template-id="restore-draft-tooltip-template">
+                        {{{rendered_markdown content}}}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -386,7 +386,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         const state = {
             get_events_running_called: 1,
             reify_message_id_checked: 0,
-            send_msg_called: 1,
+            send_msg_called: 2,
         };
         assert.deepEqual(stub_state, state);
         assert.ok(echo_error_msg_checked);

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -62,6 +62,20 @@ mock_esm("../src/markdown", {
 });
 mock_esm("../src/overlays", {
     open_overlay: noop,
+    close_overlay: noop,
+});
+
+mock_esm("../src/components", {
+    toggle(_opts) {
+        return {
+            get() {
+                return {
+                    prependTo: noop,
+                    addClass: noop,
+                };
+            },
+        };
+    },
 });
 
 const tippy_sel = ".top_left_drafts .unread_count";
@@ -287,7 +301,10 @@ test("initialize", ({override_rewire}) => {
 
     drafts.initialize();
     drafts.initialize_ui();
-    drafts_overlay_ui.initialize();
+    drafts_overlay_ui.initialize({
+        on_send_message_success(_request, _data) {},
+        send_message(_request, _on_success, _error) {},
+    });
 });
 
 test("update_draft", ({override, override_rewire}) => {
@@ -627,6 +644,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         // Tests formatting and time-sorting of drafts
         assert.deepEqual(data.narrow_drafts, []);
         assert.deepEqual(data.other_drafts, expected);
+        assert.deepEqual(data.outbox_message, []);
         return "<draft table stub>";
     });
 
@@ -636,7 +654,16 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     $.create("#drafts_table .overlay-message-row", {children: []});
+    $(".outbox-selection-checkbox").filter = () => [];
     $(".draft-selection-checkbox").filter = () => [];
+
+    const $drafts_table = $.create("drafts_table");
+    const $child = $(".message_content.rendered_markdown.restore-overlay-message");
+    $drafts_table.set_find_results(
+        ".message_content.rendered_markdown.restore-overlay-message",
+        $child,
+    );
+
     drafts_overlay_ui.launch();
 
     $.clear_all_elements();
@@ -655,7 +682,14 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
 
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
+    $(".outbox-selection-checkbox").filter = () => [];
     $(".draft-selection-checkbox").filter = () => [];
+
+    $drafts_table.set_find_results(
+        ".message_content.rendered_markdown.restore-overlay-message",
+        $child,
+    );
+
     drafts_overlay_ui.launch();
 });
 
@@ -818,6 +852,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
     compose_state.private_message_recipient(aaron.email);
 
     $.create("#drafts_table .overlay-message-row", {children: []});
+    $(".outbox-selection-checkbox").filter = () => [];
     $(".draft-selection-checkbox").filter = () => [];
     drafts_overlay_ui.launch();
 });


### PR DESCRIPTION

### How Does the Outbox Work?

* When the user is offline and attempts to send a message, instead of just displaying it in the chat with `resend` and `delete` options, the message is now also stored in the Outbox. This reassures the user that their message will be preserved and sent once they’re back online.
* Once the user goes from offline to online mode, the **new implementation** immediately tries to send the message, regardless of when it was originally created.
* If the message still fails to send due to technical issues, it remains in the Outbox. The user can then manually retry sending it using the `resend` button or choose to remove it entirely using the `delete` option.

---

Fixes: #32999 

<details>
<summary>Both `Drafts` and `Outbox` tab with empty message.</summary>
<img width="850" alt="Screenshot 2025-04-14 at 10 07 16 AM" src="https://github.com/user-attachments/assets/7e986307-85f4-4a1e-8bba-df201eed8c6c" />
<img width="866" alt="Screenshot 2025-04-14 at 10 03 23 AM" src="https://github.com/user-attachments/assets/0f474d85-5319-41bb-bc42-d7c115d78382" />
</details>





<details>
<summary>`Drafts` tab with message and `Outbox` tab with no message.</summary>
<img width="850" alt="Screenshot 2025-04-14 at 10 07 59 AM" src="https://github.com/user-attachments/assets/4896cc40-b153-4d7e-8752-2dae79580e92" />
<img width="850" alt="Screenshot 2025-04-14 at 10 08 10 AM" src="https://github.com/user-attachments/assets/6f15e4c5-831a-4bdd-bae8-8d58e9b5edfb" />
</details>

<details>
<summary>Both `Drafts` and `Outbox` tab with some message.</summary>
<img width="850" alt="Screenshot 2025-04-14 at 10 07 59 AM" src="https://github.com/user-attachments/assets/4896cc40-b153-4d7e-8752-2dae79580e92" />
<img width="850" alt="Screenshot 2025-04-14 at 10 10 54 AM" src="https://github.com/user-attachments/assets/186d80a0-4a4a-4b22-ba6e-5556c67597f9" />
</details>

<details>
<summary>Tooltip for saving as Drafts and Outbox.</summary>
<img width="419" alt="Screenshot 2025-04-14 at 10 36 17 AM" src="https://github.com/user-attachments/assets/199ac582-c167-4ffd-b14f-b211b8e3ee5f" />
<img width="406" alt="Screenshot 2025-04-14 at 12 26 48 PM" src="https://github.com/user-attachments/assets/12675d79-e0fc-4497-ae28-a7350cbb2a05" />
</details>

<details>
<summary>The function attempts to send the message once the app is back online.</summary>

https://github.com/user-attachments/assets/84a93417-20a0-4853-8982-c50cf87b1dc5


</details>


<details>
<summary>The message is stored in the outbox when the app is reloaded.</summary>

https://github.com/user-attachments/assets/7bed4ebe-9d87-494b-96ef-b9002f1eabd6


</details>


<details>
<summary>When the user attempts to delete or resend the message from the outbox overlay after coming back online.</summary>

https://github.com/user-attachments/assets/42448aa3-65cb-491d-937e-8d580ff4b592


https://github.com/user-attachments/assets/d2e3849c-0131-4046-9b4f-f056d4730729


</details>

<details>
<summary>Deleting the message through either the outbox overlay or directly from the message feed.</summary>

https://github.com/user-attachments/assets/c1e4621a-5e4e-45d8-a1e1-0410895e5628

https://github.com/user-attachments/assets/e8e77982-99dd-478c-ac35-86ade2aae73c




</details>


<details>
<summary>Bulk deletion of the outbox, both while offline and online. </summary>

https://github.com/user-attachments/assets/0be60508-d9c3-47d2-bb51-e3470a8ebc2a


https://github.com/user-attachments/assets/64ed0e01-eb1a-414c-b326-220191544396



</details>


<details>
<summary>Implementation to handle the race condition that occurs when the user manually clicks the resend button while the now Implemented resend function is already in the process of sending the message.</summary>

https://github.com/user-attachments/assets/be77f39f-ec92-49dc-b1fd-20ecc9ed66eb


</details>



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
