### PR TITLE
reactions: Fix bottom border missing.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -166,9 +166,6 @@
 
 .emoji-picker-popover {
     padding: 0;
-    /* TODO: Calculate a more accurate height. This is a bit cut off at 12px and
-       has a bit of white below it at 20px. */
-    height: 24em;
     user-select: none;
 
     .emoji-popover {
@@ -279,7 +276,7 @@
         background-color: var(--color-background-emoji-picker-popover);
         min-height: 2.9333em; /* 44px at 15px/em */
         width: 16.6667em; /* 250px at 15px/em */
-        border-radius: 0 0 3px 3px;
+        border-radius: 0 0 6px 6px;
 
         .emoji-preview {
             position: absolute;


### PR DESCRIPTION
We align bottom border radius with that of the popover to get border to appear around the bottom edges.

`height` was not required on `emoji-picker-popover` as the height is already being limited by `.emoji-popover-emoji-map` which is enough to get the scrolling effect on overflow.

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e721a491-8709-4f36-b75f-27347c0cf933) | ![image](https://github.com/user-attachments/assets/b8d871a3-4b00-49d8-8e1a-56477534d9eb) |
