### PR TITLE
Modify archive followup

### DIFF
--- a/web/src/typing.ts
+++ b/web/src/typing.ts
@@ -82,6 +82,10 @@ function send_stream_typing_notification(
     topic: string,
     operation: "start" | "stop",
 ): void {
+    const stream = stream_data.get_sub_by_id(stream_id)!;
+    if (!stream_data.can_post_messages_in_stream(stream)) {
+        return;
+    }
     const data = {
         type: "stream",
         stream_id: JSON.stringify(stream_id),

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -484,7 +484,7 @@ def has_message_access(
     stream: Stream | None = None,
     is_subscribed: bool | None = None,
     user_group_membership_details: UserGroupMembershipDetails,
-    is_modifying_message: bool = False,
+    is_modifying_message: bool,
 ) -> bool:
     """
     Returns whether a user has access to a given message.
@@ -655,6 +655,7 @@ def bulk_access_messages(
             stream=streams.get(message.recipient_id) if stream is None else stream,
             is_subscribed=is_subscribed,
             user_group_membership_details=user_group_membership_details,
+            is_modifying_message=False,
         ):
             filtered_messages.append(message)
     return filtered_messages

--- a/zerver/tests/test_message_move_stream.py
+++ b/zerver/tests/test_message_move_stream.py
@@ -1318,6 +1318,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                     user_group_membership_details=UserGroupMembershipDetails(
                         user_recursive_group_ids=None
                     ),
+                    is_modifying_message=False,
                 ),
                 has_access,
             )
@@ -1717,6 +1718,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             True,
         )
@@ -1736,6 +1738,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             False,
         )
@@ -1763,6 +1766,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             False,
         )
@@ -1800,6 +1804,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             True,
         )
@@ -1819,6 +1824,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             False,
         )
@@ -1839,6 +1845,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             False,
         )
@@ -1868,6 +1875,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             True,
         )
@@ -1881,6 +1889,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             True,
         )
@@ -1915,6 +1924,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             False,
         )
@@ -1935,6 +1945,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             False,
         )
@@ -1963,6 +1974,7 @@ class MessageMoveStreamTest(ZulipTestCase):
                 user_group_membership_details=UserGroupMembershipDetails(
                     user_recursive_group_ids=None
                 ),
+                is_modifying_message=False,
             ),
             True,
         )


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes part of #33688

Does not fix the last point yet:
> Possibly some other changes proposed in [#design > Settings for deactivated channels @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/Settings.20for.20deactivated.20channels/near/2105508).


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
