### PR TITLE
puppet: Allow for arbitrary queues to have more than one worker.

### DIFF
--- a/docs/production/system-configuration.md
+++ b/docs/production/system-configuration.md
@@ -177,6 +177,13 @@ large numbers of very large image files are uploaded at once. (When
 backlogged, image previews for images that have not yet been
 thumbnailed will appear as loading spinners).
 
+#### `email_senders_workers`
+
+How many email-sending workers to run. Defaults to 1; adding more
+workers can prevent email-sending queue backlogging when large numbers
+of very large emails are enqueued at once. This is generally only
+necessary on quite large installs.
+
 #### `nameserver`
 
 When the [S3 storage backend][s3-backend] is in use, downloads from S3 are

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -176,7 +176,11 @@ class zulip::app_frontend_base {
 
   # Not the different naming scheme for sharded workers, where each gets its own queue,
   # vs when multiple workers service the same queue.
-  $thumbnail_workers = Integer(zulipconf('application_server', 'thumbnail_workers', 1))
+  $worker_counts = Hash(zulipconf_keys('application_server').filter |$key| {
+    $key =~ /_workers$/
+  }.map |$key| {
+    [regsubst($key, '_workers$', ''), Integer(zulipconf('application_server', $key, 1))]
+  })
   $mobile_notification_shards = Integer(zulipconf('application_server', 'mobile_notification_shards', 1))
   $tornado_ports = $zulip::tornado_sharding::tornado_ports
 

--- a/puppet/zulip/templates/supervisor/zulip.conf.template.erb
+++ b/puppet/zulip/templates/supervisor/zulip.conf.template.erb
@@ -78,17 +78,20 @@ directory=/home/zulip/deployments/current/
 <% if @queues_multiprocess %>
 <% @queues.each do |queue| -%>
 [program:zulip_events_<%= queue %>]
-<% if queue == "missedmessage_mobile_notifications" and @mobile_notification_shards > 1 -%>
-process_name=zulip_events_<%= queue %>_shard%(process_num)s
+<%-
+  numprocs = 1
+  term = "worker"
+  if queue == "missedmessage_mobile_notifications"
+    numprocs = @mobile_notification_shards
+    term = "shard"
+  elsif @worker_counts.has_key?(queue)
+    numprocs = @worker_counts[queue]
+  end -%>
+<%- if numprocs > 1 -%>
+process_name=zulip_events_<%= queue %>_<%= term %>%(process_num)s
 command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %> --skip-checks --worker_num %(process_num)s
-stdout_logfile=/var/log/zulip/events_<%= queue %>_shard%(process_num)s.log         ; stdout log path, NONE for none; default AUTO
-numprocs=<%= @mobile_notification_shards %>
-numprocs_start=1
-<% elsif queue == "thumbnail" and @thumbnail_workers > 1 -%>
-process_name=zulip_events_<%= queue %>_worker%(process_num)s
-command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %> --skip-checks --worker_num %(process_num)s
-stdout_logfile=/var/log/zulip/events_<%= queue %>_worker%(process_num)s.log         ; stdout log path, NONE for none; default AUTO
-numprocs=<%= @thumbnail_workers %>
+stdout_logfile=/var/log/zulip/events_<%= queue %>_<%= term %>%(process_num)s.log         ; stdout log path, NONE for none; default AUTO
+numprocs=<%= numprocs %>
 numprocs_start=1
 <% else -%>
 command=nice -n10 /home/zulip/deployments/current/manage.py process_queue --queue_name=<%= queue %> --skip-checks

--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -62,8 +62,10 @@ for queue_name, count in consumers.items():
         target_count = int(
             get_config(config_file, "application_server", "mobile_notification_shards", "1")
         )
-    elif queue_name == "thumbnail":
-        target_count = int(get_config(config_file, "application_server", "thumbnail_workers", "1"))
+    else:
+        target_count = int(
+            get_config(config_file, "application_server", f"{queue_name}_workers", "1")
+        )
 
     atomic_nagios_write(
         "check-rabbitmq-consumers-" + queue_name,


### PR DESCRIPTION
This generalizes from thumbnail_workers, to include any other queue. We only additionally choose to document `email_senders_workers`, however, since other queues are not guaranteed to work correctly with multiple consumers.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
