### PR TITLE
css: Add more space next to privacy icon in dropdowns.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2198,7 +2198,7 @@ body:not(.hide-left-sidebar) {
         font-size: 0.93em;
         width: 0.93em;
         height: 0.93em;
-        padding-right: 2px;
+        padding-right: 5px;
     }
 
     .zulip-icon {


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![Screenshot 2025-03-05 120554](https://github.com/user-attachments/assets/bc73b23d-955e-490f-bb1c-0ec183f57c69) | ![Screenshot 2025-03-05 120455](https://github.com/user-attachments/assets/c370e52c-c111-4fd1-a541-f9a5860bc218) |