### PR TITLE
migration: Rename "(no topic)" to empty string topic.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 10.0
 
+**Feature level 370**
+
+* [`POST /messages`](/api/send-message),
+  [`POST /scheduled_messages`](/api/create-scheduled-message),
+  [`PATCH /scheduled_messages/<int:scheduled_message_id>`](/api/update-scheduled-message):
+  The `"(no topic)"` value when used for `topic` parameter is
+  now interpreted as an empty string.
+
 **Feature level 369**
 
 * [`POST /register`](/api/register-queue): Added `navigation_tour_video_url`

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 369  # Last bumped for adding `navigation_tour_video_url`.
+API_FEATURE_LEVEL = 370  # Last bumped to interpret "(no topic)" as empty string.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -108,7 +108,8 @@ export function create_message_object(message_content = compose_state.message_co
             message.to = people.user_ids_string_to_ids_array(message.to_user_ids);
         }
     } else {
-        message.topic = compose_state.topic();
+        const topic = compose_state.topic();
+        message.topic = util.is_topic_name_considered_empty(topic) ? "" : topic;
         const stream_id = compose_state.stream_id();
         message.stream_id = stream_id;
         message.to = stream_id;

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1762,7 +1762,7 @@ def check_message(
             # else can sneak past the access check.
             assert sender.bot_type == sender.OUTGOING_WEBHOOK_BOT
 
-        if realm.mandatory_topics and topic_name in ("(no topic)", ""):
+        if realm.mandatory_topics and topic_name == "":
             raise JsonableError(_("Topics are required in this organization"))
 
     elif addressee.is_private():

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -5,7 +5,10 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.string_validation import check_stream_topic
-from zerver.lib.topic import maybe_rename_general_chat_to_empty_topic
+from zerver.lib.topic import (
+    maybe_rename_general_chat_to_empty_topic,
+    maybe_rename_no_topic_to_empty_topic,
+)
 from zerver.models import Realm, Stream, UserProfile
 from zerver.models.users import (
     get_user_by_id_in_realm_including_cross_realm,
@@ -148,6 +151,7 @@ class Addressee:
     def for_stream(stream: Stream, topic_name: str) -> "Addressee":
         topic_name = topic_name.strip()
         topic_name = maybe_rename_general_chat_to_empty_topic(topic_name)
+        topic_name = maybe_rename_no_topic_to_empty_topic(topic_name)
         check_stream_topic(topic_name)
         return Addressee(
             msg_type="stream",
@@ -159,6 +163,7 @@ class Addressee:
     def for_stream_name(stream_name: str, topic_name: str) -> "Addressee":
         topic_name = topic_name.strip()
         topic_name = maybe_rename_general_chat_to_empty_topic(topic_name)
+        topic_name = maybe_rename_no_topic_to_empty_topic(topic_name)
         check_stream_topic(topic_name)
         return Addressee(
             msg_type="stream",
@@ -170,6 +175,7 @@ class Addressee:
     def for_stream_id(stream_id: int, topic_name: str) -> "Addressee":
         topic_name = topic_name.strip()
         topic_name = maybe_rename_general_chat_to_empty_topic(topic_name)
+        topic_name = maybe_rename_no_topic_to_empty_topic(topic_name)
         check_stream_topic(topic_name)
         return Addressee(
             msg_type="stream",

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -384,6 +384,12 @@ def maybe_rename_general_chat_to_empty_topic(topic_name: str) -> str:
     return topic_name
 
 
+def maybe_rename_no_topic_to_empty_topic(topic_name: str) -> str:
+    if topic_name == "(no topic)":
+        topic_name = ""
+    return topic_name
+
+
 def maybe_rename_empty_topic_to_general_chat(
     topic_name: str, is_channel_message: bool, allow_empty_topic_name: bool
 ) -> str:

--- a/zerver/migrations/0696_rename_no_topic_to_empty_string_topic.py
+++ b/zerver/migrations/0696_rename_no_topic_to_empty_string_topic.py
@@ -1,0 +1,168 @@
+from typing import Any
+
+import orjson
+from django.conf import settings
+from django.db import connection, migrations, transaction
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import F, Func, JSONField, TextField, Value
+from django.db.models.functions import Cast
+from django.utils.timezone import now as timezone_now
+from psycopg2.sql import SQL, Literal
+
+LAST_EDIT_TIME = timezone_now()
+LAST_EDIT_TIMESTAMP = int(LAST_EDIT_TIME.timestamp())
+
+
+def update_messages_for_topic_edit(message_queryset: Any, notification_bot: Any) -> None:
+    edit_history_entry = {
+        "user_id": notification_bot.id,
+        "timestamp": LAST_EDIT_TIMESTAMP,
+        "prev_topic": "(no topic)",
+        "topic": "",
+    }
+    update_fields: dict[str, object] = {
+        "subject": "",
+        "last_edit_time": LAST_EDIT_TIME,
+        "edit_history": Cast(
+            Func(
+                Cast(
+                    Value(orjson.dumps([edit_history_entry]).decode()),
+                    JSONField(),
+                ),
+                Cast(
+                    Func(
+                        F("edit_history"),
+                        Value("[]"),
+                        function="COALESCE",
+                    ),
+                    JSONField(),
+                ),
+                function="",
+                arg_joiner=" || ",
+            ),
+            TextField(),
+        ),
+    }
+    message_queryset.update(**update_fields)
+
+
+def update_user_topic(channel_ids: list[int], user_topic_model: type[Any]) -> None:
+    if not channel_ids:
+        return
+
+    # Both insert and delete query uses index "zerver_mutedtopic_stream_topic".
+    channel_ids_str = SQL(",").join(map(Literal, channel_ids))
+    query = SQL(
+        """
+        INSERT INTO zerver_usertopic(user_profile_id, stream_id, recipient_id, topic_name, last_updated, visibility_policy)
+        SELECT user_profile_id, stream_id, recipient_id, '', last_updated, visibility_policy
+        FROM zerver_usertopic
+        WHERE stream_id IN ({channel_ids})
+        AND lower(topic_name) = '(no topic)'
+        ON CONFLICT (user_profile_id, stream_id, lower(topic_name)) DO UPDATE SET
+        last_updated = EXCLUDED.last_updated,
+        visibility_policy = EXCLUDED.visibility_policy;
+        """
+    ).format(channel_ids=channel_ids_str)
+    with connection.cursor() as cursor:
+        cursor.execute(query)
+
+    user_topic_model.objects.filter(
+        stream_id__in=channel_ids, topic_name__iexact="(no topic)"
+    ).delete()
+
+
+def move_messages_from_no_topic_to_empty_string_topic(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    """Move messages from "(no topic)" to the empty string topic.
+
+    This helps in our plan to interpret messages sent to
+    "(no topic)" as being sent to "".
+
+    That interpretation is particularly helpful for older
+    clients where sending messages with empty topic input box
+    results in messages being sent to "(no topic)" topic.
+
+    Note: In 0680, we moved messages from the "general chat" topic
+    to the empty string topic. Therefore, we skip moving messages
+    from "(no topic)" if an empty string topic already exists.
+
+    Such cases—where both "(no topic)" and an empty string topic
+    coexist in a channel—should be rare. The solution is to either
+    manually rename the "(no topic)" topic or manually move its
+    messages to the empty string topic.
+    """
+    Realm = apps.get_model("zerver", "Realm")
+    Message = apps.get_model("zerver", "Message")
+    UserTopic = apps.get_model("zerver", "UserTopic")
+    ArchivedMessage = apps.get_model("zerver", "ArchivedMessage")
+    ScheduledMessage = apps.get_model("zerver", "ScheduledMessage")
+    UserProfile = apps.get_model("zerver", "UserProfile")
+
+    try:
+        internal_realm = Realm.objects.get(string_id=settings.SYSTEM_BOT_REALM)
+    except Realm.DoesNotExist:
+        # Server not initialized.
+        return
+    notification_bot = UserProfile.objects.get(
+        email__iexact=settings.NOTIFICATION_BOT, realm=internal_realm
+    )
+
+    for realm in Realm.objects.all():
+        with transaction.atomic(durable=True):
+            # Uses index "zerver_message_realm_recipient_subject"
+            channel_ids_with_empty_string_topic = set(
+                Message.objects.filter(realm=realm, is_channel_message=True, subject="")
+                .distinct("recipient__type_id")
+                .values_list("recipient__type_id", flat=True)
+            )
+            # Uses index "zerver_message_realm_upper_subject"
+            message_queryset = Message.objects.filter(
+                realm=realm, is_channel_message=True, subject__iexact="(no topic)"
+            ).exclude(recipient__type_id__in=channel_ids_with_empty_string_topic)
+            channel_ids = list(
+                message_queryset.distinct("recipient__type_id").values_list(
+                    "recipient__type_id", flat=True
+                )
+            )
+
+            update_messages_for_topic_edit(message_queryset, notification_bot)
+
+            update_user_topic(channel_ids, UserTopic)
+
+            # Uses index zerver_archivedmessage_realm_id_fab86889
+            archived_channel_ids_with_empty_string_topic = set(
+                ArchivedMessage.objects.filter(realm=realm, is_channel_message=True, subject="")
+                .distinct("recipient__type_id")
+                .values_list("recipient__type_id", flat=True)
+            )
+            channel_ids_with_empty_string_topic = channel_ids_with_empty_string_topic.union(
+                archived_channel_ids_with_empty_string_topic
+            )
+            # Uses index zerver_archivedmessage_realm_id_fab86889
+            archived_message_queryset = ArchivedMessage.objects.filter(
+                realm=realm, is_channel_message=True, subject__iexact="(no topic)"
+            ).exclude(recipient__type_id__in=channel_ids_with_empty_string_topic)
+            update_messages_for_topic_edit(archived_message_queryset, notification_bot)
+
+            ScheduledMessage.objects.filter(realm=realm, subject__iexact="(no topic)").update(
+                subject=""
+            )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "0695_is_channel_message_stats"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            move_messages_from_no_topic_to_empty_string_topic,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6640,14 +6640,17 @@ paths:
                     [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum topic length.
 
-                    Note: When the value of `realm_empty_topic_display_name` found in
-                    the [POST /register](/api/register-queue) response is used for this
+                    Note: When `"(no topic)"` or the value of `realm_empty_topic_display_name`
+                    found in the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
                     be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
-                    **Changes**: Before Zulip 10.0 (feature level 334), empty string
+                    **Changes**: Before Zulip 10.0 (feature level 370), `"(no topic)"`
+                    was not interpreted as an empty string.
+
+                    Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
                   type: string
                   example: Castle
@@ -6814,14 +6817,17 @@ paths:
                     [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum topic length.
 
-                    Note: When the value of `realm_empty_topic_display_name` found in
-                    the [POST /register](/api/register-queue) response is used for this
+                    Note: When `"(no topic)"` or the value of `realm_empty_topic_display_name`
+                    found in the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
                     be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
-                    **Changes**: Before Zulip 10.0 (feature level 334), empty string
+                    **Changes**: Before Zulip 10.0 (feature level 370), `"(no topic)"`
+                    was not interpreted as an empty string.
+
+                    Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
                   type: string
                   example: Castle
@@ -7503,14 +7509,17 @@ paths:
                     [`POST /register`](/api/register-queue) endpoint to determine
                     the maximum topic length.
 
-                    Note: When the value of `realm_empty_topic_display_name` found in
-                    the [POST /register](/api/register-queue) response is used for this
+                    Note: When `"(no topic)"` or the value of `realm_empty_topic_display_name`
+                    found in the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
 
                     When [topics are required](/help/require-topics), this parameter can't
                     be `"(no topic)"`, an empty string, or the value of `realm_empty_topic_display_name`.
 
-                    **Changes**: Before Zulip 10.0 (feature level 334), empty string
+                    **Changes**: Before Zulip 10.0 (feature level 370), `"(no topic)"`
+                    was not interpreted as an empty string.
+
+                    Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
 
                     New in Zulip 2.0.0. Previous Zulip releases encoded

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -9,7 +9,7 @@ class SlackIncomingHookTests(WebhookTestCase):
     WEBHOOK_DIR_NAME = "slack_incoming"
 
     def test_message(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 Hello, world.
 """.strip()
@@ -40,7 +40,7 @@ Hello, world.
             self.assert_channel_message(
                 message=msg,
                 channel_name=self.CHANNEL_NAME,
-                topic_name="(no topic)",
+                topic_name="",
                 content=output_value,
             )
 
@@ -89,7 +89,7 @@ Danny Torrence left the following *review* for your property:
         )
 
     def test_message_with_blocks(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 Danny Torrence left the following review for your property:
 
@@ -142,7 +142,7 @@ Danny Torrence left the following review for your property:
         # Paste the JSON into
         # https://api.slack.com/tools/block-kit-builder to see how it
         # is rendered in Slack
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## Hello from TaskBot
 
@@ -177,7 +177,7 @@ There are two ways to quickly create tasks:
     def test_attachment_blocks(self) -> None:
         # On https://api.slack.com/tools/block-kit-builder choose
         # "Attachment preview" and paste the JSON in.
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 This is a section block with an accessory image.
 
@@ -199,7 +199,7 @@ This is a section block with a button.
         )
 
     def test_attachment_fields(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 Build bla bla succeeded
 
@@ -219,7 +219,7 @@ Value without title
         )
 
     def test_attachment_pieces(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## Test
 
@@ -243,7 +243,7 @@ Value without title
         return self.webhook_fixture_data("slack_incoming", fixture_name, file_type=file_type)
 
     def test_attachment_pieces_title_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 Sample pretext.
 
@@ -263,7 +263,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_image_url_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -283,7 +283,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_ts_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -303,7 +303,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_text_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -323,7 +323,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_pretext_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -343,7 +343,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_footer_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -363,7 +363,7 @@ Sample text.
         )
 
     def test_attachment_pieces_title_link_null(self) -> None:
-        expected_topic_name = "(no topic)"
+        expected_topic_name = ""
         expected_message = """
 ## Sample title.
 

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1288,6 +1288,7 @@ def generate_and_send_messages(
             message.subject = random.choice(possible_topic_names[message.recipient.id])
             saved_data["subject"] = message.subject
 
+        message.is_channel_message = recipient_type == Recipient.STREAM
         message.date_sent = choose_date_sent(
             num_messages, tot_messages, options["oldest_message_days"], options["threads"]
         )


### PR DESCRIPTION
Commit 1: [#backend > general chat and database indexes @ 💬](https://chat.zulip.org/#narrow/channel/3-backend/topic/general.20chat.20and.20database.20indexes/near/2128773)
Commit 2: Migration `"(no topic)"` -> `""`
Commit 3: Server should interpret `"(no topic)"` as empty string
Commit 4: The bug I mentioned in my check-in, yesterday.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
