### PR TITLE
reactions: Stop using height: fit-content for emoji picker.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -166,7 +166,9 @@
 
 .emoji-picker-popover {
     padding: 0;
-    height: fit-content;
+    /* TODO: Calculate a more accurate height. This is a bit cut off at 12px and
+       has a bit of white below it at 20px. */
+    height: 24em;
     user-select: none;
 
     .emoji-popover {


### PR DESCRIPTION
This fixes a bug introduced in b2c5eed70df375d4249e3f46d36a991e3aec5b24 and discussed here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20triangle.20next.20to.20emoji.20button/near/2105156
