### PR TITLE
message_row: Fix message focus ring cutoff near date headers.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -22,10 +22,6 @@
     &.private-message {
         background-color: var(--color-background-private-message-content);
 
-        .date_row {
-            background-color: var(--color-background-private-message-content);
-        }
-
         .data-container::after {
             background: linear-gradient(
                 0deg,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
When viewing messages near date separators at certain zoom levels (60-90%),
the message focus ring was getting clipped at the bottom. This removes the
background-color from .date_row which prevents the visual clipping.

This fix follows the same approach used in [#25806](https://github.com/zulip/zulip/pull/25806) for a similar issue,
where removing the background color allows the focus ring to properly render
beyond container boundaries without being cut off by rendering boundaries.

Fixes: [Message focus box is cut off at the bottom. #33571](https://github.com/zulip/zulip/issues/33571) 


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| **Before** | **After** |
|------------|----------|
| ![Screenshot 2025-03-14 131023](https://github.com/user-attachments/assets/adbb8f22-aeb0-4057-9e0e-ec4ede1ba7df) | ![Screenshot 2025-03-14 131011](https://github.com/user-attachments/assets/a3079567-986e-45ff-9c03-eb9228475d3d) | 


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
