### PR TITLE
saved_snippets: Add support for editing saved snippets.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 368**
+
+* [`GET /events`](/api/get-events): An event with `type: "saved_snippet"`
+  and `op: "update"` is sent to the current user when a saved snippet is edited.
+* [`PATCH /saved_snippets/{saved_snippet_id}`](/api/edit-saved-snippet):
+  Added a new endpoint for editing a saved snippet.
+
 **Feature level 367**
 
 * [`POST /register`](/api/register-queue), [`POST /events`](/api/get-events):

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -34,6 +34,7 @@
 * [Delete a draft](/api/delete-draft)
 * [Get all saved snippets](/api/get-saved-snippets)
 * [Create a saved snippet](/api/create-saved-snippet)
+* [Edit a saved snippet](/api/edit-saved-snippet)
 * [Delete a saved snippet](/api/delete-saved-snippet)
 
 #### Channels

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 367
+API_FEATURE_LEVEL = 368
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/saved_snippets.ts
+++ b/web/src/saved_snippets.ts
@@ -21,7 +21,7 @@ export function get_saved_snippet_by_id(saved_snippet_id: number): SavedSnippet 
     return saved_snippet;
 }
 
-export function add_saved_snippet(saved_snippet: SavedSnippet): void {
+export function update_saved_snippet_dict(saved_snippet: SavedSnippet): void {
     saved_snippets_dict.set(saved_snippet.id, saved_snippet);
 }
 
@@ -39,6 +39,7 @@ export function get_options_for_dropdown_widget(): Option[] {
         description: saved_snippet.content,
         bold_current_selection: true,
         has_delete_icon: true,
+        has_edit_icon: true,
     }));
 
     return options;

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -577,11 +577,15 @@ export function dispatch_normal_event(event) {
         case "saved_snippets":
             switch (event.op) {
                 case "add":
-                    saved_snippets.add_saved_snippet(event.saved_snippet);
+                    saved_snippets.update_saved_snippet_dict(event.saved_snippet);
                     saved_snippets_ui.rerender_dropdown_widget();
                     break;
                 case "remove":
                     saved_snippets.remove_saved_snippet(event.saved_snippet_id);
+                    saved_snippets_ui.rerender_dropdown_widget();
+                    break;
+                case "update":
+                    saved_snippets.update_saved_snippet_dict(event.saved_snippet);
                     saved_snippets_ui.rerender_dropdown_widget();
                     break;
             }

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -688,6 +688,16 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".saved_snippets-dropdown-list-container .dropdown-list-edit",
+        content: $t({defaultMessage: "Edit snippet"}),
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".generate-channel-email-button-container.disabled_setting_tooltip",
         content: $t({defaultMessage: "You do not have permission to post in this channel."}),
         appendTo: () => document.body,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1706,7 +1706,8 @@ textarea.new_message_textarea {
     }
 }
 
-#add-new-saved-snippet-modal {
+#add-new-saved-snippet-modal,
+#edit-saved-snippet-modal {
     & .saved-snippet-title {
         width: 97%;
         margin-bottom: 20px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2194,11 +2194,21 @@ body:not(.spectator-view) {
             top: 0.2419em;
         }
 
-        .dropdown-list-delete {
+        .dropdown-list-delete,
+        .dropdown-list-edit {
             position: absolute;
             top: 0;
             right: 5px;
             visibility: hidden;
+        }
+
+        .dropdown-list-edit {
+            color: var(--color-text-neutral-icon-button);
+            right: 30px;
+
+            &:hover {
+                color: var(--color-text-neutral-icon-button-hover);
+            }
         }
 
         &:focus,
@@ -2208,7 +2218,8 @@ body:not(.spectator-view) {
             background-color: var(--background-color-active-dropdown-item);
             outline: none;
 
-            .dropdown-list-delete {
+            .dropdown-list-delete,
+            .dropdown-list-edit {
                 visibility: visible;
             }
         }

--- a/web/templates/dropdown_list.hbs
+++ b/web/templates/dropdown_list.hbs
@@ -5,6 +5,9 @@
             <span class="dropdown-list-item-name">
                 {{#if bold_current_selection}}
                     <span class="dropdown-list-bold-selected">{{name}}</span>
+                    {{#if has_edit_icon}}
+                        {{> components/icon_button custom_classes="dropdown-list-edit" intent="brand" icon="edit" aria-label=(t "Edit snippet") }}
+                    {{/if}}
                     {{#if has_delete_icon}}
                         {{> components/icon_button custom_classes="dropdown-list-delete" intent="danger" icon="trash" aria-label=(t "Delete snippet") }}
                     {{/if}}

--- a/web/templates/edit_saved_snippet_modal.hbs
+++ b/web/templates/edit_saved_snippet_modal.hbs
@@ -1,0 +1,10 @@
+<div id="edit-saved-snippet-modal" class="new-style">
+    <form id="edit-saved-snippet-form" class="new-style">
+        <label for="title" class="modal-field-label">{{t "Title" }}</label>
+        <input id="edit-saved-snippet-title" type="text" name="title" class="modal_text_input saved-snippet-title" value="{{title}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+        <div>{{t "Content" }}</div>
+        <textarea class="settings_textarea saved-snippet-content" rows="4">
+            {{~content~}}
+        </textarea>
+    </form>
+</div>

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -194,7 +194,7 @@ run_test("saved_snippets", ({override}) => {
     override(saved_snippets_ui, "rerender_dropdown_widget", noop);
     {
         const stub = make_stub();
-        override(saved_snippets, "add_saved_snippet", stub.f);
+        override(saved_snippets, "update_saved_snippet_dict", stub.f);
 
         dispatch(add_event);
         assert.equal(stub.num_calls, 1);
@@ -209,6 +209,16 @@ run_test("saved_snippets", ({override}) => {
         dispatch(remove_event);
         assert.equal(stub.num_calls, 1);
         assert_same(stub.get_args("event").event, remove_event.saved_snippet_id);
+    }
+
+    const update_event = event_fixtures.saved_snippets__update;
+    {
+        const stub = make_stub();
+        override(saved_snippets, "update_saved_snippet_dict", stub.f);
+
+        dispatch(update_event);
+        assert.equal(stub.num_calls, 1);
+        assert_same(stub.get_args("event").event, update_event.saved_snippet);
     }
 });
 

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -666,6 +666,17 @@ exports.fixtures = {
         saved_snippet_id: 1,
     },
 
+    saved_snippets__update: {
+        type: "saved_snippets",
+        op: "update",
+        saved_snippet: {
+            id: 1,
+            title: "Example 2",
+            content: "Welcome to the organization.",
+            date_created: 1681662420,
+        },
+    },
+
     scheduled_messages__add: {
         type: "scheduled_messages",
         op: "add",

--- a/web/tests/saved_snippets.test.cjs
+++ b/web/tests/saved_snippets.test.cjs
@@ -41,7 +41,7 @@ run_test("add_saved_snippet", () => {
         content: "Test content",
         date_created: 128374878,
     };
-    saved_snippets.add_saved_snippet(saved_snippet);
+    saved_snippets.update_saved_snippet_dict(saved_snippet);
 
     const my_saved_snippet = saved_snippets.get_saved_snippet_by_id(2);
     assert.equal(my_saved_snippet, saved_snippet);
@@ -54,7 +54,7 @@ run_test("options for dropdown widget", () => {
         content: "Test content",
         date_created: 128374876,
     };
-    saved_snippets.add_saved_snippet(saved_snippet);
+    saved_snippets.update_saved_snippet_dict(saved_snippet);
 
     assert.deepEqual(saved_snippets.get_options_for_dropdown_widget(), [
         {
@@ -63,6 +63,7 @@ run_test("options for dropdown widget", () => {
             description: "Test content",
             bold_current_selection: true,
             has_delete_icon: true,
+            has_edit_icon: true,
         },
         {
             unique_id: 2,
@@ -70,6 +71,7 @@ run_test("options for dropdown widget", () => {
             description: "Test content",
             bold_current_selection: true,
             has_delete_icon: true,
+            has_edit_icon: true,
         },
         {
             unique_id: 1,
@@ -77,6 +79,7 @@ run_test("options for dropdown widget", () => {
             description: "Test content",
             bold_current_selection: true,
             has_delete_icon: true,
+            has_edit_icon: true,
         },
     ]);
 });

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -63,6 +63,7 @@ from zerver.lib.event_types import (
     EventRestart,
     EventSavedSnippetsAdd,
     EventSavedSnippetsRemove,
+    EventSavedSnippetsUpdate,
     EventScheduledMessagesAdd,
     EventScheduledMessagesRemove,
     EventScheduledMessagesUpdate,
@@ -189,6 +190,7 @@ check_realm_user_remove = make_checker(EventRealmUserRemove)
 check_restart = make_checker(EventRestart)
 check_saved_snippets_add = make_checker(EventSavedSnippetsAdd)
 check_saved_snippets_remove = make_checker(EventSavedSnippetsRemove)
+check_saved_snippets_update = make_checker(EventSavedSnippetsUpdate)
 check_scheduled_message_add = make_checker(EventScheduledMessagesAdd)
 check_scheduled_message_remove = make_checker(EventScheduledMessagesRemove)
 check_scheduled_message_update = make_checker(EventScheduledMessagesUpdate)

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -710,6 +710,12 @@ class EventSavedSnippetsAdd(BaseEvent):
     saved_snippet: SavedSnippetFields
 
 
+class EventSavedSnippetsUpdate(BaseEvent):
+    type: Literal["saved_snippets"]
+    op: Literal["update"]
+    saved_snippet: SavedSnippetFields
+
+
 class EventSavedSnippetsRemove(BaseEvent):
     type: Literal["saved_snippets"]
     op: Literal["remove"]

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -969,6 +969,11 @@ def apply_event(
                 if saved_snippet["id"] == event["saved_snippet_id"]:
                     del state["saved_snippets"][idx]
                     break
+        elif event["op"] == "update":
+            for idx, saved_snippet in enumerate(state["saved_snippets"]):
+                if saved_snippet["id"] == event["saved_snippet"]["id"]:
+                    state["saved_snippets"][idx] = event["saved_snippet"]
+                    break
 
     elif event["type"] == "drafts":
         if event["op"] == "add":

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5510,6 +5510,41 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
+                                Event containing details of the edited saved snippet.
+
+                                Clients should update the existing saved snippet with the
+                                ID provided in the `saved_snippet` object.
+
+                                **Changes**: New in Zulip 10.0 (feature level 368).
+                              properties:
+                                id:
+                                  $ref: "#/components/schemas/EventIdSchema"
+                                type:
+                                  allOf:
+                                    - $ref: "#/components/schemas/EventTypeSchema"
+                                    - enum:
+                                        - saved_snippets
+                                op:
+                                  type: string
+                                  enum:
+                                    - update
+                                saved_snippet:
+                                  $ref: "#/components/schemas/SavedSnippet"
+                              example:
+                                {
+                                  "type": "saved_snippets",
+                                  "op": "update",
+                                  "saved_snippet":
+                                    {
+                                      "id": 1,
+                                      "title": "Example",
+                                      "content": "Welcome to the organization.",
+                                      "date_created": 1681662420,
+                                    },
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
                                 Event containing the ID of a deleted saved snippet.
 
                                 **Changes**: New in Zulip 10.0 (feature level 297).
@@ -6398,6 +6433,78 @@ paths:
                       A typical failed JSON response for when either title or content is
                       empty:
   /saved_snippets/{saved_snippet_id}:
+    patch:
+      operationId: edit-saved-snippet
+      tags: ["drafts"]
+      summary: Edit a saved snippet
+      description: |
+        Edit a saved snippet for the current user.
+
+        **Changes**: New in Zulip 10.0 (feature level 368).
+      parameters:
+        - name: saved_snippet_id
+          in: path
+          schema:
+            type: integer
+          description: |
+            The ID of the saved snippet to edit.
+          required: true
+          example: 3
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: |
+                    The title of the saved snippet.
+                  example: Welcome message
+                content:
+                  type: string
+                  description: |
+                    The content of the saved snippet in text/markdown format.
+
+                    Clients should insert this content into a message when using
+                    a saved snippet.
+                  example: Welcome to the organization.
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "No new data is supplied",
+                        "result": "error",
+                      }
+                    description: |
+                      A typical failed JSON response for when neither title nor content is
+                      provided in the request:
+        "404":
+          description: Not Found.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - description: |
+                      A typical failed JSON response for when no saved snippet exists
+                      with the provided ID:
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "result": "error",
+                        "msg": "Saved snippet does not exist.",
+                      }
     delete:
       operationId: delete-saved-snippet
       tags: ["drafts"]

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -92,7 +92,11 @@ from zerver.actions.realm_settings import (
     do_set_realm_user_default_setting,
     do_set_realm_zulip_update_announcements_stream,
 )
-from zerver.actions.saved_snippets import do_create_saved_snippet, do_delete_saved_snippet
+from zerver.actions.saved_snippets import (
+    do_create_saved_snippet,
+    do_delete_saved_snippet,
+    do_edit_saved_snippet,
+)
 from zerver.actions.scheduled_messages import (
     check_schedule_message,
     delete_scheduled_message,
@@ -186,6 +190,7 @@ from zerver.lib.event_schema import (
     check_realm_user_update,
     check_saved_snippets_add,
     check_saved_snippets_remove,
+    check_saved_snippets_update,
     check_scheduled_message_add,
     check_scheduled_message_remove,
     check_scheduled_message_update,
@@ -1767,6 +1772,10 @@ class NormalActionsTest(BaseAction):
         saved_snippet_id = (
             SavedSnippet.objects.filter(user_profile=self.user_profile).order_by("id")[0].id
         )
+        with self.verify_action() as events:
+            do_edit_saved_snippet(saved_snippet_id, "Example", None, self.user_profile)
+        check_saved_snippets_update("events[0]", events[0])
+
         with self.verify_action() as events:
             do_delete_saved_snippet(saved_snippet_id, self.user_profile)
         check_saved_snippets_remove("events[0]", events[0])

--- a/zerver/tests/test_saved_snippets.py
+++ b/zerver/tests/test_saved_snippets.py
@@ -49,6 +49,36 @@ class SavedSnippetTests(ZulipTestCase):
             msg=f"title is too long (limit: {SavedSnippet.MAX_TITLE_LENGTH} characters)",
         )
 
+    def test_edit_saved_snippet(self) -> None:
+        """Tests updation of saved snippets."""
+
+        user = self.example_user("hamlet")
+        self.login_user(user)
+        saved_snippet_id = self.create_example_saved_snippet(user)
+
+        result = self.client_patch(
+            f"/json/saved_snippets/{saved_snippet_id}",
+            {"title": "New title"},
+        )
+        self.assert_json_success(result)
+
+        result = self.client_patch(
+            f"/json/saved_snippets/{saved_snippet_id}", {"content": "New content"}
+        )
+        self.assert_json_success(result)
+
+        result = self.client_patch(
+            f"/json/saved_snippets/{saved_snippet_id}",
+        )
+        self.assert_json_error(result, "No new data is supplied", status_code=400)
+
+        # Tests if error is thrown when the provided ID does not exist.
+        result = self.client_patch(
+            "/json/saved_snippets/10",
+            {"content": "New content"},
+        )
+        self.assert_json_error(result, "Saved snippet does not exist.", status_code=404)
+
     def test_delete_saved_snippet(self) -> None:
         """Tests deletion of saved snippets."""
 

--- a/zerver/views/saved_snippets.py
+++ b/zerver/views/saved_snippets.py
@@ -2,15 +2,18 @@ from typing import Annotated
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
+from django.utils.translation import gettext as _
 from pydantic import StringConstraints
 
 from zerver.actions.saved_snippets import (
     do_create_saved_snippet,
     do_delete_saved_snippet,
+    do_edit_saved_snippet,
     do_get_saved_snippets,
 )
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.response import json_success
-from zerver.lib.typed_endpoint import typed_endpoint
+from zerver.lib.typed_endpoint import PathOnly, typed_endpoint
 from zerver.models import SavedSnippet, UserProfile
 
 
@@ -43,6 +46,32 @@ def create_saved_snippet(
     content = content.strip()
     saved_snippet = do_create_saved_snippet(title, content, user_profile)
     return json_success(request, data={"saved_snippet_id": saved_snippet.id})
+
+
+@typed_endpoint
+def edit_saved_snippet(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    *,
+    saved_snippet_id: PathOnly[int],
+    title: Annotated[
+        str | None,
+        StringConstraints(
+            min_length=1, max_length=SavedSnippet.MAX_TITLE_LENGTH, strip_whitespace=True
+        ),
+    ] = None,
+    content: Annotated[
+        str | None,
+        StringConstraints(
+            min_length=1, max_length=settings.MAX_MESSAGE_LENGTH, strip_whitespace=True
+        ),
+    ] = None,
+) -> HttpResponse:
+    if title is None and content is None:
+        raise JsonableError(_("No new data is supplied"))
+
+    do_edit_saved_snippet(saved_snippet_id, title, content, user_profile)
+    return json_success(request)
 
 
 def delete_saved_snippet(

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -153,6 +153,7 @@ from zerver.views.report import report_csp_violations
 from zerver.views.saved_snippets import (
     create_saved_snippet,
     delete_saved_snippet,
+    edit_saved_snippet,
     get_saved_snippets,
 )
 from zerver.views.scheduled_messages import (
@@ -346,7 +347,11 @@ v1_api_and_json_patterns = [
     rest_path("drafts/<int:draft_id>", PATCH=edit_draft, DELETE=delete_draft),
     # saved_snippets -> zerver.views.saved_snippets
     rest_path("saved_snippets", GET=get_saved_snippets, POST=create_saved_snippet),
-    rest_path("saved_snippets/<int:saved_snippet_id>", DELETE=delete_saved_snippet),
+    rest_path(
+        "saved_snippets/<int:saved_snippet_id>",
+        DELETE=delete_saved_snippet,
+        PATCH=edit_saved_snippet,
+    ),
     # New scheduled messages are created via send_message_backend.
     rest_path(
         "scheduled_messages", GET=fetch_scheduled_messages, POST=create_scheduled_message_backend


### PR DESCRIPTION
<!-- Describe your pull request here.-->
<details><summary>Screenshots</summary>
<p>




| state | dark | light |
|--------|--------|--------|
| without hover | ![Screenshot 2025-03-13 145415](https://github.com/user-attachments/assets/ab73d5c3-ad3a-4f02-a481-8383c24cdee5) | ![Screenshot 2025-03-13 145517](https://github.com/user-attachments/assets/fbb58ee7-1d56-4f3d-9422-48722bc4871e) |
| hover | ![Screenshot 2025-03-13 145424](https://github.com/user-attachments/assets/95347883-fd5a-4a70-ac72-ba8318400060) | ![Screenshot 2025-03-13 145527](https://github.com/user-attachments/assets/f5ec4b99-acad-4060-bd62-4b9c2560cbef) | 

![image](https://github.com/user-attachments/assets/f0bf47b4-2a13-4cdc-9aa3-54e5efceb9e1)

</p>
</details> 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

Fixes #33708.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
