### PR TITLE
ui_init: Don't add `with` operator if topic has no messages.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -668,16 +668,16 @@ export function initialize_everything(state_data) {
                 topic,
             );
 
-            assert(latest_msg_id !== undefined);
+            const narrow = [
+                {operator: "channel", operand: sub.stream_id.toString()},
+                {operator: "topic", operand: topic},
+            ];
 
-            message_view.show(
-                [
-                    {operator: "channel", operand: sub.stream_id.toString()},
-                    {operator: "topic", operand: topic},
-                    {operator: "with", operand: latest_msg_id},
-                ],
-                {trigger: "sidebar"},
-            );
+            if (latest_msg_id !== undefined) {
+                narrow.push({operator: "with", operand: latest_msg_id});
+            }
+
+            message_view.show(narrow, {trigger: "sidebar"});
         },
     });
     drafts.initialize_ui();


### PR DESCRIPTION
Left sidebar can contain links empty topics. If user clicks on them, we add `with` operator to the narrow if the topic is empty.

Reproducer:
* Click on a topic in left sidebar.
* Delete all the messages in the topic.
* Click on the topic again.

