### PR TITLE
help and integrations: Update doc on using Zulip via email.

### DIFF
--- a/help/using-zulip-via-email.md
+++ b/help/using-zulip-via-email.md
@@ -13,14 +13,12 @@ setup is complete.
 2. Create a Zulip channel that will receive mailing list traffic, or
    use an existing one.
 
-3. [Find the email address](/help/message-a-channel-by-email#message-a-channel-by-email_1)
-   for the channel you created. You can customize the details of how emails
-   are formatted in Zulip using the
-   [Configuration options][configuration-options].
-
-[configuration-options]: /help/message-a-channel-by-email#configuration-options
+3. [Generate an email
+   address](/help/message-a-channel-by-email#message-a-channel-by-email_1) for
+   the channel you created.
 
 4. Add the email address for the channel to the mailing list.
+
 {end_tabs}
 
 New emails sent to the email list will now be mirrored to the channel.


### PR DESCRIPTION
I think it's actually best to keep these instructions simple, and not call out the config options (which are described on the help page we link to).

![Screenshot 2025-02-28 at 09 58 19](https://github.com/user-attachments/assets/872a003e-0182-4858-9a31-f03f35a191cf)
![Screenshot 2025-02-28 at 09 58 37](https://github.com/user-attachments/assets/05e17f56-2d6f-4315-bc87-bdae0297467c)
