### PR TITLE
improving position of "forgot password" in login page

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -146,7 +146,7 @@
                     <img class="top-menu-tab-user-img" src="{{ realm_icon }}" />
                     <span class="top-menu-tab-user-name">{{ realm_name }}</span>
                 </label>
-                <div class="top-menu-submenu singup-column">
+                <div class="top-menu-submenu signup-column">
                     <div class="top-menu-submenu-column">
                         <ul class="top-menu-submenu-list">
                             <li class="top-menu-submenu-list-item">

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -110,6 +110,13 @@ page can be easily identified in it's respective JavaScript file. -->
                                 <label for="id_password">{{ _('Password') }}</label>
                                 <i class="fa fa-eye-slash password_visibility_toggle" role="button" tabindex="0"></i>
                             </div>
+
+                            <div class="actions forgot-password-container">
+                                {% if email_auth_enabled %}
+                                <a class="forgot-password" href="/accounts/password/reset/">{{ _('Forgot your password?') }}</a>
+                                {% endif %}
+                            </div>
+
                             {% else %}
                             {% include "two_factor/_wizard_forms.html" %}
                             {% endif %}
@@ -145,10 +152,8 @@ page can be easily identified in it's respective JavaScript file. -->
                     </div>
                     {% endfor %}
 
-                    <div class="actions">
-                        {% if email_auth_enabled %}
-                        <a class="forgot-password" href="/accounts/password/reset/">{{ _('Forgot your password?') }}</a>
-                        {% endif %}
+                    <div class="actions signup-link-wrapper">
+                        {{ _("Don't have an account?")}}
                         {% if not register_link_disabled %}
                         <a class="register-link float-right" href="/register/">{{ _('Sign up') }}</a>
                         {% endif %}

--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -280,7 +280,7 @@ details summary::-webkit-details-marker {
 }
 
 @media (width <= 1400px) {
-    .top-menu-submenu.singup-column {
+    .top-menu-submenu.signup-column {
         justify-content: flex-end;
         right: 55px;
     }

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -862,6 +862,20 @@ button#register_auth_button_gitlab {
 .back-to-login-wrapper {
     margin: 20px 0 0;
     text-align: left;
+
+    &.forgot-password-container {
+        margin: 0;
+    }
+
+    &.signup-link-wrapper {
+        font-weight: normal;
+        float: right;
+
+        .register-link {
+            font-size: 1rem;
+            margin-left: 5px;
+        }
+    }
 }
 
 .register-page-container .register-form-login-redirect {


### PR DESCRIPTION
this PR about improving the position of the "forgot your password" and "signup" actions. make it more user-friendly.
moving the "forgot your password" action to more closer to password input for UX. also add the user prompt before signup to guide user. 

## Screenshots:

**Before:**
![before](https://github.com/user-attachments/assets/2519f374-4ecc-464d-ab41-cba14279bd0c)


**After:**
![after](https://github.com/user-attachments/assets/6af305bb-bd8c-42b3-a490-76d00ce432bd)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
