### PR TITLE
right_sidebar: Improve grid on list-style menu.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -639,7 +639,10 @@
 
     .popover-menu-link:not(.display-style-selector-header) {
         display: grid;
-        grid-template: "left-icon row-content" auto / 18px 1fr;
+        grid-template: "left-icon row-content" auto / 18px minmax(
+                max-content,
+                1fr
+            );
         align-items: center;
 
         .popover-menu-icon,


### PR DESCRIPTION
This improves the grid definition on the buddy list popover to ensure the full width is displayed on Safari. There is no effect from this on other browsers.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/User.20List.20Style.20Menu.20styling.20Issue.20in.20Safari/near/2111081)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Safari, Before | Safari, After |
| --- | --- |
| ![user-list-style-safari-before](https://github.com/user-attachments/assets/653ae406-fc1e-48e2-b69d-fabf003e40cd) | ![user-list-style-safari-after](https://github.com/user-attachments/assets/30ce26e3-5eb8-4d4c-9b76-fd5c3446a63c) |

| Firefox, Before | Firefox, After (no change) |
| --- | --- |
| ![user-list-style-ff-before](https://github.com/user-attachments/assets/06180041-4666-4e83-a573-511ceed45708) | ![user-list-style-ff-after](https://github.com/user-attachments/assets/e1d55fab-5a78-4ceb-862d-813d5463ad69) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>