### PR TITLE
help and docs: Document how to disable file uploads on a server.

### DIFF
--- a/docs/production/upload-backends.md
+++ b/docs/production/upload-backends.md
@@ -17,7 +17,9 @@ provider supported by the `boto` library).
 
 Regardless of the backend you choose, you can configure the maximum
 size of individual uploaded files using the `MAX_FILE_UPLOAD_SIZE`
-[server setting](../production/settings.md).
+[server setting](../production/settings.md). Setting it to 0 disables
+file uploads, and hides the UI for uploading files from the web and
+desktop apps.
 
 ## S3 backend configuration
 

--- a/help/share-and-upload-files.md
+++ b/help/share-and-upload-files.md
@@ -125,7 +125,8 @@ The Zulip Cloud Free [plan](https://zulip.com/plans/#cloud) includes a total of
 
 In organizations on a self-hosted server, server administrators can configure
 the maximum size for uploaded files via the `MAX_FILE_UPLOAD_SIZE`
-[server setting][system-settings].
+[server setting][system-settings]. Setting it to 0 disables file uploads, and
+hides the UI for uploading files from the web and desktop apps.
 
 [system-settings]: https://zulip.readthedocs.io/en/stable/production/settings.html
 


### PR DESCRIPTION
Note: We don't currently hide the UI in mobile apps. @chrisbobbe is filing a Flutter app issue.

https://zulip.com/help/share-and-upload-files

![Screenshot 2025-03-07 at 16 43 14@2x](https://github.com/user-attachments/assets/9a6f856a-b6d1-45d4-8268-f156cc769701)

