### PR TITLE
settings: Disable deactivate button in profile modal for last owner.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1013,6 +1013,19 @@ export function is_current_user_only_owner(): boolean {
     return true;
 }
 
+export function is_user_only_owner(user: User): boolean {
+    if (!user.is_owner) {
+        return false;
+    }
+
+    for (const person of active_user_dict.values()) {
+        if (person.is_owner && !person.is_bot && person.user_id !== user.user_id) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export function filter_all_persons(pred: (person: User) => boolean): User[] {
     const ret = [];
     for (const person of people_by_user_id_dict.values()) {

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -389,6 +389,18 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: "#deactivate_user_account_container.disabled_setting_tooltip",
+        content: $t({
+            defaultMessage:
+                "Because this is the only organization owner, you cannot deactivate this account.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: "#deactivate_realm_button_container.disabled_setting_tooltip",
         content: $t({
             defaultMessage: "Only organization owners may deactivate an organization.",

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1134,6 +1134,7 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
         return;
     }
 
+    const is_user_only_owner = people.is_user_only_owner(person);
     const html_body = render_admin_human_form({
         user_id,
         email: person.delivery_email,
@@ -1141,6 +1142,7 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
         user_role_values: settings_config.user_role_values,
         disable_role_dropdown: person.is_owner && !current_user.is_owner,
         is_active,
+        is_user_only_owner,
     });
 
     $container.append($(html_body));

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -28,7 +28,7 @@
     </form>
     <div class="input-group">
         {{#if is_active}}
-        {{> ../components/action_button custom_classes="deactivate_user_button" type="quiet" intent="danger" label=(t "Deactivate user") aria-label=(t "Deactivate user") }}
+        <div id="deactivate_user_account_container" class="inline-block {{#if is_user_only_owner}}disabled_setting_tooltip{{/if}}">{{> ../components/action_button custom_classes="deactivate_user_button" type="quiet" intent="danger" label=(t "Deactivate user") aria-label=(t "Deactivate user") disabled=is_user_only_owner}}</div>
         {{else}}
         {{> ../components/action_button custom_classes="reactivate_user_button" type="quiet" intent="success" label=(t "Reactivate user") aria-label=(t "Reactivate user") }}
         {{/if}}

--- a/web/tests/people.test.cjs
+++ b/web/tests/people.test.cjs
@@ -740,6 +740,20 @@ test_people("set_custom_profile_field_data", () => {
     assert.ok(!(field.id in person.profile_data));
 });
 
+test_people("is_user_only_owner", ({override}) => {
+    const user = people.get_by_email(me.email);
+    user.is_owner = false;
+    override(user, "is_owner", false);
+    assert.ok(!people.is_user_only_owner(user));
+
+    user.is_owner = true;
+    override(user, "is_owner", true);
+    assert.ok(people.is_user_only_owner(user));
+
+    people.add_active_user(realm_owner);
+    assert.ok(!people.is_user_only_owner(user));
+});
+
 test_people("is_current_user_only_owner", ({override}) => {
     const person = people.get_by_email(me.email);
     person.is_owner = false;


### PR DESCRIPTION
This PR
- disables deactivate button in "Manage user" modal if user is last owner.
- adds tooltip with text "Because this is the only organization owner, you cannot deactivate this account." to the disabled deactivate button.

fixes: #33910


## Screenshot

<img width="710" alt="Screenshot 2025-03-11 at 7 03 49 PM" src="https://github.com/user-attachments/assets/d744a24d-3241-4d1c-ba0c-83a5a58f9050" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
