### PR TITLE
message_hover: Correct for non-existant span selector.

### DIFF
--- a/web/src/message_list_hover.ts
+++ b/web/src/message_list_hover.ts
@@ -14,7 +14,7 @@ export function message_unhover(): void {
     if ($current_message_hover === undefined) {
         return;
     }
-    $current_message_hover.find("span.edit_content").empty();
+    $current_message_hover.find(".edit_content").empty();
     $current_message_hover = undefined;
 }
 


### PR DESCRIPTION
That `span.edit_content` does not exist in the DOM (`edit_content` is a class on a `<div>`, not a `<span>`) may well be part of why we've continued to see reflow errors under certain conditions.

Whether this fixes that or not, clearly we're trying to find and empty a non-existent element here.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.E2.9D.93messages.20reflowing.20after.20local.20echo/near/2120105)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>