### PR TITLE
rendered_markdown: Scale code-span padding with font size.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -788,7 +788,8 @@
         unicode-bidi: embed;
         direction: ltr;
         white-space: pre-wrap;
-        padding: 1px 2px;
+        /* 1px at 14px/1em */
+        padding: 0.0714em 2px;
         color: var(--color-markdown-code-text);
         background-color: var(--color-markdown-code-background);
         border-radius: 3px;


### PR DESCRIPTION
This PR is motivated by code-span text that appears to sink below the baseline on certain displays (most reliably, the desktop app on an external monitor). Note in the screenshots below, however, that the adjustment in this PR does not seem to uniformly change baselines everywhere--though it does appear to improve text that is most obviously below the baseline.

CZO discussion

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_At 20px font-size, 1.4 line-height:_

| Desktop app, before | Desktop app, after |
| --- | --- |
| ![desktop-app-before](https://github.com/user-attachments/assets/d804513c-798a-472f-b59b-bfc02f06c292) | ![desktop-app-after](https://github.com/user-attachments/assets/f800b3a1-bdc7-4318-bed1-464d03e3bb46) |

| Firefox, before | After (no baseline shift apparent) |
| --- | --- |
| ![firefox-code-spans-before](https://github.com/user-attachments/assets/0dcd3414-19ab-4c55-8c3f-1c92d8e4e6fb) | ![firefox-code-spans-after](https://github.com/user-attachments/assets/f4b41bb3-49eb-4c95-8670-dc0f0e00a998) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>