### PR TITLE
navbar: Limit #navbar-middle margin to non-spectator views.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1612,7 +1612,7 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
         @extend %hide-right-sidebar;
     }
 
-    #navbar-middle {
+    body:not(.spectator-view) #navbar-middle {
         margin-right: var(--right-column-collapsed-sidebar-width);
     }
 


### PR DESCRIPTION
Previously, when the right sidebar was hidden, `#navbar-middle` still had a margin-right applied, causing layout inconsistencies for logged-out users.

This happened because the `.hide-right-sidebar` class on `<body>` affected all views, including spectators (logged-out users), even though they don’t have a right sidebar. As a result, the navbar was misaligned when `right-sidebar` was stored in localStorage.

This PR updates the CSS selector to `body:not(.spectator-view)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|----------|-------|
|![image](https://github.com/user-attachments/assets/661e69f3-b4db-4f9b-b74b-248708da239e)|![image](https://github.com/user-attachments/assets/44e26190-8744-4968-8534-b97144fc70e4)|

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
