### PR TITLE
popup_banners: Redesign connection error banner.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -180,14 +180,7 @@
     <source class="notification-sound-source-mp3" type="audio/mpeg" />
 </audio>
 
-<div class="alert-box">
-    <div class="alert alert_sidebar alert-error home-error-bar" id="connection-error">
-        <div class="exit"></div>
-        <strong class="message">{{ _('Unable to connect to Zulip.') }}</strong>
-        {{ _('Updates may be delayed.') }}
-        {{ _('Retrying soon…') }}
-        <a class="restart_get_events_button">{{ _('Try now.') }}</a>
-    </div>
+<div id="popup_banners_wrapper" class="banner-wrapper alert-box">
     <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
         <div class="exit"></div>
         {# The below isn't tagged for translation

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -64,6 +64,7 @@ EXEMPT_FILES = make_set(
         "web/src/bootstrap_typeahead.ts",
         "web/src/browser_history.ts",
         "web/src/buddy_list.ts",
+        "web/src/buttons.ts",
         "web/src/click_handlers.ts",
         "web/src/color_picker_popover.ts",
         "web/src/compose.js",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -182,6 +182,7 @@ EXEMPT_FILES = make_set(
         "web/src/popover_menus.ts",
         "web/src/popover_menus_data.ts",
         "web/src/popovers.ts",
+        "web/src/popup_banners.ts",
         "web/src/read_receipts.ts",
         "web/src/realm_icon.ts",
         "web/src/realm_logo.ts",

--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -1,0 +1,34 @@
+import $ from "jquery";
+
+import * as loading from "./loading.ts";
+
+export function show_button_loading_indicator($button: JQuery): void {
+    // If the button already has a loading indicator, do nothing.
+    if ($button.find(".button-loading-indicator").length > 0) {
+        return;
+    }
+    // First, we disable the button and hide its contents.
+    $button.prop("disabled", true);
+    $button.find(".zulip-icon").css("visibility", "hidden");
+    $button.find(".action-button-label").css("visibility", "hidden");
+    // Next, we create a loading indicator with a unique id.
+    // The unique id is required for the `filter` element in the loader SVG,
+    // to prevent the loading indicator from being hidden due to duplicate ids.
+    // Reference commit: 995d073dbfd8f22a2ef50c1320e3b1492fd28649
+    const loading_indicator_unique_id = `button-loading-indicator-${Date.now()}`;
+    const $button_loading_indicator = $("<span>")
+        .attr("id", loading_indicator_unique_id)
+        .addClass("button-loading-indicator");
+    $button.append($button_loading_indicator);
+    loading.make_indicator($button_loading_indicator, {
+        width: $button.width(),
+        height: $button.height(),
+    });
+}
+
+export function hide_button_loading_indicator($button: JQuery): void {
+    $button.find(".button-loading-indicator").remove();
+    $button.prop("disabled", false);
+    $button.find(".zulip-icon").css("visibility", "visible");
+    $button.find(".action-button-label").css("visibility", "visible");
+}

--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import * as banners from "./banners.ts";
 import type {Banner} from "./banners.ts";
+import * as buttons from "./buttons.ts";
 import {$t} from "./i18n.ts";
 
 const CONNECTION_ERROR_POPUP_BANNER: Banner = {
@@ -24,8 +25,18 @@ export function open_connection_error_popup_banner(opts: {
     on_retry_callback: () => void;
     is_get_events_error?: boolean;
 }): void {
-    // If the banner is already open, don't open it again.
-    if ($("#popup_banners_wrapper").find(".connection-error-banner").length > 0) {
+    // If the banner is already open, don't open it again, and instead remove
+    // the loading indicator on the retry button, if it was being shown.
+    const $banner = $("#popup_banners_wrapper").find(".connection-error-banner");
+    if ($banner.length > 0) {
+        const $retry_connection_button = $banner.find(".retry-connection");
+        if ($retry_connection_button.find(".button-loading-indicator").length > 0) {
+            // Add some delay before hiding the loading indicator, to visually
+            // indicate that the retry sequence was executed again but failed.
+            setTimeout(() => {
+                buttons.hide_button_loading_indicator($retry_connection_button);
+            }, 1000);
+        }
         return;
     }
     // Prevent the interference between the server errors from
@@ -36,10 +47,11 @@ export function open_connection_error_popup_banner(opts: {
     }
     banners.append(CONNECTION_ERROR_POPUP_BANNER, $("#popup_banners_wrapper"));
 
-    $("#popup_banners_wrapper").on("click", ".retry-connection", (e) => {
+    $("#popup_banners_wrapper").on("click", ".retry-connection", function (this: HTMLElement, e) {
         e.preventDefault();
         e.stopPropagation();
 
+        buttons.show_button_loading_indicator($(this));
         opts.on_retry_callback();
     });
 }

--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -1,0 +1,79 @@
+import $ from "jquery";
+
+import * as banners from "./banners.ts";
+import type {Banner} from "./banners.ts";
+import {$t} from "./i18n.ts";
+
+const CONNECTION_ERROR_POPUP_BANNER: Banner = {
+    intent: "danger",
+    label: $t({
+        defaultMessage: "Unable to connect to Zulip. Retrying soon…",
+    }),
+    buttons: [
+        {
+            type: "quiet",
+            label: $t({defaultMessage: "Try now"}),
+            custom_classes: "retry-connection",
+        },
+    ],
+    close_button: true,
+    custom_classes: "connection-error-banner popup-banner",
+};
+
+export function open_connection_error_popup_banner(opts: {
+    on_retry_callback: () => void;
+    is_get_events_error?: boolean;
+}): void {
+    // If the banner is already open, don't open it again.
+    if ($("#popup_banners_wrapper").find(".connection-error-banner").length > 0) {
+        return;
+    }
+    // Prevent the interference between the server errors from
+    // get_events in web/src/server_events.js and the one from
+    // load_messages in web/src/message_fetch.ts.
+    if (opts.is_get_events_error) {
+        CONNECTION_ERROR_POPUP_BANNER.custom_classes += " get-events-error";
+    }
+    banners.append(CONNECTION_ERROR_POPUP_BANNER, $("#popup_banners_wrapper"));
+
+    $("#popup_banners_wrapper").on("click", ".retry-connection", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        opts.on_retry_callback();
+    });
+}
+
+export function close_connection_error_popup_banner(check_if_get_events_error = false): void {
+    const $banner = $("#popup_banners_wrapper").find(".connection-error-banner");
+    if ($banner.length === 0) {
+        return;
+    }
+    if (check_if_get_events_error && $banner.hasClass("get-events-error")) {
+        return;
+    }
+    $banner.addClass("fade-out");
+    // The delay is the same as the animation duration for fade-out.
+    setTimeout(() => {
+        banners.close($banner);
+    }, 300);
+}
+
+export function initialize(): void {
+    $("#popup_banners_wrapper").on(
+        "click",
+        ".banner-close-action",
+        function (this: HTMLElement, e) {
+            // Override the banner close event listener in web/src/banners.ts,
+            // to add a fade-out animation when the banner is closed.
+            e.preventDefault();
+            e.stopPropagation();
+            const $banner = $(this).closest(".banner");
+            $banner.addClass("fade-out");
+            // The delay is the same as the animation duration for fade-out.
+            setTimeout(() => {
+                banners.close($banner);
+            }, 300);
+        },
+    );
+}

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -90,6 +90,7 @@ import * as pm_conversations from "./pm_conversations.ts";
 import * as pm_list from "./pm_list.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as popovers from "./popovers.ts";
+import * as popup_banners from "./popup_banners.ts";
 import * as presence from "./presence.ts";
 import * as pygments_data from "./pygments_data.ts";
 import * as realm_logo from "./realm_logo.ts";
@@ -517,6 +518,7 @@ export function initialize_everything(state_data) {
     message_viewport.initialize();
     banners.initialize();
     navbar_alerts.initialize();
+    popup_banners.initialize();
     message_list_hover.initialize();
     initialize_kitchen_sink_stuff();
     local_message.initialize(state_data.local_message);

--- a/web/styles/alerts.css
+++ b/web/styles/alerts.css
@@ -12,6 +12,9 @@
 }
 
 .alert-animations {
+    /* TODO: Remove these animations in favour of those
+       in web/styles/banners.css, once all the alert popups
+       have been converted to use the new banner component. */
     &.show {
         animation-name: fadeIn;
         animation-duration: 0.3s;

--- a/web/styles/alerts.css
+++ b/web/styles/alerts.css
@@ -32,6 +32,10 @@
     }
 }
 
+.home-error-bar {
+    display: none;
+}
+
 /* alert box component changes */
 .alert-box {
     /* We define this variable in web/styles/app_variables.css,

--- a/web/styles/alerts.css
+++ b/web/styles/alerts.css
@@ -31,18 +31,36 @@
 
 /* alert box component changes */
 .alert-box {
+    /* We define this variable in web/styles/app_variables.css,
+       but we need to redefine it here since this is shared
+       with portico.
+       TODO: Remove this once we remove the alert box component,
+       after the migration to the new banners is complete. */
+    --popup-banner-translate-y-distance: 100px;
     /* Ensure alert box remains in viewport,
       regardless of scroll position in message
       list. */
     position: fixed;
-    top: 0;
+    /* Offset to account for the top padding + 5px from the top. */
+    top: calc(5px + (-1 * var(--popup-banner-translate-y-distance)));
     left: 0;
-    width: 900px;
-    margin-left: calc(50% - 450px);
+    display: flex;
+    /* Using column-reverse flex direction enables a stack-like
+       behavior where the most recent alert is always on top. */
+    flex-direction: column-reverse;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    width: 100%;
     z-index: 220;
     max-height: 100%;
     overflow-y: auto;
     overscroll-behavior: contain;
+    /* Set top padding to account for the translate-y motion of the
+       animation to prevent the vertical scroll bar from appearing. */
+    padding-top: var(--popup-banner-translate-y-distance);
+    /* Allow click events to passthrough in any area without the alerts. */
+    pointer-events: none;
 
     .stacktrace {
         @extend .alert-display, .alert-animations;
@@ -50,7 +68,6 @@
         font-size: 1rem;
         color: hsl(0deg 80% 40%);
 
-        margin-top: 5px;
         padding: 1rem 0;
 
         background-color: hsl(0deg 100% 98%);
@@ -150,8 +167,12 @@
     .alert {
         @extend .alert-animations;
 
+        box-sizing: border-box;
+        max-width: 900px;
+        width: 100%;
         border-radius: 4px;
         background-color: hsl(0deg 0% 100%);
+        pointer-events: auto;
 
         position: relative;
 
@@ -216,7 +237,9 @@
 @keyframes fadeIn {
     0% {
         opacity: 0;
-        transform: translateY(-100px);
+        transform: translateY(
+            calc(-1 * var(--popup-banner-translate-y-distance))
+        );
     }
 
     100% {
@@ -233,16 +256,16 @@
 
     100% {
         opacity: 0;
-        transform: translateY(-100px);
+        transform: translateY(
+            calc(-1 * var(--popup-banner-translate-y-distance))
+        );
     }
 }
 
 /* @media queries */
 @media (width < $lg_min) {
-    .alert-box {
-        width: 80%;
-        left: 10%;
-        margin-left: 0;
+    .alert-box .alert {
+        max-width: 90%;
     }
 }
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -647,6 +647,9 @@
         ". . banner-label banner-label banner-close-button banner-close-button"
         ". banner-action-buttons banner-action-buttons banner-action-buttons banner-action-buttons .";
 
+    /* Popup banner related variables */
+    --popup-banner-translate-y-distance: 100px;
+
     /* Colors used across the app */
     --color-date: light-dark(hsl(0deg 0% 15% / 75%), hsl(0deg 0% 100% / 75%));
     --color-background-private-message-header: light-dark(

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -145,3 +145,55 @@
     color: var(--color-text-danger-banner);
     border-color: var(--color-border-danger-banner);
 }
+
+@keyframes popup-banner-fadeIn {
+    0% {
+        opacity: 0;
+        transform: translateY(
+            calc(-1 * var(--popup-banner-translate-y-distance))
+        );
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes popup-banner-fadeOut {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(
+            calc(-1 * var(--popup-banner-translate-y-distance))
+        );
+    }
+}
+
+.popup-banner-animations {
+    animation-name: popup-banner-fadeIn;
+    animation-duration: 0.3s;
+    animation-fill-mode: forwards;
+
+    &.fade-out {
+        animation-name: popup-banner-fadeOut;
+    }
+}
+
+.popup-banner {
+    @extend .popup-banner-animations;
+
+    pointer-events: auto;
+    max-width: 900px;
+    width: 100%;
+
+    /* Here the container width == viewport width,
+       so we can work with the media breakpoints. */
+    @container banner (width < $lg_min) {
+        max-width: 90%;
+    }
+}

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -1,4 +1,5 @@
 .action-button {
+    position: relative;
     display: flex;
     gap: 0.75ch;
     justify-content: center;
@@ -381,6 +382,7 @@
 .icon-button {
     /* This class should always be used with an icon-button-* class
        defining the color scheme of the button, defined below. */
+    position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -581,6 +583,27 @@
             background-color: var(
                 --color-background-danger-icon-button-square-active
             );
+        }
+    }
+}
+
+.button-loading-indicator {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .loading_indicator_spinner {
+        /* Override standard values defined
+           in web/styles/app_components.css */
+        height: 100%;
+        width: unset;
+        aspect-ratio: 1;
+
+        & path {
+            /* Set the loading indicator color
+               to the font color of the button. */
+            fill: currentcolor;
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1015,10 +1015,6 @@ div.focused-message-list.is-conversation-view .recipient_row {
     margin-right: var(--right-sidebar-avatar-right-margin);
 }
 
-.home-error-bar {
-    display: none;
-}
-
 .streamname {
     font-weight: bold;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1016,12 +1016,7 @@ div.focused-message-list.is-conversation-view .recipient_row {
 }
 
 .home-error-bar {
-    margin-top: 5px;
     display: none;
-
-    .alert {
-        margin-bottom: auto;
-    }
 }
 
 .streamname {

--- a/web/tests/server_events.test.cjs
+++ b/web/tests/server_events.test.cjs
@@ -23,10 +23,8 @@ page_params.test_suite = false;
 // we also directly write to pointer
 set_global("pointer", {});
 
-mock_esm("../src/ui_report", {
-    hide_error() {
-        return false;
-    },
+mock_esm("../src/popup_banners", {
+    close_connection_error_popup_banner() {},
 });
 
 mock_esm("../src/stream_events", {


### PR DESCRIPTION
This PR serves as the base commit for the Popup banners and redesigns the connection error banner.

Fixes: #31282

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-05 at 12 31 53 PM](https://github.com/user-attachments/assets/3e507a03-b36e-4165-b2a2-794e1a22a8aa) | ![Screenshot 2025-03-05 at 12 21 28 PM](https://github.com/user-attachments/assets/ffeb5199-a92a-4a5b-aa12-cac2aeddcae7) | 
| ![Screenshot 2025-03-05 at 12 32 11 PM](https://github.com/user-attachments/assets/575280ad-e8f9-41ae-9138-463266b1ca35) | ![Screenshot 2025-03-05 at 12 20 57 PM](https://github.com/user-attachments/assets/708ee2d7-a49c-4575-b398-a9459667ce8a) | 

**Animation and stacking order:**

https://github.com/user-attachments/assets/bcceba43-126c-44b5-8d24-f2bf86dcdaf9


**Responsiveness:**

https://github.com/user-attachments/assets/08dab3e4-dd3b-4876-87e3-15dbb3e2b8cc


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
