### PR TITLE
help: Split out call provider config into separate page.

### DIFF
--- a/help/configure-call-provider.md
+++ b/help/configure-call-provider.md
@@ -1,0 +1,57 @@
+# Configure call provider
+
+{!admin-only.md!}
+
+By default, Zulip integrates with
+[Jitsi Meet](https://jitsi.org/jitsi-meet/), a fully-encrypted, 100% open
+source video conferencing solution. Organization administrators can also
+change the organization's call provider. The call providers
+supported by Zulip are:
+
+* [Jitsi Meet](/integrations/doc/jitsi)
+* [Zoom integration](/integrations/doc/zoom)
+* [BigBlueButton integration](/integrations/doc/big-blue-button)
+
+!!! tip ""
+
+    You can disable the video and voice call buttons for your organization
+    by setting the **call provider** to "None".
+
+## Configure your organization's call provider
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Compose settings**, select the desired provider from the
+   **Call provider** dropdown.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Use a self-hosted instance of Jitsi Meet
+
+Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
+as its default call provider. You can also use a self-hosted
+instance of Jitsi Meet.
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Compose settings**, select **Custom URL** from the
+   **Jitsi server URL** dropdown.
+
+1. Enter the URL of your self-hosted Jitsi Meet server.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Related articles
+
+* [Start a call](/help/start-a-call)
+* [Jitsi Meet integration](/integrations/doc/jitsi)
+* [Zoom integration](/integrations/doc/zoom)
+* [BigBlueButton integration](/integrations/doc/big-blue-button)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -244,6 +244,7 @@
 ## Organization settings
 * [Configure organization language](/help/configure-organization-language)
 * [Custom emoji](/help/custom-emoji)
+* [Configure call provider](/help/configure-call-provider)
 * [Add a custom linkifier](/help/add-a-custom-linkifier)
 * [Require topics in channel messages](/help/require-topics)
 * [Disable message edit history](/help/disable-message-edit-history)

--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -2,7 +2,8 @@
 
 Zulip makes it convenient to add a video or voice call link to any message,
 using the call provider (Jitsi, Zoom, etc.)
-[configured](#change-your-call-provider) by your organization's administrators.
+[configured](/help/configure-call-provider) by your organization's
+administrators.
 
 ## Start a video call
 
@@ -77,57 +78,6 @@ using the call provider (Jitsi, Zoom, etc.)
 
 {end_tabs}
 
-## Change your call provider
-
-{!admin-only.md!}
-
-By default, Zulip integrates with
-[Jitsi Meet](https://jitsi.org/jitsi-meet/), a fully-encrypted, 100% open
-source video conferencing solution. Organization administrators can also
-change the organization's call provider. The call providers
-supported by Zulip are:
-
-* [Jitsi Meet](/integrations/doc/jitsi)
-* [Zoom integration](/integrations/doc/zoom)
-* [BigBlueButton integration](/integrations/doc/big-blue-button)
-
-!!! tip ""
-
-    You can disable the video and voice call buttons for your organization
-    by setting the **call provider** to "None".
-
-### Change your organization's call provider
-
-{start_tabs}
-
-{settings_tab|organization-settings}
-
-1. Under **Compose settings**, select the desired provider from the
-   **Call provider** dropdown.
-
-{!save-changes.md!}
-
-{end_tabs}
-
-### Use a self-hosted instance of Jitsi Meet
-
-Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
-as its default call provider. You can also use a self-hosted
-instance of Jitsi Meet.
-
-{start_tabs}
-
-{settings_tab|organization-settings}
-
-1. Under **Compose settings**, select **Custom URL** from the
-   **Jitsi server URL** dropdown.
-
-1. Enter the URL of your self-hosted Jitsi Meet server.
-
-{!save-changes.md!}
-
-{end_tabs}
-
 ## Unlink your Zoom account from Zulip
 
 If you linked your Zoom account to Zulip, and no longer want it to be connected,
@@ -149,7 +99,8 @@ you can unlink it.
 
 ## Related articles
 
+* [Configure call provider](/help/configure-call-provider)
 * [Jitsi Meet integration](/integrations/doc/jitsi)
-* [Zoom integration integration](/integrations/doc/zoom)
+* [Zoom integration](/integrations/doc/zoom)
 * [BigBlueButton integration](/integrations/doc/big-blue-button)
 * [Insert a link](/help/insert-a-link)

--- a/templates/corporate/comparison_table_integrated.html
+++ b/templates/corporate/comparison_table_integrated.html
@@ -162,7 +162,7 @@
             <tr>
                 <td class="comparison-table-feature">
                     <a href="/help/start-a-call">Voice and video calls (1:1)</a>
-                    <div class="comparison-table-feature-desc">Choose a call provider (Zoom, Jitsi, etc.)</div>
+                    <div class="comparison-table-feature-desc"><a href="/help/configure-call-provider">Choose a call provider</a> (Zoom, Jitsi, etc.)</div>
                 </td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-infinity"></i></td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-infinity"></i></td>
@@ -176,7 +176,7 @@
             <tr>
                 <td class="comparison-table-feature">
                     <a href="/help/start-a-call">Voice and video calls (group)</a>
-                    <div class="comparison-table-feature-desc">Choose a call provider (Zoom, Jitsi, etc.)</div>
+                    <div class="comparison-table-feature-desc"><a href="/help/configure-call-provider">Choose a call provider</a> (Zoom, Jitsi, etc.)</div>
                 </td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-infinity"></i></td>
                 <td class="comparison-value-positive cloud-cell"><i class="icon icon-infinity"></i></td>
@@ -511,7 +511,7 @@
             </tr>
             <tr>
                 <td class="comparison-table-feature">
-                    <a href="/help/start-a-call#change-your-video-call-provider">
+                    <a href="/help/configure-call-provider">
                         Configurable call provider
                     </a>
                     <div class="comparison-table-feature-desc">Zoom, Jitsi, BigBlueButton, etc.</div>

--- a/templates/zerver/integrations/big-blue-button.md
+++ b/templates/zerver/integrations/big-blue-button.md
@@ -1,12 +1,22 @@
-# Zulip BigBlueButton integration
+# Use BigBlueButton as your call provider in Zulip
 
-Zulip supports using [BigBlueButton](https://bigbluebutton.org/) as its
-video call provider.
+You can configure BigBlueButton as the call provider for your organization.
+Users will be able to start a BigBlueButton call and invite others using the
+**add video call** (<i class="zulip-icon zulip-icon-video-call"></i>) or
+**add voice call** (<i class="zulip-icon zulip-icon-voice-call"></i>) button
+[in the compose box](/help/start-a-call).
 
 !!! warn ""
 
     **Note:** This is currently only possible on self-hosted Zulip
     installations, and you'll need a BigBlueButton server.
+
+## Configure BigBlueButton as your call provider
+
+By default, Zulip integrates with
+[Jitsi Meet](https://jitsi.org/jitsi-meet/), a fully-encrypted, 100% open
+source video conferencing solution. You can configure Zulip to use BigBlueButton
+as your call provider instead.
 
 {start_tabs}
 
@@ -22,16 +32,18 @@ video call provider.
 1. Restart the Zulip server with
    `/home/zulip/deployments/current/scripts/restart-server`.
 
-1. Select BigBlueButton as the organization's
-   [video call provider][video call provider].
+{settings_tab|organization-settings}
+
+1. Under **Compose settings**, select BigBlueButton from the **Call provider**
+   dropdown.
+
+1. Click **Save changes**.
 
 {end_tabs}
 
-You're done! Zulip's [call button](/help/start-a-call) will now create
-meetings using BigBlueButton.
-
 ### Related documentation
 
+- [How to start a call](/help/start-a-call)
+- [Jitsi Meet integration](/integrations/doc/jitsi)
+- [Zoom integration](/integrations/doc/zoom)
 * [BigBlueButton server configuration](https://docs.bigbluebutton.org/administration/customize/#other-configuration-changes)
-
-[video call provider]: /help/start-a-call#changing-your-organizations-video-call-provider

--- a/templates/zerver/integrations/jitsi.md
+++ b/templates/zerver/integrations/jitsi.md
@@ -1,33 +1,34 @@
+# Use Jitsi Meet as your call provider in Zulip
+
 By default, Zulip integrates with [Jitsi Meet](https://jitsi.org/jitsi-meet/),
-a fully-encrypted, 100% open source video conferencing solution.
+a fully-encrypted, 100% open source video conferencing solution. Users will be
+able to start a Jitsi Meet call and invite others using the **add video call**
+(<i class="zulip-icon zulip-icon-video-call"></i>) or **add voice call**
+(<i class="zulip-icon zulip-icon-voice-call"></i>) button [in the compose
+box](/help/start-a-call).
+
+## Configure a self-hosted instance of Jitsi Meet
 
 Zulip uses the [cloud version of Jitsi Meet](https://meet.jit.si/)
 as its default video call provider. You can also use a self-hosted
 instance of Jitsi Meet.
 
-### Using Jitsi Meet
+{start_tabs}
 
 {settings_tab|organization-settings}
 
-1. Under **Compose settings**, select **Jitsi Meet** from the **Call provider**
-   dropdown.
+1. Under **Compose settings**, confirm **Jitsi Meet** is selected in the
+   **Call provider** dropdown.
 
-1. _(optional)_ Select **Custom URL** from the **Jitsi server URL** dropdown,
-   and enter the URL of your self-hosted Jitsi Meet server. You can also set
-   `JITSI_SERVER_URL` in `/etc/zulip/settings.py` to specify the server's URL.
+1. Select **Custom URL** from the **Jitsi server URL** dropdown, and enter
+   the URL of your self-hosted Jitsi Meet server.
 
-1. Click **Save changes**, and use <kbd>Esc</kbd> to exit the settings.
+1. Click **Save changes**.
 
-1. [Open the compose box](/help/open-the-compose-box), and click the
-   **video camera** (<i class="fa fa-video-camera"></i>) icon to insert
-   a video call link, or the **phone** (<i class="fa fa-phone"></i>) icon
-   to insert an audio call link into your message.
+{end_tabs}
 
-1. Send the message, and click on the link in the message to start or join
-   the call.
+## Related documentation
 
-!!! tip ""
-
-    You can replace the call link label with any text you like.
-
-[jitsi-server-url]: /help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet
+- [How to start a call](/help/start-a-call)
+- [Zoom integration](/integrations/doc/zoom)
+- [BigBlueButton integration](/integrations/doc/big-blue-button)

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -76,7 +76,7 @@
                 <div class="input-group">
                     <label for="id_realm_video_chat_provider" class="settings-field-label">
                         {{t 'Call provider' }}
-                        {{> ../help_link_widget link="/help/start-a-call" }}
+                        {{> ../help_link_widget link="/help/configure-call-provider" }}
                     </label>
                     <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
                         {{#each realm_available_video_chat_providers}}
@@ -88,7 +88,7 @@
                         <div>
                             <label for="id_realm_jitsi_server_url" class="settings-field-label">
                                 {{t "Jitsi server URL" }}
-                                {{> ../help_link_widget link="/help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet" }}
+                                {{> ../help_link_widget link="/help/configure-call-provider#use-a-self-hosted-instance-of-jitsi-meet" }}
                             </label>
                             <select name="realm_jitsi_server_url" id="id_realm_jitsi_server_url" class="setting-widget prop-element settings_select bootstrap-focus-style" data-setting-widget-type="jitsi-server-url-setting">
                                 {{#if server_jitsi_server_url}}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1020,9 +1020,10 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent to a user's clients when the user completes the
-                                OAuth flow for the [Zoom integration](/help/start-a-call). Clients need
-                                to know whether initiating Zoom OAuth is required before creating a Zoom call.
+                                Event sent to a user's clients when the user completes the OAuth flow
+                                for the [Zoom integration](/help/configure-call-provider). Clients need
+                                to know whether initiating Zoom OAuth is required before creating a Zoom
+                                call.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -5269,7 +5270,7 @@ paths:
                                     video_chat_provider:
                                       type: integer
                                       description: |
-                                        The configured [video call provider](/help/start-a-call) for the
+                                        The configured [video call provider](/help/configure-call-provider) for the
                                         organization.
 
                                         - 0 = None
@@ -16190,9 +16191,10 @@ paths:
                         description: |
                           Present if `video_calls` is present in `fetch_event_types`.
 
-                          A boolean which signifies whether the user has a zoom token and has thus completed
-                          OAuth flow for the [Zoom integration](/help/start-a-call). Clients need
-                          to know whether initiating Zoom OAuth is required before creating a Zoom call.
+                          A boolean which signifies whether the user has a Zoom token and has thus
+                          completed OAuth flow for the [Zoom integration](/help/configure-call-provider).
+                          Clients need to know whether initiating Zoom OAuth is required before
+                          creating a Zoom call.
                       giphy_api_key:
                         type: string
                         description: |
@@ -17455,7 +17457,7 @@ paths:
                       realm_video_chat_provider:
                         type: integer
                         description: |
-                          The configured [video call provider](/help/start-a-call) for the
+                          The configured [video call provider](/help/configure-call-provider) for the
                           organization.
 
                           - 0 = None
@@ -17779,13 +17781,12 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          Dictionary where each entry describes a supported
-                          [video call provider](/help/start-a-call)
-                          that is configured on this server and could be selected by an
-                          organization administrator.
+                          Dictionary where each entry describes a supported [video call
+                          provider](/help/configure-call-provider) that is configured on this
+                          server and could be selected by an organization administrator.
 
-                          Useful for administrative settings UI that allows changing the
-                          realm setting `video_chat_provider`.
+                          Useful for administrative settings UI that allows changing the realm
+                          setting `video_chat_provider`.
                         additionalProperties:
                           description: |
                             `{provider_name}`: Dictionary containing the details of the


### PR DESCRIPTION
@laurynmm Could you please finish this transition? I think we need to review these links, and update as needed. For configuring links, linking to the overall page rather than a subsection seems mostly fine, now that it just has a brief intro.

```
templates/zerver/integrations/big-blue-button.md:You're done! Zulip's [call button](/help/start-a-call) will now create
templates/zerver/integrations/big-blue-button.md:[video call provider]: /help/start-a-call#changing-your-organizations-video-call-provider
templates/zerver/integrations/jitsi.md:[jitsi-server-url]: /help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet
templates/zerver/integrations/zoom.md:box](/help/start-a-call).
templates/zerver/integrations/zoom.md:- [How to start a call](/help/start-a-call)
web/templates/settings/organization_settings_admin.hbs:                        {{> ../help_link_widget link="/help/start-a-call" }}
web/templates/settings/organization_settings_admin.hbs:                                {{> ../help_link_widget link="/help/start-a-call#configure-a-self-hosted-instance-of-jitsi-meet" }}
zerver/openapi/zulip.yaml:                                OAuth flow for the [Zoom integration](/help/start-a-call). Clients need
zerver/openapi/zulip.yaml:                                        The configured [video call provider](/help/start-a-call) for the
zerver/openapi/zulip.yaml:                          OAuth flow for the [Zoom integration](/help/start-a-call). Clients need
zerver/openapi/zulip.yaml:                          The configured [video call provider](/help/start-a-call) for the
zerver/openapi/zulip.yaml:                          [video call provider](/help/start-a-call)

```

On the /features page, let's try:
```
                <td class="comparison-table-feature">
                    <a href="/help/start-a-call">Voice and video calls (1:1)</a>
                    <div class="comparison-table-feature-desc"><a href="/help/configure-call-provider">Choose a call provider</a> (Zoom, Jitsi, etc.)</div>
                </td>
```

I think I changed the `docs/production/video-calls.md` links as needed, and other /help/ and /for/X links look good as they are.


Current:  https://zulip.com/help/start-a-call
<details>
<summary>
separate admin page
</summary>

![Screenshot 2025-03-04 at 16 57 13](https://github.com/user-attachments/assets/43986f6b-c4eb-4cdd-9215-67fe76b2eeab)

</details>