### PR TITLE
Add input-pill for branches in integration-URL modal

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -125,6 +125,7 @@ EXEMPT_FILES = make_set(
         "web/src/info_overlay.ts",
         "web/src/information_density.ts",
         "web/src/input_pill.ts",
+        "web/src/integration_branch_pill.ts",
         "web/src/integration_url_modal.ts",
         "web/src/invite.ts",
         "web/src/invite_stream_picker_pill.ts",

--- a/web/src/integration_branch_pill.ts
+++ b/web/src/integration_branch_pill.ts
@@ -1,0 +1,35 @@
+import type {InputPillConfig, InputPillContainer} from "./input_pill.ts";
+import * as input_pill from "./input_pill.ts";
+
+type BranchPill = {
+    type: "branch";
+    branch: string;
+};
+
+export type BranchPillWidget = InputPillContainer<BranchPill>;
+
+export function create_item_from_branch_name(
+    branch: string,
+    current_items: BranchPill[],
+): BranchPill | undefined {
+    const existing_branches = current_items.map((item) => item.branch);
+    return existing_branches.includes(branch) ? undefined : {type: "branch", branch};
+}
+
+export function get_branch_name_from_item(item: BranchPill): string {
+    return item.branch;
+}
+
+export function create_pills(
+    $pill_container: JQuery,
+    pill_config?: InputPillConfig,
+): input_pill.InputPillContainer<BranchPill> {
+    const pill_container = input_pill.create({
+        $container: $pill_container,
+        pill_config,
+        create_item_from_text: create_item_from_branch_name,
+        get_text_from_item: get_branch_name_from_item,
+        get_display_value_from_item: get_branch_name_from_item,
+    });
+    return pill_container;
+}

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -772,7 +772,7 @@
         color-mix(in srgb, #c2c2c2 80%, transparent),
         color-mix(in srgb, #fff 5%, transparent)
     );
-    --color-background-invitee-emails-pill-container: light-dark(
+    --color-background-pill-container-without-placeholder: light-dark(
         hsl(0deg 0% 100%),
         hsl(0deg 0% 0% / 20%)
     );

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -234,7 +234,9 @@
 #integration-url-filter-branches .pill-container {
     width: 100%;
     box-sizing: border-box;
-    background-color: var(--color-background-invitee-emails-pill-container);
+    background-color: var(
+        --color-background-pill-container-without-placeholder
+    );
 }
 
 .add_subscribers_container .pill-container,

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -230,7 +230,8 @@
     }
 }
 
-#invitee_emails_container .pill-container {
+#invitee_emails_container .pill-container,
+#integration-url-filter-branches .pill-container {
     width: 100%;
     box-sizing: border-box;
     background-color: var(--color-background-invitee-emails-pill-container);

--- a/web/templates/settings/generate_integration_url_filter_branches_modal.hbs
+++ b/web/templates/settings/generate_integration_url_filter_branches_modal.hbs
@@ -10,7 +10,8 @@
 <div class="input-group hide" id="integration-url-filter-branches">
     <label for="integration-url-branches-text" class="modal-label-field">
         {{t "Which branches should notifications be sent for?"}}
-        (<i>{{t "comma-separated list"}}</i>)
     </label>
-    <input type="text" id="integration-url-branches-text" class="modal_text_input integration-url-parameter" value="main"/>
+    <div class="pill-container">
+        <div id="integration-url-branches-text" class="input" contenteditable="true"></div>
+    </div>
 </div>


### PR DESCRIPTION
Follow-up to: #33754
(I was more than halfway done when the previous PR was merged, so I followed through with the original idea of adding branch pills.)

Removed the "comma-separated" bracketed suffix, because though this does not have typeahead, we start with the default value "main", so it should be clear that valid entries are pills.
(Would we still want to tell users that only commas and enter keys add the input pill, as opposed to other keys like tab and space, to be clear?)

The branch values are retained even if the "Send notifications for all branches" is checked on (hiding the branch filtering UI), and is unchecked again.

Also includes some minor refactoring to the email pill widget in `invite.ts` in the second commit.

<details>
<summary><h3>Screenshots:</h3></summary>

<h3>Default value</h3>

![image](https://github.com/user-attachments/assets/776e299c-580a-45fb-a782-77294d2130ff)
![image](https://github.com/user-attachments/assets/3ca3cb11-5f5e-43c2-a0e5-97616663992d)

<h3>Custom values</h3>

![image](https://github.com/user-attachments/assets/be1ab9fa-5ffe-4b3a-bdc7-ce79efba1728)

<h3>No pills case</h3>

![image](https://github.com/user-attachments/assets/5e7e44eb-8d22-495a-9893-a23983dc5bcf)

<h3>Invite modal - Email Pills</h3>

To verify that their behavior has not been affected in any way.

![image](https://github.com/user-attachments/assets/22fca53d-654a-497b-8a53-0a4ab8d42e89)


</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

