### PR TITLE
copy_messages: Remove `clipboard.write` usage

### DIFF
--- a/web/src/copy_messages.ts
+++ b/web/src/copy_messages.ts
@@ -141,31 +141,20 @@ function remove_div(_div: JQuery, ranges: Range[]): void {
     }, 0);
 }
 
-async function copy_selection_to_clipboard(selection: Selection): Promise<void> {
+function copy_selection_to_clipboard(selection: Selection): void {
     const range = selection.getRangeAt(0);
     const div = document.createElement("div");
     div.append(range.cloneContents());
     const html_content = div.innerHTML.trim();
     const plain_text = selection.toString().trim();
 
-    // Reference: https://stackoverflow.com/a/77305170/21940401
-    if (typeof ClipboardItem !== "undefined") {
-        // Shiny new Clipboard API, not fully supported in Firefox.
-        // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#browser_compatibility
-        const html = new Blob([html_content], {type: "text/html"});
-        const text = new Blob([plain_text], {type: "text/plain"});
-        const data = new ClipboardItem({"text/html": html, "text/plain": text});
-        await navigator.clipboard.write([data]);
-    } else {
-        // Fallback using the deprecated `document.execCommand`.
-        // https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#browser_compatibility
-        const cb = (e: ClipboardEvent): void => {
-            e.clipboardData?.setData("text/html", html_content);
-            e.clipboardData?.setData("text/plain", plain_text);
-            e.preventDefault();
-        };
-        clipboard_handler.execute_copy(cb);
-    }
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#browser_compatibility
+    const cb = (e: ClipboardEvent): void => {
+        e.clipboardData?.setData("text/html", html_content);
+        e.clipboardData?.setData("text/plain", plain_text);
+        e.preventDefault();
+    };
+    clipboard_handler.execute_copy(cb);
 }
 
 // We want to grab the closest katex-display up the tree
@@ -230,7 +219,7 @@ function improve_katex_selection_range(selection: Selection): void {
     }
 }
 
-export async function copy_handler(): Promise<void> {
+export function copy_handler(): void {
     // This is the main handler for copying message content via
     // `Ctrl+C` in Zulip (note that this is totally independent of the
     // "select region" copy behavior on Linux; that is handled
@@ -272,14 +261,14 @@ export async function copy_handler(): Promise<void> {
         // TODO: Add a reference for this statement, I just tested
         // it in console for various selection directions and found this
         // to be the case not sure why there is no online reference for it.
-        await copy_selection_to_clipboard(selection);
+        copy_selection_to_clipboard(selection);
         return;
     }
 
     if (!skip_same_td_check && start_id === end_id) {
         // Check whether the selection both starts and ends in the
         // same message.  If so, Let the browser handle this.
-        await copy_selection_to_clipboard(selection);
+        copy_selection_to_clipboard(selection);
         return;
     }
 


### PR DESCRIPTION
The `clipboard.write` API requires new permissions and can throw `NotAllowedError` under certain circumstances in the browser (and always in the current version of Zulip Desktop).

- Closes #33681
- [Discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20copying.20message.20text.20not.20working.20in.20desktop.20app/near/2104750)