### PR TITLE
Fix export of mirror dummy users and SavedSnippet

### DIFF
--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -85,6 +85,7 @@ from zerver.models import (
 from zerver.models.presence import PresenceSequence
 from zerver.models.realm_audit_logs import AuditLogEventType
 from zerver.models.realms import get_realm
+from zerver.models.saved_snippets import SavedSnippet
 from zerver.models.users import get_system_bot, get_user_profile_by_id
 
 if TYPE_CHECKING:
@@ -333,6 +334,7 @@ DATE_FIELDS: dict[TableName, list[Field]] = {
         "date_failed",
         "date_deleted",
     ],
+    "zerver_savedsnippet": ["date_created"],
     "zerver_scheduledmessage": ["scheduled_timestamp"],
     "zerver_stream": ["date_created"],
     "zerver_namedusergroup": ["date_created"],
@@ -1023,6 +1025,13 @@ def add_user_profile_child_configs(user_profile_config: Config) -> None:
         model=OnboardingStep,
         normal_parent=user_profile_config,
         include_rows="user_id__in",
+    )
+
+    Config(
+        table="zerver_savedsnippet",
+        model=SavedSnippet,
+        normal_parent=user_profile_config,
+        include_rows="user_profile_id__in",
     )
 
     Config(

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -102,6 +102,7 @@ IdSource: TypeAlias = tuple[TableName, Field]
 SourceFilter: TypeAlias = Callable[[Record], bool]
 
 CustomFetch: TypeAlias = Callable[[TableData, Context], None]
+CustomReturnIds: TypeAlias = Callable[[TableData], set[int]]
 
 
 class MessagePartial(TypedDict):
@@ -507,6 +508,7 @@ class Config:
         filter_args: FilterArgs | None = None,
         custom_fetch: CustomFetch | None = None,
         custom_tables: list[TableName] | None = None,
+        custom_return_ids: CustomReturnIds | None = None,
         concat_and_destroy: list[TableName] | None = None,
         id_source: IdSource | None = None,
         source_filter: SourceFilter | None = None,
@@ -527,6 +529,7 @@ class Config:
         self.exclude = exclude
         self.custom_fetch = custom_fetch
         self.custom_tables = custom_tables
+        self.custom_return_ids = custom_return_ids
         self.concat_and_destroy = concat_and_destroy
         self.id_source = id_source
         self.source_filter = source_filter
@@ -589,6 +592,13 @@ class Config:
                     need to assign a virtual_parent, or there
                     may be deeper issues going on."""
                 )
+
+    def return_ids(self, response: TableData) -> set[int]:
+        if self.custom_return_ids is not None:
+            return self.custom_return_ids(response)
+        else:
+            assert self.table is not None
+            return {row["id"] for row in response[self.table]}
 
 
 def export_from_config(
@@ -655,7 +665,7 @@ def export_from_config(
         assert parent is not None
         assert parent.table is not None
         assert config.include_rows is not None
-        parent_ids = [r["id"] for r in response[parent.table]]
+        parent_ids = parent.return_ids(response)
         filter_params: dict[str, Any] = {config.include_rows: parent_ids}
         if config.filter_args is not None:
             filter_params.update(config.filter_args)
@@ -825,6 +835,12 @@ def get_realm_config() -> Config:
             "zerver_userprofile",
             "zerver_userprofile_mirrordummy",
         ],
+        # When child tables want to fetch the list of ids of objects exported from
+        # the parent table, they should get ids from both zerver_userprofile and
+        # zerver_userprofile_mirrordummy:
+        custom_return_ids=lambda table_data: {
+            row["id"] for row in table_data["zerver_userprofile"]
+        }.union({row["id"] for row in table_data["zerver_userprofile_mirrordummy"]}),
         # set table for children who treat us as normal parent
         table="zerver_userprofile",
         virtual_parent=realm_config,

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -172,6 +172,7 @@ ID_MAP: dict[str, dict[int, int]] = {
     "realmuserdefault": {},
     "scheduledmessage": {},
     "onboardingusermessage": {},
+    "savedsnippet": {},
 }
 
 id_map_to_list: dict[str, dict[int, list[int]]] = {
@@ -1523,6 +1524,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         bulk_import_model(data, AlertWord)
 
     if "zerver_savedsnippet" in data:
+        fix_datetime_fields(data, "zerver_savedsnippet")
         re_map_foreign_keys(
             data, "zerver_savedsnippet", "user_profile", related_table="user_profile"
         )

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -34,6 +34,7 @@ from zerver.actions.realm_settings import (
     do_change_realm_plan_type,
     do_set_realm_authentication_methods,
 )
+from zerver.actions.saved_snippets import do_create_saved_snippet
 from zerver.actions.scheduled_messages import check_schedule_message
 from zerver.actions.user_activity import do_update_user_activity_interval
 from zerver.actions.user_settings import do_change_user_setting
@@ -2486,6 +2487,15 @@ class SingleUserExportTest(ExportFile):
                     message=smile_message_id,
                 ),
             )
+
+        # We violate alphabetical order here but this creates a RealmAuditLog entry and we want the stream
+        # subscription event which will occur next to be the last RealmAuditLog entry.
+        do_create_saved_snippet("snippet title", "snippet content", cordelia)
+
+        @checker
+        def zerver_savedsnippet(records: list[Record]) -> None:
+            self.assertEqual(records[-1]["title"], "snippet title")
+            self.assertEqual(records[-1]["content"], "snippet content")
 
         self.subscribe(cordelia, "Scotland")
 


### PR DESCRIPTION
Commit 1) Export of mirror dummy users, as rare as it might be, was broken. Their related objects were not exported at all, resulting in missing objects such as `UserPresence` and, in particular, `Recipient` - meaning `user_profile.recipient` was `None` for them after importing - making these `UserProfile`s broken.

Commit 2) The export/import code for `SavedSnippet` was incomplete.

Detailed explanation in commit messages.