### PR TITLE
Fix bugs related to connection error banner.

### DIFF
--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -20,10 +20,14 @@ export function show_button_loading_indicator($button: JQuery): void {
     const $button_loading_indicator = $("<span>")
         .attr("id", loading_indicator_unique_id)
         .addClass("button-loading-indicator");
-    $button.append($button_loading_indicator);
-    loading.make_indicator($button_loading_indicator, {
-        width: $button.width(),
-        height: $button.height(),
+    requestAnimationFrame(() => {
+        // We want this to happen in the same animation frame to
+        // avoid showing a non spinning loading indicator.
+        $button.append($button_loading_indicator);
+        loading.make_indicator($button_loading_indicator, {
+            width: $button.width(),
+            height: $button.height(),
+        });
     });
 }
 

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -394,25 +394,22 @@ export function load_messages(opts: MessageFetchOptions, attempt = 1): void {
         });
     }
 
+    if (load_messages_timeout !== undefined) {
+        clearTimeout(load_messages_timeout);
+    }
+
     void channel.get({
         url: "/json/messages",
         data,
         success(raw_data) {
-            if (load_messages_timeout !== undefined) {
-                clearTimeout(load_messages_timeout);
-            }
             popup_banners.close_connection_error_popup_banner("message_fetch");
             const data = response_schema.parse(raw_data);
             get_messages_success(data, opts);
         },
         error(xhr) {
             if (xhr.status === 400) {
-                // We successfully reached the server, so hide the
-                // connection error notice, even if the request failed
-                // for other reasons.
-                if (load_messages_timeout !== undefined) {
-                    clearTimeout(load_messages_timeout);
-                }
+                // Even though the request failed, we did reach the
+                // server, and can hide the connection error notice.
                 popup_banners.close_connection_error_popup_banner("message_fetch");
             }
 


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Glitchy.20connection.20error.20popup.20banner/with/2122090

Fixes the errors described by @alya here:

- If I press "try now", after that fails, it tells me that the next attempt will be soon/in 5 seconds/etc.. I would expect it to still be in 30 seconds or whatever if that's where we're at in the retry frequency.

- I saw the timer go down to 5 seconds and then just jump to 17 seconds, and then later down to 16 seconds and jumping to 25 seconds. This is after I'd pressed "try now" a few times, so I dunno if the banner was lying to me at that point? (see above)

- Less important, but the spinner seems to freeze for a moment when it first appears. This is if I don't press anything.