### PR TITLE
user_profile: Override default width of input, to avoid overflow.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -588,6 +588,9 @@ ul.popover-group-menu-member-list {
             text-overflow: ellipsis;
             overflow: hidden;
             margin-bottom: 0;
+            /* Override default modal input width, since that overflows.
+               This is 185px (the default "width: unset" width) at 14px/em */
+            width: 13.2142em;
         }
 
         .group-search:placeholder-shown + #clear_groups_search,


### PR DESCRIPTION
This affects both the "Channels" and "User groups" tab in similar ways.

12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-02-25 at 12 50 51](https://github.com/user-attachments/assets/665554ba-ee32-4594-b314-c2a167bc7d5f) | ![Screen Shot 2025-02-25 at 12 47 53](https://github.com/user-attachments/assets/ba8ca248-8777-44af-94a4-152f0415d0ae) |
| ![Screen Shot 2025-02-25 at 12 50 36](https://github.com/user-attachments/assets/56e4896c-2388-4ca8-ae07-556a1cdeb70e) | ![Screen Shot 2025-02-25 at 12 48 18](https://github.com/user-attachments/assets/1ea4746c-2470-4529-a0f3-7afff129d0ed) |
| ![Screen Shot 2025-02-25 at 12 50 21](https://github.com/user-attachments/assets/81e053a8-8ba6-463b-bf52-27f66dc27422) | ![Screen Shot 2025-02-25 at 12 48 30](https://github.com/user-attachments/assets/71293b6c-ebd9-4fc5-998e-6ab14304d19d) |
| ![Screen Shot 2025-02-25 at 12 50 02](https://github.com/user-attachments/assets/27d6a8a1-1d2a-427b-8137-e468951963ea) | ![Screen Shot 2025-02-25 at 12 48 53](https://github.com/user-attachments/assets/c5da4400-de52-499b-a28a-7ec4106ace27) |
