### PR TITLE
compose: Correct alignment, ellipsis on general chat placeholder.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1028,7 +1028,15 @@ textarea.new_message_textarea {
 
 #compose_recipient_box {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    /* When displaying #topic-not-mandatory-placeholder,
+       we let it occupy the entire topic box. Otherwise,
+       we set and preserve named areas for the ordinary
+       topic text and the clear-topic button. */
+    grid-template-columns:
+        [topic-box-start topic-start] minmax(0, 1fr)
+        [topic-end topic-clear-button-start] auto [topic-clear-button-end topic-box-end];
+    grid-template-rows: auto;
+    align-content: center;
     align-items: stretch;
     flex: 1 1 0;
     border: 1px solid var(--color-compose-recipient-box-border-color);
@@ -1051,6 +1059,7 @@ textarea.new_message_textarea {
 
     /* Styles for input in the recipient_box */
     #stream_message_recipient_topic {
+        grid-area: topic;
         color: var(--color-compose-recipient-box-text-color);
         /* Override grid's effective `max-content` min-width */
         overflow: hidden;
@@ -1069,7 +1078,10 @@ textarea.new_message_textarea {
     }
 
     #topic-not-mandatory-placeholder {
-        position: absolute;
+        grid-area: topic-box;
+        white-space: nowrap;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
         padding: 5px 6px;
         display: none;
         visibility: hidden;
@@ -1078,6 +1090,7 @@ textarea.new_message_textarea {
 
     /* Styles for new conversation button in the recipient_box */
     #recipient_box_clear_topic_button {
+        grid-area: topic-clear-button;
         /* Set the border radius smaller, relative to the parent */
         border-radius: 2px;
         padding: 6px;


### PR DESCRIPTION
This rewrites the grid and adds some critical properties on the general-topic placeholder to make both overflow work as expected, and sure that the faux placeholder and ordinary topic text occupies the same baseline in the composebox.

CZO issues:
* [#issues > 🎯 compose box placeholder text misaligned @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20compose.20box.20placeholder.20text.20misaligned/near/2104852)
* [#issues > 🎯 topic placeholder spills out with long channel name @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20topic.20placeholder.20spills.20out.20with.20long.20channel.20name/near/2105576)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![before-faux-placeholder](https://github.com/user-attachments/assets/81cd48c6-4738-4bfb-8a0d-87b55f808fbf) | ![after-16px-faux-placeholder](https://github.com/user-attachments/assets/cb65eb67-bc39-454c-a2ad-3141682f2db1) |
| ![before-actual-topic](https://github.com/user-attachments/assets/1874c1e2-20a2-4340-9300-cd60bb11f64b) | ![after-16px-actual-topic](https://github.com/user-attachments/assets/170fa99c-7f98-4d62-8f56-6af8fb3b5f2d) |

_Comparing the faux place holder with an actual topic (same text as the placeholder, minus the sanity-check `<faked>` part, to easily verify exact alignment between both), at 12px, 16px, and 20px:_

| Faux placeholder | Actual topic |
| --- | --- |
| ![after-12px-faux-placeholder](https://github.com/user-attachments/assets/f24fa979-be9e-4e65-a55a-4bc38664886a) | ![after-12px-actual-topic](https://github.com/user-attachments/assets/58f0f3e9-ec1c-4013-a4a9-31f49baa02be) |
| ![after-16px-faux-placeholder](https://github.com/user-attachments/assets/cb65eb67-bc39-454c-a2ad-3141682f2db1) | ![after-16px-actual-topic](https://github.com/user-attachments/assets/170fa99c-7f98-4d62-8f56-6af8fb3b5f2d) |
| ![after-20px-faux-placeholder](https://github.com/user-attachments/assets/2bb36ac0-32c0-4e22-8839-740497872fd6) | ![after-20px-actual-topic](https://github.com/user-attachments/assets/c42574c4-a878-4288-b26f-07fc882d4d9c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>