### PR TITLE
input: Remove usage of `propertychange` event.

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -71,7 +71,7 @@ export function initialize() {
         compose_ui.handle_keyup(event, $("textarea#compose-textarea").expectOne());
     });
 
-    $("textarea#compose-textarea").on("input propertychange", () => {
+    $("textarea#compose-textarea").on("input", () => {
         if ($("#compose").hasClass("preview_mode")) {
             compose.render_preview_area();
         }

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -620,7 +620,7 @@ function edit_message($row: JQuery, raw_content: string): void {
         }
     });
 
-    $form.on("input propertychange", () => {
+    $form.on("input", () => {
         compose_validate.check_overflow_text($row);
     });
 

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -952,7 +952,7 @@ export function deactivate_organization(e: JQuery.Event): void {
         });
 
         $("#custom-realm-deletion-time").on(
-            "input propertychange",
+            "input",
             ".custom-time-input-value, .custom-time-input-unit",
             () => {
                 custom_deletion_time_input = util.check_time_input(


### PR DESCRIPTION
The `propertychange` event is [deprecated](https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa743134%28v%3Dvs.85%29?utm_source=chatgpt.com) and was only supported in older versions of Internet Explorer. It is also not listed among the available [jQuery events](https://api.jquery.com/category/events/).

With this commit, I have replaced all instances of `propertychange` with the standard `change` event.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
