### PR TITLE
leftsidebar: Add alert words view to the leftsidebar. 

### DIFF
--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1204,6 +1204,9 @@ export class Filter {
         if (_.isEqual(term_types, ["is-mentioned"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["is-alerted"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }
@@ -1279,6 +1282,8 @@ export class Filter {
                     return "/#narrow/is/mentioned";
                 case "channels-public":
                     return "/#narrow/channels/public";
+                case "is-alerted":
+                    return "/#narrow/is/alerted";
                 case "dm":
                     return "/#narrow/dm/" + people.emails_to_slug(this.operands("dm").join(","));
                 case "is-resolved":

--- a/web/src/filter.ts
+++ b/web/src/filter.ts
@@ -1363,6 +1363,9 @@ export class Filter {
             case "is-followed":
                 zulip_icon = "follow";
                 break;
+            case "is-alerted":
+                zulip_icon = "eye";
+                break;
             default:
                 icon = undefined;
                 break;
@@ -1459,7 +1462,7 @@ export class Filter {
                 // formatted in the message view header. They are used in narrow.js to
                 // update the browser title.
                 case "is-alerted":
-                    return $t({defaultMessage: "Alerted messages"});
+                    return $t({defaultMessage: "Alerted Messages"});
                 case "is-unread":
                     return $t({defaultMessage: "Unread messages"});
             }
@@ -1495,6 +1498,13 @@ export class Filter {
                         defaultMessage: "Messages in topics you follow.",
                     }),
                     link: "/help/follow-a-topic",
+                };
+            case "is-alerted":
+                return {
+                    description: $t({
+                        defaultMessage: "Messages containing alert words",
+                    }),
+                    link: "/help/dm-mention-alert-notifications",
                 };
         }
         if (

--- a/web/src/left_sidebar_navigation_area_popovers.ts
+++ b/web/src/left_sidebar_navigation_area_popovers.ts
@@ -2,6 +2,7 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import type * as tippy from "tippy.js";
 
+import render_left_sidebar_alert_words_popover from "../templates/popovers/left_sidebar/left_sidebar_alert_words_popover.hbs";
 import render_left_sidebar_all_messages_popover from "../templates/popovers/left_sidebar/left_sidebar_all_messages_popover.hbs";
 import render_left_sidebar_condensed_views_popover from "../templates/popovers/left_sidebar/left_sidebar_condensed_views_popover.hbs";
 import render_left_sidebar_drafts_popover from "../templates/popovers/left_sidebar/left_sidebar_drafts_popover.hbs";
@@ -153,6 +154,32 @@ export function initialize(): void {
         onHidden(instance) {
             instance.destroy();
             popover_menus.popover_instances.left_sidebar_inbox_popover = null;
+            ui_util.hide_left_sidebar_menu_icon();
+        },
+    });
+
+    // Alert Words Settings popover
+    popover_menus.register_popover_menu(".alert-words-sidebar-menu-icon", {
+        ...popover_menus.left_sidebar_tippy_options,
+        onMount(instance) {
+            const $popper = $(instance.popper);
+            popover_menus.popover_instances.left_sidebar_alert_words_popover = instance;
+            assert(instance.reference instanceof HTMLElement);
+            ui_util.show_left_sidebar_menu_icon(instance.reference);
+
+            $popper.one("click", "#alert_words_settings", {instance}, () => {
+                window.location.href = "#alert-words-settings";
+            });
+        },
+        onShow(instance) {
+            popovers.hide_all();
+            instance.setContent(
+                ui_util.parse_html(render_left_sidebar_alert_words_popover()), // Render the content from the HBS template
+            );
+        },
+        onHidden(instance) {
+            instance.destroy();
+            popover_menus.popover_instances.left_sidebar_alert_words_popover = null;
             ui_util.hide_left_sidebar_menu_icon();
         },
     });

--- a/web/src/left_sidebar_tooltips.ts
+++ b/web/src/left_sidebar_tooltips.ts
@@ -87,6 +87,18 @@ export function initialize(): void {
                         ),
                     );
                     break;
+                case "alert_words":
+                    display_count = 0; // This will be updated once we get the unread alert words count
+                    $container.find(".views-message-count").text(
+                        $t(
+                            {
+                                defaultMessage:
+                                    "You have {display_count, plural, =0 {no alerted messages} one {# Alerted message} other {# alerted messages}}.",
+                            },
+                            {display_count},
+                        ),
+                    );
+                    break;
             }
 
             // Since the tooltip is attached to the anchor tag which doesn't

--- a/web/src/narrow_banner.ts
+++ b/web/src/narrow_banner.ts
@@ -279,6 +279,11 @@ export function pick_empty_narrow_banner(current_filter: Filter): NarrowBannerDa
                     return {
                         title: $t({defaultMessage: "You have no unread messages!"}),
                     };
+                case "alerted":
+                    // You have no alerted messages.
+                    return {
+                        title: $t({defaultMessage: "You have no alerted messages!"}),
+                    };
                 case "resolved":
                     return {
                         title: $t({defaultMessage: "No topics are marked as resolved."}),

--- a/web/src/popover_menus.ts
+++ b/web/src/popover_menus.ts
@@ -20,6 +20,7 @@ type PopoverName =
     | "left_sidebar_inbox_popover"
     | "left_sidebar_all_messages_popover"
     | "left_sidebar_recent_view_popover"
+    | "left_sidebar_alert_words_popover"
     | "top_left_sidebar"
     | "message_actions"
     | "stream_card_popover"
@@ -41,6 +42,7 @@ export const popover_instances: Record<PopoverName, tippy.Instance | null> = {
     left_sidebar_inbox_popover: null,
     left_sidebar_all_messages_popover: null,
     left_sidebar_recent_view_popover: null,
+    left_sidebar_alert_words_popover: null,
     top_left_sidebar: null,
     message_actions: null,
     stream_card_popover: null,

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -37,6 +37,14 @@
                         <span class="unread_count"></span>
                     </a>
                 </li>
+                <li class="top_left_alerts left-sidebar-navigation-condensed-item">
+                    <a href="#narrow/is/alerted" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="alert-words-tooltip-template">
+                        <span class="filter-icon">
+                            <i class="zulip-icon zulip-icon-at-sign" aria-hidden="true"></i>
+                        </span>
+                        <span class="unread_count normal-count"></span>
+                    </a>
+                </li>
                 <li class="top_left_starred_messages left-sidebar-navigation-condensed-item">
                     <a href="#narrow/is/starred" class="tippy-left-sidebar-tooltip left-sidebar-navigation-icon-container" data-tooltip-template-id="starred-message-tooltip-template">
                         <span class="filter-icon">
@@ -97,6 +105,19 @@
                     <span class="left-sidebar-navigation-label">{{t 'Mentions' }}</span>
                     <span class="unread_count"></span>
                 </a>
+            </li>
+            <li class="top_left_alerts top_left_row hidden-for-spectators">
+                <a class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" href="#narrow/is/alerted" data-tooltip-template-id="alert-words-tooltip-template">
+                    <span class="filter-icon">
+                        <i class="zulip-icon zulip-icon-eye" aria-hidden="true"></i>
+                    </span>
+                    {{~!-- squash whitespace --~}}
+                    <span class="left-sidebar-navigation-label">{{t 'Alerts' }}</span>
+                    {{!-- <span class="unread_count normal-count">190</span> --}}
+                </a>
+                <span class="arrow sidebar-menu-icon alert-words-sidebar-menu-icon hidden-for-spectators">
+                    <i class="zulip-icon zulip-icon-more-vertical" aria-label="{{t 'Alert Words Settings'}}"></i>
+                </span>
             </li>
             <li class="top_left_my_reactions top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container tippy-left-sidebar-tooltip" href="#narrow/has/reaction/sender/me" data-tooltip-template-id="my-reactions-tooltip-template">

--- a/web/templates/popovers/left_sidebar/left_sidebar_alert_words_popover.hbs
+++ b/web/templates/popovers/left_sidebar/left_sidebar_alert_words_popover.hbs
@@ -1,0 +1,12 @@
+<div class="popover-menu" data-simplebar data-simplebar-tab-index="-1">
+    <ul role="menu" class="popover-menu-list">
+        <li role="none" class="link-item popover-menu-list-item">
+            <a role="menuitem" href="/#settings/alert-words" id="alert_words_settings" class="popover-menu-link" tabindex="0">
+                <i class="popover-menu-icon zulip-icon zulip-icon-gear" aria-hidden="true"></i>
+                <span class="popover-menu-label">{{t "Alert Words Settings"}}</span>
+            </a>
+        </li>
+    </ul>
+</div>
+
+

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -175,6 +175,12 @@
         <div class="tootlip-inner-content views-message-count italic"></div>
     </div>
 </template>
+<template id="alert-words-tooltip-template">
+    <div class="views-tooltip-container" data-view-code="alert_words">
+        <div>{{t 'Alert Words' }}</div>
+        <div class="tootlip-inner-content views-message-count italic"></div>
+    </div>
+</template>
 <template id="filter-streams-tooltip-template">
     {{t 'Filter channels' }}
     {{tooltip_hotkey_hints "Q"}}

--- a/web/tests/filter.test.cjs
+++ b/web/tests/filter.test.cjs
@@ -2329,6 +2329,15 @@ test("navbar_helpers", ({override}) => {
             link: "/help/view-your-mentions",
         },
         {
+            terms: is_alerted,
+            is_common_narrow: true,
+            zulip_icon: "eye",
+            title: "translated: Alerted Messages",
+            redirect_url_with_search: "/#narrow/is/alerted",
+            description: "translated: Messages containing alert words",
+            link: "/help/dm-mention-alert-notifications",
+        },
+        {
             terms: is_resolved,
             is_common_narrow: true,
             icon: "check",
@@ -2480,10 +2489,12 @@ test("navbar_helpers", ({override}) => {
         },
         {
             terms: is_alerted,
-            is_common_narrow: false,
-            icon: undefined,
-            title: "translated: Alerted messages",
-            redirect_url_with_search: "#",
+            is_common_narrow: true,
+            zulip_icon: "eye",
+            title: "translated: Alerted Messages",
+            redirect_url_with_search: "/#narrow/is/alerted",
+            description: "translated: Messages containing alert words",
+            link: "/help/dm-mention-alert-notifications",
         },
         {
             terms: is_unread,


### PR DESCRIPTION
This PR adds alert words message views to the left sidebar as mentioned in the issue description. Also this PR adds alert words settings popover to redirect to the alert word settings.

A new file `left_sidebar_alert_words_popover.hbs` is created for displaying the alert words settings popover. 

Now, as alert words is added to left sidebar, so in the test file I have converted the `is:alerted` narrow to `is_common _narrow` endpoint. 

This pull request adds alert words view to the left sidebar but showing count of unread messages with alert words remain. 

Fixes: #28778 

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/59147382-d8da-4f72-a7e7-8e0ca1bdb993




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
