### PR TITLE
rendered_markdown: Present various thumbnail and play-button improvments.

### DIFF
--- a/web/src/message_list_hover.ts
+++ b/web/src/message_list_hover.ts
@@ -109,39 +109,6 @@ export function initialize(): void {
         },
     );
 
-    function handle_video_preview_mouseenter($elem: JQuery): void {
-        // Set image height and css vars for play button position, if not done already
-        const setPosition = !$elem.data("entered-before");
-        if (setPosition) {
-            const imgW = $elem.find("img")[0]!.width;
-            const imgH = $elem.find("img")[0]!.height;
-            // Ensure height doesn't change on mouse enter
-            $elem.css("height", `${imgH}px`);
-            // variables to set play button position
-            const marginLeft = (imgW - 30) / 2;
-            const marginTop = (imgH - 26) / 2;
-            $elem.css("--margin-left", `${marginLeft}px`).css("--margin-top", `${marginTop}px`);
-            $elem.data("entered-before", true);
-        }
-        $elem.addClass("fa fa-play");
-    }
-
-    $("#main_div").on("mouseenter", ".youtube-video a", function (this: HTMLElement) {
-        handle_video_preview_mouseenter($(this));
-    });
-
-    $("#main_div").on("mouseleave", ".youtube-video a", function () {
-        $(this).removeClass("fa fa-play");
-    });
-
-    $("#main_div").on("mouseenter", ".embed-video a", function (this: HTMLElement) {
-        handle_video_preview_mouseenter($(this));
-    });
-
-    $("#main_div").on("mouseleave", ".embed-video a", function () {
-        $(this).removeClass("fa fa-play");
-    });
-
     $("body").on("mouseover", ".message_edit_content", function () {
         $(this).closest(".message_row").find(".copy_message").show();
     });

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -1,3 +1,5 @@
+import assert from "minimalistic-assert";
+
 import {$t} from "./i18n.ts";
 import * as thumbnail from "./thumbnail.ts";
 import {user_settings} from "./user_settings.ts";
@@ -50,6 +52,18 @@ export function postprocess_content(html: string): string {
             elt.setAttribute("rel", "noopener noreferrer");
         } else {
             elt.removeAttribute("target");
+        }
+
+        // Update older, smaller default.jpg YouTube preview images
+        // with higher-quality preview images (320px wide)
+        if (elt.parentElement?.classList.contains("youtube-video")) {
+            const img = elt.querySelector("img");
+            assert(img instanceof HTMLImageElement);
+            const img_src = img.src;
+            if (img_src.endsWith("/default.jpg")) {
+                const mq_src = img_src.replace(/\/default.jpg$/, "/mqdefault.jpg");
+                img.src = mq_src;
+            }
         }
 
         if (elt.parentElement?.classList.contains("message_inline_image")) {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -611,7 +611,6 @@
         &:hover {
             &::after {
                 transform: scale(1);
-                transition: transform 0.2s;
             }
         }
 
@@ -629,6 +628,7 @@
             left: 0;
             border-radius: 100%;
             transform: scale(0.8);
+            transition: transform 0.2s;
         }
 
         & video {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -606,7 +606,8 @@
     }
 
     .message_inline_video,
-    .message_inline_animated_image_still {
+    .message_inline_animated_image_still,
+    .youtube-video a[data-id] {
         &:hover {
             &::after {
                 transform: scale(1);
@@ -636,20 +637,6 @@
             height: 100%;
             width: 100%;
         }
-    }
-
-    .youtube-video .fa-play::before,
-    .embed-video .fa-play::before {
-        position: absolute;
-        margin: var(--margin-top, 32px) 0 0 var(--margin-left, 45px);
-        padding: 5px 8px 5px 10px;
-        font-size: 12px;
-        border-radius: 4px;
-        background-color: hsl(0deg 0% 0%);
-        color: hsl(0deg 0% 100%);
-        opacity: 0.7;
-        top: 0;
-        left: 0;
     }
 
     .message_embed {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -617,14 +617,15 @@
         &::after {
             content: "";
             background-image: url("../images/play_button.svg");
-            display: block;
-            width: 32px;
-            height: 32px;
+            background-position: center center;
+            background-repeat: no-repeat;
+            /* 32px at 14px/1em */
+            background-size: 2.2857em;
             position: absolute;
-            /* video width (100px) / 2 - icon width (32px) / 2 */
-            top: 34px;
-            /* video height (150px) / 2 - icon height (32px) / 2 */
-            left: 59px;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
             border-radius: 100%;
             transform: scale(0.8);
         }

--- a/web/tests/lib/index.cjs
+++ b/web/tests/lib/index.cjs
@@ -23,6 +23,7 @@ const dom = new JSDOM("", {url: "http://zulip.zulipdev.com/"});
 global.DOMParser = dom.window.DOMParser;
 global.HTMLAnchorElement = dom.window.HTMLAnchorElement;
 global.HTMLElement = dom.window.HTMLElement;
+global.HTMLImageElement = dom.window.HTMLImageElement;
 global.Window = dom.window.Window;
 Object.defineProperty(global, "navigator", {
     value: {

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -24,6 +24,11 @@ run_test("postprocess_content", () => {
                 '<div class="message_inline_image">' +
                 '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" title="inline image">upload</a> ' +
                 '<a role="button">button</a> ' +
+                "</div>" +
+                '<div class="youtube-video message_inline_image">' +
+                '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM">' +
+                '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/default.jpg">' +
+                "</a>" +
                 "</div>",
         ),
         '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
@@ -34,6 +39,11 @@ run_test("postprocess_content", () => {
             '<div class="message_inline_image">' +
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
             '<a role="button">button</a> ' +
+            "</div>" +
+            '<div class="youtube-video message_inline_image">' +
+            '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
+            '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" loading="lazy">' +
+            "</a>" +
             "</div>",
     );
 });

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -879,7 +879,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         yt_id = self.youtube_id(url)
 
         if yt_id is not None:
-            return f"https://i.ytimg.com/vi/{yt_id}/default.jpg"
+            return f"https://i.ytimg.com/vi/{yt_id}/mqdefault.jpg"
         return None
 
     def vimeo_id(self, url: str) -> str | None:

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -994,7 +994,7 @@ class PreviewTestCase(ZulipTestCase):
             )
 
         msg.refresh_from_db()
-        expected_content = f"""<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">YouTube - Clearer Code at Scale - Static Types at Zulip and Dropbox</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="{get_camo_url("https://i.ytimg.com/vi/eSJTXC7Ixgg/default.jpg")}"></a></div>"""
+        expected_content = f"""<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">YouTube - Clearer Code at Scale - Static Types at Zulip and Dropbox</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="{get_camo_url("https://i.ytimg.com/vi/eSJTXC7Ixgg/mqdefault.jpg")}"></a></div>"""
         self.assertEqual(expected_content, msg.rendered_content)
 
     @responses.activate
@@ -1034,5 +1034,5 @@ class PreviewTestCase(ZulipTestCase):
             )
 
         msg.refresh_from_db()
-        expected_content = f"""<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">YouTube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="{get_camo_url("https://i.ytimg.com/vi/eSJTXC7Ixgg/default.jpg")}"></a></div>"""
+        expected_content = f"""<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">YouTube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="{get_camo_url("https://i.ytimg.com/vi/eSJTXC7Ixgg/mqdefault.jpg")}"></a></div>"""
         self.assertEqual(expected_content, msg.rendered_content)

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -735,7 +735,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p>Check out the debate: <a href="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="{get_camo_url("https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg")}"></a></div>""",
+            f"""<p>Check out the debate: <a href="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="{get_camo_url("https://i.ytimg.com/vi/hx1mjT73xYE/mqdefault.jpg")}"></a></div>""",
         )
 
         msg = "http://www.youtube.com/watch?v=hx1mjT73xYE"
@@ -743,7 +743,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p><a href="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="{get_camo_url("https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg")}"></a></div>""",
+            f"""<p><a href="http://www.youtube.com/watch?v=hx1mjT73xYE">http://www.youtube.com/watch?v=hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="http://www.youtube.com/watch?v=hx1mjT73xYE"><img src="{get_camo_url("https://i.ytimg.com/vi/hx1mjT73xYE/mqdefault.jpg")}"></a></div>""",
         )
 
         msg = "https://youtu.be/hx1mjT73xYE"
@@ -751,7 +751,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p><a href="https://youtu.be/hx1mjT73xYE">https://youtu.be/hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="https://youtu.be/hx1mjT73xYE"><img src="{get_camo_url("https://i.ytimg.com/vi/hx1mjT73xYE/default.jpg")}"></a></div>""",
+            f"""<p><a href="https://youtu.be/hx1mjT73xYE">https://youtu.be/hx1mjT73xYE</a></p>\n<div class="youtube-video message_inline_image"><a data-id="hx1mjT73xYE" href="https://youtu.be/hx1mjT73xYE"><img src="{get_camo_url("https://i.ytimg.com/vi/hx1mjT73xYE/mqdefault.jpg")}"></a></div>""",
         )
 
         msg = "https://www.youtube.com/playlist?list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo"
@@ -767,7 +767,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p><a href="https://www.youtube.com/watch?v=O5nskjZ_GoI&amp;list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo">https://www.youtube.com/watch?v=O5nskjZ_GoI&amp;list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo</a></p>\n<div class="youtube-video message_inline_image"><a data-id="O5nskjZ_GoI" href="https://www.youtube.com/watch?v=O5nskjZ_GoI&amp;list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo"><img src="{get_camo_url("https://i.ytimg.com/vi/O5nskjZ_GoI/default.jpg")}"></a></div>""",
+            f"""<p><a href="https://www.youtube.com/watch?v=O5nskjZ_GoI&amp;list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo">https://www.youtube.com/watch?v=O5nskjZ_GoI&amp;list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo</a></p>\n<div class="youtube-video message_inline_image"><a data-id="O5nskjZ_GoI" href="https://www.youtube.com/watch?v=O5nskjZ_GoI&amp;list=PL8dPuuaLjXtNlUrzyH5r6jN9ulIgZBpdo"><img src="{get_camo_url("https://i.ytimg.com/vi/O5nskjZ_GoI/mqdefault.jpg")}"></a></div>""",
         )
 
         msg = "http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw"
@@ -775,7 +775,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p><a href="http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw">http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw</a></p>\n<div class="youtube-video message_inline_image"><a data-id="nOJgD4fcZhI" href="http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw"><img src="{get_camo_url("https://i.ytimg.com/vi/nOJgD4fcZhI/default.jpg")}"></a></div>""",
+            f"""<p><a href="http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw">http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw</a></p>\n<div class="youtube-video message_inline_image"><a data-id="nOJgD4fcZhI" href="http://www.youtube.com/watch_videos?video_ids=nOJgD4fcZhI,i96UO8-GFvw"><img src="{get_camo_url("https://i.ytimg.com/vi/nOJgD4fcZhI/mqdefault.jpg")}"></a></div>""",
         )
 
     def test_inline_image_preview(self) -> None:
@@ -1135,7 +1135,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<div class="spoiler-block"><div class="spoiler-header">\n<p>Check out this PyCon video</p>\n</div><div class="spoiler-content" aria-hidden="true">\n<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg")}"></a></div></div></div>""",
+            f"""<div class="spoiler-block"><div class="spoiler-header">\n<p>Check out this PyCon video</p>\n</div><div class="spoiler-content" aria-hidden="true">\n<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/mqdefault.jpg")}"></a></div></div></div>""",
         )
 
         # Test YouTube URLs in normal messages.
@@ -1144,7 +1144,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">YouTube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg")}"></a></div>""",
+            f"""<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">YouTube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/mqdefault.jpg")}"></a></div>""",
         )
 
         msg = "https://www.youtube.com/watch?v=0c46YHS3RY8\n\nSample text\n\nhttps://www.youtube.com/watch?v=lXFO2ULktEI"
@@ -1152,7 +1152,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
 
         self.assertEqual(
             converted,
-            f"""<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg")}"></a></div><p>Sample text</p>\n<p><a href="https://www.youtube.com/watch?v=lXFO2ULktEI">https://www.youtube.com/watch?v=lXFO2ULktEI</a></p>\n<div class="youtube-video message_inline_image"><a data-id="lXFO2ULktEI" href="https://www.youtube.com/watch?v=lXFO2ULktEI"><img src="{get_camo_url("https://i.ytimg.com/vi/lXFO2ULktEI/default.jpg")}"></a></div>""",
+            f"""<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/mqdefault.jpg")}"></a></div><p>Sample text</p>\n<p><a href="https://www.youtube.com/watch?v=lXFO2ULktEI">https://www.youtube.com/watch?v=lXFO2ULktEI</a></p>\n<div class="youtube-video message_inline_image"><a data-id="lXFO2ULktEI" href="https://www.youtube.com/watch?v=lXFO2ULktEI"><img src="{get_camo_url("https://i.ytimg.com/vi/lXFO2ULktEI/mqdefault.jpg")}"></a></div>""",
         )
 
         # Test order of YouTube inline previews in same paragraph.
@@ -1160,7 +1160,7 @@ class MarkdownEmbedsTest(ZulipTestCase):
         converted = markdown_convert_wrapper(msg)
         self.assertEqual(
             converted,
-            f"""<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a><br>\n<a href="https://www.youtube.com/watch?v=lXFO2ULktEI">https://www.youtube.com/watch?v=lXFO2ULktEI</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg")}"></a></div><div class="youtube-video message_inline_image"><a data-id="lXFO2ULktEI" href="https://www.youtube.com/watch?v=lXFO2ULktEI"><img src="{get_camo_url("https://i.ytimg.com/vi/lXFO2ULktEI/default.jpg")}"></a></div>""",
+            f"""<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a><br>\n<a href="https://www.youtube.com/watch?v=lXFO2ULktEI">https://www.youtube.com/watch?v=lXFO2ULktEI</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="{get_camo_url("https://i.ytimg.com/vi/0c46YHS3RY8/mqdefault.jpg")}"></a></div><div class="youtube-video message_inline_image"><a data-id="lXFO2ULktEI" href="https://www.youtube.com/watch?v=lXFO2ULktEI"><img src="{get_camo_url("https://i.ytimg.com/vi/lXFO2ULktEI/mqdefault.jpg")}"></a></div>""",
         )
 
     def test_twitter_id_extraction(self) -> None:


### PR DESCRIPTION
This PR corrects the alignment of the play button on video thumbnails, and does so in a way that ensures a uniform play-button presentation regardless of video type (uploaded, YouTube, or otherwise embedded).

It also writes logic to request the higher-resolution `/mqdefault.jpg` thumbnail available from [the YouTube API](https://developers.google.com/youtube/v3/getting-started#Sample_Partial_Requests), so that YouTube previews should no longer be letterboxed as frequently or presented at dinky sizes, especially when users specify a larger font-size. Adjustments to post-processing on the content ensures older `default.jpg` thumbnails get rewritten. While that might cause a double request, the `default.jpg` thumbnails are so few bytes that I expect this would be negligible. 

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/play.20buttons.20on.20inline.20videos/near/2113542)

Fixes:
* [#redesign project > scaling of image previews @ 💬](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/scaling.20of.20image.20previews/near/2110875)
* [#feedback > 🎯 play button not centered on previews @ 💬](https://chat.zulip.org/#narrow/channel/137-feedback/topic/.F0.9F.8E.AF.20play.20button.20not.20centered.20on.20previews/near/2112632)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing 12px, 16px, and 22px_

| Before | After |
| --- | --- |
| ![thumbs-12px-before](https://github.com/user-attachments/assets/ce9e5127-af5a-4ffd-9149-0900bc5d27d8) | ![thumbs-12px-after](https://github.com/user-attachments/assets/6cf3d139-1a0c-4d55-b257-190fc78b6952) |
| ![thumbs-16px-before](https://github.com/user-attachments/assets/cee99610-1291-4325-be28-7376aef8187d) | ![thumbs-16px-after](https://github.com/user-attachments/assets/b72474aa-c6b0-4249-bfb5-0ada289de031) |
| ![thumbs-22px-before](https://github.com/user-attachments/assets/2048be4e-165d-46a8-9935-0987797b4d7e) | ![thumbs-22px-after](https://github.com/user-attachments/assets/10b0091c-1177-4ed7-b15d-c653b40f3506) |

_Transition effects now smoothly return the play button to size on mouse exit (the pointer is actually a finger-pointer, but macOS's screen recording uses an arrow here):_

| Before | After |
| --- | --- |
| ![hover-transition-before](https://github.com/user-attachments/assets/a3dc368c-c073-4bb5-871a-80107e622b67) | ![hover-transition-after](https://github.com/user-attachments/assets/f5cd4802-1c11-4a45-b2e6-624f38b53bdc) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>