### PR TITLE
copy_paste: Fix issue when copy-pasting from Mac terminal

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -60,6 +60,19 @@ export function is_white_space_pre(paste_html: string): boolean {
     );
 }
 
+function is_from_mac_terminal(html_fragment: HTMLBodyElement): boolean {
+    const html_tag = html_fragment.parentElement;
+    if (!html_tag || html_tag.nodeName !== "HTML") {
+        return false;
+    }
+
+    const has_mac_terminal_metadata = [...html_tag.querySelectorAll("meta")].some(
+        (meta) => meta.name === "Generator" && meta.content?.includes("Cocoa HTML Writer"),
+    );
+
+    return has_mac_terminal_metadata;
+}
+
 function is_from_excel(html_fragment: HTMLBodyElement): boolean {
     const html_tag = html_fragment.parentElement;
     if (!html_tag || html_tag.nodeName !== "HTML") {
@@ -118,6 +131,11 @@ export function paste_handler_converter(
         .parseFromString(paste_html, "text/html")
         .querySelector("body");
     assert(copied_html_fragment !== null);
+
+    // If the copied content is from Mac Terminal, we use its text content directly
+    if (is_from_mac_terminal(copied_html_fragment)) {
+        paste_html = copied_html_fragment.textContent ?? "";
+    }
 
     const copied_within_single_element = within_single_element(copied_html_fragment);
     const outer_elements_to_retain = ["PRE", "UL", "OL", "A", "CODE"];


### PR DESCRIPTION
When using Chrome on Mac, copy-pasting from terminal into the compose box creates extra line breaks and spaces. This is likely due to how Zulip handles pasted content. So if the clipboard contains text copied from the terminal, we won't use Zulip's paste converter. 

This commit attempts to fix it by adding a new function to check whether the clipboard contains text copied from the Mac terminal or not.

<!-- Describe your pull request here.-->

Fixes: #33569 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| ---- | ---- |
| <img width="738" alt="image" src="https://github.com/user-attachments/assets/025bec75-3588-4e43-bcff-cfe7377541fc" /> | <img width="734" alt="image" src="https://github.com/user-attachments/assets/0530ea03-f654-468f-9b05-977213c5f297" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
