### PR TITLE
Search: Update dm-including pills to include multiple users in a single pill

### DIFF
--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -259,8 +259,9 @@ function get_messages_success(data: MessageFetchResponse, opts: MessageFetchOpti
 function handle_operators_supporting_id_based_api(narrow_parameter: string): string {
     // We use the canonical operator when checking these sets, so legacy
     // operators, such as "pm-with" and "stream", are not included here.
-    const operators_supporting_ids = new Set(["dm"]);
-    const operators_supporting_id = new Set(["id", "channel", "sender", "dm-including"]);
+    // In message_fetch.ts
+    const operators_supporting_ids = new Set(["dm", "dm-including"]);
+    const operators_supporting_id = new Set(["id", "channel", "sender"]);
     const parsed_narrow_data = z.array(narrow_term_schema).parse(JSON.parse(narrow_parameter));
 
     const narrow_terms: {

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -6,7 +6,7 @@ import render_user_pill from "../templates/user_pill.hbs";
 import {MAX_ITEMS} from "./bootstrap_typeahead.ts";
 import * as common from "./common.ts";
 import * as direct_message_group_data from "./direct_message_group_data.ts";
-import {Filter, create_user_pill_context} from "./filter.ts";
+import {Filter} from "./filter.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
@@ -196,7 +196,7 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         !check_validity(
             last_complete_term,
             terms.slice(-1),
-            ["dm", "pm-with"],
+            ["dm", "dm-including", "pm-with"],
             [{operator: "channel"}],
         )
     ) {
@@ -222,6 +222,15 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         return [];
     }
 
+    const excluded_emails = new Set<string>();
+    for (const term of terms) {
+        if (term.operator === "dm-including") {
+            for (const email of term.operand.split(",")) {
+                excluded_emails.add(email);
+            }
+        }
+    }
+
     const operand = last.operand;
     const negated = last.negated;
 
@@ -243,6 +252,8 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         last_part = operand.slice(last_comma_index + 1);
     }
 
+    const dedupedEmails = [...new Set(all_but_last_part.split(","))].join(",");
+
     // We don't suggest a person if their email is already present in the
     // operand (not including the last part).
     const parts = [...all_but_last_part.split(","), people.my_current_email()];
@@ -259,49 +270,52 @@ function get_group_suggestions(last: NarrowTerm, terms: NarrowTerm[]): Suggestio
         }
         all_users_but_last_part.push(user);
     }
-    const user_pill_contexts = all_users_but_last_part.map((person) =>
-        create_user_pill_context(person),
-    );
 
     const person_matcher = people.build_person_matcher(last_part);
-    let persons = people.filter_all_persons((person) => {
-        if (parts.includes(person.email)) {
-            return false;
-        }
-        return last_part === "" || person_matcher(person);
-    });
+    let persons = people.filter_all_persons(
+        (person) =>
+            !excluded_emails.has(person.email) && (last_part === "" || person_matcher(person)),
+    );
+    // Exclude the current user from group suggestions.
+    persons = persons.filter((person) => person.email !== people.my_current_email());
 
     persons.sort(compare_by_direct_message_group(parts));
 
     // Take top 15 persons, since they're ordered by pm_recipient_count.
     persons = persons.slice(0, 15);
 
-    const prefix = Filter.operator_to_prefix("dm", negated);
+    const prefix = Filter.operator_to_prefix(last_complete_term.operator, negated);
+    const operator = last_complete_term.operator;
 
     const person_highlighter = make_person_highlighter(last_part);
 
     return persons.map((person) => {
-        const term = {
-            operator: "dm",
-            operand: all_but_last_part + "," + person.email,
-            negated,
-        };
-
-        let terms: NarrowTerm[] = [term];
-        if (negated) {
-            terms = [{operator: "is", operand: "dm"}, term];
+        let term;
+        if (dedupedEmails === "") {
+            term = {
+                operator,
+                operand: person.email,
+                negated,
+            };
+        } else {
+            term = {
+                operator,
+                operand: dedupedEmails + "," + person.email,
+                negated,
+            };
         }
 
-        const all_user_pill_contexts = [
-            ...user_pill_contexts,
-            highlight_person(person, person_highlighter),
-        ];
+        let suggestion_terms = [term];
+        if (negated) {
+            suggestion_terms = [{operator: "is", operand: "dm", negated: undefined}, term];
+        }
 
+        const new_user_pill = highlight_person(person, person_highlighter);
         return {
             description_html: prefix,
-            search_string: Filter.unparse(terms),
+            search_string: Filter.unparse(suggestion_terms),
             is_people: true,
-            users: all_user_pill_contexts.map((user_pill_context) => ({user_pill_context})),
+            users: [{user_pill_context: new_user_pill}],
         };
     });
 }
@@ -954,7 +968,8 @@ class Attacher {
                 const last_base_string = last_base_term.search_string;
                 const new_search_string = suggestion.search_string;
                 if (
-                    new_search_string.startsWith("dm:") &&
+                    (new_search_string.startsWith("dm:") ||
+                        new_search_string.startsWith("dm-including:")) &&
                     new_search_string.includes(last_base_string)
                 ) {
                     suggestion_line = [...this.base.slice(0, -1), suggestion];

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -691,7 +691,7 @@ class NarrowBuilder:
         return set(self_recipient_ids) & set(narrow_recipient_ids)
 
     def by_dm_including(
-    self, query: Select, operand: str | int | Iterable[int], maybe_negate: ConditionTransform
+        self, query: Select, operand: str | int | Iterable[int], maybe_negate: ConditionTransform
     ) -> Select:
         # This operator does not support is_web_public_query.
         assert not self.is_web_public_query
@@ -723,7 +723,7 @@ class NarrowBuilder:
                     user_profiles.append(user)
                 except UserProfile.DoesNotExist:
                     continue
-            
+
             # If no valid users were found, raise an error
             if not user_profiles:
                 raise BadNarrowOperatorError("No valid users found in " + str(operand))
@@ -767,7 +767,9 @@ class NarrowBuilder:
                 *one_on_one_conditions,
                 and_(
                     column("recipient_id", Integer).in_(direct_message_group_recipient_ids),
-                ) if direct_message_group_recipient_ids else false(),
+                )
+                if direct_message_group_recipient_ids
+                else false(),
             ),
         )
         return query.where(maybe_negate(cond))


### PR DESCRIPTION
<!-- Describe your pull request here. -->
This PR improves the behavior of the `dm-including` search operator to support multiple recipients in a single pill, similar to how the `dm` operator works. The changes include:

1. **Multi-user support**:
   - Typing a comma after selecting a user now suggests additional matching users.
   - Starting to type a name provides relevant user suggestions.

2. **Data handling**:
   - The `dm-including` operator now properly handles lists of emails instead of user IDs.
   - Duplicate emails are automatically removed before constructing the narrow query.

3. **Pill behavior**:
   - Duplicate users are prevented from being added.

**Fixes**: <!-- Issue link, or clear description --> issue #33342

| **Before** | **After** |
|------------|----------|
| ![Before](https://github.com/user-attachments/assets/d1386e53-806a-492d-89f5-d1564d044591) | ![Screenshot 2025-02-28 003813](https://github.com/user-attachments/assets/66f45cc5-c6f9-45dd-b6b3-e802010d2629) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
