### PR TITLE
message_edit: Fix preview issues in editing

### DIFF
--- a/web/src/click_handlers.ts
+++ b/web/src/click_handlers.ts
@@ -387,6 +387,14 @@ export function initialize(): void {
         },
     );
 
+    $("body").on("input", ".message_edit_form textarea", function (this: HTMLElement) {
+        const $row = $(this).closest(".message_row");
+
+        if ($row.hasClass("preview_mode")) {
+            message_edit.render_preview_area($row);
+        }
+    });
+
     // RESOLVED TOPICS
     $("body").on("click", ".message_header .on_hover_topic_resolve", (e) => {
         e.stopPropagation();

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1787,7 +1787,6 @@ export function show_preview_area($element: JQuery): void {
     $row.addClass("preview_mode");
     $row.find(".preview_mode_disabled .compose_control_button").attr("tabindex", -1);
 
-    $msg_edit_content.hide();
     $row.find(".markdown_preview").hide();
     $row.find(".undo_markdown_preview").show();
     const $preview_message_area = $row.find(".preview_message_area");
@@ -1810,7 +1809,6 @@ export function clear_preview_area($element: JQuery): void {
     $row.removeClass("preview_mode");
     $row.find(".preview_mode_disabled .compose_control_button").attr("tabindex", 0);
 
-    $row.find(".message_edit_content").show();
     $row.find(".undo_markdown_preview").hide();
     $row.find(".preview_message_area").hide();
     $row.find(".preview_content").empty();

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1778,9 +1778,6 @@ export function is_message_oldest_or_newest(
 
 export function show_preview_area($element: JQuery): void {
     const $row = rows.get_closest_row($element);
-    const $msg_edit_content = $row.find<HTMLTextAreaElement>("textarea.message_edit_content");
-    const content = $msg_edit_content.val();
-    assert(content !== undefined);
 
     // Disable unneeded compose_control_buttons as we don't
     // need them in preview mode.
@@ -1789,6 +1786,14 @@ export function show_preview_area($element: JQuery): void {
 
     $row.find(".markdown_preview").hide();
     $row.find(".undo_markdown_preview").show();
+
+    render_preview_area($row);
+}
+
+export function render_preview_area($row: JQuery): void {
+    const $msg_edit_content = $row.find<HTMLTextAreaElement>("textarea.message_edit_content");
+    const content = $msg_edit_content.val();
+    assert(content !== undefined);
     const $preview_message_area = $row.find(".preview_message_area");
     compose_ui.render_and_show_preview(
         $row,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1806,4 +1806,15 @@ textarea.new_message_textarea {
             pointer-events: none;
         }
     }
+
+    .message-edit-textbox {
+        /* In preview mode, we hide the message edit
+           textbox to prevent it from appearing behind
+           the preview container. We cannot set its
+           display to none or visibility to hidden, as
+           that would prevent us from modifying the
+           textarea's value. */
+        height: 0;
+        overflow: hidden;
+    }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -764,13 +764,15 @@
     border-radius: 4px;
     border: 1px solid var(--color-message-content-container-border);
     transition: border-color 0.2s ease;
+    display: grid;
+    grid-template-areas: "message-edit-content";
 
     &:has(.message_edit_content:focus) {
         border-color: var(--color-message-content-container-border-focus);
     }
 
     .message-edit-textbox {
-        position: relative;
+        grid-area: message-edit-content;
 
         .textarea-over-limit {
             background-color: var(
@@ -954,6 +956,7 @@ of the base style defined for a read-only textarea in dark mode. */
 
     .preview_message_area {
         max-height: var(--max-message-edit-height);
+        grid-area: message-edit-content;
     }
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

When I cancel an ongoing upload while in preview mode, returning to the editing still shows "Uploading..":

![before_new](https://github.com/user-attachments/assets/8f89cba0-c491-4e4f-a27d-435a3adc6eb1)

What I have found is this: 
- When an upload is cancelled we use [`text-field-edit's`](https://www.npmjs.com/package/text-field-edit) `replaceFieldText` method for replacing the "Uploading.." text with the old text. 
- When we activate preview mode in editing, we set the textarea's display to none using jquery's `hide()` method & for some reason `replaceFieldText` does not work when the text area's display is set to none (I have tested this separately).

To address this issue, I replaced the `hide()` method with some custom css to hide the textarea without setting it's display to none (negative z-index, 0 height).

Fixes: [#issues > Stale syntax upon cancelling upload in preview](https://chat.zulip.org/#narrow/channel/9-issues/topic/Stale.20syntax.20upon.20cancelling.20upload.20in.20preview)

| Before | After |
| -------- | -------- |
| ![before_new](https://github.com/user-attachments/assets/8f89cba0-c491-4e4f-a27d-435a3adc6eb1) |![after_new](https://github.com/user-attachments/assets/67ebe670-4037-4b97-b547-911f145b8d7b) |

Also added another commit for updating preview whenever textarea is updated in message editing (what we did in [PR#33621](https://github.com/zulip/zulip/pull/33621) for compose).

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
