### PR TITLE
settings: Update remove/unsubscribe buttons to action button component.

### DIFF
--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -466,8 +466,8 @@ export function initialize(): void {
     });
 
     $("#channels_overlay_container").on(
-        "submit",
-        ".edit_subscribers_for_stream .subscriber_list_remove form",
+        "click",
+        ".edit_subscribers_for_stream .remove-subscriber-button",
         function (this: HTMLElement, e): void {
             e.preventDefault();
 

--- a/web/src/user_group_edit_members.ts
+++ b/web/src/user_group_edit_members.ts
@@ -509,8 +509,8 @@ export function initialize(): void {
     });
 
     $("#groups_overlay_container").on(
-        "submit",
-        ".edit_members_for_user_group .subscriber_list_remove form",
+        "click",
+        ".edit_members_for_user_group .remove-subscriber-button",
         function (this: HTMLElement, e): void {
             e.preventDefault();
 
@@ -523,8 +523,8 @@ export function initialize(): void {
     );
 
     $("#groups_overlay_container").on(
-        "submit",
-        ".edit_members_for_user_group .subgroup_list_remove form",
+        "click",
+        ".edit_members_for_user_group .remove-subgroup-button",
         function (this: HTMLElement, e): void {
             e.preventDefault();
 

--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -54,6 +54,7 @@ import * as subscriber_api from "./subscriber_api.ts";
 import * as timerender from "./timerender.ts";
 import type {HTMLSelectOneElement} from "./types.ts";
 import * as ui_report from "./ui_report.ts";
+import * as ui_util from "./ui_util.ts";
 import type {UploadWidget} from "./upload_widget.ts";
 import * as user_deactivation_ui from "./user_deactivation_ui.ts";
 import * as user_group_edit_members from "./user_group_edit_members.ts";
@@ -233,19 +234,13 @@ function change_state_of_subscribe_button(
     assert(user_profile_subscribe_widget !== undefined);
     user_profile_subscribe_widget.render();
     const $subscribe_button = $("#user-profile-modal .add-subscription-button");
-    const $element: (tippy.ReferenceElement & HTMLElement) | undefined =
-        $subscribe_button.parent()[0];
-    assert($element !== undefined);
-    $element._tippy?.destroy();
-    $subscribe_button.prop("disabled", false);
+    ui_util.enable_element_and_remove_tooltip($subscribe_button);
 }
 
 function reset_subscribe_widget(): void {
-    $("#user-profile-modal .add-subscription-button").prop("disabled", true);
-    settings_components.initialize_disable_button_hint_popover(
-        $("#user-profile-modal .add-subscription-button-wrapper"),
+    ui_util.disable_element_and_add_tooltip(
+        $("#user-profile-modal .add-subscription-button"),
         $t({defaultMessage: "Select a channel to subscribe"}),
-        {},
     );
     $("#user_profile_subscribe_widget .dropdown_widget_value").text(
         $t({defaultMessage: "Select a channel"}),

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -609,12 +609,6 @@ ul.popover-group-menu-member-list {
         margin-bottom: 5px;
         -webkit-overflow-scrolling: touch;
 
-        .remove-subscription-button,
-        .remove-member-button {
-            padding-top: 2px;
-            padding-bottom: 2px;
-        }
-
         .user-stream-list,
         .user-group-list {
             width: 100%;
@@ -637,7 +631,7 @@ ul.popover-group-menu-member-list {
 
                     &.remove_subscription,
                     &.remove_member {
-                        text-align: right;
+                        float: right;
                         padding-right: 10px;
                     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1569,7 +1569,3 @@ ul.popover-menu-list {
     flex: 1;
     min-width: 0;
 }
-
-.add-groups-button-wrapper {
-    flex: 0 0 auto;
-}

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -178,12 +178,6 @@ h4.user_group_setting_subsection_title {
                 }
             }
 
-            .subscriber_list_remove,
-            .subgroup-list-remove {
-                padding-right: 16px;
-                display: inline-block;
-            }
-
             & thead th {
                 &:first-of-type {
                     border-top-left-radius: 4px;
@@ -272,11 +266,6 @@ h4.user_group_setting_subsection_title {
 
 .choose-subscribers-label {
     display: inline;
-}
-
-.remove-subscriber-form,
-.remove-subgroup-form {
-    margin: 0;
 }
 
 .subscriptions-container .subscriptions-header .fa-chevron-left,

--- a/web/templates/components/action_button.hbs
+++ b/web/templates/components/action_button.hbs
@@ -1,4 +1,4 @@
-<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{attention}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
+<button type="{{#if type}}{{type}}{{else}}button{{/if}}" {{#if id}}id="{{id}}"{{/if}} class="{{#if custom_classes}}{{custom_classes}} {{/if}}action-button action-button-{{attention}}-{{intent}} {{#if hidden}}hide{{/if}}" {{#if data-tippy-content}}data-tippy-content="{{data-tippy-content}}"{{/if}} {{#if data-tooltip-template-id}}data-tooltip-template-id="{{data-tooltip-template-id}}"{{/if}} tabindex="0" {{#if aria-label}}aria-label="{{aria-label}}"{{/if}}
   {{#if disabled}}disabled{{/if}}
   >
     {{#if icon}}

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -9,17 +9,11 @@
     {{/if}}
     {{#if can_remove_subscribers}}
     <td class="unsubscribe">
-        <div class="subscriber_list_remove">
-            <form class="remove-subscriber-form">
-                <button type="submit" name="unsubscribe" class="remove-subscriber-button button small rounded button-danger">
-                    {{#if for_user_group_members}}
-                    {{t 'Remove'}}
-                    {{else}}
-                    {{t 'Unsubscribe' }}
-                    {{/if}}
-                </button>
-            </form>
-        </div>
+        {{#if for_user_group_members}}
+            {{> ../components/action_button label=(t "Remove") custom_classes="remove-subscriber-button" attention="quiet" intent="danger" aria-label=(t "Remove") }}
+        {{else}}
+            {{> ../components/action_button label=(t "Unsubscribe") custom_classes="remove-subscriber-button" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") }}
+        {{/if}}
     </td>
     {{/if}}
 </tr>

--- a/web/templates/user_group_list_item.hbs
+++ b/web/templates/user_group_list_item.hbs
@@ -8,13 +8,13 @@
     </td>
     {{#if can_remove_members }}
     <td class="remove_member">
-        <div class="group_list_remove">
-            <span {{#unless is_direct_member}}class="tippy-zulip-tooltip" data-tippy-content="{{#if is_me}}{{t 'You are a member of {name} because you are a member of a subgroup ({subgroups_name}).'}} {{else}}{{t 'This user is a member of {name} because they are a member of a subgroup ({subgroups_name}).'}}{{/if}}"{{/unless}}>
-                <button type="button" name="remove" class="remove-member-button button small rounded button-danger" {{#unless is_direct_member}}disabled="disabled"{{/unless}} >
-                    {{t 'Remove' }}
-                </button>
+        {{#if is_direct_member}}
+            {{> components/action_button label=(t "Remove") custom_classes="remove-member-button" attention="quiet" intent="danger" aria-label=(t "Remove") }}
+        {{else}}
+            <span class="tippy-zulip-tooltip" data-tippy-content="{{#if is_me}}{{t 'You are a member of {name} because you are a member of a subgroup ({subgroups_name}).'}} {{else}}{{t 'This user is a member of {name} because they are a member of a subgroup ({subgroups_name}).'}}{{/if}}">
+                {{> components/action_button label=(t "Remove") custom_classes="remove-member-button" attention="quiet" intent="danger" aria-label=(t "Remove") disabled="disabled" }}
             </span>
-        </div>
+        {{/if}}
     </td>
     {{/if}}
 </tr>

--- a/web/templates/user_group_settings/user_group_subgroup_entry.hbs
+++ b/web/templates/user_group_settings/user_group_subgroup_entry.hbs
@@ -5,13 +5,7 @@
     <td class="empty-email-col-for-user-group"></td>
     {{#if can_remove_members}}
     <td class="remove">
-        <div class="subgroup_list_remove">
-            <form class="remove-subgroup-form">
-                <button type="submit" name="remove" class="remove-subgroup-button button small rounded button-danger">
-                    {{t 'Remove'}}
-                </button>
-            </form>
-        </div>
+        {{> ../components/action_button custom_classes="remove-subgroup-button" label=(t "Remove") attention="quiet" intent="danger" aria-label=(t "Remove") }}
     </td>
     {{/if}}
 </tr>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -146,11 +146,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="add-groups-button-wrapper">
-                                    <button type="button" name="subscribe" class="add-groups-button button small rounded">
-                                        {{t 'Add' }}
-                                    </button>
-                                </div>
+                                {{> components/action_button label=(t "Add") custom_classes="add-groups-button" attention="quiet" intent="brand" aria-label=(t "Add") }}
                             </div>
                         {{/if}}
                         <div class="group-list-top-section">

--- a/web/templates/user_profile_subscribe_widget.hbs
+++ b/web/templates/user_profile_subscribe_widget.hbs
@@ -1,8 +1,4 @@
 <div class="user_profile_subscribe_widget">
     {{> dropdown_widget widget_name="user_profile_subscribe"}}
-    <div class="add-subscription-button-wrapper">
-        <button type="button" name="subscribe" class="add-subscription-button button small rounded">
-            {{t 'Subscribe' }}
-        </button>
-    </div>
+    {{> components/action_button label=(t "Subscribe") custom_classes="add-subscription-button" attention="quiet" intent="brand" aria-label=(t "Subscribe") }}
 </div>

--- a/web/templates/user_stream_list_item.hbs
+++ b/web/templates/user_stream_list_item.hbs
@@ -9,11 +9,13 @@
     </td>
     {{#if show_unsubscribe_button}}
     <td class="remove_subscription">
-        <div class="subscription_list_remove">
-            <button type="button" name="unsubscribe" class="remove-subscription-button button small rounded button-danger {{#if (or show_private_stream_unsub_tooltip show_last_user_in_private_stream_unsub_tooltip)}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{#if show_private_stream_unsub_tooltip}}{{t "Use channel settings to unsubscribe from private channels."}}{{else}}{{t "Use channel settings to unsubscribe the last user from a private channel."}}{{/if}}'>
-                {{t 'Unsubscribe' }}
-            </button>
-        </div>
+        {{#if show_private_stream_unsub_tooltip}}
+            {{> components/action_button label=(t "Unsubscribe") custom_classes="remove-subscription-button tippy-zulip-tooltip" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Use channel settings to unsubscribe from private channels.") }}
+        {{else if show_last_user_in_private_stream_unsub_tooltip}}
+            {{> components/action_button label=(t "Unsubscribe") custom_classes="remove-subscription-button tippy-zulip-tooltip" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") data-tippy-content=(t "Use channel settings to unsubscribe the last user from a private channel.") }}
+        {{else}}
+            {{> components/action_button label=(t "Unsubscribe") custom_classes="remove-subscription-button" attention="quiet" intent="danger" aria-label=(t "Unsubscribe") }}
+        {{/if}}
     </td>
     {{/if}}
 </tr>


### PR DESCRIPTION
This PR updates the remove and unsubscribe buttons in user profile modal, channel settings and user group settings to use the action button component.

Fixes part of #33027.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
## User Profile Modal
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-28 at 2 00 09 AM](https://github.com/user-attachments/assets/dec3fab1-0dfd-4035-8e93-f01399becda8) | ![Screenshot 2025-03-28 at 1 55 40 AM](https://github.com/user-attachments/assets/48aad621-c92f-4633-9c55-8a29defba530) |
| ![Screenshot 2025-03-28 at 1 59 47 AM](https://github.com/user-attachments/assets/a447eb0f-5902-4356-b49e-1d96c4cf2ba9) | ![Screenshot 2025-03-28 at 1 58 22 AM](https://github.com/user-attachments/assets/4c789845-e6dd-429b-a49b-853ceadb0013) |
| ![Screenshot 2025-03-28 at 2 00 14 AM](https://github.com/user-attachments/assets/9fb8cebc-501f-4faf-9814-c335f60208c5) | ![Screenshot 2025-03-28 at 1 55 51 AM](https://github.com/user-attachments/assets/2af3c7fd-0524-4ac7-80ac-d8600aa81232) |
| ![Screenshot 2025-03-28 at 1 59 57 AM](https://github.com/user-attachments/assets/5be9490c-1d78-4e15-ae13-d4e7b98a1ed4) | ![Screenshot 2025-03-28 at 1 56 06 AM](https://github.com/user-attachments/assets/cef97dfd-8bd6-405b-b97d-9d1c15c09e25) |

## Channel settings
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-22 at 9 02 59 AM](https://github.com/user-attachments/assets/0c85c400-7f4e-41e6-a8d6-e9a1a5005d63) | ![Screenshot 2025-03-22 at 9 03 55 AM](https://github.com/user-attachments/assets/ef2460a5-7305-4d78-b484-4743e4100026) |
| ![Screenshot 2025-03-22 at 9 02 06 AM](https://github.com/user-attachments/assets/1651e61b-00e2-45f2-a894-b6369d5d9acf) | ![Screenshot 2025-03-22 at 8 35 57 AM](https://github.com/user-attachments/assets/b52941fb-d7e5-4555-9ab8-7bcabb750368) |

## User group settings
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-22 at 9 03 09 AM](https://github.com/user-attachments/assets/fdde7ab7-0055-48e2-9ca3-571f9df09553) | ![Screenshot 2025-03-22 at 9 03 33 AM](https://github.com/user-attachments/assets/74677873-f038-4d25-8a9b-e898d3095dc3) | 
| ![Screenshot 2025-03-22 at 9 01 34 AM](https://github.com/user-attachments/assets/3b4013b4-b7db-4629-8954-31ae7bef7c7f) | ![Screenshot 2025-03-22 at 8 35 00 AM](https://github.com/user-attachments/assets/51073244-ba99-4c63-90f1-2c732d533752) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
