### PR TITLE
Rendering Display Of a yellow banner at the top of the group settings UI when a group is deactivated. #33803.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -100,7 +100,21 @@ h3,
     cursor: not-allowed;
 }
 
-
+/*
+Add the CSS for the banner in the appropriate stylesheet
+*/
+.deactivated-group-banner {
+    background-color: #ffff99; /* Light yellow */
+    color: #333; /* Dark text for contrast */
+    padding: 10px;
+    text-align: center;
+    font-weight: bold;
+    border-bottom: 1px solid #e6e600; /* Slightly darker yellow border */
+    margin-bottom: 10px; /* Space below the banner */
+    position: sticky; /* Optional: keep it visible while scrolling */
+    top: 0;
+    z-index: 1;
+}
 
 #account-settings .deactivate_realm_button {
     margin-left: 10px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -100,21 +100,7 @@ h3,
     cursor: not-allowed;
 }
 
-/*
-Add the CSS for the banner in the appropriate stylesheet
-*/
-.deactivated-group-banner {
-    background-color: #ffff99; /* Light yellow */
-    color: #333; /* Dark text for contrast */
-    padding: 10px;
-    text-align: center;
-    font-weight: bold;
-    border-bottom: 1px solid #e6e600; /* Slightly darker yellow border */
-    margin-bottom: 10px; /* Space below the banner */
-    position: sticky; /* Optional: keep it visible while scrolling */
-    top: 0;
-    z-index: 1;
-}
+
 
 #account-settings .deactivate_realm_button {
     margin-left: 10px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -100,6 +100,22 @@ h3,
     cursor: not-allowed;
 }
 
+/*
+Add the CSS for the banner in the appropriate stylesheet
+*/
+.deactivated-group-banner {
+    background-color: #ffff99; /* Light yellow */
+    color: #333; /* Dark text for contrast */
+    padding: 10px;
+    text-align: center;
+    font-weight: bold;
+    border-bottom: 1px solid #e6e600; /* Slightly darker yellow border */
+    margin-bottom: 10px; /* Space below the banner */
+    position: sticky; /* Optional: keep it visible while scrolling */
+    top: 0;
+    z-index: 1;
+}
+
 #account-settings .deactivate_realm_button {
     margin-left: 10px;
 }

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -17,6 +17,11 @@
 </div>
 <div class="user_group_settings_wrapper" data-group-id="{{group.id}}">
     <div class="inner-box">
+        {{#if group.deactivated}}
+        <div class="deactivated-group-banner">
+            This group is deactivated. It can't be mentioned or used for any permissions.
+        </div>
+        {{/if}}
 
         <div class="group_general_settings group_setting_section" data-group-section="general">
             <div class="group-header">
@@ -34,7 +39,7 @@
                     </button>
                 </div>
             </div>
-            <div class="group-adescription-wrapper">
+            <div class="group-description-wrapper">
                 <span class="group-description">
                     {{group.description}}
                 </span>

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -17,6 +17,11 @@
 </div>
 <div class="user_group_settings_wrapper" data-group-id="{{group.id}}">
     <div class="inner-box">
+        {{#if group.deactivated}}
+        <div class="deactivated-group-banner">
+            This group is deactivated. It can't be mentioned or used for any permissions.
+        </div>
+        {{/if}}
 
         <div class="group_general_settings group_setting_section" data-group-section="general">
             <div class="group-header">

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -17,11 +17,6 @@
 </div>
 <div class="user_group_settings_wrapper" data-group-id="{{group.id}}">
     <div class="inner-box">
-        {{#if group.deactivated}}
-        <div class="deactivated-group-banner">
-            This group is deactivated. It can't be mentioned or used for any permissions.
-        </div>
-        {{/if}}
 
         <div class="group_general_settings group_setting_section" data-group-section="general">
             <div class="group-header">
@@ -39,7 +34,7 @@
                     </button>
                 </div>
             </div>
-            <div class="group-description-wrapper">
+            <div class="group-adescription-wrapper">
                 <span class="group-description">
                     {{group.description}}
                 </span>


### PR DESCRIPTION
###Author
[alya](https://github.com/aly

### Date
Date:   Fri Mar 07 16:22:40 2025 

### Description
This PR adds a yellow banner at the top of the group settings panels to indicate when a group is deactivated, as requested in #33803. The banner displays the text: "This group is deactivated. It can't be mentioned or used for any permissions."

### Changes
- Modified `web/templates/user_group_settings.hbs` to add a conditional banner using `{{#if group.deactivated}}`.
- Added styling in `web/styles/user_groups.css` with a yellow background (`#ffff99`).

### Testing
- Deactivated a group using the "Deactivate group" button.
- Verified the banner appears in all tabs (General, Members, Permissions).
- Ensured the banner is styled correctly and remains visible while scrolling.

Fixes #33803
