### PR TITLE
Restyle buttons in settings.

### DIFF
--- a/web/e2e-tests/realm-linkifier.test.ts
+++ b/web/e2e-tests/realm-linkifier.test.ts
@@ -10,7 +10,7 @@ async function test_add_linkifier(page: Page): Promise<void> {
         pattern: "#(?P<id>[0-9]+)",
         url_template: "https://trac.example.com/ticket/{id}",
     });
-    await page.click("form.admin-linkifier-form button.button");
+    await page.click('form.admin-linkifier-form button[type="submit"]');
 
     const admin_linkifier_status_selector = "div#admin-linkifier-status";
     await page.waitForSelector(admin_linkifier_status_selector, {visible: true});
@@ -52,7 +52,7 @@ async function test_add_invalid_linkifier_pattern(page: Page): Promise<void> {
         pattern: "(foo",
         url_template: "https://trac.example.com/ticket/{id}",
     });
-    await page.click("form.admin-linkifier-form button.button");
+    await page.click('form.admin-linkifier-form button[type="submit"]');
 
     await page.waitForSelector("div#admin-linkifier-status", {visible: true});
     assert.strictEqual(

--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -101,7 +101,7 @@ export function set_up_handlers_for_add_button_state(
     $pill_container: JQuery,
 ): void {
     const $pill_widget_input = $pill_container.find(".input");
-    const $pill_widget_button = $pill_container.closest(".add-button-container").find(".button");
+    const $pill_widget_button = $pill_container.closest(".add-button-container").find("button");
     // Disable the add button first time the pill container is created.
     $pill_widget_button.prop("disabled", true);
 

--- a/web/src/banners.ts
+++ b/web/src/banners.ts
@@ -6,7 +6,7 @@ import render_banner from "../templates/components/banner.hbs";
 type ComponentIntent = "neutral" | "brand" | "info" | "success" | "warning" | "danger";
 
 type ActionButton = {
-    type: "primary" | "quiet" | "borderless";
+    attention: "primary" | "quiet" | "borderless";
     intent?: ComponentIntent;
     label: string;
     icon?: string;

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -185,17 +185,17 @@ const DESKTOP_NOTIFICATIONS_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            type: "primary",
+            attention: "primary",
             label: $t({defaultMessage: "Enable notifications"}),
             custom_classes: "request-desktop-notifications",
         },
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({defaultMessage: "Customize notifications"}),
             custom_classes: "customize-desktop-notifications",
         },
         {
-            type: "borderless",
+            attention: "borderless",
             label: $t({defaultMessage: "Never ask on this computer"}),
             custom_classes: "reject-desktop-notifications",
         },
@@ -213,7 +213,7 @@ const CONFIGURE_OUTGOING_MAIL_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({defaultMessage: "Configuration instructions"}),
             custom_classes: "configure-outgoing-mail-instructions",
         },
@@ -231,7 +231,7 @@ const INSECURE_DESKTOP_APP_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({defaultMessage: "Download the latest version"}),
             custom_classes: "download-latest-zulip-version",
         },
@@ -246,7 +246,7 @@ const PROFILE_MISSING_REQUIRED_FIELDS_BANNER: AlertBanner = {
     label: $t({defaultMessage: "Your profile is missing required fields."}),
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({defaultMessage: "Edit your profile"}),
             custom_classes: "edit-profile-required-fields",
         },
@@ -264,7 +264,7 @@ const ORGANIZATION_PROFILE_INCOMPLETE_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({
                 defaultMessage: "Edit profile",
             }),
@@ -283,12 +283,12 @@ const SERVER_NEEDS_UPGRADE_BANNER: AlertBanner = {
     }),
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({defaultMessage: "Learn more"}),
             custom_classes: "server-upgrade-learn-more",
         },
         {
-            type: "borderless",
+            attention: "borderless",
             label: $t({defaultMessage: "Dismiss for a week"}),
             custom_classes: "server-upgrade-nag-dismiss",
         },
@@ -328,12 +328,12 @@ const bankruptcy_banner = (): AlertBanner => {
         label,
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 label: $t({defaultMessage: "Yes, please!"}),
                 custom_classes: "accept-bankruptcy",
             },
             {
-                type: "borderless",
+                attention: "borderless",
                 label: $t({defaultMessage: "No, I'll catch up."}),
                 custom_classes: "banner-close-action",
             },
@@ -385,12 +385,12 @@ const time_zone_update_offer_banner = (): AlertBanner => {
         ),
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 label: $t({defaultMessage: "Yes, please!"}),
                 custom_classes: "accept-update-time-zone",
             },
             {
-                type: "borderless",
+                attention: "borderless",
                 label: $t({defaultMessage: "No, don't ask again."}),
                 custom_classes: "decline-time-zone-update",
             },

--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -12,7 +12,7 @@ const CONNECTION_ERROR_POPUP_BANNER: Banner = {
     }),
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             label: $t({defaultMessage: "Try now"}),
             custom_classes: "retry-connection",
         },

--- a/web/src/portico/showroom.ts
+++ b/web/src/portico/showroom.ts
@@ -7,7 +7,7 @@ import {$t, $t_html} from "../i18n.ts";
 type ComponentIntent = "neutral" | "brand" | "info" | "success" | "warning" | "danger";
 
 type ActionButton = {
-    type: "primary" | "quiet" | "borderless";
+    attention: "primary" | "quiet" | "borderless";
     intent: ComponentIntent;
     label: string;
     icon?: string | undefined;
@@ -41,7 +41,7 @@ const custom_normal_banner: Banner = {
     label: "This is a normal banner. Use the controls below to modify this banner.",
     buttons: [
         {
-            type: "quiet",
+            attention: "quiet",
             intent: "neutral",
             label: "Quiet Button",
         },
@@ -56,7 +56,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "This is a navbar alerts banner. Use the controls below to modify this banner.",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "neutral",
                 label: "Quiet Button",
             },
@@ -70,12 +70,12 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Welcome back! You have 12 unread messages. Do you want to mark them all as read?",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "info",
                 label: "Yes, please!",
             },
             {
-                type: "borderless",
+                attention: "borderless",
                 intent: "info",
                 label: "No, I'll catch up.",
             },
@@ -89,7 +89,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Zulip needs to send email to confirm users' addresses and send notifications.",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "warning",
                 label: "Configuration instructions",
             },
@@ -135,17 +135,17 @@ const alert_banners: Record<string, AlertBanner> = {
         ),
         buttons: [
             {
-                type: "primary",
+                attention: "primary",
                 intent: "brand",
                 label: "Enable notifications",
             },
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "brand",
                 label: "Ask me later",
             },
             {
-                type: "borderless",
+                attention: "borderless",
                 intent: "brand",
                 label: "Never ask on this computer",
             },
@@ -159,7 +159,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Your profile is missing required fields.",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "warning",
                 label: "Edit your profile",
             },
@@ -173,7 +173,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "You are using an old version of the Zulip desktop app with known security bugs.",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "danger",
                 label: "Download the latest version",
             },
@@ -187,7 +187,7 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "Complete your organization profile, which is displayed on your organization's registration and login pages.",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "info",
                 label: "Edit profile",
             },
@@ -201,12 +201,12 @@ const alert_banners: Record<string, AlertBanner> = {
         label: "This Zulip server is running an old version and should be upgraded.",
         buttons: [
             {
-                type: "quiet",
+                attention: "quiet",
                 intent: "danger",
                 label: "Learn more",
             },
             {
-                type: "borderless",
+                attention: "borderless",
                 intent: "danger",
                 label: "Dismiss for a week",
             },
@@ -217,17 +217,17 @@ const alert_banners: Record<string, AlertBanner> = {
 };
 
 const sortButtons = (buttons: ActionButton[]): void => {
-    const sortOrder: Record<ActionButton["type"], number> = {
+    const sortOrder: Record<ActionButton["attention"], number> = {
         primary: 1,
         quiet: 2,
         borderless: 3,
     };
 
-    buttons.sort((a, b) => sortOrder[a.type] - sortOrder[b.type]);
+    buttons.sort((a, b) => sortOrder[a.attention] - sortOrder[b.attention]);
 };
 
 const update_buttons = (buttons: ActionButton[]): void => {
-    const primary_button = buttons.find((button) => button.type === "primary");
+    const primary_button = buttons.find((button) => button.attention === "primary");
     if (primary_button) {
         $("#enable_primary_button").prop("checked", true);
         $("#primary_button_text").val(primary_button.label);
@@ -242,7 +242,7 @@ const update_buttons = (buttons: ActionButton[]): void => {
         $("#primary_button_text").val("");
         $("#disable_primary_button_icon").prop("checked", true);
     }
-    const quiet_button = buttons.find((button) => button.type === "quiet");
+    const quiet_button = buttons.find((button) => button.attention === "quiet");
     if (quiet_button) {
         $("#enable_quiet_button").prop("checked", true);
         $("#quiet_button_text").val(quiet_button.label);
@@ -257,7 +257,7 @@ const update_buttons = (buttons: ActionButton[]): void => {
         $("#quiet_button_text").val("");
         $("#disable_quiet_button_icon").prop("checked", true);
     }
-    const borderless_button = buttons.find((button) => button.type === "borderless");
+    const borderless_button = buttons.find((button) => button.attention === "borderless");
     if (borderless_button) {
         $("#enable_borderless_button").prop("checked", true);
         $("#borderless_button_text").val(borderless_button.label);
@@ -400,7 +400,7 @@ $(window).on("load", () => {
 
     $("input[name='primary-button-select']").on("change", (e) => {
         if ($(e.target).attr("id") === "enable_primary_button") {
-            if (current_banner.buttons.some((button) => button.type === "primary")) {
+            if (current_banner.buttons.some((button) => button.attention === "primary")) {
                 return;
             }
             let label = $("#primary_button_text").val()?.toString();
@@ -409,7 +409,7 @@ $(window).on("load", () => {
             }
             const is_icon_enabled = $("#enable_primary_button_icon").prop("checked") === true;
             current_banner.buttons.push({
-                type: "primary",
+                attention: "primary",
                 intent: current_banner.intent,
                 label,
                 icon: is_icon_enabled
@@ -419,7 +419,7 @@ $(window).on("load", () => {
             $("#primary_button_text").val(label);
         } else {
             current_banner.buttons = current_banner.buttons.filter(
-                (button) => button.type !== "primary",
+                (button) => button.attention !== "primary",
             );
         }
         sortButtons(current_banner.buttons);
@@ -431,7 +431,9 @@ $(window).on("load", () => {
     });
 
     $("input[name='primary-button-icon-select']").on("change", (e) => {
-        const primary_button = current_banner.buttons.find((button) => button.type === "primary");
+        const primary_button = current_banner.buttons.find(
+            (button) => button.attention === "primary",
+        );
         if (primary_button === undefined) {
             return;
         }
@@ -448,7 +450,9 @@ $(window).on("load", () => {
     });
 
     $("#primary_button_select_icon").on("change", function (this: HTMLElement) {
-        const primary_button = current_banner.buttons.find((button) => button.type === "primary");
+        const primary_button = current_banner.buttons.find(
+            (button) => button.attention === "primary",
+        );
         if (primary_button === undefined) {
             return;
         }
@@ -464,7 +468,9 @@ $(window).on("load", () => {
     });
 
     $("#primary_button_text").on("input", function (this: HTMLElement) {
-        const primary_button = current_banner.buttons.find((button) => button.type === "primary");
+        const primary_button = current_banner.buttons.find(
+            (button) => button.attention === "primary",
+        );
         if (primary_button === undefined) {
             return;
         }
@@ -478,7 +484,7 @@ $(window).on("load", () => {
 
     $("input[name='quiet-button-select']").on("change", (e) => {
         if ($(e.target).attr("id") === "enable_quiet_button") {
-            if (current_banner.buttons.some((button) => button.type === "quiet")) {
+            if (current_banner.buttons.some((button) => button.attention === "quiet")) {
                 return;
             }
             let label = $("#quiet_button_text").val()?.toString();
@@ -487,7 +493,7 @@ $(window).on("load", () => {
             }
             const is_icon_enabled = $("#enable_quiet_button_icon").prop("checked") === true;
             current_banner.buttons.push({
-                type: "quiet",
+                attention: "quiet",
                 intent: current_banner.intent,
                 label,
                 icon: is_icon_enabled
@@ -498,7 +504,7 @@ $(window).on("load", () => {
             sortButtons(current_banner.buttons);
         } else {
             current_banner.buttons = current_banner.buttons.filter(
-                (button) => button.type !== "quiet",
+                (button) => button.attention !== "quiet",
             );
         }
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
@@ -509,7 +515,7 @@ $(window).on("load", () => {
     });
 
     $("input[name='quiet-button-icon-select']").on("change", (e) => {
-        const quiet_button = current_banner.buttons.find((button) => button.type === "quiet");
+        const quiet_button = current_banner.buttons.find((button) => button.attention === "quiet");
         if (quiet_button === undefined) {
             return;
         }
@@ -526,7 +532,7 @@ $(window).on("load", () => {
     });
 
     $("#quiet_button_select_icon").on("change", function (this: HTMLElement) {
-        const quiet_button = current_banner.buttons.find((button) => button.type === "quiet");
+        const quiet_button = current_banner.buttons.find((button) => button.attention === "quiet");
         if (quiet_button === undefined) {
             return;
         }
@@ -542,7 +548,7 @@ $(window).on("load", () => {
     });
 
     $("#quiet_button_text").on("input", function (this: HTMLElement) {
-        const quiet_button = current_banner.buttons.find((button) => button.type === "quiet");
+        const quiet_button = current_banner.buttons.find((button) => button.attention === "quiet");
         if (quiet_button === undefined) {
             return;
         }
@@ -556,7 +562,7 @@ $(window).on("load", () => {
 
     $("input[name='borderless-button-select']").on("change", function (this: HTMLElement) {
         if ($(this).attr("id") === "enable_borderless_button") {
-            if (current_banner.buttons.some((button) => button.type === "borderless")) {
+            if (current_banner.buttons.some((button) => button.attention === "borderless")) {
                 return;
             }
             let label = $("#borderless_button_text").val()?.toString();
@@ -565,7 +571,7 @@ $(window).on("load", () => {
             }
             const is_icon_enabled = $("#enable_borderless_button_icon").prop("checked") === true;
             current_banner.buttons.push({
-                type: "borderless",
+                attention: "borderless",
                 intent: current_banner.intent,
                 label,
                 icon: is_icon_enabled
@@ -576,7 +582,7 @@ $(window).on("load", () => {
             sortButtons(current_banner.buttons);
         } else {
             current_banner.buttons = current_banner.buttons.filter(
-                (button) => button.type !== "borderless",
+                (button) => button.attention !== "borderless",
             );
         }
         $("#showroom_component_banner_navbar_alerts_wrapper").html(banner_html(current_banner));
@@ -588,7 +594,7 @@ $(window).on("load", () => {
 
     $("input[name='borderless-button-icon-select']").on("change", function (this: HTMLElement) {
         const borderless_button = current_banner.buttons.find(
-            (button) => button.type === "borderless",
+            (button) => button.attention === "borderless",
         );
         if (borderless_button === undefined) {
             return;
@@ -607,7 +613,7 @@ $(window).on("load", () => {
 
     $("#borderless_button_select_icon").on("change", function (this: HTMLElement) {
         const borderless_button = current_banner.buttons.find(
-            (button) => button.type === "borderless",
+            (button) => button.attention === "borderless",
         );
         if (borderless_button === undefined) {
             return;
@@ -625,7 +631,7 @@ $(window).on("load", () => {
 
     $("#borderless_button_text").on("input", function (this: HTMLElement) {
         const borderless_button = current_banner.buttons.find(
-            (button) => button.type === "borderless",
+            (button) => button.attention === "borderless",
         );
         if (borderless_button === undefined) {
             return;

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1538,5 +1538,9 @@ export function build_page(): void {
         realm_logo.build_realm_logo_widget(upload_realm_logo_or_icon, true);
     }
 
+    $("#id_org_profile_preview").on("click", () => {
+        window.open("/login/?preview=true", "_blank", "noopener,noreferrer");
+    });
+
     $("#organization-profile .deactivate_realm_button").on("click", deactivate_organization);
 }

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -510,9 +510,7 @@ export function enable_or_disable_add_subscribers_elements(
                 .addClass("add_subscribers_disabled");
         }
     } else {
-        const $add_subscribers_button = $container_elem
-            .find('button[name="add_subscriber"]')
-            .expectOne();
+        const $add_subscribers_button = $container_elem.find(".add-subscriber-button").expectOne();
         $add_subscribers_button.prop("disabled", !enable_elem);
         if (enable_elem) {
             $add_subscribers_button.css("pointer-events", "");

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -129,7 +129,7 @@ function update_add_members_elements(group: UserGroup): void {
     // Otherwise, we adjust whether the widgets are disabled based on
     // whether this user is authorized to add members.
     const $input_element = $add_members_container.find(".input").expectOne();
-    const $button_element = $add_members_container.find('button[name="add_member"]').expectOne();
+    const $button_element = $add_members_container.find("#add_member").expectOne();
 
     if (settings_data.can_add_members_to_user_group(group.id)) {
         $input_element.prop("contenteditable", true);

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,4 @@
-<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{type}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{attention}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
   {{#if disabled}}disabled{{/if}}
   >
     {{#if icon}}

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,4 @@
-<button type="button" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{attention}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{attention}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
   {{#if disabled}}disabled{{/if}}
   >
     {{#if icon}}

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -4,7 +4,7 @@
         <div class="password-input-row">
             <input type="password" autocomplete="off" name="old_password" id="old_password" class="inline-block modal_password_input" value="" />
             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button" tabindex="0"></i>
-            <a href="/accounts/password/reset/" class="settings-forgot-password sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
+            <a href="/accounts/password/reset/" class="settings-forgot-password" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
         </div>
     </div>
     <div class="settings-password-div">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -57,7 +57,7 @@
                     <div class="input-group">
                         {{> ../components/action_button
                           label=(t "Change your password")
-                          type="quiet"
+                          attention="quiet"
                           intent="brand"
                           id="change_password"
                           }}
@@ -70,7 +70,7 @@
                 <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}disabled_setting_tooltip{{/if}}">
                     {{> ../components/action_button
                       label=(t "Deactivate account")
-                      type="quiet"
+                      attention="quiet"
                       intent="danger"
                       id="user_deactivate_account_button"
                       disabled=user_is_only_organization_owner
@@ -79,7 +79,7 @@
                 {{#if owner_is_only_user_in_organization}}
                     {{> ../components/action_button
                       label=(t "Deactivate organization")
-                      type="quiet"
+                      attention="quiet"
                       intent="danger"
                       custom_classes="deactivate_realm_button inline-block"
                       }}
@@ -153,7 +153,7 @@
                 <div id="api_key_button_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
                     {{> ../components/action_button
                       label=(t "Manage your API key")
-                      type="quiet"
+                      attention="quiet"
                       intent="brand"
                       id="api_key_button"
                       disabled=(not user_has_email_set)

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -36,9 +36,12 @@
                             {{#*inline "z-link-convert-demo-organization-help"}}<a href="/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
                         {{/tr}}
                     </p>
-                    <button id="demo_organization_add_email_button" type="button" class="button rounded sea-green">
-                        {{t "Add email"}}
-                    </button>
+                    {{> ../components/action_button
+                      id="demo_organization_add_email_button"
+                      label=(t "Add email")
+                      attention="quiet"
+                      intent="brand"
+                      }}
                 </div>
                 {{/if}}
             </form>

--- a/web/templates/settings/admin_realm_domains_list.hbs
+++ b/web/templates/settings/admin_realm_domains_list.hbs
@@ -8,6 +8,13 @@
             <span class="rendered-checkbox"></span>
         </label>
     </td>
-    <td><button class="button button-danger small rounded delete_realm_domain">{{t "Remove" }}</button></td>
+    <td>
+        {{> ../components/action_button
+          label=(t "Remove")
+          custom_classes="delete_realm_domain"
+          attention="quiet"
+          intent="danger"
+          }}
+    </td>
 </tr>
 {{/with}}

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -6,7 +6,7 @@
     </form>
     {{> ../components/action_button
       label=(t "Add alert word")
-      type="quiet"
+      attention="quiet"
       intent="brand"
       id="open-add-alert-word-modal"
       }}

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -13,7 +13,7 @@
         <div>
             {{> ../components/action_button
               label=(t "Add a new bot")
-              type="quiet"
+              attention="quiet"
               intent="brand"
               custom_classes="add-a-new-bot"
               hidden=(not can_create_new_bots)

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -19,9 +19,13 @@
         <span class="export_status_text"></span>
     </div>
     <form>
-        <button type="submit" class="button rounded sea-green" id="start-export-button">
-            {{t 'Start export' }}
-        </button>
+        {{> ../components/action_button
+          label=(t "Start export")
+          id="start-export-button"
+          attention="quiet"
+          intent="brand"
+          type="submit"
+          }}
     </form>
     {{/if}}
 

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -5,7 +5,13 @@
         <h3>{{t "Default channels"}}</h3>
         <div class="add_default_streams_button_container">
             {{#if is_admin}}
-                <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add channel" }}</button>
+                {{> ../components/action_button
+                  id="show-add-default-streams-modal"
+                  label=(t "Add channel")
+                  attention="quiet"
+                  intent="brand"
+                  type="submit"
+                  }}
             {{/if}}
             {{> filter_text_input placeholder=(t 'Filter') aria_label=(t 'Filter default channels')}}
         </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -5,9 +5,13 @@
     <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
         {{t "Add extra emoji for members of the {realm_name} organization." }}
     </p>
-    <button id="add-custom-emoji-button" class="button rounded sea-green {{#unless can_add_emojis}}hide{{/unless}}">
-        {{t 'Add a new emoji' }}
-    </button>
+    {{> ../components/action_button
+      id="add-custom-emoji-button"
+      attention="quiet"
+      intent="brand"
+      label=(t "Add a new emoji")
+      hidden=(not can_add_emojis)
+      }}
 
     <div class="settings_panel_list_header">
         <h3>{{t "Custom emoji"}}</h3>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -46,9 +46,12 @@
                     <input type="text" id="linkifier_template" class="settings_text_input" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" />
                     <div class="alert" id="admin-linkifier-template-status"></div>
                 </div>
-                <button type="submit" class="button rounded sea-green">
-                    {{t 'Add linkifier' }}
-                </button>
+                {{> ../components/action_button
+                  label=(t 'Add linkifier')
+                  attention="quiet"
+                  intent="brand"
+                  type="submit"
+                  }}
             </div>
         </div>
     </form>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -49,11 +49,14 @@
               is_editable_by_current_user = is_admin
               image = realm_icon_url }}
         </div>
-        <a href="/login/?preview=true" target="_blank" rel="noopener noreferrer" class="button rounded sea-green block" id="id_org_profile_preview">
-            {{t 'Preview organization profile' }}
-            <i class="fa fa-external-link" aria-hidden="true"></i>
-        </a>
-
+        {{> ../components/action_button
+          label=(t "Preview organization profile")
+          custom_classes="block"
+          id="id_org_profile_preview"
+          icon="external-link"
+          attention="quiet"
+          intent="brand"
+          }}
         <div class="subsection-header">
             <h3>{{t "Organization logo" }}
                 {{> ../help_link_widget link="/help/create-your-organization-profile#add-a-wide-logo" }}

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -91,7 +91,7 @@
                 <div id="deactivate_realm_button_container" class="inline-block {{#unless is_owner}}disabled_setting_tooltip{{/unless}}">
                     {{> ../components/action_button
                       label=(t "Deactivate organization")
-                      type="quiet"
+                      attention="quiet"
                       intent="danger"
                       custom_classes="deactivate_realm_button"
                       }}

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -54,9 +54,13 @@
                         <label for="playground_url_template"> {{t "URL template" }}</label>
                         <input type="text" id="playground_url_template" class="settings_text_input" name="url_template" placeholder="https://play.rust-lang.org/?code={code}" />
                     </div>
-                    <button type="submit" id="submit_playground_button" class="button rounded sea-green">
-                        {{t 'Add code playground' }}
-                    </button>
+                    {{> ../components/action_button
+                      id="submit_playground_button"
+                      label=(t "Add code playground")
+                      attention="quiet"
+                      intent="brand"
+                      type="submit"
+                      }}
                 </div>
             </div>
         </form>

--- a/web/templates/settings/profile_field_settings_admin.hbs
+++ b/web/templates/settings/profile_field_settings_admin.hbs
@@ -3,7 +3,12 @@
         <h3>{{t "Custom profile fields"}}</h3>
         <div class="alert-notification" id="admin-profile-field-status"></div>
         {{#if is_admin}}
-        <button class="button rounded sea-green" id="add-custom-profile-field-button">{{t "Add a new profile field" }}</button>
+            {{> ../components/action_button
+              id="add-custom-profile-field-button"
+              label=(t "Add a new profile field")
+              attention="quiet"
+              intent="brand"
+              }}
         {{/if}}
     </div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -71,7 +71,7 @@
             </div>
             {{> ../components/action_button
               label=(t "Preview profile")
-              type="quiet"
+              attention="quiet"
               intent="brand"
               id="show_my_user_profile_modal"
               icon="external-link"

--- a/web/templates/settings/realm_domains_modal.hbs
+++ b/web/templates/settings/realm_domains_modal.hbs
@@ -15,7 +15,14 @@
                     <span class="rendered-checkbox"></span>
                 </label>
             </td>
-            <td><button type="button" class="button sea-green small rounded" id="submit-add-realm-domain">{{t "Add" }}</button></td>
+            <td>
+                {{> ../components/action_button
+                  label=(t "Add")
+                  id="submit-add-realm-domain"
+                  attention="quiet"
+                  intent="brand"
+                  }}
+            </td>
         </tr>
     </tfoot>
 </table>

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -7,9 +7,13 @@
     </div>
     {{#if (not hide_add_button)}}
         <div class="add_subscriber_button_wrapper inline-block">
-            <button type="submit" name="add_subscriber" class="button add-subscriber-button add-users-button small rounded sea-green" tabindex="0">
-                {{t 'Add' }}
-            </button>
+            {{> ../components/action_button
+              label=(t "Add")
+              custom_classes="add-subscriber-button add-users-button"
+              attention="quiet"
+              intent="brand"
+              type="submit"
+              }}
         </div>
     {{/if}}
 </div>

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -37,7 +37,12 @@
                             <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
                         </label>
                         <span class="add_all_users_to_stream_button_container">
-                            <button class="add_all_users_to_stream small button rounded sea-green">{{t 'Add all users'}}</button>
+                            {{> ../components/action_button
+                              label=(t "Add all users")
+                              custom_classes="add_all_users_to_stream inline-block"
+                              attention="quiet"
+                              intent="brand"
+                              }}
                         </span>
                         <div id="stream_subscription_error" class="stream_creation_error"></div>
                         <div class="controls" id="people_to_add"></div>
@@ -47,12 +52,35 @@
         </div>
         <div class="settings-sticky-footer">
             <div class="settings-sticky-footer-left">
-                <button id="stream_creation_go_to_configure_channel_settings" class="button small sea-green rounded hide">{{t "Back to settings" }}</button>
+                {{> ../components/action_button
+                  label=(t "Back to settings")
+                  custom_classes="hide"
+                  id="stream_creation_go_to_configure_channel_settings"
+                  attention="quiet"
+                  intent="brand"
+                  }}
             </div>
             <div class="settings-sticky-footer-right">
-                <button class="create_stream_cancel button small white rounded">{{t "Cancel" }}</button>
-                <button class="finalize_create_stream button small sea-green rounded hide" type="submit">{{t "Create" }}</button>
-                <button id="stream_creation_go_to_subscribers" class="button small sea-green rounded">{{t "Continue to add subscribers" }}</button>
+                {{> ../components/action_button
+                  label=(t "Cancel")
+                  custom_classes="create_stream_cancel inline-block"
+                  attention="quiet"
+                  intent="neutral"
+                  }}
+                {{> ../components/action_button
+                  label=(t "Create")
+                  custom_classes="finalize_create_stream hide"
+                  attention="quiet"
+                  intent="brand"
+                  type="submit"
+                  }}
+                {{> ../components/action_button
+                  label=(t "Continue to add subscribers")
+                  custom_classes="inline-block"
+                  id="stream_creation_go_to_subscribers"
+                  attention="quiet"
+                  intent="brand"
+                  }}
             </div>
         </div>
     </form>

--- a/web/templates/topic_edit_form.hbs
+++ b/web/templates/topic_edit_form.hbs
@@ -4,7 +4,7 @@
     <input type="text" value="" autocomplete="off" maxlength="{{ max_topic_length }}"
       class="inline_topic_edit header-v {{#unless realm_mandatory_topics}}empty-topic-placeholder-display{{/unless}}"
       {{#unless realm_mandatory_topics}}placeholder="{{empty_string_topic_display_name}}"{{/unless}} />
-    {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" type="primary" intent="brand" data-tooltip-template-id="save-button-tooltip-template" }}
-    {{> components/action_button custom_classes="topic_edit_cancel tippy-zulip-delayed-tooltip" icon="circle-x" type="borderless" intent="neutral" data-tooltip-template-id="cancel-button-tooltip-template" }}
+    {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" attention="primary" intent="brand" data-tooltip-template-id="save-button-tooltip-template" }}
+    {{> components/action_button custom_classes="topic_edit_cancel tippy-zulip-delayed-tooltip" icon="circle-x" attention="borderless" intent="neutral" data-tooltip-template-id="cancel-button-tooltip-template" }}
     <div class="topic_edit_spinner"></div>
 </form>

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -7,9 +7,14 @@
     </div>
     {{#if (not hide_add_button)}}
         <div class="add_member_button_wrapper inline-block">
-            <button type="submit" name="add_member" class="button add-member-button add-users-button small rounded sea-green" tabindex="0">
-                {{t 'Add' }}
-            </button>
+            {{> ../components/action_button
+              label=(t "Add")
+              custom_classes="add-member-button add-users-button"
+              id="add_member"
+              attention="quiet"
+              intent="brand"
+              type="submit"
+              }}
         </div>
     {{/if}}
 </div>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -4,7 +4,12 @@
 <br />
 
 {{t "Do you want to add everyone?"}}
-<button class="add_all_users_to_user_group small button rounded sea-green">{{t 'Add all users'}}</button>
+{{> ../components/action_button
+  label=(t "Add all users")
+  custom_classes="add_all_users_to_user_group inline-block"
+  attention="quiet"
+  intent="brand"
+  }}
 
 <div class="create_member_list_header">
     <h4 class="user_group_setting_subsection_title">{{t 'Members preview' }}</h4>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -46,12 +46,35 @@
         </div>
         <div class="settings-sticky-footer">
             <div class="settings-sticky-footer-left">
-                <button id="user_group_go_to_configure_settings" class="button small sea-green rounded hide">{{t "Back to settings" }}</button>
+                {{> ../components/action_button
+                  label=(t "Back to settings")
+                  custom_classes="hide"
+                  attention="quiet"
+                  intent="brand"
+                  id="user_group_go_to_configure_settings"
+                  }}
             </div>
             <div class="settings-sticky-footer-right">
-                <button class="create_user_group_cancel button small white rounded">{{t "Cancel" }}</button>
-                <button class="finalize_create_user_group button small sea-green rounded hide" type="submit">{{t "Create" }}</button>
-                <button id="user_group_go_to_members" class="button small sea-green rounded">{{t "Continue to add members" }}</button>
+                {{> ../components/action_button
+                  label=(t "Cancel")
+                  custom_classes="create_user_group_cancel inline-block"
+                  attention="quiet"
+                  intent="neutral"
+                  }}
+                {{> ../components/action_button
+                  label=(t "Create")
+                  custom_classes="finalize_create_user_group hide"
+                  attention="quiet"
+                  intent="brand"
+                  type="submit"
+                  }}
+                {{> ../components/action_button
+                  label=(t "Continue to add members")
+                  id="user_group_go_to_members"
+                  custom_classes="inline-block"
+                  attention="quiet"
+                  intent="brand"
+                  }}
             </div>
         </div>
     </form>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Commit 1:

>Previously, we were using **type** to describe the **attention** level of the
>action button. We want to rename the type parameter to attention
>as we need the type parameter separately for describing the type of
>button.(suggested by @sayamsamal )

Commit 2:


>Restyle all the remaining `sea-green` button of organization settings including the ones in the table header.

Commit 3

>Restyle all the `sea-green` button of channel and group settings.
>Also, restyled `cancel` button to match the current UI.

Fixes part of #33130.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Commit 2**


| **Location**           | **Before(at 16 px)** | **After (At 12px)** | **After (At 16px)** | **After (At 20px)** |
|------------------------|-----------|--------------------|--------------------|--------------------|
| Add a new Emoji       | ![Before](https://github.com/user-attachments/assets/42cd5c97-6ad7-4374-a4ec-d802ab20ca3f) | ![12px](https://github.com/user-attachments/assets/87e27681-8b95-4fa8-b017-451ee3225f6f) | ![16px](https://github.com/user-attachments/assets/abf0ad31-3de8-4e80-bbd4-554ca02f9699) | ![20px](https://github.com/user-attachments/assets/093e029a-2325-4a4e-bafb-1332ef2c401c) |
| Add linkifier         | ![Before](https://github.com/user-attachments/assets/c65b7bf6-1f5f-41a5-9935-a7081a2414c0) | ![12px](https://github.com/user-attachments/assets/46896368-0dae-4268-ab94-2755410e8ea1) | ![16px](https://github.com/user-attachments/assets/7f46f962-2ad4-431e-9933-e16ba61b9c05) | ![20px](https://github.com/user-attachments/assets/91ba78ab-4df3-4253-8887-6d4f4fcfb243) |
| Add Code playground   | ![Before](https://github.com/user-attachments/assets/64f44283-3a59-49e9-b872-4c3131461718) | ![12px](https://github.com/user-attachments/assets/2ff18010-fecd-4eb3-b12d-bc5a855e0fff) | ![16px](https://github.com/user-attachments/assets/8af51ef5-fc50-4bde-97b2-d70c7c7a8a57) | ![20px](https://github.com/user-attachments/assets/1558b962-057b-4c08-9abc-9ea7ffd37750) |
| Add a new profile data| ![Before](https://github.com/user-attachments/assets/3331ac4d-f2b0-477f-9f3d-4edd3f1cf19e) | ![12px](https://github.com/user-attachments/assets/ba0d4a73-1c2e-4a24-8637-09188dde7e51) | ![16px](https://github.com/user-attachments/assets/6dded8fc-460c-4e9e-87f9-4fd468c719c0) | ![20px](https://github.com/user-attachments/assets/09048e80-22a8-4713-a11c-7b6ce3a56390) |
| Add Channel          | ![Before](https://github.com/user-attachments/assets/59f8b2d5-5b88-4120-b054-17bc455c07b5) | ![12px](https://github.com/user-attachments/assets/fc805f0d-78c9-4a5c-8738-56fa1e3a95c7) | ![16px](https://github.com/user-attachments/assets/fd6c76fb-86d2-4912-87cd-f949ba3cc959) | ![20px](https://github.com/user-attachments/assets/ab1659d7-8a5e-4384-9018-28627867e566) |
| Start export         | ![Before](https://github.com/user-attachments/assets/b9029322-ee15-4a24-8103-a58d66a88208) | ![12px](https://github.com/user-attachments/assets/41bf20e5-f234-410c-8d06-551ef007ff72) | ![16px](https://github.com/user-attachments/assets/f69595d0-640f-4b6a-94ea-48d92c301adf) | ![20px](https://github.com/user-attachments/assets/44280b69-27ed-4107-8a70-6d794d4fa72a) |
| Preview OrganizationProfile | <img width="266" alt="Screenshot 2025-03-07 at 6 14 57 PM" src="https://github.com/user-attachments/assets/498494bb-c7c9-449f-8b3f-c8befc560d19" /> | <img width="256" alt="Screenshot 2025-03-07 at 3 56 48 PM" src="https://github.com/user-attachments/assets/30131f8c-2e8a-4e78-bd40-f80b90bca1c8" /> | <img width="318" alt="Screenshot 2025-03-07 at 3 57 00 PM" src="https://github.com/user-attachments/assets/8ba064e5-02f7-4b0f-912e-8268ddd25488" /> | <img width="197" alt="Screenshot 2025-03-07 at 3 56 36 PM" src="https://github.com/user-attachments/assets/2a8b5638-be5c-4541-8a8c-34984227064b" /> | 
| Add email | <img width="157" alt="Screenshot 2025-03-07 at 9 57 50 PM" src="https://github.com/user-attachments/assets/f3759f35-0691-4fbf-b3b5-a156b798c4c9" /> | <img width="83" alt="Screenshot 2025-03-07 at 6 24 20 PM" src="https://github.com/user-attachments/assets/4a7737c2-00dd-469d-b5a5-8cc57ab3e06a" /> | <img width="110" alt="Screenshot 2025-03-07 at 6 24 33 PM" src="https://github.com/user-attachments/assets/3454ad65-3f11-471a-8481-a0a5cfc98ac4" /> | <img width="133" alt="Screenshot 2025-03-07 at 6 24 43 PM" src="https://github.com/user-attachments/assets/849b4b23-7e71-42b9-bfad-e282023d0a91" /> |


**Commit 3**

| **Location**                  | **Before** | **After (At 12px)** | **After (At 16px)** | **After (At 20px)** |
|--------------------------------|-----------|--------------------|--------------------|--------------------|
| **Continue to add subscribers** | <img width="274" alt="Screenshot 1" src="https://github.com/user-attachments/assets/941d9c7b-edb5-44c6-964b-1448e330a3dc" /> | <img width="231" alt="Screenshot 2" src="https://github.com/user-attachments/assets/aab76ed4-7bd1-45cd-a404-1de565157935" /> | <img width="306" alt="Screenshot 3" src="https://github.com/user-attachments/assets/c173a150-04a0-4dd4-bc46-df01b809fb1c" /> | <img width="374" alt="Screenshot 4" src="https://github.com/user-attachments/assets/a144e7cc-41c4-402e-8bea-75dcb3357062" /> |
| **Add all users**              | <img width="116" alt="Screenshot 5" src="https://github.com/user-attachments/assets/da56c02d-59fc-416a-9c2d-1b16c6eca176" /> | <img width="82" alt="Screenshot 6" src="https://github.com/user-attachments/assets/cd8e7098-fe6f-4328-bb6a-a477d78f1acc" /> | <img width="109" alt="Screenshot 7" src="https://github.com/user-attachments/assets/aa59455b-a5ef-4c25-af2a-6b177697dfcf" /> | <img width="127" alt="Screenshot 8" src="https://github.com/user-attachments/assets/d0613510-c22b-4f90-a0bf-cd31df4d86b2" /> |
| **Back to settings**           | <img width="146" alt="Screenshot 9" src="https://github.com/user-attachments/assets/81fedd22-6222-4219-87ba-6960778dce7f" /> | <img width="116" alt="Screenshot 10" src="https://github.com/user-attachments/assets/637cfc56-d0e4-4c6c-a28f-18ccabe3d4c3" /> | <img width="153" alt="Screenshot 11" src="https://github.com/user-attachments/assets/267e34b4-c049-4e17-bb6e-d3ffa86342a9" /> | <img width="175" alt="Screenshot 12" src="https://github.com/user-attachments/assets/6904fc08-7308-49da-9dbc-216edac54b61" /> |
| **Cancel/Create**              | <img width="144" alt="Screenshot 13" src="https://github.com/user-attachments/assets/e9704339-53e8-4b42-88b1-aff114a24b90" /> | <img width="118" alt="Screenshot 14" src="https://github.com/user-attachments/assets/af49ff8f-59d6-4280-a711-53f7dfc26020" /> | <img width="147" alt="Screenshot 15" src="https://github.com/user-attachments/assets/7e74c72b-dc3d-4ace-81f9-67783219e8ff" /> | <img width="194" alt="Screenshot 16" src="https://github.com/user-attachments/assets/8a6ca656-d47d-40b3-93bd-ac51f6d43548" /> |
| **Continue to add users**      | <img width="270" alt="Screenshot 17" src="https://github.com/user-attachments/assets/e3deedaa-3c14-4720-8f88-9d37dc921b89" /> | <img width="219" alt="Screenshot 18" src="https://github.com/user-attachments/assets/a6102ae3-9551-47ee-a2b2-0ff716fd85c4" /> | <img width="289" alt="Screenshot 19" src="https://github.com/user-attachments/assets/972cc80f-2144-4a8c-9fbf-97907b70f4d9" /> | <img width="359" alt="Screenshot 20" src="https://github.com/user-attachments/assets/82f4de04-33c5-4c91-9f91-8327c7c41c40" /> |





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
