### PR TITLE
check_rabbitmq_queue: Increase deferred_email_senders paging thresholds.

### DIFF
--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -50,7 +50,7 @@ MAX_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     digest_emails=1200,
     missedmessage_mobile_notifications=120,
     embed_links=60,
-    deferred_email_senders=240,
+    deferred_email_senders=3600,
 )
 CRITICAL_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     lambda: 60,
@@ -58,7 +58,7 @@ CRITICAL_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     missedmessage_mobile_notifications=180,
     digest_emails=1800,
     embed_links=90,
-    deferred_email_senders=300,
+    deferred_email_senders=4500,
 )
 
 


### PR DESCRIPTION
c5200e8b05b2 switched `digest_emails` from sending emails by inserting into the ScheduledEmail table, and being processed later by `deliver_scheduled_emails`, to inserting into the
`deferred_email_senders` RabbitMQ queue.  This moved it from being in an unmonitored table, to a monitored queue.

This slightly improved throughput -- but began paging, since the backlog was now in a monitored form.  Increase the paging thresholds to not page for expected behaviour.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
