### PR TITLE
Make saving indicator not clickable while saving.

### DIFF
--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1255,7 +1255,7 @@ export function register_save_discard_widget_handlers(
 
     $container.on(
         "click",
-        ".subsection-header .subsection-changes-save button",
+        ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
         function (this: HTMLElement, e: JQuery.ClickEvent) {
             e.preventDefault();
             e.stopPropagation();
@@ -1273,6 +1273,15 @@ export function register_save_discard_widget_handlers(
                     );
             }
             save_organization_settings(data, $save_button, patch_url, success_continuation);
+        },
+    );
+
+    $container.on(
+        "click",
+        ".subsection-header .subsection-changes-save button",
+        (e: JQuery.ClickEvent) => {
+            // Prevents the default form submission action when clicking a button (e.g., "Saving...").
+            e.preventDefault();
         },
     );
 }

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -816,7 +816,7 @@ export function initialize(): void {
 
     $("#channels_overlay_container").on(
         "click",
-        ".subsection-header .subsection-changes-save button",
+        ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
         function (this: HTMLElement, e) {
             e.preventDefault();
             e.stopPropagation();

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1058,7 +1058,7 @@ export function show_settings_for(group: UserGroup): void {
         .find(".realm-group-permissions")
         .on(
             "click",
-            ".subsection-header .subsection-changes-save button",
+            ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
             function (this: HTMLElement, e: JQuery.ClickEvent) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -1073,7 +1073,7 @@ export function show_settings_for(group: UserGroup): void {
         .find(".channel-group-permissions")
         .on(
             "click",
-            ".subsection-header .subsection-changes-save button",
+            ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
             function (this: HTMLElement, e: JQuery.ClickEvent) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -1095,7 +1095,7 @@ export function show_settings_for(group: UserGroup): void {
         .find(".user-group-permissions")
         .on(
             "click",
-            ".subsection-header .subsection-changes-save button",
+            ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
             function (this: HTMLElement, e: JQuery.ClickEvent) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -2034,7 +2034,7 @@ export function initialize(): void {
 
     $("#groups_overlay_container").on(
         "click",
-        ".subsection-header .subsection-changes-save button",
+        ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
         function (this: HTMLElement, e) {
             e.preventDefault();
             e.stopPropagation();

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -573,7 +573,7 @@ test("set_up", ({override, override_rewire}) => {
         override,
         $(".admin-realm-form").get_on_handler(
             "click",
-            ".subsection-header .subsection-changes-save button",
+            ".subsection-header .subsection-changes-save .save-button[data-status='unsaved']",
         ),
     );
     test_upload_realm_icon(override, upload_realm_logo_or_icon);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Currently, if we click on `Save Changes` button, it proceeds through the following steps:

1. It shows `Save Changes` text with `data-status="unsaved"`.
2. When we click on it, the text becomes `Saving` with `data-status="saving"`.
3. Then, it shows `Saved` with `data-status="saved"`.
4. Just after this, for a fraction of second, it again shows `Save Changes` with `data-status="unsaved"`.

Now, if the network is slow , we can get an error message on clicking over the button **at every step** as it again tries to call the API and the change has already been taken place.

In this PR, i'm changing the target of the on click event, hence the possibility of errors gets eliminated except for the **`Step 4`** i.e, by again clicking over the `Save changes` button that shows for a fraction of seconds.

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.22saving.22.20indicator.20shouldn't.20be.20clickable)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After  |
|-------|------|  
| ![Before](https://github.com/user-attachments/assets/a4c6c019-9b28-434b-b385-d193c9bee700) | ![After](https://github.com/user-attachments/assets/f6ae4f36-ef49-45ee-8d33-56ffafe36905) | 

**Possibility of error**


https://github.com/user-attachments/assets/1d3dc4a5-580e-4fe3-a3e6-620298ef7a2c




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
