### PR TITLE
narrow: Mark messages as read for -is:dm filter

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1128,6 +1128,24 @@ export class Filter {
         if (this.single_term_type_returns_all_messages_of_conversation()) {
             return true;
         }
+        
+        const term_types = this.sorted_term_types();
+
+        if (_.isEqual(term_types, ["not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["channel", "not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["topic", "not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["channel", "topic", "not-is-dm"])) {
+            return true;
+        }
         return false;
     }
 

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -327,6 +327,8 @@ test("basics", () => {
     assert.ok(filter.is_personal_filter());
     assert.ok(!filter.is_conversation_view());
 
+    
+
     terms = [{operator: "dm", operand: "joe@example.com"}];
     filter = new Filter(terms);
     assert.ok(filter.is_non_group_direct_message());
@@ -377,6 +379,61 @@ test("basics", () => {
     assert.ok(!filter.is_personal_filter());
     assert.ok(filter.is_conversation_view());
     assert.ok(!filter.is_conversation_view_with_near());
+
+    terms = [{operator: "is", operand: "dm", negated: true}];
+    filter = new Filter(terms);
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+
+    terms = [
+        {operator: "channel", operand: "channel_name"},
+        {operator: "is", operand: "dm", negated: true},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("channel"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_negated_operand("channel", "not-is-dm"));
+
+    terms = [
+        {operator: "topic", operand: "topic_name"},
+        {operator: "is", operand: "dm", negated: true},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("topic"));
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_negated_operand("topic", "topic_name"));
+
+    terms = [
+        {operator: "channel", operand: "channel_name"},
+        {operator: "topic", operand: "topic_name"},
+        {operator: "is", operand: "dm", negated: true},
+    ];
+    filter = new Filter(terms);
+    assert.ok(filter.has_operator("channel"));
+    assert.ok(filter.has_operator("topic"));
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.is_personal_filter());
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(!filter.has_negated_operand("channel", "channel_name"));
+    assert.ok(!filter.has_negated_operand("topic", "topic_name"));
+    assert.ok(filter.can_bucket_by("channel"));
+    assert.ok(filter.can_bucket_by("channel", "topic"));
 
     // "pm-with" was renamed to "dm"
     terms = [{operator: "pm-with", operand: "joe@example.com"}];

--- a/zulip-py3-venv
+++ b/zulip-py3-venv
@@ -1,0 +1,1 @@
+/srv/zulip-venv-cache/5f7f360c8d9ba9ee7cf140773a07e150cde380b9/zulip-py3-venv


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR updates the behaviour of -is:dm search filter such that messages will be marked as read when applying the -is:dm filter alone or with stream and topic filters, but not when a search term is also included.
Fixes:  #25113 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
