### PR TITLE
help: Document marking a whole topic or channel as unread.

### DIFF
--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -86,11 +86,8 @@ channel or topic as read**.
 
 {!go-to-inbox.md!}
 
-1. Hover over a channel or topic in the left sidebar.
-
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
-
-1. Click **Mark all messages as read**.
+1. Click on an unread messages counter to mark all messages in that topic or
+   channel as read.
 
 {tab|via-recent-conversations}
 

--- a/help/marking-messages-as-unread.md
+++ b/help/marking-messages-as-unread.md
@@ -40,6 +40,42 @@ There are many ways to use this feature, including:
 
 {end_tabs}
 
+## Mark all messages in a topic or channel as unread
+
+{start_tabs}
+
+{tab|via-left-sidebar}
+
+1. Hover over a topic or channel in the left sidebar.
+
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
+
+1. Click **Mark all messages as unread**. This option will appear only if all
+   messages in the topic or channel are currently marked as read.
+
+!!! tip ""
+
+    You can also mark all messages in your current view as unread by
+    jumping to the top with the <kbd>Home</kbd> key, and marking as unread
+    [from the first message](#mark-as-unread-from-selected-message).
+
+{tab|via-recent-conversations}
+
+{!go-to-recent-conversations.md!}
+
+1. Hover over a topic.
+
+1. Click on the **ellipsis** (<i class="zulip-icon
+   zulip-icon-more-vertical"></i>) next to the unread messages counter. You may
+   need to hover over the indicator icon for a followed (<i class="zulip-icon
+   zulip-icon-follow"></i>) or muted (<i class="zulip-icon
+   zulip-icon-mute-new"></i>) topic in order to see it.
+
+1. Click **Mark all messages as unread**. This option will appear only if all
+   messages in the topic are currently marked as read.
+
+{end_tabs}
+
 ## Related articles
 
 * [Reading strategies](/help/reading-strategies)


### PR DESCRIPTION
This is a follow-up to #33067.


Current: https://zulip.com/help/marking-messages-as-read
<details>
<summary>
Updated
</summary>

![Screenshot 2025-03-04 at 00 21 13@2x](https://github.com/user-attachments/assets/ac0eef3b-2c4a-4f35-a2f8-3447cd6ea1e8)
</details>

---

Current:  https://zulip.com/help/marking-messages-as-unread
<details>
<summary>
Updated
</summary>

![Screenshot 2025-03-04 at 00 23 30@2x](https://github.com/user-attachments/assets/6dea3c33-623d-4202-86cc-cdd82f297b90)
![Screenshot 2025-03-04 at 00 23 36@2x](https://github.com/user-attachments/assets/0084a378-9d6f-4dc4-a661-0e7d721d0857)
![Screenshot 2025-03-04 at 00 26 37@2x](https://github.com/user-attachments/assets/abbbc7ef-ed4b-499f-8d20-c07ff79e0ad2)


</details>

---

Follow-up idea that came up while working on this: [#design > When to show Mark all messages as unread on channel popover @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/When.20to.20show.20Mark.20all.20messages.20as.20unread.20on.20channel.20popover/near/2111219)