### PR TITLE
compose_paste: Use `katex-mathml` for filtering.

### DIFF
--- a/web/src/compose_paste.ts
+++ b/web/src/compose_paste.ts
@@ -280,9 +280,11 @@ export function paste_handler_converter(
 
     turndownService.addRule("katex-inline-math", {
         filter(node) {
-            if (node.classList.contains("katex")) {
-                const parent = node.parentElement;
-                if (parent?.classList.contains("katex-display")) {
+            if (node.classList.contains("katex-mathml") || node.classList.contains("katex-html")) {
+                // Check if this lies within a `.katex-display` which
+                // is processed as a math block.
+                const grand_parent = node.parentElement?.parentElement;
+                if (grand_parent?.classList.contains("katex-display")) {
                     // This is already processed by the math block rule.
                     return false;
                 }
@@ -292,8 +294,11 @@ export function paste_handler_converter(
         },
         replacement(content, node: Node) {
             assert(node instanceof HTMLElement);
+            if (node.classList.contains("katex-html")) {
+                return "";
+            }
             const annotation_element = node.querySelector(
-                `.katex-mathml annotation[encoding="application/x-tex"]`,
+                `annotation[encoding="application/x-tex"]`,
             );
             const katex_source = annotation_element?.textContent?.trim() ?? content;
             return `$$${katex_source}$$`;

--- a/zerver/tests/fixtures/katex_test_cases.json
+++ b/zerver/tests/fixtures/katex_test_cases.json
@@ -54,6 +54,9 @@
             "description":"Another katex inline expression containing nested tags",
             "expected_output":"world ~~it works **out $$a+b=c$$** so `well` if you try *this*** not $$p+q=r$$ that~~ good good",
             "original_markup":"world ~~it works **out $$a+b=c$$** so `well` if you try *this*** not $$p+q=r$$ that~~ good good"
+        },{
+            "original_markup":"$$a^{b^{c}}$$",
+            "expected_output":"$$a^{b^{c}}$$"
         }
     ],
     "text_node_to_span_conversion_tests":[


### PR DESCRIPTION
This is better than using `.katex` as sometimes
the selection range starts from the `.katex-mathml`.

Since `.katex-mathml` is always the immediate child of `.katex`, this filtering/replacement change will make copy pasting inline expressions better.

