### PR TITLE
help: Document is:muted search filter better.

### DIFF
--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -19,6 +19,10 @@ Muting has the following effects:
 - In the desktop/web app, muted topics are sorted to the bottom of their channel,
   and muted channels are sorted to the bottom of their channel section.
 
+You can search muted messages using the `is:muted` [search
+filter](/help/search-for-messages#search-by-message-status), or exclude them
+from search results with `-is:muted`.
+
 !!! warn ""
 
     **Note**: Some parts of the Zulip experience may start to degrade

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -117,10 +117,9 @@ Zulip offers the following filters based on the location of the message.
 * `is:resolved`: Search messages in [resolved topics](/help/resolve-a-topic).
 * `-is:resolved`: Search messages in [unresolved topics](/help/resolve-a-topic).
 * `is:unread`: Search your unread messages.
-* `is:muted`: Search messages in [muted topics](/help/mute-a-topic) or
-  [muted channels](/help/mute-a-channel).
-* `-is:muted`: Search messages outside [muted topics](/help/mute-a-topic) and
-  [muted channels](/help/mute-a-channel).
+* `is:muted`: Search [muted](/help/mute-a-topic) messages.
+* `-is:muted`: Search only [unmuted](/help/mute-a-topic) messages. By default,
+  both muted and unmuted messages are included in keyword search results.
 * `has:reaction`: Search messages with [emoji reactions](/help/emoji-reactions).
 
 ### Search by message ID

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -154,7 +154,7 @@
                     <tr>
                         <td class="operator">is:muted</td>
                         <td class="definition">
-                            {{t 'Narrow to messages in muted topics or channels.'}}
+                            {{t 'Narrow to muted messages.'}}
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Messages in muted channels may not be muted, so the documentation was previously not quite accurate.

## Help widget
![Screenshot 2025-03-12 at 13 14 30@2x](https://github.com/user-attachments/assets/cb5f14e7-e25d-43c8-b493-48fe0747194b)

## [Search doc](https://zulip.com/help/search-for-messages)
![Screenshot 2025-03-12 at 13 11 30@2x](https://github.com/user-attachments/assets/62f102b8-9cc9-4f43-9894-0eda5b620ccb)

## [Muted topic / channel documentation](http://zulip.com//help/mute-a-topic)
![Screenshot 2025-03-12 at 13 10 01@2x](https://github.com/user-attachments/assets/9114f315-cf18-4034-b687-e3789b31b7a2)
