### PR TITLE
subscriptions: Fix bug where + button overflowed at 16px.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -349,7 +349,7 @@ h4.user_group_setting_subsection_title {
    screens where there's only one panel and the overlay doesn't
    have enough space for all the buttons. */
 @container settings-overlay (
-    ((width >= $settings_overlay_sidebar_collapse_breakpoint) and (width < calc(80em + 80px)))
+    ((width >= $settings_overlay_sidebar_collapse_breakpoint) and (width < calc(90em + 80px)))
     or ((width < $settings_overlay_sidebar_collapse_breakpoint) and (width <= 36em))
 ) {
     #subscription_overlay .subscriptions-container {


### PR DESCRIPTION
Somehow #33579 ended up getting merged with an incorrect breakpoint. Ideally this wouldn't be so fiddly, but I don't know how to set it up cleaner that this more fragile setup. Hopefully when we redesign this overlay we end up with less fragile CSS.

I've tested at 16px and also most other font sizes, at the breakpoint, but another person testing it out locally would probably be helpful just in case.

before:

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/250aa613-d178-4c70-844d-2d460afbc841" />


after:

<img width="1314" alt="image" src="https://github.com/user-attachments/assets/eaf21c94-bd5a-4938-b29f-45f9fd9f1fc4" />
