### PR TITLE
flatpickr: Use constant variable for font-size.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -514,6 +514,12 @@
     --user-group-popover-icon-text-gap: 0.3125em; /* 5px at 16px/1em */
 
     /*
+    This isn't scaled with font-size because the flatpickr is a third
+    party component that doesn't scale with font size.
+    */
+    --flatpickr-confirm-button-font-size: 18px;
+
+    /*
     Width to be reserved for document scrollbar when scrolling is disabled.
     Using `scrollbar-gutter` would be more appropriate but doesn't has wide
     support and doesn't work for `fixed` elements.

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1479,7 +1479,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     .flatpickr-confirm {
         color: hsl(0deg 0% 100%);
         background-color: hsl(213deg 90% 65%);
-        font-size: 18px;
+        font-size: var(--flatpickr-confirm-button-font-size);
         font-weight: 600;
     }
 


### PR DESCRIPTION
This is part of an effort to remove all pixel font sizes from most stylesheets. We won't scale this with font size because the flatpickr doesn't scale with font size.