### PR TITLE
registration: Fix language code missing for `find_team` emails.

### DIFF
--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -96,3 +96,10 @@ def get_default_language_for_new_user(realm: Realm, *, request: HttpRequest | No
     if browser_language_code is not None:
         return browser_language_code
     return realm.default_language
+
+
+def get_default_language_for_anonymous_user(request: HttpRequest) -> str:
+    browser_language_code = get_browser_language_code(request)
+    if browser_language_code is not None:
+        return browser_language_code
+    return settings.LANGUAGE_CODE

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -57,6 +57,7 @@ from zerver.lib.email_validation import email_allowed_for_realm, validate_email_
 from zerver.lib.exceptions import RateLimitedError
 from zerver.lib.i18n import (
     get_browser_language_code,
+    get_default_language_for_anonymous_user,
     get_default_language_for_new_user,
     get_language_name,
 )
@@ -1241,6 +1242,7 @@ def find_account(request: HttpRequest) -> HttpResponse:
                     ),
                     from_address=FromAddress.SUPPORT,
                     request=request,
+                    language=get_default_language_for_anonymous_user(request),
                 )
     return render(
         request,


### PR DESCRIPTION
If there were no users found for `find_team`, we need to provide a default langauge for the email as one cannot be extracted from `UserProfile` in this case.

Tested by finding account and checking server log with / without this commit on http://zulipdev.com:9991/accounts/find/ 

`
2025-03-21 12:38:52.500 WARN [zulip.send_email] Missing language for email template 'zerver/emails/find_team'
`

was only logged without this commit.