### PR TITLE
drafts: Add placeholders when direct message recipients aren't specified.

### DIFF
--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -578,9 +578,10 @@ export type FormattedDraft =
       }
     | {
           is_stream: false;
-          is_dm_with_self: boolean;
+          is_dm_with_self?: boolean;
           draft_id: string;
           recipients: string;
+          has_recipient_data: boolean;
           raw_content: string;
           time_stamp: string;
       };
@@ -654,6 +655,19 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         };
     }
 
+    if (draft.private_message_recipient === "") {
+        // No users were set as DM recipients when the draft was created.
+        return {
+            draft_id: draft.id,
+            is_stream: false,
+            has_recipient_data: false,
+            recipients: "",
+            raw_content: draft.content,
+            time_stamp,
+            ...markdown_data,
+        };
+    }
+
     let is_dm_with_self = false;
     const emails = util.extract_pm_recipients(draft.private_message_recipient);
     if (emails.length === 1) {
@@ -670,6 +684,7 @@ export function format_draft(draft: LocalStorageDraftWithId): FormattedDraft | u
         recipients,
         raw_content: draft.content,
         time_stamp,
+        has_recipient_data: true,
         ...markdown_data,
     };
 }

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -31,7 +31,11 @@
                     {{#if is_dm_with_self}}
                     <span class="private_message_header_name">{{t "You" }}</span>
                     {{else}}
+                    {{#if has_recipient_data}}
                     <span class="private_message_header_name">{{t "You and {recipients}" }}</span>
+                    {{else}}
+                    <em>{{t "No DM recipients" }}</em>
+                    {{/if}}
                     {{/if}}
                 </div>
                 <div class="recipient_row_date">{{ time_stamp }}</div>

--- a/web/tests/drafts.test.cjs
+++ b/web/tests/drafts.test.cjs
@@ -516,6 +516,15 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         is_sending_saving: false,
         drafts_version: 1,
     };
+    const draft_7 = {
+        private_message_recipient: "",
+        reply_to: "",
+        type: "private",
+        content: "Test direct message 4",
+        updatedAt: date(-12),
+        is_sending_saving: false,
+        drafts_version: 1,
+    };
 
     const expected = [
         {
@@ -536,6 +545,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
             draft_id: "id2",
             is_dm_with_self: true,
             is_stream: false,
+            has_recipient_data: true,
             recipients: "Aaron",
             raw_content: "Test direct message",
             time_stamp: "Jan 30",
@@ -545,6 +555,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
             is_dm_with_self: false,
             is_stream: false,
             recipients: "Iago, Zoe",
+            has_recipient_data: true,
             raw_content: "Test direct message 3",
             time_stamp: "Jan 29",
         },
@@ -553,6 +564,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
             is_dm_with_self: false,
             is_stream: false,
             recipients: "Iago",
+            has_recipient_data: true,
             raw_content: "Test direct message 2",
             time_stamp: "Jan 26",
         },
@@ -584,6 +596,14 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
             invite_only: false,
             is_web_public: false,
         },
+        {
+            draft_id: "id7",
+            is_stream: false,
+            has_recipient_data: false,
+            recipients: "",
+            raw_content: "Test direct message 4",
+            time_stamp: "Jan 19",
+        },
     ];
 
     $("#drafts_table").append = noop;
@@ -597,6 +617,7 @@ test("format_drafts", ({override, override_rewire, mock_template}) => {
         id4: draft_4,
         id5: draft_5,
         id6: draft_6,
+        id7: draft_7,
     };
     ls.set("drafts", data);
     assert.deepEqual(draft_model.get(), data);
@@ -720,6 +741,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
             draft_id: "id2",
             is_dm_with_self: true,
             is_stream: false,
+            has_recipient_data: true,
             recipients: "Aaron",
             raw_content: "Test direct message",
             time_stamp: "Jan 30",
@@ -728,6 +750,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
             draft_id: "id5",
             is_dm_with_self: true,
             is_stream: false,
+            has_recipient_data: true,
             recipients: "Aaron",
             raw_content: "Test direct message 3",
             time_stamp: "Jan 29",
@@ -736,6 +759,7 @@ test("filter_drafts", ({override, override_rewire, mock_template}) => {
             draft_id: "id4",
             is_dm_with_self: true,
             is_stream: false,
+            has_recipient_data: true,
             recipients: "Aaron",
             raw_content: "Test direct message 2",
             time_stamp: "Jan 26",


### PR DESCRIPTION
This PR improves the header name for drafts and shows "No DM recipients" as a placeholder when recipients aren't specified.

[czo thread](https://chat.zulip.org/#narrow/channel/101-design/topic/header.20bar.20when.20recipient.20isn't.20fully.20specified)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/eb4bef87-dc31-4220-b14d-c115fd1b6404) | ![After Image](https://github.com/user-attachments/assets/9c939d7d-555b-444d-957c-2bea75bd9075) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
