### PR TITLE
banner: Aligned the username icon for topic header.

### DIFF
--- a/web/styles/message_header.css
+++ b/web/styles/message_header.css
@@ -122,8 +122,8 @@
         display: flex;
         padding: 5px 0 5px 10px;
         font-weight: 600;
-        height: 1.2142em; /* 17px at 14px em */
-        line-height: 1.2142em; /* 17px at 14px em */
+        height: 1.4142em; /* 19px at 14px em */
+        line-height: 1.4142em; /* 19px at 14px em */
         color: var(--color-text-message-header);
 
         &:hover {


### PR DESCRIPTION
This commit fixes the alignment of the user emoji in the topic header. Previously, the icon in the user's name was slightly cut off at the top. This issue was resolved by setting the line height to 19px.

> Important Note:
 This UI glitch was exclusive to Safari Browser. 

|Change in 12px (Before)|Change in 12px (After)|
|---|---|
|<img width="196" alt="Screenshot 2025-02-25 at 2 26 21 AM" src="https://github.com/user-attachments/assets/9f596c8a-8a74-4f1a-875e-085d831dcab3" />|<img width="196" alt="Screenshot 2025-02-25 at 2 09 42 AM" src="https://github.com/user-attachments/assets/22af786f-9563-44d8-8ae1-b5dec93a456a" />|


|Change in 14px(Before)|Change in 14px(After)|
|---|---|
|<img width="229" alt="Screenshot 2025-02-25 at 2 28 01 AM" src="https://github.com/user-attachments/assets/09b60bdd-72f9-4ed8-b151-a89fe544c1da" />|<img width="225" alt="Screenshot 2025-02-25 at 2 10 44 AM" src="https://github.com/user-attachments/assets/ab59c471-77eb-4315-83ab-e9b51f84836c" />|



|Change in 16px(Before|Change in 16px(After)|
|---|---|
|<img width="266" alt="Screenshot 2025-02-25 at 2 29 20 AM" src="https://github.com/user-attachments/assets/581cdd99-0589-4b55-9a18-baed0b20eb88" />|<img width="261" alt="Screenshot 2025-02-25 at 2 11 35 AM" src="https://github.com/user-attachments/assets/9bad0aea-0a8e-46fe-a215-0e3e8f959442" />|

|Change in 20px(Before)|Change in 20px(After)| 
|---|---|
|<img width="313" alt="Screenshot 2025-02-25 at 2 30 41 AM" src="https://github.com/user-attachments/assets/3fafafd8-5c63-4730-af15-ba853bb732a4" />|<img width="317" alt="Screenshot 2025-02-25 at 2 12 02 AM" src="https://github.com/user-attachments/assets/b200c1db-4f35-4a8c-8278-b464b3e0297d" />|


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
