### PR TITLE
Show topic list typeahead even when a fallback md link is generated.

### DIFF
--- a/web/src/topic_link_util.ts
+++ b/web/src/topic_link_util.ts
@@ -31,6 +31,23 @@ export function escape_invalid_stream_topic_characters(text: string): string {
     }
 }
 
+// This record should be kept in sync with the
+// escape_invalid_stream_topic_characters function.
+const escaped_to_original_mapping: Record<string, string> = {
+    "&#96;": "`",
+    "&gt;": ">",
+    "&#42;": "*",
+    "&amp;": "&",
+    "&#36;&#36;": "$$",
+    "&#91;": "[",
+    "&#93;": "]",
+};
+
+export function html_unescape_invalid_stream_topic_characters(text: string): string {
+    const unescape_regex = new RegExp(Object.keys(escaped_to_original_mapping).join("|"), "g");
+    return text.replaceAll(unescape_regex, (match) => escaped_to_original_mapping[match] ?? match);
+}
+
 export function html_escape_markdown_syntax_characters(text: string): string {
     return text.replaceAll(invalid_stream_topic_regex, escape_invalid_stream_topic_characters);
 }

--- a/web/tests/topic_link_util.test.cjs
+++ b/web/tests/topic_link_util.test.cjs
@@ -125,4 +125,9 @@ run_test("stream_topic_link_syntax_test", () => {
         topic_link_util.as_html_link_syntax_unsafe("test", "example.com"),
         '<a href="example.com">test</a>',
     );
+
+    assert.equal(
+        topic_link_util.html_unescape_invalid_stream_topic_characters("&#36;&#36;MONEY&#36;&#36;"),
+        "$$MONEY$$",
+    );
 });


### PR DESCRIPTION
In #30071, we generated fallback markdown link for channel or topic names which
would produce broken `#**channel>topic**` syntax. 
This broke the feature where after selecting a channel link (`#**channel**`), we could
open the topic list by typing `>`, or even the more recent #32217.

This PR restores those features.

Some part of #33013 is also taken.

Fixes: #32556 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
