### PR TITLE
composebox_typeahead: Show CrossRealmBots in the typeahead list.

### DIFF
--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -607,7 +607,7 @@ export function get_pm_people(query: string): (UserGroupPillData | UserPillData)
         topic: compose_state.topic(),
         filter_groups_for_dm: true,
     };
-    const suggestions = get_person_suggestions(query, opts);
+    const suggestions = get_person_suggestions(query, opts, true);
     const current_user_ids = compose_pm_pill.get_user_ids();
     const my_user_id = people.my_current_user_id();
     // We know these aren't mentions because `want_broadcast` was `false`.
@@ -642,6 +642,7 @@ type PersonSuggestionOpts = {
 export function get_person_suggestions(
     query: string,
     opts: PersonSuggestionOpts,
+    exclude_non_welcome_bots = false,
 ): (UserOrMentionPillData | UserGroupPillData)[] {
     query = typeahead.clean_query_lowercase(query);
 
@@ -744,7 +745,11 @@ export function get_person_suggestions(
     if (filtered_message_persons.length >= cutoff_length) {
         filtered_persons = filtered_message_persons;
     } else {
-        filtered_persons = filter_persons(people.get_realm_users());
+        if (exclude_non_welcome_bots) {
+            filtered_persons = filter_persons(people.get_realm_users_and_welcome_bot());
+        } else {
+            filtered_persons = filter_persons(people.get_realm_users_and_system_bots());
+        }
     }
 
     return typeahead_helper.sort_recipients({

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1042,6 +1042,14 @@ export function get_realm_users(): User[] {
     return [...active_user_dict.values()];
 }
 
+export function get_realm_users_and_welcome_bot(): User[] {
+    return [...active_user_dict.values(), WELCOME_BOT];
+}
+
+export function get_realm_users_and_system_bots(): User[] {
+    return [...active_user_dict.values(), ...cross_realm_dict.values()];
+}
+
 export function get_realm_active_human_users(): User[] {
     // includes ONLY humans from your realm
     const humans = [];

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -415,6 +415,26 @@ const harry = {
 };
 const harry_item = user_item(harry);
 
+const welcome_bot = {
+    full_name: "Welcome Bot",
+    is_bot: true,
+    is_system_bot: true,
+    user_id: 110,
+    email: "welcome-bot@zulip.com",
+};
+
+const welcome_bot_item = user_item(welcome_bot);
+
+const notification_bot = {
+    full_name: "Notification Bot",
+    is_bot: true,
+    is_system_bot: true,
+    user_id: 111,
+    email: "notification-bot@zulip.com",
+};
+
+const notification_bot_item = user_item(notification_bot);
+
 const hamletcharacters = user_group_item({
     name: "hamletcharacters",
     id: 1,
@@ -629,6 +649,8 @@ function test(label, f) {
         people.add_active_user(hal);
         people.add_active_user(harry);
         people.add_active_user(deactivated_user);
+        people.add_cross_realm_user(welcome_bot);
+        people.add_cross_realm_user(notification_bot);
         people.deactivate(deactivated_user);
         people.initialize_current_user(hamlet.user_id);
 
@@ -1218,6 +1240,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
                     call_center,
                     admins,
                     members,
+                    welcome_bot_item,
                 ];
                 assert.deepEqual(actual_value, expected_value);
 
@@ -1749,7 +1772,12 @@ test("begins_typeahead", ({override, override_rewire}) => {
     ]);
 
     const mention_all = broadcast_item(ct.broadcast_mentions()[0]);
-    const users_and_all_mention = [...sorted_user_list, mention_all];
+    const users_and_all_mention = [
+        ...sorted_user_list,
+        mention_all,
+        notification_bot_item,
+        welcome_bot_item,
+    ];
     const users_and_user_groups = [
         ...sorted_user_list,
         // alphabetical
@@ -1758,6 +1786,8 @@ test("begins_typeahead", ({override, override_rewire}) => {
         call_center, // "folks working in support",
         admins,
         members,
+        notification_bot_item,
+        welcome_bot_item,
     ];
     const mention_everyone = broadcast_item(ct.broadcast_mentions()[1]);
     function mentions_with_silent_marker(mentions, is_silent) {
@@ -1766,8 +1796,6 @@ test("begins_typeahead", ({override, override_rewire}) => {
             is_silent,
         }));
     }
-    assert_typeahead_equals("@", mentions_with_silent_marker(users_and_all_mention, false));
-    // The user we're testing for is only allowed to do silent mentions of groups
     assert_typeahead_equals("@", mentions_with_silent_marker(users_and_all_mention, false));
     // The user we're testing for is only allowed to do silent mentions of groups
     assert_typeahead_equals("@_", mentions_with_silent_marker(users_and_user_groups, true));
@@ -1779,15 +1807,37 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@_**", mentions_with_silent_marker(users_and_user_groups, true));
     assert_typeahead_equals(
         "test @**o",
-        mentions_with_silent_marker([othello_item, cordelia_item, mention_everyone], false),
+        mentions_with_silent_marker(
+            [
+                othello_item,
+                cordelia_item,
+                mention_everyone,
+                notification_bot_item,
+                welcome_bot_item,
+            ],
+            false,
+        ),
     );
     assert_typeahead_equals(
         "test @_**o",
-        mentions_with_silent_marker([othello_item, cordelia_item, admins, members], true),
+
+        mentions_with_silent_marker(
+            [othello_item, cordelia_item, admins, members, notification_bot_item, welcome_bot_item],
+            true,
+        ),
     );
     assert_typeahead_equals(
         "test @*o",
-        mentions_with_silent_marker([othello_item, cordelia_item, mention_everyone], false),
+        mentions_with_silent_marker(
+            [
+                othello_item,
+                cordelia_item,
+                mention_everyone,
+                notification_bot_item,
+                welcome_bot_item,
+            ],
+            false,
+        ),
     );
     assert_typeahead_equals(
         "test @_*k",
@@ -1833,6 +1883,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 twin1_item,
                 twin2_item,
                 othello_item,
+                notification_bot_item,
             ],
             false,
         ),
@@ -1851,6 +1902,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 twin2_item,
                 othello_item,
                 admins,
+                notification_bot_item,
             ],
             true,
         ),
@@ -1868,6 +1920,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 hamlet_item,
                 othello_item,
                 mention_all,
+                welcome_bot_item,
             ],
             false,
         ),
@@ -1887,6 +1940,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
                 hamletcharacters,
                 call_center,
                 members,
+                welcome_bot_item,
             ],
             true,
         ),
@@ -1899,11 +1953,23 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals(" @_zuli", []);
     assert_typeahead_equals(
         "test @o",
-        mentions_with_silent_marker([othello_item, cordelia_item, mention_everyone], false),
+        mentions_with_silent_marker(
+            [
+                othello_item,
+                cordelia_item,
+                mention_everyone,
+                notification_bot_item,
+                welcome_bot_item,
+            ],
+            false,
+        ),
     );
     assert_typeahead_equals(
         "test @_o",
-        mentions_with_silent_marker([othello_item, cordelia_item, admins, members], true),
+        mentions_with_silent_marker(
+            [othello_item, cordelia_item, admins, members, notification_bot_item, welcome_bot_item],
+            true,
+        ),
     );
     assert_typeahead_equals("test @z", []);
     assert_typeahead_equals("test @_z", []);
@@ -2410,6 +2476,7 @@ test("typeahead_results", ({override}) => {
         not_silent(othello_item),
         not_silent(hamletcharacters),
         not_silent(call_center),
+        not_silent(welcome_bot_item),
     ]);
 
     // Verify we suggest both 'the first matching stream wildcard' and
@@ -2421,6 +2488,8 @@ test("typeahead_results", ({override}) => {
         not_silent(mention_everyone),
         not_silent(mention_topic),
         not_silent(cordelia_item),
+        not_silent(notification_bot_item),
+        not_silent(welcome_bot_item),
     ]);
 
     // Autocomplete by slash commands.


### PR DESCRIPTION
Fixes: #30817

Just fixes some tests and conflicts for #31321
