### PR TITLE
connection_error_banner: Hide loading indicator on hover.

### DIFF
--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -7,8 +7,7 @@ export function show_button_loading_indicator($button: JQuery): void {
     if ($button.find(".button-loading-indicator").length > 0) {
         return;
     }
-    // First, we disable the button and hide its contents.
-    $button.prop("disabled", true);
+    // First, we hide the current content of the button.
     $button.find(".zulip-icon").css("visibility", "hidden");
     $button.find(".action-button-label").css("visibility", "hidden");
     // Next, we create a loading indicator with a unique id.

--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -99,7 +99,17 @@ export function open_connection_error_popup_banner(opts: {
         e.preventDefault();
         e.stopPropagation();
 
-        buttons.show_button_loading_indicator($(this));
+        const $button = $(this);
+
+        // If the loading indicator is already being shown, this logic
+        // allows us to visually indicate that the retry sequence was
+        // executed again by showing the loading indicator on click.
+        $button.removeClass("button-hide-loading-indicator-on-hover");
+        $button.one("mouseleave", () => {
+            $button.addClass("button-hide-loading-indicator-on-hover");
+        });
+
+        buttons.show_button_loading_indicator($button);
         opts.on_retry_callback();
     });
 }

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -607,3 +607,14 @@
         }
     }
 }
+
+.button-hide-loading-indicator-on-hover:hover {
+    .button-loading-indicator {
+        visibility: hidden;
+    }
+
+    .action-button-label,
+    .zulip-icon {
+        visibility: visible !important;
+    }
+}


### PR DESCRIPTION
This fixes the 3rd checkpoint of #33924:
> - [ ] Show the text "Try now" button label instead of the loading indicator on the button on hover, since the user can request a retry. Button should still work in this situation.

This enables the retry button even when the loading indicator is being shown, and hides the loading indicator in favor of the original button content to indicate that the button is still interactable.

<!-- Describe your pull request here.-->

Fixes part of #33924.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![loading-indicator-hide](https://github.com/user-attachments/assets/48155326-af08-42cb-a578-1e0d2594ad67)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
