### PR TITLE
subscriptions: Remove stale reference to #subscriptions.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -276,12 +276,6 @@ h4.user_group_setting_subsection_title {
     margin: 0;
 }
 
-#subscriptions h1 {
-    font-size: 25px;
-    font-weight: 300;
-    padding-top: 40px;
-}
-
 .subscriptions-container .subscriptions-header .fa-chevron-left,
 .user-groups-container .user-groups-header .fa-chevron-left {
     position: relative;


### PR DESCRIPTION
There are no other CSS rules with this id name and also no grep results for "subscriptions" that have it as an html id, so it seems pretty safe to say this id is no longer being used.

This PR has no visual changes, and is just part of an effort to remove pixel font-size declarations in the codebase.