### PR TITLE
composebox_typeahead: Add "New" label to non existant topics.

### DIFF
--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -2153,7 +2153,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
 
     // topic_list
     // includes "more ice"
-    function typed_topics(stream, topics) {
+    function typed_topics(stream, topics, is_new_topic = false) {
         const matches_list = topics.map((topic, index) => ({
             is_channel_link: topic === stream && index === 0,
             stream_data: {
@@ -2165,6 +2165,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
             topic_display_name: get_final_topic_display_name(topic),
             type: "topic_list",
             used_syntax_prefix: "#**",
+            is_new_topic,
         }));
         return matches_list;
     }
@@ -2176,9 +2177,10 @@ test("begins_typeahead", ({override, override_rewire}) => {
         "#**Sweden>",
         typed_topics("Sweden", ["Sweden", ...sweden_topics_to_show]),
     );
+    const is_new_topic = true;
     assert_typeahead_equals(
         "#**Sweden>totally new topic",
-        typed_topics("Sweden", ["totally new topic"]),
+        typed_topics("Sweden", ["totally new topic"], is_new_topic),
     );
     assert_typeahead_equals("#**Sweden>\n\nmore ice", typed_topics("Sweden", []));
 


### PR DESCRIPTION
We add a "New" label at the end of query which doesn't match any of the existing topic to help user identify when they are linking to a topic which doesn't exist.

discussion: [#design > wrapping compose topic link typeahead @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/wrapping.20compose.20topic.20link.20typeahead/near/2113499)

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c33e8997-6b2e-4b91-94cf-5314db648836) | ![Screenshot from 2025-03-21 10-23-03](https://github.com/user-attachments/assets/50fdd044-2843-4b85-b7fa-6ac7f0ae826b) |
