### PR TITLE
message_row: Remove stale CSS for zulip-icon-more-vertical.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -570,11 +570,6 @@
                 color: var(--color-message-star-action);
             }
         }
-
-        .zulip-icon-more-vertical {
-            /* Increase visual prominence of the vdots. */
-            font-size: 21px;
-        }
     }
 
     /* Tooltips should not follow the width restrictions of their parent element. */


### PR DESCRIPTION
This was introduced in 5d293c82cdab77308d296 but shortly after 60aa58dfb99a9aa4fa renamed the use of zulip-icon-more-vertical to zulip-icon-more-vertical-spread, so the CSS classname is no longer being used there.

See also, the TODO from 60aa58d:


> TODO: If this alternate version moves forward, there are still styles
> in this PR referring to the other vdots version. So be sure to clean
> those up.