### PR TITLE
Show archive buttons to channel admins as well.

### DIFF
--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -679,6 +679,14 @@ export function can_change_permissions_requiring_metadata_access(sub: StreamSubs
     return can_administer_channel(sub);
 }
 
+export function can_archive_stream(sub: StreamSubscription): boolean {
+    if (sub.is_archived) {
+        return false;
+    }
+
+    return can_administer_channel(sub);
+}
+
 export function can_view_subscribers(sub: StreamSubscription): boolean {
     return has_metadata_access(sub);
 }

--- a/web/src/stream_settings_data.ts
+++ b/web/src/stream_settings_data.ts
@@ -23,6 +23,7 @@ export type SettingsSubscription = StreamSubscription & {
     can_access_subscribers: boolean;
     can_add_subscribers: boolean;
     can_remove_subscribers: boolean;
+    can_archive_stream: boolean;
     preview_url: string;
     is_old_stream: boolean;
     subscriber_count: number;
@@ -59,6 +60,7 @@ export function get_sub_for_settings(sub: StreamSubscription): SettingsSubscript
         can_access_subscribers: stream_data.can_view_subscribers(sub),
         can_add_subscribers: stream_data.can_subscribe_others(sub),
         can_remove_subscribers: stream_data.can_unsubscribe_others(sub),
+        can_archive_stream: stream_data.can_archive_stream(sub),
 
         preview_url: hash_util.by_stream_url(sub.stream_id),
         is_old_stream: sub.stream_weekly_traffic !== null,

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -219,10 +219,6 @@
     margin-bottom: 10px;
 }
 
-#archive-stream-modal .notification_stream_archive_warning {
-    margin-bottom: 0;
-}
-
 #read_receipts_modal {
     .modal__container {
         width: 25.7142em; /* 360px at 14px em */

--- a/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
@@ -6,23 +6,23 @@
         <li>{{#tr}}Remove it from the left sidebar for all users.{{/tr}}</li>
         <li>{{#tr}}Prevent new messages from being sent to this channel.{{/tr}}</li>
         <li>{{#tr}}Prevent messages in this channel from being edited, deleted, or moved.{{/tr}}</li>
+        {{#if is_announcement_stream}}
+        <li>{{#tr}}Disable announcements that are currently sent to this channel:{{/tr}}</li>
+        <ul>
+            {{#if is_new_stream_announcements_stream}}
+                <li>{{#tr}}New channel announcements{{/tr}}</li>
+            {{/if}}
+            {{#if is_signup_announcements_stream}}
+                <li>{{#tr}}New user announcements{{/tr}}</li>
+            {{/if}}
+            {{#if is_zulip_update_announcements_stream}}
+                <li>{{#tr}}Zulip update announcements{{/tr}}</li>
+            {{/if}}
+        </ul>
+        {{/if}}
     </ul>
     {{#tr}}
         Users can still search for messages in archived channels.<br/>
         This action cannot be undone.
     {{/tr}}
 </p>
-{{#if is_announcement_stream}}
-<p class="notification_stream_archive_warning">{{#tr}}Archiving this channel will also disable settings that were configured to use this channel:{{/tr}}</p>
-<ul>
-    {{#if is_new_stream_announcements_stream}}
-        <li>{{#tr}}New channel notifications{{/tr}}</li>
-    {{/if}}
-    {{#if is_signup_announcements_stream}}
-        <li>{{#tr}}New user notifications{{/tr}}</li>
-    {{/if}}
-    {{#if is_zulip_update_announcements_stream}}
-        <li>{{#tr}}Zulip update announcements{{/tr}}</li>
-    {{/if}}
-</ul>
-{{/if}}

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -20,14 +20,12 @@
             </button>
         </div>
         <a href="{{preview_url}}" class="button small rounded tippy-zulip-delayed-tooltip" id="preview-stream-button" role="button" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="bottom" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
-        {{#if is_realm_admin}}
-        {{#unless is_archived}}
-            <button class="button small rounded button-danger deactivate tippy-zulip-delayed-tooltip" type="button" data-tippy-content="{{t 'Archive channel'}}">
-                <span class="icon-container">
-                    <i class="zulip-icon zulip-icon-archive" aria-hidden="true"></i>
-                </span>
-            </button>
-        {{/unless}}
+        {{#if can_archive_stream}}
+        <button class="button small rounded button-danger deactivate tippy-zulip-delayed-tooltip" type="button" data-tippy-content="{{t 'Archive channel'}}">
+            <span class="icon-container">
+                <i class="zulip-icon zulip-icon-archive" aria-hidden="true"></i>
+            </span>
+        </button>
         {{/if}}
     </div>
     {{/with}}

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1801,3 +1801,32 @@ run_test("can_toggle_subscription", ({override}) => {
     social.can_subscribe_group = me_group.id;
     assert.equal(stream_data.can_toggle_subscription(social), true);
 });
+
+run_test("can_archive_stream", ({override}) => {
+    const social = {
+        subscribed: false,
+        color: "red",
+        name: "social",
+        stream_id: 2,
+        is_muted: false,
+        invite_only: false,
+        history_public_to_subscribers: false,
+        can_add_subscribers_group: me_group.id,
+        can_administer_channel_group: nobody_group.id,
+        can_subscribe_group: me_group.id,
+    };
+    override(current_user, "user_id", me.user_id);
+
+    override(current_user, "is_admin", true);
+    social.is_archived = true;
+    assert.equal(stream_data.can_archive_stream(social), false);
+
+    social.is_archived = false;
+    assert.equal(stream_data.can_archive_stream(social), true);
+
+    override(current_user, "is_admin", false);
+    assert.equal(stream_data.can_archive_stream(social), false);
+
+    social.can_administer_channel_group = me_group.id;
+    assert.equal(stream_data.can_archive_stream(social), true);
+});


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to show archive button to channel admins as well.
- Second commit is to update the way we show warning about stream being used for announcements.

Fixes: <!-- Issue link, or clear description.--> #33379

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2025-03-17 15-25-14](https://github.com/user-attachments/assets/f2682109-43f3-4a1c-ac41-5ceed078e67d)

![Screenshot from 2025-03-17 15-25-48](https://github.com/user-attachments/assets/0d1fbff6-050b-48b0-bcf5-6dd7bf14452a)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
