### PR TITLE
compose: Use standard primary button colors for compose send button.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1177,8 +1177,8 @@ textarea.new_message_textarea {
     border-radius: 4px;
     border: 0;
     margin-bottom: 0;
-    color: var(--color-compose-send-button-icon-color);
-    background-color: var(--color-compose-send-button-background);
+    color: var(--color-text-brand-primary-action-button);
+    background-color: var(--color-background-brand-primary-action-button);
 
     &:active {
         transition: transform 80ms;
@@ -1193,13 +1193,13 @@ textarea.new_message_textarea {
         border: 1px solid var(--color-compose-send-button-focus-border);
         box-shadow: 0 0 5px var(--color-compose-send-button-focus-shadow);
         background-color: var(
-            --color-compose-send-button-background-interactive
+            --color-background-brand-primary-action-button-active
         );
     }
 
     &:hover {
         background-color: var(
-            --color-compose-send-button-background-interactive
+            --color-background-brand-primary-action-button-hover
         );
     }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -720,12 +720,12 @@
     height: 2em;
     /* Match Save button's basic colors to
        the compose box Send button. */
-    color: var(--color-compose-send-button-icon-color);
-    background-color: var(--color-compose-send-button-background);
+    color: var(--color-text-brand-primary-action-button);
+    background-color: var(--color-background-brand-primary-action-button);
 
     &:hover {
         background-color: var(
-            --color-compose-send-button-background-interactive
+            --color-background-brand-primary-action-button-hover
         );
     }
 


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20incorrect.20hover.20behavior.20on.20.22send.22.20button/with/2122914
![image](https://github.com/user-attachments/assets/9a42678e-61f2-458b-9339-1ecef66c1d55)

Order of button state in screenshots is:
Normal
Hover 
Focus

| before | after |
| --- | --- |
| ![Screenshot 2025-03-14 074724](https://github.com/user-attachments/assets/539c5323-d7a6-47af-88ec-e56325700c7a) | ![Screenshot 2025-03-14 074320](https://github.com/user-attachments/assets/3e61ec09-3dfc-491c-ac4f-3b0b56059efa) |
| ![Screenshot 2025-03-14 074701](https://github.com/user-attachments/assets/52507b93-babe-44cc-bcd5-e3242723e9f2) | ![Screenshot 2025-03-14 074344](https://github.com/user-attachments/assets/c40d11a0-601f-4eff-bdd8-b2a440e2884b) |
| ![Screenshot 2025-03-14 074748](https://github.com/user-attachments/assets/11f2140f-5e9b-428a-8238-f75fd3d6acea) | ![Screenshot 2025-03-14 074414](https://github.com/user-attachments/assets/706368a3-3306-48cb-9058-df4a519ba48e) |
| ![Screenshot 2025-03-14 074541](https://github.com/user-attachments/assets/98cdad36-7abd-4b3f-8e7c-293dde9a7cb3) | ![Screenshot 2025-03-14 074503](https://github.com/user-attachments/assets/a7e42947-4f57-4f59-a4f1-bf94e27efb77) |
| ![Screenshot 2025-03-14 074607](https://github.com/user-attachments/assets/981742e1-5abb-4318-91df-973d7c1e1e16) | ![Screenshot 2025-03-14 074452](https://github.com/user-attachments/assets/2f8c1401-e2fe-47c5-9a75-0c9fc0612c0c) |
| ![Screenshot 2025-03-14 074626](https://github.com/user-attachments/assets/4fd01323-b232-438b-8044-f3042347ecbe) | ![Screenshot 2025-03-14 074431](https://github.com/user-attachments/assets/c2aa00e6-4ffd-48d7-b561-61f8cdadd285) |



