### PR TITLE
design: Fix search box overflow on screens under 450px.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -101,6 +101,9 @@
             text-overflow: ellipsis;
             overflow: hidden;
             max-width: var(--width-inbox-search);
+            /* Setting width to 100% ensures the search box takes the full width of its container,
+               preventing overflow issues by making sure it doesn't exceed the available space. */
+            width: 100%;
             height: var(--height-inbox-search);
             /* top/bottom default 1px padding / 14px em */
             /* left padding 30px / 14px em */


### PR DESCRIPTION
Set the inbox search input width to 100% to prevent overflow on small devices. Ensures the search box stays within its container for a cleaner layout.
Fixes:#33654
I just updated `/web/styles/inbox.css` and set `width:100%`
**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/230df491-2ae8-4623-9290-0dd98d013392)

### To Make sure there is no bad impact on other window sizes
![image](https://github.com/user-attachments/assets/f37a0bbc-f8ff-40c1-ba29-b00903fbb527)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
