### PR TITLE
message_list: Fix list not scrolling when new message is added.

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -579,11 +579,15 @@ export function process_from_server(messages: ServerMessage[]): ServerMessage[] 
 
     if (msgs_to_rerender_or_add_to_narrow.length > 0) {
         for (const msg_list of message_lists.all_rendered_message_lists()) {
+            // Since we already have this message locally echoed, it is ok to
+            // not scroll when this message is added to the view as user has
+            // already seen this message. Hence, we are not passing the
+            // `message_are_new` boolean as `true` here.
             if (!msg_list.data.filter.can_apply_locally()) {
                 // If this message list is a search filter that we
                 // cannot apply locally, we will not have locally
                 // echoed echoed the message at all originally, and
-                // must the server now whether to add it to the view.
+                // must request the server now whether to add it to the view.
                 message_events_util.maybe_add_narrowed_messages(
                     msgs_to_rerender_or_add_to_narrow,
                     msg_list,

--- a/web/src/message_events.ts
+++ b/web/src/message_events.ts
@@ -317,12 +317,13 @@ export function insert_new_messages(
                 continue;
             }
 
-            message_events_util.maybe_add_narrowed_messages(messages, list);
+            const messages_are_new = true;
+            message_events_util.maybe_add_narrowed_messages(messages, list, messages_are_new);
             continue;
         }
 
         // Update the message list's rendering for the newly arrived messages.
-        const render_info = list.add_messages(messages);
+        const render_info = list.add_messages(messages, {messages_are_new: true});
 
         // The render_info.need_user_to_scroll calculation, which
         // looks at message feed scroll positions to see whether the

--- a/web/src/message_events_util.ts
+++ b/web/src/message_events_util.ts
@@ -24,6 +24,7 @@ const msg_match_narrow_api_response_schema = z.object({
 export function maybe_add_narrowed_messages(
     messages: Message[],
     msg_list: MessageList,
+    messages_are_new = false,
     attempt = 1,
 ): void {
     const ids: number[] = [];
@@ -82,7 +83,7 @@ export function maybe_add_narrowed_messages(
             // Remove the elsewhere_messages from the message list since
             // they don't match the filter as per data from server.
             msg_list.remove_and_rerender(elsewhere_messages.map((msg) => msg.id));
-            msg_list.add_messages(new_messages);
+            msg_list.add_messages(new_messages, {messages_are_new});
             unread_ops.process_visible();
             compose_notifications.notify_messages_outside_current_search(elsewhere_messages);
         },
@@ -111,7 +112,7 @@ export function maybe_add_narrowed_messages(
                 if (msg_list === message_lists.current) {
                     // Don't actually try again if we un-narrowed
                     // while waiting
-                    maybe_add_narrowed_messages(messages, msg_list, attempt + 1);
+                    maybe_add_narrowed_messages(messages, msg_list, messages_are_new, attempt + 1);
                 }
             }, delay);
         },


### PR DESCRIPTION
Auto scrolling to view the new message is not working. 
This bug was introduced in 238c35f2af9f7d3ef63609f55cee5f4d2d78ffd0. 
Fixed by passing `messages_are_new` in the relevant functions.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20autoscroll.20behavior/with/2122331