### PR TITLE
dense-modes: Clean up obsolete CSS related to .more-dense-mode, less-dense-mode.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -382,15 +382,6 @@
     /* Legacy values */
     --legacy-body-line-height-unitless: calc(20 / 14);
 
-    .more-dense-mode {
-        /* The legacy values here are not altered by JavaScript */
-        --base-font-size-px: 14px;
-        --base-line-height-unitless: 1.214;
-        --markdown-interelement-space-px: 5px;
-        --markdown-interelement-doubled-space-px: 10px;
-        --message-box-markdown-aligned-vertical-space: 5px;
-    }
-
     /* Message area */
     /* In the legacy layout at 16px/1em density, 918.6px is
        the widest the message area gets, so we preserve this

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1418,18 +1418,6 @@ textarea.new_message_textarea {
     }
 }
 
-.less-dense-mode {
-    .compose-control-buttons-container {
-        .compose_control_button {
-            /* Slightly reduce width so that buttons don't overflow the available
-            space at mobile widths */
-            @media (width < 400px) {
-                width: 1.28em;
-            }
-        }
-    }
-}
-
 .message-send-controls {
     display: flex;
 


### PR DESCRIPTION
These styles are no longer warranted, owing to:

* A scrolling button area for the compose buttons (and relative, em-based sizing of the compose buttons)
* Planned removal of the "Compact mode" toggle and a more robust info-density UI in #33831

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/Information.20density.3A.20dense_mode/near/2114485)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Compose buttons below 400px, before | After (larger, but better target areas) |
| --- | --- |
| ![with-less-dense-mode-rule](https://github.com/user-attachments/assets/f13b4681-be9a-460b-ac54-d1aac9df3ba9) | ![removed-less-dense-mode-rule](https://github.com/user-attachments/assets/067101ce-f379-42c7-8488-c30f591945fa) |

| With `.more-dense-mode` rules | After (no change) |
| --- | --- |
| ![with-more-dense-mode-rules](https://github.com/user-attachments/assets/b522833e-c431-4424-bc03-fbc94f22f197) | ![removed-more-dense-mode-rules](https://github.com/user-attachments/assets/1a8c771c-2ddb-4391-8256-535b0d9035a1) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
