### PR TITLE
github: Include old issue number in transfer message for new repo.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -236,7 +236,7 @@ class GitHubWebhookTest(WebhookTestCase):
         )
 
     def test_issue_transfer_opened_message(self) -> None:
-        expected_message = "[Issue #4 Fixture collection](https://github.com/CrisisCollab/admin-frontend-mvp/issues/4) was transferred from CrisisCollab/TestWebhook."
+        expected_message = "[Issue #4 Fixture collection](https://github.com/CrisisCollab/admin-frontend-mvp/issues/4) was transferred from [CrisisCollab/TestWebhook#4](https://github.com/CrisisCollab/TestWebhook/issues/4)."
         expected_topic_name = "admin-frontend-mvp / issue #4 Fixture collection"
         self.check_webhook(
             "issues__opened_via_transfer",

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -703,12 +703,14 @@ def get_issue_transferred_body(helper: Helper) -> str:
 
 def get_issue_opened_via_transfer_body(helper: Helper) -> str:
     payload = helper.payload
-    template = "[Issue #{new_issue_number} {title}]({new_issue_url}) was transferred from {old_repo_full_name}."
+    template = "[Issue #{new_issue_number} {title}]({new_issue_url}) was transferred from [{old_repo_full_name}#{old_issue_number}]({old_issue_url})."
     return template.format(
         new_issue_number=payload["issue"]["number"].tame(check_int),
         new_issue_url=payload["issue"]["html_url"].tame(check_string),
         title=payload["issue"]["title"].tame(check_string),
         old_repo_full_name=payload["changes"]["old_repository"]["full_name"].tame(check_string),
+        old_issue_number=payload["changes"]["old_issue"]["number"].tame(check_int),
+        old_issue_url=payload["changes"]["old_issue"]["html_url"].tame(check_string),
     )
 
 


### PR DESCRIPTION
This PR updates the GitHub webhook integration to include the old issue number in the transfer message sent for the new repository, alongside the old repository's full name.

Fixes: [#integrations > github bot @ 💬](https://chat.zulip.org/#narrow/channel/127-integrations/topic/github.20bot/near/2099493)

Follow-up of #33525.

**Screenshots and screen captures:**
<img width="1007" alt="Screenshot 2025-02-27 at 1 28 44 PM" src="https://github.com/user-attachments/assets/d55d0373-3832-460d-8982-4ed75d34dee0" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
