### PR TITLE
rendered_markdown: Allow legacy YouTube thumbnails to size up.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -593,6 +593,14 @@
         cursor: pointer;
     }
 
+    .youtube-video img {
+        /* We do this for the sake of increasing
+           the size of older YouTube thumbnail
+           previews, but there are no ill effects
+           on newer preview images. */
+        object-fit: contain;
+    }
+
     &.rtl .twitter-image img,
     &.rtl .message_inline_image img,
     &.rtl .message_inline_ref img {


### PR DESCRIPTION
Because older YouTube preview images behind Camo cannot be modified to request a larger image, this fix enables a larger thumbnail display for previously linked videos.

[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/preview.20size.20on.20previously.20posted.20videos/near/2116085)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Legacy thumbnails, before | Legacy thumbnails, after |
| --- | --- |
| ![legacy-youtube-before](https://github.com/user-attachments/assets/9d6d8847-ac74-4797-8efa-b06eacbf2e95) | ![legacy-youtube-after](https://github.com/user-attachments/assets/69dd70c9-995e-4427-9741-f9339c93b017) |

| New thumbnails, before | New thumbnails, after (no change) |
| --- | --- |
| ![new-youtube-before](https://github.com/user-attachments/assets/060c8bee-7d07-412c-bc92-44e2c45bb80b) | ![new-youtube-after](https://github.com/user-attachments/assets/621d021e-ebcc-46af-9ed0-6ddd8f80b4f9) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>