### PR TITLE
stream_narrow: Scale icon in sub/unsub message with font size.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1393,14 +1393,17 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     opacity: 0.6;
 
     & i {
-        font-size: 10px;
+        font-size: 0.7143em; /* 10px at 14px / em */
+        /* TODO: Don't use relative positioning here. */
         position: relative;
-        top: 1px;
-        margin-left: 2px;
+        top: 0.1em; /* 1px at 10px / em */
+        margin-left: 0.2em; /* 2px at 10px / em */
     }
 
     .zulip-icon.zulip-icon-lock {
-        font-size: 12px;
+        font-size: 0.8571em; /* 12px at 14px / em */
+        top: 0.0833em; /* 1px at 12px / em */
+        margin-left: 0.1667em; /* 2px at 12px / em */
     }
 }
 


### PR DESCRIPTION
Lock icon at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 12 38 29](https://github.com/user-attachments/assets/e089ef56-f00a-44fa-b827-f196023c5691) | ![Screen Shot 2025-03-04 at 12 49 43](https://github.com/user-attachments/assets/6ba7c8d6-1c79-440b-ba73-ad0c3c8492b7) |
| ![Screen Shot 2025-03-04 at 12 41 53](https://github.com/user-attachments/assets/36825cc1-b73c-4111-8fa5-0c7e7c64c7b3) | ![Screen Shot 2025-03-04 at 12 47 56](https://github.com/user-attachments/assets/96626daf-9036-4b7e-b433-8c8dfe9339e5) |
| ![Screen Shot 2025-03-04 at 12 42 31](https://github.com/user-attachments/assets/827ef444-7474-412d-a833-caf0f465a5f3) | ![Screen Shot 2025-03-04 at 12 50 54](https://github.com/user-attachments/assets/188c425b-9d36-4cf7-83bd-e4565dcc149e) |
| ![Screen Shot 2025-03-04 at 12 40 22](https://github.com/user-attachments/assets/2a10d13f-2411-4dc4-8564-2a0fcd3d1c6f) | ![Screen Shot 2025-03-04 at 12 52 33](https://github.com/user-attachments/assets/949716e6-8daa-437d-8203-7a5ab7d26cfb) |

Other icons at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 12 59 05](https://github.com/user-attachments/assets/aed725a3-fd55-4540-a335-81b84c49552c) | ![Screen Shot 2025-03-04 at 12 56 25](https://github.com/user-attachments/assets/e7878f89-6d5a-4aef-9b64-7791dd577c17) |
| ![Screen Shot 2025-03-04 at 12 59 41](https://github.com/user-attachments/assets/0e3c9556-932b-4f21-8f34-5e6593cf8f97) | ![Screen Shot 2025-03-04 at 12 55 17](https://github.com/user-attachments/assets/96220079-061d-4fff-9c80-b063c397f551) |
| ![Screen Shot 2025-03-04 at 13 00 35](https://github.com/user-attachments/assets/2dfe6e91-f017-4d2e-b23a-51cad339e5d7) | ![Screen Shot 2025-03-04 at 12 54 28](https://github.com/user-attachments/assets/e9ed4935-53e2-40b7-9bff-525b3a33e38a) |
| ![Screen Shot 2025-03-04 at 13 01 11](https://github.com/user-attachments/assets/6ec655ba-56d4-4890-b4bf-df7199792477) | ![Screen Shot 2025-03-04 at 12 53 40](https://github.com/user-attachments/assets/5e554b6b-fa0b-47b6-bac3-7edd2b23ae62) |