### PR TITLE
recent_view: Enable avatars and overflow marker to scale.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -307,10 +307,14 @@
 
     .recent_view_participants {
         display: inline-flex; /* Causes LI items to display in row. */
+        /* Keep avatars centered on the line. */
+        vertical-align: middle;
         list-style-type: none;
         margin: auto; /* Centers vertically / horizontally in flex container. */
-        height: 24px;
-        padding: 4px;
+        /* 24px at 16px/1em */
+        height: 1.5em;
+        /* 4px at 16px/1em */
+        padding: 0.25em 4px;
         border-radius: 6px;
         overflow: hidden;
 
@@ -325,11 +329,13 @@
     }
 
     .recent_view_participant_item {
-        height: 24px;
+        /* 24px at 16px/1em */
+        height: 1.5em;
         margin: 0;
         padding: 0 1.5px;
         position: relative;
-        min-width: 24px;
+        /* 24px at 16px/1em */
+        min-width: 1.5em;
         cursor: pointer;
 
         .fa-user {
@@ -340,10 +346,13 @@
     .recent_view_participant_avatar,
     .recent_view_participant_overflow {
         border: 0;
-        border-radius: 6px;
+        /* Keep the rounded corners from ballooning
+           to a circle at smaller font sizes.
+           6px at 16px/1em */
+        border-radius: 0.375em;
         color: var(--color-recent-view-participant-overflow-text);
         display: block;
-        height: 24px;
+        height: 100%;
         text-align: center;
         background-color: var(
             --color-background-recent-view-participant-overflow
@@ -355,7 +364,8 @@
     }
 
     .recent_view_participant_overflow {
-        line-height: 24px;
+        /* 24px at 16px/1em */
+        line-height: 1.5;
     }
 
     & tr {


### PR DESCRIPTION
This PR enables avatars, their vertical padding, and border-radius to scale with the font size.

[CZO discussion](https://chat.zulip.org/#narrow/channel/431-redesign-project/topic/broader.20range.20of.20font.20sizes/near/2127357)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing 12px, 16px, and 20px; note better vertical alignment at the otherwise unchanged 16px:_

| Before | After |
| --- | --- |
| ![recent-avatars-12px-before](https://github.com/user-attachments/assets/883aba2c-14c3-41c7-816c-1e30f51f387e) | ![recent-avatars-12px-after](https://github.com/user-attachments/assets/b38e1dc8-6528-4315-b41f-549b77278cf9) |
| ![recent-avatars-16px-before](https://github.com/user-attachments/assets/f84d911c-e109-423d-b794-33f3c2f90f90) | ![recent-avatars-16px-after](https://github.com/user-attachments/assets/f7afa109-4238-4b82-a6b5-d63c6545da78) |
| ![recent-avatars-20px-before](https://github.com/user-attachments/assets/8c4c68f1-e133-479f-8e60-ebc44308d4fb) | ![recent-avatars-20px-after](https://github.com/user-attachments/assets/f2e69e47-86c9-4345-8540-b9d18909cbff) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
