### PR TITLE
Fixes related to typeahead.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1328,6 +1328,9 @@ export function initialize_topic_edit_typeahead(
             return topics_seen_for(stream_id);
         },
         items: max_num_items,
+        getCustomItemClassname() {
+            return "topic-edit-typeahead";
+        },
     });
 }
 

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -43,6 +43,9 @@ import type {UserPillData} from "./user_pill.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
+/* Maximum channel name length + link syntax (#**>**) + some topic characters */
+const MAX_LOOKBACK_FOR_TYPEAHEAD_COMPLETION = 60 + 6 + 20;
+
 // **********************************
 // AN IMPORTANT NOTE ABOUT TYPEAHEADS
 // **********************************
@@ -423,7 +426,7 @@ export function tokenize_compose_str(s: string): string {
 
     // We limit how far back to scan to limit potential weird behavior
     // in very long messages, and simplify performance analysis.
-    let min_i = s.length - 40;
+    let min_i = s.length - MAX_LOOKBACK_FOR_TYPEAHEAD_COMPLETION;
     if (min_i < 0) {
         min_i = 0;
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1105,10 +1105,16 @@ textarea.new_message_textarea {
     color: var(--color-compose-recipient-box-text-color);
     background-color: var(--color-compose-recipient-box-background-color);
     border-color: var(--color-compose-recipient-box-border-color);
+    max-width: 30vw;
 
     &.dropdown-widget-button {
         padding: 0 6px;
         border-radius: 4px;
+    }
+
+    .dropdown_widget_value {
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 }
 

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -67,6 +67,17 @@
                 gap: 0;
             }
 
+            &.topic-edit-typeahead {
+                display: flex;
+                flex-wrap: wrap;
+
+                .typeahead-strong-section {
+                    /* We want to wrap the topic but preserve
+                       original white spaces sequence too. */
+                    white-space: pre-wrap;
+                }
+            }
+
             .typeahead-text-container {
                 display: flex;
                 align-self: center;

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -106,7 +106,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         position: relative;
-        top: -1px;
+        top: -2px;
 
         & > a {
             color: var(--color-dropdown-item);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -2014,7 +2014,12 @@ test("tokenizing", () => {
 
     // The following cases are kinda judgment calls...
     // max scanning limit is 40 characters until chars like @, # , / are found
-    assert.equal(ct.tokenize_compose_str("foo @toomanycharactersistooridiculoustocomplete"), "");
+    assert.equal(
+        ct.tokenize_compose_str(
+            "foo @toomanycharactersistooridiculoustoautocompletethatitexceedsalllimits",
+        ),
+        "",
+    );
     assert.equal(ct.tokenize_compose_str("foo #bar@foo"), "#bar@foo");
 });
 


### PR DESCRIPTION
Extracted from #33619

Fixes following:

* Topic completion for very long stream names.
* Topic input box in compose not visible for long stream names in short windows.
* Stream description alignment in stream typeahead.
* Wrap topic name to next line in inline topic edit typeahead.

| before | after |
| --- | --- |
| ![Screenshot 2025-02-24 123116](https://github.com/user-attachments/assets/05f89ff3-023a-4029-bdac-948a246c1e3f) | ![Screenshot 2025-02-24 123100](https://github.com/user-attachments/assets/3f75e295-24bc-4728-8683-5dedfadd426f) |
| ![Screenshot 2025-02-24 194037](https://github.com/user-attachments/assets/afddae96-89f3-4198-9618-6261999c5440) | ![Screenshot 2025-02-24 194001](https://github.com/user-attachments/assets/42d74540-f890-489e-a1da-b5b5ca406e4e) |
| ![image](https://github.com/user-attachments/assets/ea05072c-d4b3-4f05-a4be-6b1e4015194b) | ![Screenshot 2025-02-25 102227](https://github.com/user-attachments/assets/3560ac45-5f16-4476-8382-7503f1a4bcaf) |

