### PR TITLE
popovers: Fix bug where tippy was getting cut off in usergroup list.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -602,7 +602,6 @@ ul.popover-group-menu-member-list {
 
     .subscription-group-list,
     .subscription-stream-list {
-        position: relative;
         border: 1px solid hsl(0deg 0% 83%);
         border-radius: 4px;
         overflow: auto;


### PR DESCRIPTION
Before:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/ed8c3161-aa91-4ff1-96fd-3e84894e3b4d" />


After:

<img width="606" alt="image" src="https://github.com/user-attachments/assets/37a7bca6-f390-4b8c-9d47-8b76ef5c0afe" />
