### PR TITLE
refactor: Rename huddle to direct message group in email templates.

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -2391,8 +2391,8 @@ msgstr "\n    لا تقم بالرد على هذا البريد. خادم \"زو
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "الرسائل المباشرة للمجموعة مع %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "الرسائل المباشرة للمجموعة مع %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/be/LC_MESSAGES/django.po
+++ b/locale/be/LC_MESSAGES/django.po
@@ -2472,7 +2472,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -2388,8 +2388,8 @@ msgstr "\n    Не отговаряйте на този имейл. Този Zul
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групови съобщения с %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групови съобщения с %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/bqi/LC_MESSAGES/django.po
+++ b/locale/bqi/LC_MESSAGES/django.po
@@ -2385,7 +2385,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -2387,7 +2387,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -2393,8 +2393,8 @@ msgstr "\n    Neodpovídejte na tento elektronický dopis. Tento server Zulipu n
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Seskupit PM s %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Seskupit PM s %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -2386,7 +2386,7 @@ msgstr "\nPeidiwch ag ymateb i'r e-bost hwn. Nid yw'r gweinydd Zulip hwn wedi'i 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -2387,7 +2387,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -2420,8 +2420,8 @@ msgstr "\n    Antworte nicht auf diese E-Mail. Dieser Zulip-Server ist nicht daf
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Gruppen-DMs mit %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Gruppen-DMs mit %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -2388,8 +2388,8 @@ msgstr "\n    Do not reply to this email. This Zulip server is not configured to
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Group DMs with %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -2407,7 +2407,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -2404,8 +2404,8 @@ msgstr "\nNo responder a este correo. Este servidor de Zulip no fue configurado 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Agrupar MDs con %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Agrupar MDs con %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -2393,8 +2393,8 @@ msgstr "\n    به این ایمیل پاسخ ندهید. این سرور زول
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "پیام مستقیم گروهی با %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "پیام مستقیم گروهی با %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2394,8 +2394,8 @@ msgstr "\nÄlä vastaa tähän sähköpostiin. Tätä Zulip-palvelinta ei ole m�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Ryhmäviestit joukolle %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Ryhmäviestit joukolle %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -2411,8 +2411,8 @@ msgstr "\n    Ne répondez pas à ce courriel. Le serveur Zulip n'est pas config
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Regrouper les messages directs avec %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Regrouper les messages directs avec %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/gl/LC_MESSAGES/django.po
+++ b/locale/gl/LC_MESSAGES/django.po
@@ -2407,7 +2407,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/gu/LC_MESSAGES/django.po
+++ b/locale/gu/LC_MESSAGES/django.po
@@ -2386,8 +2386,8 @@ msgstr "\nઆ ઇમેઇલને જવાબ આપતા ન રહેવ�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "સાથે %(huddle_display_name)s સાથે સમૂહ DMs"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "સાથે %(direct_message_group_display_name)s સાથે સમૂહ DMs"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -2391,7 +2391,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -2393,7 +2393,7 @@ msgstr "\n    Ne válaszolj erre az e-mailre. Ezen a Zulip szerveren a bejövő 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -2388,7 +2388,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -2396,8 +2396,8 @@ msgstr "\n    Non rispondere a questa email. Questo server Zulip non è configur
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Messaggi privati di gruppo con %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Messaggi privati di gruppo con %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -2397,7 +2397,7 @@ msgstr "\n    このメールに返信しないでください。このZulipサ�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # cozyplanes, 2018
 # Eugene Lee, 2024
@@ -2399,7 +2399,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # R S <renatke@gmail.com>, 2020
 msgid ""
@@ -2385,7 +2385,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -2408,7 +2408,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ml/LC_MESSAGES/django.po
+++ b/locale/ml/LC_MESSAGES/django.po
@@ -2480,7 +2480,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/mn/LC_MESSAGES/django.po
+++ b/locale/mn/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Batbuyan G, 2022
 # Batbuyan G, 2022
@@ -2395,8 +2395,8 @@ msgstr "\nЭнэ имэйлд хариу бичих хэрэггүй. Энэ Zul
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групп DM-үүд %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групп DM-үүд %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -2389,7 +2389,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -2406,7 +2406,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -2401,8 +2401,8 @@ msgstr "\n    Nie odpowiadaj na tę wiadomość email. Ten serwer Zulip nie jest
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Grupowe DM z %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Grupowe DM z %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -2395,8 +2395,8 @@ msgstr "\n    Não responda a este e-mail. Este servidor Zulip não está config
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "DMs de grupo com %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "DMs de grupo com %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -2519,7 +2519,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -2389,8 +2389,8 @@ msgstr "\n    Não responda a este email. Este servidor Zulip não está configu
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Mensagens privadas de grupo com%(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Mensagens privadas de grupo com%(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -2392,8 +2392,8 @@ msgstr "\n    Nu răspunde acestui email. Acest server Zulip nu este configurat 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Grupați DM cu %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Grupați DM cu %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -2403,8 +2403,8 @@ msgstr "\n    Не отвечайте на это письмо. Этот сер�
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групповые личные сообщения я %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групповые личные сообщения я %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/si/LC_MESSAGES/django.po
+++ b/locale/si/LC_MESSAGES/django.po
@@ -2387,7 +2387,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -2387,8 +2387,8 @@ msgstr "\n    Не одговарајте на ову е-поруку. Овај 
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "Групне ДП са %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "Групне ДП са %(direct_message_group_display_name)s"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2385,7 +2385,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/ta/LC_MESSAGES/django.po
+++ b/locale/ta/LC_MESSAGES/django.po
@@ -2455,7 +2455,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/tl/LC_MESSAGES/django.po
+++ b/locale/tl/LC_MESSAGES/django.po
@@ -2385,7 +2385,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -2396,8 +2396,8 @@ msgstr "\nBu e-postaya cevap vermeyin. Bu Zulip sunucusu gelen e-postaları alma
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
-msgstr "%(huddle_display_name)s ile olan Grup DM'leri"
+msgid "Group DMs with %(direct_message_group_display_name)s"
+msgstr "%(direct_message_group_display_name)s ile olan Grup DM'leri"
 
 #: templates/zerver/emails/missed_message.subject.txt:3
 #, python-format

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -2390,7 +2390,7 @@ msgstr "\n    Не відповідайте на цей електронний �
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -2388,7 +2388,7 @@ msgstr "\n    Do not reply to this email. This Zulip server is not configured to
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -2399,7 +2399,7 @@ msgstr "\n    请勿回复此电子邮件。 (<a href=\"%(url)s\">help</a>).\n  
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/locale/zh_TW/LC_MESSAGES/django.po
+++ b/locale/zh_TW/LC_MESSAGES/django.po
@@ -2391,7 +2391,7 @@ msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:2
 #, python-format
-msgid "Group DMs with %(huddle_display_name)s"
+msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
 #: templates/zerver/emails/missed_message.subject.txt:3

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,5 +1,5 @@
 {% if show_message_content %}
-    {% if group_pm %} {% trans %}Group DMs with {{ huddle_display_name }}{% endtrans %}
+    {% if group_pm %} {% trans %}Group DMs with {{ direct_message_group_display_name }}{% endtrans %}
     {% elif private_message %} {% trans %}DMs with {{ sender_str }}{% endtrans %}
     {% elif stream_email_notify or mention or followed_topic_email_notify %}
         {#

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -493,17 +493,17 @@ def do_send_missedmessage_events_reply_in_zulip(
         context.update(group_pm=True)
         if len(other_recipients) == 2:
             direct_message_group_display_name = " and ".join(other_recipients)
-            context.update(huddle_display_name=direct_message_group_display_name)
+            context.update(direct_message_group_display_name=direct_message_group_display_name)
         elif len(other_recipients) == 3:
             direct_message_group_display_name = (
                 f"{other_recipients[0]}, {other_recipients[1]}, and {other_recipients[2]}"
             )
-            context.update(huddle_display_name=direct_message_group_display_name)
+            context.update(direct_message_group_display_name=direct_message_group_display_name)
         else:
             direct_message_group_display_name = "{}, and {} others".format(
                 ", ".join(other_recipients[:2]), len(other_recipients) - 2
             )
-            context.update(huddle_display_name=direct_message_group_display_name)
+            context.update(direct_message_group_display_name=direct_message_group_display_name)
     elif missed_messages[0]["message"].recipient.type == Recipient.PERSONAL:
         narrow_url = personal_narrow_url(
             realm=user_profile.realm,
@@ -559,7 +559,7 @@ def do_send_missedmessage_events_reply_in_zulip(
             messages=[],
             sender_str="",
             realm_str=realm.name,
-            huddle_display_name="",
+            direct_message_group_display_name="",
             show_message_content=False,
             message_content_disabled_by_user=not user_profile.message_content_in_email_notifications,
             message_content_disabled_by_realm=not realm.message_content_allowed_in_email_notifications,


### PR DESCRIPTION
This PR renames "huddle" references to "direct_message_group" in `locale/`.

Fixes the last piece of https://github.com/zulip/zulip/issues/28640

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
