### PR TITLE
filter: Validate and parse sender:me when turning into a pill.

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -453,7 +453,7 @@ export class Filter {
     }
 
     // Parse a string into a list of terms (see below).
-    static parse(str: string): NarrowTerm[] {
+    static parse(str: string, for_pills = false): NarrowTerm[] {
         const terms: NarrowTerm[] = [];
         let search_term: string[] = [];
         let negated;
@@ -509,6 +509,14 @@ export class Filter {
                     if (sub) {
                         operand = sub.stream_id.toString();
                     }
+                }
+
+                if (
+                    for_pills &&
+                    operator === "sender" &&
+                    operand.toString().toLowerCase() === "me"
+                ) {
+                    operand = people.my_current_email();
                 }
 
                 // We use Filter.operator_to_prefix() to check if the
@@ -575,6 +583,9 @@ export class Filter {
             case "pm-with":
             case "dm-including":
             case "pm-including":
+                if (term.operand === "me") {
+                    return true;
+                }
                 return term.operand
                     .split(",")
                     .every((email) => people.get_by_email(email) !== undefined);

--- a/web/src/search.ts
+++ b/web/src/search.ts
@@ -53,7 +53,7 @@ function full_search_query_in_terms(): NarrowTerm[] {
     assert(search_pill_widget !== null);
     return [
         ...search_pill.get_current_search_pill_terms(search_pill_widget),
-        ...Filter.parse(get_search_bar_text()),
+        ...Filter.parse(get_search_bar_text(), true),
     ];
 }
 

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -1405,8 +1405,8 @@ test("parse", () => {
     let string;
     let terms;
 
-    function _test() {
-        const result = Filter.parse(string);
+    function _test(for_pills = false) {
+        const result = Filter.parse(string, for_pills);
         assert_same_terms(result, terms);
     }
 
@@ -1443,6 +1443,14 @@ test("parse", () => {
     string = "sender:leo+test@zulip.com";
     terms = [{operator: "sender", operand: "leo+test@zulip.com"}];
     _test();
+
+    string = "sender:me";
+    terms = [{operator: "sender", operand: `${me.email}`}];
+    _test(true);
+
+    string = "-sender:me";
+    terms = [{operator: "sender", operand: `${me.email}`, negated: true}];
+    _test(true);
 
     string = "https://www.google.com";
     terms = [{operator: "search", operand: "https://www.google.com"}];
@@ -1964,6 +1972,7 @@ test("is_valid_search_term", () => {
         ["topic:GhostTown", true],
         ["dm-including:alice@example.com", true],
         ["sender:ghost@zulip.com", false],
+        ["sender:me", true],
         ["dm:alice@example.com,ghost@example.com", false],
         ["dm:alice@example.com,joe@example.com", true],
     ];


### PR DESCRIPTION
Fixes #31315.

We want to parse sender:me with the email when turning it into a pill, but not before then so that "Sent by me" is still the search string in the suggestions.