### PR TITLE
Scale scroll to bottom icon with font size. 

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1983,13 +1983,13 @@ body:not(.hide-left-sidebar) {
             height: 40px;
             background: hsl(240deg 96% 68% / 50%);
             border-radius: 50%;
+            display: flex;
+            align-items: center;
 
             & .scroll-to-bottom-icon {
                 color: hsl(0deg 0% 100%);
                 margin: 0 auto;
                 font-size: 21px;
-                position: relative;
-                top: 8px;
             }
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1966,8 +1966,8 @@ body:not(.hide-left-sidebar) {
     }
 
     #scroll-to-bottom-button-clickable-area {
-        width: 60px;
-        height: 60px;
+        width: 3.75em; /* 60px at 16px em */
+        height: 3.75em; /* 60px at 16px em */
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1979,8 +1979,8 @@ body:not(.hide-left-sidebar) {
 
         #scroll-to-bottom-button {
             text-align: center;
-            width: 40px;
-            height: 40px;
+            width: 2.5em; /* 40px at 16px em */
+            height: 2.5em; /* 40px at 16px em */
             background: hsl(240deg 96% 68% / 50%);
             border-radius: 50%;
             display: flex;
@@ -1989,7 +1989,7 @@ body:not(.hide-left-sidebar) {
             & .scroll-to-bottom-icon {
                 color: hsl(0deg 0% 100%);
                 margin: 0 auto;
-                font-size: 21px;
+                font-size: 1.3125em; /* 21px at 16px em */
             }
         }
     }


### PR DESCRIPTION
discussion: [#redesign project > broader range of font sizes @ 💬](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2108463)

| before | after |
| --- | --- |
| 14px |
| ![image](https://github.com/user-attachments/assets/97aa534c-ae6b-4c9e-8171-062cf91baa53) | ![image](https://github.com/user-attachments/assets/4af1e593-1bd8-4202-a4b3-afee7698a07e) |
| 16px |
| ![image](https://github.com/user-attachments/assets/f17cc6ad-91a6-4d42-894b-a2e2bdb258bb) | ![image](https://github.com/user-attachments/assets/c59eceaa-958b-4757-b75a-2370fe751848) |
| 20px |
| ![image](https://github.com/user-attachments/assets/9f63fdbb-e3f6-47b3-bab2-545deaa92158) | ![image](https://github.com/user-attachments/assets/f77e62e3-3dd8-4014-bd69-877b788c8c97) |


Note that the chevron-down icon has shifted slightly lower (evident from the 16px before - after) due to proper centering of the icon.