### PR TITLE
alerts: Remove --base-font-size-px and allow font-size to be inherited.

### DIFF
--- a/web/styles/alerts.css
+++ b/web/styles/alerts.css
@@ -150,8 +150,6 @@
     .alert {
         @extend .alert-animations;
 
-        /* Use --base-font-size-px to prevent any chaining on the font size */
-        font-size: var(--base-font-size-px);
         border-radius: 4px;
         background-color: hsl(0deg 0% 100%);
 


### PR DESCRIPTION
This is a follow-up commit to d1de4457dc34c4297a3f0fcffc08425ca66b9a68, which had set the font-size for the alert popups to --base-font-size-px.

This removes that line of code, as it was pointed out by Tim Abbott that the web/styles/alerts.css file was also being shared with portico through the web/src/bundles/common.ts bundle, but the --base-font-size-px variable doesn't exist there.

Removing the font-size property from the alert box doesn't affect its styling since it still inherits the `--base-font-size-px` from the body in the Zulip Web App.

CZO Discussion: [#redesign project > broader range of font sizes @ 💬](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2107255)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Main Web App
![Screenshot 2025-02-28 at 1 28 04 PM](https://github.com/user-attachments/assets/ffb3a37e-844a-4f05-8c87-57efa476a042)

### Alert box in portico (created my own error for testing the css only)
![Screenshot 2025-02-28 at 1 13 58 PM](https://github.com/user-attachments/assets/1bb40664-ecb6-4f2e-9372-05594f685f23)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
