### PR TITLE
popup_banners: Update connection error banner label.

### DIFF
--- a/web/src/popup_banners.ts
+++ b/web/src/popup_banners.ts
@@ -21,14 +21,14 @@ function fade_out_popup_banner($banner: JQuery): void {
 const get_connection_error_label = (retry_delay_secs: number): string => {
     if (original_retry_delay_secs < 5) {
         // When the retry delay is less than 5 seconds, we don't show the retry
-        // delay time in the banner, and instead just show "Retrying soon…" to
-        // constant flickering of the banner label for very short times.
-        return $t({defaultMessage: "Unable to connect to Zulip. Retrying soon…"});
+        // delay time in the banner, and instead just show "Trying to reconnect soon…"
+        // to avoid constant flickering of the banner label for very short times.
+        return $t({defaultMessage: "Unable to connect to Zulip. Trying to reconnect soon…"});
     }
     return $t(
         {
             defaultMessage:
-                "Unable to connect to Zulip. {retry_delay_secs, plural, one {Trying again in {retry_delay_secs} second…} other {Trying again in {retry_delay_secs} seconds…}}",
+                "Unable to connect to Zulip. {retry_delay_secs, plural, one {Trying to reconnect in {retry_delay_secs} second…} other {Trying to reconnect in {retry_delay_secs} seconds…}}",
         },
         {retry_delay_secs},
     );
@@ -139,7 +139,7 @@ function retry_connection_click_handler(e: JQuery.ClickEvent, on_retry_callback:
     const $banner = $(e.currentTarget).closest(".banner");
     $banner
         .find(".banner-label")
-        .text($t({defaultMessage: "Unable to connect to Zulip. Retrying now…"}));
+        .text($t({defaultMessage: "Unable to connect to Zulip. Trying to reconnect soon…"}));
 
     const $button = $(e.currentTarget).closest(".retry-connection");
 


### PR DESCRIPTION
This PR updates the connection error banner label to "Unable to connect to Zulip. Trying to reconnect!" when the the user manually retries the connection via the "Try now" button and when the retry time is less than 5 seconds.

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Glitchy.20connection.20error.20popup.20banner/near/2127631)[#issues > 🎯 Glitchy connection error popup banner @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Glitchy.20connection.20error.20popup.20banner/near/2127631)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-21 at 8 34 47 PM](https://github.com/user-attachments/assets/fc8927f6-32be-4848-9a76-51b1f7476e9b) | ![Screenshot 2025-04-12 at 4 27 49 AM](https://github.com/user-attachments/assets/cdaf7860-04e1-4ce1-8dee-cc4e45eb2ec9) | 

**When the user clicks on "Try now""**
![trying-to-reconnect-2](https://github.com/user-attachments/assets/7987b671-7f96-420c-a08d-19e3c7c9be6c)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
