### PR TITLE
server_events_dispatch: Sort array entries.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -797,12 +797,12 @@ export function dispatch_normal_event(event) {
             // here from `settings_account` when this file is converted to typescript,
             // and use them instead of `privacy_settings`.
             const privacy_settings = [
-                "send_stream_typing_notifications",
+                "allow_private_data_export",
+                "email_address_visibility",
+                "presence_enabled",
                 "send_private_typing_notifications",
                 "send_read_receipts",
-                "presence_enabled",
-                "email_address_visibility",
-                "allow_private_data_export",
+                "send_stream_typing_notifications",
             ];
 
             if (privacy_settings.includes(event.property)) {
@@ -819,31 +819,31 @@ export function dispatch_normal_event(event) {
 
             const user_preferences = [
                 "color_scheme",
-                "web_font_size_px",
-                "web_line_height_percent",
                 "default_language",
-                "web_home_view",
                 "demote_inactive_streams",
                 "dense_mode",
-                "web_mark_read_on_scroll_policy",
-                "web_channel_default_view",
+                "display_emoji_reaction_users",
                 "emojiset",
-                "web_escape_navigates_to_home_view",
+                "enter_sends",
                 "fluid_layout_width",
+                "hide_ai_features",
                 "high_contrast_mode",
                 "receives_typing_notifications",
+                "starred_message_counts",
                 "timezone",
-                "twenty_four_hour_time",
                 "translate_emoticons",
-                "display_emoji_reaction_users",
+                "twenty_four_hour_time",
                 "user_list_style",
                 "web_animate_image_previews",
-                "web_stream_unreads_count_display_policy",
-                "starred_message_counts",
+                "web_channel_default_view",
+                "web_escape_navigates_to_home_view",
+                "web_font_size_px",
+                "web_home_view",
+                "web_line_height_percent",
+                "web_mark_read_on_scroll_policy",
                 "web_navigate_to_sent_message",
-                "enter_sends",
+                "web_stream_unreads_count_display_policy",
                 "web_suggest_update_timezone",
-                "hide_ai_features",
             ];
 
             const original_home_view = user_settings.web_home_view;


### PR DESCRIPTION
This is a follow-up to #30425, addressing
https://github.com/zulip/zulip/pull/30425#discussion_r1882887744

<!-- Describe your pull request here.-->

Sorting is done using JavaScript's `Array#sort`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
