### PR TITLE
todo_widget: Disable "Add task" button when a task cannot be added.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -258,6 +258,20 @@ export function initialize(): void {
         appendTo: () => document.body,
     });
 
+    tippy.delegate("body", {
+        target: ".add-task-wrapper",
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const content = $elem.attr("data-tippy-content");
+            if (content === undefined) {
+                return false;
+            }
+            instance.setContent(content);
+            return undefined;
+        },
+        appendTo: () => document.body,
+    });
+
     $("body").on(
         "blur",
         ".message_control_button, .delete-selected-drafts-button-container",

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -237,6 +237,13 @@ button {
             transition: 0.2s ease;
             transition-property: background-color, border-color, color;
         }
+
+        &:disabled {
+            cursor: not-allowed;
+            filter: saturate(0);
+            background-color: var(--color-background-zulip-button-disabled);
+            color: hsl(0deg 3% 52%);
+        }
     }
 }
 
@@ -307,4 +314,18 @@ input {
 
 .current-user-vote {
     background-color: hsl(156deg 10% 90% / 90%);
+}
+
+.add-task-wrapper {
+    display: inline;
+    position: relative;
+    z-index: 1;
+
+    /* Unlike other browsers like Chrome, Microsoft Edge, etc.,
+    Firefox does not automatically display the "not-allowed"
+    cursor for disabled elements. The below css ensures that the
+    correct cursor is shown across all browsers. */
+    &:hover {
+        cursor: not-allowed;
+    }
 }

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -13,7 +13,9 @@
     <div class="add-task-bar sea-green">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />
-        <button class="add-task">{{t "Add task" }}</button>
+        <div class="add-task-wrapper">
+            <button class="add-task">{{t "Add task" }}</button>
+        </div>
         <div class="widget-error"></div>
     </div>
 </div>


### PR DESCRIPTION
We want to prevent users from adding a duplicate or empty task to the todo list. For this purpose, we disable the "Add task" button in both the cases.

## Tasks Done

- [x] The "Add task" button should be disabled when the task name is missing, with a tooltip saying, "Name the task before adding."
- [x] Attempting to add a duplicate task name displays a warning. It would be better to disable the button instead, with a "Cannot add duplicate task." tooltip.

### Clicking "Add task" with empty input

**Before** 

![image](https://github.com/user-attachments/assets/aae0e4ea-d5b3-4f7f-b8c9-954c06aa5fbe)

![image](https://github.com/user-attachments/assets/fdb80bdc-c8c7-4ce6-a594-da0f2892f942)

**After** 

![image](https://github.com/user-attachments/assets/7caeaead-9403-4a83-a57d-121ae5fdbecb)

![image](https://github.com/user-attachments/assets/9048cc9f-42c5-4cc3-a0a8-35a03be92d5f)



### Clicking "Add task" with a duplicate input

**Before** 

![image](https://github.com/user-attachments/assets/29502367-54f3-4452-a1f4-091c2fc70175)

![image](https://github.com/user-attachments/assets/6779229c-2b78-447c-8be4-6f7500b04481)

**After** 

![image](https://github.com/user-attachments/assets/ba4f190d-6e3c-4a1c-863e-27bcc26f81bc)

![image](https://github.com/user-attachments/assets/49bd3732-9336-46d5-9068-7276eae46929)


Fixes: #20211 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
