### PR TITLE
popover_menus: Fix tippy `instance` being undefined.

### DIFF
--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -212,8 +212,10 @@ export const default_popover_props: Partial<tippy.Props> = {
                 phase: "beforeWrite",
                 requires: ["$$tippy"],
                 fn({state}) {
+                    // Since the reference element can be removed from DOM, we rely on popper
+                    // here to access the tippy instance which is reliable.
                     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-                    const instance = (state.elements.reference as tippy.ReferenceElement)._tippy!;
+                    const instance = (state.elements.popper as tippy.PopperElement)._tippy!;
                     const $popover = $(state.elements.popper);
                     const $tippy_box = $popover.find(".tippy-box");
                     // $tippy_box[0].hasAttribute("data-reference-hidden"); is the real check


### PR DESCRIPTION
Since the reference element can be removed from DOM, we rely on `popper` here to access the tippy instance which is reliable.

Reproduced the bug by deleting the user `li` from the right sidebar after opening the user card. Then, scrolling the right sidebar to move the reference position out of view. This might happen in a real environment when an event rerenders the right sidebar.