### PR TITLE
move_topic: Improve placeholder when topic is not mandatory.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -885,6 +885,31 @@ ul.popover-group-menu-member-list {
         box-sizing: border-box;
         width: 100%;
         height: auto;
+
+        &.empty-topic-display::placeholder {
+            color: inherit;
+        }
+    }
+
+    #move-topic-new-topic-input-wrapper {
+        position: relative;
+    }
+
+    .move-topic-new-topic-placeholder {
+        position: absolute;
+        left: 6px;
+        right: 6px;
+        top: 50%;
+        transform: translateY(-50%);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        pointer-events: none;
+        visibility: hidden;
+    }
+
+    .move-topic-new-topic-placeholder-visible {
+        visibility: visible;
     }
 
     #message_move_select_options {

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -9,7 +9,12 @@
         {{/unless}}
         <div class="input-group">
             <label for="move-topic-new-topic-name" class="modal-field-label">New topic</label>
-            <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input {{#unless realm_mandatory_topics}}empty-topic-placeholder-display{{/unless}}" autocomplete="off" {{#unless realm_mandatory_topics}}placeholder="{{empty_string_topic_display_name}}"{{/unless}} value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} maxlength="{{ max_topic_length }}"/>
+            <div id="move-topic-new-topic-input-wrapper">
+                <input id="move-topic-new-topic-name" name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} maxlength="{{ max_topic_length }}"/>
+                <span class="move-topic-new-topic-placeholder placeholder">
+                    {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
+                </span>
+            </div>
         </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />


### PR DESCRIPTION
Earlier, we used to show "general chat" as the placeholder.

This PR adds support to show "Enter a topic (skip for general chat)" as the placeholder when topic is not mandatory in the move-topic-new-topic input box.

We show "general chat" (as we show in compose topic input box) when move-topic-new-topic input box is not focused and topic="".

Fixes: #33846.

- [x] The "move topic" / "move messages" modals should have the same sort of topic placeholder logic as the compose box. If topics are not required and the topic is empty, show "Enter a topic (skip for general chat)" if the topic is focused, and general chat otherwise.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After |
|-------|------|
<img width="594" alt="Screenshot 2025-03-14 at 12 57 39 AM" src="https://github.com/user-attachments/assets/21549e44-5264-4490-bdd3-23123fbdbd34" /> | <img width="595" alt="Screenshot 2025-03-14 at 12 54 56 AM" src="https://github.com/user-attachments/assets/61a05b09-07df-4fd1-b841-0f4b62ca1460" /> | 

<img width="295" alt="Screenshot 2025-03-14 at 12 55 07 AM" src="https://github.com/user-attachments/assets/5cafc6ed-52c7-4cb4-ac26-e6f6ab7ff4c0" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
