### PR TITLE
search: Scale search icon in header on short screens.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -111,7 +111,7 @@
 
         @media (height < $short_navbar_cutoff_height) {
             #searchbox-input-container .search_icon {
-                font-size: 18px;
+                font-size: 1.125em; /* 18px at 16px/em */
             }
         }
     }


### PR DESCRIPTION
I chose 16px instead of 14px as the base size because it looks better to me like that, and also I think I was working on the search bar redesign at 16px so it was probably designed that way.

---

at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 16 46 17](https://github.com/user-attachments/assets/6bfe1376-e989-4c0e-bad4-bd9e4bbde164) | ![Screen Shot 2025-03-04 at 16 44 31](https://github.com/user-attachments/assets/172d8264-5b40-4b23-ae4b-38dd225d9e47) |
| ![Screen Shot 2025-03-04 at 16 46 26](https://github.com/user-attachments/assets/e10a3297-75ed-4d25-a082-c1a1dc3cb327) | ![Screen Shot 2025-03-04 at 16 44 13](https://github.com/user-attachments/assets/95f0b2f4-49dd-4a95-930e-5630958e2c5d) |
| ![Screen Shot 2025-03-04 at 16 46 38](https://github.com/user-attachments/assets/827f164e-2fa5-4c62-a669-42707bc5e147) | ![Screen Shot 2025-03-04 at 16 43 54](https://github.com/user-attachments/assets/b745a792-bdb9-446e-98a5-6b0f56b6f85b) |
| ![Screen Shot 2025-03-04 at 16 46 50](https://github.com/user-attachments/assets/d14edfc5-a018-45e6-b785-93745824a142) | ![Screen Shot 2025-03-04 at 16 43 34](https://github.com/user-attachments/assets/974dc579-0211-4c25-9ddd-c68a32036648) |