### PR TITLE
stream_settings: Improve handling of long stream titles in UI.

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -803,7 +803,7 @@ function setup_page(callback: () => void): void {
         }
 
         // show the "Stream settings" header by default.
-        $(".display-type #stream_settings_title").show();
+        $(".display-type #stream_settings_title").addClass("showing-info-title");
     }
 
     function populate_and_fill(): void {

--- a/web/src/user_group_components.ts
+++ b/web/src/user_group_components.ts
@@ -33,7 +33,7 @@ export const show_user_group_settings_pane = {
         $("#groups_overlay .settings").show();
         set_active_group_id(group.id);
         const group_name = user_groups.get_display_group_name(group.name);
-        $("#groups_overlay .user-group-info-title").text(group_name);
+        $("#groups_overlay .user-group-info-title").text(group_name).addClass("showing-info-title");
         if (group.deactivated) {
             $("#groups_overlay .deactivated-user-group-icon-right").show();
         } else {
@@ -47,9 +47,9 @@ export const show_user_group_settings_pane = {
                 $t_html({defaultMessage: "Configure new group settings"}),
             );
         } else {
-            $("#groups_overlay .user-group-info-title").text(
-                $t_html({defaultMessage: "Add members to {group_name}"}, {group_name}),
-            );
+            $("#groups_overlay .user-group-info-title")
+                .text($t_html({defaultMessage: "Add members to {group_name}"}, {group_name}))
+                .addClass("showing-info-title");
         }
         update_footer_buttons(container_name);
         $(`.${CSS.escape(container_name)}`).show();

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1375,9 +1375,9 @@ export function update_group(event: UserGroupUpdateEvent, group: UserGroup): voi
         update_group_details(group);
         if (event.data.name !== undefined) {
             // update settings title
-            $("#groups_overlay .user-group-info-title").text(
-                user_groups.get_display_group_name(group.name),
-            );
+            $("#groups_overlay .user-group-info-title")
+                .text(user_groups.get_display_group_name(group.name))
+                .addClass("showing-info-title");
         }
         if (event.data.can_mention_group !== undefined) {
             sync_group_permission_setting("can_mention_group", group);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -545,9 +545,6 @@ h4.user_group_setting_subsection_title {
 
             & a {
                 color: inherit;
-                display: flex;
-                align-items: center;
-                gap: 0.2381em; /* 5px at 21px/em */
 
                 &:hover {
                     color: inherit;
@@ -567,15 +564,25 @@ h4.user_group_setting_subsection_title {
             .user-group-info-title {
                 display: none;
                 font-size: 1.5em; /* 21px at 14px/em */
-                line-height: 1;
+                line-height: 1.25;
                 font-weight: 600;
                 word-break: break-all;
+                line-clamp: 2;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                margin: 20px 10px 0;
+
+                &.showing-info-title {
+                    display: -webkit-box;
+                }
 
                 .large-icon {
-                    display: flex;
+                    display: inline-block;
+                    margin-left: 5px;
 
                     .zulip-icon {
-                        font-size: 0.9524em; /* 20px at 21px/em */
+                        font-size: 0.75em; /* 18px at 24px/em */
                     }
                 }
             }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -566,7 +566,7 @@ h4.user_group_setting_subsection_title {
                 font-size: 1.5em; /* 21px at 14px/em */
                 line-height: 1.25;
                 font-weight: 600;
-                word-break: break-all;
+                overflow-wrap: break-word;
                 line-clamp: 2;
                 -webkit-line-clamp: 2;
                 -webkit-box-orient: vertical;


### PR DESCRIPTION
This commit makes the following changes to improve the display of long stream titles in the stream creation and user group settings UI:
- Uses `display: -webkit-box` and `line-clamp` properties to show the title upto two lines, and end with `...` if it exceeds.
- Updates icon `font-size` to align with text size.
- Updates `margin` and `line-height` to make it visually better.

[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/long.20channel.20name.20in.20creation.20flow/with/2122698)

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|----------|-------|
|![image](https://github.com/user-attachments/assets/40de51d2-417e-4e64-848e-4bfcce1181e9)|![image](https://github.com/user-attachments/assets/ff587edc-2779-4f92-84c3-e186552e48f2)|
|![image](https://github.com/user-attachments/assets/7a6d82bb-650a-4498-8d2e-b8f3280c6d76)|![image](https://github.com/user-attachments/assets/510346c8-402b-4ded-80d1-4cba2f4c10e9)|
|![image](https://github.com/user-attachments/assets/5e8b729b-719b-4554-987a-5287dd926bc9)|![image](https://github.com/user-attachments/assets/2da39aa5-9a90-48e8-9fb6-6f8151273a09)|
|![image](https://github.com/user-attachments/assets/50fdbc93-b93a-4045-90f6-7e6f5b8b6d97)|![image](https://github.com/user-attachments/assets/920084c3-a845-4be0-8136-d7ea49317cf6)|
|![image](https://github.com/user-attachments/assets/4cb2d756-6e0c-497f-8a3f-7509b2eedaa8)|![image](https://github.com/user-attachments/assets/ea8ead8f-f124-47de-895e-ff694d1191bc)|
|![image](https://github.com/user-attachments/assets/36e36305-2932-4fe8-9503-4ae76c5becbe)|![image](https://github.com/user-attachments/assets/053ad08a-ce5c-46b0-8512-2626b321ea75)|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
