### PR TITLE
Settings: Make 'Incoming webhook' the default bot type 

### DIFF
--- a/web/src/settings_bots.ts
+++ b/web/src/settings_bots.ts
@@ -305,6 +305,7 @@ export function add_a_new_bot(): void {
     }
 
     function set_up_form_fields(): void {
+        $("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE);
         $("#payload_url_inputbox").hide();
         $("#create_payload_url").val("");
         $("#service_name_list").hide();


### PR DESCRIPTION
This PR changes the default selected option in the bot type dropdown to "Incoming webhook" when creating a new bot. The order of options in the dropdown remains unchanged.

Fixes: #33740

**Modification details:**
- Modified `web/src/settings_bots.ts` to set the default bot type 
- Added `$("#create_bot_type").val(INCOMING_WEBHOOK_BOT_TYPE);` in the form initialization
- Implemented the change in TypeScript rather than template markup

**Screenshots and screen captures:**

<img width="1677" alt="Screenshot 2025-03-02 at 4 47 40 PM" src="https://github.com/user-attachments/assets/9504e2c4-0ce8-4a26-a948-b3c735a0200b" />

<img width="1667" alt="Screenshot 2025-03-02 at 4 47 56 PM" src="https://github.com/user-attachments/assets/75527061-50c4-4735-9c56-dac4148099cd" />



https://github.com/user-attachments/assets/7ffb4d6a-327b-4b1f-a1fe-1e606b59e671


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
