### PR TITLE
settings: Hide deactivate button of owner for admins.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1134,6 +1134,8 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
         return;
     }
 
+    const hide_deactivate_button =
+        current_user.is_admin && !current_user.is_owner && person.is_owner;
     const html_body = render_admin_human_form({
         user_id,
         email: person.delivery_email,
@@ -1141,6 +1143,7 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
         user_role_values: settings_config.user_role_values,
         disable_role_dropdown: person.is_owner && !current_user.is_owner,
         is_active,
+        hide_deactivate_button,
     });
 
     $container.append($(html_body));

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -26,7 +26,7 @@
         </div>
         <div class="custom-profile-field-form"></div>
     </form>
-    <div class="input-group">
+    <div class="input-group {{#if hide_deactivate_button}}hide{{/if}}">
         {{#if is_active}}
         {{> ../components/action_button custom_classes="deactivate_user_button" type="quiet" intent="danger" label=(t "Deactivate user") aria-label=(t "Deactivate user") }}
         {{else}}


### PR DESCRIPTION
Since only owners can deactivate other owners, we hide Deactivate button on owners profile when admins are using the ui.

fixes: #33910.

## Screenshots

| Before | After |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/704bbe48-8f6f-46ac-9e21-44c222b4de6b) | ![After Image](https://github.com/user-attachments/assets/753935f7-e482-493c-afcb-ba274b0e1340) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
