### PR TITLE
user_groups: Add banner to make it clear when a group is deactivated.

### DIFF
--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -503,8 +503,18 @@ export function update_group_details(group: UserGroup): void {
     $edit_container.find(".group-description").text(group.description);
 }
 
-function update_toggler_for_group_setting(): void {
-    toggler.goto(select_tab);
+function update_toggler_for_group_setting(group: UserGroup): void {
+    if (!group.deactivated) {
+        toggler.enable_tab("permissions");
+        toggler.goto(select_tab);
+    } else {
+        if (select_tab === "permissions") {
+            toggler.goto("general");
+        } else {
+            toggler.goto(select_tab);
+        }
+        toggler.disable_tab("permissions");
+    }
 }
 
 function get_membership_status_context(group: UserGroup): {
@@ -989,7 +999,7 @@ export function show_settings_for(group: UserGroup): void {
     });
 
     scroll_util.get_content_element($("#user_group_settings")).html(html);
-    update_toggler_for_group_setting();
+    update_toggler_for_group_setting(group);
 
     toggler.get().prependTo("#user_group_settings .tab-container");
     const $edit_container = get_edit_container(group);
@@ -1895,7 +1905,7 @@ export function initialize(): void {
 
                         $("#dialog_error .permissions-button").on("click", () => {
                             select_tab = "permissions";
-                            update_toggler_for_group_setting();
+                            update_toggler_for_group_setting(user_group);
                             dialog_widget.close();
                         });
                     } else {

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -6,6 +6,7 @@ import {z} from "zod";
 
 import render_confirm_delete_user from "../templates/confirm_dialog/confirm_delete_user.hbs";
 import render_confirm_join_group_direct_member from "../templates/confirm_dialog/confirm_join_group_direct_member.hbs";
+import render_modal_banner from "../templates/modal_banner/modal_banner.hbs";
 import render_group_info_banner from "../templates/modal_banner/user_group_info_banner.hbs";
 import render_settings_checkbox from "../templates/settings/settings_checkbox.hbs";
 import render_browse_user_groups_list_item from "../templates/user_group_settings/browse_user_groups_list_item.hbs";
@@ -1008,6 +1009,20 @@ export function show_settings_for(group: UserGroup): void {
     $edit_container.show();
     show_membership_settings(group);
     show_general_settings(group);
+
+    const context = {
+        banner_type: compose_banner.WARNING,
+        classname: "group_deactivated",
+        hide_close_button: true,
+        banner_text: $t({
+            defaultMessage:
+                "This group is deactivated. It can't be mentioned or used for any permissions.",
+        }),
+    };
+
+    if (group.deactivated) {
+        $("#user_group_settings .group-banner").html(render_modal_banner(context));
+    }
 
     $edit_container
         .find(".group-assigned-permissions")

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -561,6 +561,10 @@ h4.user_group_setting_subsection_title {
             margin: 0 auto 10px;
         }
 
+        .main-view-banner.group_deactivated {
+            margin-bottom: 10px;
+        }
+
         .display-type {
             height: var(--settings-overlay-subheader-height);
             display: flex;

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -19,6 +19,7 @@
     <div class="inner-box">
 
         <div class="group_general_settings group_setting_section" data-group-section="general">
+            <div class="group-banner"></div>
             <div class="group-header">
                 <div class="group-name-wrapper">
                     <span class="group-name" title="{{group.name}}">{{group.name}}


### PR DESCRIPTION
This PR adds a banner to make it super clear when a group is deactivated. Banner details:
- Color: yellow
- Text: This group is deactivated. It can't be mentioned or used for any permissions.

this also disables the 'Permissions' tab for the deactivated groups.

fixes: #33803.


**Screenshots and screen captures:**

| Dark Theme | Light Theme |
| --- | --- |
| ![Dark Theme](https://github.com/user-attachments/assets/2cef88fc-1cef-4fcd-a7ea-d03bffb20212) | ![After Image](https://github.com/user-attachments/assets/dd6b07fa-6e83-4f8f-90e2-eeced7778727) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
