### PR TITLE
settings_users: Conditionally render dropdowns for non-bots.

### DIFF
--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -35,8 +35,8 @@ export const deactivated_user_list_dropdown_widget_name = "deactivated_user_list
 let should_redraw_active_users_list = false;
 let should_redraw_deactivated_users_list = false;
 let presence_data_fetched = false;
-let active_users_role_dropdown: dropdown_widget.DropdownWidget;
-let deactivated_users_role_dropdown: dropdown_widget.DropdownWidget;
+let active_users_role_dropdown: dropdown_widget.DropdownWidget | undefined;
+let deactivated_users_role_dropdown: dropdown_widget.DropdownWidget | undefined;
 
 type UserSettingsSection = {
     dropdown_widget_name: string;
@@ -114,7 +114,7 @@ export function allow_sorting_deactivated_users_list_by_email(): boolean {
     return deactivated_humans_with_visible_email.length > 0;
 }
 
-export function update_view_on_deactivate(user_id: number): void {
+export function update_view_on_deactivate(user_id: number, is_bot: boolean): void {
     const $row = get_user_info_row(user_id);
     if ($row.length === 0) {
         return;
@@ -129,14 +129,19 @@ export function update_view_on_deactivate(user_id: number): void {
     $row.removeClass("active-user");
     $row.addClass("deactivated_user");
 
-    should_redraw_active_users_list = true;
-    should_redraw_deactivated_users_list = true;
-
-    active_users_role_dropdown.render(active_section.filters.role_code);
-    deactivated_users_role_dropdown.render(deactivated_section.filters.role_code);
+    if (!is_bot) {
+        should_redraw_active_users_list = true;
+        should_redraw_deactivated_users_list = true;
+        if (active_users_role_dropdown) {
+            active_users_role_dropdown.render(active_section.filters.role_code);
+        }
+        if (deactivated_users_role_dropdown) {
+            deactivated_users_role_dropdown.render(deactivated_section.filters.role_code);
+        }
+    }
 }
 
-export function update_view_on_reactivate(user_id: number): void {
+export function update_view_on_reactivate(user_id: number, is_bot: boolean): void {
     const $row = get_user_info_row(user_id);
     if ($row.length === 0) {
         return;
@@ -150,11 +155,16 @@ export function update_view_on_reactivate(user_id: number): void {
     $row.removeClass("deactivated_user");
     $row.addClass("active-user");
 
-    should_redraw_active_users_list = true;
-    should_redraw_deactivated_users_list = true;
-
-    active_users_role_dropdown.render(active_section.filters.role_code);
-    deactivated_users_role_dropdown.render(deactivated_section.filters.role_code);
+    if (!is_bot) {
+        should_redraw_active_users_list = true;
+        should_redraw_deactivated_users_list = true;
+        if (active_users_role_dropdown) {
+            active_users_role_dropdown.render(active_section.filters.role_code);
+        }
+        if (deactivated_users_role_dropdown) {
+            deactivated_users_role_dropdown.render(deactivated_section.filters.role_code);
+        }
+    }
 }
 
 function add_value_to_filters(

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -58,9 +58,9 @@ export const user_update_schema = z.object({user_id: z.number()}).and(
 type UserUpdate = z.output<typeof user_update_schema>;
 
 export const update_person = function update(person: UserUpdate): void {
-    const person_obj = people.maybe_get_user_by_id(person.user_id);
+    const user = people.maybe_get_user_by_id(person.user_id);
 
-    if (!person_obj) {
+    if (!user) {
         blueslip.error("Got update_person event for unexpected user", {user_id: person.user_id});
         return;
     }
@@ -80,8 +80,8 @@ export const update_person = function update(person: UserUpdate): void {
 
     if ("delivery_email" in person) {
         const delivery_email = person.delivery_email;
-        person_obj.delivery_email = delivery_email;
-        user_profile.update_profile_modal_ui(person_obj, person);
+        user.delivery_email = delivery_email;
+        user_profile.update_profile_modal_ui(user, person);
         if (people.is_my_user_id(person.user_id)) {
             assert(delivery_email !== null);
             settings_account.update_email(delivery_email);
@@ -91,13 +91,13 @@ export const update_person = function update(person: UserUpdate): void {
     }
 
     if ("full_name" in person) {
-        people.set_full_name(person_obj, person.full_name);
+        people.set_full_name(user, person.full_name);
 
         settings_users.update_user_data(person.user_id, person);
         activity_ui.redraw();
         message_live_update.update_user_full_name(person.user_id, person.full_name);
         pm_list.update_private_messages();
-        user_profile.update_profile_modal_ui(person_obj, person);
+        user_profile.update_profile_modal_ui(user, person);
         if (people.is_my_user_id(person.user_id)) {
             current_user.full_name = person.full_name;
             settings_account.update_full_name(person.full_name);
@@ -105,24 +105,24 @@ export const update_person = function update(person: UserUpdate): void {
     }
 
     if ("role" in person) {
-        person_obj.role = person.role;
-        person_obj.is_owner = person.role === settings_config.user_role_values.owner.code;
-        person_obj.is_admin =
-            person.role === settings_config.user_role_values.admin.code || person_obj.is_owner;
-        person_obj.is_guest = person.role === settings_config.user_role_values.guest.code;
-        person_obj.is_moderator = person.role === settings_config.user_role_values.moderator.code;
+        user.role = person.role;
+        user.is_owner = person.role === settings_config.user_role_values.owner.code;
+        user.is_admin =
+            person.role === settings_config.user_role_values.admin.code || user.is_owner;
+        user.is_guest = person.role === settings_config.user_role_values.guest.code;
+        user.is_moderator = person.role === settings_config.user_role_values.moderator.code;
         settings_users.update_user_data(person.user_id, person);
-        user_profile.update_profile_modal_ui(person_obj, person);
+        user_profile.update_profile_modal_ui(user, person);
 
-        if (people.is_my_user_id(person.user_id) && current_user.is_owner !== person_obj.is_owner) {
-            current_user.is_owner = person_obj.is_owner;
+        if (people.is_my_user_id(person.user_id) && current_user.is_owner !== user.is_owner) {
+            current_user.is_owner = user.is_owner;
             settings_org.maybe_disable_widgets();
             settings_org.enable_or_disable_group_permission_settings();
             settings.update_lock_icon_in_sidebar();
         }
 
-        if (people.is_my_user_id(person.user_id) && current_user.is_admin !== person_obj.is_admin) {
-            current_user.is_admin = person_obj.is_admin;
+        if (people.is_my_user_id(person.user_id) && current_user.is_admin !== user.is_admin) {
+            current_user.is_admin = user.is_admin;
             settings_linkifiers.maybe_disable_widgets();
             settings_org.maybe_disable_widgets();
             settings_org.enable_or_disable_group_permission_settings();
@@ -135,16 +135,16 @@ export const update_person = function update(person: UserUpdate): void {
 
         if (
             people.is_my_user_id(person.user_id) &&
-            current_user.is_moderator !== person_obj.is_moderator
+            current_user.is_moderator !== user.is_moderator
         ) {
-            current_user.is_moderator = person_obj.is_moderator;
+            current_user.is_moderator = user.is_moderator;
         }
     }
 
     if ("avatar_url" in person) {
         const url = person.avatar_url;
-        person_obj.avatar_url = url;
-        person_obj.avatar_version = person.avatar_version;
+        user.avatar_url = url;
+        user.avatar_version = person.avatar_version;
 
         if (people.is_my_user_id(person.user_id)) {
             current_user.avatar_source = person.avatar_source;
@@ -154,13 +154,13 @@ export const update_person = function update(person: UserUpdate): void {
             $("#personal-menu .header-button-avatar").attr("src", `${person.avatar_url_medium}`);
         }
 
-        message_live_update.update_avatar(person_obj.user_id, person.avatar_url);
-        user_profile.update_profile_modal_ui(person_obj, person);
+        message_live_update.update_avatar(user.user_id, person.avatar_url);
+        user_profile.update_profile_modal_ui(user, person);
     }
 
     if ("custom_profile_field" in person) {
         people.set_custom_profile_field_data(person.user_id, person.custom_profile_field);
-        user_profile.update_user_custom_profile_fields(person_obj);
+        user_profile.update_user_custom_profile_fields(user);
         if (person.user_id === people.my_current_user_id()) {
             navbar_alerts.maybe_toggle_empty_required_profile_fields_banner();
 
@@ -191,22 +191,22 @@ export const update_person = function update(person: UserUpdate): void {
     }
 
     if ("timezone" in person) {
-        person_obj.timezone = person.timezone;
+        user.timezone = person.timezone;
     }
 
     if ("bot_owner_id" in person) {
-        assert(person_obj.is_bot);
-        person_obj.bot_owner_id = person.bot_owner_id;
-        user_profile.update_profile_modal_ui(person_obj, person);
+        assert(user.is_bot);
+        user.bot_owner_id = person.bot_owner_id;
+        user_profile.update_profile_modal_ui(user, person);
     }
 
     if ("is_active" in person) {
-        const is_bot_user = person_obj.is_bot;
+        const is_bot_user = user.is_bot;
         if (person.is_active) {
-            people.add_active_user(person_obj);
+            people.add_active_user(user);
             settings_users.update_view_on_reactivate(person.user_id, is_bot_user);
         } else {
-            people.deactivate(person_obj);
+            people.deactivate(user);
             stream_events.remove_deactivated_user_from_all_streams(person.user_id);
             user_group_edit.remove_deactivated_user_from_all_groups(person.user_id);
             settings_users.update_view_on_deactivate(person.user_id, is_bot_user);

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -201,18 +201,19 @@ export const update_person = function update(person: UserUpdate): void {
     }
 
     if ("is_active" in person) {
+        const is_bot_user = person_obj.is_bot;
         if (person.is_active) {
             people.add_active_user(person_obj);
-            settings_users.update_view_on_reactivate(person.user_id);
+            settings_users.update_view_on_reactivate(person.user_id, is_bot_user);
         } else {
             people.deactivate(person_obj);
             stream_events.remove_deactivated_user_from_all_streams(person.user_id);
             user_group_edit.remove_deactivated_user_from_all_groups(person.user_id);
-            settings_users.update_view_on_deactivate(person.user_id);
+            settings_users.update_view_on_deactivate(person.user_id, is_bot_user);
         }
         buddy_list.insert_or_move([person.user_id]);
         settings_account.maybe_update_deactivate_account_button();
-        if (people.is_valid_bot_user(person.user_id)) {
+        if (is_bot_user) {
             settings_users.update_bot_data(person.user_id);
         } else if (!person.is_active) {
             // A human user deactivated, update 'Export permissions' table.


### PR DESCRIPTION
Previously, deactivating a bot from the bots tab without loading
the users tab caused a blueslip error because update_view_on_deactivate
tried to render uninitialized role dropdowns from a realm_user event.

This PR fixes this by passing is_bot to update_view functions
and only rendering dropdowns for non-bots if they’re initialized.


Fixes: [#issues > 🎯 Role count not updating in user and deactivated user l... @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Role.20count.20not.20updating.20in.20user.20and.20deactivated.20user.20l.2E.2E.2E/near/2122277)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
