### PR TITLE
Prevent overflow of long search queries from the screen.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1329,6 +1329,10 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
 
 .empty-feed-notice-description {
     font-size: 1.1em;
+
+    .search-query-word {
+        word-wrap: break-word;
+    }
 }
 
 .message-fade,

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -17,7 +17,7 @@
                 {{#if is_stop_word}}
                 <del>{{query_word}}</del>
                 {{else}}
-                <span>{{query_word}}</span>
+                <span class="search-query-word">{{query_word}}</span>
                 {{/if}}
             {{/each}}
         {{else}}

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -136,7 +136,7 @@ run_test("empty_narrow_html", ({mock_template}) => {
             Some common words were excluded from your search. <br/>You searched for:
             <span>channel: new</span>
             <span>topic: test</span>
-                <span>search</span>
+                <span class="search-query-word">search</span>
                 <del>a</del>
     </div>
 </div>
@@ -160,7 +160,7 @@ run_test("empty_narrow_html", ({mock_template}) => {
     <div class="empty-feed-notice-description">
             You searched for:
             <span>channel: hello world</span>
-                <span>searchA</span>
+                <span class="search-query-word">searchA</span>
     </div>
 </div>
 `,
@@ -183,7 +183,7 @@ run_test("empty_narrow_html", ({mock_template}) => {
     <div class="empty-feed-notice-description">
             You searched for:
             <span>topic: hello</span>
-                <span>searchB</span>
+                <span class="search-query-word">searchB</span>
     </div>
 </div>
 `,
@@ -608,7 +608,10 @@ run_test("show_empty_narrow_message_with_search", ({mock_template, override}) =>
 
     const current_filter = set_filter([["search", "grail"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
-    assert.match($(".empty_feed_notice_main").html(), /<span>grail<\/span>/);
+    assert.match(
+        $(".empty_feed_notice_main").html(),
+        /<span class="search-query-word">grail<\/span>/,
+    );
 });
 
 run_test("hide_empty_narrow_message", () => {


### PR DESCRIPTION
Previously, when searching for extremely long queries, they would overflow beyond the screen.

This PR fixes the bug by ensuring that long search queries do not overflow.

## Before

![image](https://github.com/user-attachments/assets/1b012734-3dc6-4578-a353-e59428c24edc)

## After

![image](https://github.com/user-attachments/assets/5697e3fc-8098-4ff6-bfe1-ca8217ada43d)


Fixes: #29568

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
