### PR TITLE
alerts: Correct for Safari container regression.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -180,7 +180,7 @@
     <source class="notification-sound-source-mp3" type="audio/mpeg" />
 </audio>
 
-<div class="alert-box">
+<div class="alert-box app-alert-box">
     <div id="popup_banners_wrapper" class="banner-wrapper">
         <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
             <div class="exit"></div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -180,40 +180,42 @@
     <source class="notification-sound-source-mp3" type="audio/mpeg" />
 </audio>
 
-<div id="popup_banners_wrapper" class="banner-wrapper alert-box">
-    <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
-        <div class="exit"></div>
-        {# The below isn't tagged for translation
-        intentionally, because the feature is only used at
-        MIT. #}
-        <strong>Your Zephyr mirror is not working.</strong>
-        <span id="normal-zephyr-mirror-error-text">
-            We recommend that
-            you <a class="webathena_login">give Zulip the ability to mirror the messages for you via
+<div class="alert-box">
+    <div id="popup_banners_wrapper" class="banner-wrapper">
+        <div class="alert alert_sidebar alert-error home-error-bar" id="zephyr-mirror-error">
+            <div class="exit"></div>
+            {# The below isn't tagged for translation
+            intentionally, because the feature is only used at
+            MIT. #}
+            <strong>Your Zephyr mirror is not working.</strong>
+            <span id="normal-zephyr-mirror-error-text">
+                We recommend that
+                you <a class="webathena_login">give Zulip the ability to mirror the messages for you via
             Webathena</a>.  If you'd prefer, you can instead
-            <a href="/zephyr-mirror/" target="_blank" rel="noopener noreferrer">run the
+                <a href="/zephyr-mirror/" target="_blank" rel="noopener noreferrer">run the
             Zephyr mirror script yourself</a> in a screen
             session.
-        </span>
-        <span id="desktop-zephyr-mirror-error-text" class="notdisplayed">
-            To fix this, you'll need to use the web interface.
-        </span>
-    </div>
-    <div class="alert alert_sidebar alert-error home-error-bar" id="home-error"></div>
-    <div class="alert alert_sidebar alert-error home-error-bar" id="reloading-application"></div>
-    <div class="alert alert_sidebar" id="request-progress-status-banner">
-        <div class="alert-zulip-logo">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
-                <circle cx="386.56" cy="386.56" r="386.56"></circle>
-                <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"></path>
-            </svg>
+            </span>
+            <span id="desktop-zephyr-mirror-error-text" class="notdisplayed">
+                To fix this, you'll need to use the web interface.
+            </span>
         </div>
-        <div class="loading-indicator"></div>
-        <div class="success-indicator">
-            <i class="fa fa-check"></i>
+        <div class="alert alert_sidebar alert-error home-error-bar" id="home-error"></div>
+        <div class="alert alert_sidebar alert-error home-error-bar" id="reloading-application"></div>
+        <div class="alert alert_sidebar" id="request-progress-status-banner">
+            <div class="alert-zulip-logo">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
+                    <circle cx="386.56" cy="386.56" r="386.56"></circle>
+                    <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"></path>
+                </svg>
+            </div>
+            <div class="loading-indicator"></div>
+            <div class="success-indicator">
+                <i class="fa fa-check"></i>
+            </div>
+            <div class="alert-content"></div>
+            <div class="exit"></div>
         </div>
-        <div class="alert-content"></div>
-        <div class="exit"></div>
     </div>
 </div>
 

--- a/web/src/alert_popup.ts
+++ b/web/src/alert_popup.ts
@@ -1,8 +1,8 @@
 import $ from "jquery";
 
 // this will hide the alerts that you click "x" on.
-$("body").on("click", ".alert-box > div .exit", function () {
-    const $alert = $(this).closest(".alert-box > div");
+$("body").on("click", ".alert-box .exit", function () {
+    const $alert = $(this).parent("div");
     $alert.addClass("fade-out");
     setTimeout(() => {
         $alert.removeClass("fade-out show");

--- a/web/styles/alerts.css
+++ b/web/styles/alerts.css
@@ -37,6 +37,22 @@
 }
 
 /* alert box component changes */
+
+/* We preserve the flexbox styles here for the .alert-box
+   in the portico; otherwise, we move them into the inner
+   .banner-wrapper to preserve the correct stacking of
+   alerts and banner display. */
+.alert-box:not(.app-alert-box),
+.app-alert-box .banner-wrapper {
+    display: flex;
+    /* Using column-reverse flex direction enables a stack-like
+       behavior where the most recent alert is always on top. */
+    flex-direction: column-reverse;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+}
+
 .alert-box {
     /* We define this variable in web/styles/app_variables.css,
        but we need to redefine it here since this is shared
@@ -51,13 +67,6 @@
     /* Offset to account for the top padding + 5px from the top. */
     top: calc(5px + (-1 * var(--popup-banner-translate-y-distance)));
     left: 0;
-    display: flex;
-    /* Using column-reverse flex direction enables a stack-like
-       behavior where the most recent alert is always on top. */
-    flex-direction: column-reverse;
-    align-items: center;
-    justify-content: center;
-    gap: 5px;
     width: 100%;
     z-index: 220;
     max-height: 100%;


### PR DESCRIPTION
This PR restructures the alerts area so that the `.banner-wrapper` appears inside the `.alert-box` class--similar to existing structures in `#navbar-fixed-container`. This avoids the Safari bug with `container:` interfering with `position: fixed` and the like.

Additionally, this makes some necessary style and behavior improvements to allow `.alert-box` to continue to be shared with the portico.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Safari.20keyboard.20nav.20not.20scrolling.20to.20unread/near/2121123)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Safari `n` behavior, before | Safari `n` behavior, after |
| --- | --- |
| ![safari-n-behavior-before](https://github.com/user-attachments/assets/bfe9d58c-3304-4b2b-9a2f-bb54ac24b129) | ![safari-n-behavior-after](https://github.com/user-attachments/assets/cf19b311-b59c-4168-9f1d-870f78ebe7a6) |

| Alert display, before | Alert display, after (no change) |
| --- | --- |
| ![alert-safari-before](https://github.com/user-attachments/assets/43a97a03-cc42-4024-bec8-cf708f8061ee) | ![alert-safari-after](https://github.com/user-attachments/assets/5d099f50-58fd-40bc-b312-e730cc485d77) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>