### PR TITLE
compose_validate: Fix buggy separated handling of empty compose box.

### DIFF
--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -77,9 +77,7 @@ export function initialize() {
         }
         compose_validate.warn_if_topic_resolved(false);
         const compose_text_length = compose_validate.check_overflow_text($("#send_message_form"));
-        if (compose_text_length !== 0 && $("textarea#compose-textarea").hasClass("invalid")) {
-            $("textarea#compose-textarea").toggleClass("invalid", false);
-        }
+
         // Change compose close button tooltip as per condition.
         // We save compose text in draft only if its length is > 2.
         if (compose_text_length > 2) {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -734,12 +734,12 @@
 .message_edit_save {
     /* Match Save button's basic colors to
        the compose box Send button. */
-    color: var(--color-text-info-primary-action-button);
-    background-color: var(--color-background-info-primary-action-button);
+    color: var(--color-text-brand-primary-action-button);
+    background-color: var(--color-background-brand-primary-action-button);
 
     &:hover {
         background-color: var(
-            --color-background-info-primary-action-button-hover
+            --color-background-brand-primary-action-button-hover
         );
     }
 

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -314,6 +314,9 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     override_private_message_recipient({override});
     mock_template("inline_decorated_stream_name.hbs", false, noop);
 
+    override(realm, "realm_direct_message_permission_group", nobody.id);
+    override(realm, "realm_direct_message_initiator_group", everyone.id);
+
     // Test direct message
     const person = {
         user_id: 22,

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -279,6 +279,8 @@ test_ui("validate", ({mock_template, override}) => {
     assert.ok(compose_validate.validate());
 
     let zephyr_error_rendered = false;
+    // For this first block, we should fail due to empty compose.
+    let expected_invalid_state = true;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         if (data.classname === compose_banner.CLASSNAMES.zephyr_not_running) {
             assert.equal(
@@ -296,14 +298,16 @@ test_ui("validate", ({mock_template, override}) => {
     compose_state.private_message_recipient("welcome-bot@example.com");
     $("textarea#compose-textarea").toggleClass = (classname, value) => {
         assert.equal(classname, "invalid");
-        assert.equal(value, true);
+        assert.equal(value, expected_invalid_state);
     };
     assert.ok(!compose_validate.validate());
     assert.ok(!$("#compose-send-button .loader").visible());
     assert.equal($("#compose-send-button").prop("disabled"), false);
     compose_validate.validate();
 
+    // Now add content to compose, and expect to see the banner.
     add_content_to_compose_box();
+    expected_invalid_state = false;
     let zephyr_checked = false;
     $("#zephyr-mirror-error").is = (arg) => {
         assert.equal(arg, ":visible");


### PR DESCRIPTION
When I adjusted 4fbf91c135cf6267217ebfdc679e95650e722b66 to no longer do a full re-validation on every character typed, that unmasked bugs in how the compose_setup handler code and compose_validate split responsibility for validating 0-length messages.

The user-facing result was the send button not enabling properly when starting to type.

Fix this by moving the 0-length message validation into compose_validate, where we already handle issues of too-long messages, sharing the same basic logic for determining when to do a full validate() call.

A benefit of this reworking is now all of the logic for handling the `invalid` class is in one place in validate, rather than split with the compose_setup module.
