### PR TITLE
typeahead: Fix alignment of secondary text in channel typeaheads.

### DIFF
--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -85,6 +85,7 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 gap: 3px;
+                align-items: baseline;
             }
 
             .compose-stream-name {
@@ -111,13 +112,11 @@
 
     .pronouns,
     .autocomplete_secondary {
-        align-self: end;
+        align-self: baseline;
         opacity: 0.8;
         font-size: 85%;
         overflow: hidden;
         text-overflow: ellipsis;
-        position: relative;
-        top: -2px;
 
         & > a {
             color: var(--color-dropdown-item);


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AFchannel.20descriptions.20vertically.20misaligned.20in.20typeahead/with/2114093

20px:
| before | after |
| --- | --- |
| ![Screenshot 2025-03-06 103057](https://github.com/user-attachments/assets/ef136c66-0813-408f-bba5-6d27bb39a837) | ![Screenshot 2025-03-06 103040](https://github.com/user-attachments/assets/c1aac60b-1882-4617-91e9-bf621cd35802) |
| ![Screenshot 2025-03-06 103104](https://github.com/user-attachments/assets/1d215d18-88ef-438c-bf3b-f0d1b09d3a28) |  ![Screenshot 2025-03-06 103031](https://github.com/user-attachments/assets/61d59c6d-4dfa-4180-8676-66e089ef1c9c) |

14px:
![Screenshot 2025-03-06 103700](https://github.com/user-attachments/assets/7c51cd79-e222-4e75-8e69-303f30933678)
![Screenshot 2025-03-06 103708](https://github.com/user-attachments/assets/16c16aeb-65ca-436e-9612-3b6ca9986aef)

