### PR TITLE
compose_actions: Fix send button disabled without any error.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -145,6 +145,8 @@ function clear_box(): void {
     $(".compose_control_button_container:has(.needs-empty-compose)").removeClass(
         "disabled-on-hover",
     );
+    // Reset send button status.
+    $(".message-send-controls").removeClass("disabled-message-send-controls");
 }
 
 let autosize_callback_opts: ComposeActionsStartOpts;


### PR DESCRIPTION
Reproducer:
* Upload a file.
* Close compose box before upload is finished.
* Open compose box.

Send message button is disabled without any error in this state. Fixed by resetting the send button state when compose box is closed.
