### PR TITLE
notification_settings: Fix the misalignment of topic notification header.

### DIFF
--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -60,14 +60,14 @@
                 {{> ../help_link_widget link="/help/topic-notifications" }}
             </h3>
             {{> settings_save_discard_widget section_name="topic-notifications-settings" show_only_indicator=(not for_realm_settings) }}
-            <p>
-                {{#tr}}
-                    You will automatically follow topics that you have configured to both <z-follow>follow</z-follow> and <z-unmute>unmute</z-unmute>.
-                    {{#*inline "z-follow"}}<a href="/help/follow-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-                    {{#*inline "z-unmute"}}<a href="/help/mute-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-                {{/tr}}
-            </p>
         </div>
+        <p>
+            {{#tr}}
+                You will automatically follow topics that you have configured to both <z-follow>follow</z-follow> and <z-unmute>unmute</z-unmute>.
+                {{#*inline "z-follow"}}<a href="/help/follow-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-unmute"}}<a href="/help/mute-a-topic" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </p>
 
         <div class="input-group">
             <label for="{{prefix}}automatically_follow_topics_policy" class="settings-field-label">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/SETTINGS.2F.20NOTIFICATIONS.20breaking.20at.20full.20size.2E)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Before starts breaking  after 14 px:**

<img width="873" alt="Screenshot 2025-03-20 at 7 14 07 PM" src="https://github.com/user-attachments/assets/6914d8ab-3450-4f77-8882-b6f72e363d7d" />


**After** 

| Font-size | UI |
|------|-------|
| At 12px |  <img width="650" alt="Screenshot 2025-03-20 at 7 10 34 PM" src="https://github.com/user-attachments/assets/0d217d59-0195-4302-acf2-c818b1f89282" /> | 
| At 16px | <img width="864" alt="Screenshot 2025-03-20 at 7 10 16 PM" src="https://github.com/user-attachments/assets/c6ac5aff-54c5-4ec8-a420-4ed43f40396b" /> |
| At 20px | <img width="1034" alt="Screenshot 2025-03-20 at 7 10 59 PM" src="https://github.com/user-attachments/assets/f10e902a-1d7b-4ff9-921b-c0bea4ce5bf9" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
