### PR TITLE
hotkey: Fix `=` to toggle reaction results in error.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1229,7 +1229,8 @@ export function process_hotkey(e, hotkey) {
                 return true;
             }
 
-            reactions.toggle_emoji_reaction(msg, first_reaction.emoji_name);
+            const canonical_name = emoji.get_emoji_name(first_reaction.emoji_code);
+            reactions.toggle_emoji_reaction(msg, canonical_name);
             return true;
         }
         case "toggle_topic_visibility_policy":


### PR DESCRIPTION
Fixes #33574

This was due to the method used to get the emoji name was incorrect.
