### PR TITLE
todo_widget: Scale checkboxes with font size.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -63,12 +63,12 @@
                 padding: 2px;
                 margin: 0;
 
-                height: 12px;
-                width: 12px;
+                font-size: 1.3em; /* 18.2px / 14px em */
+                height: 0.6593em; /* 12px at 18.2px / em */
+                width: 0.6593em; /* 12px at 18.2px / em */
 
                 font-weight: 300;
                 line-height: 0.8;
-                font-size: 1.3rem;
                 text-align: center;
                 border: 2px solid hsl(156deg 28% 70%);
 


### PR DESCRIPTION
The checkboxes still seem slightly off center, but that was already an issue and I think fixing that requires a rewrite using grid which I'm not prioritizing right now.

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 10 17 24](https://github.com/user-attachments/assets/6f354830-90cf-413a-868f-90c3b0d44027) | ![Screen Shot 2025-03-04 at 10 15 39](https://github.com/user-attachments/assets/a120688f-8554-4a68-b79f-17ce8cdf12f1) |
| ![Screen Shot 2025-03-04 at 10 19 47](https://github.com/user-attachments/assets/8fd01ccb-04e3-4680-8696-b244b38e3c2d) | ![Screen Shot 2025-03-04 at 10 15 32](https://github.com/user-attachments/assets/b738ebbf-6ee8-4da0-b832-f6da67672cf3) |
|  ![Screen Shot 2025-03-04 at 10 21 13](https://github.com/user-attachments/assets/6be2d4c7-c959-4dfd-acb1-bae02872ca2e) | ![Screen Shot 2025-03-04 at 10 15 23](https://github.com/user-attachments/assets/d1d50b40-4cc1-4280-b6c9-a4e978b83ce0) |
| ![Screen Shot 2025-03-04 at 10 18 27](https://github.com/user-attachments/assets/c7e515a8-2d92-44b0-bb32-7ba70b672499) | ![Screen Shot 2025-03-04 at 10 15 05](https://github.com/user-attachments/assets/45220ff4-e68e-4121-9b8d-2c8db5cdab8e) |
