### PR TITLE
message: Allow accessing archived channel when not modifying message.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 360**
+
+* [`GET /messages/{message_id}`](/api/get-message), [`GET
+  /messages/{message_id}/read_receipts`](/api/get-read-receipts):
+  Messages from an archived channels can now be read through these API
+  endpoints, if the channel's access control permissions permit doing
+  so.
+
 **Feature level 359**
 
 * `PATCH /bots/{bot_user_id}`: Previously, changing the owner of a bot

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 359  # Last bumped for not adjusting bot subscriptions on owner change.
+API_FEATURE_LEVEL = 360  # Last bumped for allowing access to archived channel messages on read.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1350,7 +1350,7 @@ def check_update_message(
     and raises a JsonableError if otherwise.
     It returns the number changed.
     """
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(user_profile, message_id, lock_message=True, is_modifying_message=True)
 
     # If there is a change to the content, check that it hasn't been too long
     # Allow an extra 20 seconds since we potentially allow editing 15 seconds

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -106,7 +106,7 @@ def check_add_reaction(
     reaction_type: str | None,
 ) -> None:
     message, user_message = access_message_and_usermessage(
-        user_profile, message_id, lock_message=True
+        user_profile, message_id, lock_message=True, is_modifying_message=True
     )
 
     if emoji_code is None or reaction_type is None:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -313,6 +313,8 @@ def access_message(
     user_profile: UserProfile,
     message_id: int,
     lock_message: bool = False,
+    *,
+    is_modifying_message: bool = False,
 ) -> Message:
     """You can access a message by ID in our APIs that either:
     (1) You received or have previously accessed via starring
@@ -349,6 +351,7 @@ def access_message(
         message,
         has_user_message=has_user_message,
         user_group_membership_details=user_group_membership_details,
+        is_modifying_message=is_modifying_message,
     ):
         return message
     raise JsonableError(_("Invalid message(s)"))
@@ -358,6 +361,8 @@ def access_message_and_usermessage(
     user_profile: UserProfile,
     message_id: int,
     lock_message: bool = False,
+    *,
+    is_modifying_message: bool = False,
 ) -> tuple[Message, UserMessage | None]:
     """As access_message, but also returns the usermessage, if any."""
     try:
@@ -379,6 +384,7 @@ def access_message_and_usermessage(
         message,
         has_user_message=has_user_message,
         user_group_membership_details=user_group_membership_details,
+        is_modifying_message=is_modifying_message,
     ):
         return (message, user_message)
     raise JsonableError(_("Invalid message(s)"))
@@ -478,6 +484,7 @@ def has_message_access(
     stream: Stream | None = None,
     is_subscribed: bool | None = None,
     user_group_membership_details: UserGroupMembershipDetails,
+    is_modifying_message: bool = False,
 ) -> bool:
     """
     Returns whether a user has access to a given message.
@@ -500,7 +507,7 @@ def has_message_access(
         # You can't access public stream messages in other realms
         return False
 
-    if stream.deactivated:
+    if is_modifying_message and stream.deactivated:
         # You can't access messages in deactivated streams
         return False
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -205,7 +205,7 @@ def delete_message_backend(
     # concurrently are serialized properly with deleting the message; this prevents a deadlock
     # that would otherwise happen because of the other transaction holding a lock on the `Message`
     # row.
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(user_profile, message_id, lock_message=True, is_modifying_message=True)
     validate_can_delete_message(user_profile, message)
     try:
         do_delete_messages(user_profile.realm, [message], acting_user=user_profile)

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -40,7 +40,7 @@ def remove_reaction(
     emoji_code: str | None = None,
     reaction_type: str = "unicode_emoji",
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(user_profile, message_id, lock_message=True, is_modifying_message=True)
 
     if emoji_code is None:
         if emoji_name is None:

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -26,7 +26,7 @@ def process_submessage(
     msg_type: str,
     content: str,
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id, lock_message=True)
+    message = access_message(user_profile, message_id, lock_message=True, is_modifying_message=True)
 
     verify_submessage_sender(
         message_id=message.id,

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -80,7 +80,10 @@ def send_message_edit_notification_backend(
     operator: Annotated[Literal["start", "stop"], ApiParamConfig("op")],
     message_id: Json[int],
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id)
+    # Technically, this endpoint doesn't modify the message, but we're
+    # attempting to send a typing notification that we're editing the
+    # message.
+    message = access_message(user_profile, message_id, is_modifying_message=True)
     validate_user_can_edit_message(user_profile, message, edit_limit_buffer=0)
     recipient = message.recipient
 


### PR DESCRIPTION
Fixes #33567.

Supersedes #33457.


We have used the flag `is_modifying_message` since it's more generic than an archived channel specific flag and helps us understand better what is the condition where we do not want to allow archived channels. Message edit has an existing test for this.

Also see https://github.com/zulip/zulip/pull/33507#discussion_r1971062341


<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
