### PR TITLE
compose: fix preview not being updated when compose textarea is updated

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -58,13 +58,16 @@ export function show_preview_area() {
     $("#compose").addClass("preview_mode");
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
-    const $compose_textarea = $("textarea#compose-textarea");
-    const content = $compose_textarea.val();
-
     $("#compose .markdown_preview").hide();
     $("#compose .undo_markdown_preview").show();
     $("#compose .undo_markdown_preview").trigger("focus");
 
+    render_preview_area();
+}
+
+export function render_preview_area() {
+    const $compose_textarea = $("textarea#compose-textarea");
+    const content = $compose_textarea.val();
     const $preview_message_area = $("#compose .preview_message_area");
     compose_ui.render_and_show_preview(
         $("#compose .markdown_preview_spinner"),

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -80,6 +80,9 @@ export function initialize() {
     });
 
     $("textarea#compose-textarea").on("input propertychange", () => {
+        if ($("#compose").hasClass("preview_mode")) {
+            compose.render_preview_area();
+        }
         compose_validate.warn_if_topic_resolved(false);
         const compose_text_length = compose_validate.check_overflow_text($("#send_message_form"));
         if (compose_text_length !== 0 && $("textarea#compose-textarea").hasClass("invalid")) {

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -9,6 +9,7 @@ let message_type: "stream" | "private" | undefined;
 let recipient_edited_manually = false;
 let is_content_unedited_restored_draft = false;
 let last_focused_compose_type_input: HTMLTextAreaElement | undefined;
+let preview_render_count = 0;
 
 // We use this variable to keep track of whether user has viewed the topic resolved
 // banner for the current compose session, for a narrow. This prevents the banner
@@ -65,6 +66,14 @@ export function set_recipient_guest_ids_for_dm_warning(guest_ids: number[]): voi
 
 export function get_recipient_guest_ids_for_dm_warning(): number[] {
     return recipient_guest_ids_for_dm_warning;
+}
+
+export function get_preview_render_count(): number {
+    return preview_render_count;
+}
+
+export function set_preview_render_count(count: number): void {
+    preview_render_count = count;
 }
 
 export function composing(): boolean {

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1354,8 +1354,12 @@ export function render_and_show_preview(
             url: "/json/messages/render",
             data: {content},
             success(response_data) {
-                if (preview_render_count !== compose_state.get_preview_render_count()) {
-                    // The compose input has already been updated with new raw Markdown
+                if (
+                    preview_render_count !== compose_state.get_preview_render_count() ||
+                    !$("#compose").hasClass("preview_mode")
+                ) {
+                    // The user is no longer in preview mode or the compose
+                    // input has already been updated with new raw Markdown
                     // since this rendering request was sent off to the server, so
                     // there's nothing to do.
                     return;


### PR DESCRIPTION
In preview mode, background updates to the compose box don’t refresh the preview. For example, canceling an ongoing file upload after activating preview mode still shows "uploading".

To fix this, we modified `show_preview_area` function to accept an argument for skipping initialization and only re-rendering, then called it on compose text area's `change` event listener.

Fixes [#33589](https://github.com/zulip/zulip/issues/33589)

**Screenshots and screen captures:**
Before | After
--- | ---
![before](https://github.com/user-attachments/assets/81e11019-b310-41ab-9cd3-3af2db2194b9) | ![after](https://github.com/user-attachments/assets/9ec949b3-d02c-423c-8a55-ee3b19fd3627)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
