### PR TITLE
message_edit: Show edited notice when revealing a muted user's message.

### DIFF
--- a/web/src/message_list_view.ts
+++ b/web/src/message_list_view.ts
@@ -1667,6 +1667,8 @@ export class MessageListView {
             ),
         );
 
+        this.set_edited_notice_locations(message_container);
+
         const $rendered_msg = $(this._get_message_template(message_container));
         if (message_content_edited) {
             $rendered_msg.addClass("fade-in-message");


### PR DESCRIPTION
Previously, the edited notice was not displayed when a user revealed an edited message sent by a muted user. This commit ensures that the notice appears correctly in such cases.

<!-- Describe your pull request here.-->

Fixes: https://chat.zulip.org/#narrow/channel/9-issues/topic/Can't.20see.20the.20.22EDITED.22.20label.20for.20muted.20user.20messages/with/2131135

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After|
|--------|--------|
| ![before](https://github.com/user-attachments/assets/02af4d0d-21f5-47db-8386-0b06d15d34d2)| ![after](https://github.com/user-attachments/assets/d48dff66-cf73-46cc-85b9-e9e2b972dc7d)| 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
