### PR TITLE
typeahead: Replace code block language hint text with more clear options

### DIFF
--- a/tools/setup/build_pygments_data
+++ b/tools/setup/build_pygments_data
@@ -6,6 +6,7 @@ from pygments.lexers import get_all_lexers
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 # The current priorities data set is based on StackOverflow's 2020 survey.
+# We also prioritize text, quote, math, spoiler over others to enhance UX.
 DATA_PATH = os.path.join(ZULIP_PATH, "tools", "setup", "lang.json")
 OUT_PATH = os.path.join(ZULIP_PATH, "web", "generated", "pygments_data.json")
 

--- a/tools/setup/lang.json
+++ b/tools/setup/lang.json
@@ -1,5 +1,6 @@
 {
     "default": {
+        "text": 31,
         "javascript": 27,
         "python": 26,
         "java": 25,
@@ -30,9 +31,9 @@
     },
     "custom": {
         "latex": 10,
-        "math": 5,
-        "quote": 5,
-        "spoiler": 5
+        "math": 28,
+        "quote": 30,
+        "spoiler": 29
     },
     "aliases": {
         "js": 27,

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -113,6 +113,7 @@ export let render_typeahead_item = (args: {
     topic_object?: TopicSuggestion;
     is_stream_topic?: boolean;
     is_empty_string_topic?: boolean;
+    is_default_language?: boolean;
 }): string => {
     const has_image = args.img_src !== undefined;
     const has_status = args.status_emoji_info !== undefined;
@@ -434,8 +435,15 @@ function retain_unique_language_aliases(matches: string[]): string[] {
 
 export function sort_languages(matches: LanguageSuggestion[], query: string): LanguageSuggestion[] {
     const languages = matches.map((object) => object.language);
+    const default_language = realm.realm_default_code_block_language;
     const results = typeahead.triage(query, languages, (x) => x, compare_language);
-    const unique_languages = retain_unique_language_aliases([...results.matches, ...results.rest]);
+    let language_results;
+    if (default_language && results.matches.includes(default_language)) {
+        language_results = [default_language, ...results.matches, ...results.rest];
+    } else {
+        language_results = [...results.matches, ...results.rest];
+    }
+    const unique_languages = retain_unique_language_aliases(language_results);
     return unique_languages.map((language) => ({
         language,
         type: "syntax",

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2343,6 +2343,7 @@ body:not(.spectator-view) {
     }
 }
 
+.default-language-display,
 .empty-topic-display,
 .empty-topic-placeholder-display::placeholder {
     font-style: italic;

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -26,7 +26,7 @@
 {{else}}
 {{!-- Separate container to ensure overflowing text remains in this container. --}}
 <div class="typeahead-text-container{{#if has_secondary_html}} has_secondary_html{{/if}}">
-    <strong class="typeahead-strong-section{{#if is_empty_string_topic}} empty-topic-display{{/if}}">
+    <strong class="typeahead-strong-section{{#if is_empty_string_topic}} empty-topic-display{{/if}}{{#if is_default_language}} default-language-display{{/if}}">
         {{~#if stream~}}
             {{~> inline_decorated_channel_name stream=stream ~}}
             {{~else~}}

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -2306,7 +2306,10 @@ test("content_highlighter_html", ({override_rewire}) => {
     ct.get_or_set_completing_for_tests("syntax");
     th_render_typeahead_item_called = false;
     override_rewire(typeahead_helper, "render_typeahead_item", (item) => {
-        assert.deepEqual(item, {primary: "py"});
+        assert.deepEqual(item, {
+            is_default_language: false,
+            primary: "py",
+        });
         th_render_typeahead_item_called = true;
     });
     ct.content_highlighter_html({type: "syntax", language: "py"});

--- a/web/tests/realm_playground.test.cjs
+++ b/web/tests/realm_playground.test.cjs
@@ -78,6 +78,10 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     let iterator = candidates.entries();
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
+    assert.equal(iterator.next().value[1], "Text only (text, text)");
+    assert.equal(iterator.next().value[1], "quote (quote, quote)");
+    assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
+    assert.equal(iterator.next().value[1], "math (math, math)");
     assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
     assert.equal(
         iterator.next().value[1],
@@ -96,6 +100,10 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     );
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
+    assert.equal(iterator.next().value[1], "Text only (text, text)");
+    assert.equal(iterator.next().value[1], "quote (quote, quote)");
+    assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
+    assert.equal(iterator.next().value[1], "math (math, math)");
     assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
     assert.equal(
         iterator.next().value[1],
@@ -107,9 +115,7 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     iterator = candidates.entries();
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
     assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
-    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
-    assert.equal(
-        iterator.next().value[1],
-        "Python (python, bazel, py, py3, pyi, python3, sage, starlark, python, bazel, py, py3, pyi, python3, sage, starlark)",
-    );
+    assert.equal(iterator.next().value[1], "Text only (text, text)");
+    assert.equal(iterator.next().value[1], "quote (quote, quote)");
+    assert.equal(iterator.next().value[1], "spoiler (spoiler, spoiler)");
 });

--- a/web/tests/typeahead_helper.test.cjs
+++ b/web/tests/typeahead_helper.test.cjs
@@ -394,12 +394,15 @@ test("sort_streams", ({override, override_rewire}) => {
 
 function language_items(languages) {
     return languages.map((language) => ({
-        type: "syntax",
         language,
+        type: "syntax",
     }));
 }
 
-test("sort_languages", ({override_rewire}) => {
+test("sort_languages", ({override, override_rewire}) => {
+    override(realm, "realm_default_code_block_language", "dart");
+    const default_language = realm.realm_default_code_block_language;
+
     override_rewire(pygments_data, "langs", {
         python: {priority: 26},
         javascript: {priority: 27},
@@ -407,20 +410,52 @@ test("sort_languages", ({override_rewire}) => {
         pascal: {priority: 15},
         perl: {priority: 3},
         css: {priority: 21},
+        spoiler: {priority: 29},
+        text: {priority: 31},
+        quote: {priority: 30},
+        math: {priority: 28},
     });
 
-    let test_langs = language_items(["pascal", "perl", "php", "python", "javascript"]);
+    let test_langs = language_items(["pascal", "perl", "php", "python", "spoiler", "javascript"]);
     test_langs = th.sort_languages(test_langs, "p");
 
     // Sort languages by matching first letter, and then by popularity
-    assert.deepEqual(test_langs, language_items(["python", "php", "pascal", "perl", "javascript"]));
+    assert.deepEqual(
+        test_langs,
+        language_items(["python", "php", "pascal", "perl", "spoiler", "javascript"]),
+    );
 
     // Test if popularity between two languages are the same
     pygments_data.langs.php = {priority: 26};
-    test_langs = language_items(["pascal", "perl", "php", "python", "javascript"]);
+    test_langs = language_items(["pascal", "perl", "php", "python", "spoiler", "javascript"]);
     test_langs = th.sort_languages(test_langs, "p");
 
-    assert.deepEqual(test_langs, language_items(["php", "python", "pascal", "perl", "javascript"]));
+    assert.deepEqual(
+        test_langs,
+        language_items(["php", "python", "pascal", "perl", "spoiler", "javascript"]),
+    );
+
+    test_langs = language_items([
+        default_language,
+        "text",
+        "quote",
+        "math",
+        "python",
+        "javascript",
+    ]);
+    const test_langs_for_default = th.sort_languages(test_langs, "d");
+
+    assert.deepEqual(
+        test_langs_for_default,
+        language_items([default_language, "text", "quote", "math", "javascript", "python"]),
+    );
+
+    test_langs = th.sort_languages(test_langs, "t");
+
+    assert.deepEqual(
+        test_langs,
+        language_items(["text", "quote", "math", "javascript", "python", default_language]),
+    );
 });
 
 test("sort_languages on actual data", () => {


### PR DESCRIPTION
This PR
- Replace the blank option with an italicized option that's the current default language, if there is one selected with "default" label.
- Make the "text" option more informative by adding (no highlighting) to the label.
- Remove the hint for "text".
- Prioritize as left to right, before start typing: blank/default language, text, quote, spoiler, math, everything else...

Note: Since this PR is increasing the rankings of priority languages, we have to run `tools/setup/build_pygments_data` to generate data with new rankings.

fixes: #33682

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![Before Image](https://github.com/user-attachments/assets/2a0a1426-9f64-4f8c-89f7-077af1ad7569) | ![After Image](https://github.com/user-attachments/assets/dce041a1-a957-4805-a88f-cfcce983e94a) |
| ![Before Image](https://github.com/user-attachments/assets/22f3719d-fc2d-427a-93fb-cddb0850225d) | ![After Image](https://github.com/user-attachments/assets/3dd17e71-84c0-4725-8821-9a8a8dea5092) |




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
