### PR TITLE
api: Add endpoint `/messages/{message_id}/typing`.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 361**
+
+* [`POST /messages/{message_id}/typing`](/api/set-typing-status-for-message-edit):
+  Renamed `POST /messages/{message_id}/typing` to
+  `POST /message_edit_typing`, passing the one `message_id` parameter
+  in the URL path, for consistency with the rest of the API.
+
 **Feature level 360**
 
 * [`GET /messages/{message_id}`](/api/get-message), [`GET

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 360  # Last bumped for allowing access to archived channel messages on read.
+API_FEATURE_LEVEL = 361
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -51,11 +51,10 @@ function send_message_edit_typing_notification_ajax(
     operation: "start" | "stop",
 ): void {
     const data = {
-        message_id: JSON.stringify(message_id),
         op: operation,
     };
     void channel.post({
-        url: "/json/message_edit_typing",
+        url: `/json/messages/${message_id}/typing`,
         data,
         error(xhr) {
             if (xhr.readyState !== 0) {

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1608,43 +1608,35 @@ def set_typing_status(client: Client) -> None:
     validate_against_openapi_schema(result, "/typing", "post", "200")
 
 
-@openapi_test_function("/message_edit_typing:post")
-def set_message_edit_typing_status(client: Client) -> None:
-    message = {"type": "stream", "to": "Verona", "topic": "test_topic", "content": "test content"}
-    response = client.send_message(message)
-    message_id = response["id"]
+@openapi_test_function("/messages/{message_id}/typing:post")
+def set_message_edit_typing_status(client: Client, message_id: int) -> None:
     # {code_example|start}
-    # The user has started typing while editing a message
+    # The user has started typing while editing a message.
     request = {
         "op": "start",
-        "message_id": message_id,
     }
     result = client.call_endpoint(
-        "message_edit_typing",
+        f"/messages/{message_id}/typing",
         method="POST",
         request=request,
     )
     # {code_example|end}
     assert_success_response(result)
-    validate_against_openapi_schema(result, "/message_edit_typing", "post", "200")
+    validate_against_openapi_schema(result, f"/messages/{message_id}/typing", "post", "200")
 
-    message = {"type": "stream", "to": "Verona", "topic": "test_topic", "content": "test content"}
-    response = client.send_message(message)
-    message_id = response["id"]
     # {code_example|start}
     # The user has stopped typing while editing a message.
     request = {
         "op": "stop",
-        "message_id": message_id,
     }
     result = client.call_endpoint(
-        "message_edit_typing",
+        f"/messages/{message_id}/typing",
         method="POST",
         request=request,
     )
     # {code_example|end}
     assert_success_response(result)
-    validate_against_openapi_schema(result, "/message_edit_typing", "post", "200")
+    validate_against_openapi_schema(result, "/messages/{message_id}/typing", "post", "200")
 
 
 @openapi_test_function("/realm/emoji/{emoji_name}:post")
@@ -1794,7 +1786,7 @@ def test_invalid_stream_error(client: Client) -> None:
 def test_messages(client: Client, nonadmin_client: Client) -> None:
     render_message(client)
     message_id = send_message(client)
-    set_message_edit_typing_status(client)
+    set_message_edit_typing_status(client, message_id)
     add_reaction(client, message_id)
     remove_reaction(client, message_id)
     update_message(client, message_id)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2975,7 +2975,12 @@ paths:
                                 sender_id:
                                   type: integer
                                   description: |
-                                    The ID of the user who sent the message.
+                                    The ID of the user who is typing the edit of the
+                                    message.
+
+                                    Clients should be careful to display this user as the person who
+                                    is typing, not that of the sender of the message, in case a
+                                    collaborative editing feature be might be added in the future.
                                 message_id:
                                   type: integer
                                   description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21320,7 +21320,7 @@ paths:
                     description: |
                       An example JSON error response when the user composes a channel message
                       and `stream_id` is not specified:
-  /message_edit_typing:
+  /messages/{message_id}/typing:
     post:
       operationId: set-typing-status-for-message-edit
       summary: Set "typing" status for message editing
@@ -21329,10 +21329,25 @@ paths:
         Notify other users whether the current user is editing a message.
 
         Typing notifications for editing messages follow the same protocol as
-        [set-typing-status](/api/set-typing-status), see that endpoint for details.
+        [set-typing-status](/api/set-typing-status), see that endpoint for
+        details.
 
-        **Changes**: New in Zulip 10.0 (feature level 351). Previously,
-        typing notifications were not available when editing messages.
+        **Changes**: Before Zulip 10.0 (feature level 361), the endpoint was
+        named `/message_edit_typing` with `message_id` a required parameter in
+        the request body. Clients are recommended to start using sending these
+        typing notifications starting from this feature level.
+
+        New in Zulip 10.0 (feature level 351). Previously, typing notifications were
+        not available when editing messages.
+      parameters:
+        - name: message_id
+          in: path
+          description: |
+            The target message's ID.
+          schema:
+            type: integer
+          example: 47
+          required: true
       requestBody:
         required: true
         content:
@@ -21348,14 +21363,8 @@ paths:
                     - start
                     - stop
                   example: start
-                message_id:
-                  description: |
-                    Describes the message id of the message being edited.
-                  type: integer
-                  example: 47
               required:
                 - op
-                - message_id
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -2,7 +2,7 @@ from typing import Annotated, Literal
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
-from pydantic import Json
+from pydantic import Json, NonNegativeInt
 
 from zerver.actions.message_edit import validate_user_can_edit_message
 from zerver.actions.typing import (
@@ -16,7 +16,7 @@ from zerver.lib.message import access_message
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id_for_message, access_stream_for_send_message
 from zerver.lib.topic import maybe_rename_general_chat_to_empty_topic
-from zerver.lib.typed_endpoint import ApiParamConfig, OptionalTopic, typed_endpoint
+from zerver.lib.typed_endpoint import ApiParamConfig, OptionalTopic, PathOnly, typed_endpoint
 from zerver.models import Recipient, UserProfile
 from zerver.models.recipients import get_direct_message_group_user_ids
 
@@ -77,8 +77,8 @@ def send_message_edit_notification_backend(
     request: HttpRequest,
     user_profile: UserProfile,
     *,
+    message_id: PathOnly[NonNegativeInt],
     operator: Annotated[Literal["start", "stop"], ApiParamConfig("op")],
-    message_id: Json[int],
 ) -> HttpResponse:
     # Technically, this endpoint doesn't modify the message, but we're
     # attempting to send a typing notification that we're editing the

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -399,7 +399,7 @@ v1_api_and_json_patterns = [
     # POST sends a typing notification event to recipients
     rest_path("typing", POST=send_notification_backend),
     # POST sends a message edit typing notification
-    rest_path("message_edit_typing", POST=send_message_edit_notification_backend),
+    rest_path("messages/<int:message_id>/typing", POST=send_message_edit_notification_backend),
     # user_uploads -> zerver.views.upload
     rest_path("user_uploads", POST=upload_file_backend),
     rest_path(


### PR DESCRIPTION
Replaces `/message_edit_typing` with `/messages/{message_id}/typing`. The `message_id` parameter, previously passed in the request body, is now included in the URL path.

[CZO thread](https://chat.zulip.org/#narrow/channel/378-api-design/topic/typing.20notifications.20for.20editing.20messages/near/2105514)

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
