### PR TITLE
recent_view: Avoid rendering rows before user scrolls to them.

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -62,6 +62,7 @@ type BaseListWidget = {
 
 export type ListWidget<Key, Item = Key> = BaseListWidget & {
     get_current_list: () => Item[];
+    get_rendered_list: () => Item[];
     filter_and_sort: () => void;
     retain_selected_items: () => void;
     all_rendered: () => boolean;
@@ -292,6 +293,10 @@ export function create<Key, Item = Key>(
     const widget: ListWidget<Key, Item> = {
         get_current_list() {
             return meta.filtered_list;
+        },
+
+        get_rendered_list() {
+            return meta.filtered_list.slice(0, meta.offset);
         },
 
         filter_and_sort() {

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -953,7 +953,7 @@ export function bulk_inplace_rerender(row_keys: string[]): void {
     topics_widget.filter_and_sort();
     // Iterate in the order of which the rows should be present so that
     // we are not inserting rows without any rows being present around them.
-    for (const topic_data of topics_widget.get_current_list()) {
+    for (const topic_data of topics_widget.get_rendered_list()) {
         const msg = message_store.get(topic_data.last_msg_id);
         assert(msg !== undefined);
         const topic_key = recent_view_util.get_key_from_message(msg);


### PR DESCRIPTION
This is just a bug fix based on observation that we would only be updating rows that are rendered and not all of them. This can potentially lead to rows being rendered twice but is hard to observe since newly updated topics usually are the top of the recent view.

discussion: [#issues > 🎯 ❓Duplicates in recent view](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20.E2.9D.93Duplicates.20in.20recent.20view/with/2033239)