### PR TITLE
settings: Adjust widths in change email modal with font size.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -87,7 +87,12 @@ h3,
 
 #change_password_modal,
 #change_email_modal {
-    max-width: 480px;
+    width: 34.2857em; /* 480px at 14px/em */
+    max-width: 90vw;
+}
+
+#change-email-form-input-email {
+    max-width: 90%;
 }
 
 #change_email_modal {


### PR DESCRIPTION
at 12px and 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-05 at 16 52 09](https://github.com/user-attachments/assets/5590e78f-d68c-426d-83b7-2dc6c863d83e) | ![Screen Shot 2025-03-05 at 16 52 27](https://github.com/user-attachments/assets/75eb09c9-8f64-4b2b-81b0-89da9c00bc35) |
| ![Screen Shot 2025-03-05 at 16 51 47](https://github.com/user-attachments/assets/252336e1-b699-4073-980d-bb46e1550153) | ![Screen Shot 2025-03-05 at 16 52 42](https://github.com/user-attachments/assets/652abc76-bf3e-4888-8051-64b918ad5517) |

And for narrower screens the input shrinks:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/d3dfa8f8-c785-469a-ba2c-7224d7ab1d26" />
