### PR TITLE
realms: Require a non-empty set of users who can manage billing.

### DIFF
--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -812,7 +812,7 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
         can_manage_billing_group=GroupPermissionSetting(
             require_system_group=False,
             allow_internet_group=False,
-            allow_nobody_group=True,
+            allow_nobody_group=False,
             allow_everyone_group=False,
             default_group_name=SystemGroups.ADMINISTRATORS,
         ),


### PR DESCRIPTION
This isn't a configuration that's useful, and it seems marginally helpful to make it hard to end up in a state where this is the empty set.
