### PR TITLE
navbar: Show "Muted user" instead of muted user's name.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -11,6 +11,7 @@ import {$t} from "./i18n.ts";
 import * as message_parser from "./message_parser.ts";
 import * as message_store from "./message_store.ts";
 import type {Message} from "./message_store.ts";
+import * as muted_users from "./muted_users.ts";
 import {page_params} from "./page_params.ts";
 import type {User} from "./people.ts";
 import * as people from "./people.ts";
@@ -1389,7 +1390,13 @@ export class Filter {
                 if (!person) {
                     return email;
                 }
+                if (muted_users.is_user_muted(person.user_id)) {
+                    if (people.should_add_guest_user_indicator(person.user_id)) {
+                        return $t({defaultMessage: "Muted user (guest)"});
+                    }
 
+                    return $t({defaultMessage: "Muted user"});
+                }
                 if (people.should_add_guest_user_indicator(person.user_id)) {
                     return $t({defaultMessage: "{name} (guest)"}, {name: person.full_name});
                 }

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -19,6 +19,7 @@ const people = zrequire("people");
 const {Filter} = zrequire("../src/filter");
 const {set_current_user, set_realm} = zrequire("state_data");
 const {initialize_user_settings} = zrequire("user_settings");
+const muted_users = zrequire("muted_users");
 
 const realm = {};
 set_realm(realm);
@@ -54,11 +55,28 @@ const alice = {
     is_guest: true,
 };
 
+const jeff = {
+    email: "jeff@foo.com",
+    user_id: 34,
+    full_name: "jeff",
+};
+
+const annie = {
+    email: "annie@foo.com",
+    user_id: 35,
+    full_name: "annie",
+    is_guest: true,
+};
+
 people.add_active_user(me);
 people.add_active_user(joe);
 people.add_active_user(steve);
 people.add_active_user(alice);
+people.add_active_user(jeff);
+people.add_active_user(annie);
 people.initialize_current_user(me.user_id);
+muted_users.add_muted_user(jeff.user_id);
+muted_users.add_muted_user(annie.user_id);
 
 function assert_same_terms(result, terms) {
     // If negated flag is undefined, we explicitly
@@ -2174,8 +2192,16 @@ test("navbar_helpers", ({override}) => {
     ];
     const dm_group = [{operator: "dm", operand: "joe@example.com,STEVE@foo.com"}];
     const dm_with_guest = [{operator: "dm", operand: "alice@example.com"}];
+    const dm_with_muted_user = [{operator: "dm", operand: "jeff@foo.com"}];
+    const dm_with_muted_guest_user = [{operator: "dm", operand: "annie@foo.com"}];
     const dm_group_including_guest = [
         {operator: "dm", operand: "alice@example.com,joe@example.com"},
+    ];
+    const dm_group_including_muted_user = [
+        {operator: "dm", operand: "jeff@foo.com,joe@example.com"},
+    ];
+    const dm_group_including_muted_guest_user = [
+        {operator: "dm", operand: "annie@foo.com,joe@example.com"},
     ];
     const dm_group_including_missing_person = [
         {operator: "dm", operand: "joe@example.com,STEVE@foo.com,sally@doesnotexist.com"},
@@ -2333,6 +2359,20 @@ test("navbar_helpers", ({override}) => {
             redirect_url_with_search: "/#narrow/dm/" + joe.user_id + "," + steve.user_id + "-group",
         },
         {
+            terms: dm_with_muted_user,
+            is_common_narrow: true,
+            zulip_icon: "user",
+            title: "translated: Muted user",
+            redirect_url_with_search: "/#narrow/dm/" + jeff.user_id + "-" + jeff.full_name,
+        },
+        {
+            terms: dm_with_muted_guest_user,
+            is_common_narrow: true,
+            zulip_icon: "user",
+            title: "translated: Muted user (guest)",
+            redirect_url_with_search: "/#narrow/dm/" + annie.user_id + "-" + annie.full_name,
+        },
+        {
             terms: dm_with_guest,
             is_common_narrow: true,
             zulip_icon: "user",
@@ -2346,6 +2386,20 @@ test("navbar_helpers", ({override}) => {
             zulip_icon: "user",
             title: "joe and translated: alice (guest)",
             redirect_url_with_search: "/#narrow/dm/" + joe.user_id + "," + alice.user_id + "-group",
+        },
+        {
+            terms: dm_group_including_muted_user,
+            is_common_narrow: true,
+            zulip_icon: "user",
+            title: "joe and translated: Muted user",
+            redirect_url_with_search: "/#narrow/dm/" + joe.user_id + "," + jeff.user_id + "-group",
+        },
+        {
+            terms: dm_group_including_muted_guest_user,
+            is_common_narrow: true,
+            zulip_icon: "user",
+            title: "joe and translated: Muted user (guest)",
+            redirect_url_with_search: "/#narrow/dm/" + joe.user_id + "," + annie.user_id + "-group",
         },
         {
             terms: dm_group_including_missing_person,


### PR DESCRIPTION
This PR shows the string "Muted user" instead of muted user's name in DM's navbar.

fixes: #33673

**Screenshots and screen captures:**


|                                    |               Private DMs                    |
|-------------------------------------------|-------------------------------------------|
| Before     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/52b3e7fb-06c0-48af-a7f7-23a23233c5e4)    |
| After  | ![dm](https://github.com/user-attachments/assets/4c5d6bcd-fc93-4373-87d2-04465ff0d299) |


|                                    |                message groups                  |
|-------------------------------------------|-------------------------------------------|
| Before     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/9ecca4cd-9c78-4806-98d2-823208278d45)    |
| After  | ![dm](https://github.com/user-attachments/assets/81bf560d-4f8c-4e1f-b5e2-b6c5ab1606ff) |
| Muted Guest  | ![dm](https://github.com/user-attachments/assets/01beef62-3a05-4923-b064-214f3210379a) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
