### PR TITLE
recent_view: Make icon change on hover for visibility indicator robust.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -484,6 +484,12 @@
         }
     }
 
+    #recent_view
+        .change_visibility_policy
+        .visibility-status-icon:not(.recent-view-row-topic-menu):hover {
+        filter: invert(1);
+    }
+
     .drafts-container .header-body .delete-drafts-group > *:focus {
         background-color: hsl(228deg 11% 17%);
     }

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -60,9 +60,19 @@
             }
         }
 
-        &.change_visibility_policy .visibility-status-icon:hover::before {
+        &.change_visibility_policy
+            .visibility-status-icon:not(.recent-view-row-topic-menu):hover {
             /* Show vertical ellipsis when user hovers over visibility indicator icon. */
-            content: "\f155";
+            background-image: url("../shared/icons/more-vertical.svg");
+            background-repeat: no-repeat;
+            background-position: left bottom;
+            background-size: contain;
+            width: var(--base-font-size-px);
+            height: var(--base-font-size-px);
+
+            &::before {
+                content: "";
+            }
         }
 
         &.change_visibility_policy .recent-view-row-topic-menu {


### PR DESCRIPTION
Using character index for changing icon is not reliable, so we use `background-image` to change the icon being displayed here.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20moons.20instead.20of.20dots.20.3F.3F/with/2114059

No visual change, just restored the original behaviour.

| no hover | hover |
| --- | --- |
| ![Screenshot 2025-03-06 100759](https://github.com/user-attachments/assets/e76c60ce-da77-4a61-b782-f3d69ffdca3f) | ![Screenshot 2025-03-06 100752](https://github.com/user-attachments/assets/06b80291-6f94-455f-9dcc-e24883ff4d01) |
| ![image](https://github.com/user-attachments/assets/dd7c6ffb-91c7-4a15-b820-b2dd21989325) | ![image](https://github.com/user-attachments/assets/9024f48a-3311-400a-aec6-0e5255bfe510) |
