### PR TITLE
Has message access followups 2

### DIFF
--- a/tools/screenshots/generate-user-messages-screenshot
+++ b/tools/screenshots/generate-user-messages-screenshot
@@ -186,7 +186,9 @@ def send_stream_messages(
 
 
 def add_message_reactions(message_id: int, emoji: str, users: list[UserProfile]) -> None:
-    preview_message = access_message(user_profile=DEFAULT_USER, message_id=message_id)
+    preview_message = access_message(
+        user_profile=DEFAULT_USER, message_id=message_id, is_modifying_message=False
+    )
     emoji_data = get_emoji_data(realm.id, emoji)
     for user in users:
         do_add_reaction(

--- a/zerver/actions/message_flags.py
+++ b/zerver/actions/message_flags.py
@@ -349,6 +349,7 @@ def do_update_message_flags(
                         "recipient"
                     )
                 ),
+                is_modifying_message=False,
             )
             if len(historical_messages) != len(historical_message_ids):
                 raise JsonableError(_("Invalid message(s)"))

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -656,7 +656,9 @@ def handle_missedmessage_emails(
         msg = min(msg_list, key=lambda msg: msg.date_sent)
         if msg.is_stream_message() and UserMessage.has_any_mentions(user_profile_id, msg.id):
             context_messages = get_context_for_message(msg)
-            filtered_context_messages = bulk_access_messages(user_profile, context_messages)
+            filtered_context_messages = bulk_access_messages(
+                user_profile, context_messages, is_modifying_message=False
+            )
             msg_list.extend(filtered_context_messages)
 
     # Sort emails by least recently-active discussion.

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -614,6 +614,7 @@ def bulk_access_messages(
     messages: Collection[Message] | QuerySet[Message],
     *,
     stream: Stream | None = None,
+    is_modifying_message: bool,
 ) -> list[Message]:
     """This function does the full has_message_access check for each
     message.  If stream is provided, it is used to avoid unnecessary

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -314,7 +314,7 @@ def access_message(
     message_id: int,
     lock_message: bool = False,
     *,
-    is_modifying_message: bool = False,
+    is_modifying_message: bool,
 ) -> Message:
     """You can access a message by ID in our APIs that either:
     (1) You received or have previously accessed via starring
@@ -362,7 +362,7 @@ def access_message_and_usermessage(
     message_id: int,
     lock_message: bool = False,
     *,
-    is_modifying_message: bool = False,
+    is_modifying_message: bool,
 ) -> tuple[Message, UserMessage | None]:
     """As access_message, but also returns the usermessage, if any."""
     try:

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -965,7 +965,7 @@ def update_narrow_terms_containing_with_operator(
 
     if maybe_user_profile.is_authenticated:
         try:
-            message = access_message(maybe_user_profile, message_id)
+            message = access_message(maybe_user_profile, message_id, is_modifying_message=False)
         except JsonableError:
             can_user_access_target_message = False
     else:

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -1300,7 +1300,10 @@ def handle_push_notification(user_profile_id: int, missed_message: dict[str, Any
     with transaction.atomic(savepoint=False):
         try:
             (message, user_message) = access_message_and_usermessage(
-                user_profile, missed_message["message_id"], lock_message=True
+                user_profile,
+                missed_message["message_id"],
+                lock_message=True,
+                is_modifying_message=False,
             )
         except JsonableError:
             if ArchivedMessage.objects.filter(id=missed_message["message_id"]).exists():

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1520,7 +1520,7 @@ Output:
         """
         Mark all messages within the topic associated with message `target_message_id` as resolved.
         """
-        message = access_message(acting_user, target_message_id)
+        message = access_message(acting_user, target_message_id, is_modifying_message=False)
         return self.api_patch(
             acting_user,
             f"/api/v1/messages/{target_message_id}",

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1798,7 +1798,9 @@ class MessageAccessTests(ZulipTestCase):
                 Message.objects.select_related("recipient").get(id=message_id)
                 for message_id in sorted(message_ids)
             ]
-            list_result = bulk_access_messages(user, messages, stream=stream)
+            list_result = bulk_access_messages(
+                user, messages, stream=stream, is_modifying_message=False
+            )
         with self.assert_database_query_count(bulk_access_stream_messages_query_count):
             message_query = (
                 Message.objects.select_related("recipient")
@@ -1948,7 +1950,9 @@ class MessageAccessTests(ZulipTestCase):
         other_stream = get_stream("Denmark", unsubscribed_user.realm)
         with self.assertRaises(AssertionError):
             messages = [Message.objects.get(id=id) for id in message_ids]
-            bulk_access_messages(unsubscribed_user, messages, stream=other_stream)
+            bulk_access_messages(
+                unsubscribed_user, messages, stream=other_stream, is_modifying_message=False
+            )
 
         # Verify that bulk_access_stream_messages_query is empty with a stream mismatch
         message_query = Message.objects.select_related("recipient").filter(id__in=message_ids)

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -119,7 +119,7 @@ def get_message_edit_history(
         == MessageEditHistoryVisibilityPolicyEnum.none.value
     ):
         raise JsonableError(_("Message edit history is disabled in this organization"))
-    message = access_message(user_profile, message_id)
+    message = access_message(user_profile, message_id, is_modifying_message=False)
 
     # Extract the message edit history from the message
     if message.edit_history is not None:
@@ -228,7 +228,9 @@ def json_fetch_raw_message(
         message = access_web_public_message(realm, message_id)
         user_profile = None
     else:
-        (message, user_message) = access_message_and_usermessage(maybe_user_profile, message_id)
+        (message, user_message) = access_message_and_usermessage(
+            maybe_user_profile, message_id, is_modifying_message=False
+        )
         user_profile = maybe_user_profile
 
     flags = ["read"]

--- a/zerver/views/read_receipts.py
+++ b/zerver/views/read_receipts.py
@@ -17,7 +17,7 @@ def read_receipts(
     *,
     message_id: PathOnly[NonNegativeInt],
 ) -> HttpResponse:
-    message = access_message(user_profile, message_id)
+    message = access_message(user_profile, message_id, is_modifying_message=False)
 
     if not user_profile.realm.enable_read_receipts:
         raise JsonableError(_("Read receipts are disabled in this organization."))


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #33688 

The second commit adds `is_modifying_message` to `bulk_access_messages`. I think it is the right change, but kept it as a separate commit in case there was some doubt about adding that argument to `bulk_access_message`

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
