### PR TITLE
Exclude archived streams from notification_stream_options.

### DIFF
--- a/web/src/stream_settings_data.ts
+++ b/web/src/stream_settings_data.ts
@@ -157,7 +157,9 @@ export function get_streams_for_settings_page(): SettingsSubscription[] {
     }
     subscribed_rows.sort(by_name);
     unsubscribed_rows.sort(by_name);
-    const all_subs = [...unsubscribed_rows, ...subscribed_rows];
+    const all_subs = [...unsubscribed_rows, ...subscribed_rows].filter(
+        (stream) => !stream.is_archived,
+    );
 
     return get_subs_for_settings(all_subs);
 }

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -613,6 +613,7 @@ test("stream_settings", ({override}) => {
         can_subscribe_group: admins_group.id,
         date_created: 1691057093,
         creator_id: null,
+        is_archived: true,
     };
     stream_data.add_sub(cinnamon);
     stream_data.add_sub(amber);
@@ -620,8 +621,8 @@ test("stream_settings", ({override}) => {
 
     let sub_rows = stream_settings_data.get_streams_for_settings_page();
     assert.equal(sub_rows[0].color, "blue");
-    assert.equal(sub_rows[1].color, "amber");
-    assert.equal(sub_rows[2].color, "cinnamon");
+    /* Archived channel "ambed" is skipped, since it is archived. */
+    assert.equal(sub_rows[1].color, "cinnamon");
 
     sub_rows = stream_data.get_streams_for_admin();
     assert.equal(sub_rows[0].name, "a");


### PR DESCRIPTION
Selecting an archived stream from the announcement dropdown widgets caused an error because we are not allowed to send messages in archived streams. With this PR, we exclude the archived stream from rendering in the dropdown.

> **NOTE**: Archived "devel" named channel to demonstrate the changes.

## Before 

![image](https://github.com/user-attachments/assets/a91f1b56-c20a-4381-8c2e-f1ab6d951ac8)


## After

![image](https://github.com/user-attachments/assets/9334ca80-3ecf-4b02-a8ae-f683b4df4561)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
