### PR TITLE
message-edit-history: Update web app overlay for showing move history only.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -117,7 +117,9 @@ export function fetch_and_render_message_history(message: Message): void {
     const move_history_only =
         realm.realm_message_edit_history_visibility_policy ===
         message_edit_history_visibility_policy_values.moves_only.code;
-    $("#message-edit-history-overlay-container").html(render_message_history_overlay());
+    $("#message-edit-history-overlay-container").html(
+        render_message_history_overlay({move_history_only}),
+    );
     open_overlay();
     show_loading_indicator();
     void channel.get({

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -27,18 +27,18 @@
             <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
                 <div class="messagebox">
                     <div class="messagebox-content">
+                        {{#if stream_changed}}
+                        <div class="message_content message_edit_history_content">
+                            <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span>
+                                <span class="highlight_text_deleted">{{ prev_stream }}</span>
+                            </p>
+                        </div>
+                        {{/if}}
                         {{#if topic_edited}}
                         <div class="message_content message_edit_history_content">
                             <p>{{t "Topic" }}:
                                 <span class="highlight_text_inserted {{#if is_empty_string_new_topic}}empty-topic-display{{/if}}">{{ new_topic_display_name }}</span>
                                 <span class="highlight_text_deleted {{#if is_empty_string_prev_topic}}empty-topic-display{{/if}}">{{ prev_topic_display_name }}</span>
-                            </p>
-                        </div>
-                        {{/if}}
-                        {{#if stream_changed}}
-                        <div class="message_content message_edit_history_content">
-                            <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span>
-                                <span class="highlight_text_deleted">{{ prev_stream }}</span>
                             </p>
                         </div>
                         {{/if}}

--- a/web/templates/message_edit_history.hbs
+++ b/web/templates/message_edit_history.hbs
@@ -27,6 +27,14 @@
             <div class="message_row{{#unless is_stream}} private-message{{/unless}}" role="listitem">
                 <div class="messagebox">
                     <div class="messagebox-content">
+                        {{#if initial_entry_for_move_history}}
+                        <div class="message_content message_edit_history_content">
+                            <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span></p>
+                            <p>{{t "Topic" }}:
+                                <span class="highlight_text_inserted {{#if is_empty_string_new_topic}}empty-topic-display{{/if}}">{{ new_topic_display_name }}</span>
+                            </p>
+                        </div>
+                        {{else}}
                         {{#if stream_changed}}
                         <div class="message_content message_edit_history_content">
                             <p>{{t "Channel" }}: <span class="highlight_text_inserted">{{ new_stream }}</span>
@@ -46,6 +54,7 @@
                         <div class="message_content rendered_markdown message_edit_history_content">
                             {{ rendered_markdown body_to_render}}
                         </div>
+                        {{/if}}
                         {{/if}}
                     </div>
                 </div>

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -2,7 +2,11 @@
     <div class="flex overlay-content">
         <div class="message-edit-history-container overlay-messages-container overlay-container">
             <div class="overlay-messages-header">
+                {{#if move_history_only}}
+                <h1>{{t "Message move history" }}</h1>
+                {{else}}
                 <h1>{{t "Message edit history" }}</h1>
+                {{/if}}
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>


### PR DESCRIPTION
When an organization has restricted viewing message history to only moves, we want to make sure the message history overlay is consistent with that setting in the web app.

**Updates**:
- When viewing any change that altered both the channel and topic of the message, we now show the channel change before the topic change. See screenshots for edit and move history to see this one change.
- If only move history can be viewed, the overlay's header is now "MESSAGE MOVE HISTORY".
- If only move history can be viewed, instead of showing the original message content at the top, we now show the original channel and topic.

**Questions**:
- For the original channel and topic entry, I thought it looked best with the green highlighting. We could also not have any highlighting on those. See final screenshot comparison for example.
- If we want the header for the overlay to match the tooltip options ("View move history", "View edit history", "View edit and move history") exactly, that could be a follow-up to these more general improvements. Note that if a message is edited and also has topic resolve/unresolve edits, then those would be shown in the history overlay even though the tooltip will only say "View edit history".

[Relevant CZO disscussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20message.20edit.20history.20-.20org.20setting.20.22move.20history.20only.22/with/2114826)

---

**Screenshots and screen captures:**

### Edit and move history:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-14 21-20-27](https://github.com/user-attachments/assets/3f2905da-eb30-4a5a-a20c-ce3915200054) | ![Screenshot from 2025-03-14 21-20-02](https://github.com/user-attachments/assets/3cb27048-d093-484d-a09b-e8bbf40141e5) |

### Move only history:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-14 21-21-04](https://github.com/user-attachments/assets/870c6425-425c-4006-8fd7-17963c986b72) | ![Screenshot from 2025-03-14 21-21-34](https://github.com/user-attachments/assets/9c679203-d222-4870-b5d1-9b2c3b5e8b94) |

### Move only history - topic move:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-14 21-30-26](https://github.com/user-attachments/assets/918dd2f1-5da2-4adc-982e-e86061015308) | ![Screenshot from 2025-03-14 21-30-04](https://github.com/user-attachments/assets/bca0d708-3aa1-42e4-9d1c-05199869b55b) |

### Move only history - channel move:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-14 21-32-54](https://github.com/user-attachments/assets/54504e8e-be21-48e0-a950-fc0c8fbd8bf6) | ![Screenshot from 2025-03-14 21-33-17](https://github.com/user-attachments/assets/3bbcbffe-1290-4476-a87b-c1598b485409) |

### Green highlight vs no highlight on original channel and topic:
| Green (current PR changes) | None |
| --- | --- |
| ![Screenshot from 2025-03-14 21-33-17](https://github.com/user-attachments/assets/fac1273f-175b-4803-a1f5-be655f3e7ee9) | ![Screenshot from 2025-03-14 21-36-06](https://github.com/user-attachments/assets/0d954b33-5f35-4034-8f9d-aa6152e7dba4) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
