### PR TITLE
compose: Attempt to keep buttons from spilling over border.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -322,7 +322,8 @@
         );
     grid-template-areas: "message-content composebox-buttons";
     border-radius: 4px;
-    border: 1px solid var(--color-message-content-container-border);
+    /* 1px at 20px/1em */
+    border: max(1px, 0.05em) solid var(--color-message-content-container-border);
     transition: border-color 0.2s ease;
 
     &:has(.new_message_textarea:focus) {
@@ -485,8 +486,9 @@
     border-radius: 0 0 3px 3px;
     background-color: var(--color-message-formatting-controls-container);
     /* margin on either side to let the border of
-       .message-content-container show through. */
-    margin: 0 1px;
+       .message-content-container show through.
+       1px at 20px/1em */
+    margin: 0 max(1px, 0.05em);
 }
 
 .compose-scrolling-buttons-container {


### PR DESCRIPTION
This PR represents an attempt to fix a state reported by @alya where the compose buttons would overflow the border around the area.

While I was unable to replicate that in dev, the adjustments here maintain a 1px border and margin below 20px, and switch to an em value when moving larger.

Additionally, on 2025-03-11, I added a commit to pull padding from the width of the button, in hopes that that might introduce some subpixel shenanigans. However, I am still unable to reproduce in Chrome or the Desktop app.

Handing over to Alya to test and see if she can't replicate the bug.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFbuttons.20spilling.20out.20of.20compose.20box.20when.20zoomed.20out/near/2106449)

**Screenshots:**

| Before | After |
| --- | --- |
| ![btn-forward-before](https://github.com/user-attachments/assets/8fcef652-433f-40a9-aeb6-c8d12f9180b4) | ![btn-forward-after](https://github.com/user-attachments/assets/be8389b6-2f0f-44b2-b653-d7774a94f44e) |
| ![btn-backward-before](https://github.com/user-attachments/assets/203aad43-81a9-4e53-a302-017752f92c4b) | ![btn-backward-after](https://github.com/user-attachments/assets/0142d8b0-3744-4079-a54c-78b41666a4b2) |



