### PR TITLE
action_buttons: Correct to Vlad's specifications.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -914,6 +914,11 @@ of the base style defined for a read-only textarea in dark mode. */
     margin-bottom: 10px;
     cursor: default;
 
+    .edit-form {
+        /* Override Bootstrap. */
+        margin-bottom: 0;
+    }
+
     .edit-controls {
         margin-left: 0;
         margin-top: 0;

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -713,6 +713,14 @@
     border-radius: 4px;
     border: 0;
     line-height: 1;
+
+    &:focus {
+        outline: none;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--color-outline-focus);
+    }
 }
 
 .message_edit_save {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -704,6 +704,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    /* 28px at 16px/1em, per Vlad's spec. */
+    height: 1.75em;
+    /* 65px at 16px/1em, which is the width of
+       the Cancel button. */
+    min-width: 4.0625em;
     padding: 0 10px;
     border-radius: 4px;
     border: 0;
@@ -711,13 +716,6 @@
 }
 
 .message_edit_save {
-    /* Because the save button is inside this container,
-       we set the height here so the container stretches
-       with the flexbox. However, we also want to match
-       this to the height of the compose box's Send button,
-       so we specify a matching 2em height here
-       (32px at 16px/1em) */
-    height: 2em;
     /* Match Save button's basic colors to
        the compose box Send button. */
     color: var(--color-text-brand-primary-action-button);

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -1,7 +1,7 @@
 {{! Client-side Handlebars template for rendering the message edit form. }}
 <div class="message_edit">
     <div class="message_edit_form">
-        <form id="edit_form_{{message_id}}">
+        <form class="edit-form" id="edit_form_{{message_id}}">
             <div class="edit_form_banners"></div>
             <div class="edit-controls edit-content-container {{#if is_editable}}surround-formatting-buttons-row{{/if}}">
                 <div class="message-edit-textbox">


### PR DESCRIPTION
This PR sets a 28px height on action buttons (Save, Cancel, and Close), and also sets a minimum width based on the English Cancel button at 16px.

Additionally, a focus ring is only shown on `:focus-visible`, preventing the flash of a ring when clicking any of these buttons.

Finally, this corrects for unwanted bottom margin on the edit form that was being inherited from Boostrap 💀

CZO issues:
* [#redesign project > 🎯 "save" / "cancel" buttons for message editing @ 💬](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/.F0.9F.8E.AF.20.22save.22.20.2F.20.22cancel.22.20buttons.20for.20message.20editing/near/2122825)
* [#issues > 🎯 close button height @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20close.20button.20height/near/2123546)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Form bottom margin, before | Form bottom margin, after |
| --- | --- |
| ![message-space-at-20-before](https://github.com/user-attachments/assets/c2487e7b-4c0a-4f8f-8476-263f12342c6e) | ![message-space-at-20-after](https://github.com/user-attachments/assets/3f33b6b7-c745-479f-85a4-975e06955e59) |

| Before | After |
| --- | --- |
| ![action-buttons-before](https://github.com/user-attachments/assets/303cf1b6-baea-42af-8015-b5fcb4d666e4) | ![action-buttons-after](https://github.com/user-attachments/assets/7cd826d5-6e5d-4620-a9d5-ae9dc1473824) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>