### PR TITLE
puppet: Add gettext to dependencies for app instances.

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -16,6 +16,8 @@ class zulip::app_frontend_base {
   }
   zulip::safepackage {
     [
+      # For `manage.py compilemessages` when upgrading from Git.
+      'gettext',
       # For Slack import.
       'unzip',
       # Ensures `/etc/ldap/ldap.conf` exists; the default


### PR DESCRIPTION
This is already installed on a lot of systems, and is used indirectly when upgrading Zulip from Git.
