### PR TITLE
postprocess_content: Drop invalid inline image elements.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -112,7 +112,17 @@ export function postprocess_content(html: string): string {
         // `/user_uploads/thumbnail`, even though that's what the
         // server writes in the markup, because Firefox will have
         // already prepended the origin to the source of an image.
-        const image_url = new URL(inline_img.src, window.location.origin);
+        let image_url;
+        try {
+            image_url = new URL(inline_img.src, window.location.origin);
+        } catch {
+            // If the image source URL can't be parsed, likely due to
+            // some historical bug in the Markdown processor, just
+            // drop the invalid image element.
+            inline_img.closest("div.message_inline_image")!.remove();
+            continue;
+        }
+
         if (
             image_url.origin === window.location.origin &&
             image_url.pathname.startsWith("/user_uploads/thumbnail/")

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -151,4 +151,18 @@ run_test("message_inline_animated_image_still", ({override}) => {
             "</a>" +
             "</div>",
     );
+
+    // Broken/invalid source URLs in image previews should be
+    // dropped. Inspired by a real message found in chat.zulip.org
+    // history.
+    assert.equal(
+        postprocess_content(
+            '<div class="message_inline_image">' +
+                '<a href="https://zulip.%20[Click%20to%20join%20video%20call](https://meeting.example.com/abcd1234)%20example.com/user_uploads/2/ab/abcd1234/image.png" target="_blank" title="image.png">' +
+                '<img src="https://zulip.%20[Click%20to%20join%20video%20call](https://meeting.example.com/abcd1234)%20example.com/user_uploads/2/ab/abcd1234/image.png">' +
+                "</a>" +
+                "</div>",
+        ),
+        "",
+    );
 });


### PR DESCRIPTION
These shouldn't exist without bugs in the Markdown processor, but at least some ancient messages in chat.zulip.org seem to have them.