### PR TITLE
narrow-banner: Pass filter when showing/picking empty narrow banner.

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -49,7 +49,9 @@ export function initialize(): void {
             const button_type = $elem.attr("data-reply-button-type");
             switch (button_type) {
                 case "direct_disabled": {
-                    instance.setContent(pick_empty_narrow_banner().title);
+                    const narrow_filter = narrow_state.filter();
+                    assert(narrow_filter !== undefined);
+                    instance.setContent(pick_empty_narrow_banner(narrow_filter).title);
                     return;
                 }
                 case "stream_disabled": {

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -127,7 +127,7 @@ export function fetch_more_if_required_for_current_msg_list(
     if (has_found_oldest && has_found_newest && message_lists.current.visibly_empty()) {
         // Even after loading more messages, we have
         // no messages to display in this narrow.
-        narrow_banner.show_empty_narrow_message();
+        narrow_banner.show_empty_narrow_message(message_lists.current.data.filter);
         compose_closed_ui.update_buttons_for_private();
         compose_recipient.check_posting_policy_for_compose_box();
     }
@@ -433,7 +433,7 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
                     !opts.msg_list.is_combined_feed_view &&
                     opts.msg_list.visibly_empty()
                 ) {
-                    narrow_banner.show_empty_narrow_message();
+                    narrow_banner.show_empty_narrow_message(opts.msg_list.data.filter);
                 }
 
                 // TODO: This should probably do something explicit with

--- a/web/src/message_list.ts
+++ b/web/src/message_list.ts
@@ -583,7 +583,7 @@ export class MessageList {
             // Show the empty narrow message only if we're certain
             // that the view doesn't have messages that we're
             // waiting for the server to send us.
-            narrow_banner.show_empty_narrow_message();
+            narrow_banner.show_empty_narrow_message(this.data.filter);
         } else {
             narrow_banner.hide_empty_narrow_message();
         }

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -297,31 +297,18 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
             }
             // fallthrough to default case if no match is found
             break;
-        case "channel":
-            if (!stream_data.is_subscribed(Number.parseInt(first_operand, 10))) {
-                // You are narrowed to a stream which does not exist or is a private stream
-                // in which you were never subscribed.
-
+        case "channel": {
+            const stream_sub = stream_data.get_sub_by_id_string(first_operand);
+            if (!stream_sub?.subscribed) {
+                // You are narrowed to a channel that either does not exist,
+                // is private, or a channel you're not currently subscribed to.
                 if (page_params.is_spectator) {
                     spectators.login_to_access(true);
                     return SPECTATOR_STREAM_NARROW_BANNER;
                 }
-
-                function can_toggle_narrowed_stream(): boolean | undefined {
-                    const stream_name = narrow_state.stream_name();
-
-                    if (!stream_name) {
-                        return false;
-                    }
-
-                    const stream_sub = stream_data.get_sub_by_id_string(first_operand);
-                    return stream_sub && stream_data.can_toggle_subscription(stream_sub);
-                }
-
-                if (can_toggle_narrowed_stream()) {
+                if (stream_sub && stream_data.can_toggle_subscription(stream_sub)) {
                     return default_banner;
                 }
-
                 return {
                     title: $t({
                         defaultMessage:
@@ -331,6 +318,7 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
             }
             // else fallthrough to default case
             break;
+        }
         case "search": {
             // You are narrowed to empty search results.
             return {

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -3,10 +3,10 @@ import _ from "lodash";
 import assert from "minimalistic-assert";
 
 import * as compose_validate from "./compose_validate.ts";
+import type {Filter} from "./filter.ts";
 import {$t, $t_html} from "./i18n.ts";
 import type {NarrowBannerData, SearchData} from "./narrow_error.ts";
 import {narrow_error} from "./narrow_error.ts";
-import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
 import * as spectators from "./spectators.ts";
@@ -62,10 +62,8 @@ const STARRED_MESSAGES_VIEW_EMPTY_BANNER = {
     ),
 };
 
-function retrieve_search_query_data(): SearchData {
+function retrieve_search_query_data(current_filter: Filter): SearchData {
     // when search bar contains multiple filters, only retrieve search queries
-    const current_filter = narrow_state.filter();
-    assert(current_filter !== undefined);
     const search_query = current_filter.operands("search")[0];
     const query_words = search_query!.split(" ");
 
@@ -107,7 +105,7 @@ function retrieve_search_query_data(): SearchData {
     return search_string_result;
 }
 
-export function pick_empty_narrow_banner(): NarrowBannerData {
+export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerData {
     const default_banner = {
         title: $t({defaultMessage: "There are no messages here."}),
         // Spectators cannot start a conversation.
@@ -127,11 +125,6 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
     };
     const default_banner_for_multiple_filters = $t({defaultMessage: "No search results."});
 
-    const current_filter = narrow_state.filter();
-    if (current_filter === undefined) {
-        // We're in either the inbox or recent conversations view.
-        return default_banner;
-    }
     if (current_filter.is_in_home()) {
         // We're in the combined feed view.
         return {
@@ -197,7 +190,7 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
         if (current_filter.operands("search").length > 0) {
             return {
                 title: default_banner_for_multiple_filters,
-                search_data: retrieve_search_query_data(),
+                search_data: retrieve_search_query_data(current_filter),
             };
         }
 
@@ -323,7 +316,7 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
             // You are narrowed to empty search results.
             return {
                 title: $t({defaultMessage: "No search results."}),
-                search_data: retrieve_search_query_data(),
+                search_data: retrieve_search_query_data(current_filter),
             };
         }
         case "dm": {
@@ -483,9 +476,9 @@ export function pick_empty_narrow_banner(): NarrowBannerData {
     return default_banner;
 }
 
-export function show_empty_narrow_message(): void {
+export function show_empty_narrow_message(current_filter: Filter): void {
     $(".empty_feed_notice_main").empty();
-    const rendered_narrow_banner = narrow_error(pick_empty_narrow_banner());
+    const rendered_narrow_banner = narrow_error(pick_empty_narrow_banner(current_filter));
     $(".empty_feed_notice_main").html(rendered_narrow_banner);
 }
 

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -18,7 +18,6 @@ const message_view = zrequire("message_view");
 const narrow_title = zrequire("narrow_title");
 const recent_view_util = zrequire("recent_view_util");
 const inbox_util = zrequire("inbox_util");
-const message_lists = zrequire("message_lists");
 const {set_current_user, set_realm} = zrequire("state_data");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
@@ -55,14 +54,7 @@ function set_filter(terms) {
         operator: op[0],
         operand: op[1],
     }));
-    message_lists.set_current({
-        data: {
-            filter: new Filter(terms),
-            fetch_status: {
-                has_found_newest: () => true,
-            },
-        },
-    });
+    return new Filter(terms);
 }
 
 const me = {
@@ -239,20 +231,9 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
-    message_lists.set_current(undefined);
-    narrow_banner.show_empty_narrow_message();
-    assert.equal(
-        $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: There are no messages here.",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
-        ),
-    );
-
     // for empty combined feed
-    const current_filter = new Filter([{operator: "in", operand: "home"}]);
-    message_lists.set_current({data: {filter: current_filter}});
-    narrow_banner.show_empty_narrow_message();
+    let current_filter = new Filter([{operator: "in", operand: "home"}]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -262,8 +243,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     );
 
     // for non-existent or private stream
-    set_filter([["stream", "999"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["stream", "999"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -271,12 +252,12 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([
+    current_filter = set_filter([
         ["stream", "999"],
         ["topic", "foo"],
         ["near", "99"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -287,8 +268,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     // for non-subbed public stream
     const rome_id = 99;
     stream_data.add_sub({name: "ROME", stream_id: rome_id});
-    set_filter([["stream", rome_id.toString()]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["stream", rome_id.toString()]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -299,8 +280,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     // for non-web-public stream for spectator
     page_params.is_spectator = true;
-    set_filter([["stream", rome_id.toString()]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["stream", rome_id.toString()]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -309,11 +290,11 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([
+    current_filter = set_filter([
         ["stream", rome_id.toString()],
         ["topic", "foo"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -325,19 +306,19 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     // for web-public stream for spectator
     const web_public_id = 1231;
     stream_data.add_sub({name: "web-public-stream", stream_id: web_public_id, is_web_public: true});
-    set_filter([
+    current_filter = set_filter([
         ["stream", web_public_id.toString()],
         ["topic", "foo"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: There are no messages here."),
     );
     page_params.is_spectator = false;
 
-    set_filter([["is", "starred"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "starred"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -346,8 +327,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([["is", "mentioned"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "mentioned"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -358,8 +339,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
-    set_filter([["is", "dm"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "dm"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -368,22 +349,22 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([["is", "unread"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "unread"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no unread messages!"),
     );
 
-    set_filter([["is", "resolved"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "resolved"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: No topics are marked as resolved."),
     );
 
-    set_filter([["is", "followed"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "followed"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You aren't following any topics."),
@@ -393,23 +374,23 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     override(realm, "realm_direct_message_permission_group", nobody.id);
 
     // prioritize information about invalid user(s) in narrow/search
-    set_filter([["dm", ["Yo"]]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", ["Yo"]]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: This user does not exist!"),
     );
 
     people.add_active_user(alice);
-    set_filter([["dm", ["alice@example.com", "Yo"]]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", ["alice@example.com", "Yo"]]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: One or more of these users do not exist!"),
     );
 
-    set_filter([["dm", "alice@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", "alice@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -421,8 +402,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     // direct messages with a bot are possible even though
     // the organization has disabled sending direct messages
     people.add_active_user(bot);
-    set_filter([["dm", "bot@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", "bot@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -433,8 +414,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     // group direct messages with bots are not possible when
     // sending direct messages is disabled
-    set_filter([["dm", bot.email + "," + alice.email]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", bot.email + "," + alice.email]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -445,8 +426,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     // sending direct messages enabled
     override(realm, "realm_direct_message_permission_group", everyone.id);
-    set_filter([["dm", "alice@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", "alice@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -458,8 +439,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     // sending direct messages to deactivated user
     override(realm, "realm_direct_message_permission_group", everyone.id);
     people.deactivate(alice);
-    set_filter([["dm", alice.email]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", alice.email]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no direct messages with Alice Smith."),
@@ -468,8 +449,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     people.add_active_user(me);
     people.initialize_current_user(me.user_id);
-    set_filter([["dm", me.email]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", me.email]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -478,8 +459,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([["dm", me.email + "," + alice.email]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", me.email + "," + alice.email]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -490,8 +471,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     // group dm with a deactivated user
     people.deactivate(alice);
-    set_filter([["dm", ray.email + "," + alice.email]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm", ray.email + "," + alice.email]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no direct messages with these users."),
@@ -502,15 +483,15 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     override(realm, "realm_direct_message_permission_group", nobody.id);
 
     // prioritize information about invalid user in narrow/search
-    set_filter([["dm-including", ["Yo"]]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm-including", ["Yo"]]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: This user does not exist!"),
     );
 
-    set_filter([["dm-including", "alice@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm-including", "alice@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -521,8 +502,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
 
     // direct messages with a bot are possible even though
     // the organization has disabled sending direct messages
-    set_filter([["dm-including", "bot@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm-including", "bot@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no direct messages including Example Bot yet."),
@@ -531,46 +512,46 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     // sending direct messages enabled
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_permission_group", everyone.id);
-    set_filter([["dm-including", "alice@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm-including", "alice@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You have no direct messages including Alice Smith yet."),
     );
 
-    set_filter([["dm-including", me.email]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["dm-including", me.email]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You don't have any direct message conversations yet."),
     );
 
-    set_filter([["sender", "ray@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["sender", "ray@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: You haven't received any messages sent by Raymond yet."),
     );
 
-    set_filter([["sender", "sinwar@example.com"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["sender", "sinwar@example.com"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: This user does not exist!"),
     );
 
-    set_filter([
+    current_filter = set_filter([
         ["sender", "alice@example.com"],
         ["stream", rome_id.toString()],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: No search results."),
     );
 
-    set_filter([["is", "invalid"]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["is", "invalid"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -587,8 +568,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
     stream_data.add_sub(my_stream);
     stream_data.subscribe_myself(my_stream);
 
-    set_filter([["stream", my_stream_id.toString()]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["stream", my_stream_id.toString()]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -597,8 +578,8 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([["stream", ""]]);
-    narrow_banner.show_empty_narrow_message();
+    current_filter = set_filter([["stream", ""]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -606,11 +587,11 @@ run_test("show_empty_narrow_message", ({mock_template, override}) => {
         ),
     );
 
-    set_filter([
+    current_filter = set_filter([
         ["has", "reaction"],
         ["sender", "me"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -625,9 +606,8 @@ run_test("show_empty_narrow_message_with_search", ({mock_template, override}) =>
 
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
-    message_lists.set_current(undefined);
-    set_filter([["search", "grail"]]);
-    narrow_banner.show_empty_narrow_message();
+    const current_filter = set_filter([["search", "grail"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.match($(".empty_feed_notice_main").html(), /<span>grail<\/span>/);
 });
 
@@ -649,9 +629,8 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
             {query_word: "grail", is_stop_word: false},
         ],
     };
-    message_lists.set_current(undefined);
-    set_filter([["search", "what about grail"]]);
-    narrow_banner.show_empty_narrow_message();
+    let current_filter = set_filter([["search", "what about grail"]]);
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: No search results.", undefined, expected_search_data),
@@ -668,11 +647,11 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
             {query_word: "grail", is_stop_word: false},
         ],
     };
-    set_filter([
+    current_filter = set_filter([
         ["stream", streamA_id.toString()],
         ["search", "what about grail"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html("translated: No search results.", undefined, expected_stream_search_data),
@@ -688,12 +667,12 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
             {query_word: "grail", is_stop_word: false},
         ],
     };
-    set_filter([
+    current_filter = set_filter([
         ["stream", streamA_id.toString()],
         ["topic", "topicA"],
         ["search", "what about grail"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -705,7 +684,6 @@ run_test("show_search_stopwords", ({mock_template, override}) => {
 });
 
 run_test("show_invalid_narrow_message", ({mock_template}) => {
-    message_lists.set_current(undefined);
     mock_template("empty_feed_notice.hbs", true, (_data, html) => html);
 
     const streamA_id = 88;
@@ -713,11 +691,11 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     stream_data.add_sub({name: "streamA", stream_id: streamA_id});
     stream_data.add_sub({name: "streamB", stream_id: streamB_id});
 
-    set_filter([
+    let current_filter = set_filter([
         ["stream", streamA_id.toString()],
         ["stream", streamB_id.toString()],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -726,11 +704,11 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
         ),
     );
 
-    set_filter([
+    current_filter = set_filter([
         ["topic", "topicA"],
         ["topic", "topicB"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
@@ -742,11 +720,11 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     people.add_active_user(ray);
     people.add_active_user(alice);
 
-    set_filter([
+    current_filter = set_filter([
         ["sender", "alice@example.com"],
         ["sender", "ray@example.com"],
     ]);
-    narrow_banner.show_empty_narrow_message();
+    narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(


### PR DESCRIPTION
We expect to have a message list and therefore a filter when we show or pick an empty narrow banner.

Refactors `show_empty_narrow_message`,  `pick_empty_narrow_banner` and `retrieve_search_query_data` to have a `Filter` passed as a parameter.

Follow-up from https://github.com/zulip/zulip/pull/32805.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
