### PR TITLE
message_view: Better tolerate different opening Markdown elements.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -150,11 +150,6 @@
 
     .message_content {
         grid-area: message;
-        /*
-        Space between two single line messages is kept in
-        lockstep with adjacent Markdown elements.
-        */
-        padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
         color: var(--color-text-message-default);
         /* We explicitly set line-height here so that
            the message area is not beholden to the legacy
@@ -375,6 +370,7 @@
         }
 
         .message_content {
+            padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
             /* Pull message content up closer to sender to
                let the text baseline sit adjacent the bottom
                of the avatar. We also need to account for the

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -50,13 +50,6 @@
         border-top: 1px solid hsl(0deg 0% 87%);
         /* Override Bootstrap with doubled interelement space */
         margin: calc(var(--markdown-interelement-space-px) * 2) 0;
-
-        &:first-child {
-            /* When a horizontal rule opens a message, or any other
-               area in the message area (e.g., spoilers), there
-               should be no space above the rule. */
-            margin-top: 0;
-        }
     }
 
     /* Headings */
@@ -443,6 +436,10 @@
         border: solid 1px transparent;
         transition: background 0.3s ease;
         background: hsl(0deg 0% 0% / 3%);
+
+        &:first-child {
+            margin-top: var(--markdown-interelement-space-px);
+        }
 
         &:hover {
             background: hsl(0deg 0% 0% / 15%);


### PR DESCRIPTION
This PR makes some very minor but significant adjustments to message-box spacing to better tolerate top-row alignment of EDITED/MOVED markers, action icons, and timestamps even when the message box opens with non-paragraph content (that is, elements other than paragraphs and ordered/unordered lists).

Note that in fixing the alignment issues here, the focus ring does appear visually closer to the top of especially heading one and heading two elements. However, it maintains a uniform space from the action icons and other materials, presenting a more uniform look overall.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20message.20action.20buttons.20misaligned.20w.2F.20header.20in.20first.20line/with/2113656)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing both 14px and 20px, before and after:_

| Before | After |
| --- | --- |
| ![markdown-alignment-before](https://github.com/user-attachments/assets/b496912a-d373-4219-b149-45dd048b315d) | ![markdown-alignment-after](https://github.com/user-attachments/assets/166c3352-fc5e-4532-bb7a-853d6233420b) |
| ![markdown-alignment-14px-before](https://github.com/user-attachments/assets/1ea167e8-4bc8-4acb-9ee6-e6738b44ad8e) | ![markdown-alignment-14px-after](https://github.com/user-attachments/assets/12fd010f-3897-4751-a687-571cd171191a) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>