### PR TITLE
settings: Update save and discard buttons to redesigned button styles.

### DIFF
--- a/web/src/banners.ts
+++ b/web/src/banners.ts
@@ -3,15 +3,8 @@ import $ from "jquery";
 
 import render_banner from "../templates/components/banner.hbs";
 
-type ComponentIntent = "neutral" | "brand" | "info" | "success" | "warning" | "danger";
-
-type ActionButton = {
-    attention: "primary" | "quiet" | "borderless";
-    intent?: ComponentIntent;
-    label: string;
-    icon?: string;
-    custom_classes?: string;
-};
+import type {ActionButton} from "./buttons.ts";
+import type {ComponentIntent} from "./types.ts";
 
 export type Banner = {
     intent: ComponentIntent;

--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -1,6 +1,19 @@
 import $ from "jquery";
 
 import * as loading from "./loading.ts";
+import type {ComponentIntent} from "./types.ts";
+
+export const ACTION_BUTTON_ATTENTION_VALUES = ["primary", "quiet", "borderless"] as const;
+
+export type ActionButtonAttention = (typeof ACTION_BUTTON_ATTENTION_VALUES)[number];
+
+export type ActionButton = {
+    attention: ActionButtonAttention;
+    intent?: ComponentIntent;
+    label: string;
+    icon?: string;
+    custom_classes?: string;
+};
 
 let loading_indicator_count = 0;
 export function show_button_loading_indicator($button: JQuery): void {

--- a/web/src/buttons.ts
+++ b/web/src/buttons.ts
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import * as loading from "./loading.ts";
+import {COMPONENT_INTENT_VALUES} from "./types.ts";
 import type {ComponentIntent} from "./types.ts";
 
 export const ACTION_BUTTON_ATTENTION_VALUES = ["primary", "quiet", "borderless"] as const;
@@ -49,4 +50,33 @@ export function hide_button_loading_indicator($button: JQuery): void {
     $button.prop("disabled", false);
     $button.find(".zulip-icon").css("visibility", "visible");
     $button.find(".action-button-label").css("visibility", "visible");
+}
+
+export function modify_action_button_style(
+    $button: JQuery,
+    opts: {
+        attention?: ActionButtonAttention;
+        intent?: ComponentIntent;
+    },
+): void {
+    if (opts.attention === undefined && opts.intent === undefined) {
+        // If neither attention nor intent is provided, do nothing.
+        return;
+    }
+    const action_button_attention_pattern = ACTION_BUTTON_ATTENTION_VALUES.join("|");
+    const component_intent_pattern = COMPONENT_INTENT_VALUES.join("|");
+    const action_button_style_regex = new RegExp(
+        `action-button-(${action_button_attention_pattern})-(${component_intent_pattern})`,
+    );
+    const action_button_style_regex_match = $button.attr("class")?.match(action_button_style_regex);
+    if (!action_button_style_regex_match) {
+        // If the button doesn't have the expected class, do nothing.
+        return;
+    }
+    const [action_button_style_class, old_attention, old_intent] = action_button_style_regex_match;
+    // Replace the old attention and intent values with the new ones, if provided.
+    $button.removeClass(action_button_style_class);
+    $button.addClass(
+        `action-button-${opts.attention ?? old_attention}-${opts.intent ?? old_intent}`,
+    );
 }

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -557,19 +557,17 @@ export function change_save_button_state($element: JQuery, state: string): void 
         return;
     }
 
-    let button_text;
+    let button_text = $t({defaultMessage: "Save changes"});
     let data_status;
     let is_show;
     switch (state) {
         case "unsaved":
-            button_text = $t({defaultMessage: "Save changes"});
             data_status = "unsaved";
             is_show = true;
 
             $element.find(".discard-button").show();
             break;
         case "saved":
-            button_text = $t({defaultMessage: "Save changes"});
             data_status = "";
             is_show = false;
             break;
@@ -584,7 +582,6 @@ export function change_save_button_state($element: JQuery, state: string): void 
             buttons.show_button_loading_indicator($save_button);
             break;
         case "failed":
-            button_text = $t({defaultMessage: "Save changes"});
             data_status = "failed";
             is_show = true;
             break;
@@ -595,9 +592,23 @@ export function change_save_button_state($element: JQuery, state: string): void 
             break;
     }
 
-    if (button_text !== undefined) {
+    requestAnimationFrame(() => {
+        // We need to use requestAnimationFrame to ensure that the
+        // button text and style are updated in the same frame.
         $textEl.text(button_text);
-    }
+        if (state === "succeeded") {
+            buttons.modify_action_button_style($save_button, {
+                attention: "borderless",
+                intent: "success",
+            });
+        } else {
+            buttons.modify_action_button_style($save_button, {
+                attention: "primary",
+                intent: "brand",
+            });
+        }
+    });
+
     assert(data_status !== undefined);
     $save_button.attr("data-status", data_status);
     if (state === "unsaved") {

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -7,6 +7,7 @@ import {z} from "zod";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 
 import * as blueslip from "./blueslip.ts";
+import * as buttons from "./buttons.ts";
 import * as compose_banner from "./compose_banner.ts";
 import type {DropdownWidget} from "./dropdown_widget.ts";
 import * as group_permission_settings from "./group_permission_settings.ts";
@@ -538,10 +539,10 @@ export function change_save_button_state($element: JQuery, state: string): void 
     }
 
     const $save_button = $element.find(".save-button");
-    const $textEl = $save_button.find(".save-discard-widget-button-text");
+    const $textEl = $save_button.find(".action-button-label");
 
     if (state !== "saving") {
-        $save_button.removeClass("saving");
+        buttons.hide_button_loading_indicator($save_button);
     }
 
     if (state === "discarded") {
@@ -573,12 +574,14 @@ export function change_save_button_state($element: JQuery, state: string): void 
             is_show = false;
             break;
         case "saving":
-            button_text = $t({defaultMessage: "Saving"});
+            // We don't change the button text on the saving
+            // state to avoid changing the button size while
+            // we show the loading indicator.
             data_status = "saving";
             is_show = true;
 
             $element.find(".discard-button").hide();
-            $save_button.addClass("saving");
+            buttons.show_button_loading_indicator($save_button);
             break;
         case "failed":
             button_text = $t({defaultMessage: "Save changes"});
@@ -592,8 +595,9 @@ export function change_save_button_state($element: JQuery, state: string): void 
             break;
     }
 
-    assert(button_text !== undefined);
-    $textEl.text(button_text);
+    if (button_text !== undefined) {
+        $textEl.text(button_text);
+    }
     assert(data_status !== undefined);
     $save_button.attr("data-status", data_status);
     if (state === "unsaved") {

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -541,20 +541,27 @@ export function change_save_button_state($element: JQuery, state: string): void 
     const $save_button = $element.find(".save-button");
     const $textEl = $save_button.find(".action-button-label");
 
-    if (state !== "saving") {
-        buttons.hide_button_loading_indicator($save_button);
-    }
-
     if (state === "discarded") {
-        let hide_delay = 0;
-        if ($save_button.attr("data-status") === "saved") {
-            // Keep saved button displayed a little longer.
-            hide_delay = 500;
+        if (
+            // When the save button is in the "saving" or "saved" state,
+            // we don't want the realm sync settings logic to hide the
+            // save discard widget before the success callback could show the
+            // "saved" state in the button.  Moreover, the visibility of the
+            // save discard widget will be handled by either the "succeeded"
+            // or the "failed" state after the request is complete.
+            $save_button.attr("data-status") === "saved" ||
+            $save_button.attr("data-status") === "saving"
+        ) {
+            return;
         }
-        show_hide_element($element, false, hide_delay, () => {
+        show_hide_element($element, false, 0, () => {
             enable_or_disable_save_button($element.closest(".settings-subsection-parent"));
         });
         return;
+    }
+
+    if (state !== "saving") {
+        buttons.hide_button_loading_indicator($save_button);
     }
 
     let button_text = $t({defaultMessage: "Save changes"});

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -574,10 +574,6 @@ export function change_save_button_state($element: JQuery, state: string): void 
 
             $element.find(".discard-button").show();
             break;
-        case "saved":
-            data_status = "";
-            is_show = false;
-            break;
         case "saving":
             // We don't change the button text on the saving
             // state to avoid changing the button size while

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1024,7 +1024,6 @@ export function save_organization_settings(
     data: Record<string, string | number | boolean>,
     $save_button: JQuery,
     patch_url: string,
-    success_continuation: (() => void) | undefined = undefined,
 ): void {
     const $subsection_parent = $save_button.closest(".settings-subsection-parent");
     const $save_button_container = $subsection_parent.find(".save-button-controls");
@@ -1036,9 +1035,6 @@ export function save_organization_settings(
         success() {
             $failed_alert_elem.hide();
             settings_components.change_save_button_state($save_button_container, "succeeded");
-            if (success_continuation !== undefined) {
-                success_continuation();
-            }
         },
         error(xhr) {
             settings_components.change_save_button_state($save_button_container, "failed");
@@ -1262,7 +1258,6 @@ export function register_save_discard_widget_handlers(
             const $save_button = $(this);
             const $subsection_elem = $save_button.closest(".settings-subsection-parent");
             let data: Record<string, string | number | boolean>;
-            let success_continuation;
             if (!for_realm_default_settings) {
                 data =
                     settings_components.populate_data_for_realm_settings_request($subsection_elem);
@@ -1272,7 +1267,7 @@ export function register_save_discard_widget_handlers(
                         $subsection_elem,
                     );
             }
-            save_organization_settings(data, $save_button, patch_url, success_continuation);
+            save_organization_settings(data, $save_button, patch_url);
         },
     );
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -16,3 +16,14 @@ export const anonymous_group_schema = z.object({
 });
 
 export const group_setting_value_schema = z.union([z.number(), anonymous_group_schema]);
+
+export const COMPONENT_INTENT_VALUES = [
+    "neutral",
+    "brand",
+    "info",
+    "success",
+    "warning",
+    "danger",
+] as const;
+
+export type ComponentIntent = (typeof COMPONENT_INTENT_VALUES)[number];

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -52,11 +52,6 @@ kbd {
     .hide-sm {
         display: none !important;
     }
-
-    #settings_page .save-button-controls {
-        display: block;
-        margin: 10px 0 0;
-    }
 }
 
 .light {
@@ -889,79 +884,10 @@ input.settings_text_input {
     display: flex;
     margin: 0.2857em 0.5714em; /* 4px 8px at 14px/em */
     align-items: center;
+    gap: 5px;
 
     &.hide {
         display: none;
-    }
-
-    .save-discard-widget-button {
-        border-radius: 5px;
-        border: 1px solid hsl(0deg 0% 80%);
-        text-decoration: none;
-        color: hsl(0deg 0% 47%);
-        min-width: 5.7142em; /* 80px at 14px/em */
-        display: flex;
-        align-items: center;
-        height: 1.8429em; /* 25.8px at 14px/em */
-
-        &:hover,
-        &:focus {
-            border: 1px solid hsl(0deg 0% 61%);
-
-            .discard-button.save-discard-widget-button-text {
-                color: hsl(0deg 0% 18%);
-            }
-        }
-
-        &.primary {
-            background-color: hsl(156deg 30% 50%);
-            color: hsl(0deg 0% 100%);
-            border: 1px solid hsl(155deg 30% 50%);
-
-            &:hover,
-            &:focus {
-                background-color: hsl(166deg 35% 57%);
-                border: 1px solid hsl(166deg 35% 57%);
-            }
-
-            .save-discard-widget-button-icon {
-                font-weight: 400;
-                color: hsl(0deg 0% 100%);
-            }
-
-            &.saving {
-                background-color: hsl(156deg 14% 40%);
-                border-color: hsl(156deg 14% 40%);
-                display: flex;
-            }
-        }
-
-        &.save-button {
-            margin-right: 5px;
-
-            .save-discard-widget-button-loading {
-                display: none;
-            }
-
-            &.saving {
-                .save-discard-widget-button-icon {
-                    display: none;
-                }
-
-                .save-discard-widget-button-loading {
-                    display: block;
-                    margin-right: 0.5em; /* 7px at 14px/em */
-                }
-            }
-        }
-
-        .save-discard-widget-button-icon {
-            margin-right: 3px;
-            font-size: 1.0714em; /* 15px at 14px/em */
-            font-weight: 400;
-            display: flex;
-            align-items: center;
-        }
     }
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -885,6 +885,10 @@ input.settings_text_input {
     &.hide {
         display: none;
     }
+
+    .save-button[data-status="saved"] {
+        pointer-events: none;
+    }
 }
 
 .stream-privacy-type-icon {

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -869,22 +869,18 @@ input.settings_text_input {
     }
 }
 
-#stream_settings,
-#settings_page,
-#user_group_settings {
-    .subsection-header {
-        display: flex;
-        flex-wrap: wrap;
-    }
+.subsection-header {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0.2857em 0;
+    gap: 0 0.625em; /* 10px at 16px em */
+    align-items: center;
 }
 
-#stream_settings .save-button-controls,
-#settings_page .save-button-controls,
-#user_group_settings .save-button-controls {
+.save-button-controls {
     display: flex;
-    margin: 0.2857em 0.5714em; /* 4px 8px at 14px/em */
     align-items: center;
-    gap: 5px;
+    gap: 0.3125em; /* 5px at 16px em */
 
     &.hide {
         display: none;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -791,20 +791,6 @@
         }
     }
 
-    #settings_page,
-    #stream_settings,
-    #user_group_settings {
-        .save-button-controls .discard-button {
-            color: hsl(0deg 0% 80%);
-
-            &:hover {
-                .save-discard-widget-button-text {
-                    color: hsl(0deg 0% 100%);
-                }
-            }
-        }
-    }
-
     .help_link_widget:hover {
         color: inherit;
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -255,21 +255,10 @@ h3,
         font-size: 0.8571em; /* 12px at 14px/em */
         font-weight: 400;
         vertical-align: middle;
-        line-height: 1.6667em; /* 20px at 12px/em */
+        line-height: inherit;
         display: inline-block;
         float: none;
         margin-top: 9px;
-    }
-
-    /* Don't apply these styling to the loading indicator inside the
-       action buttons, as the required CSS for them is already defined
-       in buttons.css */
-    .loading_indicator_spinner:not(.action-button .loading_indicator_spinner) {
-        width: 30%;
-        height: 1.4286em; /* 20px at 14px/em */
-        margin-top: 7px;
-        vertical-align: middle;
-        display: inline-block;
     }
 
     .inline {
@@ -601,8 +590,6 @@ input[type="checkbox"] {
     overflow-wrap: anywhere;
     background-color: transparent;
     border-radius: 4px;
-    margin-top: 14px;
-    margin-left: 10px;
     color: hsl(156deg 30% 50%);
     padding: 3px 10px;
 
@@ -639,8 +626,6 @@ input[type="checkbox"] {
 
     & img {
         margin-right: 6px;
-        vertical-align: middle;
-        margin-top: -2px;
     }
 
     .settings-save-checkmark {
@@ -2133,8 +2118,7 @@ label.preferences-radio-choice-label {
     }
 
     .alert-notification {
-        margin-top: auto;
-        margin-bottom: 12px;
+        margin-left: 10px;
         margin-right: auto;
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -507,13 +507,10 @@ input[type="checkbox"] {
 
 .advanced-configurations-container {
     .advance-config-title-container {
-        display: flex;
-        align-items: center;
         cursor: pointer;
-        flex-wrap: wrap;
 
         .stream_setting_subsection_title {
-            margin: 4px 8px;
+            margin: 4px 0;
         }
 
         .toggle-advanced-configurations-icon {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -261,7 +261,10 @@ h3,
         margin-top: 9px;
     }
 
-    .loading_indicator_spinner {
+    /* Don't apply these styling to the loading indicator inside the
+       action buttons, as the required CSS for them is already defined
+       in buttons.css */
+    .loading_indicator_spinner:not(.action-button .loading_indicator_spinner) {
         width: 30%;
         height: 1.4286em; /* 20px at 14px/em */
         margin-top: 7px;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -122,7 +122,7 @@ h3.user_group_setting_subsection_title {
     font-size: 1.5em;
     font-weight: normal;
     line-height: 1.5;
-    margin: 4px 15px 4px 0;
+    margin: 4px 0;
 }
 
 h4.stream_setting_subsection_title {
@@ -135,8 +135,6 @@ h4.user_group_setting_subsection_title {
     font-size: 1.35em;
     font-weight: normal;
     line-height: 1.5;
-    /* Matches right margin on h3 subsection titles */
-    margin-right: 15px;
 }
 
 .member-list-box,
@@ -306,8 +304,6 @@ h4.user_group_setting_subsection_title {
 
 .group-assigned-permissions {
     .subsection-header {
-        display: inline;
-
         h3 {
             font-size: 1.5em;
             font-weight: normal;
@@ -1545,15 +1541,6 @@ div.settings-radio-input-parent {
             display: block;
             max-width: max-content;
             white-space: nowrap;
-        }
-
-        .save-button-controls {
-            display: block;
-            margin: 0 0 10px;
-
-            &.hide {
-                display: none;
-            }
         }
     }
 }

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -91,8 +91,10 @@
         </div>
 
         <div id="privacy_settings_box">
-            <h3 class="inline-block">{{t "Privacy" }}</h3>
-            <div class="alert-notification privacy-setting-status"></div>
+            <div class="subsection-header">
+                <h3 class="inline-block">{{t "Privacy" }}</h3>
+                <div class="alert-notification privacy-setting-status"></div>
+            </div>
             <div class="input-group">
                 {{> settings_checkbox
                   setting_name="send_private_typing_notifications"

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -1,6 +1,6 @@
 <form class="notification-settings-form">
     <div class="general_notifications {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3>{{t "Notification triggers" }}</h3>
             {{> settings_save_discard_widget section_name="general-notify-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
@@ -55,7 +55,7 @@
 
     <div class="topic_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3>{{t "Topic notifications" }}
                 {{> ../help_link_widget link="/help/topic-notifications" }}
             </h3>
@@ -100,7 +100,7 @@
 
     <div class="desktop_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3>{{t "Desktop message notifications" }}
                 {{> ../help_link_widget link="/help/desktop-notifications" }}
             </h3>
@@ -148,7 +148,7 @@
 
     <div class="mobile_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3>{{t "Mobile message notifications" }}
                 {{> ../help_link_widget link="/help/mobile-notifications" }}
             </h3>
@@ -175,7 +175,7 @@
 
     <div class="email_message_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3>{{t "Email message notifications" }}
                 {{> ../help_link_widget link="/help/email-notifications" }}
             </h3>
@@ -224,7 +224,7 @@
 
     <div class="other_email_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3>{{t "Other emails" }}</h3>
             {{> settings_save_discard_widget section_name="other-emails-settings" show_only_indicator=(not for_realm_settings) }}
         </div>

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -11,7 +11,7 @@
     {{> notification_settings . prefix="realm_" for_realm_settings=true}}
 
     <div class="privacy_settings settings-subsection-parent">
-        <div class="subsection-header inline-block">
+        <div class="subsection-header">
             <h3 class="inline-block">{{t "Privacy settings" }}</h3>
             {{> settings_save_discard_widget section_name="privacy-setting" show_only_indicator=false }}
         </div>

--- a/web/templates/settings/preferences_general.hbs
+++ b/web/templates/settings/preferences_general.hbs
@@ -1,7 +1,7 @@
 <div class="general-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
     <!-- this is inline block so that the alert notification can sit beside
     it. If there's not an alert, don't make it inline-block.-->
-    <div class="subsection-header inline-block">
+    <div class="subsection-header">
         <h3>{{t "General" }}</h3>
         {{> settings_save_discard_widget section_name="general-settings" show_only_indicator=(not for_realm_settings) }}
     </div>

--- a/web/templates/settings/settings_save_discard_widget.hbs
+++ b/web/templates/settings/settings_save_discard_widget.hbs
@@ -1,21 +1,10 @@
 {{#unless show_only_indicator}}
 <div class="save-button-controls hide">
     <div class="inline-block subsection-changes-save">
-        <button class="save-discard-widget-button button primary save-button" data-status="save">
-            <span class="fa fa-spinner fa-spin save-discard-widget-button-loading"></span>
-            <span class="fa fa-check save-discard-widget-button-icon"></span>
-            <span class="save-discard-widget-button-text">
-                {{t 'Save changes' }}
-            </span>
-        </button>
+        {{> ../components/action_button custom_classes="save-button" attention="primary" intent="brand" label=(t "Save changes") }}
     </div>
     <div class="inline-block subsection-changes-discard">
-        <button class="save-discard-widget-button button discard-button">
-            <span class="fa fa-times save-discard-widget-button-icon"></span>
-            <span class="save-discard-widget-button-text">
-                {{t 'Discard' }}
-            </span>
-        </button>
+        {{> ../components/action_button custom_classes="discard-button" attention="quiet" intent="neutral" label=(t "Discard") }}
     </div>
     <div class="inline-block subsection-failed-status"><p class="hide"></p></div>
 </div>

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -189,12 +189,6 @@ function test_change_save_button_state() {
         assert.equal(props.hidden, true);
     }
     {
-        settings_components.change_save_button_state($save_button_controls, "saved");
-        assert.equal($save_button_text.text(), "translated: Save changes");
-        assert.equal(props.hidden, true);
-        assert.equal($save_button.attr("data-status"), "");
-    }
-    {
         settings_components.change_save_button_state($save_button_controls, "saving");
         assert.equal($save_button.attr("data-status"), "saving");
         assert.equal($discard_button.visible(), false);

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -185,6 +185,10 @@ function test_change_save_button_state() {
         assert.equal($discard_button.visible(), true);
     }
     {
+        settings_components.change_save_button_state($save_button_controls, "discarded");
+        assert.equal(props.hidden, true);
+    }
+    {
         settings_components.change_save_button_state($save_button_controls, "saved");
         assert.equal($save_button_text.text(), "translated: Save changes");
         assert.equal(props.hidden, true);
@@ -196,8 +200,9 @@ function test_change_save_button_state() {
         assert.equal($discard_button.visible(), false);
     }
     {
+        // The "discarded" state should not interfere during the saving stage.
         settings_components.change_save_button_state($save_button_controls, "discarded");
-        assert.equal(props.hidden, true);
+        assert.equal(props.hidden, false);
     }
     {
         settings_components.change_save_button_state($save_button_controls, "succeeded");

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -16,6 +16,10 @@ mock_esm("../src/loading", {
     make_indicator: noop,
     destroy_indicator: noop,
 });
+mock_esm("../src/buttons", {
+    show_button_loading_indicator: noop,
+    hide_button_loading_indicator: noop,
+});
 mock_esm("../src/scroll_util", {scroll_element_into_container: noop});
 set_global("document", "document-stub");
 
@@ -59,16 +63,16 @@ test("unloaded", () => {
 function createSaveButtons(subsection) {
     const $stub_save_button_header = $(`#org-${CSS.escape(subsection)}`);
     const $save_button_controls = $(".save-button-controls");
-    const $stub_save_button = $(".save-discard-widget-button.save-button");
-    const $stub_discard_button = $(".save-discard-widget-button.discard-button");
-    const $stub_save_button_text = $(".save-discard-widget-button-text");
+    const $stub_save_button = $(".save-button");
+    const $stub_discard_button = $(".discard-button");
+    const $stub_save_button_text = $(".action-button-label");
     $stub_save_button_header.set_find_results(
         ".subsection-failed-status p",
         $("<failed-status-stub>"),
     );
     $stub_save_button.closest = () => $stub_save_button_header;
     $save_button_controls.set_find_results(".save-button", $stub_save_button);
-    $stub_save_button.set_find_results(".save-discard-widget-button-text", $stub_save_button_text);
+    $stub_save_button.set_find_results(".action-button-label", $stub_save_button_text);
     $stub_save_button_header.set_find_results(".save-button-controls", $save_button_controls);
     $stub_save_button_header.set_find_results(
         ".subsection-changes-discard button",
@@ -144,7 +148,7 @@ function test_submit_settings_form(override, submit_form) {
     $subsection_elem = $(`#org-${CSS.escape(subsection)}`);
     $subsection_elem.set_find_results(".prop-element", [$realm_default_language_elem]);
 
-    submit_form.call({to_$: () => $(".save-discard-widget-button.save-button")}, ev);
+    submit_form.call({to_$: () => $(".save-button")}, ev);
     assert.ok(patched);
 
     const expected_value = {
@@ -185,9 +189,7 @@ function test_change_save_button_state() {
     }
     {
         settings_components.change_save_button_state($save_button_controls, "saving");
-        assert.equal($save_button_text.text(), "translated: Saving");
         assert.equal($save_button.attr("data-status"), "saving");
-        assert.equal($save_button.hasClass("saving"), true);
         assert.equal($discard_button.visible(), false);
     }
     {
@@ -402,7 +404,7 @@ function test_discard_changes_button({override}, discard_changes) {
 
     $discard_button_parent.set_find_results(".save-button-controls", $save_button_controls);
 
-    discard_changes.call({to_$: () => $(".save-discard-widget-button.discard-button")}, ev);
+    discard_changes.call({to_$: () => $(".discard-button")}, ev);
 
     assert.equal(
         $message_edit_history_visibility_policy.val(),

--- a/web/tests/settings_org.test.cjs
+++ b/web/tests/settings_org.test.cjs
@@ -19,9 +19,12 @@ mock_esm("../src/loading", {
 mock_esm("../src/buttons", {
     show_button_loading_indicator: noop,
     hide_button_loading_indicator: noop,
+    modify_action_button_style: noop,
 });
 mock_esm("../src/scroll_util", {scroll_element_into_container: noop});
 set_global("document", "document-stub");
+
+set_global("requestAnimationFrame", (func) => func());
 
 const settings_account = zrequire("settings_account");
 const settings_components = zrequire("settings_components");


### PR DESCRIPTION
This PR updates the save and discard buttons in the setting modals to use redesigned button styles along with the new loading indicator.

Fixes: [#issues > 🎯 save/discard buttons misaligned on some browsers @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20save.2Fdiscard.20buttons.20misaligned.20on.20some.20browsers/near/2124637)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-20 at 2 55 42 AM](https://github.com/user-attachments/assets/bc0ba408-32b5-4c17-afc5-f7c4bd047a1c) | ![Screenshot 2025-03-20 at 2 54 44 AM](https://github.com/user-attachments/assets/77393ef1-517e-4607-925a-d7543bfb641c) |
| ![Screenshot 2025-03-20 at 2 56 15 AM](https://github.com/user-attachments/assets/5658a59b-d256-4ad7-a234-3544d373f5b2) | ![Screenshot 2025-03-20 at 12 19 05 AM](https://github.com/user-attachments/assets/300d3a58-0a59-49de-b7d3-4a4b95cc8934) |
| ![Screenshot 2025-03-20 at 2 57 11 AM](https://github.com/user-attachments/assets/3a7189fd-14f5-4a6e-beb1-bdcf0cbf994b) | ![Screenshot 2025-03-20 at 12 18 25 AM](https://github.com/user-attachments/assets/9bebf637-75e4-414e-ba47-be1b6ede7eac) | 

**Responsiveness and loading indicator**
| Before | After |
|--------|--------|
| ![save_discard_button_resp_before](https://github.com/user-attachments/assets/6846a176-2b13-450e-aeb7-6a0d00bdc918) | ![save_discard_button_resp_after](https://github.com/user-attachments/assets/cb60eee0-04f3-432f-8b7b-40c26590c759) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
