### PR TITLE
recent_view: Scale unread icon with font size on small screens.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -511,7 +511,7 @@
 
         .recent_topic_actions {
             margin-right: 5px;
-            font-size: 15px;
+            font-size: 1.0714em; /* 15px at 14px / em */
         }
     }
 


### PR DESCRIPTION
at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 11 14 54](https://github.com/user-attachments/assets/33af3d08-7c8d-4866-a209-5f5693dc1afc) | ![Screen Shot 2025-03-04 at 11 09 52](https://github.com/user-attachments/assets/acefbcb5-68f7-4288-991d-83124c25b22a) |
| ![Screen Shot 2025-03-04 at 11 15 11](https://github.com/user-attachments/assets/bf1119d6-4057-4a2f-bad5-447b41067679) | ![Screen Shot 2025-03-04 at 11 10 08](https://github.com/user-attachments/assets/fdcd1346-5120-4daf-b5a6-306c7a2963a0) |
| ![Screen Shot 2025-03-04 at 11 15 29](https://github.com/user-attachments/assets/e0237dc0-c8ee-40f3-92a2-5bbae6579f53) | ![Screen Shot 2025-03-04 at 11 10 32](https://github.com/user-attachments/assets/e0013548-152c-4376-a831-e6c610746929) |
| ![Screen Shot 2025-03-04 at 11 15 46](https://github.com/user-attachments/assets/389aa986-6760-4ada-a20d-4ba3a0ccf3e5) | ![Screen Shot 2025-03-04 at 11 10 51](https://github.com/user-attachments/assets/1974b12d-14cc-46df-97c0-91bb23607572) |