### PR TITLE
compose: Fix buggy tooltip on validation.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -206,6 +206,7 @@ export let complete_starting_tasks = (opts: ComposeActionsOpts): void => {
         compose_notifications.maybe_show_one_time_interleaved_view_messages_fading_banner();
     }
     compose_ui.maybe_show_scrolling_formatting_buttons("#message-formatting-controls-container");
+    compose_validate.validate_and_update_send_button_status();
 };
 
 export function rewire_complete_starting_tasks(value: typeof complete_starting_tasks): void {

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -71,14 +71,6 @@ export function initialize() {
         compose_ui.handle_keyup(event, $("textarea#compose-textarea").expectOne());
     });
 
-    $("#compose-send-button").on("mouseenter", () => {
-        compose_validate.validate(false, false);
-        compose_validate.update_send_button_status();
-    });
-    $("#compose-send-button").on("mouseleave", () => {
-        $("#compose-send-button").removeClass("disabled-message-send-controls");
-    });
-
     $("textarea#compose-textarea").on("input propertychange", () => {
         if ($("#compose").hasClass("preview_mode")) {
             compose.render_preview_area();
@@ -606,6 +598,7 @@ export function initialize() {
         const $input = $("input#stream_message_recipient_topic");
         $input.val("");
         $input.trigger("focus");
+        compose_validate.validate_and_update_send_button_status();
     });
 
     $("input#stream_message_recipient_topic").on("focus", () => {

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import _, {isNumber} from "lodash";
+import type {ReferenceElement} from "tippy.js";
 
 import * as resolved_topic from "../shared/src/resolved_topic.ts";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
@@ -950,6 +951,13 @@ export let validate_and_update_send_button_status = function (): void {
     const is_valid = validate(false, false);
     const $send_button = $("#compose-send-button");
     $send_button.toggleClass("disabled-message-send-controls", !is_valid);
+    const send_button_element: ReferenceElement = util.the($send_button);
+    if (send_button_element._tippy?.state.isVisible) {
+        // If the tooltip is displayed, we update tooltip content
+        // and other properties by hiding and showing the tooltip again.
+        send_button_element._tippy.hide();
+        send_button_element._tippy.show();
+    }
 };
 
 export function rewire_validate_and_update_send_button_status(

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -66,6 +66,7 @@ const echo = zrequire("echo");
 const people = zrequire("people");
 const {set_current_user, set_realm} = zrequire("state_data");
 const stream_data = zrequire("stream_data");
+const compose_validate = zrequire("compose_validate");
 const {initialize_user_settings} = zrequire("user_settings");
 
 const realm = {};
@@ -306,6 +307,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         const server_message_id = 127;
         override(markdown, "render", noop);
 
+        override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
         override_rewire(echo, "try_deliver_locally", (message_request) => {
             const local_id_float = 123.04;
             return echo.insert_local_message(message_request, local_id_float, (messages) => {
@@ -637,6 +639,7 @@ test_ui("update_fade", ({override, override_rewire}) => {
     override_rewire(compose_recipient, "update_narrow_to_recipient_visibility", () => {
         update_narrow_to_recipient_visibility_called = true;
     });
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     override_rewire(drafts, "update_compose_draft_count", noop);
     override(compose_pm_pill, "get_user_ids", () => []);
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -8,6 +8,7 @@ const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
 
+const compose_validate = zrequire("compose_validate");
 const user_groups = zrequire("user_groups");
 
 const nobody = {
@@ -153,6 +154,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "blur_compose_inputs", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
@@ -302,6 +304,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     mock_banners();
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     const $elem = $("#send_message_form");
     const $textarea = $("textarea#compose-textarea");
     const $indicator = $("#compose-limit-indicator");
@@ -446,6 +449,7 @@ test("quote_message", ({disallow, override, override_rewire}) => {
 
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     override_private_message_recipient({override});
 
     let selected_message;

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -531,9 +531,10 @@ test_ui("test_stream_posting_permission", ({mock_template, override}) => {
     assert.ok(!banner_rendered);
 });
 
-test_ui("test_check_overflow_text", ({override}) => {
+test_ui("test_check_overflow_text", ({override, override_rewire}) => {
     const fake_compose_box = new FakeComposeBox();
 
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
     override(realm, "max_message_length", 10000);
 
     // RED

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -34,6 +34,7 @@ const compose_ui = zrequire("compose_ui");
 const upload = zrequire("upload");
 const message_lists = mock_esm("../src/message_lists");
 const {set_realm} = zrequire("state_data");
+const compose_validate = zrequire("compose_validate");
 
 const realm = {};
 set_realm(realm);
@@ -248,7 +249,7 @@ test("upload_files", async ({mock_template, override, override_rewire}) => {
         banner_shown = true;
         return "<banner-stub>";
     });
-    override(compose_state, "get_message_type", () => "stream");
+    override_rewire(compose_validate, "validate", () => false);
     await upload.upload_files(uppy, config, files);
     assert.ok($("#compose-send-button").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);
@@ -456,10 +457,11 @@ test("copy_paste", ({override, override_rewire}) => {
     assert.equal(upload_files_called, false);
 });
 
-test("uppy_events", ({override, override_rewire, mock_template}) => {
+test("uppy_events", ({override_rewire, mock_template}) => {
     $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
     override_rewire(compose_ui, "smart_insert_inline", noop);
+    override_rewire(compose_validate, "validate_and_update_send_button_status", noop);
 
     const callbacks = {};
     let state = {};
@@ -518,7 +520,6 @@ test("uppy_events", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
-    override(compose_state, "get_message_type", () => "stream");
     on_upload_success_callback(file, response);
 
     assert.ok(compose_ui_replace_syntax_called);


### PR DESCRIPTION
Compose send tooltip was not correctly displayed when the compose box was in an invalid state.

We significanlty improve the logic for displaying the tooltip here to provide a more robust experience to the user.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.F0.9F.9B.A0.EF.B8.8F.20incorrect.20hover.20behavior.20on.20.22send.22.20button/with/2125622

Things tested:

Empty compose state 

![image](https://github.com/user-attachments/assets/dffe7127-9356-4db0-a9da-588b6412bf2a)

Restore compose content from draft:

![image](https://github.com/user-attachments/assets/e5f9b4ac-10b8-4042-8847-bc0f61c05685)

Recipient change to DM:

![image](https://github.com/user-attachments/assets/49111703-bad1-4283-addd-2793064c9a22)

Not required topics:

![image](https://github.com/user-attachments/assets/c1e56512-8912-4dda-aa7f-ea5de5c95771)

Posting permission:

![image](https://github.com/user-attachments/assets/f6936ba8-2154-4ff7-aeaf-0c973da2e583)

Uploading image:

![image](https://github.com/user-attachments/assets/4ac0f7a0-4bdb-4f36-95fd-9d82ac43d27f)

Empty channel:

![image](https://github.com/user-attachments/assets/a2d23d97-5f0b-4e58-bfd2-7617e2e27df0)

Message length exceeded:

![image](https://github.com/user-attachments/assets/0b0590d9-8013-4d4b-b220-328108c14e2c)
