### PR TITLE
help: Improve explanation of Zulip's topics for users from other apps.

### DIFF
--- a/help/include/when-to-start-a-new-topic.md
+++ b/help/include/when-to-start-a-new-topic.md
@@ -8,7 +8,13 @@ Topic names should be brief but specific, for example:
 * **Not so good topic names:** "question", "hi", "help", "this topic is about
 a question I have about topics"
 
-
 Don't stress about making it perfect! The first 2-3 words that
 come to mind are probably fine, and you can always [change it
 later](/help/rename-a-topic).
+
+With time, there will be lots of topics in your organization, which is just how
+it's supposed to be. Zulip's UI is designed to make it easy to see what's new
+(in your [inbox](/help/inbox), [recent
+conversations](/help/recent-conversations), and the [left
+sidebar](/help/left-sidebar)), while still helping you
+[find](/help/search-for-messages) prior discussions.

--- a/help/introduction-to-topics.md
+++ b/help/introduction-to-topics.md
@@ -12,6 +12,60 @@ Zulip lets you start a new conversation in any channel, no matter where you are.
 
 {!how-to-start-a-new-topic.md!}
 
+## What about threads?
+
+Topics in Zulip fill the role of threads in other chat apps. This
+section will help you understand how concepts you might be familiar
+with from other applications show up in Zulip.
+
+### Where are the threads?
+
+In other team chat applications, you might be used to seeing threads
+in a small panel on the side of the app. In busy organizations, that
+cramped panel is where you may read most of the substantive
+discussions.
+
+In Zulip, you won't see a threads sidebar, because threads appear in the main
+message view instead. Threads help keep conversations organized, so Zulip puts
+them front and center.
+
+### How do I find threads?
+
+In other apps, threads generally start from a message in the main channel feed.
+That message becomes the key to finding a thread (which can often be tricky to
+do).
+
+In Zulip, there's nothing special about the first message in a thread. Instead,
+each thread is labeled with a topic. This makes threads in Zulip easy to find.
+You can:
+
+- See recent threads in each channel you're subscribed to in the [left
+  sidebar](/help/left-sidebar).
+- See a list of threads where you have unread messages in your
+  [inbox](/help/inbox).
+- Get an overview of all threads with recent messages in [recent
+  conversations](/help/recent-conversations).
+
+### How do I reply?
+
+Many chat apps have prominent “reply” or “reply in thread” buttons. These
+buttons are necessary, because it's often hard to figure out what conversation
+messages belong to if you don't use them.
+
+When you [start composing](/help/replying-to-messages) a message in Zulip, it
+will automatically be addressed to the conversation thread you're reading
+(unless you are [starting a new
+thread](/help/introduction-to-topics#how-to-start-a-new-topic)). Because
+everything is organized into threads, it'll almost always be clear what you're
+responding to. This means there is no need to repeat what has already been said
+when you reply.
+
+You can still [quote](/help/quote-or-forward-a-message#quote-a-message) part of
+an older message for reference, or
+[forward](/help/quote-or-forward-a-message#forward-a-message) a message to
+another thread.
+
+
 ## Further reading
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)


### PR DESCRIPTION
Current: https://zulip.com/help/introduction-to-topics

Updated/new sections:

![Screenshot 2025-02-28 at 17 28 53@2x](https://github.com/user-attachments/assets/8f316ee9-a968-4f00-8794-5fc34df8e48c)

![Screenshot 2025-02-28 at 17 29 00@2x](https://github.com/user-attachments/assets/7e99dab0-1287-494d-9319-6869e3bb4915)

