### PR TITLE
Recipient dropdown isolation

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -989,7 +989,7 @@ input.settings_text_input {
     /* We do not need to pull up lock icons in dropdowns
        so we reset their margin-top to the original value
        for a dropdown's .zulip-icon */
-    margin-top: 2px !important;
+    margin-top: 0 !important;
 }
 
 /* This includes css needed to display messages in an overlay. */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2171,10 +2171,11 @@ body:not(.spectator-view) {
 
     &.compose_select_recipient-dropdown-list-container {
         .dropdown-list .dropdown-list-item-common-styles {
-            /* We align items to center for the sake of the
-               compose_select_recipient dropdown, which has
-               icons not present in other dropdowns. */
-            align-items: center;
+            /* We align items to the baseline for the sake of
+               the compose_select_recipient dropdown, which has
+               icons not present in other dropdowns. We also want
+               to hold the icon to the first baseline. */
+            align-items: first baseline;
         }
     }
 
@@ -2194,9 +2195,13 @@ body:not(.spectator-view) {
             regardless of the height. */
             width: 0.93em;
             padding-right: 5px;
-            /* Override the [data-tippy-root]
-            style in `tooltips.css`. */
-            top: 0;
+            /* Override the [data-tippy-root] style in
+               `tooltips.css`.
+               Because we are manually holding icon
+               alignment to the first/only line of a
+               channel, we make this adjustment here,
+               calculated by 4.5px / (0.93 * 20px) */
+            top: 0.2419em;
         }
 
         .dropdown-list-delete {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2168,6 +2168,56 @@ body:not(.spectator-view) {
         line-height: 20px;
         white-space: normal;
     }
+
+    &.compose_select_recipient-dropdown-list-container {
+        .dropdown-list .dropdown-list-item-common-styles {
+            /* We align items to center for the sake of the
+               compose_select_recipient dropdown, which has
+               icons not present in other dropdowns. */
+            align-items: center;
+        }
+    }
+
+    .dropdown-list .dropdown-list-item-common-styles {
+        position: relative;
+        display: flex;
+        color: var(--color-dropdown-item);
+        padding: 3px 10px 3px 8px;
+        font-weight: 400;
+        line-height: var(--base-line-height-unitless);
+        white-space: normal;
+
+        .stream-privacy-type-icon {
+            font-size: 0.93em;
+            /* We set only the width so that flexbox
+            can do its work to properly center,
+            regardless of the height. */
+            width: 0.93em;
+            padding-right: 5px;
+            /* Override the [data-tippy-root]
+            style in `tooltips.css`. */
+            top: 0;
+        }
+
+        .dropdown-list-delete {
+            position: absolute;
+            top: 0;
+            right: 5px;
+            visibility: hidden;
+        }
+
+        &:focus,
+        &:hover {
+            color: var(--color-dropdown-item);
+            text-decoration: none;
+            background-color: var(--background-color-active-dropdown-item);
+            outline: none;
+
+            .dropdown-list-delete {
+                visibility: visible;
+            }
+        }
+    }
 }
 
 .dropdown-list-container .list-item {
@@ -2192,48 +2242,6 @@ body:not(.spectator-view) {
         &.active {
             background-color: var(--background-color-active-dropdown-item);
             outline: none;
-        }
-    }
-}
-
-.dropdown-list-container .dropdown-list .dropdown-list-item-common-styles {
-    position: relative;
-    display: flex;
-    align-items: center;
-    color: var(--color-dropdown-item);
-    padding: 3px 10px 3px 8px;
-    font-weight: 400;
-    line-height: var(--base-line-height-unitless);
-    white-space: normal;
-
-    .stream-privacy-type-icon {
-        font-size: 0.93em;
-        /* We set only the width so that flexbox
-           can do its work to properly center,
-           regardless of the height. */
-        width: 0.93em;
-        padding-right: 5px;
-        /* Override the [data-tippy-root]
-           style in `tooltips.css`. */
-        top: 0;
-    }
-
-    .dropdown-list-delete {
-        position: absolute;
-        top: 0;
-        right: 5px;
-        visibility: hidden;
-    }
-
-    &:focus,
-    &:hover {
-        color: var(--color-dropdown-item);
-        text-decoration: none;
-        background-color: var(--background-color-active-dropdown-item);
-        outline: none;
-
-        .dropdown-list-delete {
-            visibility: visible;
         }
     }
 }


### PR DESCRIPTION
This PR isolates changes originally from #33889 so as to only affect their intended dropdown, the channel picker.

Additionally, it improves icon-alignment on multi-line channels (single line channels are slightly improved too, especially private channels marked by the lock icon).

CZO issues:
* [#issues > 🎯 misaligned dropdown menu in "Recent conversations" @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20misaligned.20dropdown.20menu.20in.20.22Recent.20conversations.22/near/2118152)
* [#issues > 🎯 channel-picker dropdown items alignment @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20channel-picker.20dropdown.20items.20alignment/near/2118057)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Non-channel-picker widgets, before | After |
| --- | --- |
| ![snippets-before](https://github.com/user-attachments/assets/1446a97d-47f9-4bae-92be-0e2e8943c635) | ![snippets-after](https://github.com/user-attachments/assets/f3cf361a-27a3-48ab-9ad1-d305cdb191d6) |
| ![recent-filter-before](https://github.com/user-attachments/assets/edbf7df0-62ca-49d3-b5ad-5b907d3e3772) | ![recent-filter-after](https://github.com/user-attachments/assets/4d6a820f-8107-421d-8cb9-c162095e8e6d) |

| Channel-picker, before | After |
| --- | --- |
| ![channel-widget-before](https://github.com/user-attachments/assets/a813b32c-fef8-4539-b5d6-5cc413ce0515) | ![channel-widget-after](https://github.com/user-attachments/assets/d80cc257-5f88-4b81-933f-6164be44a046) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
