### PR TITLE
tippy: Remove default fixed font size.

### DIFF
--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -101,13 +101,6 @@ i.zulip-icon.zulip-icon-bot {
     color: var(--color-icon-bot);
 }
 
-.tippy-content {
-    /* Set the default font size for tooltips. Popovers override this with
-       a rule looking at the data-theme.
-     */
-    font-size: 12px;
-}
-
 /* Hide the somewhat buggy browser show password feature in IE, Edge,
    since it duplicates our own "show password" widget. */
 input::-ms-reveal {


### PR DESCRIPTION
Though it's difficult to confirm, we're pretty sure this is always overridden. Regardless, we don't want to have fixed pixel font sizes and it's better if the default is the default font size instead of 12px.

Further discussion:
https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2113503
