### PR TITLE
message_list_hover: Optimize code for show edit message icon.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -571,15 +571,27 @@
     }
 
     .edit_content {
-        /* Icons for editing content are determined on message hover;
-           we set an empty `.edit_content` to take the eventual width
-           of whatever icon is displayed, so as to avoid a grid shift. */
-        &:empty {
-            width: var(--message-box-icon-width);
-        }
+        width: var(--message-box-icon-width);
 
         &:hover {
             cursor: pointer;
+        }
+
+        .move_message_button,
+        .edit_content_button {
+            display: none;
+        }
+
+        &.can-edit-content {
+            .edit_content_button {
+                display: inline;
+            }
+        }
+
+        &.can-move-message {
+            .move_message_button {
+                display: inline;
+            }
         }
     }
 

--- a/web/templates/edit_content_button.hbs
+++ b/web/templates/edit_content_button.hbs
@@ -1,5 +1,0 @@
-{{#if is_content_editable}}
-<i class="message-controls-icon zulip-icon zulip-icon-edit edit_content_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)"></i>
-{{else if can_move_message}}
-<i class="message-controls-icon zulip-icon zulip-icon-move-alt move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (m)"></i>
-{{/if}}

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -1,6 +1,9 @@
 {{#unless is_archived}}
     {{#if msg/sent_by_me}}
-        <div class="edit_content message_control_button"></div>
+        <div class="edit_content message_control_button">
+            <i class="message-controls-icon zulip-icon zulip-icon-edit edit_content_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)"></i>
+            <i class="message-controls-icon zulip-icon zulip-icon-move-alt move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (m)"></i>
+        </div>
     {{/if}}
 
     {{#unless msg/sent_by_me}}


### PR DESCRIPTION
Doing a lot of DOM manipulation on message hover leads to tooltips being not hidden / displayed when they should be.

This commit is an attempt to optimize that code to do minimal updates.

@karlstolley requesting a review from you here.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20random.20edit.20message.20tooltips.20appearing/with/2124294