### PR TITLE
stream settings: Scale advanced configuration toggle icon with font size

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -511,7 +511,7 @@ input[type="checkbox"] {
         }
 
         .toggle-advanced-configurations-icon {
-            font-size: 20px;
+            font-size: 1.4286em; /* 20px at 14px / em */
         }
     }
 


### PR DESCRIPTION
at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 11 00 10](https://github.com/user-attachments/assets/a9edb7d6-4bf3-435a-80cd-3ebf329fca1a) | ![Screen Shot 2025-03-04 at 10 59 40](https://github.com/user-attachments/assets/1617b926-d465-4d54-afa9-0ef0b07bb38e) |
| ![Screen Shot 2025-03-04 at 11 00 20](https://github.com/user-attachments/assets/f45613d4-2533-40e0-969c-072e81dd2330) | ![Screen Shot 2025-03-04 at 10 59 28](https://github.com/user-attachments/assets/8c2d1691-5c15-426e-9e54-07f770564e03) |
| ![Screen Shot 2025-03-04 at 11 00 28](https://github.com/user-attachments/assets/a5537591-82fd-4f15-8e24-f0f79f09cf46) | ![Screen Shot 2025-03-04 at 10 58 52](https://github.com/user-attachments/assets/f5d5da03-751a-4226-950a-853b3499db93) |
| ![Screen Shot 2025-03-04 at 11 00 48](https://github.com/user-attachments/assets/1bd93e10-acd5-468b-a5d4-aeb06403aaca) | ![Screen Shot 2025-03-04 at 10 59 13](https://github.com/user-attachments/assets/ff46a7c4-e620-453c-89ae-6ae4a4b607f2) |
