### PR TITLE
move_topic_modal: Add unsubscribed participants warning banner.

### DIFF
--- a/web/src/buddy_data.ts
+++ b/web/src/buddy_data.ts
@@ -465,7 +465,7 @@ function get_filtered_user_id_list(
     const user_ids_set = new Set([...base_user_id_list, ...conversation_participants]);
     return filter_user_ids(user_filter_text, [...user_ids_set]);
 }
-
+// get participants of the current viewed conversation.
 export function get_conversation_participants_callback(): () => Set<number> {
     return () => {
         if (

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -628,7 +628,7 @@ export function update_messages(events: UpdateMessageEvent[]): void {
 
             // Remove the stream_topic_entry for the old topics;
             // must be called after we call set message topic since
-            // it calls `get_messages_in_topic` which thinks that
+            // it calls `get_loaded_messages_in_topic` which thinks that
             // `topic` and `stream` of the messages are correctly set.
             const num_messages = event_messages.length;
             if (num_messages > 0) {

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -29,11 +29,11 @@ export function get_count_of_messages_in_topic_sent_after_current_message(
     topic: string,
     message_id: number,
 ): number {
-    const all_messages = get_messages_in_topic(stream_id, topic);
+    const all_messages = get_loaded_messages_in_topic(stream_id, topic);
     return all_messages.filter((msg) => msg.id >= message_id).length;
 }
 
-export function get_messages_in_topic(stream_id: number, topic: string): Message[] {
+export function get_loaded_messages_in_topic(stream_id: number, topic: string): Message[] {
     return all_messages_data
         .all_messages()
         .filter(

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -808,11 +808,11 @@ export function process_topic_edit(
     // logic behind this and important notes on use of this function.
     recent_view_data.conversations.delete(recent_view_util.get_topic_key(old_stream_id, old_topic));
 
-    const old_topic_msgs = message_util.get_messages_in_topic(old_stream_id, old_topic);
+    const old_topic_msgs = message_util.get_loaded_messages_in_topic(old_stream_id, old_topic);
     process_messages(old_topic_msgs);
 
     new_stream_id = new_stream_id || old_stream_id;
-    const new_topic_msgs = message_util.get_messages_in_topic(new_stream_id, new_topic);
+    const new_topic_msgs = message_util.get_loaded_messages_in_topic(new_stream_id, new_topic);
     process_messages(new_topic_msgs);
 }
 
@@ -834,7 +834,7 @@ export function update_topics_of_deleted_message_ids(message_ids: number[]): voi
     const msgs_to_process = [];
     for (const [stream_id, topic] of topics_to_rerender.values()) {
         recent_view_data.conversations.delete(recent_view_util.get_topic_key(stream_id, topic));
-        const msgs = message_util.get_messages_in_topic(stream_id, topic);
+        const msgs = message_util.get_loaded_messages_in_topic(stream_id, topic);
         msgs_to_process.push(...msgs);
     }
 

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -528,7 +528,7 @@ export async function build_move_topic_to_stream_popover(
             return;
         }
 
-        const locally_cached_conversation_messages = message_util.get_messages_in_topic(
+        const locally_cached_conversation_messages = message_util.get_loaded_messages_in_topic(
             current_stream_id,
             topic_name,
         );
@@ -837,7 +837,7 @@ export async function build_move_topic_to_stream_popover(
                 message_id,
             );
         }
-        return message_util.get_messages_in_topic(current_stream_id, topic_name).length;
+        return message_util.get_loaded_messages_in_topic(current_stream_id, topic_name).length;
     }
 
     function update_move_messages_count_text(selected_option: string, message_id?: number): void {

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -6,6 +6,7 @@ import {z} from "zod";
 import render_inline_decorated_channel_name from "../templates/inline_decorated_channel_name.hbs";
 import render_inline_stream_or_topic_reference from "../templates/inline_stream_or_topic_reference.hbs";
 import render_topic_already_exists_warning_banner from "../templates/modal_banner/topic_already_exists_warning_banner.hbs";
+import render_unsubscribed_participants_warning_banner from "../templates/modal_banner/unsubscribed_participants_warning_banner.hbs";
 import render_move_topic_to_stream from "../templates/move_topic_to_stream.hbs";
 import render_left_sidebar_stream_actions_popover from "../templates/popovers/left_sidebar/left_sidebar_stream_actions_popover.hbs";
 
@@ -15,6 +16,7 @@ import * as browser_history from "./browser_history.ts";
 import * as clipboard_handler from "./clipboard_handler.ts";
 import * as compose_banner from "./compose_banner.ts";
 import * as composebox_typeahead from "./composebox_typeahead.ts";
+import {ConversationParticipants} from "./conversation_participants.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import * as hash_util from "./hash_util.ts";
@@ -26,6 +28,8 @@ import * as message_util from "./message_util.ts";
 import * as message_view from "./message_view.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
+import * as peer_data from "./peer_data.ts";
+import * as people from "./people.ts";
 import * as popover_menus from "./popover_menus.ts";
 import {left_sidebar_tippy_options} from "./popover_menus.ts";
 import {web_channel_default_view_values} from "./settings_config.ts";
@@ -37,6 +41,7 @@ import * as stream_settings_components from "./stream_settings_components.ts";
 import * as stream_settings_ui from "./stream_settings_ui.ts";
 import * as stream_topic_history from "./stream_topic_history.ts";
 import * as sub_store from "./sub_store.ts";
+import * as subscriber_api from "./subscriber_api.ts";
 import * as ui_report from "./ui_report.ts";
 import * as ui_util from "./ui_util.ts";
 import * as unread from "./unread.ts";
@@ -512,6 +517,113 @@ export async function build_move_topic_to_stream_popover(
             is_disabled;
     }
 
+    let curr_selected_stream: number;
+    // Warn if any of current topic participants are NOT subscribed
+    // to the destination stream.
+    async function warn_unsubscribed_participants(destination_stream_id: number): Promise<void> {
+        $("#move_topic_modal .unsubscribed-participants-warning").remove();
+
+        // Do nothing if it's the same stream.
+        if (destination_stream_id === current_stream_id) {
+            return;
+        }
+
+        const locally_cached_conversation_messages = message_util.get_messages_in_topic(
+            current_stream_id,
+            topic_name,
+        );
+
+        const active_human_participant_ids = new ConversationParticipants(
+            locally_cached_conversation_messages,
+        ).visible();
+
+        const unsubscribed_participant_ids: number[] = [];
+        for (const user_id of active_human_participant_ids) {
+            const is_subscribed = await peer_data.maybe_fetch_is_user_subscribed(
+                destination_stream_id,
+                user_id,
+                false,
+            );
+            if (!is_subscribed) {
+                unsubscribed_participant_ids.push(user_id);
+            }
+        }
+
+        if (destination_stream_id !== curr_selected_stream) {
+            // If user selects another stream after the above await finishes
+            // but before the function finishes, we should NOT show
+            // the banner, as it would belong to the previously selected stream.
+            return;
+        }
+
+        const unsubscribed_participants_count = unsubscribed_participant_ids.length;
+
+        if (unsubscribed_participants_count === 0) {
+            // This is true in the following cases, for all of which we do nothing :
+            // 1- Conversation (topic) has no participants.
+            // 2- All participants are subscribed to the destination stream.
+            return;
+        }
+
+        const participant_names = unsubscribed_participant_ids.map(
+            (user_id) => people.get_user_by_id_assert_valid(user_id).full_name,
+        );
+        const unsubscribed_participant_formatted_names_list =
+            util.format_array_as_list_with_highlighted_elements(
+                participant_names,
+                "long",
+                "conjunction",
+            );
+
+        const destination_stream = stream_data.get_sub_by_id(destination_stream_id)!;
+        const can_subscribe_other_users = stream_data.can_subscribe_others(destination_stream);
+        const few_unsubscribed_participants = unsubscribed_participants_count <= 5;
+
+        const context = {
+            banner_type: compose_banner.WARNING,
+            classname: "unsubscribed-participants-warning",
+            button_text: can_subscribe_other_users
+                ? few_unsubscribed_participants
+                    ? $t({defaultMessage: "Subscribe them"})
+                    : $t({defaultMessage: "Subscribe all of them"})
+                : null,
+            hide_close_button: true,
+            stream: destination_stream,
+            unsubscribed_participant_formatted_names_list,
+            unsubscribed_participants_count,
+            few_unsubscribed_participants,
+        };
+
+        const warning_banner = render_unsubscribed_participants_warning_banner(context);
+        $("#move_topic_modal .simplebar-content").prepend($(warning_banner));
+
+        $(
+            "#move_topic_modal .unsubscribed-participants-warning .main-view-banner-action-button",
+        ).on("click", (event) => {
+            event.preventDefault();
+
+            function success(): void {
+                $(event.target).parents(".main-view-banner").remove();
+            }
+
+            function xhr_failure(xhr: JQuery.jqXHR): void {
+                $(event.target).parents(".main-view-banner").remove();
+                ui_report.error(
+                    $t_html({defaultMessage: "Failed to subscribe participants"}),
+                    xhr,
+                    $("#move_topic_modal #dialog_error"),
+                );
+            }
+
+            subscriber_api.add_user_ids_to_stream(
+                unsubscribed_participant_ids,
+                destination_stream,
+                success,
+                xhr_failure,
+            );
+        });
+    }
+
     function move_topic(): void {
         const params = get_params_from_form();
 
@@ -691,11 +803,13 @@ export async function build_move_topic_to_stream_popover(
 
     function move_topic_on_update(event: JQuery.ClickEvent, dropdown: {hide: () => void}): void {
         stream_widget_value = Number.parseInt($(event.currentTarget).attr("data-unique-id")!, 10);
+        curr_selected_stream = stream_widget_value;
 
         update_submit_button_disabled_state(stream_widget_value);
         set_stream_topic_typeahead();
         render_selected_stream();
         maybe_show_topic_already_exists_warning();
+        void warn_unsubscribed_participants(stream_widget_value);
 
         dropdown.hide();
         event.preventDefault();
@@ -862,7 +976,7 @@ export async function build_move_topic_to_stream_popover(
         });
 
         if (only_topic_edit) {
-            // Set select_stream_id to current_stream_id since we user is not allowed
+            // Set select_stream_id to current_stream_id since user is not allowed
             // to edit stream in topic-edit only UI.
             const select_stream_id = current_stream_id;
             $topic_input.on("input", () => {

--- a/web/src/stream_topic_history.ts
+++ b/web/src/stream_topic_history.ts
@@ -305,7 +305,7 @@ export function remove_messages(opts: {
 
     // Update max_message_id in topic
     if (existing_topic.message_id <= max_removed_msg_id) {
-        const msgs_in_topic = message_util.get_messages_in_topic(stream_id, topic_name);
+        const msgs_in_topic = message_util.get_loaded_messages_in_topic(stream_id, topic_name);
         let max_message_id = 0;
         for (const msg of msgs_in_topic) {
             if (msg.id > max_message_id) {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -465,8 +465,10 @@ export function format_array_as_list_with_highlighted_elements(
     const formatted_parts = list_formatter.formatToParts(array);
     return formatted_parts
         .map((part) => {
+            // There are two types of parts: elements (the actual
+            // items), and literals (commas, etc.). We need to
+            // HTML-escape the elements, but not the literals.
             if (part.type === "element") {
-                // Only highlight the values passed in array and not commas, etc.
                 return `<b>${Handlebars.Utils.escapeExpression(part.value)}</b>`;
             }
             return part.value;

--- a/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
+++ b/web/templates/modal_banner/unsubscribed_participants_warning_banner.hbs
@@ -1,0 +1,18 @@
+{{#> modal_banner . }}
+    <p class="banner_message">
+        {{#if few_unsubscribed_participants}}
+            {{#tr}}
+                Some topic participants <z-user-names></z-user-names> are not subscribed to &nbsp;<z-stream></z-stream>.
+                {{#*inline "z-user-names"}}({{{unsubscribed_participant_formatted_names_list}}}){{/inline}}
+                {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
+            {{/tr}}
+
+        {{else}}
+            {{#tr}}
+                {n_unsubscribed_participants} topic participants are not subscribed to &nbsp;<z-stream></z-stream>.
+                {{#*inline "z-stream"}}<strong>{{> ../inline_decorated_channel_name stream=stream show_colored_icon=true}}</strong>{{/inline}}
+            {{/tr}}
+        {{/if}}
+    </p>
+
+{{/modal_banner}}

--- a/web/tests/stream_topic_history.test.cjs
+++ b/web/tests/stream_topic_history.test.cjs
@@ -76,7 +76,7 @@ test("basics", () => {
     assert.deepEqual(history, ["Topic1", "topic2"]);
     assert.deepEqual(max_message_id, 104);
 
-    message_util.get_messages_in_topic = () => [{id: 101}, {id: 102}];
+    message_util.get_loaded_messages_in_topic = () => [{id: 101}, {id: 102}];
     message_util.get_max_message_id_in_stream = () => 103;
     // Removing the last msg in topic1 changes the order
     stream_topic_history.remove_messages({
@@ -91,7 +91,7 @@ test("basics", () => {
     max_message_id = stream_topic_history.get_max_message_id(stream_id);
     assert.deepEqual(max_message_id, 103);
 
-    delete message_util.get_messages_in_topic;
+    delete message_util.get_loaded_messages_in_topic;
     // Removing first topic1 message has no effect.
     stream_topic_history.remove_messages({
         stream_id,


### PR DESCRIPTION
In Move messages and Move topic modals, Show a warning banner if any of current topic participants are NOT subscribed to the destination stream.

Fixes #33627

**Screenshots and screen captures:**
## Warning when 5 or fewer users aren't subscribed:

![private_stream_banner](https://github.com/user-attachments/assets/8a12726c-16f6-4f93-bc5b-0f53b3a56997)


## Warning when more users aren't subscribed:

![many_public_stream_banner](https://github.com/user-attachments/assets/fbac0e18-0cad-4793-9cc2-ba0dc246123a)


# Testing

## Banner appears in :
1. While user is viewing the conversation (most common case).
2. User is moving a topic while viewing the conversation of **another**, this is was very important test because it makes sure that fetched participants do NOT get confused with the currently viewed conversation's participants. 
3. Recent, Inbox, Combined, Mentions and Starred views.

## Banner does NOT appear when:
1. Conversation has no participants
2. Destination channel does NOT change
3. Destination channel changes (appears) then user comes back to the same channel or any other channel that has all the participants subscribed to (disappears) 
4. User subscribes the participants via the banner button.
5. All conversation participants are subscribed to the destination channel.
