### PR TITLE
sidebars: Show overlays full-screen, in proper stacking order.

### DIFF
--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -38,6 +38,7 @@ export const container_breakpoints = {
     cq_xl_min: xl / base_em_px + "em",
     cq_lg_min: lg / base_em_px + "em",
     cq_md_min: md / base_em_px + "em",
+    cq_ml_min: ml / base_em_px + "em",
     cq_sm_min: sm / base_em_px + "em",
     cq_mm_min: mm / base_em_px + "em",
 };

--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -44,11 +44,13 @@ export let left_sidebar_expanded_as_overlay = false;
 export let right_sidebar_expanded_as_overlay = false;
 
 export function hide_userlist_sidebar(): void {
-    $(".app-main .column-right").removeClass("expanded");
+    const $userlist_sidebar = $(".app-main .column-right");
+    $userlist_sidebar.removeClass("expanded topmost-overlay");
     right_sidebar_expanded_as_overlay = false;
 }
 
 export function show_userlist_sidebar(): void {
+    const $streamlist_sidebar = $(".app-main .column-left");
     const $userlist_sidebar = $(".app-main .column-right");
     if ($userlist_sidebar.css("display") !== "none") {
         // Return early if the right sidebar is already visible.
@@ -62,14 +64,24 @@ export function show_userlist_sidebar(): void {
     }
 
     $userlist_sidebar.addClass("expanded");
+    if (left_sidebar_expanded_as_overlay) {
+        $userlist_sidebar.addClass("topmost-overlay");
+        $streamlist_sidebar.removeClass("topmost-overlay");
+    }
     fix_invite_user_button_flicker();
     resize.resize_page_components();
     right_sidebar_expanded_as_overlay = true;
 }
 
 export function show_streamlist_sidebar(): void {
+    const $userlist_sidebar = $(".app-main .column-right");
+    const $streamlist_sidebar = $(".app-main .column-left");
     // Left sidebar toggle icon is attached to middle column.
     $(".app-main .column-left, #navbar-middle").addClass("expanded");
+    if (right_sidebar_expanded_as_overlay) {
+        $streamlist_sidebar.addClass("topmost-overlay");
+        $userlist_sidebar.removeClass("topmost-overlay");
+    }
     resize.resize_stream_filters_container();
     left_sidebar_expanded_as_overlay = true;
 }
@@ -90,7 +102,9 @@ export function show_left_sidebar(): void {
 }
 
 export function hide_streamlist_sidebar(): void {
+    const $streamlist_sidebar = $(".app-main .column-left");
     $(".app-main .column-left, #navbar-middle").removeClass("expanded");
+    $streamlist_sidebar.removeClass("topmost-overlay");
     left_sidebar_expanded_as_overlay = false;
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -544,6 +544,19 @@ body.has-overlay-scrollbar {
     top: 0;
 }
 
+.app-main .column-right.expanded,
+.app-main .column-left.expanded {
+    /* We share a baseline z-index to make
+       sure overlays respect the .topmost-overlay
+       below. */
+    z-index: 10;
+}
+
+.app-main .column-right.expanded.topmost-overlay,
+.app-main .column-left.expanded.topmost-overlay {
+    z-index: 15;
+}
+
 #message_feed_container,
 .app-main .column-left .left-sidebar,
 .app-main .column-right .right-sidebar {
@@ -1784,6 +1797,20 @@ body:not(.hide-left-sidebar) {
     }
 }
 
+@container app (width <= $cq_ml_min) {
+    .column-right.expanded,
+    .column-left.expanded {
+        width: 100vw;
+        max-width: 100%;
+    }
+
+    .app-main .column-right.expanded .right-sidebar,
+    .app-main .column-left.expanded .left-sidebar {
+        width: 100vw;
+        max-width: 100%;
+    }
+}
+
 @container header-container (width <= $cq_sm_min) {
     .narrow_description {
         display: none;
@@ -1867,6 +1894,22 @@ body:not(.hide-left-sidebar) {
         #scheduled_message_indicator,
         #compose-content {
             margin-left: 7px;
+        }
+    }
+}
+
+@media (width <= $ml_min) {
+    .without-container-query-support {
+        .column-right.expanded,
+        .column-left.expanded {
+            width: 100vw;
+            max-width: 100%;
+        }
+
+        .app-main .column-right.expanded .right-sidebar,
+        .app-main .column-left.expanded .left-sidebar {
+            width: 100vw;
+            max-width: 100%;
         }
     }
 }


### PR DESCRIPTION
This takes effect only at narrow viewports (425px and smaller, at 16px/1em).

Fixes: #33713

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/Right.20sidebar.20width/near/2111477)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Right sidebar, before | Right sidebar, after |
| --- | --- |
| ![right-opened-before](https://github.com/user-attachments/assets/36ee9251-7056-474b-9f71-9a62d59249d4) | ![right-opened-second](https://github.com/user-attachments/assets/3b70ce33-9b72-4901-b9e5-1b95fc5c351c) |

| Left sidebar opened second, before | Left sidebar opened second, after |
| --- | --- |
| ![left-opened-second-before](https://github.com/user-attachments/assets/261a3e9f-afdb-4973-94a1-48f20bc35318) | ![left-opened-second-after](https://github.com/user-attachments/assets/32462cf2-e710-41d8-aa75-f67f51b9cab2) |



| Left sidebar opened second (wider screen), before | Left sidebar opened second (wider screen), after |
| --- | --- |
| ![left-sidebar-opened-second-wider-before](https://github.com/user-attachments/assets/11dc22a1-4dbe-4b0d-9a6b-3bbf8877df85) | ![left-sidebar-opened-second-wider-after](https://github.com/user-attachments/assets/33a3ca5d-e9d3-4fd7-928a-9e7687e880bf) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>