### PR TITLE
register: Optimize computing realm group settings.

### DIFF
--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -24,7 +24,7 @@ from zerver.lib.send_email import FromAddress, send_email, send_email_to_admins
 from zerver.lib.sessions import delete_realm_user_sessions
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.timezone import canonicalize_timezone
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.lib.upload import delete_message_attachments
 from zerver.lib.user_counts import realm_user_count_by_role
 from zerver.lib.user_groups import (
@@ -179,7 +179,7 @@ def do_change_realm_permission_group_setting(
     realm: Realm,
     setting_name: str,
     user_group: UserGroup,
-    old_setting_api_value: int | AnonymousSettingGroupDict | None = None,
+    old_setting_api_value: int | UserGroupMembersDict | None = None,
     *,
     acting_user: UserProfile | None,
 ) -> None:

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -50,7 +50,7 @@ from zerver.lib.streams import (
     stream_to_dict,
 )
 from zerver.lib.subscription_info import bulk_get_subscriber_peer_info, get_subscribers_query
-from zerver.lib.types import AnonymousSettingGroupDict, APISubscriptionDict
+from zerver.lib.types import APISubscriptionDict, UserGroupMembersDict
 from zerver.lib.user_groups import (
     get_group_setting_value_for_api,
     get_group_setting_value_for_audit_log_data,
@@ -500,7 +500,7 @@ def send_stream_creation_events_for_previously_inaccessible_streams(
     recent_traffic = get_streams_traffic(stream_ids, realm)
 
     streams = [stream_dict[stream_id] for stream_id in stream_ids]
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] | None = None
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] | None = None
 
     for stream_id, stream_users_ids in altered_user_dict.items():
         stream = stream_dict[stream_id]
@@ -1359,7 +1359,7 @@ def do_change_stream_permission(
     )
 
 
-def get_users_string_with_permission(setting_value: int | AnonymousSettingGroupDict) -> str:
+def get_users_string_with_permission(setting_value: int | UserGroupMembersDict) -> str:
     if isinstance(setting_value, int):
         setting_group = NamedUserGroup.objects.get(id=setting_value)
         return silent_mention_syntax_for_user_group(setting_group)
@@ -1386,8 +1386,8 @@ def get_users_string_with_permission(setting_value: int | AnonymousSettingGroupD
 def send_stream_posting_permission_update_notification(
     stream: Stream,
     *,
-    old_setting_value: int | AnonymousSettingGroupDict,
-    new_setting_value: int | AnonymousSettingGroupDict,
+    old_setting_value: int | UserGroupMembersDict,
+    new_setting_value: int | UserGroupMembersDict,
     acting_user: UserProfile,
 ) -> None:
     sender = get_system_bot(settings.NOTIFICATION_BOT, acting_user.realm_id)
@@ -1632,7 +1632,7 @@ def do_change_stream_group_based_setting(
     setting_name: str,
     user_group: UserGroup,
     *,
-    old_setting_api_value: int | AnonymousSettingGroupDict | None = None,
+    old_setting_api_value: int | UserGroupMembersDict | None = None,
     acting_user: UserProfile | None = None,
 ) -> None:
     old_user_group = getattr(stream, setting_name)

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.lib.user_groups import (
     get_group_setting_value_for_api,
     get_group_setting_value_for_audit_log_data,
@@ -226,7 +226,7 @@ def check_add_user_group(
 
 
 def do_send_user_group_update_event(
-    user_group: NamedUserGroup, data: dict[str, str | int | AnonymousSettingGroupDict]
+    user_group: NamedUserGroup, data: dict[str, str | int | UserGroupMembersDict]
 ) -> None:
     event = dict(type="user_group", op="update", group_id=user_group.id, data=data)
     if "name" in data:
@@ -473,7 +473,7 @@ def do_change_user_group_permission_setting(
     setting_name: str,
     setting_value_group: UserGroup,
     *,
-    old_setting_api_value: int | AnonymousSettingGroupDict | None = None,
+    old_setting_api_value: int | UserGroupMembersDict | None = None,
     acting_user: UserProfile | None,
 ) -> None:
     old_value = getattr(user_group, setting_name)
@@ -515,7 +515,7 @@ def do_change_user_group_permission_setting(
         },
     )
 
-    event_data_dict: dict[str, str | int | AnonymousSettingGroupDict] = {
+    event_data_dict: dict[str, str | int | UserGroupMembersDict] = {
         setting_name: new_setting_api_value
     }
     do_send_user_group_update_event(user_group, event_data_dict)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -39,7 +39,7 @@ from zerver.lib.streams import (
     stream_to_dict,
 )
 from zerver.lib.subscription_info import bulk_get_subscriber_peer_info
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.lib.user_counts import realm_user_count_by_role
 from zerver.lib.user_groups import get_system_user_group_for_user
 from zerver.lib.users import (
@@ -287,7 +287,7 @@ def send_group_update_event_for_anonymous_group_setting(
     realm = setting_group.realm
     for setting_name in NamedUserGroup.GROUP_PERMISSION_SETTINGS:
         if getattr(named_group, setting_name + "_id") == setting_group.id:
-            new_setting_value = AnonymousSettingGroupDict(
+            new_setting_value = UserGroupMembersDict(
                 direct_members=group_members_dict[setting_group.id],
                 direct_subgroups=group_subgroups_dict[setting_group.id],
             )
@@ -310,7 +310,7 @@ def send_realm_update_event_for_anonymous_group_setting(
     realm = setting_group.realm
     for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
         if getattr(realm, setting_name + "_id") == setting_group.id:
-            new_setting_value = AnonymousSettingGroupDict(
+            new_setting_value = UserGroupMembersDict(
                 direct_members=group_members_dict[setting_group.id],
                 direct_subgroups=group_subgroups_dict[setting_group.id],
             )

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -114,7 +114,7 @@ from zerver.lib.event_types import (
     PlanTypeData,
 )
 from zerver.lib.topic import ORIG_TOPIC, TOPIC_NAME
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.models import Realm, RealmUserDefault, Stream, UserProfile
 
 
@@ -535,7 +535,7 @@ def check_stream_update(
         assert value in Stream.STREAM_POST_POLICY_TYPES
     elif prop in Stream.stream_permission_group_settings:
         assert extra_keys == set()
-        assert isinstance(value, int | AnonymousSettingGroupDict)
+        assert isinstance(value, int | UserGroupMembersDict)
     elif prop == "first_message_id":
         assert extra_keys == set()
         assert isinstance(value, int)

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from pydantic import AfterValidator, BaseModel
 
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 
 
 def check_url(val: str) -> str:
@@ -508,26 +508,26 @@ class GroupSettingUpdateDataCore(BaseModel):
 
 class GroupSettingUpdateData(GroupSettingUpdateDataCore):
     # TODO: fix types to avoid optional fields
-    create_multiuse_invite_group: int | AnonymousSettingGroupDict | None = None
-    can_access_all_users_group: int | AnonymousSettingGroupDict | None = None
-    can_add_custom_emoji_group: int | AnonymousSettingGroupDict | None = None
-    can_add_subscribers_group: int | AnonymousSettingGroupDict | None = None
-    can_create_bots_group: int | AnonymousSettingGroupDict | None = None
-    can_create_groups: int | AnonymousSettingGroupDict | None = None
-    can_create_public_channel_group: int | AnonymousSettingGroupDict | None = None
-    can_create_private_channel_group: int | AnonymousSettingGroupDict | None = None
-    can_create_web_public_channel_group: int | AnonymousSettingGroupDict | None = None
-    can_create_write_only_bots_group: int | AnonymousSettingGroupDict | None = None
-    can_delete_any_message_group: int | AnonymousSettingGroupDict | None = None
-    can_delete_own_message_group: int | AnonymousSettingGroupDict | None = None
-    can_invite_users_group: int | AnonymousSettingGroupDict | None = None
-    can_manage_all_groups: int | AnonymousSettingGroupDict | None = None
-    can_mention_many_users_group: int | AnonymousSettingGroupDict | None = None
-    can_move_messages_between_channels_group: int | AnonymousSettingGroupDict | None = None
-    can_move_messages_between_topics_group: int | AnonymousSettingGroupDict | None = None
-    can_summarize_topics_group: int | AnonymousSettingGroupDict | None = None
-    direct_message_initiator_group: int | AnonymousSettingGroupDict | None = None
-    direct_message_permission_group: int | AnonymousSettingGroupDict | None = None
+    create_multiuse_invite_group: int | UserGroupMembersDict | None = None
+    can_access_all_users_group: int | UserGroupMembersDict | None = None
+    can_add_custom_emoji_group: int | UserGroupMembersDict | None = None
+    can_add_subscribers_group: int | UserGroupMembersDict | None = None
+    can_create_bots_group: int | UserGroupMembersDict | None = None
+    can_create_groups: int | UserGroupMembersDict | None = None
+    can_create_public_channel_group: int | UserGroupMembersDict | None = None
+    can_create_private_channel_group: int | UserGroupMembersDict | None = None
+    can_create_web_public_channel_group: int | UserGroupMembersDict | None = None
+    can_create_write_only_bots_group: int | UserGroupMembersDict | None = None
+    can_delete_any_message_group: int | UserGroupMembersDict | None = None
+    can_delete_own_message_group: int | UserGroupMembersDict | None = None
+    can_invite_users_group: int | UserGroupMembersDict | None = None
+    can_manage_all_groups: int | UserGroupMembersDict | None = None
+    can_mention_many_users_group: int | UserGroupMembersDict | None = None
+    can_move_messages_between_channels_group: int | UserGroupMembersDict | None = None
+    can_move_messages_between_topics_group: int | UserGroupMembersDict | None = None
+    can_summarize_topics_group: int | UserGroupMembersDict | None = None
+    direct_message_initiator_group: int | UserGroupMembersDict | None = None
+    direct_message_permission_group: int | UserGroupMembersDict | None = None
 
 
 class PlanTypeData(BaseModel):
@@ -745,9 +745,9 @@ class EventScheduledMessagesUpdate(BaseEvent):
 
 class BasicStreamFields(BaseModel):
     is_archived: bool
-    can_administer_channel_group: int | AnonymousSettingGroupDict
-    can_remove_subscribers_group: int | AnonymousSettingGroupDict
-    can_send_message_group: int | AnonymousSettingGroupDict
+    can_administer_channel_group: int | UserGroupMembersDict
+    can_remove_subscribers_group: int | UserGroupMembersDict
+    can_send_message_group: int | UserGroupMembersDict
     creator_id: int | None
     date_created: int
     description: str
@@ -784,7 +784,7 @@ class EventStreamUpdateCore(BaseEvent):
     type: Literal["stream"]
     op: Literal["update"]
     property: str
-    value: bool | int | str | AnonymousSettingGroupDict | Literal[None]
+    value: bool | int | str | UserGroupMembersDict | Literal[None]
     name: str
     stream_id: int
 
@@ -807,9 +807,9 @@ class EventSubmessage(BaseEvent):
 
 class SingleSubscription(BaseModel):
     is_archived: bool
-    can_administer_channel_group: int | AnonymousSettingGroupDict
-    can_remove_subscribers_group: int | AnonymousSettingGroupDict
-    can_send_message_group: int | AnonymousSettingGroupDict
+    can_administer_channel_group: int | UserGroupMembersDict
+    can_remove_subscribers_group: int | UserGroupMembersDict
+    can_send_message_group: int | UserGroupMembersDict
     creator_id: int | None
     date_created: int
     description: str
@@ -1040,12 +1040,12 @@ class Group(BaseModel):
     direct_subgroup_ids: list[int]
     description: str
     is_system_group: bool
-    can_add_members_group: int | AnonymousSettingGroupDict
-    can_join_group: int | AnonymousSettingGroupDict
-    can_leave_group: int | AnonymousSettingGroupDict
-    can_manage_group: int | AnonymousSettingGroupDict
-    can_mention_group: int | AnonymousSettingGroupDict
-    can_remove_members_group: int | AnonymousSettingGroupDict
+    can_add_members_group: int | UserGroupMembersDict
+    can_join_group: int | UserGroupMembersDict
+    can_leave_group: int | UserGroupMembersDict
+    can_manage_group: int | UserGroupMembersDict
+    can_mention_group: int | UserGroupMembersDict
+    can_remove_members_group: int | UserGroupMembersDict
     deactivated: bool
 
 
@@ -1097,12 +1097,12 @@ class UserGroupData(UserGroupDataCore):
     # TODO: fix types to avoid optional fields
     name: str | None = None
     description: str | None = None
-    can_add_members_group: int | AnonymousSettingGroupDict | None = None
-    can_join_group: int | AnonymousSettingGroupDict | None = None
-    can_leave_group: int | AnonymousSettingGroupDict | None = None
-    can_manage_group: int | AnonymousSettingGroupDict | None = None
-    can_mention_group: int | AnonymousSettingGroupDict | None = None
-    can_remove_members_group: int | AnonymousSettingGroupDict | None = None
+    can_add_members_group: int | UserGroupMembersDict | None = None
+    can_join_group: int | UserGroupMembersDict | None = None
+    can_leave_group: int | UserGroupMembersDict | None = None
+    can_manage_group: int | UserGroupMembersDict | None = None
+    can_mention_group: int | UserGroupMembersDict | None = None
+    can_remove_members_group: int | UserGroupMembersDict | None = None
     deactivated: bool | None = None
 
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -61,8 +61,9 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.topic import TOPIC_NAME, maybe_rename_general_chat_to_empty_topic
 from zerver.lib.user_groups import (
-    get_group_setting_value_for_api,
+    get_group_setting_value_for_register_api,
     get_recursive_membership_groups,
+    get_role_based_system_groups_dict,
     get_server_supported_permission_settings,
     user_groups_in_realm_serialized,
 )
@@ -100,7 +101,6 @@ from zerver.models.realms import (
     MessageEditHistoryVisibilityPolicyEnum,
     get_corresponding_policy_value_for_group_setting,
     get_realm_domains,
-    get_realm_with_settings,
 )
 from zerver.models.streams import get_default_stream_groups
 from zerver.tornado.django_api import get_user_events, request_event_queue
@@ -269,6 +269,27 @@ def fetch_initial_state_data(
         # Send server_timestamp, to match the format of `GET /presence` requests.
         state["server_timestamp"] = time.time()
 
+    realm_setting_group_ids = {
+        getattr(realm, setting_name + "_id")
+        for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS
+    }
+
+    if want("realm_user_groups") or want("realm"):
+        # Optimizing opportunity: This fetches more data than
+        # we strictly need when "realm_user_groups" is not in
+        # fetch_event_types; we need the membership of the
+        # anonymous groups in realm_setting_group_ids and the
+        # IDs of the NamedUserGroup objects used there, but
+        # don't need the other NamedUserGroup fields.
+        realm_groups_data = user_groups_in_realm_serialized(
+            realm,
+            include_deactivated_groups=include_deactivated_groups,
+            realm_setting_group_ids=realm_setting_group_ids,
+        )
+
+    if want("realm_user_groups"):
+        state["realm_user_groups"] = realm_groups_data.api_groups
+
     if want("realm"):
         # The realm bundle includes both realm properties and server
         # properties, since it's rare that one would want one and not
@@ -295,17 +316,25 @@ def fetch_initial_state_data(
             state["realm_" + property_name] = getattr(realm, property_name)
 
         for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
-            setting_value = getattr(realm, setting_name)
-            state["realm_" + setting_name] = get_group_setting_value_for_api(setting_value)
+            setting_group_id = getattr(realm, setting_name + "_id")
+            state["realm_" + setting_name] = get_group_setting_value_for_register_api(
+                setting_group_id, realm_groups_data.realm_setting_anonymous_group_membership
+            )
 
         state["realm_create_public_stream_policy"] = (
             get_corresponding_policy_value_for_group_setting(
-                realm, "can_create_public_channel_group", Realm.COMMON_POLICY_TYPES
+                realm,
+                "can_create_public_channel_group",
+                Realm.COMMON_POLICY_TYPES,
+                realm_groups_data.system_groups_name_dict,
             )
         )
         state["realm_create_private_stream_policy"] = (
             get_corresponding_policy_value_for_group_setting(
-                realm, "can_create_private_channel_group", Realm.COMMON_POLICY_TYPES
+                realm,
+                "can_create_private_channel_group",
+                Realm.COMMON_POLICY_TYPES,
+                realm_groups_data.system_groups_name_dict,
             )
         )
         state["realm_create_web_public_stream_policy"] = (
@@ -313,12 +342,14 @@ def fetch_initial_state_data(
                 realm,
                 "can_create_web_public_channel_group",
                 Realm.CREATE_WEB_PUBLIC_STREAM_POLICY_TYPES,
+                realm_groups_data.system_groups_name_dict,
             )
         )
         state["realm_wildcard_mention_policy"] = get_corresponding_policy_value_for_group_setting(
             realm,
             "can_mention_many_users_group",
             Realm.WILDCARD_MENTION_POLICY_TYPES,
+            realm_groups_data.system_groups_name_dict,
         )
 
         # Most state is handled via the property_types framework;
@@ -526,11 +557,6 @@ def fetch_initial_state_data(
 
     if want("realm_playgrounds"):
         state["realm_playgrounds"] = get_realm_playgrounds(realm)
-
-    if want("realm_user_groups"):
-        state["realm_user_groups"] = user_groups_in_realm_serialized(
-            realm, include_deactivated_groups=include_deactivated_groups
-        )
 
     if user_profile is not None:
         settings_user = user_profile
@@ -1330,6 +1356,7 @@ def apply_event(
                 )
 
         elif event["op"] == "update_dict":
+            system_groups_name_dict: dict[int, str] | None = None
             for key, value in event["data"].items():
                 if key == "max_file_upload_size_mib":
                     state["max_file_upload_size_mib"] = value
@@ -1350,12 +1377,26 @@ def apply_event(
                     "can_create_private_channel_group",
                     "can_create_web_public_channel_group",
                 ]:
+                    if system_groups_name_dict is None:
+                        # Here we do a database query, because
+                        # get_corresponding_policy_value_for_group_setting
+                        # requires the full set of system groups.
+                        # This could be avoided if realm_user_group were in
+                        # fetch_event_types, since the system groups should
+                        # all be there, but the query itself is cheap enough
+                        # that it's likely not worth that complexity.
+                        system_groups = get_role_based_system_groups_dict(user_profile.realm)
+                        system_groups_name_dict = {}
+                        for group in system_groups.values():
+                            system_groups_name_dict[group.id] = group.name
+
                     if key == "can_create_public_channel_group":
                         state["realm_create_public_stream_policy"] = (
                             get_corresponding_policy_value_for_group_setting(
                                 user_profile.realm,
                                 "can_create_public_channel_group",
                                 Realm.COMMON_POLICY_TYPES,
+                                system_groups_name_dict,
                             )
                         )
                         state["can_create_public_streams"] = user_profile.has_permission(key)
@@ -1365,6 +1406,7 @@ def apply_event(
                                 user_profile.realm,
                                 "can_create_private_channel_group",
                                 Realm.COMMON_POLICY_TYPES,
+                                system_groups_name_dict,
                             )
                         )
                         state["can_create_private_streams"] = user_profile.has_permission(key)
@@ -1374,6 +1416,7 @@ def apply_event(
                                 user_profile.realm,
                                 "can_create_web_public_channel_group",
                                 Realm.CREATE_WEB_PUBLIC_STREAM_POLICY_TYPES,
+                                system_groups_name_dict,
                             )
                         )
                         state["can_create_web_public_streams"] = user_profile.has_permission(key)
@@ -1390,11 +1433,25 @@ def apply_event(
                     )
 
                 if key == "can_mention_many_users_group":
+                    if system_groups_name_dict is None:
+                        # Here we do a database query, because
+                        # get_corresponding_policy_value_for_group_setting
+                        # requires the full set of system groups.
+                        # This could be avoided if realm_user_group were in
+                        # fetch_event_types, since the system groups should
+                        # all be there, but the query itself is cheap enough
+                        # that it's likely not worth that complexity.
+                        system_groups = get_role_based_system_groups_dict(user_profile.realm)
+                        system_groups_name_dict = {}
+                        for group in system_groups.values():
+                            system_groups_name_dict[group.id] = group.name
+
                     state["realm_wildcard_mention_policy"] = (
                         get_corresponding_policy_value_for_group_setting(
                             user_profile.realm,
                             "can_mention_many_users_group",
                             Realm.WILDCARD_MENTION_POLICY_TYPES,
+                            system_groups_name_dict,
                         )
                     )
 
@@ -1819,14 +1876,6 @@ def do_events_register(
         event_types_set = set(event_types)
     else:
         event_types_set = None
-
-    # Fetch the realm object again to prefetch all the
-    # settings that will be used in 'fetch_initial_state_data'
-    # to avoid unnecessary DB queries.
-    # The settings include:
-    # * group settings which support anonymous groups
-    # * announcements streams
-    realm = get_realm_with_settings(realm_id=realm.id)
 
     if user_profile is None:
         # TODO: Unify the two fetch_initial_state_data code paths.

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -23,7 +23,7 @@ from zerver.lib.stream_subscription import (
 from zerver.lib.stream_traffic import get_average_weekly_stream_traffic, get_streams_traffic
 from zerver.lib.string_validation import check_stream_name
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.types import AnonymousSettingGroupDict, APIStreamDict
+from zerver.lib.types import APIStreamDict, UserGroupMembersDict
 from zerver.lib.user_groups import (
     UserGroupMembershipDetails,
     get_recursive_membership_groups,
@@ -145,7 +145,7 @@ def send_stream_creation_event(
     stream: Stream,
     user_ids: list[int],
     recent_traffic: dict[int, int] | None = None,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] | None = None,
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] | None = None,
 ) -> None:
     event = dict(
         type="stream",
@@ -262,7 +262,7 @@ def create_stream_if_needed(
     can_remove_subscribers_group: UserGroup | None = None,
     can_subscribe_group: UserGroup | None = None,
     acting_user: UserProfile | None = None,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] | None = None,
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] | None = None,
 ) -> tuple[Stream, bool]:
     history_public_to_subscribers = get_default_value_for_history_public_to_subscribers(
         realm, invite_only, history_public_to_subscribers
@@ -355,7 +355,7 @@ def create_streams_if_needed(
     realm: Realm,
     stream_dicts: list[StreamDict],
     acting_user: UserProfile | None = None,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] | None = None,
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] | None = None,
 ) -> tuple[list[Stream], list[Stream]]:
     """Note that stream_dict["name"] is assumed to already be stripped of
     whitespace"""
@@ -1279,7 +1279,7 @@ def list_to_streams(
     autocreate: bool = False,
     unsubscribing_others: bool = False,
     is_default_stream: bool = False,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] | None = None,
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] | None = None,
 ) -> tuple[list[Stream], list[Stream]]:
     """Converts list of dicts to a list of Streams, validating input in the process
 
@@ -1455,7 +1455,7 @@ def get_stream_post_policy_value_based_on_group_setting(setting_group: UserGroup
 def stream_to_dict(
     stream: Stream,
     recent_traffic: dict[int, int] | None = None,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] | None = None,
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] | None = None,
 ) -> APIStreamDict:
     if recent_traffic is not None:
         stream_weekly_traffic = get_average_weekly_stream_traffic(
@@ -1634,7 +1634,7 @@ def get_streams_for_user(
 
 def get_group_setting_value_dict_for_streams(
     streams: list[Stream],
-) -> dict[int, int | AnonymousSettingGroupDict]:
+) -> dict[int, int | UserGroupMembersDict]:
     setting_group_ids = set()
     for stream in streams:
         for setting_name in Stream.stream_permission_group_settings:
@@ -1645,10 +1645,10 @@ def get_group_setting_value_dict_for_streams(
 
 def get_setting_values_for_group_settings(
     group_ids: list[int],
-) -> dict[int, int | AnonymousSettingGroupDict]:
+) -> dict[int, int | UserGroupMembersDict]:
     user_groups = UserGroup.objects.filter(id__in=group_ids).select_related("named_user_group")
 
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict] = dict()
+    setting_groups_dict: dict[int, int | UserGroupMembersDict] = dict()
     anonymous_group_ids = []
     for group in user_groups:
         if hasattr(group, "named_user_group"):
@@ -1678,13 +1678,13 @@ def get_setting_values_for_group_settings(
     all_members = user_members.union(group_subgroups)
     for member_type, group_id, member_id in all_members:
         if group_id not in setting_groups_dict:
-            setting_groups_dict[group_id] = AnonymousSettingGroupDict(
+            setting_groups_dict[group_id] = UserGroupMembersDict(
                 direct_members=[],
                 direct_subgroups=[],
             )
 
         anonymous_group_dict = setting_groups_dict[group_id]
-        assert isinstance(anonymous_group_dict, AnonymousSettingGroupDict)
+        assert isinstance(anonymous_group_dict, UserGroupMembersDict)
         if member_type == "user":
             anonymous_group_dict.direct_members.append(member_id)
         else:

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -29,13 +29,13 @@ from zerver.lib.streams import (
 )
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.types import (
-    AnonymousSettingGroupDict,
     APIStreamDict,
     NeverSubscribedStreamDict,
     RawStreamDict,
     RawSubscriptionDict,
     SubscriptionInfo,
     SubscriptionStreamDict,
+    UserGroupMembersDict,
 )
 from zerver.lib.user_groups import UserGroupMembershipDetails, get_recursive_membership_groups
 from zerver.models import Realm, Stream, Subscription, UserProfile
@@ -147,7 +147,7 @@ def build_unsubscribed_sub_from_stream_dict(
 def build_stream_api_dict(
     raw_stream_dict: RawStreamDict,
     recent_traffic: dict[int, int] | None,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict],
+    setting_groups_dict: dict[int, int | UserGroupMembersDict],
 ) -> APIStreamDict:
     # Add a few computed fields not directly from the data models.
     if recent_traffic is not None:
@@ -277,7 +277,7 @@ def build_stream_dict_for_sub(
 def build_stream_dict_for_never_sub(
     raw_stream_dict: RawStreamDict,
     recent_traffic: dict[int, int] | None,
-    setting_groups_dict: dict[int, int | AnonymousSettingGroupDict],
+    setting_groups_dict: dict[int, int | UserGroupMembersDict],
 ) -> NeverSubscribedStreamDict:
     is_archived = raw_stream_dict["deactivated"]
     creator_id = raw_stream_dict["creator_id"]

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -142,7 +142,7 @@ class UserTopicDict(TypedDict, total=False):
 
 
 @dataclass
-class AnonymousSettingGroupDict:
+class UserGroupMembersDict:
     direct_members: list[int]
     direct_subgroups: list[int]
 
@@ -199,11 +199,11 @@ class SubscriptionStreamDict(TypedDict):
     """
 
     audible_notifications: bool | None
-    can_add_subscribers_group: int | AnonymousSettingGroupDict
-    can_administer_channel_group: int | AnonymousSettingGroupDict
-    can_send_message_group: int | AnonymousSettingGroupDict
-    can_remove_subscribers_group: int | AnonymousSettingGroupDict
-    can_subscribe_group: int | AnonymousSettingGroupDict
+    can_add_subscribers_group: int | UserGroupMembersDict
+    can_administer_channel_group: int | UserGroupMembersDict
+    can_send_message_group: int | UserGroupMembersDict
+    can_remove_subscribers_group: int | UserGroupMembersDict
+    can_subscribe_group: int | UserGroupMembersDict
     color: str
     creator_id: int | None
     date_created: int
@@ -233,11 +233,11 @@ class SubscriptionStreamDict(TypedDict):
 
 class NeverSubscribedStreamDict(TypedDict):
     is_archived: bool
-    can_add_subscribers_group: int | AnonymousSettingGroupDict
-    can_administer_channel_group: int | AnonymousSettingGroupDict
-    can_send_message_group: int | AnonymousSettingGroupDict
-    can_remove_subscribers_group: int | AnonymousSettingGroupDict
-    can_subscribe_group: int | AnonymousSettingGroupDict
+    can_add_subscribers_group: int | UserGroupMembersDict
+    can_administer_channel_group: int | UserGroupMembersDict
+    can_send_message_group: int | UserGroupMembersDict
+    can_remove_subscribers_group: int | UserGroupMembersDict
+    can_subscribe_group: int | UserGroupMembersDict
     creator_id: int | None
     date_created: int
     description: str
@@ -263,11 +263,11 @@ class DefaultStreamDict(TypedDict):
     """
 
     is_archived: bool
-    can_add_subscribers_group: int | AnonymousSettingGroupDict
-    can_administer_channel_group: int | AnonymousSettingGroupDict
-    can_send_message_group: int | AnonymousSettingGroupDict
-    can_remove_subscribers_group: int | AnonymousSettingGroupDict
-    can_subscribe_group: int | AnonymousSettingGroupDict
+    can_add_subscribers_group: int | UserGroupMembersDict
+    can_administer_channel_group: int | UserGroupMembersDict
+    can_send_message_group: int | UserGroupMembersDict
+    can_remove_subscribers_group: int | UserGroupMembersDict
+    can_subscribe_group: int | UserGroupMembersDict
     creator_id: int | None
     date_created: int
     description: str

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -171,7 +171,7 @@ class EventsEndpointTest(ZulipTestCase):
                 status_code=401,
             )
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(16):
             result = self.client_post("/json/register")
             result_dict = self.assert_json_success(result)
             self.assertEqual(result_dict["queue_id"], None)
@@ -1218,7 +1218,7 @@ class FetchQueriesTest(ZulipTestCase):
         realm = get_realm_with_settings(realm_id=user.realm_id)
 
         with (
-            self.assert_database_query_count(47),
+            self.assert_database_query_count(46),
             mock.patch("zerver.lib.events.always_want") as want_mock,
         ):
             fetch_initial_state_data(user, realm=realm)
@@ -1244,7 +1244,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_linkifiers=0,
             realm_playgrounds=1,
             realm_user=4,
-            realm_user_groups=3,
+            realm_user_groups=2,
             realm_user_settings_defaults=1,
             recent_private_conversations=1,
             saved_snippets=1,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -237,7 +237,7 @@ from zerver.lib.test_helpers import (
 )
 from zerver.lib.timestamp import convert_to_UTC, datetime_to_timestamp
 from zerver.lib.topic import TOPIC_NAME
-from zerver.lib.types import AnonymousSettingGroupDict, ProfileDataElementUpdateDict
+from zerver.lib.types import ProfileDataElementUpdateDict, UserGroupMembersDict
 from zerver.lib.upload import upload_message_attachment
 from zerver.lib.user_groups import (
     get_group_setting_value_for_api,
@@ -1943,7 +1943,7 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(events[0]["group"]["can_join_group"], nobody_group.id)
         self.assertEqual(
             events[0]["group"]["can_manage_group"],
-            AnonymousSettingGroupDict(direct_members=[12], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[12], direct_subgroups=[]),
         )
         everyone_group = NamedUserGroup.objects.get(
             name=SystemGroups.EVERYONE, realm=self.user_profile.realm, is_system_group=True
@@ -1972,19 +1972,19 @@ class NormalActionsTest(BaseAction):
         check_user_group_add("events[0]", events[0])
         self.assertEqual(
             events[0]["group"]["can_join_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[othello.id], direct_subgroups=[moderators_group.id]
             ),
         )
         self.assertEqual(
             events[0]["group"]["can_manage_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[othello.id], direct_subgroups=[moderators_group.id]
             ),
         )
         self.assertEqual(
             events[0]["group"]["can_mention_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[othello.id], direct_subgroups=[moderators_group.id]
             ),
         )
@@ -2031,7 +2031,7 @@ class NormalActionsTest(BaseAction):
         check_user_group_update("events[0]", events[0], {"can_mention_group"})
         self.assertEqual(
             events[0]["data"]["can_mention_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[othello.id], direct_subgroups=[moderators_group.id]
             ),
         )
@@ -3194,21 +3194,19 @@ class NormalActionsTest(BaseAction):
         check_user_group_update("events[6]", events[6], {"can_mention_group"})
         self.assertEqual(
             events[3]["data"]["can_add_members_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[]),
         )
         self.assertEqual(
             events[4]["data"]["can_manage_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[]),
         )
         self.assertEqual(
             events[5]["data"]["can_create_public_channel_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[members_group.id]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[members_group.id]),
         )
         self.assertEqual(
             events[6]["data"]["can_mention_group"],
-            AnonymousSettingGroupDict(
-                direct_members=[hamlet.id], direct_subgroups=[members_group.id]
-            ),
+            UserGroupMembersDict(direct_members=[hamlet.id], direct_subgroups=[members_group.id]),
         )
 
         user_profile = self.example_user("cordelia")
@@ -3224,21 +3222,19 @@ class NormalActionsTest(BaseAction):
         check_user_group_update("events[6]", events[6], {"can_mention_group"})
         self.assertEqual(
             events[3]["data"]["can_add_members_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[]),
         )
         self.assertEqual(
             events[4]["data"]["can_manage_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[]),
         )
         self.assertEqual(
             events[5]["data"]["can_create_public_channel_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[members_group.id]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[members_group.id]),
         )
         self.assertEqual(
             events[6]["data"]["can_mention_group"],
-            AnonymousSettingGroupDict(
-                direct_members=[hamlet.id], direct_subgroups=[members_group.id]
-            ),
+            UserGroupMembersDict(direct_members=[hamlet.id], direct_subgroups=[members_group.id]),
         )
 
         user_profile = self.example_user("shiva")
@@ -3258,7 +3254,7 @@ class NormalActionsTest(BaseAction):
         check_realm_user_remove("events[4]]", events[4])
         self.assertEqual(
             events[3]["data"]["can_mention_group"],
-            AnonymousSettingGroupDict(direct_members=[], direct_subgroups=[members_group.id]),
+            UserGroupMembersDict(direct_members=[], direct_subgroups=[members_group.id]),
         )
 
         user_profile = self.example_user("aaron")
@@ -3349,21 +3345,21 @@ class NormalActionsTest(BaseAction):
         check_user_group_update("events[6]", events[6], {"can_mention_group"})
         self.assertEqual(
             events[3]["data"]["can_add_members_group"],
-            AnonymousSettingGroupDict(direct_members=[user_profile.id], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[user_profile.id], direct_subgroups=[]),
         )
         self.assertEqual(
             events[4]["data"]["can_manage_group"],
-            AnonymousSettingGroupDict(direct_members=[user_profile.id], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[user_profile.id], direct_subgroups=[]),
         )
         self.assertEqual(
             events[5]["data"]["can_create_public_channel_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[user_profile.id], direct_subgroups=[hamletcharacters_group.id]
             ),
         )
         self.assertEqual(
             events[6]["data"]["can_mention_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[user_profile.id], direct_subgroups=[members_group.id]
             ),
         )
@@ -4047,9 +4043,7 @@ class RealmPropertyActionTest(BaseAction):
         check_realm_update_dict("events[0]", events[0])
         self.assertEqual(
             events[0]["data"][setting_name],
-            AnonymousSettingGroupDict(
-                direct_members=[othello.id], direct_subgroups=[admins_group.id]
-            ),
+            UserGroupMembersDict(direct_members=[othello.id], direct_subgroups=[admins_group.id]),
         )
 
         old_setting_api_value = get_group_setting_value_for_api(setting_group)
@@ -4093,7 +4087,7 @@ class RealmPropertyActionTest(BaseAction):
         check_realm_update_dict("events[0]", events[0])
         self.assertEqual(
             events[0]["data"][setting_name],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[self.user_profile.id], direct_subgroups=[moderators_group.id]
             ),
         )
@@ -4786,7 +4780,7 @@ class SubscribeActionTest(BaseAction):
         check_stream_update("events[0]", events[0])
         self.assertEqual(
             events[0]["value"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[self.user_profile.id], direct_subgroups=[moderators_group.id]
             ),
         )

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -281,7 +281,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(56),
+            self.assert_database_query_count(55),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -586,7 +586,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(54),
+            self.assert_database_query_count(53),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -618,7 +618,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(51):
+        with self.assert_database_query_count(50):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -281,7 +281,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(55),
+            self.assert_database_query_count(54),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -586,7 +586,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(53),
+            self.assert_database_query_count(52),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -618,7 +618,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(50):
+        with self.assert_database_query_count(49):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -101,11 +101,11 @@ from zerver.lib.test_helpers import (
     reset_email_visibility_to_everyone_in_zulip_realm,
 )
 from zerver.lib.types import (
-    AnonymousSettingGroupDict,
     APIStreamDict,
     APISubscriptionDict,
     NeverSubscribedStreamDict,
     SubscriptionInfo,
+    UserGroupMembersDict,
 )
 from zerver.lib.user_groups import UserGroupMembershipDetails, is_user_in_group
 from zerver.models import (
@@ -865,7 +865,7 @@ class TestCreateStreams(ZulipTestCase):
         event_stream = events[0]["event"]["streams"][0]
         self.assertEqual(
             event_stream["can_administer_channel_group"],
-            AnonymousSettingGroupDict(direct_members=[hamlet.id], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[hamlet.id], direct_subgroups=[]),
         )
 
         self.assertEqual(event_stream["can_add_subscribers_group"], nobody_group.id)
@@ -7702,7 +7702,7 @@ class GetSubscribersTest(ZulipTestCase):
             if sub["name"] == "stream_1":
                 self.assertEqual(
                     sub["can_remove_subscribers_group"],
-                    AnonymousSettingGroupDict(
+                    UserGroupMembersDict(
                         direct_members=[hamlet.id],
                         direct_subgroups=[admins_group.id],
                     ),
@@ -7710,7 +7710,7 @@ class GetSubscribersTest(ZulipTestCase):
             elif sub["name"] == "stream_2":
                 self.assertEqual(
                     sub["can_remove_subscribers_group"],
-                    AnonymousSettingGroupDict(
+                    UserGroupMembersDict(
                         direct_members=[cordelia.id],
                         direct_subgroups=[admins_group.id],
                     ),
@@ -7797,7 +7797,7 @@ class GetSubscribersTest(ZulipTestCase):
         [stream_5_sub] = [sub for sub in subscribed_streams if sub["name"] == "stream_5"]
         self.assertEqual(
             stream_5_sub["can_send_message_group"],
-            AnonymousSettingGroupDict(
+            UserGroupMembersDict(
                 direct_members=[cordelia.id],
                 direct_subgroups=[admins_group.id],
             ),

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -104,7 +104,9 @@ class UserGroupTestCase(ZulipTestCase):
         empty_user_group = check_add_user_group(realm, "newgroup", [], acting_user=user)
         do_deactivate_user(self.example_user("hamlet"), acting_user=None)
 
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=False)
+        user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=False
+        ).api_groups
         self.assert_length(user_groups, 10)
         self.assertEqual(user_groups[0]["id"], user_group.id)
         self.assertEqual(user_groups[0]["creator_id"], user_group.creator_id)
@@ -183,7 +185,9 @@ class UserGroupTestCase(ZulipTestCase):
             },
             acting_user=self.example_user("desdemona"),
         )
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=False)
+        user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=False
+        ).api_groups
         self.assertEqual(user_groups[10]["id"], new_user_group.id)
         self.assertEqual(user_groups[10]["creator_id"], new_user_group.creator_id)
         self.assertEqual(
@@ -215,7 +219,9 @@ class UserGroupTestCase(ZulipTestCase):
             new_user_group, [another_new_group, owners_system_group], acting_user=None
         )
         do_deactivate_user_group(another_new_group, acting_user=None)
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=True)
+        user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=True
+        ).api_groups
         self.assert_length(user_groups, 12)
         self.assertEqual(user_groups[10]["id"], new_user_group.id)
         self.assertEqual(user_groups[10]["name"], "newgroup2")
@@ -227,13 +233,50 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[11]["name"], "newgroup3")
         self.assertTrue(user_groups[11]["deactivated"])
 
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=False)
-        self.assert_length(user_groups, 11)
-        self.assertEqual(user_groups[10]["id"], new_user_group.id)
-        self.assertEqual(user_groups[10]["name"], "newgroup2")
-        self.assertFalse(user_groups[10]["deactivated"])
+        do_change_realm_permission_group_setting(
+            realm, "create_multiuse_invite_group", hamletcharacters_group, acting_user=None
+        )
+        cordelia = self.example_user("cordelia")
+        setting_group = self.create_or_update_anonymous_group_for_setting(
+            [cordelia], [owners_system_group]
+        )
+        do_change_realm_permission_group_setting(
+            realm, "can_create_public_channel_group", setting_group, acting_user=None
+        )
+        realm_setting_group_ids = {
+            realm.create_multiuse_invite_group_id,
+            realm.can_create_public_channel_group_id,
+        }
+
+        realm_user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=False, realm_setting_group_ids=realm_setting_group_ids
+        )
+        named_user_groups = realm_user_groups.api_groups
+        self.assert_length(named_user_groups, 11)
+        self.assertEqual(named_user_groups[10]["id"], new_user_group.id)
+        self.assertEqual(named_user_groups[10]["name"], "newgroup2")
+        self.assertFalse(named_user_groups[10]["deactivated"])
         self.assertCountEqual(
-            user_groups[10]["direct_subgroup_ids"], [another_new_group.id, owners_system_group.id]
+            named_user_groups[10]["direct_subgroup_ids"],
+            [another_new_group.id, owners_system_group.id],
+        )
+
+        system_groups_dict = realm_user_groups.system_groups_name_dict
+        self.assertEqual(system_groups_dict[user_group.id], SystemGroups.NOBODY)
+        self.assertEqual(system_groups_dict[owners_system_group.id], SystemGroups.OWNERS)
+        self.assertEqual(system_groups_dict[admins_system_group.id], SystemGroups.ADMINISTRATORS)
+        self.assertEqual(system_groups_dict[everyone_group.id], SystemGroups.EVERYONE)
+
+        realm_setting_anonymous_group_membership = (
+            realm_user_groups.realm_setting_anonymous_group_membership
+        )
+        self.assertEqual(
+            realm_setting_anonymous_group_membership,
+            {
+                realm.can_create_public_channel_group_id: UserGroupMembersDict(
+                    direct_members=[cordelia.id], direct_subgroups=[owners_system_group.id]
+                )
+            },
         )
 
     def test_get_direct_user_groups(self) -> None:

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -37,7 +37,7 @@ from zerver.lib.streams import ensure_stream
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_usermessage
 from zerver.lib.timestamp import datetime_to_timestamp
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.lib.user_groups import (
     get_direct_user_groups,
     get_recursive_group_members,
@@ -163,7 +163,7 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[9]["members"], [])
         self.assertEqual(
             user_groups[9]["can_manage_group"],
-            AnonymousSettingGroupDict(direct_members=[11], direct_subgroups=[]),
+            UserGroupMembersDict(direct_members=[11], direct_subgroups=[]),
         )
         self.assertEqual(user_groups[9]["can_mention_group"], everyone_group.id)
         self.assertFalse(user_groups[0]["deactivated"])
@@ -194,14 +194,14 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[10]["description"], "")
         self.assertEqual(user_groups[10]["members"], [othello.id])
 
-        assert isinstance(user_groups[10]["can_manage_group"], AnonymousSettingGroupDict)
+        assert isinstance(user_groups[10]["can_manage_group"], UserGroupMembersDict)
         self.assertEqual(user_groups[10]["can_manage_group"].direct_members, [othello.id])
         self.assertCountEqual(
             user_groups[10]["can_manage_group"].direct_subgroups,
             [admins_system_group.id, hamletcharacters_group.id],
         )
 
-        assert isinstance(user_groups[10]["can_mention_group"], AnonymousSettingGroupDict)
+        assert isinstance(user_groups[10]["can_mention_group"], UserGroupMembersDict)
         self.assertEqual(user_groups[10]["can_mention_group"].direct_members, [othello.id])
         self.assertCountEqual(
             user_groups[10]["can_mention_group"].direct_subgroups,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -86,7 +86,7 @@ from zerver.lib.topic import (
 )
 from zerver.lib.typed_endpoint import ApiParamConfig, PathOnly, typed_endpoint
 from zerver.lib.typed_endpoint_validators import check_color
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.lib.user_groups import (
     GroupSettingChangeRequest,
     UserGroupMembershipDetails,
@@ -599,11 +599,11 @@ def add_subscriptions_backend(
     is_default_stream: Json[bool] = False,
     history_public_to_subscribers: Json[bool] | None = None,
     message_retention_days: Json[str] | Json[int] = RETENTION_DEFAULT,
-    can_add_subscribers_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_administer_channel_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_send_message_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_remove_subscribers_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_subscribe_group: Json[int | AnonymousSettingGroupDict] | None = None,
+    can_add_subscribers_group: Json[int | UserGroupMembersDict] | None = None,
+    can_administer_channel_group: Json[int | UserGroupMembersDict] | None = None,
+    can_send_message_group: Json[int | UserGroupMembersDict] | None = None,
+    can_remove_subscribers_group: Json[int | UserGroupMembersDict] | None = None,
+    can_subscribe_group: Json[int | UserGroupMembersDict] | None = None,
     announce: Json[bool] = False,
     principals: Json[list[str] | list[int]] | None = None,
     authorization_errors_fatal: Json[bool] = True,
@@ -646,8 +646,8 @@ def add_subscriptions_backend(
             if permission_configuration.default_group_name == "stream_creator_or_nobody":
                 # Default for some settings like "can_administer_channel_group"
                 # is anonymous group with stream creator.
-                setting_groups_dict[group_settings_map[setting_name].id] = (
-                    AnonymousSettingGroupDict(direct_subgroups=[], direct_members=[user_profile.id])
+                setting_groups_dict[group_settings_map[setting_name].id] = UserGroupMembersDict(
+                    direct_subgroups=[], direct_members=[user_profile.id]
                 )
             else:
                 setting_groups_dict[group_settings_map[setting_name].id] = group_settings_map[

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -22,7 +22,7 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.mention import MentionBackend, silent_mention_syntax_for_user
 from zerver.lib.response import json_success
 from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
-from zerver.lib.types import AnonymousSettingGroupDict
+from zerver.lib.types import UserGroupMembersDict
 from zerver.lib.user_groups import (
     GroupSettingChangeRequest,
     access_user_group_for_deactivation,
@@ -60,12 +60,12 @@ def add_user_group(
     members: Json[list[int]],
     description: str,
     subgroups: Json[list[int]] | None = None,
-    can_add_members_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_join_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_leave_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_manage_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_mention_group: Json[int | AnonymousSettingGroupDict] | None = None,
-    can_remove_members_group: Json[int | AnonymousSettingGroupDict] | None = None,
+    can_add_members_group: Json[int | UserGroupMembersDict] | None = None,
+    can_join_group: Json[int | UserGroupMembersDict] | None = None,
+    can_leave_group: Json[int | UserGroupMembersDict] | None = None,
+    can_manage_group: Json[int | UserGroupMembersDict] | None = None,
+    can_mention_group: Json[int | UserGroupMembersDict] | None = None,
+    can_remove_members_group: Json[int | UserGroupMembersDict] | None = None,
 ) -> HttpResponse:
     user_profile.realm.ensure_not_on_limited_plan()
     user_profiles = user_ids_to_users(members, user_profile.realm, allow_deactivated=False)

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -119,7 +119,7 @@ def get_user_groups(
 ) -> HttpResponse:
     user_groups = user_groups_in_realm_serialized(
         user_profile.realm, include_deactivated_groups=include_deactivated_groups
-    )
+    ).api_groups
     return json_success(request, data={"user_groups": user_groups})
 
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is a refactor commit.
- Second commit is to update code to not fetch all setting fields using `select_related`.

Fixes: <!-- Issue link, or clear description.--> #33656

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
