### PR TITLE
search: Improve search-icon layout, spectator alignment.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -81,6 +81,13 @@
 
         #searchbox-input-container {
             width: var(--search-box-width);
+
+            @media (width < $md_min) {
+                grid-template:
+                    "search-icon search-pills" var(--search-box-height)
+                    / var(--search-box-height) 0;
+                column-gap: 0;
+            }
         }
 
         .search-input {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1576,6 +1576,19 @@ div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     }
 }
 
+@media (width < $md_min) {
+    .spectator-view {
+        #navbar-middle {
+            /* = (width of button, square with header) * 3 (number of buttons) */
+            margin-right: calc(var(--header-height) * 3);
+        }
+
+        .header-main .column-right {
+            width: calc(var(--header-height) * 3);
+        }
+    }
+}
+
 %hide-right-sidebar {
     .column-right {
         display: none;


### PR DESCRIPTION
This PR corrects the search-icon grid below 768px so that it doesn't overlap the items in the right column.

In spectator view, this also improves the right-hand alignment of the standalone search icon.

Fixes: #34007

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20navbar.20messed.20up.20for.20spectators/near/2113761)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Spectator, before | Spectator, after |
| --- | --- |
| ![search-icon-spectator-before](https://github.com/user-attachments/assets/3afac6e1-3d03-4960-8468-b6b816ef0e1a) | ![search-icon-spectator-after](https://github.com/user-attachments/assets/4b4fc5df-d988-4187-821c-2ecb23ffbf99) |

| Logged in, before | Logged in, after (no change, but note simplified grid) |
| --- | --- |
| ![search-icon-logged-in-before](https://github.com/user-attachments/assets/b66f94ec-ea96-40b3-af75-433b790bfd97) | ![search-icon-logged-in-after-no-change](https://github.com/user-attachments/assets/6c7cef33-bfda-4461-8def-1229dae72016) |
| ![search-showing-grid-before](https://github.com/user-attachments/assets/31049bc1-2eff-4bf5-a82b-92b070d98463) | ![search-showing-grid-after](https://github.com/user-attachments/assets/62d3de4b-7f29-4c1a-baa6-406c2b1aa25b) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>