### PR TITLE
message_edit_history: Fix empty string topic not displaying correctly.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -25,6 +25,7 @@ import {get_color} from "./stream_data.ts";
 import * as sub_store from "./sub_store.ts";
 import * as timerender from "./timerender.ts";
 import * as ui_report from "./ui_report.ts";
+import * as util from "./util.ts";
 
 type EditHistoryEntry = {
     edited_at_time: string;
@@ -34,8 +35,10 @@ type EditHistoryEntry = {
     recipient_bar_color: string | undefined;
     body_to_render: string | undefined;
     topic_edited: boolean | undefined;
-    prev_topic: string | undefined;
-    new_topic: string | undefined;
+    prev_topic_display_name: string | undefined;
+    new_topic_display_name: string | undefined;
+    is_empty_string_prev_topic: boolean | undefined;
+    is_empty_string_new_topic: boolean | undefined;
     stream_changed: boolean | undefined;
     prev_stream: string | undefined;
     prev_stream_id: number | undefined;
@@ -139,8 +142,10 @@ export function fetch_and_render_message_history(message: Message): void {
                 let edited_by_notice;
                 let body_to_render;
                 let topic_edited;
-                let prev_topic;
-                let new_topic;
+                let prev_topic_display_name;
+                let new_topic_display_name;
+                let is_empty_string_prev_topic;
+                let is_empty_string_new_topic;
                 let stream_changed;
                 let prev_stream;
                 let prev_stream_id;
@@ -152,13 +157,17 @@ export function fetch_and_render_message_history(message: Message): void {
                     edited_by_notice = $t({defaultMessage: "Edited by {full_name}"}, {full_name});
                     body_to_render = msg.content_html_diff;
                     topic_edited = true;
-                    prev_topic = msg.prev_topic;
-                    new_topic = msg.topic;
+                    prev_topic_display_name = util.get_final_topic_display_name(msg.prev_topic);
+                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
+                    is_empty_string_prev_topic = msg.prev_topic === "";
+                    is_empty_string_new_topic = msg.topic === "";
                 } else if (msg.prev_topic !== undefined && msg.prev_stream) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     topic_edited = true;
-                    prev_topic = msg.prev_topic;
-                    new_topic = msg.topic;
+                    prev_topic_display_name = util.get_final_topic_display_name(msg.prev_topic);
+                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
+                    is_empty_string_prev_topic = msg.prev_topic === "";
+                    is_empty_string_new_topic = msg.topic === "";
                     stream_changed = true;
                     prev_stream_id = msg.prev_stream;
                     prev_stream = get_display_stream_name(msg.prev_stream);
@@ -168,8 +177,10 @@ export function fetch_and_render_message_history(message: Message): void {
                 } else if (msg.prev_topic !== undefined) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     topic_edited = true;
-                    prev_topic = msg.prev_topic;
-                    new_topic = msg.topic;
+                    prev_topic_display_name = util.get_final_topic_display_name(msg.prev_topic);
+                    new_topic_display_name = util.get_final_topic_display_name(msg.topic);
+                    is_empty_string_prev_topic = msg.prev_topic === "";
+                    is_empty_string_new_topic = msg.topic === "";
                 } else if (msg.prev_stream) {
                     edited_by_notice = $t({defaultMessage: "Moved by {full_name}"}, {full_name});
                     stream_changed = true;
@@ -191,8 +202,10 @@ export function fetch_and_render_message_history(message: Message): void {
                     recipient_bar_color: undefined,
                     body_to_render,
                     topic_edited,
-                    prev_topic,
-                    new_topic,
+                    prev_topic_display_name,
+                    new_topic_display_name,
+                    is_empty_string_prev_topic,
+                    is_empty_string_new_topic,
                     stream_changed,
                     prev_stream,
                     prev_stream_id,

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -29,8 +29,9 @@
                     <div class="messagebox-content">
                         {{#if topic_edited}}
                         <div class="message_content message_edit_history_content">
-                            <p>{{t "Topic" }}: <span class="highlight_text_inserted">{{ new_topic }}</span>
-                                <span class="highlight_text_deleted">{{ prev_topic}}</span>
+                            <p>{{t "Topic" }}:
+                                <span class="highlight_text_inserted {{#if is_empty_string_new_topic}}empty-topic-display{{/if}}">{{ new_topic_display_name }}</span>
+                                <span class="highlight_text_deleted {{#if is_empty_string_prev_topic}}empty-topic-display{{/if}}">{{ prev_topic_display_name }}</span>
                             </p>
                         </div>
                         {{/if}}


### PR DESCRIPTION
[#api design > general chat api changes @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/general.20chat.20api.20changes/near/2105708):
> So it looks like the topic edit history has one of those bugs where it isn't displaying the previous topic of "", probably because that's falsey.


PR to fix the above bug.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="441" alt="Screenshot 2025-02-27 at 12 15 54 PM" src="https://github.com/user-attachments/assets/a5de6412-146c-4d3c-9439-a043ddf88441" />

<img width="305" alt="Screenshot 2025-02-27 at 12 16 03 PM" src="https://github.com/user-attachments/assets/6debb6e7-0ee6-414f-87f5-3ab9f72549e4" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
