### PR TITLE
subscriptions/user_groups: Remove custom styling for <=500px screens.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1511,22 +1511,3 @@ div.settings-radio-input-parent {
         }
     }
 }
-
-@media (width <= 500px) {
-    #groups_overlay,
-    #subscription_overlay {
-        .groups_settings_header,
-        .stream_settings_header {
-            display: block;
-            text-align: center;
-            margin-left: 0;
-
-            .tab-container {
-                .ind-tab {
-                    min-width: 85px;
-                    width: auto;
-                }
-            }
-        }
-    }
-}


### PR DESCRIPTION
This was causing issues with the red icon having the wrong height and centered buttons looking weird at narrow screens.

Further discussion here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20UI.20issues.20in.20channel.20settings.20.28narrow.20windows.29/near/2105436

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-03 at 14 55 44](https://github.com/user-attachments/assets/c54e66a0-ea9d-4d1e-883e-55124ab66ee9) | ![Screen Shot 2025-03-03 at 14 57 29](https://github.com/user-attachments/assets/d505e115-907a-4a5a-bc99-75ea6641afe6) |
| ![Screen Shot 2025-03-03 at 14 55 28](https://github.com/user-attachments/assets/d2b8ff82-4a4b-4570-8df4-8504b3add687) | ![Screen Shot 2025-03-03 at 14 59 59](https://github.com/user-attachments/assets/dc0c6cd5-7282-4cfb-aa43-da46917708d8) |
| ![Screen Shot 2025-03-03 at 14 55 20](https://github.com/user-attachments/assets/2a980027-5705-46cc-99f4-390ede344a95) | ![Screen Shot 2025-03-03 at 15 00 07](https://github.com/user-attachments/assets/34b71391-bfbd-419a-bf97-4f96f630e06a) |
| ![Screen Shot 2025-03-03 at 14 55 10](https://github.com/user-attachments/assets/dad91fff-63b8-4bdb-9ca9-3963d16518da) | ![Screen Shot 2025-03-03 at 15 00 20](https://github.com/user-attachments/assets/ae7e6155-02c5-4f7e-88d3-de60b1447f97) |
