### PR TITLE
message_edit: Allow Save/Cancel buttons to properly size and flex.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -701,13 +701,13 @@
 
 .message-actions-button {
     box-sizing: border-box;
+    align-self: stretch;
     /* Display the actions buttons as
        flex containers for positioning
        text and spinners. */
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 28px;
     padding: 0 10px;
     border-radius: 4px;
     border: 0;
@@ -715,6 +715,10 @@
 }
 
 .message_edit_save {
+    /* Because the save button is inside this container,
+       we set the height here so the container stretches
+       with the flexbox. */
+    height: 100%;
     /* Match Save button's basic colors to
        the compose box Send button. */
     color: var(--color-compose-send-button-icon-color);


### PR DESCRIPTION
While I couldn't quite replicate the misalignment reported on CZO, the fixes here improve the size and layout of message-edit buttons generally--largely because this rids a hard-coded 28px height on the button areas, and allows them to grow with the flexbox containing the countdown timer.

[CZO issue](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/line.20height.20options/near/2115175)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing 14px and 20px, both at an exaggerated 200 line-height (no change at 14px):_

| Before | After |
| --- | --- |
| ![message-edit-14-200-before](https://github.com/user-attachments/assets/2a7675a3-0c47-4196-ab32-3efe406d7d6e) | ![message-edit-14-200-after-no-change](https://github.com/user-attachments/assets/c6ad4f49-9116-449e-8cf7-a62b1e59c359) |
| ![message-edit-20-200-before](https://github.com/user-attachments/assets/f146f64c-5122-480c-af0c-1b92b71ac1f1) | ![message-edit-20-200-after](https://github.com/user-attachments/assets/826f1368-5cd4-4a28-933b-cbc62f37ac61) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>