### PR TITLE
get_realm_with_settings: Fix unnecessary joins with channel.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -429,31 +429,16 @@ def fetch_initial_state_data(
 
         state["server_can_summarize_topics"] = settings.TOPIC_SUMMARIZATION_MODEL is not None
 
-        moderation_request_channel = realm.moderation_request_channel
-        if moderation_request_channel:
-            state["realm_moderation_request_channel_id"] = moderation_request_channel.id
-        else:
-            state["realm_moderation_request_channel_id"] = -1
-
-        new_stream_announcements_stream = realm.new_stream_announcements_stream
-        if new_stream_announcements_stream:
-            state["realm_new_stream_announcements_stream_id"] = new_stream_announcements_stream.id
-        else:
-            state["realm_new_stream_announcements_stream_id"] = -1
-
-        signup_announcements_stream = realm.signup_announcements_stream
-        if signup_announcements_stream:
-            state["realm_signup_announcements_stream_id"] = signup_announcements_stream.id
-        else:
-            state["realm_signup_announcements_stream_id"] = -1
-
-        zulip_update_announcements_stream = realm.zulip_update_announcements_stream
-        if zulip_update_announcements_stream:
-            state["realm_zulip_update_announcements_stream_id"] = (
-                zulip_update_announcements_stream.id
-            )
-        else:
-            state["realm_zulip_update_announcements_stream_id"] = -1
+        for channel_field in [
+            "moderation_request_channel_id",
+            "new_stream_announcements_stream_id",
+            "signup_announcements_stream_id",
+            "zulip_update_announcements_stream_id",
+        ]:
+            if getattr(realm, channel_field) is None:
+                state["realm_" + channel_field] = -1
+            else:
+                state["realm_" + channel_field] = getattr(realm, channel_field)
 
         state["max_stream_name_length"] = Stream.MAX_NAME_LENGTH
         state["max_stream_description_length"] = Stream.MAX_DESCRIPTION_LENGTH

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -1208,9 +1208,7 @@ def get_realm_with_settings(realm_id: int) -> Realm:
     # even when it cannot be set to anonymous groups because
     # the setting is used when fetching users in the realm.
     # * All the settings that can be set to anonymous groups.
-    # * Announcements streams.
     return Realm.objects.select_related(
-        "moderation_request_channel",
         "create_multiuse_invite_group",
         "create_multiuse_invite_group__named_user_group",
         "can_access_all_users_group",
@@ -1251,9 +1249,6 @@ def get_realm_with_settings(realm_id: int) -> Realm:
         "direct_message_initiator_group__named_user_group",
         "direct_message_permission_group",
         "direct_message_permission_group__named_user_group",
-        "new_stream_announcements_stream",
-        "signup_announcements_stream",
-        "zulip_update_announcements_stream",
     ).get(id=realm_id)
 
 


### PR DESCRIPTION
We were not actually using anything but the IDs here, so it was a bunch of wasted work to fetch these.

This essentially reverts f48e87cd3cb6846d99db5099cafe604390a9b667. At
the time, something like that was required, because we needed to check
if the channel was deactivated before exposing it to the API, but more
recent reworking of the system to change the setting if the channel is
deactivated, rather than masking it in fetch_initial_state_data, means
we can do this cleanup.

@prakhar1144 FYI.