### PR TITLE
settings: Standardize right panel button height for streams/usergroups.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1040,8 +1040,12 @@ h4.user_group_setting_subsection_title {
         margin-left: 15px;
 
         .tab-container {
+            .tab-switcher {
+                margin: 0;
+            }
+
             .ind-tab {
-                padding: 3px 4px;
+                padding: 0 4px;
                 min-width: 80px;
                 width: auto;
                 display: flex;
@@ -1052,6 +1056,8 @@ h4.user_group_setting_subsection_title {
             padding-top: 5px;
             margin-left: auto;
             margin-right: 18px;
+            height: var(--settings-overlay-header-button-height);
+            display: flex;
 
             .subscribe-button,
             .join_leave_button,
@@ -1059,6 +1065,11 @@ h4.user_group_setting_subsection_title {
             .deactivate {
                 margin-right: 3px;
                 text-decoration: none;
+                padding: 0 10px;
+                height: 100%;
+                display: flex;
+                align-items: center;
+                box-sizing: border-box;
             }
 
             .deactivate {
@@ -1067,11 +1078,6 @@ h4.user_group_setting_subsection_title {
                 .icon-container {
                     display: flex;
                 }
-            }
-
-            /* We need this rule to center the user-group-x icon better */
-            .deactivate-group-button {
-                padding: 8px 10px 4px;
             }
         }
     }


### PR DESCRIPTION
It didn't seem to preserve the way things look at 14px, but I also think it looks fine in the after screenshots. I can come back to this with more care or tweaks if the after screenshots don't look good enough.


----

channel settings at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-05 at 15 05 35](https://github.com/user-attachments/assets/8289cca0-9b91-42c1-be24-a9facfc9a6bc) | ![Screen Shot 2025-03-06 at 11 37 20](https://github.com/user-attachments/assets/c67186c7-d9ac-4f1f-b206-ed6830c17838) |
| ![Screen Shot 2025-03-05 at 15 05 25](https://github.com/user-attachments/assets/f809e458-77eb-431f-bdc0-2286525aee5d) | ![Screen Shot 2025-03-06 at 11 37 33](https://github.com/user-attachments/assets/69d3621c-4def-424f-a444-0e8a40279385) |
| ![Screen Shot 2025-03-05 at 15 05 11](https://github.com/user-attachments/assets/002e2011-c4e7-45ab-ac47-4f8295792957) | ![Screen Shot 2025-03-06 at 11 37 47](https://github.com/user-attachments/assets/d2f261a3-bc4a-42dc-b9fd-0e811fd69f7a) |
| ![Screen Shot 2025-03-05 at 15 04 58](https://github.com/user-attachments/assets/e15b9a60-f19d-4570-83ac-f0fa24b57e30) | ![Screen Shot 2025-03-06 at 11 38 01](https://github.com/user-attachments/assets/d788fd24-a047-4020-be98-f37bf93bab22) |

user groups at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-05 at 15 01 25](https://github.com/user-attachments/assets/d6936854-6ebe-483d-b713-f8062f7b30a6) | ![Screen Shot 2025-03-06 at 11 37 16](https://github.com/user-attachments/assets/42a6e34c-1ce5-4ed0-9a1a-cee237b7bfeb) |
| ![Screen Shot 2025-03-05 at 15 01 45](https://github.com/user-attachments/assets/aff36299-572b-418b-8fe3-ced0ec23c85b) | ![Screen Shot 2025-03-06 at 11 37 28](https://github.com/user-attachments/assets/c5e3655f-98b3-45e1-b7d6-e443340de6e6) |
| ![Screen Shot 2025-03-05 at 15 01 54](https://github.com/user-attachments/assets/6e622a33-47cd-45af-a09b-d514c7328415) | ![Screen Shot 2025-03-06 at 11 37 41](https://github.com/user-attachments/assets/8be86a01-8c18-48d8-968e-d21796b6ece0) |
| ![Screen Shot 2025-03-05 at 15 02 09](https://github.com/user-attachments/assets/e129f774-6272-4edb-96fe-3db85027ddae) | ![Screen Shot 2025-03-06 at 11 37 56](https://github.com/user-attachments/assets/fa32dbae-f623-4de7-aefe-eacc1a776101) |