### PR TITLE
spectator: Don't apply right-sidebar hiding for spectators

### DIFF
--- a/web/src/sidebar_ui.ts
+++ b/web/src/sidebar_ui.ts
@@ -27,7 +27,12 @@ import {user_settings} from "./user_settings.ts";
 function save_sidebar_toggle_status(): void {
     const ls = localstorage();
     ls.set("left-sidebar", $("body").hasClass("hide-left-sidebar"));
-    ls.set("right-sidebar", $("body").hasClass("hide-right-sidebar"));
+
+    if (!page_params.is_spectator) {
+        // The right sidebar is never shown in the spectator mode;
+        // avoid interacting with local storage state for it.
+        ls.set("right-sidebar", $("body").hasClass("hide-right-sidebar"));
+    }
 }
 
 export function restore_sidebar_toggle_status(): void {
@@ -35,7 +40,11 @@ export function restore_sidebar_toggle_status(): void {
     if (ls.get("left-sidebar")) {
         $("body").addClass("hide-left-sidebar");
     }
-    if (ls.get("right-sidebar")) {
+
+    if (!page_params.is_spectator && ls.get("right-sidebar")) {
+        // The right sidebar is never shown in the spectator mode;
+        // avoid processing local storage state for hiding the right
+        // sidebar.
         $("body").addClass("hide-right-sidebar");
     }
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #34007 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

Before : 

https://github.com/user-attachments/assets/3aa6c8b7-9cb6-40f1-bd44-fc9037b329b2

Following this, the procedure below can reproduce the behaviour (irrespective of browser):

Login using any username (say AARON).
Hide the right-sidebar which will add right-sidebar key to localStorage.
Logout and observe that UI was overriding .


After :


https://github.com/user-attachments/assets/551a4184-b35e-4e7a-9135-91e720c3eaef

in web/src/sidebar_ui.ts

I have added !page_params.is_spectator , so now in logged out view the ui looks fine 

    if (ls.get("right-sidebar") && !page_params.is_spectator) {
        $("body").addClass("hide-right-sidebar");
    }
    


## Problem
When a user hides the right sidebar while logged in and then logs out,
the `hide-right-sidebar` class is still applied to the body, causing 
extra space to the right of the search button in narrow windows for
spectators (logged-out users).

## Solution
Modified the `restore_sidebar_toggle_status()` function to only apply 
the right sidebar hiding preference from localStorage if the user is 
not a spectator (logged-out user).

## Testing
Tested the following scenarios:
1. Log in, hide right sidebar, log out - Verified no extra space
2. Verify spectator view has correct layout at various window widths
3. Verified logged-in user sidebar preferences are still preserved

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
