### PR TITLE
Overflowing compose button

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -506,9 +506,9 @@
     grid-area: message-formatting-controls-container;
     border-radius: 0 0 3px 3px;
     background-color: var(--color-message-formatting-controls-container);
-    /* margin on either side to let the border of
-       .message-content-container show through. */
-    margin: 0 1px;
+    border: 1px solid var(--color-message-content-container-border);
+    border-top: none;
+    border-bottom: none;
 }
 
 .compose-scrolling-buttons-container {


### PR DESCRIPTION
This PR fixes the overflowing icon in compose box as reported in [#issues > ❓buttons spilling out of compose box when zoomed out](https://chat.zulip.org/#narrow/channel/9-issues/topic/.E2.9D.93buttons.20spilling.20out.20of.20compose.20box.20when.20zoomed.20out/with/2128249) which occurs due to issues in border and margin.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

|Before|After|
|----------|-------|
|![image](https://github.com/user-attachments/assets/c1fbac86-f341-4a8b-a68c-2cc8d93ea1ba)|![image](https://github.com/user-attachments/assets/5d5b815e-7b9f-4de6-bbae-07df53e54be3)|


[CZO discussion](https://chat.zulip.org/#narrow/channel/9-issues/topic/.E2.9D.93buttons.20spilling.20out.20of.20compose.20box.20when.20zoomed.20out/with/2128249)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
