### PR TITLE
settings: Add help link to who can manage plans and billing.

### DIFF
--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -338,9 +338,19 @@
                 {{> settings_save_discard_widget section_name="other-permissions" }}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
-                {{> group_setting_value_pill_input
-                  setting_name="realm_can_manage_billing_group"
-                  label=group_setting_labels.can_manage_billing_group}}
+                {{#if is_plan_self_hosted}}
+                    {{> group_setting_value_pill_input
+                      setting_name="realm_can_manage_billing_group"
+                      label=group_setting_labels.can_manage_billing_group
+                      help_link="https://zulip.com//help/self-hosted-billing"
+                      }}
+                {{else}}
+                    {{> group_setting_value_pill_input
+                      setting_name="realm_can_manage_billing_group"
+                      label=group_setting_labels.can_manage_billing_group
+                      help_link="/help/zulip-cloud-billing"
+                      }}
+                {{/if}}
 
                 <div class="disabled-unfinished-feature" style="display: none">
                     {{#unless server_can_summarize_topics}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR adds a help (`?`) link next to the "Who can manage plans and billing" setting.

Fixes : [#33922](https://github.com/zulip/zulip/issues/33922)

### Changes
- Displays a help link based on the hosting type:
  - **Zulip Cloud orgs**: Links to `/help/zulip-cloud-billing`
  - **Self-hosted orgs**: Links to `/help/self-hosted-billing`
- Uses `{{#if is_plan_self_hosted}}` to determine the correct link.

### Why?
This improves user accessibility by providing direct documentation links.

### Testing
- Verified that the correct link appears for both **cloud** and **self-hosted** deployments.
- Manually tested UI behavior.

Let me know if any changes are needed! 🚀



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/user-attachments/assets/9e423654-c6cf-49d0-8ddd-4e157d467a27)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
