### PR TITLE
sidebars: Improve right-sidebar space usage, allow vdots to scale.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -260,12 +260,15 @@
        that rely on this value, but not necessarily as
        applied to `width:` or `max-width:`. */
     --left-sidebar-width: min(33.3333%, var(--left-sidebar-max-width));
+    --right-sidebar-left-spacing: 5px;
     /* 50px per icon * 4 icons + 3px space (legacy) = 203px at 20px/1em */
     --right-column-collapsed-sidebar-width: 10.15em;
     /* 288px at 14px/1em */
     --right-column-max-width: 20.57em;
     --right-column-width: clamp(10em, 50%, var(--right-column-max-width));
-    --right-sidebar-width: calc(var(--right-column-width) - 10px);
+    --right-sidebar-width: calc(
+        var(--right-column-width) - var(--right-sidebar-left-spacing)
+    );
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to
        not touch the row outline. */
@@ -277,7 +280,6 @@
     --left-sidebar-bottom-scrolling-buffer: calc(
         (var(--legacy-body-line-height-unitless) * 1em) + 0.3571em
     );
-    --right-sidebar-left-spacing: 5px;
     /* Used in both left and right sidebar at the bottom, to allow
        the user to scroll past the bottom-most elements a little bit.
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -269,6 +269,7 @@
     --right-sidebar-width: calc(
         var(--right-column-width) - var(--right-sidebar-left-spacing)
     );
+    --right-sidebar-vdots-width: 25px;
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to
        not touch the row outline. */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -227,7 +227,8 @@
     --left-sidebar-icon-content-gap: 0.4375em;
     /* The space allotted in gridded rows for the toggle icon. */
     --left-sidebar-header-icon-toggle-width: 20px;
-    --left-sidebar-vdots-width: 26px;
+    /* 26px at 16px/1em */
+    --left-sidebar-vdots-width: 1.625em;
     /* Other rows need an offset to preserve a column the
        entire height of the left sidebar for where toggles sit. */
     --left-sidebar-toggle-width-offset: var(
@@ -269,7 +270,8 @@
     --right-sidebar-width: calc(
         var(--right-column-width) - var(--right-sidebar-left-spacing)
     );
-    --right-sidebar-vdots-width: 25px;
+    /* 25px at 16px/1em */
+    --right-sidebar-vdots-width: 1.5625em;
     /* The width of the icon is reduced by 2px, to account for 2px
        of top and bottom margin needed for hover backgrounds to
        not touch the row outline. */

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -405,13 +405,15 @@
        that controls remain aligned with the username,
        even when there is a status line shown below.
 
-       The 26px column for the vdots is less than the
+       The 25px column for the vdots is less than the
        30px allotted in the left sidebar, but it holds
        the username area constant, so that no ellipsis
-       appears on the username on hover. */
+       appears on the username on hover. The 25px value
+       is necessary for correct vdots alignment with the
+       filter row's vdots. */
     grid-template:
         "row-content ending-anchor-element" var(--line-height-sidebar-row)
-        "row-content ." auto / minmax(0, 1fr) 26px;
+        "row-content ." auto / minmax(0, 1fr) var(--right-sidebar-vdots-width);
     align-content: baseline;
     margin-right: var(--width-simplebar-scroll-hover);
     margin-left: var(--right-sidebar-toggle-width-offset);
@@ -518,8 +520,12 @@
         color: var(--color-vdots-visible);
         justify-content: center;
         display: grid;
-        width: 25px;
+        width: var(--right-sidebar-vdots-width);
         margin-left: 5px;
+        /* Push back against default right-sidebar
+           spacing for better vdots alignment. */
+        margin-right: 0;
+        padding-left: 0;
 
         &:hover {
             color: var(--color-vdots-hover);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -518,7 +518,7 @@ body.has-overlay-scrollbar {
     }
 
     .column-right .right-sidebar {
-        padding-left: 5px;
+        padding-left: var(--right-sidebar-left-spacing);
         width: var(--right-sidebar-width);
     }
 


### PR DESCRIPTION
The bulk of this PR is an immediate follow-up to #33249, which ensures that the buddy-list elements of the right sidebar better occupy the entire space (note that an adjustment originally part of #33249, which caused the right sidebar to hug the right side of the viewport, has been abandoned for the solutions here).

Additionally, this PR introduces fixes for both the left and right sidebars to allow vdots to scale. As can be seen in the screenshots below, vdots button areas previously became extremely wide at small font sizes, and extremely narrow at larger ones. The scaling maintains the squared look of the vdots, regardless of font size. Additionally, some adjustments to the right sidebar now perfectly align the filter-row vdots with the individual user row vdots.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/sidebar.20follow-ups/near/2106365)

**Screenshots and screen captures:**

_Showing a 1000w (no change; right sidebar hidden), 1200w, and 1800w viewport--all at 16px:_

| Right sidebar, before | Right sidebar, after |
| --- | --- |
| ![1000-w-before](https://github.com/user-attachments/assets/83dcbc3b-6cc9-485b-bb6a-f6988044ce78) | ![1000-w-after-no-change](https://github.com/user-attachments/assets/e677c728-8b8a-4ff1-a92c-5619ec29980c) |
| ![1200-w-before](https://github.com/user-attachments/assets/bdb3a082-d50f-4604-b03c-adb3cdd55026) | ![1200-w-after](https://github.com/user-attachments/assets/a0395bde-41c9-48db-8f5f-b19b14fdddcf) |
| ![1800-w-before](https://github.com/user-attachments/assets/3abdf630-b9e7-4dbd-aae5-94d5e323ea8f) | ![1800-w-after](https://github.com/user-attachments/assets/26d4f100-103a-4119-ba3c-a4eb23c08975) |

_Showing 10px, 16px, and 24px:_

| Right sidebar vdots, before | Right sidebar vdots, after |
| --- | --- |
| ![10px-vdots-right-before](https://github.com/user-attachments/assets/6d675ab6-3796-4e62-82c8-240be191b79a) | ![10px-vdots-right-after](https://github.com/user-attachments/assets/d84bb4fe-7a7b-4ad2-81d5-728b19c785f0) |
| ![16px-vdots-right-before](https://github.com/user-attachments/assets/b405708b-3868-4193-821c-960082e1b819) | ![16px-vdots-right-after](https://github.com/user-attachments/assets/dea3f5c4-1e18-4f5c-8af5-2ac56329abbe) |
| ![24px-vdots-right-before](https://github.com/user-attachments/assets/f2d9133c-de6d-49f0-8fc6-496dccb853ee) | ![24px-vdots-right-after](https://github.com/user-attachments/assets/a454d75b-32a0-4c96-8915-d1eeedb79750) |

_Showing 10px, 16px (no change), and 24px:_

| Left sidebar vdots, before | Left sidebar vdots, after |
| --- | --- |
| ![10px-vdots-left-before](https://github.com/user-attachments/assets/2a92c8a0-7962-4df1-ad79-be9f292f37ff) | ![10px-vdots-left-after](https://github.com/user-attachments/assets/cd0f8fa7-3b4a-4130-9753-612bdca6f283) |
| ![16px-vdots-left-before](https://github.com/user-attachments/assets/6b2da681-0720-47ba-9151-79a5e8e7fed1) | ![16px-vdots-left-after-no-change](https://github.com/user-attachments/assets/3054b802-f4e8-4146-8871-94d31eede86f) |
| ![24px-vdots-left-before](https://github.com/user-attachments/assets/b106a96e-542e-4af6-b547-2c1b3e380e16) | ![24px-vdots-left-after](https://github.com/user-attachments/assets/3b5b0ae4-78a1-4ab1-b09a-db18d74a2548) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
