### PR TITLE
emoji: Allow emoji space, including alt_code, to better scale.

### DIFF
--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -73,12 +73,7 @@
         .emoji_alt_code {
             /* Apply the same margins as on graphical emoji. */
             margin: 1px 3px;
-            /* Reset some properties from the base .emoji_alt_code
-               class that aren't appropriate in a flexbox context. */
-            position: static;
-            /* Flexbox will handle baselines, so don't mess with the
-               line-height. */
-            line-height: inherit;
+            font-size: 0.8em;
         }
     }
 
@@ -89,12 +84,12 @@
            flexbox to handle the vertical alignment. */
         margin: 0 3px;
         /* Set the 12.6px text on a 13px line;
-           the goal is to have that 13px line
-           center correctly on the vertical with
-           the 17px-square emoji, resulting in
-           2px of space above and below the
-           reaction count/name. */
-        line-height: 13px;
+           the goal is to center correctly on the
+           vertical with square emoji, resulting in
+           equal space above and below the reaction
+           count/name.
+           13px at 12.6/1em */
+        line-height: 1.0317em;
     }
 
     .message_reaction:hover .message_reaction_count {
@@ -303,16 +298,6 @@
             overflow: hidden;
         }
     }
-}
-
-.emoji_alt_code {
-    position: relative;
-    top: 4px;
-    font-size: 0.8em;
-    display: inline-block;
-    vertical-align: top;
-    margin: 0 1px 0 0;
-    line-height: 1em;
 }
 
 .typeahead .emoji {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1305,7 +1305,9 @@ label.preferences-radio-choice-label {
 }
 
 .right.show .emoji_alt_code {
-    font-size: 1.2em;
+    /* This better aligns the example alt code
+       with the other emoji styles. */
+    margin-right: 1px;
 }
 
 .invite-user-link .fa-user-plus {


### PR DESCRIPTION
This makes some improvements to the settings UI and to the code behind app-wide presentation of emoji (though no changes are visible outside the settings UI).

[CZO discussion](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/line.20height.20options/near/2116113)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![emoji-settings-before](https://github.com/user-attachments/assets/5ca42085-b024-47cd-9b48-93fa0c2e46a1) | ![emoji-settings-after](https://github.com/user-attachments/assets/715bf889-c65e-41bc-b607-15d404761d40) |
| ![emoji-reactions-before](https://github.com/user-attachments/assets/bfb66eb8-9438-48f5-ad4e-7564f7ce9d43) | ![emoji-reactions-after](https://github.com/user-attachments/assets/7031cb2f-6d27-467f-bea8-474c181d4712) |
| ![emoji-text-reactions-before](https://github.com/user-attachments/assets/a1a993b0-efe0-418a-bc67-f2832ebfb60a) | ![emoji-text-reactions-after-no-change](https://github.com/user-attachments/assets/5cceb772-4086-4cd4-b16c-9c369b7d5f55) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>