### PR TITLE
Tweak inline topic editing UI

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -452,6 +452,38 @@ function handle_inline_topic_edit_keydown(this: HTMLElement, e: JQuery.KeyDownEv
 
 function handle_inline_topic_edit_change(this: HTMLInputElement): void {
     const $inline_topic_edit_input = $(this);
+
+    // We use a hidden span element, which we update with the value
+    // of the input field on every input change to calculate the
+    // width of the topic value. This allows us to dynamically adjust
+    // the max-width of the input field.
+    const $topic_value_mirror = $inline_topic_edit_input
+        .closest(".topic_edit_form")
+        .find(".topic_value_mirror");
+    $topic_value_mirror.text(this.value);
+    const topic_width = $topic_value_mirror.width();
+    if (this.value.length > 0) {
+        // When the user starts typing in the inline topic edit input field,
+        // we dynamically adjust the max-width of the input field to match
+        // width of the text in the input field + 1ch width for some cushion.
+        $inline_topic_edit_input.css("max-width", `calc(${topic_width}px + 1ch)`);
+    } else {
+        // When the user deletes all the text in the inline topic edit input field,
+        // we check if the input field has a placeholder and if it does, we set the
+        // max-width of the input field to the length of the placeholder + 1ch
+        // width for some cushion.
+        const $placeholder = $inline_topic_edit_input
+            .closest(".topic_edit_form")
+            .find(".inline-topic-edit-placeholder");
+        if ($placeholder.length > 0) {
+            const placeholder_width = $placeholder.width();
+            $inline_topic_edit_input.css("max-width", `calc(${placeholder_width}px + 1ch)`);
+        } else {
+            // Otherwise, we set the max-width to a reasonable 20ch width.
+            $inline_topic_edit_input.css("max-width", "20ch");
+        }
+    }
+
     if ($inline_topic_edit_input.hasClass("invalid-input")) {
         // If invalid-input class is present on the inline topic edit
         // input field, remove it as soon as the user starts typing
@@ -944,6 +976,7 @@ export function start_inline_topic_edit($recipient_row: JQuery): void {
     const $form = $(
         render_topic_edit_form({
             max_topic_length: realm.max_topic_length,
+            is_mandatory_topics: realm.realm_mandatory_topics,
             empty_string_topic_display_name: util.get_final_topic_display_name(""),
         }),
     );
@@ -955,6 +988,11 @@ export function start_inline_topic_edit($recipient_row: JQuery): void {
     const topic = message.topic;
     const $inline_topic_edit_input = $form.find<HTMLInputElement>("input.inline_topic_edit");
     $inline_topic_edit_input.val(topic).trigger("select").trigger("focus");
+    const $stream_topic = $recipient_row.find(".stream_topic");
+    const topic_width = $stream_topic.width();
+    // Set the width of the inline topic edit input to the
+    // width of the topic name + 1ch width for some cushion.
+    $inline_topic_edit_input.css("max-width", `calc(${topic_width}px + 1ch)`);
     const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     composebox_typeahead.initialize_topic_edit_typeahead(
         $inline_topic_edit_input,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -958,9 +958,6 @@ div.focused-message-list.is-conversation-view .recipient_row {
 
 .inline_topic_edit {
     flex: 1;
-    /* Set the max width of the inline topic edit input to the realm's
-       max_topic_length (60 chars) + 5 chars extra for some cushion. */
-    max-width: 65ch;
     line-height: 1.2142em;
     padding: 0 5px;
     color: hsl(0deg 0% 33%);

--- a/web/templates/topic_edit_form.hbs
+++ b/web/templates/topic_edit_form.hbs
@@ -5,7 +5,7 @@
     <span class="inline-topic-edit-placeholder placeholder">
         {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
     </span>
-    {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" attention="primary" intent="brand" data-tooltip-template-id="save-button-tooltip-template" }}
+    {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" attention="quiet" intent="neutral" data-tooltip-template-id="save-button-tooltip-template" }}
     {{> components/action_button custom_classes="topic_edit_cancel tippy-zulip-delayed-tooltip" icon="circle-x" attention="borderless" intent="neutral" data-tooltip-template-id="cancel-button-tooltip-template" }}
     <div class="topic_edit_spinner"></div>
 </form>

--- a/web/templates/topic_edit_form.hbs
+++ b/web/templates/topic_edit_form.hbs
@@ -1,10 +1,13 @@
 {{! Client-side Handlebars template for rendering the topic edit form. }}
 
 <form class="topic_edit_form">
+    <span class="topic_value_mirror hide"></span>
     <input type="text" value="" autocomplete="off" maxlength="{{ max_topic_length }}" class="inline_topic_edit header-v"/>
-    <span class="inline-topic-edit-placeholder placeholder">
-        {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
-    </span>
+    {{#unless is_mandatory_topics}}
+        <span class="inline-topic-edit-placeholder placeholder">
+            {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
+        </span>
+    {{/unless}}
     {{> components/action_button custom_classes="topic_edit_save tippy-zulip-delayed-tooltip" icon="check" attention="quiet" intent="neutral" data-tooltip-template-id="save-button-tooltip-template" }}
     {{> components/action_button custom_classes="topic_edit_cancel tippy-zulip-delayed-tooltip" icon="circle-x" attention="borderless" intent="neutral" data-tooltip-template-id="cancel-button-tooltip-template" }}
     <div class="topic_edit_spinner"></div>


### PR DESCRIPTION
This PR consists of two commits:
- **Commit 1**: Update save button to neutral + quiet button style.
- **Commit 2**: Adds a hidden topic_value_mirror span element, and uses that to dynamically set the width of the input field to the width of the topic text inside it + some cushion.

Fixes: #33844.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**No input - Placeholder text**
![Screenshot 2025-03-13 at 1 17 35 PM](https://github.com/user-attachments/assets/dcd0ea9c-ef0a-4b14-aeaf-eb4aa4eed43b)

**No input - Placeholder text in non-English**
![Screenshot 2025-03-13 at 1 18 22 PM](https://github.com/user-attachments/assets/197d314f-f21d-4fda-9692-c1568de4b9fb)

**Responsive inline topic edit input**
![Dynamic Inline Edit](https://github.com/user-attachments/assets/566e1c50-8959-4b7e-b789-be2e17ba26e8)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
