### PR TITLE
compose: Improve recipient row and collapsed compose buttons.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1036,7 +1036,7 @@ textarea.new_message_textarea {
     grid-template-columns:
         [topic-box-start topic-start] minmax(0, 1fr)
         [topic-end topic-clear-button-start] auto [topic-clear-button-end topic-box-end];
-    grid-template-rows: auto;
+    grid-template-rows: [topic-box-start topic-start topic-clear-button-start] auto [topic-clear-button-end topic-end topic-box-end];
     align-content: center;
     align-items: stretch;
     flex: 1 1 0;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -87,6 +87,7 @@
 
         .compose-reply-button-wrapper {
             flex-grow: 1;
+            display: flex;
             overflow: hidden;
         }
 
@@ -104,6 +105,7 @@
             min-width: inherit;
             margin: 1px;
             flex-shrink: 0;
+            align-self: stretch;
 
             color: var(--color-compose-embedded-button-text-color);
 
@@ -133,9 +135,14 @@
         }
     }
 
+    .new_direct_message_button_container {
+        display: flex;
+    }
+
     #new_direct_message_button {
         /* Keep the new message button sized to match
            adjacent buttons. */
+        align-self: stretch;
         font-size: inherit;
         min-width: inherit;
         line-height: var(--line-height-compose-buttons);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1335,6 +1335,10 @@ textarea.new_message_textarea {
 }
 
 #compose-recipient {
+    /* Enforce a shared, 'normal' line-height on
+       the recipient elements for baseline alignment,
+       and better use of the recipient-row space. */
+    line-height: normal;
     display: flex;
     flex: 1 1 0;
     /* Use this containing flex element to

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -222,6 +222,7 @@
             /* Ensure the marker ( < ) stays centered vertically
               with the dropdown, even when adjacent stacking pills
               in, e.g., a group DM. */
+            align-self: center;
             display: flex;
             align-items: center;
             /* Ensure horizontal centering, too. */
@@ -1463,8 +1464,6 @@ textarea.new_message_textarea {
 
 #compose_select_recipient_widget_wrapper {
     display: flex;
-    justify-content: flex-start;
-    height: var(--compose-recipient-box-min-height);
 
     &:focus-visible {
         outline: 0;


### PR DESCRIPTION
This PR makes some grid and flexbox improvements to the recipient row, and establishes a shared `normal` line-height on the stream button and topic input. While those do not follow the app's info-density settings, neither does the compose box itself.

I attempted yet again to replicate the low-res emoji issue in #31153, but was unable to do so. I have, however, presented screenshots below that suggest the emoji lines are undisturbed by the other improvements here.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20issues.20with.20topic.20box.20height/near/2113434)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_The crux of the issue here, with mismatched stream-picker and topic box heights, is easy to spot with an exaggerated line height (here, 300):_

| Before | After |
| --- | --- |
| ![closed-compose-exaggerated-300-line-height-before](https://github.com/user-attachments/assets/114fba37-b696-47f9-8730-a193a0c46f99) | ![closed-compose-exaggerated-300-line-height-after](https://github.com/user-attachments/assets/5dd4050a-fbae-406f-bc4f-91d60a33e4c8) |
| ![open-compose-exaggerated-300-line-height-before](https://github.com/user-attachments/assets/fd93b511-cbce-4e4e-b410-7f213dbeb495) | ![open-compose-exaggerated-300-line-height-after](https://github.com/user-attachments/assets/262e5d76-30e7-4b6e-a7e8-d6817984b021) |

_Other, more reasonable font-sizes and line-heights (14/122 and 16/140):_

| Before | After |
| --- | --- |
| ![14-122-open-before](https://github.com/user-attachments/assets/ce26662a-3348-4dd3-99c1-25b73eaa4e1e) | ![14-122-open-after](https://github.com/user-attachments/assets/65d74e08-08fc-4ff7-a069-f2f014e25063) |
| ![14-122-closed-before](https://github.com/user-attachments/assets/bb2f9920-56f9-461f-a405-6249f4d8feca) | ![14-122-close-after-no-change](https://github.com/user-attachments/assets/2e304f7e-cb0b-4ab0-9b7e-5b401551674b) |
| ![16-140-open-before](https://github.com/user-attachments/assets/116e3ee6-c4da-4073-897c-7887f9b9bcc7) | ![16-140-open-after](https://github.com/user-attachments/assets/875d0b97-7b64-4756-8ebe-f3cd893eb321) |
| ![16-140-closed-before](https://github.com/user-attachments/assets/ae743154-0e18-458d-8c97-7d9e030455cb) | ![16-140-closed-after-no-change](https://github.com/user-attachments/assets/697eed54-eaf9-48bc-ab7b-fc80c5b35c28) |

_Emoji, high and low res (no changes, apart from those above with heights):_

| Before | After |
| --- | --- |
| ![emoji-high-res-expanded-before](https://github.com/user-attachments/assets/28f5fb48-a6be-4a5c-a4c3-a226589c02de) | ![emoji-high-res-expanded-after](https://github.com/user-attachments/assets/1dfc500d-bf86-499a-bb55-5292f367cf5a) |
| ![emoji-high-res-collapsed-before](https://github.com/user-attachments/assets/5d723a67-1606-4621-9003-65c36542a227) | ![emoji-high-res-collapsed-after](https://github.com/user-attachments/assets/ca34a65f-ba07-4e02-933a-b8821cb759ed) |
| ![emoji-low-res-expanded-before](https://github.com/user-attachments/assets/7b1a6b61-50e5-4f2a-bf28-3a7019830a8f) | ![emoji-low-res-expanded-after](https://github.com/user-attachments/assets/bd665e06-d42e-4fe3-94c5-3a07068339fa) |
| ![emoji-low-res-collapsed-before](https://github.com/user-attachments/assets/11535c78-0964-4a07-bbc6-307c7d928cb9) | ![emoji-low-res-collapsed-after](https://github.com/user-attachments/assets/9877cd52-0189-4ea1-b42f-6f234820d198) |

_Finally, the general chat placeholder and topic are still aligned; both of these are with the After version:_

| Placeholder | Literal topic |
| --- | --- |
| ![enter-a-topic-after](https://github.com/user-attachments/assets/f9eb4a4e-4333-4ec7-88c5-f6182893da19) | ![enter-a-topic-text-after](https://github.com/user-attachments/assets/c42b74f1-97bb-4895-a89d-4665d4cbb76c) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>