### PR TITLE
compose: Refine the space occupied by the channel.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1146,14 +1146,17 @@ textarea.new_message_textarea {
 }
 
 #compose_select_recipient_widget {
-    width: auto;
+    /* We set width to 100% to get the ellipsis when
+       needed, but the flex and max-width properties
+       on the widget wrapper ultimately determine
+       how much space the channel picker occupies. */
+    width: 100%;
     outline: none;
     /* We override the component-level colors to
        ensure concord with the topic box. */
     color: var(--color-compose-recipient-box-text-color);
     background-color: var(--color-compose-recipient-box-background-color);
     border-color: var(--color-compose-recipient-box-border-color);
-    max-width: 30vw;
 
     &.dropdown-widget-button {
         padding: 0 6px;
@@ -1487,6 +1490,17 @@ textarea.new_message_textarea {
 
 #compose_select_recipient_widget_wrapper {
     display: flex;
+    /* Allow the contents wrapped here to
+       expand the available space... */
+    white-space: nowrap;
+    flex: 0 1 fit-content;
+    /* But force an ellipsis here, rather than
+       just on an inner element. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    /* Finally, hold this to a maximum width of
+       40% of the recipient row. */
+    max-width: 40%;
 
     &:focus-visible {
         outline: 0;


### PR DESCRIPTION
Channels with long names take up too much room on the recipient row. This improves the layout descriptions and width constraints in the area to fix the display of long channels, while leaving shorter channel names undisturbed.

CZO discussion

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After (no change for `#test` channel) |
| --- | --- |
| ![long-channel-before](https://github.com/user-attachments/assets/7a5d9a93-6c02-486a-bc10-26e3d22fb63a) | ![long-channel-after](https://github.com/user-attachments/assets/b3311352-3c75-4e40-93f2-32e08b1cf1f4) |
| ![short-channel-before](https://github.com/user-attachments/assets/d4497b47-f30e-4868-a9db-98997a2c8f62) | ![short-channel-after-no-change](https://github.com/user-attachments/assets/754c2140-c60f-44e7-b6ba-b73ea7d3759e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>