### PR TITLE
ui_init: Hide sidebar when clicking a topic link on small devices.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -686,6 +686,15 @@ export function initialize_everything(state_data) {
             }
 
             message_view.show(narrow, {trigger: "sidebar"});
+
+            if (sidebar_ui.left_sidebar_expanded_as_overlay) {
+                // If the left sidebar is drawn over the center pane,
+                // hide it so that the user can actually see the
+                // topic. We don't need to also hide the user list
+                // sidebar, since its own click-outside handler will
+                // hide it.
+                sidebar_ui.hide_streamlist_sidebar();
+            }
         },
     });
     drafts.initialize_ui();


### PR DESCRIPTION
Previously, clicking a topic link on small devices did not close the sidebar, and it had to be manually closed. This PR fixes that by calling `sidebar_ui.hide_streamlist_sidebar()` when a topic link is clicked on screens smaller than the `md` breakpoint.

Addresses [CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/Sidebar.20doesn't.20hide.20on.20mobile.20devices.20when.20opening.20a.20topic/with/2132110)

**Screenshots and screen captures:**

| Before | After |
| --------- | --------- |
| ![sidebar_doesnt_close_when_clicking_on_topic](https://github.com/user-attachments/assets/3153ee69-df82-4061-bd94-c266c7daed81) | ![topic_link_after](https://github.com/user-attachments/assets/39ad8ca7-1d79-4e39-a90b-358f452a05d4) |

<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
