### PR TITLE
search: Don't wrap query to next line.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -193,7 +193,7 @@
         background: transparent;
         text-overflow: ellipsis;
         overflow: hidden;
-        white-space: pre-wrap;
+        white-space: pre;
         flex-grow: 1;
 
         color: var(--color-text-search);


### PR DESCRIPTION
Instead of wrapping query to next line, we let it be hidden. User can still use mouse or arrow keys to see the end of the text they typed.

discussion: [#redesign project > broader range of font sizes @ 💬](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2105334)


| before | after |
| --- | --- |
| ![Screenshot 2025-03-05 170052](https://github.com/user-attachments/assets/579e0f2b-3283-4c71-8f20-a9e15275a99d) | ![Screenshot 2025-03-05 170036](https://github.com/user-attachments/assets/0e278c4d-7c86-491d-a0e1-b767c98d0447) |