### PR TITLE
people: Remove is_current_user legacy helper.

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -89,7 +89,7 @@ export function notifies(message: Message): boolean {
     // alert words into a message, just because that can be annoying for
     // certain types of workflows where everybody on your team, including
     // yourself, sets up an alert word to effectively mention the team.
-    return !people.is_current_user(message.sender_email) && message.alerted;
+    return !people.is_my_user_id(message.sender_id) && message.alerted;
 }
 
 export const initialize = (params: StateData["alert_words"]): void => {

--- a/web/src/compose_notifications.ts
+++ b/web/src/compose_notifications.ts
@@ -119,6 +119,9 @@ function get_message_recipient(message: Message): MessageRecipient {
         };
         return channel_message_recipient;
     }
+
+    // Only the stream format uses a string for this.
+    assert(typeof message.display_recipient !== "string");
     const direct_message_recipient: MessageRecipient = {
         message_type: "direct",
         recipient_text: "",
@@ -130,7 +133,10 @@ function get_message_recipient(message: Message): MessageRecipient {
         );
         return direct_message_recipient;
     }
-    if (people.is_current_user(message.reply_to)) {
+    if (
+        message.display_recipient.length === 1 &&
+        people.is_my_user_id(util.the(message.display_recipient).id)
+    ) {
         direct_message_recipient.recipient_text = $t({
             defaultMessage: "direct messages with yourself",
         });
@@ -322,7 +328,7 @@ function get_above_composebox_narrow_url(message: Message): string {
 // the message_lists.current (!can_apply_locally; a.k.a. "a search").
 export function notify_messages_outside_current_search(messages: Message[]): void {
     for (const message of messages) {
-        if (!people.is_current_user(message.sender_email)) {
+        if (!people.is_my_user_id(message.sender_id)) {
             continue;
         }
         const above_composebox_narrow_url = get_above_composebox_narrow_url(message);

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -1506,7 +1506,7 @@ export function initialize({
                     // filter out inactive users, inserted users and current user
                     // from pill insertion
                     const inserted_users = user_pill.get_user_ids(compose_pm_pill.widget);
-                    const current_user = people.is_current_user(user.email);
+                    const current_user = people.is_my_user_id(user.user_id);
                     if (
                         people.is_person_active(user_id) &&
                         !inserted_users.includes(user.user_id) &&

--- a/web/src/message_helper.ts
+++ b/web/src/message_helper.ts
@@ -33,7 +33,7 @@ export function process_new_message(raw_message: RawMessage, deliver_locally = f
         message_store.convert_raw_message_to_message_with_booleans(raw_message);
     people.extract_people_from_message(message_with_booleans);
 
-    const sent_by_me = people.is_current_user(message_with_booleans.sender_email);
+    const sent_by_me = people.is_my_user_id(message_with_booleans.sender_id);
     people.maybe_incr_recipient_count({...message_with_booleans, sent_by_me});
 
     let status_emoji_info;

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -352,7 +352,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
             if (!first_operand.includes(",")) {
                 const recipient_user = people.get_by_user_id(user_ids[0]);
                 // You have no direct messages with this person
-                if (people.is_current_user(recipient_user.email)) {
+                if (people.is_my_user_id(recipient_user.user_id)) {
                     return {
                         title: $t({
                             defaultMessage:
@@ -456,7 +456,7 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                     ),
                 };
             }
-            if (people.is_current_user(first_operand)) {
+            if (people.is_my_user_id(person_in_dms.user_id)) {
                 return {
                     title: $t({
                         defaultMessage: "You don't have any direct message conversations yet.",

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1716,14 +1716,6 @@ export function set_custom_profile_field_data(
     }
 }
 
-export function is_current_user(email?: string | null): boolean {
-    if (email === null || email === undefined || page_params.is_spectator) {
-        return false;
-    }
-
-    return email.toLowerCase() === my_current_email().toLowerCase();
-}
-
 export function initialize_current_user(user_id: number): void {
     my_user_id = user_id;
 }

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -664,7 +664,7 @@ export function show_user_profile(user: User, default_tab_key = "profile-tab"): 
         full_name: user.full_name,
         is_active: people.is_person_active(user.user_id),
         is_bot: user.is_bot,
-        is_me: people.is_current_user(user.email),
+        is_me: people.is_my_user_id(user.user_id),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),
         profile_data,
         should_add_guest_user_indicator: people.should_add_guest_user_indicator(user.user_id),

--- a/web/tests/alert_words.test.cjs
+++ b/web/tests/alert_words.test.cjs
@@ -38,65 +38,65 @@ people.add_active_user({
 people.initialize_current_user(42);
 
 const regular_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>a message</p>",
 };
 const own_message = {
-    sender_email: "tester@zulip.com",
+    sender_id: 42,
     content: "<p>hey this message alertone</p>",
     alerted: true,
 };
 const other_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>another alertone message</p>",
     alerted: true,
 };
 const caps_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>another ALERTtwo message</p>",
     alerted: true,
 };
 const alertwordboundary_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>another alertthreemessage</p>",
     alerted: false,
 };
 const multialert_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>another emoji alertone and then alerttwo</p>",
     alerted: true,
 };
 const unsafe_word_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>gotta al*rt.*s all</p>",
     alerted: true,
 };
 const alert_in_url_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>http://www.google.com/alertone/me</p>",
     alerted: true,
 };
 const question_word_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>still alertone? me</p>",
     alerted: true,
 };
 
 const typo_word_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content: "<p>alertones alerttwo alerttwo alertthreez</p>",
     alerted: true,
 };
 
 const alert_domain_message = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content:
         '<p>now with link <a href="http://www.alerttwo.us/foo/bar" target="_blank" title="http://www.alerttwo.us/foo/bar">www.alerttwo.us/foo/bar</a></p>',
     alerted: true,
 };
 // This test ensure we are not mucking up rendered HTML content.
 const message_with_emoji = {
-    sender_email: "another@zulip.com",
+    sender_id: 15,
     content:
         '<p>I <img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/unicode/2764.png" title="heart"> emoji!</p>',
     alerted: true,


### PR DESCRIPTION
This does lookups by email address, which is very much a legacy way to do things, and could throw exceptions if trying to lookup details on an unknown user ID.
