### PR TITLE
register: Optimizing computing stream group setting values.

### DIFF
--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -33,7 +33,7 @@ from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.soft_deactivation import queue_soft_reactivation
 from zerver.lib.stream_traffic import get_streams_traffic
 from zerver.lib.streams import (
-    get_group_setting_value_dict_for_streams,
+    get_anonymous_group_membership_dict_for_streams,
     get_streams_for_user,
     send_stream_deletion_event,
     stream_to_dict,
@@ -566,13 +566,15 @@ def send_stream_events_for_role_update(
             if stream.id in now_accessible_stream_ids
         ]
 
-        setting_groups_dict = get_group_setting_value_dict_for_streams(now_accessible_streams)
+        anonymous_group_membership = get_anonymous_group_membership_dict_for_streams(
+            now_accessible_streams
+        )
 
         event = dict(
             type="stream",
             op="create",
             streams=[
-                stream_to_dict(stream, recent_traffic, setting_groups_dict)
+                stream_to_dict(stream, recent_traffic, anonymous_group_membership)
                 for stream in now_accessible_streams
             ],
         )

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -225,12 +225,12 @@ def fetch_initial_state_data(
             get_recursive_membership_groups(settings_user).values_list("id", flat=True)
         )
 
-    if want("realm_user_groups") or want("realm"):
-        realm_setting_group_ids = {
-            getattr(realm, setting_name + "_id")
-            for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS
-        }
-
+    if (
+        want("realm_user_groups")
+        or want("realm")
+        or (want("stream") and include_streams)
+        or want("subscription")
+    ):
         # Optimizing opportunity: This fetches more data than
         # we strictly need when "realm_user_groups" is not in
         # fetch_event_types; we need the membership of the
@@ -240,7 +240,7 @@ def fetch_initial_state_data(
         realm_groups_data = user_groups_in_realm_serialized(
             realm,
             include_deactivated_groups=include_deactivated_groups,
-            realm_setting_group_ids=realm_setting_group_ids,
+            fetch_anonymous_group_membership=True,
         )
 
     if want("alert_words"):
@@ -372,7 +372,7 @@ def fetch_initial_state_data(
         for setting_name in Realm.REALM_PERMISSION_GROUP_SETTINGS:
             setting_group_id = getattr(realm, setting_name + "_id")
             state["realm_" + setting_name] = get_group_setting_value_for_register_api(
-                setting_group_id, realm_groups_data.realm_setting_anonymous_group_membership
+                setting_group_id, realm_groups_data.anonymous_group_membership
             )
 
         state["realm_create_public_stream_policy"] = (
@@ -740,9 +740,10 @@ def fetch_initial_state_data(
                 user_profile,
                 include_subscribers=include_subscribers,
                 include_archived_channels=archived_channels,
+                anonymous_group_membership=realm_groups_data.anonymous_group_membership,
             )
         else:
-            sub_info = get_web_public_subs(realm)
+            sub_info = get_web_public_subs(realm, realm_groups_data.anonymous_group_membership)
 
         state["subscriptions"] = sub_info.subscriptions
         state["unsubscribed"] = sub_info.unsubscribed
@@ -776,13 +777,16 @@ def fetch_initial_state_data(
                 user_profile,
                 include_web_public=True,
                 include_all=user_profile.is_realm_admin,
+                anonymous_group_membership=realm_groups_data.anonymous_group_membership,
             )
         else:
             # TODO: This line isn't used by the web app because it
             # gets these data via the `subscriptions` key; it will
             # be used when the mobile apps support logged-out
             # access.
-            state["streams"] = get_web_public_streams(realm)  # nocoverage
+            state["streams"] = get_web_public_streams(
+                realm, realm_groups_data.anonymous_group_membership
+            )  # nocoverage
     if want("default_streams"):
         if settings_user.is_guest:
             # Guest users and logged-out users don't have access to

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -1511,10 +1511,11 @@ def stream_to_dict(
     )
 
 
-def get_web_public_streams(realm: Realm) -> list[APIStreamDict]:  # nocoverage
+def get_web_public_streams(
+    realm: Realm, anonymous_group_membership: dict[int, UserGroupMembersDict]
+) -> list[APIStreamDict]:  # nocoverage
     query = get_web_public_streams_queryset(realm)
     streams = query.only(*Stream.API_FIELDS)
-    anonymous_group_membership = get_anonymous_group_membership_dict_for_streams(list(streams))
     stream_dicts = [stream_to_dict(stream, None, anonymous_group_membership) for stream in streams]
     return stream_dicts
 
@@ -1666,6 +1667,7 @@ def do_get_streams(
     include_default: bool = False,
     include_owner_subscribed: bool = False,
     include_can_access_content: bool = False,
+    anonymous_group_membership: dict[int, UserGroupMembersDict] | None = None,
 ) -> list[APIStreamDict]:
     # This function is only used by API clients now.
 
@@ -1683,7 +1685,8 @@ def do_get_streams(
     stream_ids = {stream.id for stream in streams}
     recent_traffic = get_streams_traffic(stream_ids, user_profile.realm)
 
-    anonymous_group_membership = get_anonymous_group_membership_dict_for_streams(streams)
+    if anonymous_group_membership is None:
+        anonymous_group_membership = get_anonymous_group_membership_dict_for_streams(streams)
 
     stream_dicts = sorted(
         (stream_to_dict(stream, recent_traffic, anonymous_group_membership) for stream in streams),

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -171,7 +171,7 @@ class EventsEndpointTest(ZulipTestCase):
                 status_code=401,
             )
 
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(15):
             result = self.client_post("/json/register")
             result_dict = self.assert_json_success(result)
             self.assertEqual(result_dict["queue_id"], None)
@@ -1213,7 +1213,7 @@ class FetchQueriesTest(ZulipTestCase):
         self.login_user(user)
 
         with (
-            self.assert_database_query_count(46),
+            self.assert_database_query_count(42),
             mock.patch("zerver.lib.events.always_want") as want_mock,
         ):
             fetch_initial_state_data(user, realm=user.realm)
@@ -1230,8 +1230,8 @@ class FetchQueriesTest(ZulipTestCase):
             onboarding_steps=1,
             presence=1,
             # 2 of the 3 queries here are a single query that is used
-            # both for the 'realm' event type and the
-            # 'realm_user_groups' event type.
+            # for all the 'realm', 'stream', 'subscription'
+            # and 'realm_user_groups' event types.
             realm=3,
             # Similarly, this query is shared with the realm_user total.
             realm_billing=1,
@@ -1250,8 +1250,12 @@ class FetchQueriesTest(ZulipTestCase):
             saved_snippets=1,
             scheduled_messages=1,
             starred_messages=1,
+            # 3 of the 5 queries here are shared with other event types
+            # as mentioned above.
             stream=5,
             stop_words=0,
+            # 3 of the 9 queries here are shared with other event types
+            # as mentioned above.
             subscription=9,
             update_display_settings=0,
             update_global_notifications=0,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -276,7 +276,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         with (
-            self.assert_database_query_count(54),
+            self.assert_database_query_count(52),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page(stream="Denmark")
@@ -577,7 +577,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         with (
-            self.assert_database_query_count(53),
+            self.assert_database_query_count(51),
             patch("zerver.lib.cache.cache_set") as cache_mock,
         ):
             result = self._get_home_page()
@@ -609,7 +609,7 @@ class HomeTest(ZulipTestCase):
         self._get_home_page()
 
         # Then for the second page load, measure the number of queries.
-        with self.assert_database_query_count(49):
+        with self.assert_database_query_count(47):
             result = self._get_home_page()
 
         # Do a sanity check that our new streams were in the payload.


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is a preparatory refactor.
- Second commit is to optimize computing stream group setting values.

Fixes: <!-- Issue link, or clear description.--> #32561

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
