### PR TITLE
information_density: Update tooltip text to show correct unit

### DIFF
--- a/web/src/information_density.ts
+++ b/web/src/information_density.ts
@@ -355,22 +355,22 @@ export function get_tooltip_context_for_info_density_buttons(
         if (is_default_button) {
             if (is_current_value_default) {
                 tooltip_first_line = $t(
-                    {defaultMessage: "Already at default font size ({default_value}pt)"},
+                    {defaultMessage: "Already at default font size ({default_value})"},
                     {default_value},
                 );
             } else {
                 tooltip_first_line = $t(
-                    {defaultMessage: "Reset to default font size ({default_value}pt)"},
+                    {defaultMessage: "Reset to default font size ({default_value})"},
                     {default_value},
                 );
                 tooltip_second_line = $t(
-                    {defaultMessage: "Current font size: {current_value}pt"},
+                    {defaultMessage: "Current font size: {current_value}"},
                     {current_value},
                 );
             }
         } else if (!$elem.prop("disabled")) {
             tooltip_first_line = $t(
-                {defaultMessage: "Change to {new_value}pt font size"},
+                {defaultMessage: "Change to font size {new_value}"},
                 {new_value},
             );
         } else {
@@ -378,14 +378,14 @@ export function get_tooltip_context_for_info_density_buttons(
                 const maximum_value = INFO_DENSITY_VALUES_DICT[property].maximum;
                 if (current_value === maximum_value) {
                     tooltip_first_line = $t(
-                        {defaultMessage: "Already at maximum font size ({maximum_value}pt)"},
+                        {defaultMessage: "Already at maximum font size ({maximum_value})"},
                         {maximum_value},
                     );
                 } else {
                     tooltip_first_line = $t(
                         {
                             defaultMessage:
-                                "Already above recommended maximum font size ({maximum_value}pt)",
+                                "Already above recommended maximum font size ({maximum_value})",
                         },
                         {maximum_value},
                     );
@@ -394,14 +394,14 @@ export function get_tooltip_context_for_info_density_buttons(
                 const minimum_value = INFO_DENSITY_VALUES_DICT[property].minimum;
                 if (current_value === minimum_value) {
                     tooltip_first_line = $t(
-                        {defaultMessage: "Already at minimum font size ({minimum_value}pt)"},
+                        {defaultMessage: "Already at minimum font size ({minimum_value})"},
                         {minimum_value},
                     );
                 } else {
                     tooltip_first_line = $t(
                         {
                             defaultMessage:
-                                "Already below recommended minimum font size ({minimum_value}pt)",
+                                "Already below recommended minimum font size ({minimum_value})",
                         },
                         {minimum_value},
                     );


### PR DESCRIPTION
Previously, the tooltips for information density buttons incorrectly used "pt" as the font size postfix, while the actual unit being used is "px":

![image](https://github.com/user-attachments/assets/d531deef-6101-4a33-93ce-ada056661eb6)![image](https://github.com/user-attachments/assets/bb50447e-7002-4e62-b554-63378604d936)

Since points (pt) and pixels (px) are different units (px ≠ px), this commit updates the tooltips to display the correct one.

*Screenshots:*

| Before | After |
|-------- | -------- |
| ![image](https://github.com/user-attachments/assets/5e9cb90c-380d-4306-8599-46a025c7cb75) | ![image](https://github.com/user-attachments/assets/3d779772-4dd3-4880-b572-edb3620aac9f) |

| Before | After |
|-------- | -------- |
| ![image](https://github.com/user-attachments/assets/16a2e4ec-f31d-4ba5-b700-0b5e2645d109) | ![image](https://github.com/user-attachments/assets/12cf7568-920f-4c7d-aeae-01604ba347fe) |

| Before | After |
|-------- | -------- |
| ![image](https://github.com/user-attachments/assets/3d7c9bb1-db1d-409d-8cbc-5f45cb25c212) | ![image](https://github.com/user-attachments/assets/181d3397-b5ee-443b-a035-7c479ddb10b2) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
