### PR TITLE
left_sidebar: Hide menu option for home view if all messages are read.

### DIFF
--- a/web/src/left_sidebar_navigation_area.ts
+++ b/web/src/left_sidebar_navigation_area.ts
@@ -76,6 +76,12 @@ export function update_dom_with_unread_counts(
     ui_util.update_unread_count_in_dom($streams_header, counts.stream_unread_messages);
     ui_util.update_unread_count_in_dom($back_to_streams, counts.stream_unread_messages);
 
+    if (counts.home_unread_messages === 0) {
+        $home_view_li.find(".sidebar-menu-icon").addClass("hide");
+    } else {
+        $home_view_li.find(".sidebar-menu-icon").removeClass("hide");
+    }
+
     if (!skip_animations) {
         animate_mention_changes($mentioned_li, counts.mentioned_message_count);
     }
@@ -239,6 +245,10 @@ export function handle_home_view_changed(new_home_view: string): void {
     const $current_home_view = $(".selected-home-view");
     const $new_home_view = get_view_rows_by_view_name(new_home_view);
     const res = unread.get_counts();
+
+    if ($current_home_view.find(".sidebar-menu-icon").hasClass("hide")) {
+        $current_home_view.find(".sidebar-menu-icon").removeClass("hide");
+    }
 
     // Remove class from current home view
     $current_home_view.removeClass("selected-home-view");

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -731,6 +731,10 @@ li.active-sub-filter {
     }
 }
 
+.sidebar-menu-icon.hide {
+    visibility: hidden;
+}
+
 /* Don't show the scheduled messages item... */
 li.top_left_scheduled_messages {
     display: none;

--- a/web/tests/left_sidebar_navigation_area.test.cjs
+++ b/web/tests/left_sidebar_navigation_area.test.cjs
@@ -104,6 +104,8 @@ run_test("update_count_in_dom", () => {
         stream_unread_messages: 666,
     };
 
+    $(".selected-home-view").set_find_results(".sidebar-menu-icon", $("<menu-icon>"));
+
     make_elem($(".top_left_mentions"), "<mentioned-count>");
 
     make_elem($(".top_left_inbox"), "<home-count>");


### PR DESCRIPTION
This PR hides sidebar menu option button instead of showing it with "Mark all messages as read" option, for home view when there are no unread messages.

related [czo](https://chat.zulip.org/#narrow/channel/101-design/topic/When.20to.20show.20Mark.20all.20messages.20as.20unread.20on.20channel.20popover)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Before     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/1ed0fee9-0519-4a03-8e16-1268da48312b)    |
| After  | ![dm](https://github.com/user-attachments/assets/3adb4630-3b40-49a4-af89-b7fdc451d402) |


<details>
<summary>light theme</summary>

|                                    |                                     |
|-------------------------------------------|-------------------------------------------|
| Before     | ![Changes visible in alignment and hover](https://github.com/user-attachments/assets/dde09ce2-4957-48a0-b415-bd5ed60c3a6f)    |
| After  | ![dm](https://github.com/user-attachments/assets/034b9cb7-037a-4c24-a180-dc26e9b0d76e) |


</details>

<details>
<summary>Video demo</summary>


https://github.com/user-attachments/assets/652c287a-dcaf-4976-8501-d632700de046



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
