### PR TITLE
errors: Improve consistently of error messages about name/channel/email/username/subdomain in use

### DIFF
--- a/corporate/tests/test_support_views.py
+++ b/corporate/tests/test_support_views.py
@@ -1902,21 +1902,21 @@ class TestSupportEndpoint(ZulipTestCase):
             "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "new-name"}
         )
         self.assert_in_success_response(
-            ["Subdomain already in use. Please choose a different one."], result
+            ["Subdomain is already in use. Please choose a different one."], result
         )
 
         result = self.client_post(
             "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "zulip"}
         )
         self.assert_in_success_response(
-            ["Subdomain already in use. Please choose a different one."], result
+            ["Subdomain is already in use. Please choose a different one."], result
         )
 
         result = self.client_post(
             "/activity/support", {"realm_id": f"{lear_realm.id}", "new_subdomain": "lear"}
         )
         self.assert_in_success_response(
-            ["Subdomain already in use. Please choose a different one."], result
+            ["Subdomain is already in use. Please choose a different one."], result
         )
 
         # Test renaming to a "reserved" subdomain

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -249,7 +249,7 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
     await page.waitForSelector("#dialog_error", {visible: true});
     assert.strictEqual(
         await common.get_text_from_selector(page, "#dialog_error"),
-        "Failed: Name is already in use!",
+        "Failed: Name is already in use.",
     );
 
     const cancel_button_selector = "#user-profile-modal .dialog_exit_button";

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -82,7 +82,7 @@ def check_subdomain_available(subdomain: str, allow_reserved_subdomain: bool = F
         "too short": _("Subdomain needs to have length 3 or greater."),
         "extremal dash": _("Subdomain cannot start or end with a '-'."),
         "bad character": _("Subdomain can only have lowercase letters, numbers, and '-'s."),
-        "unavailable": _("Subdomain already in use. Please choose a different one."),
+        "unavailable": _("Subdomain is already in use. Please choose a different one."),
         "reserved": _("Subdomain reserved. Please choose a different one."),
     }
 

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -756,3 +756,13 @@ class CannotManageDefaultChannelError(JsonableError):
     @override
     def msg_format() -> str:
         return _("You do not have permission to change default channels.")
+
+
+class EmailAlreadyInUseError(JsonableError):
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Email is already in use.")

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -874,7 +874,7 @@ def check_stream_name_available(realm: Realm, name: str) -> None:
     check_stream_name(name)
     try:
         get_stream(name, realm)
-        raise JsonableError(_("Channel name already in use."))
+        raise JsonableError(_("Channel name is already in use."))
     except Stream.DoesNotExist:
         pass
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -108,7 +108,7 @@ def check_bot_name_available(realm_id: int, full_name: str, *, is_activation: bo
                 f'There is already an active bot named "{full_name}" in this organization. To reactivate this bot, you must rename or deactivate the other one first.'
             )
         else:
-            raise JsonableError(_("Name is already in use!"))
+            raise JsonableError(_("Name is already in use."))
 
 
 def check_short_name(short_name_raw: str) -> str:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9428,7 +9428,7 @@ paths:
                   - example:
                       {
                         "code": "BAD_REQUEST",
-                        "msg": "Email 'newbie@zulip.com' already in use",
+                        "msg": "Email is already in use.",
                         "result": "error",
                       }
                     description: |

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -251,7 +251,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             short_name="hambot",
         )
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_error(result, "Email 'hambot-bot@zulip.testserver' already in use")
+        self.assert_json_error(result, "Email is already in use.")
 
         dup_full_name = "The Bot of Hamlet"
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -260,7 +260,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             short_name="whatever",
         )
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_error(result, "Name is already in use!")
+        self.assert_json_error(result, "Name is already in use.")
 
     def test_add_bot_with_user_avatar(self) -> None:
         email = "hambot-bot@zulip.testserver"
@@ -1143,7 +1143,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "full_name": already_taken_name,
         }
         result = self.client_patch(url, bot_info)
-        self.assert_json_error(result, "Name is already in use!")
+        self.assert_json_error(result, "Name is already in use.")
 
         # We can use our own name (with extra whitespace), and the
         # server should silently do nothing.

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -214,7 +214,7 @@ class TestFullStack(ZulipTestCase):
 
         # Verify error handling when the user already exists.
         result = self.client_post("/json/users", valid_params)
-        self.assert_json_error(result, "Email 'romeo@zulip.net' already in use", 400)
+        self.assert_json_error(result, "Email is already in use.", 400)
 
     def test_tornado_redirects(self) -> None:
         # Let's poke a bit at Zulip's event system.

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -261,7 +261,9 @@ class RealmTest(ZulipTestCase):
         realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=30)
         realm.save()
         result = self.client_patch("/json/realm", data)
-        self.assert_json_error(result, "Subdomain already in use. Please choose a different one.")
+        self.assert_json_error(
+            result, "Subdomain is already in use. Please choose a different one."
+        )
 
         # Now try to change the string_id to something available.
         data = dict(string_id="coolrealm")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2160,7 +2160,7 @@ class RealmCreationTest(ZulipTestCase):
     def test_subdomain_check_api(self) -> None:
         result = self.client_get("/json/realm/subdomain/zulip")
         self.assert_in_success_response(
-            ["Subdomain already in use. Please choose a different one."], result
+            ["Subdomain is already in use. Please choose a different one."], result
         )
 
         result = self.client_get("/json/realm/subdomain/zu_lip")
@@ -2990,7 +2990,7 @@ class UserSignUpTest(ZulipTestCase):
         )
         self.assert_in_success_response(
             [
-                "Subdomain already in use. Please choose a different one.",
+                "Subdomain is already in use. Please choose a different one.",
                 'value="Test"',
                 'name="realm_name"',
             ],

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2095,9 +2095,9 @@ class StreamAdminTest(ZulipTestCase):
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "stream_name1"})
         self.assert_json_error(result, "Channel already has that name.")
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "Denmark"})
-        self.assert_json_error(result, "Channel name already in use.")
+        self.assert_json_error(result, "Channel name is already in use.")
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "denmark "})
-        self.assert_json_error(result, "Channel name already in use.")
+        self.assert_json_error(result, "Channel name is already in use.")
 
         # Do a rename that is case-only--this should succeed.
         result = self.client_patch(f"/json/streams/{stream.id}", {"new_name": "sTREAm_name1"})

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1340,7 +1340,7 @@ class AdminCreateUserTest(ZulipTestCase):
 
         # we can't create the same user twice.
         result = self.client_post("/json/users", valid_params)
-        self.assert_json_error(result, "Email 'romeo@zulip.net' already in use")
+        self.assert_json_error(result, "Email is already in use.")
 
         # Don't allow user to sign up with disposable email.
         realm.emails_restricted_to_domains = False

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -45,6 +45,7 @@ from zerver.lib.bot_config import set_bot_config
 from zerver.lib.email_validation import email_allowed_for_realm, validate_email_not_already_in_realm
 from zerver.lib.exceptions import (
     CannotDeactivateLastUserError,
+    EmailAlreadyInUseError,
     JsonableError,
     MissingAuthenticationError,
     OrganizationAdministratorRequiredError,
@@ -603,7 +604,7 @@ def add_bot_backend(
         raise JsonableError(_("Bad name or username"))
     try:
         get_user_by_delivery_email(email, user_profile.realm)
-        raise JsonableError(_("Email '{email}' already in use").format(email=email))
+        raise EmailAlreadyInUseError
     except UserProfile.DoesNotExist:
         pass
 
@@ -810,7 +811,7 @@ def create_user_backend(
 
     try:
         get_user_by_delivery_email(email, user_profile.realm)
-        raise JsonableError(_("Email '{email}' already in use").format(email=email))
+        raise EmailAlreadyInUseError
     except UserProfile.DoesNotExist:
         pass
 


### PR DESCRIPTION
## **PR Description**  
This PR standardizes "already in use" error messages for consistency across the codebase.  

### **Commit 1**  
- Replace `"Email '{email}' already in use"` with `"Email is already in use."`  
- Use a shared class(`EmailAlreadyInUseError`) for displaying this error message.  

### **Commit 2**  
Ensure consistency across all "already in use" messages:  
- `"Channel name already in use"` → `"Channel name is already in use."`  
- `"Name is already in use!"` → `"Name is already in use."`  
- `"Subdomain already in use. Please choose a different one."` →  
  `"Subdomain is already in use. Please choose a different one."`  

**Fixes:** #33629 

---

## Screenshots and screen captures  
_
![screenshot_26022025_142135](https://github.com/user-attachments/assets/6a2fece6-3506-47a5-b1b1-77b8e2ba0acf)
![screenshot_27022025_135008](https://github.com/user-attachments/assets/c3f16941-2919-4f63-bdff-e13c9ec8f71a)
![screenshot_27022025_135642](https://github.com/user-attachments/assets/511a94d8-65ae-4884-8b61-9640fa3ef027)

---

<details>
  <summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.  
- [x] Communicated technical choices and ensured consistency.  
- [x] Verified that automated tests cover the changes where applicable.  
- [x] Ensured each commit is a coherent idea following [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html).  

</details>

