### PR TITLE
emoji_popover: Fix arrow detached with the popover.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -261,6 +261,11 @@
         }
 
         .emoji-search-results-container {
+            /* Keep it hidden initially to avoid it taking extra height
+               when the emoji popover is initially rendered which can
+               cause the popover to render at incorrect position when
+               the search container is hidden `onMount`. */
+            display: none;
             height: 18.8667em; /* 283px at 15px/em */
 
             .emoji-popover-results-heading {


### PR DESCRIPTION
Initialy, both emoji search container and catalog were displayed which made popper position the popover for double the height than real. When search container was hidden `onMount`, the popover position was not updated which results in arrow being detached from the popover.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20triangle.20next.20to.20emoji.20button/with/2115620
