### PR TITLE
spectator_view: Fix search input overlap with Log in button

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -506,10 +506,7 @@ body.has-overlay-scrollbar {
         right: 0;
         height: var(--header-height);
         width: var(--header-height);
-
-        @media (width >= $xl_min) and (height >= 600px) {
-            display: none;
-        }
+        display: none;
 
         .login_button {
             display: flex;
@@ -1541,32 +1538,6 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
-@media (width < $xl_min) or (height < $short_navbar_cutoff_height) {
-    .spectator-view {
-        #navbar-middle {
-            /* = (width of button, square with header) * 3 (number of buttons) + 10px extra margin. */
-            margin-right: calc(var(--header-height) * 3 + 10px);
-        }
-
-        #help-menu,
-        #gear-menu {
-            position: relative;
-            right: var(--header-height);
-        }
-
-        #top_navbar .column-right .spectator_login_buttons {
-            display: none;
-        }
-    }
-
-    .header-main .column-right {
-        /* For a diminutive right column in the navbar,
-           allow the width to be that of the flexing
-           button elements. */
-        width: auto;
-    }
-}
-
 %hide-right-sidebar {
     .column-right {
         display: none;
@@ -1736,6 +1707,34 @@ body:not(.hide-left-sidebar) {
     #navbar-middle {
         /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
         margin-right: var(--right-column-collapsed-sidebar-width);
+    }
+
+    .spectator-view {
+        #navbar-middle {
+            /* = (width of button, square with header) * 3 (number of buttons) + 10px extra margin. */
+            margin-right: calc(var(--header-height) * 3 + 10px);
+        }
+
+        #help-menu,
+        #gear-menu {
+            position: relative;
+            right: var(--header-height);
+        }
+
+        #top_navbar .column-right .spectator_login_buttons {
+            display: none;
+        }
+
+        .spectator_narrow_login_button {
+            display: block;
+        }
+    }
+
+    .header-main .column-right {
+        /* For a diminutive right column in the navbar,
+           allow the width to be that of the flexing
+           button elements. */
+        width: auto;
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1721,17 +1721,6 @@ body:not(.hide-left-sidebar) {
     }
 }
 
-body:not(.spectator-view) {
-    /* The large Log In button for spectators makes this rule
-       inappropriate for that view. */
-    @container header-container (width < $cq_xl_min) {
-        #navbar-middle {
-            /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
-            margin-right: var(--right-column-collapsed-sidebar-width);
-        }
-    }
-}
-
 /* We have some regrettable but temporarily necessary code duplication
    in the queries that follow.
 
@@ -1742,6 +1731,13 @@ body:not(.spectator-view) {
    However, in browsers that lag the spec, we fall back to the original
    media queries. The layout will not look as good as it could, but
    essential scrolling behavior will be maintained. */
+
+@container header-container (width < $cq_xl_min) {
+    #navbar-middle {
+        /* = (width of button, square with header) * 4 (number of buttons) + 3px extra margin. */
+        margin-right: var(--right-column-collapsed-sidebar-width);
+    }
+}
 
 @container app (width < $cq_xl_min) {
     .app-main {


### PR DESCRIPTION
This commit fixes the bug when search input overlaps with Log In button in spectator for a some range of viewport width.
Earlier, the rules for changing the styles for middle column in navbar and right column were defined seperately which was causing both the transitions to occur at different widths. This commit puts both the changes together to resolve the bug.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|----------|-------|
|![image](https://github.com/user-attachments/assets/723617a2-61b3-4327-96e9-462e1832d15d)|![image](https://github.com/user-attachments/assets/63ce62a7-4351-443f-a291-85b78e6286fa)|
|![image](https://github.com/user-attachments/assets/743ee7dd-13aa-4121-baa8-07d45cbfa636)|![image](https://github.com/user-attachments/assets/b8fe6935-7b80-48e5-913a-3c9537b90ccd)|

Note: **Before** here represents the state after reverting the commit 6915ed51d50bc3cb8f1799c999150813e73f471d (specator_view: Avoid Search overlap with large Log in button.)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
