### PR TITLE
help and groups: Document group deactivation process better.

### DIFF
--- a/help/deactivate-a-user-group.md
+++ b/help/deactivate-a-user-group.md
@@ -1,0 +1,43 @@
+# Deactivate a user group
+
+You can deactivate groups you no longer plan to use. Deactivated groups cannot be [mentioned](/help/mention-a-user-or-group), or used for any [permissions](/help/manage-permissions).
+
+## Deactivate a user group
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|group|all}
+
+1. Select a user group.
+
+1. Select the **Permissions** tab on the right.
+
+1. Remove all permissions.
+
+1. Click the **Deactivate group** (<i class="zulip-icon zulip-icon-user-group-x"></i>) button in the
+   upper right corner of the user group settings panel.
+
+1. Click **Confirm**.
+
+{end_tabs}
+
+## View deactivated user groups
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|group|all}
+
+1. Select **Deactivated groups** from the dropdown next to the **Filter** box
+   above the list of groups.
+
+{end_tabs}
+
+## Related articles
+
+* [User groups](/help/user-groups)
+* [Create user groups](/help/create-user-groups)
+* [Manage user groups](/help/manage-user-groups)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -229,6 +229,7 @@
 ## Permissions management
 * [Manage permissions](/help/manage-permissions)
 * [Manage user groups](/help/manage-user-groups)
+* [Deactivate a user group](/help/deactivate-a-user-group)
 * [User roles](/help/user-roles)
 * [Guest users](/help/guest-users)
 * [Restrict direct messages](/help/restrict-direct-messages)

--- a/help/manage-user-groups.md
+++ b/help/manage-user-groups.md
@@ -138,23 +138,6 @@ as needed.
 
 {end_tabs}
 
-## Deactivate a user group
-
-{start_tabs}
-
-{tab|desktop-web}
-
-{relative|group|all}
-
-1. Select a user group.
-
-1. Click the **Deactivate group** (<i class="zulip-icon zulip-icon-user-group-x"></i>) button in the
-   upper right corner of the user group settings panel.
-
-1. Click **Confirm**.
-
-{end_tabs}
-
 ## Configure who can create user groups
 
 {!admin-only.md!}
@@ -205,5 +188,6 @@ group.
 * [View group members](/help/view-group-members)
 * [Mention a user or group](/help/mention-a-user-or-group)
 * [Create user groups](/help/create-user-groups)
+* [Deactivate a user group](/help/deactivate-a-user-group)
 * [Moving to Zulip](/help/moving-to-zulip)
 * [User roles](/help/user-roles)

--- a/web/templates/user_group_settings/cannot_deactivate_group_banner.hbs
+++ b/web/templates/user_group_settings/cannot_deactivate_group_banner.hbs
@@ -1,18 +1,3 @@
 <p>
-    {{t "This group cannot be deactivated because it is used in following places:"}}
-    <ul>
-        {{#each streams_using_group_for_setting}}
-            {{#if this.setting_url}}
-            <li><a href="{{this.setting_url}}">#{{this.stream_name}}</a></li>
-            {{else}}
-            <li>{{this.stream_name}}</li>
-            {{/if}}
-        {{/each}}
-        {{#each groups_using_group_for_setting}}
-            <li><a href="{{this.setting_url}}">@{{this.group_name}}</a></li>
-        {{/each}}
-        {{#if realm_using_group_for_setting}}
-            <li><a href="#organization">{{t "Organization settings"}}</a></li>
-        {{/if}}
-    </ul>
+    {{t "To deactivate this group, you must first remove all permissions assigned to it."}}
 </p>


### PR DESCRIPTION
The help center commit is ready for integration review.

<details>
<summary>
New page
</summary>

![Screenshot 2025-03-04 at 14 14 37](https://github.com/user-attachments/assets/15892369-f50d-44ab-9430-0b47df444f95)

</details>


In the second commit, we need to add a "View permissions" button to the banner. @sahil839 could you please take care of that? Now that we have a group permissions panel, we don't need to summarize the group's permissions here. (I also didn't try to figure out if the `<p>` tags are what's causing extra space below the banner text.)

![Screenshot 2025-03-04 at 14 08 46](https://github.com/user-attachments/assets/8be452c8-1039-4e9a-a17a-4134c8d46e61)
