### PR TITLE
settings: Scale save loading spinner with font size.

### DIFF
--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -17,7 +17,6 @@ import type {PillUpdateField} from "./custom_profile_fields_ui.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
-import * as loading from "./loading.ts";
 import * as modals from "./modals.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
@@ -601,9 +600,6 @@ export function set_up(): void {
 
         /* Ideally, this code path would use do_settings_change; we're avoiding it
            in order to do the success feedback without a banner. */
-        $status_element.fadeTo(0, 1);
-        loading.make_indicator($status_element, {text: settings_ui.strings.saving});
-
         void channel.patch({
             url: "/json/settings",
             data,
@@ -626,7 +622,6 @@ export function set_up(): void {
                 dialog_widget.close();
             },
             error(xhr) {
-                loading.destroy_indicator($status_element);
                 ui_report.error(settings_ui.strings.failure_html, xhr, $change_email_error);
                 dialog_widget.hide_dialog_spinner();
             },

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -20,7 +20,7 @@ export type RequestOpts = {
 export function display_checkmark($elem: JQuery): void {
     const $check_mark = $("<img>");
     $check_mark.attr("src", checkbox_image);
-    $check_mark.css("width", "13px");
+    $check_mark.addClass("settings-save-checkmark");
     $elem.prepend($check_mark);
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -883,7 +883,7 @@ input.settings_text_input {
     .save-discard-widget-button {
         border-radius: 5px;
         border: 1px solid hsl(0deg 0% 80%);
-        padding: 3px 14px 4px 11px;
+        padding: 0.2143em 1em 0.2857em 0.7857em; /* 3px 14px 4px 11px at 14px/em */
         text-decoration: none;
         color: hsl(0deg 0% 47%);
         min-width: 80px;
@@ -919,6 +919,7 @@ input.settings_text_input {
             &.saving {
                 background-color: hsl(156deg 14% 40%);
                 border-color: hsl(156deg 14% 40%);
+                display: flex;
             }
         }
 
@@ -935,8 +936,8 @@ input.settings_text_input {
                 }
 
                 .save-discard-widget-button-loading {
-                    display: inline-block;
-                    margin-right: 2px;
+                    display: block;
+                    margin-right: 0.5em; /* 7px at 14px/em */
                 }
             }
         }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -252,10 +252,10 @@ h3,
     }
 
     .loading_indicator_text {
-        font-size: 12px;
+        font-size: 0.8571em; /* 12px at 14px/em */
         font-weight: 400;
         vertical-align: middle;
-        line-height: 20px;
+        line-height: 1.6667em; /* 20px at 12px/em */
         display: inline-block;
         float: none;
         margin-top: 9px;
@@ -263,7 +263,7 @@ h3,
 
     .loading_indicator_spinner {
         width: 30%;
-        height: 20px;
+        height: 1.4286em; /* 20px at 14px/em */
         margin-top: 7px;
         vertical-align: middle;
         display: inline-block;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -590,7 +590,8 @@ input[type="checkbox"] {
 }
 
 .alert-notification {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     vertical-align: top;
     height: auto !important;
     width: auto !important;
@@ -619,8 +620,8 @@ input[type="checkbox"] {
     }
 
     .loading_indicator_spinner {
-        width: 13px;
-        height: 20px;
+        width: 0.9283em; /* 13px at 14px/em */
+        height: 1.4286em; /* 20px at 14px/em */
         margin: 0;
     }
 
@@ -639,6 +640,10 @@ input[type="checkbox"] {
         margin-right: 6px;
         vertical-align: middle;
         margin-top: -2px;
+    }
+
+    .settings-save-checkmark {
+        width: 0.9285em; /* 13px at 14px/em */
     }
 }
 


### PR DESCRIPTION
Most instance of `loading_indicator_text` in settings are actually overwritten by a style for `.alert-notification .loading_indicator_text` font size inherit, but I found one case where that wasn't true and took screenshots there.

If I were more confident this was the only place the font size wasn't being overridden, I'd make the CSS rule more specific to only apply to this case.

---

at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-05 at 16 44 26](https://github.com/user-attachments/assets/4bf3dd9d-60fa-4871-866c-cbcdb66d57a5) | ![Screen Shot 2025-03-05 at 16 36 39](https://github.com/user-attachments/assets/4053574c-859b-4afa-ac7a-28b897515fec) |
| ![Screen Shot 2025-03-05 at 16 44 17](https://github.com/user-attachments/assets/c32a3a01-2a42-4ab5-b20c-4ce0540ae93e) | ![Screen Shot 2025-03-05 at 16 37 00](https://github.com/user-attachments/assets/348fb02d-a8cf-4593-bc12-80e87a7e3e40) |
| ![Screen Shot 2025-03-05 at 16 44 09](https://github.com/user-attachments/assets/eec9d0bd-b449-4a1f-bff5-2ed05b12d944) | ![Screen Shot 2025-03-05 at 16 37 09](https://github.com/user-attachments/assets/03f56a9d-223b-4b9f-b7ab-5b9b53ba7a79) |
| ![Screen Shot 2025-03-05 at 16 43 59](https://github.com/user-attachments/assets/da392b12-8e49-48a6-bb54-0662ac5c14e3) | ![Screen Shot 2025-03-05 at 16 37 56](https://github.com/user-attachments/assets/96c2d479-e6db-4eb7-84ca-84520fc394e9) |