### PR TITLE
composebox: Fix overlapping placeholder in recipient box for topic="".

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -365,9 +365,10 @@ export function update_topic_displayed_text(
     if (topic_name === undefined) {
         topic_name = "";
     }
-    // When topics are mandatory, we just call topic() as usual.
+    compose_state.topic(topic_name);
+
+    // When topics are mandatory, no additional adjustments are needed.
     if (realm.realm_mandatory_topics) {
-        compose_state.topic(topic_name);
         return;
     }
     // Otherwise, we have some adjustments to make to display:
@@ -400,8 +401,6 @@ export function update_topic_displayed_text(
         update_placeholder_visibility();
         $input.on("input", update_placeholder_visibility);
     }
-
-    compose_state.topic(topic_name);
 }
 
 export let update_compose_area_placeholder_text = (): void => {

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -396,7 +396,8 @@ export function update_topic_displayed_text(
         $input.attr("placeholder", util.get_final_topic_display_name(""));
         $input.addClass("empty-topic-display");
     } else {
-        $topic_not_mandatory_placeholder.show(10, update_placeholder_visibility);
+        $topic_not_mandatory_placeholder.show();
+        update_placeholder_visibility();
         $input.on("input", update_placeholder_visibility);
     }
 


### PR DESCRIPTION
PR to fix [#issues > 🎯 general chat topic overlapping placeholders @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20general.20chat.20topic.20overlapping.20placeholders/near/2106453)

> The "general chat" placeholder seems to be overlapping with "Enter a topic (skip for general chat)" here.

After fixing the above bug; composing message in another topic (not necessarily "") resulted in:
<img width="778" alt="Screenshot 2025-03-06 at 1 14 50 PM" src="https://github.com/user-attachments/assets/99094ab9-f117-4106-9c49-8a9d22ad9398" />

Fixed that in the second commit. We can squash the two commits, I don't have a strong opinion here :)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
