### PR TITLE
video_thumbnails: Precisely size, place play button.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -630,10 +630,18 @@
             /* 32px at 14px/1em */
             background-size: 2.2857em;
             position: absolute;
-            width: 100%;
-            height: 100%;
-            top: 0;
-            left: 0;
+            /* Match the width to the background size. */
+            width: 2.2857em;
+            height: 2.2857em;
+            /* Center according to those widths; at present,
+               thumbnails are 8em tall and 12em wide. So,
+               2.2857em / 2 = 1.1429em as the center of the
+               play button. We subtract that value from half
+               the height (8em/2) to get the `top:` value,
+               and then subtract the same from half the width
+               (12em/2) to get the `left:` value. */
+            top: 2.8571em;
+            left: 4.8571em;
             border-radius: 100%;
             transform: scale(0.8);
             transition: transform 0.2s;


### PR DESCRIPTION
This PR more precisely positions the play button, avoiding a fast but ultimately sub-pixel-error-prone use of `height: 100%` and `width: 100%` coupled with background-image centering.

It seems this bug only reproduced on videos at certain sizes/aspect ratios, which is likely why the bug did not reproduce uniformly in Brave or the Chrome Desktop app. A [problem video from CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/arrow.20on.20hovering.20unread.20message.20icon.20in.20recent.20conversation/near/2119072) made for easy replication of the bug in dev. Outside the hover state, at 16px/1em, the `::after` area reported itself as 153.6px × 102.4px; by huge contrast, in the hover state, it reported its area as 192px × 128px. It seems all but certain that the subpixel sizing in that particular video caused the shift, likely owing to a browser recalculation of `height` and `width` after the scaling transition completed.

You can also see in the static screenshots below that the new approach is better centering the button. Animated screenshots show the lack of a subtle downward shift after the fix is employed (different users reported shifts in different directions, but that's again likely owing to the subpixel size in play here).

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20play.20icon.20shifts.20upward/near/2119441)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_In and outside hover states (static):_

| Before | After |
| --- | --- |
| ![play-button-no-hover-before](https://github.com/user-attachments/assets/49c3dde8-121d-4378-bcc8-1c9fbc6b697a) | ![play-button-no-hover-after](https://github.com/user-attachments/assets/a4d086f6-34c8-4de6-b404-b566273d5ba0) |
| ![play-button-hover-before](https://github.com/user-attachments/assets/97cae78b-5e43-475a-8f08-3b97148c3be5) | ![play-button-hover-after](https://github.com/user-attachments/assets/673a9287-8616-4cf7-9fc7-ca086a8293e4) |

_Showing hover transition; note subtle downward shift in the Before shot:_

| Before | After |
| --- | --- |
| ![hovered-play-button-before](https://github.com/user-attachments/assets/39271ebb-f999-4fc4-b0f5-e05fa6b928d3) | ![hovered-play-button-after](https://github.com/user-attachments/assets/53141d88-4be5-40de-ab52-d87ea9bc4979) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>