### PR TITLE
compose: Correct focus-visible styles on Send button.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1192,6 +1192,8 @@ textarea.new_message_textarea {
     &:focus-visible {
         border: 1px solid var(--color-compose-send-button-focus-border);
         box-shadow: 0 0 5px var(--color-compose-send-button-focus-shadow);
+        /* Override default browser ring. */
+        outline: 0;
     }
 
     &:hover {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1192,9 +1192,6 @@ textarea.new_message_textarea {
     &:focus-visible {
         border: 1px solid var(--color-compose-send-button-focus-border);
         box-shadow: 0 0 5px var(--color-compose-send-button-focus-shadow);
-        background-color: var(
-            --color-background-info-primary-action-button-active
-        );
     }
 
     &:hover {


### PR DESCRIPTION
This removes a light-mode-only (effectively) `:focus-visible` color from the Send button. It also specifies `outline: 0` on `:focus-visible`. While that's taken care of in the `:focus` state, this will save us some pain as we move to more uniformly applying the `:focus-visible` pseudoclass to keyboard navigation.

This does not remove the `--color-background-info-primary-action-button-active` variable, as that is used in the button showroom.

[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20keyboard.20selection.20makes.20compose.20button.20darker/near/2126834)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![send-focus-dark-before](https://github.com/user-attachments/assets/485b0eff-2b2f-4969-bab4-ac7f40e7f282) | ![send-focus-dark-after](https://github.com/user-attachments/assets/37c1ce47-a039-48dc-a580-8b8e4f24147f) |
| ![send-focus-light-before](https://github.com/user-attachments/assets/5ff346c5-4a65-4892-b621-4fbd8877afb0) | ![send-focus-light-after](https://github.com/user-attachments/assets/c9822d2a-18b6-40ad-a883-6f7dc3a847d6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>