### PR TITLE
input_pill: Don't wrap words mid-word unless they're wider than input.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -178,7 +178,7 @@
         padding: 0 4px;
 
         min-width: 2px;
-        word-break: break-all;
+        overflow-wrap: anywhere;
 
         outline: none;
 


### PR DESCRIPTION
Previously we had things like this:

<img width="589" alt="image" src="https://github.com/user-attachments/assets/60123ca8-af3a-4340-afb0-10a00cd1bb7a" />

which now look like this:

<img width="589" alt="image" src="https://github.com/user-attachments/assets/2c38ebbc-8638-49a8-82f9-6ad10f813f7a" />

Note that this applies to all input fields, and words wrap when they're too long for the input field.

<img width="590" alt="image" src="https://github.com/user-attachments/assets/a1738fbf-b3e3-4e9a-8d48-7757fc0196a9" />
