### PR TITLE
user_popover: Use variable for sizes in user popover menu. 

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -565,6 +565,8 @@
     /* Shrink the user activity circle for the Recent Conversations context. */
     /* 7px at 14px/1em */
     --length-user-status-circle-recent-conversations: 0.5em;
+    --length-user-status-circle-popover-menu: 8px;
+    --length-user-popover-menu-avatar: 64px;
 
     /* Overlay heights for streams modal */
     --overlay-container-height: 95vh;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -994,13 +994,13 @@ ul.popover-group-menu-member-list {
     .popover-menu-user-avatar-container {
         position: relative;
         flex-shrink: 0;
-        width: 64px;
-        height: 64px;
+        width: var(--length-user-popover-menu-avatar);
+        height: var(--length-user-popover-menu-avatar);
     }
 
     .popover-menu-user-avatar {
-        width: 64px;
-        height: 64px;
+        width: var(--length-user-popover-menu-avatar);
+        height: var(--length-user-popover-menu-avatar);
         border-radius: 4px;
         background-size: cover;
         background-position: center;
@@ -1010,7 +1010,7 @@ ul.popover-group-menu-member-list {
         position: absolute;
         /* Presence dot does not scale, because
            the avatar itself does not scale. */
-        font-size: 8px;
+        font-size: var(--length-user-status-circle-popover-menu);
         line-height: 1;
         right: -1px;
         bottom: -1px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1104,8 +1104,6 @@ ul.popover-group-menu-member-list {
         position: absolute;
         top: unset;
         left: unset;
-        /* Presence dot does not scale, because
-           the avatar itself does not scale. */
         font-size: var(--length-user-status-circle);
         line-height: 1;
         right: -1px;


### PR DESCRIPTION
This doesn't have any visual changes and is part of an effort to remove px font sizes from most stylesheets.