### PR TITLE
message: Add acting_user to internal_prep_private_message.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1992,6 +1992,7 @@ def internal_prep_private_message(
     *,
     mention_backend: MentionBackend | None = None,
     disable_external_notifications: bool = False,
+    acting_user: UserProfile | None = None,
 ) -> SendMessageRequest | None:
     """
     See _internal_prep_message for details of how this works.
@@ -2009,6 +2010,7 @@ def internal_prep_private_message(
         content=content,
         mention_backend=mention_backend,
         disable_external_notifications=disable_external_notifications,
+        acting_user=acting_user,
     )
 
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -839,6 +839,7 @@ def send_messages_for_new_subscribers(
                     recipient_user=recipient_user,
                     content=msg,
                     mention_backend=mention_backend,
+                    acting_user=user_profile,
                 )
             )
 

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -311,6 +311,7 @@ def notify_for_user_group_subscription_changes(
                 recipient_user=recipient_user,
                 content=message,
                 mention_backend=mention_backend,
+                acting_user=acting_user,
             )
         )
 


### PR DESCRIPTION
When a user was getting subscribed to a private stream, the stream name was not linkified since acting_user was not passed. We also pass the acting user in user_groups.py, even though it doesn't introduce any behavioural change.
This commit does not attempt to pass acting user in similar message functions and just focuses on fixing the problem of a private stream not being linkified.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
