### PR TITLE
Add warning and prompt to installer

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -73,6 +73,11 @@ Options:
       This skips the Terms of Service prompt, allowing for running the installer
       with --push-notifications in scripts without requiring user input.
 
+  --yes-i-know-this-will-destroy-my-system
+      Zulip expects to be the only thing running on a server.  This installer
+      will ask for confirmation, this will bypass that confirmation.
+      Read the server requirement docs for details:
+      <https://zulip.readthedocs.io/en/stable/production/requirements.html>
 
 EOF
 }
@@ -91,7 +96,7 @@ EOF
 
 # Shell option parsing.  Over time, we'll want to move some of the
 # environment variables below into this self-documenting system.
-args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgresql-database-name:,postgresql-database-user:,postgresql-version:,postgresql-missing-dictionaries,no-init-db,puppet-classes:,no-overwrite-settings,no-dist-upgrade,push-notifications,no-push-notifications,no-submit-usage-statistics,agree-to-terms-of-service -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgresql-database-name:,postgresql-database-user:,postgresql-version:,postgresql-missing-dictionaries,no-init-db,puppet-classes:,no-overwrite-settings,no-dist-upgrade,push-notifications,no-push-notifications,no-submit-usage-statistics,agree-to-terms-of-service,yes-i-know-this-will-destroy-my-system -n "$0" -- "$@")"
 
 eval "set -- $args"
 while true; do
@@ -182,6 +187,10 @@ while true; do
             AGREE_TO_TERMS_OF_SERVICE_FLAG=1
             shift
             ;;
+        --yes-i-know-this-will-destroy-my-system)
+            DESTROY_CONFIRMATION=1
+            shift
+            ;;
         --)
             shift
             break
@@ -192,6 +201,16 @@ done
 if [ "$#" -gt 0 ]; then
     usage >&2
     exit 1
+fi
+
+if [ -z "$DESTROY_CONFIRMATION" ]; then
+    echo "Are you sure you are okay with the installer destroying any existing system config?"
+
+    read -p "yes/(no): " yn
+    case $yn in
+        [Yy]*) ;; # continue onwards
+        *) echo "Aborted"; exit 1;;
+    esac
 fi
 
 ## Options from environment variables.


### PR DESCRIPTION
With a CLI flag to bypass it, for automated installs. This is deny-by-default, which is what I would want but may not be what you want.  Apologies in advance for my lame shell scripting.

Feel free to workshop the actual flag name too.  ;-)

Fixes: #16499

Not sure how to add unit tests for this unfortunately, sorry.  The issue also mentions adding sanity checks, which are also beyond my skills (and/or available time).

**Screenshots and screen captures:**

![20250322_14h10m09s_grim](https://github.com/user-attachments/assets/14a2a79c-ae35-433f-b074-7e3c580061e0)