### PR TITLE
navbar: Better align middle column and logo elements.

### DIFF
--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -38,6 +38,7 @@ export const container_breakpoints = {
     cq_xl_min: xl / base_em_px + "em",
     cq_lg_min: lg / base_em_px + "em",
     cq_md_min: md / base_em_px + "em",
+    cq_sm_min: sm / base_em_px + "em",
     cq_mm_min: mm / base_em_px + "em",
 };
 

--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -36,6 +36,7 @@ export const media_breakpoints = {
 
 export const container_breakpoints = {
     cq_xl_min: xl / base_em_px + "em",
+    cq_lg_min: lg / base_em_px + "em",
     cq_md_min: md / base_em_px + "em",
     cq_mm_min: mm / base_em_px + "em",
 };

--- a/web/src/realm_logo.ts
+++ b/web/src/realm_logo.ts
@@ -6,6 +6,7 @@ import {current_user, realm} from "./state_data.ts";
 import * as ui_util from "./ui_util.ts";
 import * as upload_widget from "./upload_widget.ts";
 import type {UploadFunction} from "./upload_widget.ts";
+import {user_settings} from "./user_settings.ts";
 
 export function build_realm_logo_widget(upload_function: UploadFunction, is_night: boolean): void {
     let logo_section_id = "#realm-day-logo-upload-widget";
@@ -87,11 +88,22 @@ export function render(): void {
         $("#realm-night-logo-upload-widget .image-block").attr("src", realm.realm_night_logo_url);
     }
 
+    const $realm_logo = $<HTMLImageElement>("#realm-navbar-wide-logo");
     if (settings_data.using_dark_theme() && realm.realm_night_logo_source !== "D") {
-        $("#realm-navbar-wide-logo").attr("src", realm.realm_night_logo_url);
+        $realm_logo.attr("src", realm.realm_night_logo_url);
     } else {
-        $("#realm-navbar-wide-logo").attr("src", realm.realm_logo_url);
+        $realm_logo.attr("src", realm.realm_logo_url);
     }
+
+    $realm_logo.on("load", () => {
+        const logo_width = $realm_logo.width();
+        if (logo_width) {
+            $("html").css(
+                "--realm-logo-current-width",
+                logo_width / user_settings.web_font_size_px + "em",
+            );
+        }
+    });
 
     change_logo_delete_button(
         realm.realm_logo_source,

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -273,7 +273,9 @@
     --right-column-collapsed-sidebar-width: 10.15em;
     /* 288px at 14px/1em */
     --right-column-max-width: 20.57em;
-    --right-column-width: clamp(10em, 50%, var(--right-column-max-width));
+    /* We open the right sidebar at xl_min at a size of 240px,
+       here expressed as precisely 20% of the viewport. */
+    --right-column-width: min(20%, var(--right-column-max-width));
     --right-sidebar-width: calc(
         var(--right-column-width) - var(--right-sidebar-left-spacing)
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -256,6 +256,12 @@
         20.6429em - var(--left-sidebar-right-margin)
     );
     --realm-logo-max-width: 12.5em; /* 200px at 16px em */
+    /* Value updated on realm_logo.render() */
+    --realm-logo-current-width: var(--realm-logo-max-width);
+    /* 10px is just extra margin for content separation */
+    --middle-column-left-margin-fluid-layout: calc(
+        var(--header-height) + var(--realm-logo-current-width) + 10px
+    );
     /* Sidebar width is 1/3 of the screen at smaller
        sizes, but gets held to the left sidebar's max width.
        This is very useful for areas in the CSS codebase

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -380,6 +380,16 @@
         --message-box-markdown-aligned-vertical-space: 5px;
     }
 
+    /* Message area */
+    /* In the legacy layout at 16px/1em density, 918.6px is
+       the widest the message area gets, so we preserve this
+       value to better present a readable message area across
+       different info densities and the manual hiding of the
+       left and right sidebars.
+       918.6px at 16px/1em
+    */
+    --message-area-max-width: 57.4125em;
+
     /* Shared sidebar typography and effects values. */
     --font-weight-sidebar-heading: 600;
     --font-weight-sidebar-action-heading: 370;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -267,18 +267,15 @@
        This is very useful for areas in the CSS codebase
        that rely on this value, but not necessarily as
        applied to `width:` or `max-width:`. */
-    --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
+    --left-sidebar-width: min(33.3333vw, var(--left-sidebar-max-width));
     --right-sidebar-left-spacing: 5px;
     /* 50px per icon * 4 icons + 3px space (legacy) = 203px at 20px/1em */
     --right-column-collapsed-sidebar-width: 10.15em;
     /* 288px at 14px/1em */
-    --right-column-max-width: 20.57em;
+    --right-sidebar-max-width: 20.57em;
     /* We open the right sidebar at xl_min at a size of 240px,
        here expressed as precisely 20% of the viewport. */
-    --right-column-width: min(20%, var(--right-column-max-width));
-    --right-sidebar-width: calc(
-        var(--right-column-width) - var(--right-sidebar-left-spacing)
-    );
+    --right-sidebar-width: min(20vw, var(--right-sidebar-max-width));
     /* 25px at 16px/1em */
     --right-sidebar-vdots-width: 1.5625em;
     /* The width of the icon is reduced by 2px, to account for 2px

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -255,6 +255,7 @@
     --left-sidebar-max-width: calc(
         20.6429em - var(--left-sidebar-right-margin)
     );
+    --realm-logo-max-width: 12.5em; /* 200px at 16px em */
     /* Sidebar width is 1/3 of the screen at smaller
        sizes, but gets held to the left sidebar's max width.
        This is very useful for areas in the CSS codebase

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1068,7 +1068,7 @@ nav {
         .nav-logo {
             display: inline-block;
             height: 1.25em; /* 20px at 16px em */
-            max-width: 12.5em; /* 200px at 16px em */
+            max-width: var(--realm-logo-max-width);
 
             @media (height < $short_navbar_cutoff_height) {
                 height: 0.9375em; /* 15px at 16px em */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -41,7 +41,7 @@ body {
     #compose-container {
         max-width: calc(
             var(--left-sidebar-max-width) + var(--message-area-max-width) +
-                var(--right-column-max-width)
+                var(--right-sidebar-max-width)
         );
     }
 
@@ -53,7 +53,7 @@ body {
         .app .app-main,
         #compose-container {
             max-width: calc(
-                var(--message-area-max-width) + var(--right-column-max-width)
+                var(--message-area-max-width) + var(--right-sidebar-max-width)
             );
 
             /* When we're less than the xl_min breakpoint, we instead
@@ -398,8 +398,8 @@ body.has-overlay-scrollbar {
 
 /* This applies to column-left both in navbar and app. */
 .column-right {
-    width: var(--right-column-width);
-    max-width: var(--right-column-max-width);
+    width: var(--right-sidebar-width);
+    max-width: var(--right-sidebar-max-width);
     position: absolute;
     right: 0;
     top: 0;
@@ -628,7 +628,7 @@ body.has-overlay-scrollbar {
 
 .column-middle,
 #compose-content {
-    margin-right: var(--right-column-width);
+    margin-right: var(--right-sidebar-width);
     margin-left: calc(
         var(--left-sidebar-width) + var(--left-sidebar-padding-left)
     );
@@ -1557,11 +1557,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
             /* In the extended state, we open the sidebar
                to its maximum possible size (otherwise, it
                would be unnecessarily too narrow). */
-            --right-column-width: var(--right-column-max-width);
-            --right-sidebar-width: calc(
-                var(--right-column-max-width) -
-                    var(--right-sidebar-left-spacing)
-            );
+            --right-sidebar-width: var(--right-sidebar-max-width);
             display: block;
             position: absolute;
             float: none;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1554,6 +1554,14 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         display: none;
 
         &.expanded {
+            /* In the extended state, we open the sidebar
+               to its maximum possible size (otherwise, it
+               would be unnecessarily too narrow). */
+            --right-column-width: var(--right-column-max-width);
+            --right-sidebar-width: calc(
+                var(--right-column-max-width) -
+                    var(--right-sidebar-left-spacing)
+            );
             display: block;
             position: absolute;
             float: none;
@@ -1567,9 +1575,8 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
             .right-sidebar {
                 box-shadow: 0 -2px 3px 0 hsl(0deg 0% 0% / 10%);
                 border-left: 1px solid var(--color-border-sidebar);
-                padding-right: 15px;
-                padding-left: 15px;
                 height: 100%;
+                width: var(--right-sidebar-width);
                 right: 0;
                 background-color: var(--color-background);
             }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1599,6 +1599,12 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         .app-main .column-middle {
             margin-left: 7px;
         }
+
+        @container header-container (width > $cq_md_min) {
+            #navbar-middle {
+                margin-left: var(--middle-column-left-margin-fluid-layout);
+            }
+        }
     }
 
     @container header-container (width < $cq_xl_min) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1599,11 +1599,11 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         .app-main .column-middle {
             margin-left: 7px;
         }
+    }
 
-        @container header-container (width > $cq_md_min) {
-            #navbar-middle {
-                margin-left: var(--middle-column-left-margin-fluid-layout);
-            }
+    @container header-container (width > $cq_md_min) {
+        #navbar-middle {
+            margin-left: var(--middle-column-left-margin-fluid-layout);
         }
     }
 
@@ -1613,10 +1613,27 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         }
     }
 
+    @container header-container (width < $cq_md_min) {
+        #navbar-middle {
+            margin-left: 0;
+        }
+    }
+
     @container app (width < $cq_xl_min) {
         #compose-content,
         .app-main .column-middle {
             margin-left: 7px;
+        }
+    }
+}
+
+/* Media-query fallback for the cinched-up logo presentation. */
+@media (width > $md_min) {
+    .without-container-query-support {
+        &.hide-left-sidebar {
+            #navbar-middle {
+                margin-left: var(--middle-column-left-margin-fluid-layout);
+            }
         }
     }
 }
@@ -1677,7 +1694,10 @@ body:not(.hide-left-sidebar) {
     }
 
     .top-navbar-container {
-        margin-left: 40px;
+        /* The --header-height variable is used to make
+        the squared toggle area, so we offset it
+        accordingly. */
+        margin-left: var(--header-height);
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1594,11 +1594,9 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         @extend %hide-left-sidebar;
     }
 
-    &.fluid_layout_width {
-        #compose-content,
-        .app-main .column-middle {
-            margin-left: 7px;
-        }
+    #compose-content,
+    .app-main .column-middle {
+        margin-left: 7px;
     }
 
     @container header-container (width > $cq_md_min) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -45,6 +45,61 @@ body {
         );
     }
 
+    /* When sidebars are manually hidden, we set the max-width
+       for the layout to a different maximum width. This keeps
+       the message area predictably readable. */
+    &.hide-left-sidebar:not(.fluid_layout_width) {
+        .header-main,
+        .app .app-main,
+        #compose-container {
+            max-width: calc(
+                var(--message-area-max-width) + var(--right-column-max-width)
+            );
+
+            /* When we're less than the xl_min breakpoint, we instead
+               constrain to just the message area's max-width, since
+               the right column will be hidden below that point. */
+            @container header-container (width < $cq_xl_min) {
+                max-width: var(--message-area-max-width);
+            }
+
+            @container app (width < $cq_xl_min) {
+                max-width: var(--message-area-max-width);
+            }
+        }
+    }
+
+    /* Fallback media query. */
+    @media (width < $xl_min) {
+        &.without-container-query-support.hide-left-sidebar:not(
+                .fluid_layout_width
+            ) {
+            .header-main,
+            .app .app-main,
+            #compose-container {
+                max-width: var(--message-area-max-width);
+            }
+        }
+    }
+
+    &.hide-right-sidebar:not(.fluid_layout_width) {
+        .header-main,
+        .app .app-main,
+        #compose-container {
+            max-width: calc(
+                var(--left-sidebar-max-width) + var(--message-area-max-width)
+            );
+        }
+    }
+
+    &.hide-left-sidebar.hide-right-sidebar:not(.fluid_layout_width) {
+        .header-main,
+        .app .app-main,
+        #compose-container {
+            max-width: var(--message-area-max-width);
+        }
+    }
+
     &.fluid_layout_width {
         .header-main,
         .app .app-main,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1723,6 +1723,12 @@ body:not(.hide-left-sidebar) {
     }
 }
 
+@container header-container (width <= $cq_sm_min) {
+    .narrow_description {
+        display: none;
+    }
+}
+
 /* Begin fallback media queries. */
 @media (width < $xl_min) {
     .without-container-query-support {
@@ -1800,6 +1806,14 @@ body:not(.hide-left-sidebar) {
         #scheduled_message_indicator,
         #compose-content {
             margin-left: 7px;
+        }
+    }
+}
+
+@media (width <= $sm_min) {
+    .without-container-query-support {
+        .narrow_description {
+            display: none;
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -39,9 +39,10 @@ body {
     .header-main,
     .app .app-main,
     #compose-container {
-        /* 1417px at 14px/1em; (14px * 20.5em) - 12px + 880 + 250px = 1417px */
-        max-width: 100.3571em;
-        max-width: calc(var(--left-sidebar-max-width) + 62.8571em + 250px);
+        max-width: calc(
+            var(--left-sidebar-max-width) + var(--message-area-max-width) +
+                var(--right-column-max-width)
+        );
     }
 
     &.fluid_layout_width {


### PR DESCRIPTION
This PR better presents the navbar elements in and outside of the "Use full width" setting, and with regard to the manual hiding of the left sidebar. Essentially, we now handle breakpoints and layout shifts the same, regardless of the "Use full width" setting--which setting now effectively only removes the otherwise-enforced `max-width` on the UI.

The PR also hides descriptions below a certain minimum screen size. While this approximates what's called for in #33685, a better engineered solution will likely require a container query and possibly a gridded presentation, so that we can maintain an ellipsis-free view/channel name

Fixes: #30619; fixes #33715. Provides partial, interim fix for #33685.

Things tested:

* Resizing window width with different font sizes
* Resizing window with and without the left sidebar showing, with and without "Use full screen" selected (see screenshots)
* Hard reloading the page

| Fixed layout, left sidebar shown | Fixed layout, left sidebar hidden |
| --- | --- |
| ![fixed-width-lsb-showing](https://github.com/user-attachments/assets/81aeff07-2b2a-423d-b86e-78d26504282f) | ![fixed-width-lsb-hidden](https://github.com/user-attachments/assets/cc36d5d8-547b-4711-a778-331f76500dbf) |

| Full-screen layout, left sidebar shown | Full-screen layout, left sidebar hidden |
| --- | --- |
| ![fluid-width-lsb-showing](https://github.com/user-attachments/assets/764258f0-b734-4d05-86ac-89c4f8039e30) | ![fluid-width-lsb-hidden](https://github.com/user-attachments/assets/05e77540-d0b6-4181-b2f1-fd30a028761e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>