### PR TITLE
styles: Remove obsolete ‘transition: none …’ workaround

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -362,7 +362,7 @@ div.overlay {
     opacity: 0;
     visibility: hidden;
 
-    transition: none 0.2s ease-in;
+    transition: 0.2s ease-in;
     transition-property: opacity, visibility;
     overflow: hidden;
 
@@ -686,7 +686,7 @@ input.settings_text_input {
 
 .animated-purple-button {
     color: hsl(0deg 0% 100%);
-    transition: none 80ms linear;
+    transition: 80ms linear;
     transition-property: background-color, box-shadow;
     box-shadow: none;
     /* This color just passes WCAG AA */
@@ -737,7 +737,7 @@ input.settings_text_input {
             transition: color 0.2s ease;
         }
 
-        transition: none 0.2s ease;
+        transition: 0.2s ease;
         transition-property: background-color, color;
     }
 

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -17,14 +17,14 @@
     border: none;
     cursor: pointer;
     clip-path: inset(-1px);
-    transition: none 0.05s ease-in;
+    transition: 0.05s ease-in;
     transition-property: background-color, clip-path;
 
     &:hover {
         background-color: var(
             --color-background-neutral-quiet-action-button-hover
         );
-        transition: none 0.1s ease-out;
+        transition: 0.1s ease-out;
         transition-property: background-color, clip-path;
     }
 
@@ -392,11 +392,11 @@
     border: none;
     border-radius: 4px;
     clip-path: inset(-1px);
-    transition: none 0.05s ease-in;
+    transition: 0.05s ease-in;
     transition-property: background-color, clip-path;
 
     &:hover {
-        transition: none 0.1s ease-out;
+        transition: 0.1s ease-out;
         transition-property: background-color, clip-path;
     }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -242,7 +242,7 @@
                 color: var(--color-compose-chevron-arrow);
                 text-decoration: none;
                 cursor: default;
-                transition: none 0.2s ease-in-out;
+                transition: 0.2s ease-in-out;
                 transition-property: background, color;
 
                 &.narrow_to_compose_recipients {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -64,7 +64,7 @@
                 font-size: 1.1428em; /* 16px at 14px em */
                 color: var(--color-icons-inbox);
                 opacity: 0.4;
-                transition: none 140ms;
+                transition: 140ms;
                 transition-property: background-color, opacity, transform;
                 /* 5px at 16px font-size at 14px em */
                 padding: 0.3125em;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -488,7 +488,7 @@
     .message_control_button {
         opacity: 0;
         visibility: hidden;
-        transition: none 0.2s ease;
+        transition: 0.2s ease;
         transition-property: opacity, visibility;
         /* Allow buttons to grow to fill the available space,
            in concord with the column calculated for the

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -59,7 +59,7 @@
             width: 120px;
             height: 70px;
             background-color: hsl(0deg 0% 94%);
-            transition: none 0.2s ease;
+            transition: 0.2s ease;
             transition-property: background-color, border-color;
             display: inline-block;
             text-align: center;

--- a/web/styles/portico/hello.css
+++ b/web/styles/portico/hello.css
@@ -165,7 +165,7 @@ ul {
             "pnum" on,
             "lnum" on;
         color: hsl(0deg 0% 100%);
-        transition: none 0.8s ease-out;
+        transition: 0.8s ease-out;
         transition-property: background, transform;
         cursor: pointer;
     }
@@ -421,7 +421,7 @@ ul {
     }
 
     .quote__text {
-        transition: none 0.5s ease-out;
+        transition: 0.5s ease-out;
         transition-property: background, box-shadow;
         font-family: var(--font-ss3);
         font-style: normal;

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -192,7 +192,7 @@
                 padding: 6px 10px 3px;
                 margin: 3px 0;
                 border-radius: 5px;
-                transition: none 0.3s ease;
+                transition: 0.3s ease;
                 transition-property: background-color, color;
                 color: var(--color-integrations-category-text);
 
@@ -266,7 +266,7 @@
                     var(--color-integrations-light-blue-border);
                 border-bottom: 1px solid
                     var(--color-integrations-light-blue-border);
-                transition: none 0.3s ease;
+                transition: 0.3s ease;
                 transition-property: background-color, color;
                 font-size: 0.9em;
 
@@ -323,7 +323,7 @@
         border: 1px solid var(--color-integrations-light-blue-border);
         color: var(--color-integrations-category-text);
         text-align: center;
-        transition: none 0.3s ease;
+        transition: 0.3s ease;
         transition-property: border-color;
 
         &:hover {
@@ -514,7 +514,7 @@
                     width: 165px;
                     text-align: center;
                     border-radius: 5px;
-                    transition: none 0.3s ease;
+                    transition: 0.3s ease;
                     transition-property: background-color, color;
                     background-color: var(
                         --color-integrations-light-blue-border

--- a/web/styles/portico/navbar.css
+++ b/web/styles/portico/navbar.css
@@ -194,7 +194,7 @@ details summary::-webkit-details-marker {
     opacity: 0;
     height: 0;
     width: 100%;
-    transition: none 0.05s;
+    transition: 0.05s;
     transition-property:
         height, opacity; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
 }
@@ -240,7 +240,7 @@ details summary::-webkit-details-marker {
     gap: 16px;
     opacity: 0;
     visibility: hidden;
-    transition: none 0.2s;
+    transition: 0.2s;
     transition-property: opacity, visibility;
 }
 
@@ -506,7 +506,7 @@ details summary::-webkit-details-marker {
     position: sticky;
     top: 0;
     z-index: 1;
-    transition: none 0.3s;
+    transition: 0.3s;
     transition-property: background, backdrop-filter;
     height: 60px;
     overflow: hidden;

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -831,7 +831,7 @@ input.new-organization-button {
         padding: 2px 7px 1px 8px;
         font-weight: 600;
         font-size: 16px;
-        transition: none 0.2s ease-in;
+        transition: 0.2s ease-in;
         transition-property: background-color, color;
         border-radius: 4px;
 
@@ -1098,7 +1098,7 @@ input.new-organization-button {
             right: calc(100% - 40px);
             fill: hsl(0deg 0% 100%);
             z-index: 2;
-            transition: none 0.3s ease;
+            transition: 0.3s ease;
             transition-property:
                 right, top; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
             cursor: pointer;

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -424,7 +424,7 @@ html {
         border: none;
         border-radius: 4px;
 
-        transition: none 0.3s ease;
+        transition: 0.3s ease;
         transition-property: background-color, outline;
 
         &:hover {
@@ -568,7 +568,7 @@ html {
 
             margin-top: 1px;
 
-            transition: none 0.3s ease;
+            transition: 0.3s ease;
             transition-property:
                 color, font-size, font-weight, transform; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
         }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1844,7 +1844,7 @@ label.preferences-radio-choice-label {
                 color: hsl(0deg 0% 67%);
                 padding: 2px 10px;
                 cursor: pointer;
-                transition: none 0.3s ease;
+                transition: 0.3s ease;
                 transition-property: opacity, transform;
             }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -294,7 +294,7 @@ h4.user_group_setting_subsection_title {
 
     cursor: pointer;
 
-    transition: none 0.3s ease;
+    transition: 0.3s ease;
     transition-property: opacity, transform;
 }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -218,20 +218,21 @@ button {
         padding: 4px;
         padding-left: 14px;
         padding-right: 14px;
-        transition-property: background-color, border-color, color;
 
         &:hover,
         &:focus {
             outline: 0;
             border-color: hsl(156deg 30% 50%);
-            transition: none 0.2s ease;
+            transition: 0.2s ease;
+            transition-property: background-color, border-color, color;
         }
 
         &:active {
             border-color: hsl(156deg 30% 40%);
             color: hsl(156deg 44% 43%);
             background-color: hsl(154deg 33% 96%);
-            transition: none 0.2s ease;
+            transition: 0.2s ease;
+            transition-property: background-color, border-color, color;
         }
     }
 }


### PR DESCRIPTION
https://github.com/kristerkari/stylelint-high-performance-animation/issues/216 was fixed upstream.

- Followup to #32109