### PR TITLE
search: Fix race condition in search index for new messages

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -61,8 +61,9 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.timezone import canonicalize_timezone
 from zerver.lib.topic import TOPIC_NAME, maybe_rename_general_chat_to_empty_topic
 from zerver.lib.user_groups import (
-    get_group_setting_value_for_api,
+    get_group_setting_value_for_register_api,
     get_recursive_membership_groups,
+    get_role_based_system_groups_dict,
     get_server_supported_permission_settings,
     user_groups_in_realm_serialized,
 )
@@ -100,7 +101,6 @@ from zerver.models.realms import (
     MessageEditHistoryVisibilityPolicyEnum,
     get_corresponding_policy_value_for_group_setting,
     get_realm_domains,
-    get_realm_with_settings,
 )
 from zerver.models.streams import get_default_stream_groups
 from zerver.tornado.django_api import get_user_events, request_event_queue
@@ -269,6 +269,27 @@ def fetch_initial_state_data(
         # Send server_timestamp, to match the format of `GET /presence` requests.
         state["server_timestamp"] = time.time()
 
+    realm_setting_group_ids = {
+        getattr(realm, setting_name + "_id")
+        for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS
+    }
+
+    if want("realm_user_groups") or want("realm"):
+        # Optimizing opportunity: This fetches more data than
+        # we strictly need when "realm_user_groups" is not in
+        # fetch_event_types; we need the membership of the
+        # anonymous groups in realm_setting_group_ids and the
+        # IDs of the NamedUserGroup objects used there, but
+        # don't need the other NamedUserGroup fields.
+        realm_groups_data = user_groups_in_realm_serialized(
+            realm,
+            include_deactivated_groups=include_deactivated_groups,
+            realm_setting_group_ids=realm_setting_group_ids,
+        )
+
+    if want("realm_user_groups"):
+        state["realm_user_groups"] = realm_groups_data.api_groups
+
     if want("realm"):
         # The realm bundle includes both realm properties and server
         # properties, since it's rare that one would want one and not
@@ -295,17 +316,25 @@ def fetch_initial_state_data(
             state["realm_" + property_name] = getattr(realm, property_name)
 
         for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
-            setting_value = getattr(realm, setting_name)
-            state["realm_" + setting_name] = get_group_setting_value_for_api(setting_value)
+            setting_group_id = getattr(realm, setting_name + "_id")
+            state["realm_" + setting_name] = get_group_setting_value_for_register_api(
+                setting_group_id, realm_groups_data.realm_setting_anonymous_group_membership
+            )
 
         state["realm_create_public_stream_policy"] = (
             get_corresponding_policy_value_for_group_setting(
-                realm, "can_create_public_channel_group", Realm.COMMON_POLICY_TYPES
+                realm,
+                "can_create_public_channel_group",
+                Realm.COMMON_POLICY_TYPES,
+                realm_groups_data.system_groups_name_dict,
             )
         )
         state["realm_create_private_stream_policy"] = (
             get_corresponding_policy_value_for_group_setting(
-                realm, "can_create_private_channel_group", Realm.COMMON_POLICY_TYPES
+                realm,
+                "can_create_private_channel_group",
+                Realm.COMMON_POLICY_TYPES,
+                realm_groups_data.system_groups_name_dict,
             )
         )
         state["realm_create_web_public_stream_policy"] = (
@@ -313,12 +342,14 @@ def fetch_initial_state_data(
                 realm,
                 "can_create_web_public_channel_group",
                 Realm.CREATE_WEB_PUBLIC_STREAM_POLICY_TYPES,
+                realm_groups_data.system_groups_name_dict,
             )
         )
         state["realm_wildcard_mention_policy"] = get_corresponding_policy_value_for_group_setting(
             realm,
             "can_mention_many_users_group",
             Realm.WILDCARD_MENTION_POLICY_TYPES,
+            realm_groups_data.system_groups_name_dict,
         )
 
         # Most state is handled via the property_types framework;
@@ -526,11 +557,6 @@ def fetch_initial_state_data(
 
     if want("realm_playgrounds"):
         state["realm_playgrounds"] = get_realm_playgrounds(realm)
-
-    if want("realm_user_groups"):
-        state["realm_user_groups"] = user_groups_in_realm_serialized(
-            realm, include_deactivated_groups=include_deactivated_groups
-        )
 
     if user_profile is not None:
         settings_user = user_profile
@@ -1330,6 +1356,7 @@ def apply_event(
                 )
 
         elif event["op"] == "update_dict":
+            system_groups_name_dict: dict[int, str] | None = None
             for key, value in event["data"].items():
                 if key == "max_file_upload_size_mib":
                     state["max_file_upload_size_mib"] = value
@@ -1350,12 +1377,26 @@ def apply_event(
                     "can_create_private_channel_group",
                     "can_create_web_public_channel_group",
                 ]:
+                    if system_groups_name_dict is None:
+                        # Here we do a database query, because
+                        # get_corresponding_policy_value_for_group_setting
+                        # requires the full set of system groups.
+                        # This could be avoided if realm_user_group were in
+                        # fetch_event_types, since the system groups should
+                        # all be there, but the query itself is cheap enough
+                        # that it's likely not worth that complexity.
+                        system_groups = get_role_based_system_groups_dict(user_profile.realm)
+                        system_groups_name_dict = {}
+                        for group in system_groups.values():
+                            system_groups_name_dict[group.id] = group.name
+
                     if key == "can_create_public_channel_group":
                         state["realm_create_public_stream_policy"] = (
                             get_corresponding_policy_value_for_group_setting(
                                 user_profile.realm,
                                 "can_create_public_channel_group",
                                 Realm.COMMON_POLICY_TYPES,
+                                system_groups_name_dict,
                             )
                         )
                         state["can_create_public_streams"] = user_profile.has_permission(key)
@@ -1365,6 +1406,7 @@ def apply_event(
                                 user_profile.realm,
                                 "can_create_private_channel_group",
                                 Realm.COMMON_POLICY_TYPES,
+                                system_groups_name_dict,
                             )
                         )
                         state["can_create_private_streams"] = user_profile.has_permission(key)
@@ -1374,6 +1416,7 @@ def apply_event(
                                 user_profile.realm,
                                 "can_create_web_public_channel_group",
                                 Realm.CREATE_WEB_PUBLIC_STREAM_POLICY_TYPES,
+                                system_groups_name_dict,
                             )
                         )
                         state["can_create_web_public_streams"] = user_profile.has_permission(key)
@@ -1390,11 +1433,25 @@ def apply_event(
                     )
 
                 if key == "can_mention_many_users_group":
+                    if system_groups_name_dict is None:
+                        # Here we do a database query, because
+                        # get_corresponding_policy_value_for_group_setting
+                        # requires the full set of system groups.
+                        # This could be avoided if realm_user_group were in
+                        # fetch_event_types, since the system groups should
+                        # all be there, but the query itself is cheap enough
+                        # that it's likely not worth that complexity.
+                        system_groups = get_role_based_system_groups_dict(user_profile.realm)
+                        system_groups_name_dict = {}
+                        for group in system_groups.values():
+                            system_groups_name_dict[group.id] = group.name
+
                     state["realm_wildcard_mention_policy"] = (
                         get_corresponding_policy_value_for_group_setting(
                             user_profile.realm,
                             "can_mention_many_users_group",
                             Realm.WILDCARD_MENTION_POLICY_TYPES,
+                            system_groups_name_dict,
                         )
                     )
 
@@ -1819,14 +1876,6 @@ def do_events_register(
         event_types_set = set(event_types)
     else:
         event_types_set = None
-
-    # Fetch the realm object again to prefetch all the
-    # settings that will be used in 'fetch_initial_state_data'
-    # to avoid unnecessary DB queries.
-    # The settings include:
-    # * group settings which support anonymous groups
-    # * announcements streams
-    realm = get_realm_with_settings(realm_id=realm.id)
 
     if user_profile is None:
         # TODO: Unify the two fetch_initial_state_data code paths.

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -281,7 +281,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(55),
+            self.assert_database_query_count(54),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -586,7 +586,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(53),
+            self.assert_database_query_count(52),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -618,7 +618,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(50):
+        with self.assert_database_query_count(49):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -104,7 +104,9 @@ class UserGroupTestCase(ZulipTestCase):
         empty_user_group = check_add_user_group(realm, "newgroup", [], acting_user=user)
         do_deactivate_user(self.example_user("hamlet"), acting_user=None)
 
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=False)
+        user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=False
+        ).api_groups
         self.assert_length(user_groups, 10)
         self.assertEqual(user_groups[0]["id"], user_group.id)
         self.assertEqual(user_groups[0]["creator_id"], user_group.creator_id)
@@ -183,7 +185,9 @@ class UserGroupTestCase(ZulipTestCase):
             },
             acting_user=self.example_user("desdemona"),
         )
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=False)
+        user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=False
+        ).api_groups
         self.assertEqual(user_groups[10]["id"], new_user_group.id)
         self.assertEqual(user_groups[10]["creator_id"], new_user_group.creator_id)
         self.assertEqual(
@@ -215,7 +219,9 @@ class UserGroupTestCase(ZulipTestCase):
             new_user_group, [another_new_group, owners_system_group], acting_user=None
         )
         do_deactivate_user_group(another_new_group, acting_user=None)
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=True)
+        user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=True
+        ).api_groups
         self.assert_length(user_groups, 12)
         self.assertEqual(user_groups[10]["id"], new_user_group.id)
         self.assertEqual(user_groups[10]["name"], "newgroup2")
@@ -227,13 +233,50 @@ class UserGroupTestCase(ZulipTestCase):
         self.assertEqual(user_groups[11]["name"], "newgroup3")
         self.assertTrue(user_groups[11]["deactivated"])
 
-        user_groups = user_groups_in_realm_serialized(realm, include_deactivated_groups=False)
-        self.assert_length(user_groups, 11)
-        self.assertEqual(user_groups[10]["id"], new_user_group.id)
-        self.assertEqual(user_groups[10]["name"], "newgroup2")
-        self.assertFalse(user_groups[10]["deactivated"])
+        do_change_realm_permission_group_setting(
+            realm, "create_multiuse_invite_group", hamletcharacters_group, acting_user=None
+        )
+        cordelia = self.example_user("cordelia")
+        setting_group = self.create_or_update_anonymous_group_for_setting(
+            [cordelia], [owners_system_group]
+        )
+        do_change_realm_permission_group_setting(
+            realm, "can_create_public_channel_group", setting_group, acting_user=None
+        )
+        realm_setting_group_ids = {
+            realm.create_multiuse_invite_group_id,
+            realm.can_create_public_channel_group_id,
+        }
+
+        realm_user_groups = user_groups_in_realm_serialized(
+            realm, include_deactivated_groups=False, realm_setting_group_ids=realm_setting_group_ids
+        )
+        named_user_groups = realm_user_groups.api_groups
+        self.assert_length(named_user_groups, 11)
+        self.assertEqual(named_user_groups[10]["id"], new_user_group.id)
+        self.assertEqual(named_user_groups[10]["name"], "newgroup2")
+        self.assertFalse(named_user_groups[10]["deactivated"])
         self.assertCountEqual(
-            user_groups[10]["direct_subgroup_ids"], [another_new_group.id, owners_system_group.id]
+            named_user_groups[10]["direct_subgroup_ids"],
+            [another_new_group.id, owners_system_group.id],
+        )
+
+        system_groups_dict = realm_user_groups.system_groups_name_dict
+        self.assertEqual(system_groups_dict[user_group.id], SystemGroups.NOBODY)
+        self.assertEqual(system_groups_dict[owners_system_group.id], SystemGroups.OWNERS)
+        self.assertEqual(system_groups_dict[admins_system_group.id], SystemGroups.ADMINISTRATORS)
+        self.assertEqual(system_groups_dict[everyone_group.id], SystemGroups.EVERYONE)
+
+        realm_setting_anonymous_group_membership = (
+            realm_user_groups.realm_setting_anonymous_group_membership
+        )
+        self.assertEqual(
+            realm_setting_anonymous_group_membership,
+            {
+                realm.can_create_public_channel_group_id: UserGroupMembersDict(
+                    direct_members=[cordelia.id], direct_subgroups=[owners_system_group.id]
+                )
+            },
         )
 
     def test_get_direct_user_groups(self) -> None:

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -119,7 +119,7 @@ def get_user_groups(
 ) -> HttpResponse:
     user_groups = user_groups_in_realm_serialized(
         user_profile.realm, include_deactivated_groups=include_deactivated_groups
-    )
+    ).api_groups
     return json_success(request, data={"user_groups": user_groups})
 
 


### PR DESCRIPTION
search: Fix race condition in search index for new messages.

This fixes a race condition that occurs when a message is sent while looking at a search view.

Fixes: #33267

<!-- Describe your pull request here.-->
When a message is sent while looking at a search view, the client asks the server if 
the new message matches the search terms, but if the message is still waiting to be 
indexed in `fts_update_log`, the server incorrectly reports that it doesn't match.

The solution adds a check in `messages_in_narrow_backend` for messages in `fts_update_log` 
and returns a '`pending_search_index`' status. The client then handles these messages by 
retrying the check with exponential backoff until the message is properly indexed.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>