### PR TITLE
widget: Center error message and scale with font size.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -250,7 +250,9 @@ input {
 
 .widget-error {
     color: hsl(1deg 45% 50%);
-    font-size: 12px;
+    font-size: 0.8571em; /* 12px at 14px/em */
+    display: flex;
+    align-items: center;
 }
 
 .poll-question-check,


### PR DESCRIPTION
at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-04 at 17 04 27](https://github.com/user-attachments/assets/037e461c-ee28-421f-a36f-87e213ba1759) | ![Screen Shot 2025-03-04 at 17 02 59](https://github.com/user-attachments/assets/4254f02b-40e1-48e2-8b5e-fe6e3ebe19c2) |
| ![Screen Shot 2025-03-04 at 17 04 16](https://github.com/user-attachments/assets/a0106c2a-345d-4b3c-b30d-45d6eef2e286) | ![Screen Shot 2025-03-04 at 17 03 20](https://github.com/user-attachments/assets/116894d5-43aa-4829-9767-b388eac1394c) |
| ![Screen Shot 2025-03-04 at 17 04 08](https://github.com/user-attachments/assets/dfaa69a1-c717-4f33-8c4d-1f631abb6fc8) | ![Screen Shot 2025-03-04 at 17 03 31](https://github.com/user-attachments/assets/82a72e2c-2739-4321-bbff-2f5c3f04a892) |
| ![Screen Shot 2025-03-04 at 17 03 57](https://github.com/user-attachments/assets/8cee00dc-3133-497e-98b8-0c2168e9ceb5) | ![Screen Shot 2025-03-04 at 17 03 41](https://github.com/user-attachments/assets/c07fd573-9723-4aba-8ce9-0046b7832733) |