### PR TITLE
widgets: Fix not showing add poll option  when poll has no title.

### DIFF
--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -61,7 +61,6 @@ export function activate({
         const input_mode = poll_data.get_input_mode();
         const can_edit = is_my_poll && !input_mode;
         const has_question = question.trim() !== "";
-        const can_vote = has_question;
         const waiting = !is_my_poll && !has_question;
         const author_help = is_my_poll && !has_question;
 
@@ -71,7 +70,7 @@ export function activate({
         update_edit_controls();
 
         $elem.find(".poll-question-bar").toggle(input_mode);
-        $elem.find(".poll-option-bar").toggle(can_vote);
+        $elem.find(".poll-option-bar").show();
 
         $elem.find(".poll-please-wait").toggle(waiting);
 

--- a/web/src/poll_widget.ts
+++ b/web/src/poll_widget.ts
@@ -62,7 +62,6 @@ export function activate({
         const can_edit = is_my_poll && !input_mode;
         const has_question = question.trim() !== "";
         const waiting = !is_my_poll && !has_question;
-        const author_help = is_my_poll && !has_question;
 
         $elem.find(".poll-question-header").toggle(!input_mode);
         $elem.find(".poll-question-header").text(question);
@@ -73,8 +72,6 @@ export function activate({
         $elem.find(".poll-option-bar").show();
 
         $elem.find(".poll-please-wait").toggle(waiting);
-
-        $elem.find(".poll-author-help").toggle(author_help);
     }
 
     function start_editing(): void {

--- a/web/templates/widgets/poll_widget.hbs
+++ b/web/templates/widgets/poll_widget.hbs
@@ -11,9 +11,6 @@
     <div class="poll-please-wait">
         {{t 'We are about to have a poll.  Please wait for the question.'}}
     </div>
-    <div class="poll-author-help">
-        {{t 'Tip: You can also send "/poll Some question"'}}
-    </div>
     <ul class="poll-widget">
     </ul>
     <div class="poll-option-bar">

--- a/web/tests/poll_widget.test.cjs
+++ b/web/tests/poll_widget.test.cjs
@@ -253,7 +253,6 @@ run_test("activate another person poll", ({mock_template}) => {
 
     const $poll_vote_button = set_widget_find_result("button.poll-vote");
     const $poll_please_wait = set_widget_find_result(".poll-please-wait");
-    const $poll_author_help = set_widget_find_result(".poll-author-help");
 
     set_widget_find_result("button.poll-question-remove");
     set_widget_find_result("input.poll-question");
@@ -267,7 +266,6 @@ run_test("activate another person poll", ({mock_template}) => {
     assert.ok(!$poll_question_submit.visible());
     assert.ok(!$poll_edit_question.visible());
     assert.ok(!$poll_please_wait.visible());
-    assert.ok(!$poll_author_help.visible());
 
     assert.equal($widget_elem.html(), "widgets/poll_widget");
     assert.equal($widget_option_container.html(), "widgets/poll_widget_results");
@@ -367,7 +365,6 @@ run_test("activate own poll", ({mock_template}) => {
 
     set_widget_find_result("button.poll-vote");
     const $poll_please_wait = set_widget_find_result(".poll-please-wait");
-    const $poll_author_help = set_widget_find_result(".poll-author-help");
 
     set_widget_find_result("button.poll-question-remove");
 
@@ -377,7 +374,6 @@ run_test("activate own poll", ({mock_template}) => {
         assert.ok(!$poll_question_container.visible());
         assert.ok($poll_edit_question.visible());
         assert.ok(!$poll_please_wait.visible());
-        assert.ok(!$poll_author_help.visible());
     }
 
     poll_widget.activate(opts);


### PR DESCRIPTION
This PR makes it possible to add poll options even when the poll has no title/question.
Also this does removes the tip shown on polls without questions.

changes:
- removes `.poll-author-help` divs to remove the tip shown for user.
- also removes the .poll-author-help from poll_widget.test.cjs
- removed can_vote condition and always show `Add option` button.

fixes: #33672

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Before     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/30c8dc28-64fe-408f-a7a8-344e6441b252)    |
| After  | ![dm](https://github.com/user-attachments/assets/0f614bd2-1bac-4789-86f0-d780e8334555) |




<details>
<summary>Recipients sides</summary>

|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Before     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/7836dbb3-c30f-4ba1-ae5f-a7c9ae90f115)    |
| After  | ![dm](https://github.com/user-attachments/assets/e2458794-e702-41b0-839d-39f03dc2d3db) |

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
