### PR TITLE
messagebox: Scale slow send spinner with info density.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -814,7 +814,7 @@ strong {
 
 .messagebox-content .slow-send-spinner {
     display: block;
-    font-size: 12px;
+    font-size: 0.8571em; /* 12px at 14px/em */
     text-align: right;
     opacity: 0.8;
     color: var(--color-text-default);


### PR DESCRIPTION
at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-05 at 10 25 23](https://github.com/user-attachments/assets/0806e770-3d06-41d5-9fdf-d047c245bef7) | ![Screen Shot 2025-03-05 at 10 24 57](https://github.com/user-attachments/assets/31f0dfb3-c115-4ee1-8d3b-dc36ec82da58) |
| ![Screen Shot 2025-03-05 at 10 25 32](https://github.com/user-attachments/assets/5958cbc1-c62a-4e23-b310-7bd0c745c705) | ![Screen Shot 2025-03-05 at 10 24 47](https://github.com/user-attachments/assets/97e3e335-967b-4e55-835b-322bfd3d4412) |
| ![Screen Shot 2025-03-05 at 10 25 40](https://github.com/user-attachments/assets/114c3ef4-e651-4e27-bd9b-9a83c6bc0d01) | ![Screen Shot 2025-03-05 at 10 24 37](https://github.com/user-attachments/assets/e66d0bb0-38b2-4c30-ba13-c5f474b74e98) |
| ![Screen Shot 2025-03-05 at 10 25 54](https://github.com/user-attachments/assets/189d7ba4-58a1-4ba4-92a3-7a2f35cad88b) | ![Screen Shot 2025-03-05 at 10 24 19](https://github.com/user-attachments/assets/8cbdb71d-04fd-4eaa-81e1-eae72684d65e) |