### PR TITLE
settings: Correct heights, borders for mobile scales.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -565,10 +565,10 @@
     /* The width of the settings sidebar. */
     --settings-sidebar-width: 18.2142em; /* 255px at 14px/em */
     /* .subscriptions-header and .settings-header */
-    --settings-overlay-header-height: 3.2142em; /* 45px at 14px/em */
+    --settings-overlay-header-height: 3.2143em; /* 45px at 14px/em */
     /* .display-type and .list-toggler-container
        in subscriptions and user group settings overlays */
-    --settings-overlay-subheader-height: 3.1428em; /* 44px at 14px/em */
+    --settings-overlay-subheader-height: 3.1429em; /* 44px at 14px/em */
     --settings-overlay-header-button-height: 2em;
     /* .settings-sticky-footer */
     --subscriptions-overlay-sticky-footer-height: 60px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1475,7 +1475,7 @@ label.preferences-radio-choice-label {
 
         &.mobile {
             display: none;
-            border-bottom: 1px solid hsl(0deg 0% 87%);
+            border-bottom: 1px solid var(--color-border-modal-bar);
 
             .fa-chevron-left {
                 float: left;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1837,6 +1837,10 @@ label.preferences-radio-choice-label {
             display: flex;
             justify-content: space-between;
             height: var(--settings-overlay-header-height);
+            /* We need the height to disregard border and
+               padding values added to other instances of
+               .settings-header. */
+            box-sizing: border-box;
 
             .fa-chevron-left {
                 transform: translate(-50px, 0);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1889,12 +1889,6 @@ label.preferences-radio-choice-label {
                 100% - var(--settings-overlay-header-height) -
                     var(--settings-overlay-subheader-height)
             );
-
-            & li.active {
-                /* Don't highlight the active section in the settings list. */
-                background: inherit;
-                border-bottom: 1px solid hsl(0deg 0% 93%);
-            }
         }
     }
 }


### PR DESCRIPTION
[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20settings.20modal.20borders/near/2111930)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_The dark-mode settings list looks to be missing a border,
but that's just owing to the border color's similarity to the subheader._

| Dark, before | Dark, after |
| --- | --- |
| ![settings-list-dark-before](https://github.com/user-attachments/assets/c10477c3-41ef-485b-9821-46481c232a29) | ![settings-list-dark-after](https://github.com/user-attachments/assets/8e25bc74-bbe8-4ab3-b162-1f34b582f74e) |
| ![preferences-dark-before](https://github.com/user-attachments/assets/7e29516c-9011-4289-8b3e-dc70ff15b71a) | ![preferences-dark-after](https://github.com/user-attachments/assets/7d5d2f81-1880-4d5b-b6b4-d7e383883f60) |

| Light, before | Light, after |
| --- | --- |
| ![settings-list-light-before](https://github.com/user-attachments/assets/573fd177-07ec-4686-8b89-86affe6c9f65) | ![settings-list-light-after](https://github.com/user-attachments/assets/57464e1f-9605-4056-b7e5-f0cbf87e9779) |
| ![preferences-light-before](https://github.com/user-attachments/assets/2b9b79c4-3fee-4040-964f-07cb4fe8933f) | ![preferences-light-after](https://github.com/user-attachments/assets/c876562b-f7a4-4391-b19e-43db6277f88e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>