### PR TITLE
compose_validate: Remove on hover message validation.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -460,6 +460,7 @@ export let cancel = (): void => {
         }
         return;
     }
+    compose_validate.check_compose_content_validity_and_adjust_send_button_tooltip();
     hide_box();
     clear_box();
     compose_banner.clear_message_sent_banners();

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -119,6 +119,7 @@ export function update_on_recipient_change(): void {
     compose_validate.warn_if_guest_in_dm_recipient();
     drafts.update_compose_draft_count();
     check_posting_policy_for_compose_box();
+    compose_validate.check_compose_content_validity_and_adjust_send_button_tooltip();
 }
 
 export function get_posting_policy_error_message(): string {
@@ -179,6 +180,7 @@ function switch_message_type(message_type: MessageType): void {
     update_compose_for_message_type(opts);
     update_compose_area_placeholder_text();
     compose_ui.set_focus(opts);
+    compose_validate.check_compose_content_validity_and_adjust_send_button_tooltip();
 }
 
 function update_recipient_label(stream_id?: number): void {

--- a/web/src/compose_reply.ts
+++ b/web/src/compose_reply.ts
@@ -11,6 +11,7 @@ import * as compose_paste from "./compose_paste.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
 import * as compose_ui from "./compose_ui.ts";
+import * as compose_validate from "./compose_validate.ts";
 import * as copy_messages from "./copy_messages.ts";
 import * as hash_util from "./hash_util.ts";
 import {$t} from "./i18n.ts";
@@ -432,4 +433,5 @@ export function initialize(): void {
     $("body").on("click", ".compose_reply_button", () => {
         respond_to_message({trigger: "reply button"});
     });
+    compose_validate.check_compose_content_validity_and_adjust_send_button_tooltip();
 }

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -71,14 +71,6 @@ export function initialize() {
         compose_ui.handle_keyup(event, $("textarea#compose-textarea").expectOne());
     });
 
-    $("#compose-send-button").on("mouseenter", () => {
-        compose_validate.validate(false, false);
-        compose_validate.update_send_button_status();
-    });
-    $("#compose-send-button").on("mouseleave", () => {
-        $("#compose-send-button").removeClass("disabled-message-send-controls");
-    });
-
     $("textarea#compose-textarea").on("input propertychange", () => {
         if ($("#compose").hasClass("preview_mode")) {
             compose.render_preview_area();
@@ -606,6 +598,7 @@ export function initialize() {
         const $input = $("input#stream_message_recipient_topic");
         $input.val("");
         $input.trigger("focus");
+        compose_validate.check_compose_content_validity_and_adjust_send_button_tooltip();
     });
 
     $("input#stream_message_recipient_topic").on("focus", () => {

--- a/web/src/compose_tooltips.ts
+++ b/web/src/compose_tooltips.ts
@@ -228,6 +228,9 @@ export function initialize(): void {
             }
             return undefined;
         },
+        onHidden(instance) {
+            instance.destroy();
+        },
     });
 
     tippy.delegate("body", {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -12,6 +12,7 @@ const $ = require("./lib/zjquery.cjs");
 const {page_params} = require("./lib/zpage_params.cjs");
 
 const user_groups = zrequire("user_groups");
+const compose_validate = zrequire("compose_validate");
 
 set_global("document", {
     querySelector() {},
@@ -337,7 +338,11 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
             success(payload);
             stub_state.send_msg_called += 1;
         });
-
+        override_rewire(
+            compose_validate,
+            "check_compose_content_validity_and_adjust_send_button_tooltip",
+            noop,
+        );
         override_rewire(echo, "reify_message_id", (local_id, message_id) => {
             assert.equal(typeof local_id, "string");
             assert.equal(typeof message_id, "number");
@@ -637,6 +642,12 @@ test_ui("update_fade", ({override, override_rewire}) => {
     override_rewire(compose_recipient, "update_narrow_to_recipient_visibility", () => {
         update_narrow_to_recipient_visibility_called = true;
     });
+    override_rewire(
+        compose_validate,
+        "check_compose_content_validity_and_adjust_send_button_tooltip",
+        noop,
+    );
+
     override_rewire(drafts, "update_compose_draft_count", noop);
     override(compose_pm_pill, "get_user_ids", () => []);
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -9,6 +9,7 @@ const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 
 const user_groups = zrequire("user_groups");
+const compose_validate = zrequire("compose_validate");
 
 const nobody = {
     name: "role:nobody",
@@ -162,6 +163,12 @@ test("start", ({override, override_rewire, mock_template}) => {
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(
+        compose_validate,
+        "check_compose_content_validity_and_adjust_send_button_tooltip",
+        noop,
+    );
+
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
@@ -311,6 +318,12 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
 
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
+    override_rewire(
+        compose_validate,
+        "check_compose_content_validity_and_adjust_send_button_tooltip",
+        noop,
+    );
+
     override_private_message_recipient({override});
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
@@ -495,6 +508,11 @@ test("quote_message", ({disallow, override, override_rewire}) => {
             assert.equal(topic, "");
         }
     });
+    override_rewire(
+        compose_validate,
+        "check_compose_content_validity_and_adjust_send_button_tooltip",
+        noop,
+    );
 
     $("textarea#compose-textarea").caret = noop;
     $("textarea#compose-textarea").attr("id", "compose-textarea");

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -531,11 +531,15 @@ test_ui("test_stream_posting_permission", ({mock_template, override}) => {
     assert.ok(!banner_rendered);
 });
 
-test_ui("test_check_overflow_text", ({override}) => {
+test_ui("test_check_overflow_text", ({override, override_rewire}) => {
     const fake_compose_box = new FakeComposeBox();
 
     override(realm, "max_message_length", 10000);
-
+    override_rewire(
+        compose_validate,
+        "check_compose_content_validity_and_adjust_send_button_tooltip",
+        noop,
+    );
     // RED
     {
         fake_compose_box.set_textarea_val("a".repeat(10005));

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -28,6 +28,9 @@ mock_esm("@uppy/tus", {default: class Tus {}});
 const compose_actions = mock_esm("../src/compose_actions");
 const compose_reply = mock_esm("../src/compose_reply");
 const compose_state = mock_esm("../src/compose_state");
+const compose_validate = mock_esm("../src/compose_validate", {
+    set_upload_in_progress: noop,
+});
 const rows = mock_esm("../src/rows");
 
 const compose_ui = zrequire("compose_ui");
@@ -248,9 +251,9 @@ test("upload_files", async ({mock_template, override, override_rewire}) => {
         banner_shown = true;
         return "<banner-stub>";
     });
-    override(compose_state, "get_message_type", () => "stream");
+    override(compose_validate, "set_upload_in_progress", () => {});
     await upload.upload_files(uppy, config, files);
-    assert.ok($("#compose-send-button").hasClass("disabled-message-send-controls"));
+    assert.ok(!$("#compose-send-button").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);
     assert.ok(compose_ui_insert_syntax_and_focus_called);
     assert.ok(compose_ui_autosize_textarea_called);
@@ -456,7 +459,7 @@ test("copy_paste", ({override, override_rewire}) => {
     assert.equal(upload_files_called, false);
 });
 
-test("uppy_events", ({override, override_rewire, mock_template}) => {
+test("uppy_events", ({override_rewire, mock_template}) => {
     $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
     override_rewire(compose_ui, "smart_insert_inline", noop);
@@ -518,7 +521,6 @@ test("uppy_events", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
-    override(compose_state, "get_message_type", () => "stream");
     on_upload_success_callback(file, response);
 
     assert.ok(compose_ui_replace_syntax_called);


### PR DESCRIPTION
Kindly read the commit message where I've tried to explain my thought process
and the cases where we need to re-evaluate the send button state and tooltip content.

### Here is a 53 second video that tries to cover cases 2, 3, 4, 5 mentioned in the commit message.

https://github.com/user-attachments/assets/4c8f5fac-0b40-4d13-844c-f06f02d6138d


### This 17 second video contains the upload file case and clear topic using `x` cases(1,6) iin the commit message.

https://github.com/user-attachments/assets/45f6bbff-474c-43c7-a933-3f0ff1ca3f13

