### PR TITLE
channels: Include unsubscribed channels in move selectors.

### DIFF
--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -1062,3 +1062,21 @@ export function get_options_for_dropdown_widget(): (dropdown_widget.Option & {
         }))
         .sort((a, b) => util.strcmp(a.name.toLowerCase(), b.name.toLowerCase()));
 }
+
+export function get_streams_for_move_messages_widget(): (dropdown_widget.Option & {
+    stream: StreamSubscription;
+})[] {
+    return get_unsorted_subs_with_content_access()
+        .filter((stream) => !stream.is_archived)
+        .sort((a, b) => {
+            if (a.subscribed !== b.subscribed) {
+                return a.subscribed ? -1 : 1;
+            }
+            return util.strcmp(a.name.toLowerCase(), b.name.toLowerCase());
+        })
+        .map((stream) => ({
+            name: stream.name,
+            unique_id: stream.stream_id,
+            stream,
+        }));
+}

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -866,7 +866,7 @@ export async function build_move_topic_to_stream_popover(
 
         stream_widget_value = current_stream_id;
         const streams_list_options = (): dropdown_widget.Option[] =>
-            stream_data.get_options_for_dropdown_widget().filter(({stream}) => {
+            stream_data.get_streams_for_move_messages_widget().filter(({stream}) => {
                 if (stream.stream_id === current_stream_id) {
                     return true;
                 }

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -139,6 +139,9 @@ test("basics", () => {
         is_muted: true,
         invite_only: true,
         history_public_to_subscribers: true,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
     };
     const social = {
         subscribed: true,
@@ -148,6 +151,9 @@ test("basics", () => {
         is_muted: false,
         invite_only: true,
         history_public_to_subscribers: false,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
     };
     const test = {
         subscribed: true,
@@ -156,6 +162,9 @@ test("basics", () => {
         stream_id: 3,
         is_muted: true,
         invite_only: false,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
     };
     const web_public_stream = {
         subscribed: false,
@@ -166,6 +175,9 @@ test("basics", () => {
         invite_only: false,
         history_public_to_subscribers: true,
         is_web_public: true,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
     };
     stream_data.add_sub(denmark);
     stream_data.add_sub(social);
@@ -249,6 +261,14 @@ test("basics", () => {
     const stream_starting_with_25 = {
         name: "25-or-6-to-4",
         stream_id: 400,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
+        subscribed: false,
+        is_muted: false,
+        invite_only: false,
+        history_public_to_subscribers: true,
+        is_web_public: false,
     };
     stream_data.add_sub(stream_starting_with_25);
     assert.equal(stream_data.slug_to_stream_id("25-or-6-to-4"), 400);
@@ -263,6 +283,9 @@ test("basics", () => {
     const stream_99 = {
         name: "99",
         stream_id: 401,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
     };
     stream_data.add_sub(stream_99);
     assert.equal(stream_data.slug_to_stream_id("99"), 401);
@@ -272,6 +295,9 @@ test("basics", () => {
     const stream_id_99 = {
         name: "Some Stream",
         stream_id: 99,
+        can_add_subscribers_group: admins_group.id,
+        can_administer_channel_group: admins_group.id,
+        can_subscribe_group: admins_group.id,
     };
     stream_data.add_sub(stream_id_99);
     assert.equal(stream_data.slug_to_stream_id("99"), 99);
@@ -293,6 +319,9 @@ test("basics", () => {
                 name: "social",
                 stream_id: 2,
                 subscribed: true,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
             },
             unique_id: 2,
         },
@@ -305,8 +334,100 @@ test("basics", () => {
                 name: "test",
                 stream_id: 3,
                 subscribed: true,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
             },
             unique_id: 3,
+        },
+    ]);
+
+    assert.deepEqual(stream_data.get_streams_for_move_messages_widget(), [
+        {
+            name: "social",
+            stream: {
+                color: "red",
+                history_public_to_subscribers: false,
+                invite_only: true,
+                is_muted: false,
+                name: "social",
+                stream_id: 2,
+                subscribed: true,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 2,
+        },
+        {
+            name: "test",
+            stream: {
+                color: "yellow",
+                invite_only: false,
+                is_muted: true,
+                name: "test",
+                stream_id: 3,
+                subscribed: true,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 3,
+        },
+        {
+            name: "25-or-6-to-4",
+            stream: {
+                history_public_to_subscribers: true,
+                invite_only: false,
+                is_muted: false,
+                is_web_public: false,
+                name: "25-or-6-to-4",
+                stream_id: 400,
+                subscribed: false,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 400,
+        },
+        {
+            name: "web_public_stream",
+            stream: {
+                name: "web_public_stream",
+                stream_id: 4,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+                color: "yellow",
+                history_public_to_subscribers: true,
+                invite_only: false,
+                is_muted: false,
+                is_web_public: true,
+                subscribed: false,
+            },
+            unique_id: 4,
+        },
+        {
+            name: "99",
+            stream: {
+                name: "99",
+                stream_id: 401,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 401,
+        },
+        {
+            name: "Some Stream",
+            stream: {
+                name: "Some Stream",
+                stream_id: 99,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 99,
         },
     ]);
 
@@ -322,8 +443,75 @@ test("basics", () => {
                 name: "social",
                 stream_id: 2,
                 subscribed: true,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
             },
             unique_id: 2,
+        },
+    ]);
+
+    social.invite_only = true;
+    social.can_subscribe_group = me_group.id;
+    social.subscribed = false;
+
+    stream_starting_with_25.invite_only = true;
+
+    assert.deepEqual(stream_data.get_streams_for_move_messages_widget(), [
+        {
+            name: "social",
+            stream: {
+                color: "red",
+                history_public_to_subscribers: false,
+                invite_only: true,
+                is_muted: false,
+                name: "social",
+                stream_id: 2,
+                subscribed: false,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: me_group.id,
+            },
+            unique_id: 2,
+        },
+        {
+            name: "web_public_stream",
+            stream: {
+                color: "yellow",
+                history_public_to_subscribers: true,
+                invite_only: false,
+                is_muted: false,
+                is_web_public: true,
+                name: "web_public_stream",
+                stream_id: 4,
+                subscribed: false,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 4,
+        },
+        {
+            name: "99",
+            stream: {
+                name: "99",
+                stream_id: 401,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 401,
+        },
+        {
+            name: "Some Stream",
+            stream: {
+                name: "Some Stream",
+                stream_id: 99,
+                can_add_subscribers_group: admins_group.id,
+                can_administer_channel_group: admins_group.id,
+                can_subscribe_group: admins_group.id,
+            },
+            unique_id: 99,
         },
     ]);
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR includes the unsubscribed channels in move topics/messages dropdown. From the [conversation](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Channels.20to.20suggest.20when.20moving.20topics/with/2101733), all the channels (subscribed as well as unsubscribed) to which the user has content access will be shown in the move selector dropdown.

A new function ```get_sorted_stream_with_content_access()``` has been created to return subscribed channels first, followed by unsubscribed ones, with each group sorted individually.

With these changes, some tests were failing, so I have made some necessary changes in the tests in order to ensure that they pass.

Fixes: #33670 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![subscribed](https://github.com/user-attachments/assets/2c171345-2e44-4adc-b304-023ae854818f)

![unsubscribed](https://github.com/user-attachments/assets/8a3c66c2-9724-43a1-afe1-75f4d565becb)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
