### PR TITLE
typeahead: Rename header text as more accurate footer text.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -41,15 +41,15 @@
  *
  *   Our custom changes include all mentions of this.trigger_selection.
  *
- * 3. Header text:
+ * 3. Footer text:
  *
- *   This adds support for showing a custom header text like: "You are now
- *   completing a user mention". Provide the function `this.header_html` that
- *   returns a string containing the header text, or false.
+ *   This adds support for showing a custom footer text like: "You are now
+ *   completing a user mention". Provide the function `this.footer_html` that
+ *   returns a string containing the footer text, or false.
  *
- *   Our custom changes include all mentions of this.header_html, some CSS changes
+ *   Our custom changes include all mentions of this.footer_html, some CSS changes
  *   in compose.css and splitting $container out of $menu so we can insert
- *   additional HTML before $menu.
+ *   additional HTML after $menu.
  *
  * 4. Escape hooks:
  *
@@ -195,8 +195,8 @@ export function rewire_MAX_ITEMS(value: typeof MAX_ITEMS): void {
 /* TYPEAHEAD PUBLIC CLASS DEFINITION
  * ================================= */
 
-const HEADER_ELEMENT_HTML =
-    '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>';
+const FOOTER_ELEMENT_HTML =
+    '<p class="typeahead-footer"><span id="typeahead-footer-text"></span></p>';
 const CONTAINER_HTML = '<div class="typeahead dropdown-menu"></div>';
 const MENU_HTML = '<ul class="typeahead-menu" data-simplebar></ul>';
 const ITEM_HTML = '<li class="typeahead-item"><a class="typeahead-item-link"></a></li>';
@@ -230,14 +230,14 @@ export class Typeahead<ItemType extends string | object> {
     ) => string | undefined;
     $container: JQuery;
     $menu: JQuery;
-    $header: JQuery;
+    $footer: JQuery;
     source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
     dropup: boolean;
     automated: () => boolean;
     trigger_selection: (event: JQuery.KeyDownEvent) => boolean;
     on_escape: (() => void) | undefined;
-    // returns a string to show in typeahead header or false.
-    header_html: () => string | false;
+    // returns a string to show in typeahead footer or false.
+    footer_html: () => string | false;
     // returns a string to show in typeahead items or false.
     option_label: (matching_items: ItemType[], item: ItemType) => string | false;
     suppressKeyPressRepeat = false;
@@ -288,14 +288,14 @@ export class Typeahead<ItemType extends string | object> {
             $(options.non_tippy_parent_element).append(this.$container);
         }
         this.$menu = $(MENU_HTML).appendTo(this.$container);
-        this.$header = $(HEADER_ELEMENT_HTML).appendTo(this.$container);
+        this.$footer = $(FOOTER_ELEMENT_HTML).appendTo(this.$container);
         this.source = options.source;
         this.dropup = options.dropup ?? false;
         this.automated = options.automated ?? (() => false);
         this.trigger_selection = options.trigger_selection ?? (() => false);
         this.on_escape = options.on_escape;
-        // return a string to show in typeahead header or false.
-        this.header_html = options.header_html ?? (() => false);
+        // return a string to show in typeahead footer or false.
+        this.footer_html = options.footer_html ?? (() => false);
         // return a string to show in typeahead items or false.
         this.option_label = options.option_label ?? (() => false);
         this.stopAdvance = options.stopAdvance ?? false;
@@ -560,17 +560,17 @@ export class Typeahead<ItemType extends string | object> {
             return $i;
         });
 
-        // We want to re render the typeahead header for ever update
+        // We want to re render the typeahead footer for ever update
         // in user's string since once typeahead is shown after `@`,
-        // header might change depending on whether next character is
+        // footer might change depending on whether next character is
         // `_` (silent mention) or not.
-        const header_text_html = this.header_html();
+        const footer_text_html = this.footer_html();
 
-        if (header_text_html) {
-            this.$header.find("span#typeahead-header-text").html(header_text_html);
-            this.$header.show();
+        if (footer_text_html) {
+            this.$footer.find("span#typeahead-footer-text").html(footer_text_html);
+            this.$footer.show();
         } else {
-            this.$header.hide();
+            this.$footer.hide();
         }
 
         if (this.requireHighlight || this.shouldHighlightFirstResult()) {
@@ -892,7 +892,7 @@ type TypeaheadOptions<ItemType> = {
     automated?: () => boolean;
     closeInputFieldOnHide?: () => void;
     dropup?: boolean;
-    header_html?: () => string | false;
+    footer_html?: () => string | false;
     helpOnEmptyStrings?: boolean;
     hideOnEmptyAfterBackspace?: boolean;
     matcher?: (item: ItemType, query: string) => boolean;

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -133,7 +133,7 @@ export let emoji_collection: Emoji[] = [];
 
 // This has mostly been replaced with `type` fields on
 // the typeahead items, but is still used for the stream>topic
-// flow and for `get_header_html`. It would be great if we could
+// flow and for `get_footer_html`. It would be great if we could
 // get rid of it altogether.
 let completing: string | null;
 let token: string;
@@ -1363,7 +1363,7 @@ export function initialize_topic_edit_typeahead(
     });
 }
 
-function get_header_html(): string | false {
+function get_footer_html(): string | false {
     let tip_text = "";
     switch (completing) {
         case "silent_mention":
@@ -1417,7 +1417,7 @@ export function initialize_compose_typeahead($element: JQuery<HTMLTextAreaElemen
                 return false;
             },
             trigger_selection: compose_trigger_selection,
-            header_html: get_header_html,
+            footer_html: get_footer_html,
             hideAfterSelect() {
                 // After selecting a stream, we immediately show topic options,
                 // so we don't want to hide the typeahead.
@@ -1477,7 +1477,7 @@ export function initialize({
             }
             return false;
         },
-        header_html: render_topic_typeahead_hint,
+        footer_html: render_topic_typeahead_hint,
     });
 
     const private_message_typeahead_input: TypeaheadInputElement = {

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -145,7 +145,7 @@
         overflow-y: auto;
     }
 
-    .typeahead-header {
+    .typeahead-footer {
         margin: 0;
         padding: 4px 10px;
         border-top: 1px solid hsl(0deg 0% 0% / 20%);
@@ -153,7 +153,7 @@
         align-items: center;
     }
 
-    #typeahead-header-text {
+    #typeahead-footer-text {
         color: var(--color-dropdown-item);
         font-size: 0.8571em; /* 12px at 14px/em */
     }


### PR DESCRIPTION
This was moved to the bottom in 3e3deb2, but the naming had not been updated.

Followup to #33584.

