### PR TITLE
message_editing: Make bouncing "..." open edit history modal on click.

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -126,7 +126,11 @@ export function initialize(): void {
         }
 
         // UI elements for triggering message editing or viewing edit history.
-        if ($target.is("i.edit_message_button") || $target.is(".message_edit_notice")) {
+        if (
+            $target.is("i.edit_message_button") ||
+            $target.is(".message_edit_notice") ||
+            $target.is(".edit-notifications")
+        ) {
             return true;
         }
 

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -294,7 +294,7 @@ export function handle_keyboard_events(event_key: string): void {
 }
 
 export function initialize(): void {
-    $("body").on("mouseenter", ".message_edit_notice", (e) => {
+    $("body").on("mouseenter", ".message_edit_notice, .edit-notifications", (e) => {
         if (
             realm.realm_message_edit_history_visibility_policy !==
             message_edit_history_visibility_policy_values.never.code
@@ -303,7 +303,7 @@ export function initialize(): void {
         }
     });
 
-    $("body").on("mouseleave", ".message_edit_notice", (e) => {
+    $("body").on("mouseleave", ".message_edit_notice, .edit-notifications", (e) => {
         if (
             realm.realm_message_edit_history_visibility_policy !==
             message_edit_history_visibility_policy_values.never.code
@@ -312,30 +312,34 @@ export function initialize(): void {
         }
     });
 
-    $("body").on("click", ".message_edit_notice", function (this: HTMLElement, e) {
-        e.stopPropagation();
-        e.preventDefault();
+    $("body").on(
+        "click",
+        ".message_edit_notice, .edit-notifications",
+        function (this: HTMLElement, e) {
+            e.stopPropagation();
+            e.preventDefault();
 
-        const message_id = rows.id($(this).closest(".message_row"));
-        assert(message_lists.current !== undefined);
-        const $row = message_lists.current.get_row(message_id);
-        const row_id = rows.id($row);
-        const message = message_lists.current.get(row_id);
-        assert(message !== undefined);
+            const message_id = rows.id($(this).closest(".message_row"));
+            assert(message_lists.current !== undefined);
+            const $row = message_lists.current.get_row(message_id);
+            const row_id = rows.id($row);
+            const message = message_lists.current.get(row_id);
+            assert(message !== undefined);
 
-        if (page_params.is_spectator) {
-            spectators.login_to_access();
-            return;
-        }
+            if (page_params.is_spectator) {
+                spectators.login_to_access();
+                return;
+            }
 
-        if (
-            realm.realm_message_edit_history_visibility_policy !==
-            message_edit_history_visibility_policy_values.never.code
-        ) {
-            fetch_and_render_message_history(message);
-            $("#message-history-overlay .exit-sign").trigger("focus");
-        }
-    });
+            if (
+                realm.realm_message_edit_history_visibility_policy !==
+                message_edit_history_visibility_policy_values.never.code
+            ) {
+                fetch_and_render_message_history(message);
+                $("#message-history-overlay .exit-sign").trigger("focus");
+            }
+        },
+    );
 
     $("body").on(
         "focus",


### PR DESCRIPTION
Previously, clicking on the bouncing "..." (indicating an ongoing edit) did not open the edit history modal, even when the message had prior edits. This made it difficult for users to view the edit history while an edit was in progress.

This commit updates the behavior so that if a message has an edit history, clicking on the bouncing "..." will open the edit history modal, just as clicking on the "EDITED" notice does. If no prior edits exist, the indicator doesn't show any tooltip.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|Without previous edits|With previous edits|
|---------------------------------|----------------------------|
|![image](https://github.com/user-attachments/assets/249350f6-b92c-41fc-b397-58562f50ccd0)|![image](https://github.com/user-attachments/assets/7b727578-268c-474a-be8b-be655a471f52)|
|![Screencast_20250305_114940-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f4db4dd8-1fe5-48c4-8376-83bbe5f20927)|![Screencast_20250305_114327-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c31ccc3e-de70-4636-91f3-f373a561b129)|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
