### PR TITLE
message_edit: Match button height to compose Send button.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -717,8 +717,11 @@
 .message_edit_save {
     /* Because the save button is inside this container,
        we set the height here so the container stretches
-       with the flexbox. */
-    height: 100%;
+       with the flexbox. However, we also want to match
+       this to the height of the compose box's Send button,
+       so we specify a matching 2em height here
+       (32px at 16px/1em) */
+    height: 2em;
     /* Match Save button's basic colors to
        the compose box Send button. */
     color: var(--color-compose-send-button-icon-color);


### PR DESCRIPTION
Rather than setting `height: 100%`, we set an em-based height that always matches the height of the Send button in the compose box. Flexbox in the area continues to do its job maintaining the height and alignment of other elements.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Reduced.20height.20of.20Save.20button.20in.20message.20edit.20box.2E/near/2119699)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_At minimum, default, and maximum font size/line height values:_

| Before | After |
| --- | --- |
| ![message-edit-min-before](https://github.com/user-attachments/assets/1e2583fe-12a2-486e-b647-3cc85b4ef9d9) | ![message-edit-min-after](https://github.com/user-attachments/assets/2a605c88-b5b6-4792-8a94-e754627c33c3) |
| ![message-edit-default-before](https://github.com/user-attachments/assets/976b55ee-b139-4294-be83-daa08890ecd6) | ![message-edit-default-after](https://github.com/user-attachments/assets/5e8e7256-83ff-4aaf-b948-5294e7586a9e) |
| ![message-edit-max-before](https://github.com/user-attachments/assets/51d5fae4-6eb8-4877-81e0-2713a5652471) | ![message-edit-max-after](https://github.com/user-attachments/assets/d4577d61-b14e-41c1-9529-d2c6ea927111) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>