### PR TITLE
compose: Use info colors for send button.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1177,8 +1177,8 @@ textarea.new_message_textarea {
     border-radius: 4px;
     border: 0;
     margin-bottom: 0;
-    color: var(--color-text-brand-primary-action-button);
-    background-color: var(--color-background-brand-primary-action-button);
+    color: var(--color-text-info-primary-action-button);
+    background-color: var(--color-background-info-primary-action-button);
 
     &:active {
         transition: transform 80ms;
@@ -1193,13 +1193,13 @@ textarea.new_message_textarea {
         border: 1px solid var(--color-compose-send-button-focus-border);
         box-shadow: 0 0 5px var(--color-compose-send-button-focus-shadow);
         background-color: var(
-            --color-background-brand-primary-action-button-active
+            --color-background-info-primary-action-button-active
         );
     }
 
     &:hover {
         background-color: var(
-            --color-background-brand-primary-action-button-hover
+            --color-background-info-primary-action-button-hover
         );
     }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -722,12 +722,12 @@
 .message_edit_save {
     /* Match Save button's basic colors to
        the compose box Send button. */
-    color: var(--color-text-brand-primary-action-button);
-    background-color: var(--color-background-brand-primary-action-button);
+    color: var(--color-text-info-primary-action-button);
+    background-color: var(--color-background-info-primary-action-button);
 
     &:hover {
         background-color: var(
-            --color-background-brand-primary-action-button-hover
+            --color-background-info-primary-action-button-hover
         );
     }
 


### PR DESCRIPTION
Related PR #33989

https://chat.zulip.org/#narrow/channel/101-design/topic/send.20button.20color
![Screenshot from 2025-03-17 22-17-58](https://github.com/user-attachments/assets/9895833a-b4d0-4675-af28-51eb6848d1e6)
![Screenshot from 2025-03-17 22-17-50](https://github.com/user-attachments/assets/b8827594-1bca-43d7-bd17-b9cc98d53d92)
![Screenshot from 2025-03-17 22-21-06](https://github.com/user-attachments/assets/988a2ff4-d4f6-491d-8011-87cc1dc14c97)
![Screenshot from 2025-03-17 22-20-56](https://github.com/user-attachments/assets/7a4fa7ad-832f-449d-a5f9-642b5dc36232)
