### PR TITLE
compose_banner: Fix automatic visibility policy banner rendering.

### DIFF
--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -44,6 +44,7 @@ type MessageRecipient =
     | {
           message_type: "channel";
           channel_name: string;
+          topic_name: string;
           topic_display_name: string;
           is_empty_string_topic: boolean;
       }
@@ -91,6 +92,8 @@ export function notify_automatic_new_visibility_policy(
             classname: compose_banner.CLASSNAMES.automatic_new_visibility_policy,
             link_msg_id: data.id,
             channel_name: message_recipient.channel_name,
+            // The base compose_banner.hbs expects a data-topic-name.
+            topic_name: message_recipient.topic_name,
             topic_display_name: message_recipient.topic_display_name,
             is_empty_string_topic: message_recipient.is_empty_string_topic,
             narrow_url,
@@ -110,6 +113,7 @@ function get_message_recipient(message: Message): MessageRecipient {
         const channel_message_recipient: MessageRecipient = {
             message_type: "channel",
             channel_name: stream_data.get_stream_name_from_id(message.stream_id),
+            topic_name: message.topic,
             topic_display_name: util.get_final_topic_display_name(message.topic),
             is_empty_string_topic: message.topic === "",
         };


### PR DESCRIPTION
Earlier when a new user sent a message in empty string topic, it resulted in an error while displaying the automatic new visibility policy banner.

<img width="949" alt="Screenshot 2025-02-27 at 3 54 55 PM" src="https://github.com/user-attachments/assets/d1611478-0def-417f-a93b-b78c46a148ac" />


<!-- Describe your pull request here.-->




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
