### PR TITLE
channel_picker: Better align privacy icons with shifting line height.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2190,6 +2190,7 @@ body:not(.spectator-view) {
 .dropdown-list-container .dropdown-list .dropdown-list-item-common-styles {
     position: relative;
     display: flex;
+    align-items: center;
     color: var(--color-dropdown-item);
     padding: 3px 10px 3px 8px;
     font-weight: 400;
@@ -2198,13 +2199,14 @@ body:not(.spectator-view) {
 
     .stream-privacy-type-icon {
         font-size: 0.93em;
+        /* We set only the width so that flexbox
+           can do its work to properly center,
+           regardless of the height. */
         width: 0.93em;
-        height: 0.93em;
         padding-right: 5px;
-    }
-
-    .zulip-icon {
-        margin-top: 2px;
+        /* Override the [data-tippy-root]
+           style in `tooltips.css`. */
+        top: 0;
     }
 
     .dropdown-list-delete {


### PR DESCRIPTION
This improves icon alignment in the channel picker, both at very large line-heights and at smaller ones, too. 

<!-- Describe your pull request here.-->

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20channel-picker.20dropdown.20items.20alignment/near/2115328)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_There are some slight but not-uniform shifts at 122 line-height. Note that those are not uniform across all rows. Ideally, I think, post-10.0, we might look at getting a padlock icon that is sized and plays better with the globe and hash icons._

| Before | After |
| --- | --- |
| ![channel-picker-200-before](https://github.com/user-attachments/assets/2cb6b355-c9c6-4942-9151-23439b951bd4) | ![channel-picker-200-after](https://github.com/user-attachments/assets/b54f2e92-dccf-499e-8c33-a247845a2584) |
| ![channel-picker-122-after](https://github.com/user-attachments/assets/0545af9f-cec1-4b0b-9cfb-2d201a767e78) | ![channel-picker-122-before](https://github.com/user-attachments/assets/63283f46-e77c-4409-9ba2-ad1670828e71) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>