### PR TITLE
predicate: Add support for channels operator.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -590,7 +590,7 @@ export class Filter {
                 return stream_data.get_sub_by_id_string(term.operand) !== undefined;
             case "channels":
             case "streams":
-                return term.operand === "public";
+                return ["public", "web-public", "archived"].includes(term.operand);
             case "topic":
                 return true;
             case "sender":
@@ -661,7 +661,9 @@ export class Filter {
     static sorted_term_types(term_types: string[]): string[] {
         const levels = [
             "in",
+            "channels-web-public",
             "channels-public",
+            "channels-archived",
             "channel",
             "topic",
             "dm",
@@ -1142,6 +1144,8 @@ export class Filter {
             "not-is-muted",
             "in-home",
             "in-all",
+            "channels-archived",
+            "not-channels-archived",
             "channels-public",
             "not-channels-public",
             "channels-web-public",
@@ -1245,7 +1249,13 @@ export class Filter {
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["channels-archived"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["channels-public"])) {
+            return true;
+        }
+        if (_.isEqual(term_types, ["channels-web-public"])) {
             return true;
         }
         if (_.isEqual(term_types, ["sender"])) {
@@ -1483,8 +1493,12 @@ export class Filter {
                     return $t({defaultMessage: "Combined feed"});
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted channels"});
+                case "channels-archived":
+                    return $t({defaultMessage: "Messages in all archived channels"});
                 case "channels-public":
                     return $t({defaultMessage: "Messages in all public channels"});
+                case "channels-web-public":
+                    return $t({defaultMessage: "Messages in all web-public channels"});
                 case "is-starred":
                     return $t({defaultMessage: "Starred messages"});
                 case "is-mentioned":
@@ -1871,8 +1885,12 @@ export class Filter {
             "not-is-followed",
             "is-resolved",
             "not-is-resolved",
+            "channels-archived",
+            "not-channels-archived",
             "channels-public",
             "not-channels-public",
+            "channels-web-public",
+            "not-channels-web-public",
             "is-muted",
             "not-is-muted",
             "in-home",

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -208,6 +208,22 @@ function message_matches_search_term(message: Message, operator: string, operand
             return message.stream_id.toString() === operand;
         }
 
+        case "channels":
+            if (message.type !== "stream") {
+                return false;
+            }
+            switch (operand) {
+                case "web-public":
+                    return stream_data.is_web_public(message.stream_id);
+                case "public":
+                    return !stream_data.is_invite_only_by_stream_id(message.stream_id);
+                case "archived":
+                    return stream_data.is_stream_archived(message.stream_id);
+                default:
+                    blueslip.error(`Invalid channels operand: ${operand}`);
+                    return false;
+            }
+
         case "topic":
             if (message.type !== "stream") {
                 return false;
@@ -1580,13 +1596,6 @@ export class Filter {
             // processor.
             return false;
         }
-
-        // TODO: It's not clear why `channels:` filters would not be
-        // applicable locally.
-        if (this.has_operator("channels") || this.has_negated_operand("channels", "public")) {
-            return false;
-        }
-
         // If we get this far, we're good!
         return true;
     }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This is a preparatory PR for the PR  #33167  as discussed in [czo](https://chat.zulip.org/#narrow/channel/6-frontend/topic/Predicate.20function.20does.20not.20handle.20channels.20operator.3F/with/2111456).

This PR adds support for `channels:` operator to be predicated and tested, previously it always returned true because it was handled in `can_apply_locally` function even though we can handle it locally. 

Fixes: Predicate `channels` operator

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
