### PR TITLE
domains_modal: Fix width of modal_text_input.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -470,6 +470,12 @@
     }
 }
 
+#add-realm-domain-widget {
+    .modal_text_input {
+        width: 14.7143em; /* 206px at 14px em */
+    }
+}
+
 #create_bot_short_name {
     /* A shorter dropdown width (~200px at 14px em)
        to ensure the email all fits on one line. */


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes the modal for conifguring domains for emails by overwriting the width of modal_text_input of `add-realm-domain-widget`.

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Allowed.20domains.20modal).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (at 12 px) | After (at 16 px) | After (at 20 px) |
|--------|--------|--------|--------|
| <img width="606" alt="Screenshot 2025-03-11 at 10 46 21 PM" src="https://github.com/user-attachments/assets/e8d3c22f-ebd5-44e0-997a-61cd8a1dcc9b" /> | <img width="456" alt="Screenshot 2025-03-11 at 10 37 35 PM" src="https://github.com/user-attachments/assets/454a9080-bcb0-4e54-b5ba-269a22976ffe" /> | <img width="598" alt="Screenshot 2025-03-11 at 10 37 54 PM" src="https://github.com/user-attachments/assets/265e2530-938d-43f9-a84e-0d0d28959073" /> | <img width="750" alt="Screenshot 2025-03-11 at 10 38 16 PM" src="https://github.com/user-attachments/assets/7404fb4b-c5af-4cab-94fc-c4a127a61cfe" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
