### PR TITLE
 Hide topic resolved banner when channel picker is open.

### DIFF
--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -312,6 +312,8 @@ function on_show_callback(): void {
 // NOTE: Since tippy triggers this on `mousedown` it is always triggered before say a `click` on `textarea`.
 function on_hidden_callback(): void {
     $("#compose_select_recipient_widget").removeClass("widget-open");
+    compose_state.set_is_processing_forward_message(false);
+    compose_validate.warn_if_topic_resolved(false);
     if (!compose_select_recipient_dropdown_widget.item_clicked) {
         // If the dropdown was NOT closed due to selecting an item,
         // don't do anything.

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -256,7 +256,7 @@ export function quote_message(opts: {
             topic = message.topic;
             stream_id = message.stream_id;
         }
-
+        compose_state.set_is_processing_forward_message(true);
         compose_actions.start({
             message_type: message.type,
             topic,

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -74,7 +74,11 @@ export function initialize() {
         if ($("#compose").hasClass("preview_mode")) {
             compose.render_preview_area();
         }
-        compose_validate.warn_if_topic_resolved(false);
+        const recipient_widget_hidden =
+            $(".compose_select_recipient-dropdown-list-container").length === 0;
+        if (recipient_widget_hidden) {
+            compose_validate.warn_if_topic_resolved(false);
+        }
         const compose_text_length = compose_validate.check_overflow_text($("#send_message_form"));
 
         // Change compose close button tooltip as per condition.

--- a/web/src/compose_state.ts
+++ b/web/src/compose_state.ts
@@ -10,6 +10,7 @@ let recipient_edited_manually = false;
 let is_content_unedited_restored_draft = false;
 let last_focused_compose_type_input: HTMLTextAreaElement | undefined;
 let preview_render_count = 0;
+let is_processing_forward_message = false;
 
 // We use this variable to keep track of whether user has viewed the topic resolved
 // banner for the current compose session, for a narrow. This prevents the banner
@@ -83,6 +84,14 @@ export function get_preview_render_count(): number {
 
 export function set_preview_render_count(count: number): void {
     preview_render_count = count;
+}
+
+export function set_is_processing_forward_message(val: boolean): void {
+    is_processing_forward_message = val;
+}
+
+export function get_is_processing_forward_message(): boolean {
+    return is_processing_forward_message;
 }
 
 export function composing(): boolean {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -439,6 +439,17 @@ export function warn_if_topic_resolved(topic_changed: boolean): void {
     //
     // Pass topic_changed=true if this function was called in response
     // to a topic being edited.
+    const recipient_widget_hidden =
+        $(".compose_select_recipient-dropdown-list-container").length === 0;
+    if (compose_state.get_is_processing_forward_message() && recipient_widget_hidden) {
+        // This is for the case of forwarding a message when the
+        // channel picker is opened. There is a possibility that
+        // this banner might be displayed at the same time the
+        // channel picker is opened. We don't want that situation.
+        // Therefore, we are preventing the display of this
+        // banner when the channel picker is opened.
+        return;
+    }
 
     const stream_id = compose_state.stream_id();
     if (stream_id === undefined) {


### PR DESCRIPTION
It was reported that when forwarding messages, the channel picker and the topic resolved banner were displayed simultaneously, with the channel picker being over the banner. This did not look well as the channel picker hid some left part of the banner.

This PR fixes the bug by displaying the banner only when the channel picker is not open.
<table border="1">
<tr>
 <th>Before</th>
 <th>After</th>
 </tr>
 <tr>
 <td>
   
![Screenshot from 2025-03-10 01-37-33](https://github.com/user-attachments/assets/50d7c69b-6813-4797-ad8f-a4a65472a16d)

 </td>
 <td>

![Screenshot from 2025-03-10 01-35-34](https://github.com/user-attachments/assets/fa53caf7-4938-4e08-804d-086f2e3e6133)

 </td>
 </tr>
 <tr>
<td>
</td>
 <td>
   
![Screenshot from 2025-03-10 01-36-52](https://github.com/user-attachments/assets/fd7a1d1b-9a29-40f7-ab99-4afa4526f97a)

</td>
</tr>

</table>



Fixes: #33449

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
