### PR TITLE
compose: Hold DM picker, topic marker to top recipient line.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -220,8 +220,22 @@
 
     #compose-recipient {
         &.compose-recipient-direct-selected {
+            #compose_select_recipient_widget_wrapper {
+                /* As the DM-pill area expands, we want to
+                   hold the DM picker to the first line. */
+                align-self: flex-start;
+            }
+
             #compose_select_recipient_widget {
                 border-radius: 4px !important;
+                height: var(--compose-recipient-box-min-height);
+            }
+
+            .topic-marker-container {
+                /* As the DM-pill area expands, we likewise
+                   want to keep the topic marker aligned with
+                   the DM picker. */
+                align-self: flex-start;
             }
         }
 


### PR DESCRIPTION
This restores the original design for the DM picker, so that it does not grow alongside a multi-line DM pill recipient container.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20channel.20picker.20dropdown.20stretches.20in.20DMs/near/2118202)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change on single-line DM) |
| --- | --- |
| ![dm-picker-single-line-before](https://github.com/user-attachments/assets/709bde53-857f-4d4a-8126-2d8c97b1a9cf) | ![dm-picker-single-line-after](https://github.com/user-attachments/assets/15389f94-e930-46e2-8f6f-6f2cd873d023) |
| ![dm-picker-multi-line-before](https://github.com/user-attachments/assets/2a4f335b-7a8b-4ed7-86a4-5ead08304ca1) | ![dm-picker-multi-line-after](https://github.com/user-attachments/assets/6a24cf09-75d8-4af5-b394-e7ff24dae4ce) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>