### PR TITLE
realm_export: Support up to 20GB of data via the UI.

### DIFF
--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -302,10 +302,10 @@ class RealmExportTest(ZulipTestCase):
             subgroup="public_stream",
         )
 
-        # Space limit is set as 10 GiB
+        # Space limit is set as 20 GiB
         with patch(
             "zerver.models.Realm.currently_used_upload_space_bytes",
-            return_value=11 * 1024 * 1024 * 1024,
+            return_value=21 * 1024 * 1024 * 1024,
         ):
             result = self.client_post("/json/export/realm")
         self.assert_json_error(

--- a/zerver/views/realm_export.py
+++ b/zerver/views/realm_export.py
@@ -46,7 +46,7 @@ def export_realm(
     #
     # It's very possible that higher limits would be completely safe.
     MAX_MESSAGE_HISTORY = 250000
-    MAX_UPLOAD_QUOTA = 10 * 1024 * 1024 * 1024
+    MAX_UPLOAD_QUOTA = 20 * 1024 * 1024 * 1024
 
     # Filter based upon the number of events that have occurred in the delta
     # If we are at the limit, the incoming request is rejected


### PR DESCRIPTION
We have not see noticeable impact due to export size.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
