### PR TITLE
clipboard_handler: Fix bug when copying in Safari.

### DIFF
--- a/web/src/clipboard_handler.ts
+++ b/web/src/clipboard_handler.ts
@@ -7,12 +7,19 @@ import * as stream_data from "./stream_data.ts";
 import * as topic_link_util from "./topic_link_util.ts";
 
 // The standard Clipboard API do not support custom mime types like
-// text/x-gfm, but this approach does.
+// text/x-gfm, but this approach does, except on Safari.
 export function execute_copy(handle_copy_event: (e: ClipboardEvent) => void): void {
+    const dummy = document.createElement("input");
+    document.body.append(dummy);
+    // This is required for getting the copy command to work on Safari.
+    // The actual data copied is set by the event handler.
+    dummy.value = "dummy text";
+    dummy.select();
     document.addEventListener("copy", handle_copy_event);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     document.execCommand("copy");
     document.removeEventListener("copy", handle_copy_event);
+    dummy.remove();
 }
 
 export async function copy_link_to_clipboard(link: string): Promise<void> {


### PR DESCRIPTION
When copying a message from message actions
popover in Safari, the text wouldn't be copied
and neither would the popover close, because
document.execCommand("copy") would fail
and the copy callback wouldn't trigger.

Safari requires some DOM element to be selected
before it can successfully execute the copy
command. This PR fixes the bug by doing
just that.

Note: The mime type `text/x-gfm` is still not
copied in Safari.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
