### PR TITLE
user_groups: Remove fa-ban icon for deactivated group settings.

### DIFF
--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -26,6 +26,7 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .user-group-info-title").text(
             $t_html({defaultMessage: "User group settings"}),
         );
+        $("#groups_overlay .deactivated-user-group-icon-right").hide();
     },
     settings(group: UserGroup) {
         $("#groups_overlay .nothing-selected, #user-group-creation").hide();
@@ -33,6 +34,11 @@ export const show_user_group_settings_pane = {
         set_active_group_id(group.id);
         const group_name = user_groups.get_display_group_name(group.name);
         $("#groups_overlay .user-group-info-title").text(group_name);
+        if (group.deactivated) {
+            $("#groups_overlay .deactivated-user-group-icon-right").show();
+        } else {
+            $("#groups_overlay .deactivated-user-group-icon-right").hide();
+        }
     },
     create_user_group(container_name = "configure_user_group_settings", group_name?: string) {
         $(".user_group_creation").hide();
@@ -50,6 +56,7 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
         reset_active_group_id();
         $("#user-group-creation").show();
+        $("#groups_overlay .deactivated-user-group-icon-right").hide();
     },
 };
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1182,7 +1182,7 @@ export function handle_deleted_group(group_id: number): void {
     }
 
     if (is_editing_group(group_id)) {
-        open_right_panel_empty();
+        $("#groups_overlay .deactivated-user-group-icon-right").show();
     }
     redraw_user_group_list();
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -674,6 +674,11 @@ h4.user_group_setting_subsection_title {
     opacity: 0.6;
 }
 
+.deactivated-user-group-icon-right {
+    margin-left: 3px;
+    opacity: 0.6;
+}
+
 .left .group-name,
 .right .group-name {
     display: flex;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1507,12 +1507,6 @@ div.settings-radio-input-parent {
         }
     }
 
-    #groups_overlay {
-        .display-type {
-            display: none;
-        }
-    }
-
     #subscription_overlay,
     #groups_overlay {
         .user-groups-container,

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -21,11 +21,7 @@
         <div class="group_general_settings group_setting_section" data-group-section="general">
             <div class="group-header">
                 <div class="group-name-wrapper">
-                    <span class="group-name" title="{{group.name}}">{{group.name}}
-                        {{#if group.deactivated}}
-                            <i class="fa fa-ban deactivated-user-icon"></i>
-                        {{/if}}
-                    </span>
+                    <span class="group-name" title="{{group.name}}">{{group.name}}</span>
                 </div>
                 <div class="group_change_property_info alert-notification"></div>
                 <div class="button-group">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -39,6 +39,7 @@
             <div class="right">
                 <div class="display-type">
                     <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
+                    <i class="fa fa-ban deactivated-user-icon deactivated-user-group-icon-right"></i>
                 </div>
                 <div class="nothing-selected">
                     <div class="group-info-banner"></div>


### PR DESCRIPTION
prerequisite: #33812

Commit 1: Removes the ban icon from the group setting section.
Commit 2: Adds the ban icon to the top next to `#user_group_settings_title`
Commit 3: Ensures  `#user_group_settings_title` is visible for smaller widths.

| small width (active group) | small width (deactivated group) | 
|-----|-------|
|![image](https://github.com/user-attachments/assets/dd31b790-9042-4323-b704-b395e4b633d3)|![image](https://github.com/user-attachments/assets/89244902-8d78-451e-bde6-8bf32b2b32b2)|



