### PR TITLE
message_edit: Add last_moved_timestamp.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,25 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 365**
+
+* [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),
+  [`GET /messages/{message_id}`](/api/get-message): Added
+  `last_moved_timestamp` field to message objects for when the message
+  was last moved to a different channel or topic. If the message's topic
+  has only been [resolved or unresolved](/help/resolve-a-topic), then
+  the field is not present. Clients should use this field, rather than
+  parsing the message object's `edit_history` array, to display an
+  indicator that the message has been moved.
+ * [`GET /events`](/api/get-events), [`GET /messages`](/api/get-messages),
+  [`GET /messages/{message_id}`](/api/get-message): The
+  `last_edit_timestamp` field on message objects is only present if the
+  message's content has been edited. Previously, this field was present
+  if the message's content had been edited or moved to a different
+  channel or topic. Clients should use this field, rather than parsing
+  the message object's `edit_history` array, to display an indicator
+  that the message has been edited.
+
 **Feature level 364**
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 364
+API_FEATURE_LEVEL = 365
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -332,8 +332,11 @@ export function initialize(): void {
             }
 
             if (
-                realm.realm_message_edit_history_visibility_policy !==
-                message_edit_history_visibility_policy_values.never.code
+                realm.realm_message_edit_history_visibility_policy ===
+                    message_edit_history_visibility_policy_values.always.code ||
+                (realm.realm_message_edit_history_visibility_policy ===
+                    message_edit_history_visibility_policy_values.moves_only.code &&
+                    message.last_moved_timestamp !== undefined)
             ) {
                 fetch_and_render_message_history(message);
                 $("#message-history-overlay .exit-sign").trigger("focus");

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -9,7 +9,6 @@ import render_narrow_tooltip from "../templates/narrow_tooltip.hbs";
 import * as compose_validate from "./compose_validate.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
-import type {Message} from "./message_store.ts";
 import * as popover_menus from "./popover_menus.ts";
 import * as reactions from "./reactions.ts";
 import * as rows from "./rows.ts";
@@ -124,21 +123,9 @@ export function destroy_all_message_list_tooltips(): void {
     message_list_tippy_instances.clear();
 }
 
-function get_last_edit_timestr(message: Message): string | null {
-    let last_edit_timestamp;
-    if (message.local_edit_timestamp !== undefined) {
-        last_edit_timestamp = message.local_edit_timestamp;
-    } else {
-        last_edit_timestamp = message.last_edit_timestamp!;
-    }
-    const last_edit_time = new Date(last_edit_timestamp * 1000);
-
-    // Return null if the timestamp is invalid (i.e., there's no edit history).
-    if (Number.isNaN(last_edit_time.getTime())) {
-        return null;
-    }
-
-    let date = timerender.render_date(last_edit_time).textContent;
+function get_time_string(timestamp: number): string {
+    const last_modified_time = new Date(timestamp * 1000);
+    let date = timerender.render_date(last_modified_time).textContent;
     // If the date is today or yesterday, we don't want to show the date as capitalized.
     // Thus, we need to check if the date string contains a digit or not using regex,
     // since any other date except today/yesterday will contain a digit.
@@ -149,7 +136,7 @@ function get_last_edit_timestr(message: Message): string | null {
         {defaultMessage: "{date} at {time}"},
         {
             date,
-            time: timerender.stringify_time(last_edit_time),
+            time: timerender.stringify_time(last_modified_time),
         },
     );
 }
@@ -392,15 +379,22 @@ export function initialize(): void {
             assert(message_lists.current !== undefined);
             const message_container = message_lists.current.view.message_containers.get(message_id);
             assert(message_container !== undefined);
-            const last_edit_timestr = get_last_edit_timestr(message_container.msg);
-            if (last_edit_timestr === null) {
+            // If there is no indicator that the message has been modified (saving,
+            // edited, moved), then we don't show the message edit notice tooltip.
+            if (!message_container.modified) {
                 return false;
             }
+            // We know the message has been modified, so we either have a timestamp
+            // from the server or from a local edit.
+            assert(message_container.last_edit_timestamp !== undefined);
+            const last_modified_time_string = get_time_string(
+                message_container.last_edit_timestamp,
+            );
             instance.setContent(
                 parse_html(
                     render_message_edit_notice_tooltip({
                         moved: message_container.moved,
-                        last_edit_timestr,
+                        last_edit_timestr: last_modified_time_string,
                         realm_message_edit_history_is_visible:
                             realm.realm_message_edit_history_visibility_policy !==
                             message_edit_history_visibility_policy_values.never.code,

--- a/web/src/message_list_tooltips.ts
+++ b/web/src/message_list_tooltips.ts
@@ -384,20 +384,36 @@ export function initialize(): void {
             if (!message_container.modified) {
                 return false;
             }
-            // We know the message has been modified, so we either have a timestamp
-            // from the server or from a local edit.
-            assert(message_container.last_edit_timestamp !== undefined);
-            const last_modified_time_string = get_time_string(
-                message_container.last_edit_timestamp,
-            );
+            let edited_time_string = "";
+            let moved_time_string = "";
+            if (message_container.edited) {
+                // We know the message has been edited, so we either have a timestamp
+                // from the server or from a local edit.
+                assert(message_container.last_edit_timestamp !== undefined);
+                edited_time_string = get_time_string(message_container.last_edit_timestamp);
+            }
+            if (message_container.moved) {
+                // We know the message has been moved, so we have a timestamp from
+                // the server.
+                assert(message_container.last_moved_timestamp !== undefined);
+                moved_time_string = get_time_string(message_container.last_moved_timestamp);
+            }
+            const edit_history_access =
+                realm.realm_message_edit_history_visibility_policy ===
+                message_edit_history_visibility_policy_values.always.code;
+            const message_moved_and_move_history_access =
+                realm.realm_message_edit_history_visibility_policy ===
+                    message_edit_history_visibility_policy_values.moves_only.code &&
+                message_container.moved;
             instance.setContent(
                 parse_html(
                     render_message_edit_notice_tooltip({
                         moved: message_container.moved,
-                        last_edit_timestr: last_modified_time_string,
-                        realm_message_edit_history_is_visible:
-                            realm.realm_message_edit_history_visibility_policy !==
-                            message_edit_history_visibility_policy_values.never.code,
+                        edited: message_container.edited,
+                        edited_time_string,
+                        moved_time_string,
+                        edit_history_access,
+                        message_moved_and_move_history_access,
                     }),
                 ),
             );

--- a/web/src/message_store.ts
+++ b/web/src/message_store.ts
@@ -74,6 +74,7 @@ export const raw_message_schema = z.intersection(
             id: z.number(),
             is_me_message: z.boolean(),
             last_edit_timestamp: z.optional(z.number()),
+            last_moved_timestamp: z.optional(z.number()),
             reactions: z.array(message_reaction_schema),
             recipient_id: z.number(),
             sender_email: z.string(),

--- a/web/src/server_message.ts
+++ b/web/src/server_message.ts
@@ -49,6 +49,7 @@ export const server_message_schema = z
         id: z.number(),
         is_me_message: z.boolean(),
         last_edit_timestamp: z.number().optional(),
+        last_moved_timestamp: z.number().optional(),
         reactions: message_reaction_schema,
         recipient_id: z.number(),
         sender_email: z.string(),

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -4,13 +4,13 @@
         <div class="message_edit_notice">
             {{t "SAVING"}}
         </div>
-    {{else if moved}}
+    {{else if edited}}
         <div class="message_edit_notice">
-            {{t "MOVED"}}
+            {{t "EDITED"}}
         </div>
     {{else}}
         <div class="message_edit_notice">
-            {{t "EDITED"}}
+            {{t "MOVED"}}
         </div>
     {{/if}}
 {{/if}}

--- a/web/templates/message_edit_notice_tooltip.hbs
+++ b/web/templates/message_edit_notice_tooltip.hbs
@@ -1,15 +1,30 @@
 <div>
-    {{#if realm_message_edit_history_is_visible}}
-    <div>{{t "View edit history"}}</div>
-    {{/if}}
-    <div class="tooltip-inner-content italic">
-        {{#if moved}}
-        {{t 'Last moved {last_edit_timestr}.'}}
-        {{else}}
-        {{t 'Last edited {last_edit_timestr}.'}}
+    {{#if edit_history_access}}
+        {{#if edited}}
+            {{#if moved}}
+            <div>{{t "View edit and move history"}}</div>
+            {{else}}
+            <div>{{t "View edit history"}}</div>
+            {{/if}}
+        {{else if moved}}
+            <div>{{t "View move history"}}</div>
         {{/if}}
+    {{else if message_moved_and_move_history_access}}
+        <div>{{t "View move history"}}</div>
+    {{/if}}
+    {{#if edited}}
+        <div class="tooltip-inner-content italic">
+            {{t 'Last edited {edited_time_string}.'}}
+        </div>
+    {{/if}}
+    {{#if moved}}
+    <div class="tooltip-inner-content italic">
+        {{t 'Last moved {moved_time_string}.'}}
     </div>
+    {{/if}}
 </div>
-{{#if realm_message_edit_history_is_visible}}
+{{#if edit_history_access}}
+{{tooltip_hotkey_hints "Shift" "H"}}
+{{else if message_moved_and_move_history_access}}
 {{tooltip_hotkey_hints "Shift" "H"}}
 {{/if}}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7216,6 +7216,7 @@ paths:
                                 id: {}
                                 is_me_message: {}
                                 last_edit_timestamp: {}
+                                last_moved_timestamp: {}
                                 reactions: {}
                                 recipient_id: {}
                                 sender_email: {}
@@ -8583,6 +8584,7 @@ paths:
                               id: {}
                               is_me_message: {}
                               last_edit_timestamp: {}
+                              last_moved_timestamp: {}
                               reactions: {}
                               recipient_id: {}
                               sender_email: {}
@@ -22456,6 +22458,7 @@ paths:
                           id: {}
                           is_me_message: {}
                           last_edit_timestamp: {}
+                          last_moved_timestamp: {}
                           reactions: {}
                           recipient_id: {}
                           sender_email: {}
@@ -24114,6 +24117,7 @@ components:
             id: {}
             is_me_message: {}
             last_edit_timestamp: {}
+            last_moved_timestamp: {}
             reactions: {}
             recipient_id: {}
             sender_email: {}
@@ -24304,10 +24308,32 @@ components:
         last_edit_timestamp:
           type: integer
           description: |
-            The UNIX timestamp for when the message was last edited,
-            in UTC seconds.
+            The UNIX timestamp for when the message's content was last edited, in
+            UTC seconds.
 
-            Not present if the message has never been edited.
+            Not present if the message's content has never been edited.
+
+            Clients should use this field, rather than parsing the `edit_history`
+            array, to display an indicator that the message has been edited.
+
+            **Changes**: Prior to Zulip 10.0 (feature level 365), this was the
+            time when the message was last edited or moved.
+        last_moved_timestamp:
+          type: integer
+          description: |
+            The UNIX timestamp for when the message was last moved to a different
+            channel or topic, in UTC seconds.
+
+            Not present if the message has never been moved, or if the only topic
+            moves for the message are [resolving or unresolving](/help/resolve-a-topic)
+            the message's topic.
+
+            Clients should use this field, rather than parsing the `edit_history`
+            array, to display an indicator that the message has been moved.
+
+            **Changes**: New in Zulip 10.0 (feature level 365). Previously,
+            parsing the `edit_history` array was required in order to correctly
+            display moved message indicators.
         reactions:
           type: array
           description: |

--- a/zerver/tests/test_message_move_topic.py
+++ b/zerver/tests/test_message_move_topic.py
@@ -22,6 +22,7 @@ from zerver.actions.realm_settings import (
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.message import truncate_topic
 from zerver.lib.test_classes import ZulipTestCase, get_topic_messages
+from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, messages_for_topic
 from zerver.lib.types import StreamMessageEditRequest
 from zerver.lib.user_topics import (
@@ -1471,6 +1472,14 @@ class MessageMoveTopicTest(ZulipTestCase):
             f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as resolved.",
         )
 
+        message_fetch_result = self.client_get(
+            f"/json/messages/{msg_id}",
+        )
+        self.assert_json_success(message_fetch_result)
+        message_dict = orjson.loads(message_fetch_result.content)["message"]
+        self.assert_json_success(result)
+        self.assertNotIn("last_moved_timestamp", message_dict)
+
         # Note that we are removing the prefix from the already truncated topic,
         # so unresolved_topic_name will not be the same as the original topic_name
         unresolved_topic_name = new_topic_name.replace(RESOLVED_TOPIC_PREFIX, "")
@@ -1490,6 +1499,14 @@ class MessageMoveTopicTest(ZulipTestCase):
             f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as unresolved.",
         )
 
+        message_fetch_result = self.client_get(
+            f"/json/messages/{msg_id}",
+        )
+        self.assert_json_success(message_fetch_result)
+        message_dict = orjson.loads(message_fetch_result.content)["message"]
+        self.assert_json_success(result)
+        self.assertNotIn("last_moved_timestamp", message_dict)
+
     def test_notify_resolve_and_move_topic(self) -> None:
         user_profile = self.example_user("hamlet")
         self.login("hamlet")
@@ -1498,16 +1515,22 @@ class MessageMoveTopicTest(ZulipTestCase):
         self.subscribe(user_profile, stream.name)
 
         # Resolve a topic normally first
-        msg_id = self.send_stream_message(user_profile, stream.name, "foo", topic_name=topic_name)
+        time_zero = timezone_now().replace(microsecond=0)
+        with time_machine.travel(time_zero, tick=False):
+            msg_id = self.send_stream_message(
+                user_profile, stream.name, "foo", topic_name=topic_name
+            )
         resolved_topic_name = RESOLVED_TOPIC_PREFIX + topic_name
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id),
-            {
-                "topic": resolved_topic_name,
-                "propagate_mode": "change_all",
-            },
-        )
-        self.assert_json_success(result)
+        first_message_move_time = time_zero + timedelta(seconds=2)
+        with time_machine.travel(first_message_move_time, tick=False):
+            result = self.client_patch(
+                "/json/messages/" + str(msg_id),
+                {
+                    "topic": resolved_topic_name,
+                    "propagate_mode": "change_all",
+                },
+            )
+            self.assert_json_success(result)
 
         messages = get_topic_messages(user_profile, stream, resolved_topic_name)
         self.assert_length(messages, 2)
@@ -1516,15 +1539,25 @@ class MessageMoveTopicTest(ZulipTestCase):
             f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as resolved.",
         )
 
+        message_fetch_result = self.client_get(
+            f"/json/messages/{msg_id}",
+        )
+        self.assert_json_success(message_fetch_result)
+        message_dict = orjson.loads(message_fetch_result.content)["message"]
+        self.assert_json_success(result)
+        self.assertNotIn("last_moved_timestamp", message_dict)
+
         # Test unresolving a topic while moving it (✔ test -> bar)
         new_topic_name = "bar"
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id),
-            {
-                "topic": new_topic_name,
-                "propagate_mode": "change_all",
-            },
-        )
+        second_message_move_time = time_zero + timedelta(seconds=4)
+        with time_machine.travel(second_message_move_time, tick=False):
+            result = self.client_patch(
+                "/json/messages/" + str(msg_id),
+                {
+                    "topic": new_topic_name,
+                    "propagate_mode": "change_all",
+                },
+            )
         self.assert_json_success(result)
         messages = get_topic_messages(user_profile, stream, new_topic_name)
         self.assert_length(messages, 3)
@@ -1533,21 +1566,45 @@ class MessageMoveTopicTest(ZulipTestCase):
             f"This topic was moved here from #**public stream>✔ test** by @_**{user_profile.full_name}|{user_profile.id}**.",
         )
 
+        message_fetch_result = self.client_get(
+            f"/json/messages/{msg_id}",
+        )
+        self.assert_json_success(message_fetch_result)
+        message_dict = orjson.loads(message_fetch_result.content)["message"]
+        self.assert_json_success(result)
+        self.assertEqual(
+            message_dict["last_moved_timestamp"],
+            datetime_to_timestamp(second_message_move_time),
+        )
+
         # Now test moving the topic while also resolving it (bar -> ✔ baz)
         new_resolved_topic_name = RESOLVED_TOPIC_PREFIX + "baz"
-        result = self.client_patch(
-            "/json/messages/" + str(msg_id),
-            {
-                "topic": new_resolved_topic_name,
-                "propagate_mode": "change_all",
-            },
-        )
+        third_message_move_time = time_zero + timedelta(seconds=6)
+        with time_machine.travel(third_message_move_time, tick=False):
+            result = self.client_patch(
+                "/json/messages/" + str(msg_id),
+                {
+                    "topic": new_resolved_topic_name,
+                    "propagate_mode": "change_all",
+                },
+            )
         self.assert_json_success(result)
         messages = get_topic_messages(user_profile, stream, new_resolved_topic_name)
         self.assert_length(messages, 4)
         self.assertEqual(
             messages[3].content,
             f"This topic was moved here from #**public stream>{new_topic_name}** by @_**{user_profile.full_name}|{user_profile.id}**.",
+        )
+
+        message_fetch_result = self.client_get(
+            f"/json/messages/{msg_id}",
+        )
+        self.assert_json_success(message_fetch_result)
+        message_dict = orjson.loads(message_fetch_result.content)["message"]
+        self.assert_json_success(result)
+        self.assertEqual(
+            message_dict["last_moved_timestamp"],
+            datetime_to_timestamp(third_message_move_time),
         )
 
     def test_mark_topic_as_resolved(self) -> None:


### PR DESCRIPTION
This will allow clients to display MOVED/EDITED indicators, and their tooltips, without interacting with the `edit_history` section of message objects, which we plan to remove in the future.

Supporting that requires both introducing both last_moved_timestamp, and changing the definition of last_edit_timestamp to not include message moves, which involves recalculating it at the API layer.
