### PR TITLE
help: Add instructions for adding user to groups via profile.

### DIFF
--- a/help/include/add-users-to-a-group.md
+++ b/help/include/add-users-to-a-group.md
@@ -1,6 +1,6 @@
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-group-settings}
 
 {relative|group|all}
 
@@ -12,5 +12,17 @@
    `#channel` to add all subscribers to the group.
 
 1. Click **Add**. Zulip will notify everyone who is added to the group.
+
+{tab|via-user-profile}
+
+{!right-sidebar-view-profile.md!}
+
+1. Select the **User groups** tab.
+
+1. Under **Add to groups**, enter the groups you want to add the user to. You
+   can start typing to filter suggestions.
+
+1. Click the **Add** button. Zulip will notify the user about the groups they've
+   been added to.
 
 {end_tabs}

--- a/help/include/remove-from-a-group.md
+++ b/help/include/remove-from-a-group.md
@@ -21,6 +21,7 @@
 
 1. Find the group you would like to remove the user from.
 
-1. Click the **Remove** button in that row.
+1. Click the **Remove** button in that row. Zulip will notify the user about the
+   groups they've been removed from.
 
 {end_tabs}

--- a/help/include/right-sidebar-user-card.md
+++ b/help/include/right-sidebar-user-card.md
@@ -1,4 +1,5 @@
 1. Hover over a user's name in the right sidebar.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
-   to the right of their name to open their **user card**.
+1. Click on their avatar or the **ellipsis** (<i class="zulip-icon
+   zulip-icon-more-vertical"></i>) to the right of their name to open their
+   **user card**.


### PR DESCRIPTION
Note:
- The instructions don't perfectly match the field label, which also includes the user's name. I think it's OK? Seems more awkward to include it as a variable somehow.

# [Manage a user's group membership](https://zulip.com/help/manage-user-group-membership#add-a-user-to-a-group)

![Screenshot 2025-03-14 at 13 18 21@2x](https://github.com/user-attachments/assets/08b5c3a2-0260-42fe-92b9-d16c94abf227)

# UI being documented

![Screenshot 2025-03-14 at 13 18 54@2x](https://github.com/user-attachments/assets/419359ca-7f0e-48e7-95f9-4ae32f5a339c)
