### PR TITLE
compose_tooltips: Fix send button tooltip

### DIFF
--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -218,13 +218,17 @@ export function initialize(): void {
         appendTo: () => document.body,
         onShow(instance) {
             // Don't show send-area tooltips if the popover is displayed or if the send button is disabled.
-            if (
-                popover_menus.is_scheduled_messages_popover_displayed() ||
-                $(".message-send-controls").hasClass("disabled-message-send-controls")
-            ) {
+            if (popover_menus.is_scheduled_messages_popover_displayed()) {
                 return false;
             }
-            if (user_settings.enter_sends) {
+
+            if ($(".message-send-controls").hasClass("disabled-message-send-controls")) {
+                instance.setContent(
+                    compose_recipient.get_posting_policy_error_message() ||
+                        compose_validate.get_disabled_send_tooltip(),
+                );
+                return undefined;
+            } else if (user_settings.enter_sends) {
                 instance.setContent(parse_html($("#send-enter-tooltip-template").html()));
             } else {
                 instance.setContent(parse_html($("#send-ctrl-enter-tooltip-template").html()));
@@ -266,27 +270,6 @@ export function initialize(): void {
 
             return parse_html(render_narrow_to_compose_recipients_tooltip({display_current_view}));
         },
-        onHidden(instance) {
-            instance.destroy();
-        },
-    });
-
-    tippy.delegate("body", {
-        // TODO: Might need to target just the Send button itself
-        // in the new design
-        target: ".disabled-message-send-controls",
-        // 350px at 14px/1em
-        maxWidth: "25em",
-        onTrigger(instance) {
-            instance.setContent(
-                compose_recipient.get_posting_policy_error_message() ||
-                    compose_validate.get_disabled_send_tooltip(),
-            );
-        },
-        content: () =>
-            compose_recipient.get_posting_policy_error_message() ||
-            compose_validate.get_disabled_send_tooltip(),
-        appendTo: () => document.body,
         onHidden(instance) {
             instance.destroy();
         },


### PR DESCRIPTION
Previously, the tooltip was triggered by the entire message controls row, which also contains the options button. This caused overlapping tooltips as the options button has its own tooltip.

This commit resolves the issue by applying the tooltip only to the send button.

Fixes: [CZO Discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/send.20button.20tooltip.20hangs.20around/with/2116318)

**Screenshots and screen captures:**

| Before | After |
| -------- | ------- |
|![send_button_tooltip_before](https://github.com/user-attachments/assets/1f5de3da-8e11-408d-8da0-17ae3538a737) | ![send_button_tooltip_after](https://github.com/user-attachments/assets/c0f5d949-86cb-4126-bae8-003151277b79) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
