### PR TITLE
Convert TypeScript enums to unions; enable erasableSyntaxOnly

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
         "noEmit": true,
 
         /* Interop Constraints */
+        "erasableSyntaxOnly": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "verbatimModuleSyntax": true,

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -33,10 +33,7 @@ export const post_presence_response_schema = z.object({
 });
 
 /* Keep in sync with views.py:update_active_status_backend() */
-export enum ActivityState {
-    ACTIVE = "active",
-    IDLE = "idle",
-}
+export type ActivityState = "active" | "idle";
 
 /*
     Helpers for detecting user activity and managing user idle states
@@ -103,15 +100,15 @@ export function compute_active_status(): ActivityState {
     // detection; older desktop app releases never set that property.
     if (electron_bridge?.get_idle_on_system !== undefined) {
         if (electron_bridge.get_idle_on_system()) {
-            return ActivityState.IDLE;
+            return "idle";
         }
-        return ActivityState.ACTIVE;
+        return "active";
     }
 
     if (client_is_active) {
-        return ActivityState.ACTIVE;
+        return "active";
     }
-    return ActivityState.IDLE;
+    return "idle";
 }
 
 export let send_presence_to_server = (redraw?: () => void): void => {

--- a/web/src/billing/billing.ts
+++ b/web/src/billing/billing.ts
@@ -9,18 +9,20 @@ const billing_frequency_schema = z.enum(["Monthly", "Annual"]);
 const billing_base_url = $("#billing-page").attr("data-billing-base-url")!;
 
 // Matches the CustomerPlan model in the backend.
-enum BillingFrequency {
-    BILLING_SCHEDULE_ANNUAL = 1,
-    BILLING_SCHEDULE_MONTHLY = 2,
-}
+const BillingFrequency = {
+    BILLING_SCHEDULE_ANNUAL: 1,
+    BILLING_SCHEDULE_MONTHLY: 2,
+} as const;
+type BillingFrequency = (typeof BillingFrequency)[keyof typeof BillingFrequency];
 
-enum CustomerPlanStatus {
-    ACTIVE = 1,
-    DOWNGRADE_AT_END_OF_CYCLE = 2,
-    FREE_TRIAL = 3,
-    SWITCH_TO_ANNUAL_AT_END_OF_CYCLE = 4,
-    SWITCH_TO_MONTHLY_AT_END_OF_CYCLE = 6,
-}
+const CustomerPlanStatus = {
+    ACTIVE: 1,
+    DOWNGRADE_AT_END_OF_CYCLE: 2,
+    FREE_TRIAL: 3,
+    SWITCH_TO_ANNUAL_AT_END_OF_CYCLE: 4,
+    SWITCH_TO_MONTHLY_AT_END_OF_CYCLE: 6,
+} as const;
+type CustomerPlanStatus = (typeof CustomerPlanStatus)[keyof typeof CustomerPlanStatus];
 
 export function create_update_current_cycle_license_request(): void {
     $("#current-manual-license-count-update-button .billing-button-text").text("");
@@ -410,7 +412,7 @@ export function initialize(): void {
             (switch_to_monthly_eoc && billing_frequency_selected === "Annual")
         ) {
             $("#org-billing-frequency-confirm-button").toggleClass("hide", false);
-            let new_status = CustomerPlanStatus.ACTIVE;
+            let new_status: CustomerPlanStatus = CustomerPlanStatus.ACTIVE;
             if (downgrade_at_end_of_cycle) {
                 new_status = CustomerPlanStatus.DOWNGRADE_AT_END_OF_CYCLE;
             } else if (free_trial) {
@@ -419,10 +421,10 @@ export function initialize(): void {
             $("#org-billing-frequency-confirm-button").attr("data-status", new_status);
         } else if (current_billing_frequency !== billing_frequency_selected) {
             $("#org-billing-frequency-confirm-button").toggleClass("hide", false);
-            let new_status = free_trial
+            let new_status: CustomerPlanStatus = free_trial
                 ? CustomerPlanStatus.FREE_TRIAL
                 : CustomerPlanStatus.SWITCH_TO_ANNUAL_AT_END_OF_CYCLE;
-            let new_schedule = BillingFrequency.BILLING_SCHEDULE_ANNUAL;
+            let new_schedule: BillingFrequency = BillingFrequency.BILLING_SCHEDULE_ANNUAL;
             if (billing_frequency_selected === "Monthly") {
                 new_status = free_trial
                     ? CustomerPlanStatus.FREE_TRIAL

--- a/web/src/compose_recipient.ts
+++ b/web/src/compose_recipient.ts
@@ -27,11 +27,6 @@ import * as user_groups from "./user_groups.ts";
 import * as util from "./util.ts";
 
 type MessageType = "stream" | "private";
-type DirectMessagesOption = {
-    is_direct_message: boolean;
-    unique_id: string | number;
-    name: string;
-};
 
 let compose_select_recipient_dropdown_widget: DropdownWidget;
 
@@ -272,8 +267,7 @@ function item_click_callback(event: JQuery.ClickEvent, dropdown: tippy.Instance)
 }
 
 function get_options_for_recipient_widget(): Option[] {
-    const options: (Option | DirectMessagesOption)[] =
-        stream_data.get_options_for_dropdown_widget();
+    const options: Option[] = stream_data.get_options_for_dropdown_widget();
 
     const direct_messages_option = {
         is_direct_message: true,

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -31,8 +31,13 @@ export enum DataTypes {
 export type Option = {
     unique_id: number | string;
     name: string;
+    description?: string;
+    is_direct_message?: boolean;
     is_setting_disabled?: boolean;
     stream?: StreamSubscription;
+    bold_current_selection?: boolean;
+    has_delete_icon?: boolean;
+    has_edit_icon?: boolean;
 };
 
 export type DropdownWidgetOptions = {

--- a/web/src/dropdown_widget.ts
+++ b/web/src/dropdown_widget.ts
@@ -23,10 +23,7 @@ const noop = (): void => {
     // Empty function for default values.
 };
 
-export enum DataTypes {
-    NUMBER = "number",
-    STRING = "string",
-}
+export type DataType = "number" | "string";
 
 export type Option = {
     unique_id: number | string;
@@ -70,7 +67,7 @@ export type DropdownWidgetOptions = {
     tippy_props?: Partial<tippy.Props>;
     // NOTE: Any value other than `undefined` will be rendered when class is initialized.
     default_id?: string | number | undefined;
-    unique_id_type?: DataTypes;
+    unique_id_type?: DataType;
     // Text to show if the current value is not in `get_options()`.
     text_if_current_value_not_in_options?: string;
     hide_search_box?: boolean;
@@ -107,7 +104,7 @@ export class DropdownWidget {
     instance: tippy.Instance | undefined;
     default_id: string | number | undefined;
     current_value: string | number | undefined;
-    unique_id_type: DataTypes | undefined;
+    unique_id_type: DataType | undefined;
     $events_container: JQuery;
     text_if_current_value_not_in_options: string;
     hide_search_box: boolean;
@@ -492,7 +489,7 @@ export class DropdownWidget {
                     const selected_unique_id = $(event.currentTarget).attr("data-unique-id");
                     assert(selected_unique_id !== undefined);
                     this.current_value = selected_unique_id;
-                    if (this.unique_id_type === DataTypes.NUMBER) {
+                    if (this.unique_id_type === "number") {
                         this.current_value = Number.parseInt(this.current_value, 10);
                     }
                     this.item_click_callback(event, instance, this, false);

--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -1,6 +1,7 @@
 import {z} from "zod";
 
 import * as blueslip from "./blueslip.ts";
+import type * as dropdown_widget from "./dropdown_widget.ts";
 import {$t} from "./i18n.ts";
 import * as settings_config from "./settings_config.ts";
 import {realm} from "./state_data.ts";
@@ -110,15 +111,10 @@ export function get_realm_user_groups_for_setting(
     return [...system_user_groups, ...user_groups_excluding_system_groups];
 }
 
-export type UserGroupForDropdownListWidget = {
-    name: string;
-    unique_id: number;
-};
-
 export function get_realm_user_groups_for_dropdown_list_widget(
     setting_name: string,
     setting_type: "realm" | "stream" | "group",
-): UserGroupForDropdownListWidget[] {
+): dropdown_widget.Option[] {
     const allowed_setting_groups = get_realm_user_groups_for_setting(setting_name, setting_type);
 
     return allowed_setting_groups.map((group) => {

--- a/web/src/integration_url_modal.ts
+++ b/web/src/integration_url_modal.ts
@@ -254,7 +254,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             item_click_callback: integration_item_click_callback,
             $events_container: $("#generate-integration-url-modal"),
             default_id: default_integration_option.unique_id,
-            unique_id_type: dropdown_widget.DataTypes.STRING,
+            unique_id_type: "string",
         });
         integration_input_dropdown_widget.setup();
 
@@ -298,7 +298,7 @@ export function show_generate_integration_url_modal(api_key: string): void {
             item_click_callback: stream_item_click_callback,
             $events_container: $("#generate-integration-url-modal"),
             default_id: direct_messages_option.unique_id,
-            unique_id_type: dropdown_widget.DataTypes.NUMBER,
+            unique_id_type: "number",
         });
         stream_input_dropdown_widget.setup();
 

--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -13,13 +13,7 @@ import * as popovers from "./popovers.ts";
 import * as rows from "./rows.ts";
 import * as util from "./util.ts";
 
-enum MediaType {
-    Image = "image",
-    InlineVideo = "inline-video",
-    YoutubeVideo = "youtube-video",
-    VimeoVideo = "vimeo-video",
-    EmbedVideo = "embed-video",
-}
+type MediaType = "image" | "inline-video" | "youtube-video" | "vimeo-video" | "embed-video";
 
 type Media = {
     // Sender's full name
@@ -342,7 +336,7 @@ function display_video(payload: Media): void {
     ).hide();
     $(".player-container").show();
 
-    if (payload.type === MediaType.InlineVideo) {
+    if (payload.type === "inline-video") {
         $(".player-container").hide();
         $(".video-player, .media-description").show();
         const $video = $("<video>");
@@ -396,7 +390,7 @@ export function build_open_media_function(
         const payload = parse_media_data(util.the($media));
 
         assert(payload !== undefined);
-        if (payload.type === MediaType.Image) {
+        if (payload.type === "image") {
             display_image(payload);
         } else {
             display_video(payload);
@@ -534,18 +528,18 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
     const transcoded_image = $media.attr("data-transcoded-image");
 
     if (is_inline_video) {
-        type = MediaType.InlineVideo;
+        type = "inline-video";
         // Render video from original source to reduce load on our own servers.  The `url` is the
         // non-Camo'd version; `preview` is the Camo'd URL.
         source = url;
     } else if (is_youtube_video) {
-        type = MediaType.YoutubeVideo;
+        type = "youtube-video";
         source = "https://www.youtube.com/embed/" + $parent.attr("data-id");
     } else if (is_vimeo_video) {
-        type = MediaType.VimeoVideo;
+        type = "vimeo-video";
         source = "https://player.vimeo.com/video/" + $parent.attr("data-id");
     } else if (is_embed_video) {
-        type = MediaType.EmbedVideo;
+        type = "embed-video";
         source =
             "data:text/html," +
             window.encodeURIComponent(
@@ -553,7 +547,7 @@ export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Me
                     $parent.attr("data-id"),
             );
     } else {
-        type = MediaType.Image;
+        type = "image";
         if ($media.attr("data-src-fullsize")) {
             source = $media.attr("data-src-fullsize");
         } else if (transcoded_image && preview_src) {

--- a/web/src/saved_snippets_ui.ts
+++ b/web/src/saved_snippets_ui.ts
@@ -200,7 +200,7 @@ export function setup_saved_snippets_dropdown_widget(widget_selector: string): v
         get_options: saved_snippets.get_options_for_dropdown_widget,
         item_click_callback,
         $events_container: $("body"),
-        unique_id_type: dropdown_widget.DataTypes.NUMBER,
+        unique_id_type: "number",
         sticky_bottom_option: $t({
             defaultMessage: "Create a new saved snippet",
         }),

--- a/web/src/settings_exports.ts
+++ b/web/src/settings_exports.ts
@@ -239,7 +239,7 @@ export function populate_export_consents_table(): void {
 
     filter_by_consent_dropdown_widget = new dropdown_widget.DropdownWidget({
         widget_name: "filter_by_consent",
-        unique_id_type: dropdown_widget.DataTypes.NUMBER,
+        unique_id_type: "number",
         get_options: () => filter_by_consent_options,
         item_click_callback(
             event: JQuery.ClickEvent,

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1068,9 +1068,9 @@ function set_up_dropdown_widget(
         text_if_current_value_not_in_options = $t({defaultMessage: "Cannot view channel"});
     }
 
-    let unique_id_type = dropdown_widget.DataTypes.NUMBER;
+    let unique_id_type: dropdown_widget.DataType = "number";
     if (setting_type === "language") {
-        unique_id_type = dropdown_widget.DataTypes.STRING;
+        unique_id_type = "string";
     }
 
     const setting_dropdown_widget = new dropdown_widget.DropdownWidget({

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -13,7 +13,6 @@ import {csrf_token} from "./csrf.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import * as group_permission_settings from "./group_permission_settings.ts";
-import type {UserGroupForDropdownListWidget} from "./group_permission_settings.ts";
 import {$t, $t_html, get_language_name} from "./i18n.ts";
 import * as information_density from "./information_density.ts";
 import * as keydown_util from "./keydown_util.ts";
@@ -1113,7 +1112,7 @@ export function set_up_dropdown_widget_for_realm_group_settings(): void {
             // we use pills UI.
             continue;
         }
-        const get_setting_options = (): UserGroupForDropdownListWidget[] =>
+        const get_setting_options = (): dropdown_widget.Option[] =>
             group_permission_settings.get_realm_user_groups_for_dropdown_list_widget(
                 setting_name,
                 "realm",

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -217,7 +217,7 @@ function count_users_by_role(user_ids: number[]): Record<number, number> {
     return role_counts;
 }
 
-function get_roles_with_counts(user_ids: number[]): {unique_id: number; name: string}[] {
+function get_roles_with_counts(user_ids: number[]): dropdown_widget.Option[] {
     const role_counts = count_users_by_role(user_ids);
     return [
         {
@@ -240,12 +240,12 @@ function get_roles_with_counts(user_ids: number[]): {unique_id: number; name: st
     ];
 }
 
-function get_roles_count_for_active_users(): {unique_id: number; name: string}[] {
+function get_roles_count_for_active_users(): dropdown_widget.Option[] {
     const active_user_ids = people.get_realm_active_human_user_ids();
     return get_roles_with_counts(active_user_ids);
 }
 
-function get_roles_count_for_deactivated_users(): {unique_id: number; name: string}[] {
+function get_roles_count_for_deactivated_users(): dropdown_widget.Option[] {
     const deactivated_user_ids = people.get_non_active_human_ids();
     return get_roles_with_counts(deactivated_user_ids);
 }
@@ -253,7 +253,7 @@ function get_roles_count_for_deactivated_users(): {unique_id: number; name: stri
 function create_role_filter_dropdown(
     $events_container: JQuery,
     section: UserSettingsSection,
-    get_role_options: () => {unique_id: number; name: string}[],
+    get_role_options: () => dropdown_widget.Option[],
 ): dropdown_widget.DropdownWidget {
     return new dropdown_widget.DropdownWidget({
         widget_name: section.dropdown_widget_name,

--- a/web/src/settings_users.ts
+++ b/web/src/settings_users.ts
@@ -257,7 +257,7 @@ function create_role_filter_dropdown(
 ): dropdown_widget.DropdownWidget {
     return new dropdown_widget.DropdownWidget({
         widget_name: section.dropdown_widget_name,
-        unique_id_type: dropdown_widget.DataTypes.NUMBER,
+        unique_id_type: "number",
         get_options: get_role_options,
         $events_container,
         item_click_callback: role_selected_handler,

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -4,6 +4,7 @@ import * as blueslip from "./blueslip.ts";
 import type {Bot} from "./bot_data.ts";
 import * as bot_data from "./bot_data.ts";
 import * as color_data from "./color_data.ts";
+import type * as dropdown_widget from "./dropdown_widget.ts";
 import {FoldDict} from "./fold_dict.ts";
 import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
@@ -1011,11 +1012,9 @@ export function remove_default_stream(stream_id: number): void {
     default_stream_ids.delete(stream_id);
 }
 
-export function get_options_for_dropdown_widget(): {
-    name: string;
-    unique_id: number;
+export function get_options_for_dropdown_widget(): (dropdown_widget.Option & {
     stream: StreamSubscription;
-}[] {
+})[] {
     return subscribed_subs()
         .filter((stream) => !stream.is_archived)
         .map((stream) => ({

--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -464,7 +464,7 @@ function show_stream_email_address_modal(address: string, sub: StreamSubscriptio
             item_click_callback,
             $events_container: $("#copy_email_address_modal"),
             default_id: people.EMAIL_GATEWAY_BOT.user_id,
-            unique_id_type: dropdown_widget.DataTypes.NUMBER,
+            unique_id_type: "number",
             hide_search_box: true,
         });
         sender_dropdown_widget.setup();

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -781,11 +781,7 @@ export async function build_move_topic_to_stream_popover(
         }
 
         stream_widget_value = current_stream_id;
-        const streams_list_options = (): {
-            name: string;
-            unique_id: number;
-            stream: sub_store.StreamSubscription;
-        }[] =>
+        const streams_list_options = (): dropdown_widget.Option[] =>
             stream_data.get_options_for_dropdown_widget().filter(({stream}) => {
                 if (stream.stream_id === current_stream_id) {
                     return true;

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -680,11 +680,9 @@ export function switch_stream_sort(tab_name: string): void {
     redraw_left_panel();
 }
 
-function filters_dropdown_options(current_value: string | number | undefined): {
-    unique_id: string;
-    name: string;
-    bold_current_selection: boolean;
-}[] {
+function filters_dropdown_options(
+    current_value: string | number | undefined,
+): dropdown_widget.Option[] {
     return [
         {
             unique_id: stream_settings_data.FILTERS.ARCHIVED_CHANNELS,

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -2,12 +2,13 @@ import {z} from "zod";
 
 import {group_setting_value_schema} from "./types.ts";
 
-export const enum StreamPostPolicy {
-    EVERYONE = 1,
-    ADMINS = 2,
-    RESTRICT_NEW_MEMBERS = 3,
-    MODERATORS = 4,
-}
+export const StreamPostPolicy = {
+    EVERYONE: 1,
+    ADMINS: 2,
+    RESTRICT_NEW_MEMBERS: 3,
+    MODERATORS: 4,
+} as const;
+export type StreamPostPolicy = (typeof StreamPostPolicy)[keyof typeof StreamPostPolicy];
 
 export const stream_permission_group_settings_schema = z.enum([
     "can_add_subscribers_group",
@@ -33,12 +34,7 @@ export const stream_schema = z.object({
     name: z.string(),
     rendered_description: z.string(),
     stream_id: z.number(),
-    stream_post_policy: z.nativeEnum({
-        EVERYONE: StreamPostPolicy.EVERYONE,
-        ADMINS: StreamPostPolicy.ADMINS,
-        RESTRICT_NEW_MEMBERS: StreamPostPolicy.RESTRICT_NEW_MEMBERS,
-        MODERATORS: StreamPostPolicy.MODERATORS,
-    }),
+    stream_post_policy: z.nativeEnum(StreamPostPolicy),
     can_add_subscribers_group: group_setting_value_schema,
     can_administer_channel_group: group_setting_value_schema,
     can_remove_subscribers_group: group_setting_value_schema,

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1662,11 +1662,9 @@ export function filter_click_handler(
     widget.render();
 }
 
-function filters_dropdown_options(current_value: string | number | undefined): {
-    unique_id: string;
-    name: string;
-    bold_current_selection: boolean;
-}[] {
+function filters_dropdown_options(
+    current_value: string | number | undefined,
+): dropdown_widget.Option[] {
     return [
         {
             unique_id: FILTERS.ACTIVE_GROUPS,

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -261,20 +261,12 @@ function reset_subscribe_widget(): void {
     }
 }
 
-export function get_user_unsub_streams_for_dropdown(): {
-    name: string;
-    unique_id: number;
-    stream: StreamSubscription;
-}[] {
+export function get_user_unsub_streams_for_dropdown(): dropdown_widget.Option[] {
     const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id")!, 10);
     return get_user_unsub_streams(target_user_id);
 }
 
-export function get_user_unsub_streams(user_id: number): {
-    name: string;
-    unique_id: number;
-    stream: StreamSubscription;
-}[] {
+export function get_user_unsub_streams(user_id: number): dropdown_widget.Option[] {
     return stream_data
         .get_streams_for_user(user_id)
         .can_subscribe.map((stream) => ({

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -216,7 +216,7 @@ function render_user_profile_subscribe_widget(): void {
         get_options: get_user_unsub_streams_for_dropdown,
         item_click_callback: change_state_of_subscribe_button,
         $events_container: $("#user-profile-modal"),
-        unique_id_type: dropdown_widget.DataTypes.NUMBER,
+        unique_id_type: "number",
     };
     user_profile_subscribe_widget =
         user_profile_subscribe_widget ?? new dropdown_widget.DropdownWidget(opts);
@@ -963,7 +963,7 @@ export function show_edit_bot_info_modal(user_id: number, $container: JQuery): v
             item_click_callback,
             $events_container: $("#bot-edit-form"),
             default_id: owner_id,
-            unique_id_type: dropdown_widget.DataTypes.NUMBER,
+            unique_id_type: "number",
         });
         bot_owner_dropdown_widget.setup();
 

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -5,7 +5,7 @@ import * as activity_ui from "./activity_ui.ts";
 import * as compose_actions from "./compose_actions.ts";
 import * as compose_recipient from "./compose_recipient.ts";
 import * as compose_state from "./compose_state.ts";
-import * as dropdown_widget from "./dropdown_widget.ts";
+import type * as dropdown_widget from "./dropdown_widget.ts";
 import {$t} from "./i18n.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_view_header from "./message_view_header.ts";
@@ -34,7 +34,7 @@ const TIPPY_PROPS: Partial<tippy.Props> = {
 export const COMMON_DROPDOWN_WIDGET_PARAMS = {
     get_options: filters_dropdown_options,
     tippy_props: TIPPY_PROPS,
-    unique_id_type: dropdown_widget.DataTypes.STRING,
+    unique_id_type: "string",
     hide_search_box: true,
     disable_for_spectators: true,
 } satisfies Partial<dropdown_widget.DropdownWidgetOptions>;

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -36,9 +36,8 @@ export const COMMON_DROPDOWN_WIDGET_PARAMS = {
     tippy_props: TIPPY_PROPS,
     unique_id_type: dropdown_widget.DataTypes.STRING,
     hide_search_box: true,
-    bold_current_selection: true,
     disable_for_spectators: true,
-};
+} satisfies Partial<dropdown_widget.DropdownWidgetOptions>;
 
 export function filters_dropdown_options(current_value: string | number | undefined): {
     unique_id: string;

--- a/web/src/views_util.ts
+++ b/web/src/views_util.ts
@@ -39,12 +39,9 @@ export const COMMON_DROPDOWN_WIDGET_PARAMS = {
     disable_for_spectators: true,
 } satisfies Partial<dropdown_widget.DropdownWidgetOptions>;
 
-export function filters_dropdown_options(current_value: string | number | undefined): {
-    unique_id: string;
-    name: string;
-    description: string;
-    bold_current_selection: boolean;
-}[] {
+export function filters_dropdown_options(
+    current_value: string | number | undefined,
+): dropdown_widget.Option[] {
     return [
         {
             unique_id: FILTERS.FOLLOWED_TOPICS,

--- a/web/tests/recent_view.test.cjs
+++ b/web/tests/recent_view.test.cjs
@@ -197,9 +197,7 @@ mock_esm("../src/unread", {
 mock_esm("../src/resize", {
     update_recent_view: noop,
 });
-const dropdown_widget = mock_esm("../src/dropdown_widget", {
-    DataTypes: {NUMBER: "number", STRING: "string"},
-});
+const dropdown_widget = mock_esm("../src/dropdown_widget");
 dropdown_widget.DropdownWidget = function DropdownWidget() {
     this.setup = noop;
     this.render = noop;


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-8.html#the---erasablesyntaxonly-option

> Recently, Node.js 23.6 unflagged [experimental support for running TypeScript files directly](https://nodejs.org/api/typescript.html#type-stripping); however, only certain constructs are supported under this mode. Node.js has unflagged a mode called `--experimental-strip-types` which requires that any TypeScript-specific syntax cannot have runtime semantics. Phrased differently, it must be possible to easily erase or “strip out” any TypeScript-specific syntax from a file, leaving behind a valid JavaScript file.
>
> That means constructs like the following are not supported:
>
> - `enum` declarations
> - `namespace`s and `module`s with runtime code
> - parameter properties in classes
> - Non-ECMAScript `import =` and `export =` assignments