### PR TITLE
recent_view: Hold unread header to a minimum width.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -434,6 +434,8 @@
 
     .recent-view-unread-header {
         width: 7%;
+        /* 64px at 20px/1em */
+        min-width: 3.2em;
 
         .zulip-icon-unread {
             position: relative;


### PR DESCRIPTION
This adds an em-based `min-width` to the unread header to prevent the sort icon from annoyingly shifting to its own line at certain viewport widths.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/arrow.20on.20hovering.20unread.20message.20icon.20in.20recent.20conversation/near/2119072)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![unread-header-before](https://github.com/user-attachments/assets/e59839cd-f98d-4d04-81ab-d81668ad884f) | ![unread-header-after](https://github.com/user-attachments/assets/1dc2397b-c477-4b28-85ad-d667421f1c6d) |
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>