### PR TITLE
composebox: Typing "general chat" should suggest empty string topic.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1342,10 +1342,21 @@ export function initialize_topic_edit_typeahead(
     return new Typeahead(bootstrap_typeahead_input, {
         dropup,
         highlighter_html(item: string): string {
-            return typeahead_helper.render_typeahead_item({primary: item});
+            const is_empty_string_topic = item === "";
+            const topic_display_name = util.get_final_topic_display_name(item);
+            return typeahead_helper.render_typeahead_item({
+                primary: topic_display_name,
+                is_empty_string_topic,
+            });
+        },
+        matcher(item: string, query: string): boolean {
+            const matcher = get_topic_matcher(query);
+            return matcher(item);
         },
         sorter(items: string[], query: string): string[] {
-            const sorted = typeahead_helper.sorter(query, items, (x) => x);
+            const sorted = typeahead_helper.sorter(query, items, (x) =>
+                util.get_final_topic_display_name(x),
+            );
             if (sorted.length > 0 && !sorted.includes(query)) {
                 sorted.unshift(query);
             }

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1464,15 +1464,21 @@ export function initialize({
                 is_empty_string_topic,
             });
         },
+        matcher(item: string, query: string): boolean {
+            const matcher = get_topic_matcher(query);
+            return matcher(item);
+        },
         sorter(items: string[], query: string): string[] {
-            const sorted = typeahead_helper.sorter(query, items, (x) => x);
+            const sorted = typeahead_helper.sorter(query, items, (x) =>
+                util.get_final_topic_display_name(x),
+            );
             if (sorted.length > 0 && !sorted.includes(query)) {
                 sorted.unshift(query);
             }
             return sorted;
         },
         option_label(matching_items: string[], item: string): string | false {
-            if (item !== "" && !matching_items.includes(item)) {
+            if (!matching_items.includes(item)) {
                 return `<em>${$t({defaultMessage: "New"})}</em>`;
             }
             return false;


### PR DESCRIPTION
This PR makes sure to suggest *general chat* topic on typing "general chat" in compose recipient box.



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After |
|-------|------|
 | <img width="232" alt="Screenshot 2025-03-05 at 12 52 23 PM" src="https://github.com/user-attachments/assets/8c7eb32d-dcda-4055-90f8-42147417e77d" /> | <img width="213" alt="Screenshot 2025-03-05 at 12 20 14 PM" src="https://github.com/user-attachments/assets/be931f4d-56e5-48b1-a6ab-c8b18ae70d88" />
| <img width="214" alt="Screenshot 2025-03-05 at 12 55 24 PM" src="https://github.com/user-attachments/assets/8dbb55a7-5c50-4da2-a0eb-91fdbce1e95e" /> | <img width="216" alt="Screenshot 2025-03-05 at 12 42 24 PM" src="https://github.com/user-attachments/assets/c5e0ae73-d5bc-4845-84a3-7e0ebf618192" />
| <img width="220" alt="Screenshot 2025-03-05 at 12 53 23 PM" src="https://github.com/user-attachments/assets/21e655ec-8448-431d-8e92-6e2a41fc8be1" /> | <img width="259" alt="Screenshot 2025-03-05 at 12 43 10 PM" src="https://github.com/user-attachments/assets/e848c466-fa60-41c0-b281-203f273fa45b" />
| <img width="216" alt="Screenshot 2025-03-05 at 12 54 27 PM" src="https://github.com/user-attachments/assets/581dd0be-f938-4fd3-b9bc-961a21c7b32c" /> | <img width="218" alt="Screenshot 2025-03-05 at 12 45 19 PM" src="https://github.com/user-attachments/assets/3a326957-706c-4272-bafe-ee3b80d95f0b" />










<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
