### PR TITLE
Improve connection error banner and prevent glicthy open/close of the banner.

### DIFF
--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import * as loading from "./loading.ts";
 
+let loading_indicator_count = 0;
 export function show_button_loading_indicator($button: JQuery): void {
     // If the button already has a loading indicator, do nothing.
     if ($button.find(".button-loading-indicator").length > 0) {
@@ -14,7 +15,8 @@ export function show_button_loading_indicator($button: JQuery): void {
     // The unique id is required for the `filter` element in the loader SVG,
     // to prevent the loading indicator from being hidden due to duplicate ids.
     // Reference commit: 995d073dbfd8f22a2ef50c1320e3b1492fd28649
-    const loading_indicator_unique_id = `button-loading-indicator-${Date.now()}`;
+    const loading_indicator_unique_id = `button-loading-indicator-${loading_indicator_count}`;
+    loading_indicator_count += 1;
     const $button_loading_indicator = $("<span>")
         .attr("id", loading_indicator_unique_id)
         .addClass("button-loading-indicator");

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -192,7 +192,7 @@ function get_events({dont_block = false} = {}) {
             try {
                 get_events_xhr = undefined;
                 get_events_failures = 0;
-                popup_banners.close_connection_error_popup_banner();
+                popup_banners.close_connection_error_popup_banner("server_events");
 
                 get_events_success(data.events);
             } catch (error) {
@@ -201,6 +201,7 @@ function get_events({dont_block = false} = {}) {
             get_events_timeout = setTimeout(get_events, 0);
         },
         error(xhr, error_type) {
+            const retry_delay_secs = util.get_retry_backoff_seconds(xhr, get_events_failures);
             try {
                 get_events_xhr = undefined;
                 // If we're old enough that our message queue has been
@@ -220,26 +221,24 @@ function get_events({dont_block = false} = {}) {
                 } else if (error_type === "timeout") {
                     // Retry indefinitely on timeout.
                     get_events_failures = 0;
-                    popup_banners.close_connection_error_popup_banner();
+                    popup_banners.close_connection_error_popup_banner("server_events");
                 } else {
                     get_events_failures += 1;
                 }
 
                 if (get_events_failures >= 8) {
                     popup_banners.open_connection_error_popup_banner({
+                        caller: "server_events",
+                        retry_delay_secs,
                         on_retry_callback() {
                             restart_get_events({dont_block: true});
                         },
-                        is_get_events_error: true,
                     });
-                } else {
-                    popup_banners.close_connection_error_popup_banner();
                 }
             } catch (error) {
                 blueslip.error("Failed to handle get_events error", undefined, error);
             }
 
-            const retry_delay_secs = util.get_retry_backoff_seconds(xhr, get_events_failures);
             get_events_timeout = setTimeout(get_events, retry_delay_secs * 1000);
         },
     });


### PR DESCRIPTION
This PR is a completion PR for #33974 and completes the first two checkpoints of #33924:

> - [ ] Change the banner text to:
> > Unable to connect to Zulip. Trying again in {x} seconds… [Try now]
> - [ ] Show a loading indicator on the button any time that a retry is currently in progress.

Changes from #33974:
- Simplifies the logic to prevent the two codepaths opening the connection error banner.
- Modifies the `message_fetch: Synchronize message fetch attempts.` commit and removes the `load_messages_attempts` variable since as @timabbott mentioned that `message_fetch`, unlike `server_events` does not have a singleton module -- you can have several fetches for different parameters running at the same time. This way the `load_messages` remains a recursive function which can be called with different parameters.

Fixes: #33924

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Connection error banner on message_fetch error:

https://github.com/user-attachments/assets/526dc6fb-f445-4105-ada1-a02ce945d032

### Connection error banner on server_events error:

https://github.com/user-attachments/assets/d6acefb7-1bd1-4245-8072-72acf6957f19


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
