### PR TITLE
message_edit: Scale resolve topic spinner with font size.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -735,7 +735,7 @@ export function start($row: JQuery, edit_box_open_callback?: () => void): void {
 function show_toggle_resolve_topic_spinner($row: JQuery): void {
     const $spinner = $row.find(".toggle_resolve_topic_spinner");
     loading.make_indicator($spinner);
-    $spinner.css({width: "18px"});
+    $spinner.css({width: "1em"});
     $row.find(".on_hover_topic_resolve, .on_hover_topic_unresolve").hide();
     $row.find(".toggle_resolve_topic_spinner").show();
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1229,16 +1229,19 @@ nav {
     text-align: center;
 }
 
-div.topic_edit_spinner {
+div.topic_edit_spinner,
+div.toggle_resolve_topic_spinner {
     display: flex;
     align-items: center;
     width: 1.2em; /* 18px at 15px/em  (from font size set in .message-header-contents) */
     height: 1.2em; /* 18px at 15px/em */
 }
 
-div.toggle_resolve_topic_spinner {
-    margin-top: -12px;
-    padding-left: 9px;
+.on_hover_topic_unresolve,
+.on_hover_topic_resolve {
+    /* Matches the width set in `show_toggle_resolve_topic_spinner`,
+       to ensure spinner and resolve icon are the same width */
+    width: 1em;
 }
 
 div.topic_edit_spinner .loading_indicator_spinner,

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -56,7 +56,7 @@
                 {{else}}
                     <i class="fa fa-check on_hover_topic_resolve recipient-bar-control recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as resolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as resolved' }}"></i>
                 {{/if}}
-                <div class="toggle_resolve_topic_spinner" style="display: none"></div>
+                <div class="toggle_resolve_topic_spinner recipient_bar_icon" style="display: none"></div>
             {{/if}}
 
             {{#if (and is_subscribed (not is_archived))}}


### PR DESCRIPTION
This commit also changes the width of the spinner so that the resolve icon and spinner take up the same width.

at 12px, 14px, 16px, 20px:

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-10 at 15 03 38](https://github.com/user-attachments/assets/210f1bab-3c28-451c-81ea-be4b1e3be7d0) | ![Screen Shot 2025-03-10 at 14 57 41](https://github.com/user-attachments/assets/8b576753-bb3b-4341-b0f3-b12573b6d3c9) |
| ![Screen Shot 2025-03-10 at 15 03 32](https://github.com/user-attachments/assets/58d31055-e35c-410a-a9df-4892d80d6a5c) | ![Screen Shot 2025-03-10 at 14 57 35](https://github.com/user-attachments/assets/d4fc423f-13ea-46a6-882a-4a63ba5f0966) |
| ![Screen Shot 2025-03-10 at 15 03 27](https://github.com/user-attachments/assets/ac741e58-7f95-4c9f-b1ae-4878625accbe) | ![Screen Shot 2025-03-10 at 14 57 28](https://github.com/user-attachments/assets/b603a644-6d5f-459a-a9e8-e2d7351b147c) |
| ![Screen Shot 2025-03-10 at 15 03 18](https://github.com/user-attachments/assets/ffd5eb91-bd6e-4cb6-911e-b0cb09cd7261) | ![Screen Shot 2025-03-10 at 14 57 20](https://github.com/user-attachments/assets/48bb10f7-e305-4aa2-a390-b289d461b7bd) |