### PR TITLE
email: Bulk clearing of scheduled emails for multiple users.

### DIFF
--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -480,7 +480,7 @@ def do_change_user_setting(
 
     # Disabling digest emails should clear a user's email queue
     if setting_name == "enable_digest_emails" and not db_setting_value:
-        clear_scheduled_emails(user_profile.id, ScheduledEmail.DIGEST)
+        clear_scheduled_emails([user_profile.id], ScheduledEmail.DIGEST)
 
     if setting_name == "email_notifications_batching_period_seconds":
         assert isinstance(old_value, int)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -532,7 +532,7 @@ def do_deactivate_user(
 
         change_user_is_active(user_profile, False)
 
-        clear_scheduled_emails(user_profile.id)
+        clear_scheduled_emails([user_profile.id])
         revoke_invites_generated_by_user(user_profile)
 
         event_time = timezone_now()

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -2215,7 +2215,7 @@ class ActivateTest(ZulipTestCase):
             delay=timedelta(hours=1),
         )
         self.assertEqual(ScheduledEmail.objects.count(), 1)
-        clear_scheduled_emails(hamlet.id)
+        clear_scheduled_emails([hamlet.id])
         self.assertEqual(ScheduledEmail.objects.count(), 1)
         self.assertEqual(ScheduledEmail.objects.filter(users=hamlet).count(), 0)
         self.assertEqual(ScheduledEmail.objects.filter(users=iago).count(), 1)

--- a/zerver/views/unsubscribe.py
+++ b/zerver/views/unsubscribe.py
@@ -42,7 +42,7 @@ def do_missedmessage_unsubscribe(user_profile: UserProfile) -> None:
 
 
 def do_welcome_unsubscribe(user_profile: UserProfile) -> None:
-    clear_scheduled_emails(user_profile.id, ScheduledEmail.WELCOME)
+    clear_scheduled_emails([user_profile.id], ScheduledEmail.WELCOME)
 
 
 def do_digest_unsubscribe(user_profile: UserProfile) -> None:


### PR DESCRIPTION
This commit is a preparatory step for allowing organization owners to reset user preferences(#31474), refactors the `clear_scheduled_emails` function to support bulk operations.

Prep PR of #33701.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
