### PR TITLE
copy: Use a global copy event listener.

### DIFF
--- a/web/e2e-tests/copy-messages.test.ts
+++ b/web/e2e-tests/copy-messages.test.ts
@@ -24,24 +24,22 @@ async function copy_messages(
             window.getSelection()!.removeAllRanges();
             window.getSelection()!.addRange(selectedRange);
 
-            // Remove existing copy/paste divs, which may linger from the previous
-            // example.  (The code clears these out with a zero-second timeout, which
-            // is probably sufficient for human users, but which causes problems here.)
-            document.querySelector("#copytempdiv")?.remove();
-
             // emulate copy event
-            document.dispatchEvent(
-                new KeyboardEvent("keydown", {
-                    key: "c",
-                    code: "KeyC",
-                    ctrlKey: true,
-                    keyCode: 67,
-                    which: 67,
-                }),
-            );
+            const clipboard_data = new DataTransfer();
+            const copy_event = new ClipboardEvent("copy", {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: clipboard_data,
+            });
+            document.dispatchEvent(copy_event);
 
-            // find temp div with copied text
-            return [...document.querySelectorAll("#copytempdiv > p")].map((p) => p.textContent!);
+            const copied_html = clipboard_data.getData("text/html");
+
+            // Convert the copied HTML into separate message strings
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(copied_html, "text/html");
+
+            return [...doc.body.children].map((el) => el.textContent!.trim());
         },
         start_message,
         end_message,

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -15,7 +15,6 @@ import * as compose_send_menu_popover from "./compose_send_menu_popover.js";
 import * as compose_state from "./compose_state.ts";
 import * as compose_textarea from "./compose_textarea.ts";
 import * as condense from "./condense.ts";
-import * as copy_messages from "./copy_messages.ts";
 import * as deprecated_feature_notice from "./deprecated_feature_notice.ts";
 import * as drafts_overlay_ui from "./drafts_overlay_ui.ts";
 import * as emoji from "./emoji.ts";
@@ -1143,8 +1142,6 @@ export function process_hotkey(e, hotkey) {
             message_scroll_state.set_keyboard_triggered_current_scroll(true);
             navigate.page_down();
             return true;
-        case "copy_with_c":
-            return copy_messages.copy_handler();
     }
 
     if (

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -37,6 +37,7 @@ import * as compose_tooltips from "./compose_tooltips.ts";
 import * as compose_validate from "./compose_validate.ts";
 import * as composebox_typeahead from "./composebox_typeahead.ts";
 import * as condense from "./condense.ts";
+import * as copy_messages from "./copy_messages.ts";
 import * as desktop_integration from "./desktop_integration.ts";
 import * as desktop_notifications from "./desktop_notifications.ts";
 import * as drafts from "./drafts.ts";
@@ -599,6 +600,7 @@ export function initialize_everything(state_data) {
         playground_data: realm.realm_playgrounds,
         pygments_comparator_func: typeahead_helper.compare_language,
     });
+    copy_messages.initialize();
     compose_setup.initialize();
     // Typeahead must be initialized after compose_setup.initialize()
     composebox_typeahead.initialize({

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -280,6 +280,16 @@
         overflow: auto hidden;
     }
 
+    .katex-mathml annotation {
+        /* Because annotations are never displayable, browser user-agent
+           stylesheets mark them as not displayable, which has the
+           side effect of having them not be included in the HTML
+           version of copying the content. Override this, so KaTeX can
+           be copy/pasted within Zulip. */
+        user-select: all;
+        display: inline;
+    }
+
     .tex-error {
         color: hsl(0deg 0% 50%);
     }


### PR DESCRIPTION
@_**Anders Kaseorg|699** [said](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Copying.20clears.20the.20selection/near/2118741):

>My suggestion though is *never* to `preventDefault` the Ctrl+C keyboard event. We should leave Ctrl+C alone, register a global listener for the [`copy` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/copy_event) (the real one, not a synthetic one), and use `event.clipboardData.setData` if we need to do something strange.

Tries to implement this comment by @andersk. 
Fixes: #33949.

This attempts to use a global copy
event listener instead of triggering
the copy handler on Ctrl+C.

Also fixes [#issues > 📂 pasting LaTeX @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20pasting.20LaTeX/near/2120422)

