### PR TITLE
cache: Do not fail the request on cache-set failures.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from functools import _lru_cache_wrapper, lru_cache, wraps
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
+from bmemcached.exceptions import MemcachedException
 from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
@@ -225,7 +226,10 @@ def cache_set(
 
     remote_cache_stats_start()
     cache_backend = get_cache_backend(cache_name)
-    cache_backend.set(final_key, (val,), timeout=timeout)
+    try:
+        cache_backend.set(final_key, (val,), timeout=timeout)
+    except MemcachedException as e:
+        logger.exception(e)
     remote_cache_stats_finish()
 
 
@@ -277,7 +281,10 @@ def cache_set_many(
         new_items[new_key] = item
     items = new_items
     remote_cache_stats_start()
-    get_cache_backend(cache_name).set_many(items, timeout=timeout)
+    try:
+        get_cache_backend(cache_name).set_many(items, timeout=timeout)
+    except MemcachedException as e:
+        logger.exception(e)
     remote_cache_stats_finish()
 
 


### PR DESCRIPTION
Failure to update the cache should log an exception but continue.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
