### PR TITLE
compose_paste: Add test to verify pasting from Mac.

### DIFF
--- a/web/tests/compose_paste.test.cjs
+++ b/web/tests/compose_paste.test.cjs
@@ -288,6 +288,11 @@ run_test("paste_handler_converter", () => {
     // Pasting from Excel using ^⇧V should paste formatted text.
     assert.equal(compose_paste.paste_handler_converter(input), "     \n\n$ 20.00\n\n$ 7.00");
 
+    // Pasting from the mac terminal
+    input =
+        '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"><html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta http-equiv="Content-Style-Type" content="text/css"><title></title><meta name="Generator" content="Cocoa HTML Writer"><meta name="CocoaVersion" content="2575.4"><style type="text/css">p.p1 {margin: 0.0px 0.0px 0.0px 0.0px; font: 11.0px Menlo; color: #000000}span.s1 {font-variant-ligatures: no-common-ligatures}</style></head><body><p class="p1"><span class="s1">insertions</span></p></body></html>';
+    assert.equal(compose_paste.paste_handler_converter(input), "insertions");
+
     // Math block tests
 
     /*


### PR DESCRIPTION
For context, https://github.com/zulip/zulip/issues/33569 appears to have been fixed
unintentionally by https://github.com/zulip/zulip/pull/33691.

This just adds a test to verify the expected
behavior when it comes to pasting from the
Mac terminal as described by the reproduction
steps in https://github.com/zulip/zulip/issues/33569.

We might still end up with some edge case in
the future, that might not work as expected.

CZO: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20surprising.20line.20breaks.20when.20copy-pasting.20.2333569/near/2119422

Co-authored-by: Kislay Verma <kislayuv27@gmail.com>

Fixes: #33569 