### PR TITLE
docs: Update sections for organization settings tab changes.

### DIFF
--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -577,7 +577,7 @@ In frontend, we have split the `property_types` into three objects:
 Once you've determined whether the new setting belongs, the next step
 is to find the right subsection of that page to put the setting
 in. For example in this case of `mandatory_topics` it will lie in
-"Other settings" (`other_settings`) subsection.
+"Compose settings" (`org-compose-settings`) subsection.
 
 _If you're not sure in which section your feature belongs, it's
 better to discuss it in

--- a/help/animated-gifs-from-giphy.md
+++ b/help/animated-gifs-from-giphy.md
@@ -45,7 +45,7 @@ this configure or disable GIPHY integration entirely:
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, select a rating from **Maximum rating of GIFs**.
+1. Under **Compose settings**, select a rating for **GIPHY integration**.
 
 {!save-changes.md!}
 

--- a/help/code-blocks.md
+++ b/help/code-blocks.md
@@ -100,7 +100,7 @@ blocks, which will be used whenever the code block has no tag.
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, edit **Default language for code blocks**.
+1. Under **Message feed settings**, edit **Default language for code blocks**.
 
 {end_tabs}
 

--- a/help/image-video-and-website-previews.md
+++ b/help/image-video-and-website-previews.md
@@ -41,7 +41,8 @@ viewer](/help/view-images-and-videos).
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, toggle **Show previews of uploaded and linked images and videos**.
+1. Under **Message feeed settings**, toggle **Show previews of uploaded and
+   linked images and videos**.
 
 {!save-changes.md!}
 
@@ -55,7 +56,7 @@ viewer](/help/view-images-and-videos).
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, toggle **Show previews of linked websites**.
+1. Under **Message feed settings**, toggle **Show previews of linked websites**.
 
 {!save-changes.md!}
 

--- a/help/message-retention-policy.md
+++ b/help/message-retention-policy.md
@@ -30,7 +30,8 @@ Standard hosting.
 
 {settings_tab|organization-settings}
 
-4. Under **Message retention**, configure **Message retention period**.
+1. Under **Message retention period**, configure **Message retention
+   period**.
 
 {!save-changes.md!}
 

--- a/help/read-receipts.md
+++ b/help/read-receipts.md
@@ -72,7 +72,7 @@ You can configure:
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, toggle **Enable read receipts**.
+1. Under **Message feed settings**, toggle **Enable read receipts**.
 
 {!save-changes.md!}
 

--- a/help/require-topics.md
+++ b/help/require-topics.md
@@ -12,8 +12,7 @@ specified topic.
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, toggle
-   **Require topics in channel messages**.
+1. Under **Compose settings**, toggle **Require topics in channel messages**.
 
 {!save-changes.md!}
 

--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -102,7 +102,7 @@ supported by Zulip are:
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, select the desired provider from the
+1. Under **Compose settings**, select the desired provider from the
    **Call provider** dropdown.
 
 {!save-changes.md!}
@@ -119,7 +119,7 @@ instance of Jitsi Meet.
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, select **Custom URL** from the
+1. Under **Compose settings**, select **Custom URL** from the
    **Jitsi server URL** dropdown.
 
 1. Enter the URL of your self-hosted Jitsi Meet server.

--- a/templates/zerver/integrations/jitsi.md
+++ b/templates/zerver/integrations/jitsi.md
@@ -9,7 +9,7 @@ instance of Jitsi Meet.
 
 {settings_tab|organization-settings}
 
-1. Under **Other settings**, select **Jitsi Meet** from the **Call provider**
+1. Under **Compose settings**, select **Jitsi Meet** from the **Call provider**
    dropdown.
 
 1. _(optional)_ Select **Custom URL** from the **Jitsi server URL** dropdown,

--- a/templates/zerver/integrations/zoom.md
+++ b/templates/zerver/integrations/zoom.md
@@ -17,14 +17,9 @@ call provider instead.
 
 {start_tabs}
 
-1. Click on the **gear** (<i class="zulip-icon zulip-icon-gear"></i>) icon in
-   the upper right corner of the web or desktop app.
+{settings_tab|organization-settings}
 
-1. Select **Organization settings**.
-
-1. On the left, click **Organization settings**.
-
-1. Under **Other settings**, select Zoom from the **Call provider** dropdown.
+1. Under **Compose settings**, select Zoom from the **Call provider** dropdown.
 
 1. Click **Save changes**.
 


### PR DESCRIPTION
Updates help center, integration and contributor docs where for the new subsections on the organization settings tab, which were changed in #33605.

Previously, these settings were all in the "Other settings" subsection for that organization settings tab.

---

**Screenshots and screen captures:**

*Did not include a screenshot of the changes to the new feature tutorial in the contributor docs.*

| Documentation | Screenshot |
| --- | --- |
| [Animated GIFs](https://zulip.com/help/animated-gifs-from-giphy) | ![Screenshot from 2025-02-24 20-49-20](https://github.com/user-attachments/assets/e15bf726-8d45-4564-8a36-694c60f6fed5) |
| [Code blocks](https://zulip.com/help/code-blocks#default-code-block-language) | ![Screenshot from 2025-02-24 20-50-20](https://github.com/user-attachments/assets/0e910f32-2fc4-4c60-a8ec-858eaf701aeb) |
| [Image and website previews](https://zulip.com/help/image-video-and-website-previews#configure-whether-image-and-video-previews-are-shown) | ![Screenshot from 2025-02-24 20-51-47](https://github.com/user-attachments/assets/c96eb976-0a12-4cf9-8a4f-497867c1ffe4) |
| [Message retention policy](https://zulip.com/help/message-retention-policy) | ![Screenshot from 2025-02-24 20-52-36](https://github.com/user-attachments/assets/c483f4fa-8600-41e5-9d70-52551e864989) |
| [Require topics](https://zulip.com/help/require-topics) | ![Screenshot from 2025-02-24 20-53-36](https://github.com/user-attachments/assets/90862a2a-314f-486e-a93e-142849ed2b41) |
| [Read receipts](https://zulip.com/help/read-receipts#configure-whether-read-receipts-are-enabled-in-your-organization) | ![Screenshot from 2025-02-24 20-54-32](https://github.com/user-attachments/assets/372138f1-621f-4ff9-880a-cade570cfda2) |
| [Jitsi integration](https://zulip.com/integrations/doc/jitsi) | ![Screenshot from 2025-02-24 20-58-42](https://github.com/user-attachments/assets/c6fe3f52-7505-4c37-8f41-d411dc327474) |
| [Zoom integration](https://zulip.com/integrations/doc/zoom) | ![Screenshot from 2025-02-24 20-59-38](https://github.com/user-attachments/assets/75ed1616-7013-478e-bb0c-c60c2a958784) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
