### PR TITLE
help: Document nice syntax for linking in the current channel.

### DIFF
--- a/help/link-to-a-message-or-conversation.md
+++ b/help/link-to-a-message-or-conversation.md
@@ -22,13 +22,16 @@ Channel links are automatically formatted as [#channel name]().
 
 !!! tip ""
 
-    You can create a channel link manually by typing `#**channel name**`.
+    To link to the channel you're composing to, type `#>`, and pick the
+    top option from the autocomplete.
 
 {end_tabs}
 
 When you paste a channel link into Zulip, it's automatically formatted as
 `#**channel name**`. You can paste as plain text if you prefer with <kbd
 data-mac-following-key="⌥">Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd>.
+
+You can create a channel link manually by typing `#**channel name**`
 
 ## Link to a topic within Zulip
 
@@ -48,13 +51,17 @@ Topic links are automatically formatted as [#channel > topic]().
 
 !!! tip ""
 
-    You can create a topic link manually by typing `#**channel name>topic name**`.
+    To link to a topic in the channel you're composing to, type `#>`
+    followed by a few letters from the topic name, and pick the desired
+    topic from the autocomplete.
 
 {end_tabs}
 
 When you paste a topic link into Zulip, it's automatically formatted as
 `#**channel name>topic name**`. You can paste as plain text if you prefer with
 <kbd data-mac-following-key="⌥">Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd>.
+
+You can create a topic link manually by typing `#**channel name>topic name**`.
 
 ## Link to Zulip from anywhere
 
@@ -121,13 +128,11 @@ When you send your message, the link will appear as [#channel > topic @ 💬](/)
     If using Zulip in a browser, you can also click on the timestamp
     of a message, and copy the URL from your browser's address bar.
 
-!!! tip ""
-
-    When you paste a message link into Zulip, it is automatically
-    formatted for you. You can paste as plain text if you prefer with
-    <kbd data-mac-following-key="⌥">Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd>.
-
 {end_tabs}
+
+When you paste a message link into Zulip, it is automatically
+formatted for you. You can paste as plain text if you prefer with
+<kbd data-mac-following-key="⌥">Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd>.
 
 ### Get a link to a specific topic
 


### PR DESCRIPTION
Follow-up to #31669; @kuv2707 FYI.

Notes:
- I considered doing this as an addition to the instruction to enter the channel name, rather than as a tip. But I think that would be awkward, as it actually affects both that instruction and the next one.
- I think moving the info about manually typing out links down below where we introduce the syntax makes sense. It's not really a tip, in that we aren't really suggesting that people should ever do this.
- I untippified the message link tip for consistency with the prior sections.

![Screenshot 2025-02-26 at 15 59 26@2x](https://github.com/user-attachments/assets/5bd101ba-b659-443c-91a7-f30a73c3d93c)
