### PR TITLE
message_edit: Fix broken preview

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -70,6 +70,7 @@ export function render_preview_area() {
     const content = $compose_textarea.val();
     const $preview_message_area = $("#compose .preview_message_area");
     compose_ui.render_and_show_preview(
+        $("#compose"),
         $("#compose .markdown_preview_spinner"),
         $("#compose .preview_content"),
         content,

--- a/web/src/compose_ui.ts
+++ b/web/src/compose_ui.ts
@@ -1307,6 +1307,7 @@ export function show_compose_spinner(): void {
 }
 
 export function render_and_show_preview(
+    $preview_container: JQuery,
     $preview_spinner: JQuery,
     $preview_content_box: JQuery,
     content: string,
@@ -1356,7 +1357,7 @@ export function render_and_show_preview(
             success(response_data) {
                 if (
                     preview_render_count !== compose_state.get_preview_render_count() ||
-                    !$("#compose").hasClass("preview_mode")
+                    !$preview_container.hasClass("preview_mode")
                 ) {
                     // The user is no longer in preview mode or the compose
                     // input has already been updated with new raw Markdown

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1716,6 +1716,7 @@ export function show_preview_area($element: JQuery): void {
     $row.find(".undo_markdown_preview").show();
     const $preview_message_area = $row.find(".preview_message_area");
     compose_ui.render_and_show_preview(
+        $row,
         $row.find(".markdown_preview_spinner"),
         $row.find(".preview_content"),
         content,


### PR DESCRIPTION
A recent commit added a condition in `render_and_show_preview` to skip rendering if the compose box’s preview mode wasn’t active. This broke preview mode in message editing, as it relies on the same function.

This commit fixes the issue by refactoring `render_and_show_preview` to accept an element instead of hardcoding `#compose` when checking for preview mode, and updates its usages accordingly.

[CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20preview.20broken.20in.20message.20editing)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
