### PR TITLE
combined-feed-ui: Clean up undefined case from current filter.

### DIFF
--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -127,11 +127,8 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
     };
     const default_banner_for_multiple_filters = $t({defaultMessage: "No search results."});
 
-    const current_filter = narrow_state.filter();
-    if (current_filter === undefined) {
-        // We're in either the inbox or recent conversations view.
-        return default_banner;
-    }
+    const current_filter = narrow_state.filter()!;
+
     if (current_filter.is_in_home()) {
         // We're in the combined feed view.
         return {

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -239,16 +239,6 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
-    message_lists.set_current(undefined);
-    narrow_banner.show_empty_narrow_message();
-    assert.equal(
-        $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: There are no messages here.",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
-        ),
-    );
-
     // for empty combined feed
     const current_filter = new Filter([{operator: "in", operand: "home"}]);
     message_lists.set_current({data: {filter: current_filter}});


### PR DESCRIPTION
The undefined case for the current filter really
shouldn't happen as show_empty_narrow_message is
only called when we have a message list and
therefore a defined filter.

<!-- Describe your pull request here.-->

Fixes: [Follow up](https://github.com/zulip/zulip/pull/32805#issuecomment-2679211115) for PR #32805.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
