### PR TITLE
message_history: Improve overlay header.

### DIFF
--- a/web/src/message_edit_history.ts
+++ b/web/src/message_edit_history.ts
@@ -114,11 +114,18 @@ function hide_loading_indicator(): void {
 }
 
 export function fetch_and_render_message_history(message: Message): void {
+    assert(message_lists.current !== undefined);
+    const message_container = message_lists.current.view.message_containers.get(message.id);
+    assert(message_container !== undefined);
     const move_history_only =
         realm.realm_message_edit_history_visibility_policy ===
         message_edit_history_visibility_policy_values.moves_only.code;
     $("#message-edit-history-overlay-container").html(
-        render_message_history_overlay({move_history_only}),
+        render_message_history_overlay({
+            moved: message_container.moved,
+            edited: message_container.edited,
+            move_history_only,
+        }),
     );
     open_overlay();
     show_loading_indicator();

--- a/web/templates/message_history_overlay.hbs
+++ b/web/templates/message_history_overlay.hbs
@@ -5,7 +5,15 @@
                 {{#if move_history_only}}
                 <h1>{{t "Message move history" }}</h1>
                 {{else}}
-                <h1>{{t "Message edit history" }}</h1>
+                {{#if edited}}
+                    {{#if moved}}
+                    <h1>{{t "Message edit and move history" }}</h1>
+                    {{else}}
+                    <h1>{{t "Message edit history" }}</h1>
+                    {{/if}}
+                {{else if moved}}
+                    <h1>{{t "Message move history" }}</h1>
+                {{/if}}
                 {{/if}}
                 <div class="exit">
                     <span class="exit-sign">&times;</span>


### PR DESCRIPTION
The message history overlay header now matches the tooltip of the button used to get there.

Fixes: #34005 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

## Edit only:
| Tooltip | Overlay header |
| --- | --- |
| <img width="361" alt="image" src="https://github.com/user-attachments/assets/31345335-35f3-49e3-afa3-bba4cdc82355" /> | <img width="836" alt="image" src="https://github.com/user-attachments/assets/e384167e-43c9-49d8-bbd7-5af360fa9349" /> |

## Move only:
| Tooltip | Overlay header | 
| --- | --- |
| <img width="382" alt="image" src="https://github.com/user-attachments/assets/7a4c5bde-a0fb-4b47-9e90-4ec06a896aa5" /> | <img width="829" alt="image" src="https://github.com/user-attachments/assets/9bda4e2a-4389-4278-a4f5-38cc5820d0a5" />|

## Edit and move:
| Tooltip | Overlay header |
| --- | --- |
| <img width="417" alt="image" src="https://github.com/user-attachments/assets/ceec5a6d-37eb-47c7-a939-98acf09d2f2c" /> | <img width="832" alt="image" src="https://github.com/user-attachments/assets/dc0ca1d9-14d9-4706-a46c-2050ce89901a" /> |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
