### PR TITLE
styles: Remove stale CSS for spectator login divider.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -498,12 +498,6 @@ body.has-overlay-scrollbar {
                 );
             }
         }
-
-        .divider {
-            color: hsl(0deg 0% 88%);
-            font-size: 20px;
-            line-height: 1;
-        }
     }
 
     .spectator_narrow_login_button {


### PR DESCRIPTION
The divider was removed in b53836d.
