### PR TITLE
help: Document specifying sender in generate channel email modal.

### DIFF
--- a/help/message-a-channel-by-email.md
+++ b/help/message-a-channel-by-email.md
@@ -32,6 +32,9 @@ API](/api/send-message).
 
 1. Click **Generate email address** under **Email address**.
 
+1. Select **Who should be the sender of the Zulip messages for this email
+   address**.
+
 1. Toggle the configuration options as desired.
 
 1. Click **Copy address** to add the channel email address to your clipboard.
@@ -48,7 +51,15 @@ up in Zulip.
 
 ## Configuration options
 
-The options below control which parts of the email are included in the
+You can configure **who should be the sender of the Zulip messages** for the
+generated email address, with the following options:
+
+* **Email Gateway bot**: This option makes it easy to see that the message
+  was sent via email.
+* **You**: Messages will look the same as messages you send from the Zulip UI.
+* [Any bot you own](/help/view-your-bots)
+
+The following options control which parts of the email are included in the
 Zulip message.
 
 * **The sender's email address**: Adds `From: <Sender email address>` to
@@ -74,3 +85,4 @@ Zulip message.
 ## Related articles
 
 * [Using Zulip via email](/help/using-zulip-via-email)
+* [Bots overview](/help/bots-overview)


### PR DESCRIPTION
Documents setting the email sender in the generate channel email modal that was added in #32581 and #32382.

We could also add a step in the instructions for the **Who should be the sender of the Zulip messages for this email address?** question in the modal.

**Screenshots and screen captures:**

![Screenshot from 2025-02-24 19-57-07](https://github.com/user-attachments/assets/7687e52a-16b7-4881-8769-6a03cf77a861)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
