### PR TITLE
buddy_list: Fix incorrect user count in the right sidebar.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -166,6 +166,9 @@ export class BuddyList extends BuddyListConf {
     current_filter: Filter | undefined | "unset" = "unset";
 
     initialize_tooltips(): void {
+        const total_human_subscribers_count = (): number =>
+            this.render_data.total_human_subscribers_count;
+
         $("#right-sidebar").on(
             "mouseenter",
             ".buddy-list-heading",
@@ -197,12 +200,6 @@ export class BuddyList extends BuddyListConf {
                     showOnCreate: true,
                     onShow(instance) {
                         let tooltip_text;
-                        const current_sub = narrow_state.stream_sub();
-                        const pm_ids_set = narrow_state.pm_ids_set();
-                        const total_human_subscribers_count = get_total_human_subscriber_count(
-                            current_sub,
-                            pm_ids_set,
-                        );
                         const participant_count = Number.parseInt(
                             $("#buddy-list-participants-section-heading").attr("data-user-count")!,
                             10,
@@ -223,15 +220,15 @@ export class BuddyList extends BuddyListConf {
                                         defaultMessage:
                                             "{N, plural, one {# other subscriber} other {# other subscribers}}",
                                     },
-                                    {N: total_human_subscribers_count - participant_count},
+                                    {N: total_human_subscribers_count() - participant_count},
                                 );
-                            } else if (current_sub) {
+                            } else if (narrow_state.stream_sub()) {
                                 tooltip_text = $t(
                                     {
                                         defaultMessage:
                                             "{N, plural, one {# subscriber} other {# subscribers}}",
                                     },
-                                    {N: total_human_subscribers_count},
+                                    {N: total_human_subscribers_count()},
                                 );
                             } else {
                                 tooltip_text = $t(
@@ -239,12 +236,12 @@ export class BuddyList extends BuddyListConf {
                                         defaultMessage:
                                             "{N, plural, one {# participant} other {# participants}}",
                                     },
-                                    {N: total_human_subscribers_count},
+                                    {N: total_human_subscribers_count()},
                                 );
                             }
                         } else {
                             const other_users_count =
-                                people.get_active_human_count() - total_human_subscribers_count;
+                                people.get_active_human_count() - total_human_subscribers_count();
                             tooltip_text = $t(
                                 {
                                     defaultMessage:

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -42,8 +42,6 @@ function get_total_human_subscriber_count(
     current_sub: StreamSubscription | undefined,
     pm_ids_set: Set<number>,
 ): number {
-    // Excludes human users, but may include long-inactive users who
-    // might not show up in the buddy list.
     if (current_sub) {
         return peer_data.get_subscriber_count(current_sub.stream_id, false);
     } else if (pm_ids_set.size > 0) {

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -29,7 +29,7 @@ import * as ui_util from "./ui_util.ts";
 import {user_settings} from "./user_settings.ts";
 import * as util from "./util.ts";
 
-function get_formatted_sub_count(sub_count: number): string {
+function get_formatted_user_count(sub_count: number): string {
     if (sub_count < 1000) {
         return sub_count.toString();
     }
@@ -396,9 +396,9 @@ export class BuddyList extends BuddyListConf {
         const subscriber_section_user_count =
             total_human_subscribers_count - all_participant_ids.size;
 
-        const formatted_participants_count = get_formatted_sub_count(all_participant_ids.size);
-        const formatted_matching_users_count = get_formatted_sub_count(subscriber_section_user_count);
-        const formatted_other_users_count = get_formatted_sub_count(other_users_count);
+        const formatted_participants_count = get_formatted_user_count(all_participant_ids.size);
+        const formatted_matching_users_count = get_formatted_user_count(subscriber_section_user_count);
+        const formatted_other_users_count = get_formatted_user_count(other_users_count);
 
         $("#buddy-list-participants-container .buddy-list-heading-user-count").text(
             formatted_participants_count,
@@ -449,7 +449,7 @@ export class BuddyList extends BuddyListConf {
                 render_section_header({
                     id: "buddy-list-participants-section-heading",
                     header_text: $t({defaultMessage: "THIS CONVERSATION"}),
-                    user_count: get_formatted_sub_count(all_participant_ids.size),
+                    user_count: get_formatted_user_count(all_participant_ids.size),
                     is_collapsed: this.participants_is_collapsed,
                 }),
             ),
@@ -462,7 +462,7 @@ export class BuddyList extends BuddyListConf {
                     header_text: current_sub
                         ? $t({defaultMessage: "THIS CHANNEL"})
                         : $t({defaultMessage: "THIS CONVERSATION"}),
-                    user_count: get_formatted_sub_count(
+                    user_count: get_formatted_user_count(
                         total_human_subscribers_count - all_participant_ids.size,
                     ),
                     is_collapsed: this.users_matching_view_is_collapsed,
@@ -475,7 +475,7 @@ export class BuddyList extends BuddyListConf {
                 render_section_header({
                     id: "buddy-list-other-users-section-heading",
                     header_text: $t({defaultMessage: "OTHERS"}),
-                    user_count: get_formatted_sub_count(other_users_count),
+                    user_count: get_formatted_user_count(other_users_count),
                     is_collapsed: this.other_users_is_collapsed,
                 }),
             ),

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -397,14 +397,14 @@ export class BuddyList extends BuddyListConf {
             total_human_subscribers_count - all_participant_ids.size;
 
         const formatted_participants_count = get_formatted_sub_count(all_participant_ids.size);
-        const formatted_sub_users_count = get_formatted_sub_count(subscriber_section_user_count);
+        const formatted_matching_users_count = get_formatted_sub_count(subscriber_section_user_count);
         const formatted_other_users_count = get_formatted_sub_count(other_users_count);
 
         $("#buddy-list-participants-container .buddy-list-heading-user-count").text(
             formatted_participants_count,
         );
         $("#buddy-list-users-matching-view-container .buddy-list-heading-user-count").text(
-            formatted_sub_users_count,
+            formatted_matching_users_count,
         );
         $("#buddy-list-other-users-container .buddy-list-heading-user-count").text(
             formatted_other_users_count,


### PR DESCRIPTION
Previously the count was sometimes incorrect because we were subtracting unsubscribed participants from the subscriber count, getting values that were too low (and sometimes negative!)

This count is displayed in the hover tooltip and section headers.

Fixes #33452
