### PR TITLE
home: Fix compose box not visible on focus in Firefox Android.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -7,7 +7,12 @@
 {% set PAGE_DESCRIPTION = _("Browse the publicly accessible channels in {org_name} without logging in.").format(org_name=realm_name)  %}
 
 {% block meta_viewport %}
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<!-- From version 132, Firefox now defaults to not resize the viewport
+content but only the visual viewport. While this works well in
+Chrome Android, it creates a buggy experience in Firefox Android
+where the compose box is hidden under keyboard. To fix it, we rollback
+to resizing content when keyboard is shown on Firefox Android. -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no {% if is_firefox_android %}, interactive-widget=resizes-content{% endif %}" />
 {% endblock %}
 
 {% block customhead %}

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -244,6 +244,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
     csp_nonce = secrets.token_hex(24)
 
     user_permission_info = get_user_permission_info(user_profile)
+    is_firefox_android = "Firefox" in client_user_agent and "Android" in client_user_agent
 
     response = render(
         request,
@@ -254,6 +255,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
             "csp_nonce": csp_nonce,
             "color_scheme": user_permission_info.color_scheme,
             "enable_gravatar": settings.ENABLE_GRAVATAR,
+            "is_firefox_android": is_firefox_android,
             "s3_avatar_public_url_prefix": settings.S3_AVATAR_PUBLIC_URL_PREFIX
             if settings.LOCAL_UPLOADS_DIR is None
             else "",


### PR DESCRIPTION
Fixes #34010

From version 132, Firefox now defaults to not resize the viewport content but only the visual viewport. While this works well in Chrome Android, it creates a buggy experience in Firefox Android where the compose box is hidden under keyboard.

To fix it, we rollback to resizing content when keyboard is shown on Firefox Android.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20Keyboard.20hides.20composebox.20on.20mobile.20web.20on.20Firefox/with/2124110
