### PR TITLE
Improve todo widget usability

### DIFF
--- a/web/src/generic_widget.ts
+++ b/web/src/generic_widget.ts
@@ -7,7 +7,12 @@ import type {AnyWidgetData, WidgetData} from "./widget_schema.ts";
 
 type HandleInboundEventsFunction = (events: Event[]) => void;
 
-export type PostToServerFunction = (data: {msg_type: string; data: WidgetOutboundData}) => void;
+export type PostToServerFunction = (data: {
+    msg_type: string;
+    data: WidgetOutboundData;
+    on_success?: (() => void) | undefined;
+    on_error?: (() => void) | undefined;
+}) => void;
 
 type WidgetOutboundData = PollWidgetOutboundData | TodoWidgetOutboundData;
 
@@ -21,7 +26,11 @@ type WidgetImplementation = {
     };
     render: (data: {
         $elem: JQuery;
-        callback: (data: WidgetOutboundData) => void;
+        callback: (
+            data: WidgetOutboundData,
+            on_success?: () => void,
+            on_error?: () => void,
+        ) => void;
         message: Message;
         widget_data: WidgetData;
         rerender: boolean;
@@ -97,10 +106,16 @@ export function render_widget_instance(info: {
     // users. For example, if I vote on a poll, the widget from my
     // client will send data to the server using this callback, and
     // then the server will broadcast my poll vote to other users.
-    function post_to_server_callback(data: WidgetOutboundData): void {
+    function post_to_server_callback(
+        data: WidgetOutboundData,
+        on_success?: () => void,
+        on_error?: () => void,
+    ): void {
         post_to_server({
             msg_type: "widget",
             data,
+            on_success,
+            on_error,
         });
     }
 

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -254,8 +254,18 @@ export function handle_event(submsg: Submessage): void {
 
 export function make_server_callback(
     message_id: number,
-): (opts: {msg_type: string; data: WidgetOutboundData}) => void {
-    return function (opts: {msg_type: string; data: WidgetOutboundData}) {
+): (opts: {
+    msg_type: string;
+    data: WidgetOutboundData;
+    on_success?: (() => void) | undefined;
+    on_error?: (() => void) | undefined;
+}) => void {
+    return function (opts: {
+        msg_type: string;
+        data: WidgetOutboundData;
+        on_success?: (() => void) | undefined;
+        on_error?: (() => void) | undefined;
+    }) {
         const url = "/json/submessage";
 
         void channel.post({
@@ -264,6 +274,12 @@ export function make_server_callback(
                 message_id,
                 msg_type: opts.msg_type,
                 content: JSON.stringify(opts.data),
+            },
+            success() {
+                opts.on_success?.();
+            },
+            error() {
+                opts.on_error?.();
             },
         });
     };

--- a/web/src/todo_data.ts
+++ b/web/src/todo_data.ts
@@ -17,7 +17,7 @@ export type TodoWidgetExtraData = z.infer<typeof todo_widget_extra_data_schema>;
 
 const todo_widget_inbound_data = z.intersection(
     z.object({
-        type: z.enum(["new_task", "new_task_list_title", "strike"]),
+        type: z.enum(["new_task", "new_task_list_title", "strike", "edit_task"]),
     }),
     z.record(z.string(), z.unknown()),
 );
@@ -34,11 +34,25 @@ const new_task_inbound_data_schema = z.object({
     completed: z.boolean(),
 });
 
+const edit_task_inbound_data_schema = z.object({
+    type: z.literal("edit_task"),
+    key: z.string(),
+    task: z.string(),
+    desc: z.string(),
+});
+
 type NewTaskOutboundData = z.output<typeof new_task_inbound_data_schema>;
 
 type NewTaskTitleOutboundData = {
     type: "new_task_list_title";
     title: string;
+};
+
+type EditTaskItemOutboundData = {
+    type: "edit_task";
+    task: string;
+    desc: string;
+    key: string;
 };
 
 type TaskStrikeOutboundData = {
@@ -59,10 +73,15 @@ type Task = {
     completed: boolean;
 };
 
+type TodoTaskEditState = TodoTask & {
+    submitting: boolean;
+};
+
 export type TodoWidgetOutboundData =
     | NewTaskTitleOutboundData
     | NewTaskOutboundData
-    | TaskStrikeOutboundData;
+    | TaskStrikeOutboundData
+    | EditTaskItemOutboundData;
 
 export class TaskData {
     message_sender_id: number;
@@ -71,6 +90,7 @@ export class TaskData {
     report_error_function: (msg: string, more_info?: Record<string, unknown>) => void;
     task_list_title: string;
     task_map = new Map<string, Task>();
+    editing_items = new Map<string, TodoTaskEditState>();
     my_idx = 1;
 
     handle = {
@@ -169,6 +189,58 @@ export class TaskData {
             },
         },
 
+        edit_task: {
+            outbound: (
+                task: string,
+                desc: string,
+                key: string,
+            ): EditTaskItemOutboundData | undefined => {
+                const event = {
+                    type: "edit_task" as const,
+                    key,
+                    task,
+                    desc,
+                };
+                if (this.name_in_use(task, key)) {
+                    return undefined;
+                }
+                return event;
+            },
+
+            inbound: (sender_id: number, raw_data: unknown): void => {
+                const parsed = edit_task_inbound_data_schema.safeParse(raw_data);
+                if (!parsed.success) {
+                    blueslip.warn("todo widget: bad type for inbound task data", {
+                        error: parsed.error,
+                    });
+                    return;
+                }
+                if (sender_id !== this.message_sender_id) {
+                    this.report_error_function(`user ${sender_id} is not allowed to edit tasks`);
+                    return;
+                }
+                const data = parsed.data;
+                const task = data.task;
+                const desc = data.desc;
+
+                const key = data.key;
+                const item = this.task_map.get(key);
+                if (item === undefined) {
+                    blueslip.warn("Do we have legacy data? unknown key for tasks: " + key);
+                    return;
+                }
+
+                if (task === item.task && desc === item.desc) {
+                    return;
+                }
+                if (task !== item.task && this.name_in_use(task, key)) {
+                    return;
+                }
+                item.task = task;
+                item.desc = desc;
+            },
+        },
+
         strike: {
             outbound(key: string): TaskStrikeOutboundData {
                 const event = {
@@ -243,6 +315,26 @@ export class TaskData {
         return people.is_my_user_id(this.message_sender_id);
     }
 
+    get_editing_items(): Map<string, TodoTaskEditState> {
+        return this.editing_items;
+    }
+
+    set_editing_item(key: string, state: TodoTask): void {
+        const edit_state = this.editing_items.get(key);
+        this.editing_items.set(key, {...state, submitting: edit_state?.submitting ?? false});
+    }
+
+    remove_editing_item(key: string): void {
+        this.editing_items.delete(key);
+    }
+
+    set_submitting_state(key: string, is_loading: boolean): void {
+        const item = this.editing_items.get(key);
+        if (item !== undefined) {
+            item.submitting = is_loading;
+        }
+    }
+
     set_task_list_title(new_title: string): void {
         this.input_mode = false;
         this.task_list_title = new_title;
@@ -258,6 +350,10 @@ export class TaskData {
 
     clear_input_mode(): void {
         this.input_mode = false;
+    }
+
+    get_task_item(key: string): Task | undefined {
+        return this.task_map.get(key);
     }
 
     get_input_mode(): boolean {
@@ -276,9 +372,9 @@ export class TaskData {
         return widget_data;
     }
 
-    name_in_use(name: string): boolean {
+    name_in_use(name: string, current_key?: string): boolean {
         for (const item of this.task_map.values()) {
-            if (item.task === name) {
+            if (item.task === name && item.key !== current_key) {
                 return true;
             }
         }

--- a/web/src/todo_widget.ts
+++ b/web/src/todo_widget.ts
@@ -16,6 +16,17 @@ import {TaskData} from "./todo_data.ts";
 import type {Event} from "./widget_data.ts";
 import type {AnyWidgetData, WidgetData} from "./widget_schema.ts";
 
+// Captures which edit-bar input is focused and its caret/selection, so
+// the state can be restored after a rerender rebuilds the list and
+// destroys the original input elements.
+type EditInputFocusState = {
+    key: string;
+    field: "add-task" | "add-desc";
+    selection_start: number | null;
+    selection_end: number | null;
+    selection_direction: "forward" | "backward" | "none" | null;
+};
+
 export function activate({any_data, message}: {any_data: AnyWidgetData; message: Message}): {
     inbound_events_handler: (events: Event[]) => void;
     widget_data: WidgetData;
@@ -50,7 +61,11 @@ export function render({
     rerender,
 }: {
     $elem: JQuery;
-    callback: (data: TodoWidgetOutboundData) => void;
+    callback: (
+        data: TodoWidgetOutboundData,
+        on_success?: () => void,
+        on_error?: () => void,
+    ) => void;
     message: Message;
     widget_data: WidgetData;
     rerender: boolean;
@@ -148,6 +163,77 @@ export function render({
         }
     }
 
+    function abort_edit_item(key: string): void {
+        task_data.remove_editing_item(key);
+        update_task_edit_controls(key);
+        // Remove any stale error message.
+        get_task_list_item(key).find(".widget-error").text("");
+    }
+
+    function submit_task_list_item(key: string): void {
+        if (!is_my_task_list) {
+            abort_edit_item(key);
+            return;
+        }
+        const $task_list_item = get_task_list_item(key);
+        const new_task =
+            $task_list_item.find<HTMLInputElement>("input.add-task").val()?.trim() ?? "";
+        const new_desc =
+            $task_list_item.find<HTMLInputElement>("input.add-desc").val()?.trim() ?? "";
+
+        if (new_task === "") {
+            return;
+        }
+        const old_task_list_item = task_data.get_task_item(key);
+
+        if (!old_task_list_item) {
+            blueslip.warn("Do we have legacy data? unknown key for tasks: " + key);
+            abort_edit_item(key);
+            return;
+        }
+        if (new_task === old_task_list_item.task && new_desc === old_task_list_item.desc) {
+            abort_edit_item(key);
+            return;
+        }
+
+        // Reject duplicate names before entering the loading state so that the
+        // spinner never flashes on and immediately off for a no-op validation
+        // failure.
+        const data = task_data.handle.edit_task.outbound(new_task, new_desc, key);
+        if (!data) {
+            $task_list_item.find(".widget-error").text($t({defaultMessage: "Task already exists"}));
+            return;
+        }
+
+        // Show the loading spinner and disable the edit controls while the
+        // server request is in flight.  The inputs, cancel, and submit
+        // controls are all disabled, so the edit session cannot be closed
+        // or re-submitted until the server responds; the callbacks below
+        // can therefore act unconditionally.
+        enter_loading_state(key);
+
+        function success_handler(): void {
+            exit_loading_state(key);
+            abort_edit_item(key);
+        }
+
+        function error_handler(): void {
+            exit_loading_state(key);
+        }
+
+        callback(data, success_handler, error_handler);
+    }
+
+    function get_task_list_item(key: string): JQuery {
+        return $elem.find(`input.task[data-key="${key}"]`).closest("li");
+    }
+
+    function get_task_key_from_event(e: JQuery.TriggeredEvent): string {
+        const key = $(e.target).closest("li").find("label.checkbox input.task").attr("data-key");
+        assert(key !== undefined);
+        return key;
+    }
+
     function build_widget(): void {
         const html = render_widgets_todo_widget();
         $elem.html(html);
@@ -207,6 +293,63 @@ export function render({
                     add_task();
                 }
             });
+
+        $elem.find("ul.todo-widget").on("keydown", ".todo-task-edit-bar input", (e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") {
+                e.preventDefault();
+                submit_task_list_item(get_task_key_from_event(e));
+                return;
+            }
+            if (e.key === "Escape") {
+                abort_edit_item(get_task_key_from_event(e));
+            }
+        });
+
+        $elem.find("ul.todo-widget").on("click", ".todo-edit-task-icon", (e) => {
+            e.stopPropagation();
+            const key = get_task_key_from_event(e);
+            start_editing_item(key);
+            $(e.target).closest("li").find(".todo-task-edit-bar input.add-task").trigger("focus");
+        });
+
+        $elem
+            .find("ul.todo-widget")
+            .on("click", ".todo-task-edit-bar .todo-task-edit-check", (e) => {
+                e.stopPropagation();
+                submit_task_list_item(get_task_key_from_event(e));
+            });
+
+        $elem
+            .find("ul.todo-widget")
+            .on("click", ".todo-task-edit-bar .todo-task-edit-cancel", (e) => {
+                e.stopPropagation();
+                abort_edit_item(get_task_key_from_event(e));
+            });
+
+        // Persist the in-progress edit so it survives a rerender that
+        // rebuilds the list.  We store the raw value and only trim when
+        // submitting, so leading/trailing spaces a user is typing are
+        // not stripped mid-edit.
+        $elem
+            .find("ul.todo-widget")
+            .on(
+                "input",
+                ".todo-task-edit-bar input.add-task, .todo-task-edit-bar input.add-desc",
+                (e) => {
+                    const key = get_task_key_from_event(e);
+                    const $task_list_item = get_task_list_item(key);
+                    const task =
+                        $task_list_item
+                            .find<HTMLInputElement>(".todo-task-edit-bar input.add-task")
+                            .val() ?? "";
+                    const desc =
+                        $task_list_item
+                            .find<HTMLInputElement>(".todo-task-edit-bar input.add-desc")
+                            .val() ?? "";
+                    task_data.set_editing_item(key, {task, desc});
+                },
+            );
     }
 
     function update_add_task_button(): void {
@@ -234,11 +377,59 @@ export function render({
         }
     }
 
+    function update_task_edit_submit_loading(key: string, is_loading: boolean): void {
+        const $edit_item_bar = get_task_list_item(key).find(".todo-task-edit-bar");
+        $edit_item_bar.find("input").prop("disabled", is_loading);
+        $edit_item_bar.find(".todo-task-edit-cancel").prop("disabled", is_loading);
+        $edit_item_bar.find("i.todo-task-check").toggle(!is_loading);
+        $edit_item_bar.find("i.todo-task-spinner").toggle(is_loading);
+        $edit_item_bar.find(".todo-task-edit-check").prop("disabled", is_loading);
+    }
+
+    function enter_loading_state(key: string): void {
+        task_data.set_submitting_state(key, true);
+        update_task_edit_submit_loading(key, true);
+    }
+
+    function exit_loading_state(key: string): void {
+        task_data.set_submitting_state(key, false);
+        update_task_edit_submit_loading(key, false);
+    }
+
+    function update_task_edit_controls(key: string): void {
+        const input_mode = task_data.get_editing_items().has(key);
+        const $task_list_item = get_task_list_item(key);
+        const can_edit = is_my_task_list && !input_mode;
+        $task_list_item.find(".checkbox").toggle(!input_mode);
+        $task_list_item.find(".todo-task-edit-bar").toggle(input_mode);
+        $task_list_item.find(".todo-edit-task-icon").toggle(can_edit);
+    }
+
+    function start_editing_item(key: string): void {
+        const task_item = task_data.get_task_item(key);
+        if (task_item === undefined) {
+            return;
+        }
+        const $task_list_item = get_task_list_item(key);
+        $task_list_item.find(".todo-task-edit-bar input.add-task").val(task_item.task);
+        $task_list_item.find(".todo-task-edit-bar input.add-desc").val(task_item.desc);
+
+        task_data.set_editing_item(key, {task: task_item.task, desc: task_item.desc});
+        update_task_edit_controls(key);
+    }
+
     function render_results(): void {
         const widget_data = task_data.get_widget_data();
         const html = render_widgets_todo_widget_tasks(widget_data);
+
+        // Rebuilding the list below destroys the edit-bar inputs, so
+        // capture the focused input and its caret to restore afterward.
+        const edit_input_focus_state = get_edit_input_focus_state();
+
         $elem.find("ul.todo-widget").html(html);
         $elem.find(".add-task-bar .widget-error").text("");
+        $elem.find(".todo-task-edit-bar").hide();
+        $elem.find(".todo-edit-task-icon").toggle(is_my_task_list);
 
         $elem.find("input.task").on("click", (e) => {
             e.stopPropagation();
@@ -261,6 +452,78 @@ export function render({
         });
 
         update_add_task_button();
+
+        function restore_todo_item_edit_state(): void {
+            for (const [key, {task, desc, submitting}] of task_data.get_editing_items().entries()) {
+                const $task_list_item = get_task_list_item(key);
+                $task_list_item.find(".todo-task-edit-bar input.add-task").val(task);
+                $task_list_item.find(".todo-task-edit-bar input.add-desc").val(desc);
+                update_task_edit_controls(key);
+                if (submitting) {
+                    update_task_edit_submit_loading(key, true);
+                }
+            }
+        }
+
+        function get_edit_input_focus_state(): EditInputFocusState | undefined {
+            const $focused_input = $elem.find<HTMLInputElement>(
+                ".todo-task-edit-bar input.add-task:focus, .todo-task-edit-bar input.add-desc:focus",
+            );
+            const input_element = $focused_input[0];
+            if (input_element === undefined) {
+                return undefined;
+            }
+            const key = $focused_input
+                .closest("li")
+                .find("label.checkbox input.task")
+                .attr("data-key");
+            if (key === undefined) {
+                return undefined;
+            }
+            return {
+                key,
+                field: $focused_input.hasClass("add-task") ? "add-task" : "add-desc",
+                selection_start: input_element.selectionStart,
+                selection_end: input_element.selectionEnd,
+                selection_direction: input_element.selectionDirection,
+            };
+        }
+
+        function restore_edit_input_focus(focus_state: EditInputFocusState | undefined): void {
+            if (focus_state === undefined) {
+                return;
+            }
+            const $task_list_item = get_task_list_item(focus_state.key);
+            const input_element = $task_list_item.find<HTMLInputElement>(
+                `.todo-task-edit-bar input.${focus_state.field}`,
+            )[0];
+            if (input_element === undefined) {
+                return;
+            }
+
+            // The input's :focus rule animates its border-color and
+            // box-shadow. Re-focusing the freshly rebuilt input would
+            // replay that animation on every rerender, flashing the
+            // border even though, to the user, focus never left.
+            // Suppress the transition for this programmatic focus, then
+            // restore it for genuine focus changes.
+            input_element.style.transition = "none";
+            input_element.focus();
+            if (focus_state.selection_start !== null && focus_state.selection_end !== null) {
+                input_element.setSelectionRange(
+                    focus_state.selection_start,
+                    focus_state.selection_end,
+                    focus_state.selection_direction ?? undefined,
+                );
+            }
+            // Force the browser to reflow the page so that the transition is applied.
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            input_element.offsetHeight;
+            input_element.style.transition = "";
+        }
+
+        restore_todo_item_edit_state();
+        restore_edit_input_focus(edit_input_focus_state);
     }
 
     if (message_container?.is_hidden) {

--- a/web/src/todo_widget.ts
+++ b/web/src/todo_widget.ts
@@ -121,7 +121,7 @@ export function render({
     }
 
     function add_task(): void {
-        $elem.find(".widget-error").text("");
+        $elem.find(".add-task-bar .widget-error").text("");
         const task =
             $elem.find<HTMLInputElement>(".add-task-bar input.add-task").val()?.trim() ?? "";
         const desc =
@@ -136,7 +136,9 @@ export function render({
         // This case should not generally occur.
         const task_exists = task_data.name_in_use(task);
         if (task_exists) {
-            $elem.find(".widget-error").text($t({defaultMessage: "Task already exists"}));
+            $elem
+                .find(".add-task-bar .widget-error")
+                .text($t({defaultMessage: "Task already exists"}));
             return;
         }
 
@@ -152,7 +154,7 @@ export function render({
 
         // This throttling ensures that the function runs only after the user stops typing.
         const throttled_update_add_task_button = _.throttle(update_add_task_button, 300);
-        $elem.find("input.add-task").on("keyup", (e) => {
+        $elem.find(".add-task-bar input.add-task").on("keyup", (e) => {
             e.stopPropagation();
             throttled_update_add_task_button();
         });
@@ -196,17 +198,20 @@ export function render({
             add_task();
         });
 
-        $elem.find("input.add-task, input.add-desc").on("keydown", (e) => {
-            if (e.key === "Enter") {
-                e.stopPropagation();
-                e.preventDefault();
-                add_task();
-            }
-        });
+        $elem
+            .find(".add-task-bar input.add-task, .add-task-bar input.add-desc")
+            .on("keydown", (e) => {
+                if (e.key === "Enter") {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    add_task();
+                }
+            });
     }
 
     function update_add_task_button(): void {
-        const task = $elem.find<HTMLInputElement>("input.add-task").val()?.trim() ?? "";
+        const task =
+            $elem.find<HTMLInputElement>(".add-task-bar input.add-task").val()?.trim() ?? "";
         const task_exists = task_data.name_in_use(task);
         const $add_task_wrapper = $elem.find(".add-task-wrapper");
         const $add_task_button = $elem.find("button.add-task");
@@ -233,7 +238,7 @@ export function render({
         const widget_data = task_data.get_widget_data();
         const html = render_widgets_todo_widget_tasks(widget_data);
         $elem.find("ul.todo-widget").html(html);
-        $elem.find(".widget-error").text("");
+        $elem.find(".add-task-bar .widget-error").text("");
 
         $elem.find("input.task").on("click", (e) => {
             e.stopPropagation();

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -25,12 +25,16 @@
 }
 
 .todo-widget {
-    .todo-task-list-title-bar {
+    .todo-task-list-title-bar,
+    .todo-task-edit-bar {
         flex: 1 1 auto;
         display: flex;
         /* Ensure controls remain visible on narrower screens. */
         flex-flow: row wrap;
         gap: 5px;
+    }
+
+    .todo-task-list-title-bar {
         margin-bottom: var(--markdown-interelement-space-px);
     }
 
@@ -282,6 +286,8 @@ input {
 
 .poll-question-check,
 .poll-question-remove,
+.todo-task-edit-check,
+.todo-task-edit-cancel,
 .todo-task-list-title-check,
 .todo-task-list-title-remove {
     align-self: stretch;
@@ -297,6 +303,35 @@ input {
     &:hover {
         border-color: var(--color-border-zulip-button-interactive);
         background-color: var(--color-background-zulip-button-hover);
+    }
+
+    &:disabled {
+        cursor: not-allowed;
+    }
+}
+
+.todo-task-spinner {
+    animation: rotate 1s infinite linear;
+}
+
+.todo-edit-task-icon {
+    opacity: 0;
+    transition: opacity 0.15s ease-out;
+    color: var(--color-message-action-visible);
+
+    /* Always display edit icon for touch based devices */
+    @media (hover: none) {
+        opacity: 1;
+        transition: none;
+    }
+}
+
+.todo-widget li:hover .todo-edit-task-icon {
+    opacity: 1;
+    transition: opacity 0.1s ease-in;
+
+    &:hover {
+        color: var(--color-message-action-interactive);
     }
 }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -274,6 +274,10 @@ input {
     font-size: 0.8571em; /* 12px at 14px/em */
     display: flex;
     align-items: center;
+
+    &:empty {
+        display: none;
+    }
 }
 
 .poll-question-check,

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -13,5 +13,16 @@
                 {{/if}}
             </span>
         </label>
+        <i class="fa fa-pencil small todo-edit-task-icon"></i>
+        <div class="todo-task-edit-bar">
+            <input type="text" class="add-task" placeholder="{{t 'Task'}}" />
+            <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />
+            <button class="todo-task-edit-cancel"><i class="fa fa-remove"></i></button>
+            <button class="todo-task-edit-check">
+                <i class="fa fa-check todo-task-check"></i>
+                <i class="fa fa-circle-o-notch todo-task-spinner" style="display: none;"></i>
+            </button>
+        </div>
+        <div class="widget-error"></div>
     </li>
 {{/each}}

--- a/web/tests/submessage.test.cjs
+++ b/web/tests/submessage.test.cjs
@@ -62,25 +62,40 @@ run_test("make_server_callback", () => {
     const message_id = 444;
     const callback = submessage.make_server_callback(message_id);
     let was_posted;
+    let post_success;
+    let post_error;
 
     channel.post = (opts) => {
         was_posted = true;
-        assert.deepEqual(opts, {
-            url: "/json/submessage",
-            data: {
-                message_id,
-                msg_type: "whatever",
-                content: '{"foo":32}',
-            },
+        assert.equal(opts.url, "/json/submessage");
+        assert.deepEqual(opts.data, {
+            message_id,
+            msg_type: "whatever",
+            content: '{"foo":32}',
         });
+        post_success = opts.success;
+        post_error = opts.error;
     };
+
+    let on_success_called = false;
+    let on_error_called = false;
 
     callback({
         msg_type: "whatever",
         data: {foo: 32},
+        on_success() {
+            on_success_called = true;
+        },
+        on_error() {
+            on_error_called = true;
+        },
     });
 
     assert.ok(was_posted);
+    post_success();
+    assert.ok(on_success_called);
+    post_error();
+    assert.ok(on_error_called);
 });
 
 run_test("check sender", () => {

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -565,6 +565,21 @@ def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "edit_task":
+        if not is_widget_author:
+            raise ValidationError("You can't edit the task unless you are the author.")
+
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("task", check_string),
+                ("desc", check_string),
+                ("key", check_string),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -420,6 +420,12 @@ class WidgetContentTestCase(ZulipTestCase):
             result, "You can't edit the task list title unless you are the author."
         )
 
+        result = post(cordelia, dict(type="edit_task", key="5,9", task="Homework", desc=""))
+        self.assert_json_success(result)
+
+        result = post(hamlet, dict(type="edit_task", key="5,9", task="Homework", desc=""))
+        self.assert_json_error(result, "You can't edit the task unless you are the author.")
+
     def test_poll_type_validation(self) -> None:
         sender = self.example_user("cordelia")
         stream_name = "Verona"
@@ -532,6 +538,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         assert_success(dict(type="new_task", key=7, task="eat", desc="", completed=False))
         assert_success(dict(type="strike", key="5,9"))
+        assert_success(dict(type="edit_task", key="5,9", task="ea", desc=""))
 
     def test_get_widget_type(self) -> None:
         sender = self.example_user("cordelia")


### PR DESCRIPTION
Introduces edit option for todo options.

Current design-
* edit icon adjacent to each todo item.
* only todo list author can edit items (other user can't edit todo items added by them)
* can toggle input fields for multiple todo items
* edit item input state persists on rerenders

Fixes part of zulip#20213
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures:</summary>
<img width="707" height="250" alt="image" src="https://github.com/user-attachments/assets/0a439533-4e4e-45f6-b0bf-c77c3055f26f" />
<img width="707" height="250" alt="image" src="https://github.com/user-attachments/assets/b72f57c3-13f1-4a04-abaf-5b66802f531d" />

Error message on duplicate names
<img width="784" height="260" alt="image" src="https://github.com/user-attachments/assets/e0e018f8-f3e2-4b5e-9fdd-ac91dc3191e8" />

[Screencast from 2026-03-31 02-40-48.webm](https://github.com/user-attachments/assets/9221b7f7-09ce-485c-8927-8ee6382510ca)

|Before 1st commit|After 1st commit|
|-|-|
|<img width="638" height="260" alt="Screenshot from 2026-06-05 23-21-06" src="https://github.com/user-attachments/assets/f9d2f32b-2a8f-4740-b64b-600e1f38e899" />|<img width="638" height="260" alt="Screenshot from 2026-06-05 23-17-48" src="https://github.com/user-attachments/assets/da9f80aa-1ce5-42d2-827a-0e0fd7f9bc65" />|

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
