### PR TITLE
right_sidebar: Remove invite users icon at bottom of buddy list.

### DIFF
--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -605,39 +605,15 @@
     margin-bottom: var(--sidebar-bottom-spacing);
 
     .invite-user-link {
-        grid-template:
-            "left-spacing icon text" /
-            calc(var(--right-sidebar-toggle-width-offset) - 2px)
-            var(--right-sidebar-presence-circle-width)
-            minmax(0, 1fr);
-
-        .zulip-icon-user-plus {
-            grid-area: icon;
-            justify-self: center;
-            /* Smaller icon size to align the link text with the other buddy list links */
-            font-size: 13px;
-        }
-
-        .right-sidebar-wrappable-text-inner {
-            grid-area: text;
-        }
+        /* TODO: We should eventually change the grid to use the correct
+           --right-sidebar-presence-circle-width with left spacing, and
+           share that left spacing value here. */
+        padding-left: calc(var(--right-sidebar-toggle-width-offset) + 0.3em);
     }
 }
 
 #user-list.with_avatars .invite-user-link {
-    /* Subtract 2px to account for the border on this element */
-    grid-template:
-        "icon middle-spacing text" /
-        var(--right-sidebar-header-icon-toggle-width)
-        calc(
-            var(--right-sidebar-text-indent-with-avatar) - 2px -
-                var(--right-sidebar-header-icon-toggle-width)
-        )
-        minmax(0, 1fr);
-
-    .zulip-icon-user-plus {
-        margin-left: calc(var(--right-sidebar-header-icon-toggle-width) / 2);
-    }
+    padding-left: calc(var(--right-sidebar-header-icon-toggle-width) / 2);
 }
 
 #buddy-list-actions-menu-popover {

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -28,7 +28,6 @@
                 <div id="buddy_list_wrapper_padding"></div>
                 <div class="invite-user-shortcut">
                     <a class="invite-user-link right-sidebar-wrappable-text-container" role="button">
-                        <i class="zulip-icon zulip-icon-user-plus" aria-hidden="true"></i>
                         <span class="right-sidebar-wrappable-text-inner">
                             {{t 'Invite to organization' }}
                         </span>


### PR DESCRIPTION
Discussion here:
https://chat.zulip.org/#narrow/channel/101-design/topic/right.20sidebar.20design.20tweaks.20.20.2332976/near/2115335

All screenshots at 16px. I can share them at other font sizes if that's desired. I did do some manual testing at other font sizes.

**Generic screenshot**

| avatars |  no avatars |
| ---- | --- |
| <img width="267" alt="image" src="https://github.com/user-attachments/assets/b0083959-1bae-4310-a1e5-dfdb8ee81621" /> |  <img width="270" alt="image" src="https://github.com/user-attachments/assets/47851855-d517-48ac-b0cb-a1dc8620bbf2" /> |

**No headers**

| avatars |  no avatars |
| ---- | --- |
| <img width="265" alt="image" src="https://github.com/user-attachments/assets/5a924c7a-ba68-48ee-a5bd-8612aa9d850c" /> |  <img width="273" alt="image" src="https://github.com/user-attachments/assets/71bd3786-ba0a-46b5-bf6d-590ad27788a9" /> |


**OTHERS collapsed**


| avatars |  no avatars |
| ---- | --- |
| <img width="262" alt="image" src="https://github.com/user-attachments/assets/148f5727-133b-4d42-b234-7756e8dfe371" /> |  <img width="278" alt="image" src="https://github.com/user-attachments/assets/56b224b9-c2d7-438d-950a-cb09345cf5cb" /> |


**VIEW MORE links**


| avatars |  no avatars |
| ---- | --- |
| <img width="271" alt="image" src="https://github.com/user-attachments/assets/4210f7ce-7361-4dca-82eb-d6630c8e2727" /> |  <img width="263" alt="image" src="https://github.com/user-attachments/assets/94d6389e-5a89-4283-8f87-66bd378a162a" /> |
