### PR TITLE
saved_snippets: Improve saved snippets UI.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1420,3 +1420,22 @@ input.invalid-input {
         box-shadow: var(--color-invalid-input-box-shadow);
     }
 }
+
+/* This is a utility class for line clamping. */
+.line-clamp {
+    /* Despite the below prefixed properties being deprecated,
+       the co-dependency of these three properties is a fully
+       specified behavior and will continue to be supported.
+       Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/line-clamp */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    /* The value of --line-clamp-value is not defined globally and instead
+       inherits the value from another class or the parent element. If it
+       is not defined, it defaults to 2. */
+    -webkit-line-clamp: var(--line-clamp-value, 2);
+    /* Also define the standard property 'line-clamp' for compatibility,
+       for when the vendor prefix "-webkit-" is no longer required. */
+    line-clamp: var(--line-clamp-value, 2);
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1663,7 +1663,6 @@ textarea.new_message_textarea {
         }
 
         .dropdown-list-item-description {
-            white-space: nowrap;
             font-weight: 400;
             font-size: 0.9283em; /* 13px at 14px/em */
             opacity: 0.8;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2140,10 +2140,10 @@ body:not(.hide-left-sidebar) {
 }
 
 .dropdown-list-container .dropdown-list .dropdown-list-item-common-styles {
+    position: relative;
     display: flex;
     color: var(--color-dropdown-item);
     padding: 3px 10px 3px 8px;
-    gap: 4px;
     font-weight: 400;
     line-height: var(--base-line-height-unitless);
     white-space: normal;
@@ -2160,16 +2160,10 @@ body:not(.hide-left-sidebar) {
     }
 
     .dropdown-list-delete {
+        position: absolute;
+        top: 0;
+        right: 5px;
         visibility: hidden;
-        float: right;
-        margin-right: 5px;
-        cursor: pointer;
-        /* hsl(359deg 93% 39%) corresponds to var(--red-550) */
-        color: color-mix(in oklch, hsl(359deg 93% 39%) 70%, transparent);
-
-        &:hover {
-            color: hsl(359deg 93% 39%);
-        }
     }
 
     &:focus,

--- a/web/templates/dropdown_list.hbs
+++ b/web/templates/dropdown_list.hbs
@@ -6,15 +6,13 @@
                 {{#if bold_current_selection}}
                     <span class="dropdown-list-bold-selected">{{name}}</span>
                     {{#if has_delete_icon}}
-                        <span class="dropdown-list-delete">
-                            <i class="fa fa-trash-o dropdown-list-delete-icon"></i>
-                        </span>
+                        {{> components/icon_button custom_classes="dropdown-list-delete" intent="danger" icon="trash" aria-label=(t "Delete snippet") }}
                     {{/if}}
                 {{else}}
                     {{name}}
                 {{/if}}
             </span>
-            <span class="dropdown-list-item-description">
+            <span class="dropdown-list-item-description line-clamp">
                 {{description}}
             </span>
         </a>


### PR DESCRIPTION
This PR improves the saved snippets UI through the following ways:
- Reduces the space between the saved snippet title and description for a more interconnected feel.
- Changes the delete icon from the old font-awesome icons to using the new icon button component.
- Adds line-clamping to the saved snippet description to display two lines of text instead of one, presenting the user with more context.

<!-- Describe your pull request here.-->

Fixes: [#design > saved snippets UI tweaks @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/saved.20snippets.20UI.20tweaks/near/2110624)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-04 at 8 12 32 PM](https://github.com/user-attachments/assets/8e6ae960-146b-4ee1-a9a3-be182f60f38d) | ![Screenshot 2025-03-04 at 8 10 50 PM](https://github.com/user-attachments/assets/b923e663-56b8-420e-9635-bfa3a26a47cf) | 
| ![Screenshot 2025-03-04 at 8 12 21 PM](https://github.com/user-attachments/assets/3db67afb-17cf-4c47-b8d3-1aa7d74ca007) | ![Screenshot 2025-03-04 at 8 11 45 PM](https://github.com/user-attachments/assets/45707ea1-0adf-4107-bb53-3f3b3dd52f32) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
