### PR TITLE
typeahead: Re render header html for every update in user string.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -373,14 +373,6 @@ export class Typeahead<ItemType extends string | object> {
 
         // Call this early to avoid duplicate calls.
         this.shown = true;
-
-        const header_text_html = this.header_html();
-        if (header_text_html) {
-            this.$header.find("span#typeahead-header-text").html(header_text_html);
-            this.$header.show();
-        } else {
-            this.$header.hide();
-        }
         this.mouse_moved_since_typeahead = false;
 
         const input_element = this.input_element;
@@ -563,6 +555,19 @@ export class Typeahead<ItemType extends string | object> {
             }
             return $i;
         });
+
+        // We want to re render the typeahead header for ever update
+        // in user's string since once typeahead is shown after `@`,
+        // header might change depending on whether next character is
+        // `_` (silent mention) or not.
+        const header_text_html = this.header_html();
+
+        if (header_text_html) {
+            this.$header.find("span#typeahead-header-text").html(header_text_html);
+            this.$header.show();
+        } else {
+            this.$header.hide();
+        }
 
         if (this.requireHighlight || this.shouldHighlightFirstResult()) {
             $items[0]!.addClass("active");

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1359,7 +1359,7 @@ function get_header_html(): string | false {
     let tip_text = "";
     switch (completing) {
         case "silent_mention":
-            tip_text = $t({defaultMessage: "Silent mentions do not trigger notifications."});
+            tip_text = $t({defaultMessage: "This silent mention won't trigger notifications."});
             break;
         case "syntax":
             if (realm.realm_default_code_block_language !== "") {


### PR DESCRIPTION
Previously, the typeahead's header html used to be updated only once -- after it is shown.

This caused stale state in compose box typeaheads -- when user starts with an `@`, the typeahead is shown for the first time, and the header html is rendered. Then when next character is `_` (silent mention), the header html is no longer updated since it is already updated once when `@` is used.

This is fixed by updating the typeahead everytime the user string is updated.

<!-- Describe your pull request here.-->

Fixes: [CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFtypeahead.20doesn't.20update.20helper.20text.20when.20already.20shown/with/2105026)

https://github.com/user-attachments/assets/5f5e6099-31ba-4423-990b-a6e819f5604e




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
