### PR TITLE
compose_validate: Fix topic required error message not shown.

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -762,7 +762,7 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
 
     if (realm.realm_mandatory_topics) {
         const topic = compose_state.topic();
-        const missing_topic = topic === "";
+        const missing_topic = util.is_topic_name_considered_empty(topic);
         set_missing_topic(missing_topic);
         if (missing_topic) {
             report_validation_error(

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -559,8 +559,8 @@ export function is_topic_name_considered_empty(topic: string): boolean {
     // NOTE: Use this check only when realm.realm_mandatory_topics is set to true.
     topic = topic.trim();
     // When the topic is mandatory in a realm via realm_mandatory_topics, the topic
-    // can't be an empty string, "(no topic)", or realm_empty_topic_display_name.
-    if (topic === "" || topic === "(no topic)" || topic === realm.realm_empty_topic_display_name) {
+    // can't be an empty string, "(no topic)", or the displayed topic name for empty string.
+    if (topic === "" || topic === "(no topic)" || topic === get_final_topic_display_name("")) {
         return true;
     }
     return false;

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -33,7 +33,8 @@ mock_esm("../src/group_permission_settings", {
     }),
 });
 
-const realm = {};
+const REALM_EMPTY_TOPIC_DISPLAY_NAME = "general chat";
+const realm = {realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME};
 set_realm(realm);
 const current_user = {};
 set_current_user(current_user);
@@ -343,7 +344,6 @@ test_ui("validate", ({mock_template, override}) => {
     stream_data.add_sub(denmark);
     compose_state.set_stream_id(denmark.stream_id);
     override(realm, "realm_mandatory_topics", true);
-    compose_state.topic("");
     let missing_topic_error_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.topic_missing);
@@ -351,8 +351,13 @@ test_ui("validate", ({mock_template, override}) => {
         missing_topic_error_rendered = true;
         return "<banner-stub>";
     });
-    assert.ok(!compose_validate.validate());
-    assert.ok(missing_topic_error_rendered);
+
+    for (const topic_name of ["", "(no topic)", `translated: ${REALM_EMPTY_TOPIC_DISPLAY_NAME}`]) {
+        compose_state.topic(topic_name);
+        missing_topic_error_rendered = false;
+        assert.ok(!compose_validate.validate());
+        assert.ok(missing_topic_error_rendered);
+    }
 });
 
 test_ui("get_invalid_recipient_emails", ({override, override_rewire}) => {

--- a/web/tests/util.test.cjs
+++ b/web/tests/util.test.cjs
@@ -532,7 +532,7 @@ run_test("get_final_topic_display_name", ({override}) => {
 
 run_test("is_topic_name_considered_empty", ({override}) => {
     // Topic is not considered empty if it is distinct string
-    // other than "(no topic)", or realm_empty_topic_display_name.
+    // other than "(no topic)", or the displayed topic name for empty string.
     assert.ok(!util.is_topic_name_considered_empty("some topic"));
 
     // Topic is considered empty if it is an empty string.
@@ -541,9 +541,10 @@ run_test("is_topic_name_considered_empty", ({override}) => {
     // Topic is considered empty if it is equal to "(no topic)".
     assert.ok(util.is_topic_name_considered_empty("(no topic)"));
 
-    // Topic name is considered empty if it is equal to realm_empty_topic_display_name.
+    // Topic name is considered empty if it is equal to the displayed
+    // topic name for empty string.
     override(realm, "realm_empty_topic_display_name", "general chat");
-    assert.ok(util.is_topic_name_considered_empty("general chat"));
+    assert.ok(util.is_topic_name_considered_empty("translated: general chat"));
 });
 
 run_test("get_retry_backoff_seconds", () => {


### PR DESCRIPTION
With mandatory_topics enabled.

Earlier, sending messages to `"(no topic)"` and `"general chat"` didn't show the "Topics are required in this organization." error message.

The message-send operation used to fail silently.

This PR fixes the bug.

<img width="907" alt="Screenshot 2025-03-18 at 8 25 31 PM" src="https://github.com/user-attachments/assets/12fc98d7-4dfb-498d-b32d-1b8f4784cf49" />

<img width="909" alt="Screenshot 2025-03-18 at 8 25 07 PM" src="https://github.com/user-attachments/assets/a9e6f3a1-1bcf-4985-be79-cf2633738a06" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

