### PR TITLE
channel_picker: Align icon by keeping constant line-height.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2192,10 +2192,14 @@ body:not(.spectator-view) {
         color: var(--color-dropdown-item);
         padding: 3px 10px 3px 8px;
         font-weight: 400;
-        line-height: var(--base-line-height-unitless);
         white-space: normal;
+        /* Keep the line-height stable, instead of using the
+           user-set line-height, so that the icon is always
+           vertically centered properly. */
+        line-height: 1.214;
 
         .stream-privacy-type-icon {
+            line-height: 1.214;
             font-size: 0.93em;
             /* We set only the width so that flexbox
             can do its work to properly center,
@@ -2206,9 +2210,9 @@ body:not(.spectator-view) {
                `tooltips.css`.
                Because we are manually holding icon
                alignment to the first/only line of a
-               channel, we make this adjustment here,
-               calculated by 4.5px / (0.93 * 20px) */
-            top: 0.2419em;
+               channel, we make this adjustment here.
+               Calculated by eye to look good at 12px-20px. */
+            top: 0.05em;
         }
 
         .dropdown-list-delete,


### PR DESCRIPTION
Fixes issue reported here:
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20channel.20picker.20icon.20alignment/near/2122798

screenshots at 12px, 14px, 16px, 20px, all at +2 line-height (I've confirmed that it fixes similar issues at -2 line-height)

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-14 at 14 00 44](https://github.com/user-attachments/assets/0b02ec00-96cc-42b0-a674-7545085bf1b8) | ![Screen Shot 2025-03-14 at 13 59 35](https://github.com/user-attachments/assets/c1c4e777-a65f-4c0c-aabc-414c06fefdfe) |
| ![Screen Shot 2025-03-14 at 14 01 39](https://github.com/user-attachments/assets/afd91d37-2276-4f0b-9ef8-831cf1abbe7c) | ![Screen Shot 2025-03-14 at 13 57 54](https://github.com/user-attachments/assets/84baca14-3b71-4f95-bdca-eca9f4a0b645) |
| ![Screen Shot 2025-03-14 at 14 01 55](https://github.com/user-attachments/assets/e9f2986b-c924-4ff7-8922-122fb28d1000) | ![Screen Shot 2025-03-14 at 13 57 42](https://github.com/user-attachments/assets/67a081be-7aea-4c2a-9285-d0b536199398) |
| ![Screen Shot 2025-03-14 at 14 02 14](https://github.com/user-attachments/assets/3922baa3-9894-4383-8bc4-312b42a49a8c) | ![Screen Shot 2025-03-14 at 13 57 22](https://github.com/user-attachments/assets/ce8e5eae-936f-41ad-b48d-4fbe588d18c3) |