### PR TITLE
layout: Correct condensed VIEWS icons, and action icons at narrow message widths.

### DIFF
--- a/web/src/css_variables.ts
+++ b/web/src/css_variables.ts
@@ -37,6 +37,7 @@ export const media_breakpoints = {
 export const container_breakpoints = {
     cq_xl_min: xl / base_em_px + "em",
     cq_lg_min: lg / base_em_px + "em",
+    cq_mc_min: mc / base_em_px + "em",
     cq_md_min: md / base_em_px + "em",
     cq_ml_min: ml / base_em_px + "em",
     cq_sm_min: sm / base_em_px + "em",

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -623,8 +623,12 @@ li.active-sub-filter {
     justify-content: center;
 
     .left-sidebar-navigation-condensed-item {
-        /* 24px minimum width from Vlad's design. */
-        flex: 1 0 24px;
+        /* 24px minimum width from Vlad's design.
+           however, we want to permit growing and
+           shrinking to keep icons reasonably spaced
+           across different information-density
+           settings. */
+        flex: 1 1 24px;
         /* Unset padding from individual top_left items */
         padding: 0;
         border-radius: 4px;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1,3 +1,9 @@
+.with-container-query-support {
+    #message-lists-container {
+        container: message-lists / inline-size;
+    }
+}
+
 .message_row {
     display: grid;
     /* Prevent the messagebox column from overflowing the 1fr

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -478,11 +478,25 @@
     /* Ensure square icons for better centering. */
     line-height: 1;
 
-    @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
+    @container message-lists (width < $cq_sm_min) {
         /* This is intended to target the first message_controls child
            when there are 3 displayed. */
         .message_control_button:nth-last-child(3) {
             display: none;
+        }
+    }
+
+    /* Media-query fallback. Note that because we're treating
+       #message-lists-container as its own container, we can
+       express a much simpler query there. The more complex
+       conditions are necessary only for media queries. */
+    @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
+        .without-container-query-support {
+            /* This is intended to target the first message_controls child
+            when there are 3 displayed. */
+            .message_control_button:nth-last-child(3) {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
This fixes two issues noted by @alya:

* Icons in the condensed VIEWS row are no longer piled on top of each other
* Action icons are properly hidden for narrower messages, thanks to a new container query

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/Right.20sidebar.20width/near/2111710)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Condensed views, 12px, before | Condensed views, 12px, after |
| --- | --- |
| ![12-px-condensed-views-at-576w-before](https://github.com/user-attachments/assets/9bdc0e0a-648e-4c16-b191-7f8ed9274e7d) | ![12-px-condensed-views-at-576w-after](https://github.com/user-attachments/assets/badc4c76-2e0e-47fd-9d83-03582b6b0031) |

| Condensed views, 16px, before | Condensed views, 16px, after (no change)|
| --- | --- |
| ![16-px-condensed-views-at-876w-before](https://github.com/user-attachments/assets/12034745-acc0-439b-a138-7e6caf04700a) | ![16-px-condensed-views-at-876w-after](https://github.com/user-attachments/assets/86ed80fd-ea5e-46d3-8f3d-1e2dc1ba88da) |

| Action icons, before | Action icons, after |
| --- | --- |
| ![narrow-icon-area-before](https://github.com/user-attachments/assets/e57971db-7bca-47f6-84dd-4c23c49dc358) | ![narrow-icon-area-after](https://github.com/user-attachments/assets/e66cb4ea-03f6-4935-ac47-c5722301594c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>