### PR TITLE
Searchbar narrow search icon bug

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -232,7 +232,7 @@
         }
 
         &:not(.focused) {
-            max-height: var(--search-box-height);
+            height: var(--search-box-height);
             overflow: hidden;
 
             .search-input-and-pills {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1947,9 +1947,6 @@ body:not(.hide-left-sidebar) {
 
 .header-main .column-right {
     display: flex;
-    /* Make the top navbar right column its full width,
-       less 7px of space on the left and right. */
-    width: calc(var(--right-sidebar-width) - 7px - 7px);
     justify-content: flex-end;
     align-items: center;
 


### PR DESCRIPTION
Reported [here]([#issues > navbar search icon missing at narrow widths @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/navbar.20search.20icon.20missing.20at.20narrow.20widths/near/2099479)) on CZO.