### PR TITLE
message_editing: Fix unclickable area in bouncing "..."

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -816,6 +816,10 @@ of the base style defined for a read-only textarea in dark mode. */
     width: 40px;
     height: 5px;
 
+    /* Avoid this animation element blocking clicks on .edit-notifications
+       to display the message's edit history. */
+    pointer-events: none;
+
     .y-animated-dot {
         width: 4px;
         height: 4px;


### PR DESCRIPTION
The bug occurred because clicking on .message-editing-animation was not triggering the click on .edit-notifications. This commit sets the height of .message-editing-animation from 5px to 0, which resolves this bug.

Fixes: #33950

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
