### PR TITLE
models: Change default for can_resolve_topic_group.

### DIFF
--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -847,7 +847,7 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
             allow_internet_group=False,
             allow_nobody_group=True,
             allow_everyone_group=True,
-            default_group_name=SystemGroups.MEMBERS,
+            default_group_name=SystemGroups.EVERYONE,
         ),
         can_summarize_topics_group=GroupPermissionSetting(
             require_system_group=False,


### PR DESCRIPTION
It's not obvious why this should be different from the permission for moving topics.
