### PR TITLE
tables: Fixes to sorting and alignment in Recent views and Settings.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -783,8 +783,6 @@ input.settings_text_input {
         &[data-sort]:hover::after {
             content: " \f0d8";
             white-space: pre;
-            display: inline-block;
-            position: absolute;
             padding-top: 3px;
             font: normal normal normal 12px/1 FontAwesome;
             font-size: inherit;

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -775,10 +775,6 @@ input.settings_text_input {
         background-color: hsl(0deg 0% 100%);
         word-break: normal;
 
-        &[data-sort] {
-            padding-right: var(--table-header-sortable-column-padding-right);
-        }
-
         &.active::after,
         &[data-sort]:hover::after {
             content: " \f0d8";

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -618,13 +618,6 @@
     */
     --popover-tippy-arrow-before-offset: -6.5px;
 
-    /*
-    Padding used in headers for sortable columns in table to make sure
-    that the arrow is visible completely for different screen widths,
-    languages and font-size including when hovering over the header.
-    */
-    --table-header-sortable-column-padding-right: 1em;
-
     /* Color picker popover values */
     --size-color-swatch: 1em;
     --grid-gap-color-swatch: 1em;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -147,10 +147,6 @@
     .table_fix_head table th {
         padding: 8px;
         text-align: left;
-
-        &[data-sort] {
-            padding-right: var(--table-header-sortable-column-padding-right);
-        }
     }
 
     #recent_view_filter_buttons {
@@ -433,11 +429,11 @@
     }
 
     .recent-view-topic-header {
-        width: 35%;
+        width: 33%;
     }
 
     .recent-view-unread-header {
-        width: 5%;
+        width: 7%;
 
         .zulip-icon-unread {
             position: relative;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -400,8 +400,6 @@
         &[data-sort]:hover::after {
             content: " \f0d8";
             white-space: pre;
-            display: inline-block;
-            position: absolute;
             padding-top: 3px;
             font: normal normal normal 12px/1 FontAwesome;
             font-size: inherit;


### PR DESCRIPTION
While motivated largely by sort icons appearing much higher than the text at large line heights, which this PR addresses, this also simplifies the display of sort icons, making absolute positioning unnecessary (and actually a detriment to vertical alignment).

One of the consequences of those changes is that this eliminates a hover shift, easily visible on the Custom emoji settings, on certain columns (in that case, the Authors column).

This also opens up the space for the unread-sort column in Recent conversations. Obviously the area is still in need of a design pass, but this gets us into a better state.

[CZO discussion](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/line.20height.20options/near/2116113)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Recent conversations, before | Recent conversations, after |
| --- | --- |
| ![recent-view-14-122-before](https://github.com/user-attachments/assets/fe6ccb8b-d594-405c-a3a3-cbd85b8e4e41) | ![recent-view-14-122-after](https://github.com/user-attachments/assets/27068a07-94c7-41a3-987d-ac3ad2c21ca8) |
| ![recent-view-sort-looser-before](https://github.com/user-attachments/assets/ed946d68-1009-44d4-bdda-dbdf30372290)| ![recent-view-sort-looser-after](https://github.com/user-attachments/assets/83d8a3f0-7dfc-40e3-89ec-f9637073e587) |
| ![recent-view-sort-tight-before](https://github.com/user-attachments/assets/9c0d9869-430e-44bb-9cec-ffc5171ce764) | ![recent-view-sort-tight-after](https://github.com/user-attachments/assets/98dc3789-153c-4f3e-8096-33dc01653ad6) |

_The second set of images demonstrates the hover shift previously in `main`:_

| Custom emoji table, before | Custom emoji table, after |
| --- | --- |
| ![emoji-table-before](https://github.com/user-attachments/assets/fb783bda-76ca-4cd9-bdf7-42e027d8e9a8) | ![emoji-table-after](https://github.com/user-attachments/assets/d5b84b5d-cc2e-4776-ba9b-4f9647ce8710) |
| ![emoji-table-hover-before](https://github.com/user-attachments/assets/2799b3de-6371-40e3-a171-69081446999a) | ![emoji-table-hover-after](https://github.com/user-attachments/assets/6fc6a642-4ed2-457c-86da-bb2fa93018b6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>