### PR TITLE
Settings two pane rewrite

### DIFF
--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -475,7 +475,7 @@ async function test_narrow_public_streams(page: Page): Promise<void> {
             "sub_unsub_button",
         )} and normalize-space()="Subscribe"]`,
     );
-    await page.click(".subscriptions-header .exit-sign");
+    await page.click("#subscription_overlay .two-pane-settings-header .exit-sign");
     await page.waitForSelector("#subscription_overlay", {hidden: true});
     await page.goto(`http://zulip.zulipdev.com:9981/#narrow/channel/${stream_id}-Denmark`);
     let message_list_id = await common.get_current_msg_list_id(page, true);

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -218,9 +218,24 @@ function resize_navbar_alerts(): void {
     }
 }
 
+export function resize_settings_creation_overlay(): void {
+    if ($(".two-pane-settings-creation-simplebar-container").length === 0) {
+        return;
+    }
+
+    $(".two-pane-settings-creation-simplebar-container").css(
+        "height",
+        height_of($(".two-pane-settings-container")) -
+            height_of($(".two-pane-settings-header")) -
+            height_of($(".two-pane-settings-overlay .display-type")) -
+            height_of($(".settings-sticky-footer")),
+    );
+}
+
 export function resize_page_components(): void {
     resize_navbar_alerts();
     resize_sidebars();
     resize_bottom_whitespace();
     resize_stream_subscribers_list();
+    resize_settings_creation_overlay();
 }

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -83,6 +83,10 @@ export function watch_manual_resize_for_element(box: Element): (() => void)[] {
     return [box_handler, body_handler];
 }
 
+function height_of($element: JQuery): number {
+    return $element.get(0)!.getBoundingClientRect().height;
+}
+
 export function reset_compose_message_max_height(bottom_whitespace_height?: number): void {
     // If the compose-box is open, we set the `max-height` property of
     // `compose-textarea` and `preview-textarea`, so that the
@@ -95,10 +99,10 @@ export function reset_compose_message_max_height(bottom_whitespace_height?: numb
         bottom_whitespace_height = get_bottom_whitespace_height();
     }
 
-    const compose_height = $("#compose").get(0)!.getBoundingClientRect().height;
+    const compose_height = height_of($("#compose"));
     const compose_textarea_height = Math.max(
-        $("textarea#compose-textarea").get(0)!.getBoundingClientRect().height,
-        $("#preview_message_area").get(0)!.getBoundingClientRect().height,
+        height_of($("textarea#compose-textarea")),
+        height_of($("#preview_message_area")),
     );
     const compose_non_textarea_height = compose_height - compose_textarea_height;
 

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -139,7 +139,7 @@ export function resize_stream_subscribers_list(): void {
         return;
     }
 
-    const $subscriptions_info = $("#subscription_overlay .subscriptions-container .right");
+    const $subscriptions_info = $("#subscription_overlay .two-pane-settings-container .right");
     const classes_above_subscribers_list = [
         ".display-type", // = stream_settings_title
         ".subscriber_list_settings_container .stream_settings_header",

--- a/web/src/resize.ts
+++ b/web/src/resize.ts
@@ -218,6 +218,27 @@ function resize_navbar_alerts(): void {
     }
 }
 
+export function resize_settings_overlay(): void {
+    if ($(".two-pane-settings-overlay.show").length === 0) {
+        return;
+    }
+
+    $(".two-pane-settings-left-simplebar-container").css(
+        "height",
+        height_of($(".two-pane-settings-container")) -
+            height_of($(".two-pane-settings-header")) -
+            height_of($(".two-pane-settings-subheader")) -
+            height_of($(".two-pane-settings-search")),
+    );
+
+    $(".two-pane-settings-right-simplebar-container").css(
+        "height",
+        height_of($(".two-pane-settings-container")) -
+            height_of($(".two-pane-settings-header")) -
+            height_of($(".two-pane-settings-subheader")),
+    );
+}
+
 export function resize_settings_creation_overlay(): void {
     if ($(".two-pane-settings-creation-simplebar-container").length === 0) {
         return;
@@ -227,7 +248,7 @@ export function resize_settings_creation_overlay(): void {
         "height",
         height_of($(".two-pane-settings-container")) -
             height_of($(".two-pane-settings-header")) -
-            height_of($(".two-pane-settings-overlay .display-type")) -
+            height_of($(".two-pane-settings-subheader")) -
             height_of($(".settings-sticky-footer")),
     );
 }
@@ -237,5 +258,6 @@ export function resize_page_components(): void {
     resize_sidebars();
     resize_bottom_whitespace();
     resize_stream_subscribers_list();
+    resize_settings_overlay();
     resize_settings_creation_overlay();
 }

--- a/web/src/stream_create.ts
+++ b/web/src/stream_create.ts
@@ -12,6 +12,7 @@ import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as loading from "./loading.ts";
 import * as onboarding_steps from "./onboarding_steps.ts";
+import * as resize from "./resize.ts";
 import * as settings_components from "./settings_components.ts";
 import * as settings_data from "./settings_data.ts";
 import {current_user, realm} from "./state_data.ts";
@@ -458,6 +459,7 @@ export function show_new_stream_modal(): void {
     $("#stream-creation").removeClass("hide");
     $(".right .settings").hide();
     stream_ui_updates.hide_or_disable_stream_privacy_options_if_required($("#stream-creation"));
+    resize.resize_settings_creation_overlay();
 
     stream_create_subscribers.build_widgets();
 

--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -99,7 +99,9 @@ export function get_active_data(): {
 } {
     const $active_row = $("div.stream-row.active");
     const valid_active_id = Number.parseInt($active_row.attr("data-stream-id")!, 10);
-    const $active_tabs = $(".subscriptions-container").find("div.ind-tab.selected");
+    const $active_tabs = $("#subscription_overlay .two-pane-settings-container").find(
+        "div.ind-tab.selected",
+    );
     return {
         $row: $active_row,
         id: valid_active_id,

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -924,7 +924,7 @@ export function switch_to_stream_row(stream_id: number): void {
 
 function show_right_section(): void {
     $(".right").addClass("show");
-    $(".subscriptions-header").addClass("slide-left");
+    $("#subscription_overlay .two-pane-settings-header").addClass("slide-left");
     resize.resize_stream_subscribers_list();
 }
 
@@ -1160,6 +1160,6 @@ export function initialize(): void {
 
     $("#channels_overlay_container").on("click", ".fa-chevron-left", () => {
         $(".right").removeClass("show");
-        $(".subscriptions-header").removeClass("slide-left");
+        $("#channels_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
 }

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -938,6 +938,7 @@ export function change_state(
     if (section === "new") {
         do_open_create_stream();
         show_right_section();
+        resize.resize_settings_creation_overlay();
         return;
     }
 

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1016,6 +1016,7 @@ export function launch(
                 }
             }
         }, 0);
+        resize.resize_settings_overlay();
     });
 }
 

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -923,7 +923,7 @@ export function switch_to_stream_row(stream_id: number): void {
 }
 
 function show_right_section(): void {
-    $(".right").addClass("show");
+    $("#channels_overlay_container .two-pane-settings-container").addClass("right-pane-open");
     $("#subscription_overlay .two-pane-settings-header").addClass("slide-left");
     resize.resize_stream_subscribers_list();
 }
@@ -1160,7 +1160,9 @@ export function initialize(): void {
     );
 
     $("#channels_overlay_container").on("click", ".fa-chevron-left", () => {
-        $(".right").removeClass("show");
+        $("#channels_overlay_container .two-pane-settings-container").removeClass(
+            "right-pane-open",
+        );
         $("#channels_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
 }

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -573,7 +573,7 @@ export function initialize(): void {
             is inserted dynamically after handlebar got rendered. So we append the
             tooltip element to the body itself with target as the + button.
         */
-        target: "#groups_overlay .create_user_group_plus_button",
+        target: "#groups_overlay .two-pane-settings-plus-button",
         content: $t({
             defaultMessage: "Create new user group",
         }),

--- a/web/src/user_group_create.ts
+++ b/web/src/user_group_create.ts
@@ -9,6 +9,7 @@ import * as group_permission_settings from "./group_permission_settings.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
 import * as loading from "./loading.ts";
+import * as resize from "./resize.ts";
 import * as settings_components from "./settings_components.ts";
 import * as settings_data from "./settings_data.ts";
 import {realm} from "./state_data.ts";
@@ -183,6 +184,7 @@ function clear_error_display(): void {
 export function show_new_user_group_modal(): void {
     $("#user-group-creation").removeClass("hide");
     $(".right .settings").hide();
+    resize.resize_settings_creation_overlay();
 
     user_group_create_members.build_widgets();
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1314,7 +1314,7 @@ export function switch_to_group_row(group: UserGroup): void {
 }
 
 function show_right_section(): void {
-    $(".right").addClass("show");
+    $("#groups_overlay .two-pane-settings-container").addClass("right-pane-open");
     $("#groups_overlay .two-pane-settings-header").addClass("slide-left");
 }
 
@@ -1992,7 +1992,7 @@ export function initialize(): void {
     $("#groups_overlay_container").on("click", ".group-row", show_right_section);
 
     $("#groups_overlay_container").on("click", ".fa-chevron-left", () => {
-        $(".right").removeClass("show");
+        $("#groups_overlay .two-pane-settings-container").removeClass("right-pane-open");
         $("#groups_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
 

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1314,7 +1314,7 @@ export function switch_to_group_row(group: UserGroup): void {
 
 function show_right_section(): void {
     $(".right").addClass("show");
-    $(".user-groups-header").addClass("slide-left");
+    $("#groups_overlay .two-pane-settings-header").addClass("slide-left");
 }
 
 export function add_group_to_table(group: UserGroup): void {
@@ -1991,7 +1991,7 @@ export function initialize(): void {
 
     $("#groups_overlay_container").on("click", ".fa-chevron-left", () => {
         $(".right").removeClass("show");
-        $(".user-groups-header").removeClass("slide-left");
+        $("#groups_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
 
     $("#groups_overlay_container").on("click", ".join_leave_button", function (this: HTMLElement) {

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1186,7 +1186,7 @@ function empty_right_panel(): void {
 
 function open_right_panel_empty(): void {
     empty_right_panel();
-    const tab_key = $(".user-groups-container")
+    const tab_key = $("#groups_overlay .two-pane-settings-container")
         .find("div.ind-tab.selected")
         .first()
         .attr("data-tab-key");
@@ -1272,7 +1272,9 @@ export function is_group_already_present(group: UserGroup): boolean {
 }
 
 export function get_active_data(): ActiveData {
-    const $active_tabs = $(".user-groups-container").find("div.ind-tab.selected");
+    const $active_tabs = $("#groups_overlay .two-pane-settings-container").find(
+        "div.ind-tab.selected",
+    );
     const active_group_id = user_group_components.active_group_id;
     let $row;
     if (active_group_id !== undefined) {

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -2091,6 +2091,7 @@ export function launch(
             },
         });
         change_state(section, left_side_tab, right_side_tab);
+        resize.resize_settings_overlay();
     });
     if (!get_active_data().id) {
         if (section === "new") {

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -40,6 +40,7 @@ import * as ListWidget from "./list_widget.ts";
 import * as loading from "./loading.ts";
 import * as overlays from "./overlays.ts";
 import * as people from "./people.ts";
+import * as resize from "./resize.ts";
 import * as scroll_util from "./scroll_util.ts";
 import type {UserGroupUpdateEvent} from "./server_event_types.ts";
 import * as settings_components from "./settings_components.ts";
@@ -1427,6 +1428,7 @@ export function change_state(
     if (section === "new") {
         do_open_create_user_group();
         redraw_user_group_list();
+        resize.resize_settings_creation_overlay();
         return;
     }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -342,10 +342,6 @@ input::placeholder {
     }
 }
 
-.stream_sorter_toggle {
-    margin-left: auto;
-}
-
 /* -- unified overlay design component -- */
 div.overlay {
     position: fixed;

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -568,7 +568,7 @@
     --overlay-container-max-height: 1000px;
     /* The width of the settings sidebar. */
     --settings-sidebar-width: 18.2142em; /* 255px at 14px/em */
-    /* .subscriptions-header and .settings-header */
+    /* .two-pane-settings-header and .settings-header */
     --settings-overlay-header-height: 3.2143em; /* 45px at 14px/em */
     /* .display-type and .list-toggler-container
        in subscriptions and user group settings overlays */

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -574,8 +574,6 @@
        in subscriptions and user group settings overlays */
     --settings-overlay-subheader-height: 3.1429em; /* 44px at 14px/em */
     --settings-overlay-header-button-height: 2em;
-    /* .settings-sticky-footer */
-    --subscriptions-overlay-sticky-footer-height: 60px;
     /* Informational overlay */
     --informational-overlay-max-width: 43.75em;
     --modal-input-width: 23.2142em;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -369,8 +369,7 @@
         }
     }
 
-    .create_user_group_plus_button,
-    .create_stream_plus_button {
+    .two-pane-settings-plus-button {
         color: hsl(0deg 0% 100%);
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -339,6 +339,75 @@ h4.user_group_setting_subsection_title {
     }
 }
 
+/* Subheader styles */
+.two-pane-settings-container {
+    .list-toggler-container {
+        align-items: center;
+        padding: 0 8px;
+        border-bottom: 1px solid var(--color-border-modal-bar);
+        display: flex;
+        justify-content: space-between;
+        height: var(--settings-overlay-subheader-height);
+    }
+
+    #add_new_subscription {
+        height: var(--settings-overlay-header-button-height);
+    }
+
+    .display-type {
+        height: var(--settings-overlay-subheader-height);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: 600;
+        border-bottom: 1px solid var(--color-border-modal-bar);
+
+        & a {
+            color: inherit;
+
+            &:hover {
+                color: inherit;
+                text-decoration: none;
+            }
+        }
+
+        &.preview::after {
+            content: "Preview";
+        }
+
+        &.preferences::after {
+            content: "Preferences";
+        }
+
+        .stream-info-title,
+        .user-group-info-title {
+            display: none;
+            font-size: 1.5em; /* 21px at 14px/em */
+            line-height: 1.25;
+            font-weight: 600;
+            overflow-wrap: break-word;
+            line-clamp: 2;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            margin: 20px 10px 0;
+
+            &.showing-info-title {
+                display: -webkit-box;
+            }
+
+            .large-icon {
+                display: inline-block;
+                margin-left: 5px;
+
+                .zulip-icon {
+                    font-size: 0.75em; /* 18px at 24px/em */
+                }
+            }
+        }
+    }
+}
+
 #subscription_overlay .two-pane-settings-container {
     container: subscriptions / inline-size;
 }
@@ -500,19 +569,6 @@ h4.user_group_setting_subsection_title {
 
     .left {
         border-right: 1px solid var(--color-border-modal-bar);
-
-        .list-toggler-container {
-            align-items: center;
-            padding: 0 8px;
-            border-bottom: 1px solid var(--color-border-modal-bar);
-            display: flex;
-            justify-content: space-between;
-            height: var(--settings-overlay-subheader-height);
-
-            #add_new_subscription {
-                height: var(--settings-overlay-header-button-height);
-            }
-        }
     }
 
     .right {
@@ -527,59 +583,6 @@ h4.user_group_setting_subsection_title {
 
         .main-view-banner.group_deactivated {
             margin-bottom: 10px;
-        }
-
-        .display-type {
-            height: var(--settings-overlay-subheader-height);
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            font-weight: 600;
-            border-bottom: 1px solid var(--color-border-modal-bar);
-
-            & a {
-                color: inherit;
-
-                &:hover {
-                    color: inherit;
-                    text-decoration: none;
-                }
-            }
-
-            &.preview::after {
-                content: "Preview";
-            }
-
-            &.preferences::after {
-                content: "Preferences";
-            }
-
-            .stream-info-title,
-            .user-group-info-title {
-                display: none;
-                font-size: 1.5em; /* 21px at 14px/em */
-                line-height: 1.25;
-                font-weight: 600;
-                overflow-wrap: break-word;
-                line-clamp: 2;
-                -webkit-line-clamp: 2;
-                -webkit-box-orient: vertical;
-                overflow: hidden;
-                margin: 20px 10px 0;
-
-                &.showing-info-title {
-                    display: -webkit-box;
-                }
-
-                .large-icon {
-                    display: inline-block;
-                    margin-left: 5px;
-
-                    .zulip-icon {
-                        font-size: 0.75em; /* 18px at 24px/em */
-                    }
-                }
-            }
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -70,8 +70,7 @@
     height: var(--settings-overlay-header-button-height);
 }
 
-.create_user_group_plus_button,
-.create_stream_plus_button {
+.two-pane-settings-plus-button {
     font-weight: 400;
     position: relative;
     border: 1px solid hsl(0deg 0% 80%);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -77,7 +77,7 @@
     border-radius: 5px;
     background-color: hsl(0deg 0% 100%);
     color: hsl(0deg 0% 0%);
-    margin: 0 0 0 5px;
+    margin: 0;
     height: 100%;
     width: var(--settings-overlay-header-button-height);
     display: flex;
@@ -339,32 +339,44 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-/* Subheader styles */
-.two-pane-settings-container {
-    .list-toggler-container {
-        align-items: center;
-        padding: 0 8px;
-        border-bottom: 1px solid var(--color-border-modal-bar);
+.two-pane-settings-container .two-pane-settings-subheader {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--color-border-modal-bar);
+    grid-area: subheader;
+
+    .left,
+    .right {
         display: flex;
-        justify-content: space-between;
-        height: var(--settings-overlay-subheader-height);
+        justify-content: center;
     }
 
-    .stream_sorter_toggle {
+    .list-toggler-container {
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 8px;
+        display: flex;
+        justify-content: end;
+        flex-grow: 1;
+        gap: 5px;
+    }
+
+    .tab-switcher.stream_sorter_toggle {
         margin-left: auto;
     }
 
+    .tab-switcher,
     #add_new_subscription {
+        margin: 0;
         height: var(--settings-overlay-header-button-height);
     }
 
     .display-type {
-        height: var(--settings-overlay-subheader-height);
+        width: 100%;
         display: flex;
         justify-content: center;
         align-items: center;
         font-weight: 600;
-        border-bottom: 1px solid var(--color-border-modal-bar);
 
         & a {
             color: inherit;
@@ -411,68 +423,25 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-#subscription_overlay .two-pane-settings-container {
-    container: subscriptions / inline-size;
-}
-
-/* There's an awkward width of modal that is wider than the
-   breakpoint that collapses the left pane, but still narrow
-   enough that the sort buttons need a second row to be visible
-   without overlapping other UI. Note that for 16px and larger
-   font sizes, we always show two rows of buttons.
-
-   We also show two rows of buttons on particularly narrow
-   screens where there's only one panel and the overlay doesn't
-   have enough space for all the buttons. */
-@container settings-overlay (
-    ((width >= $settings_overlay_sidebar_collapse_breakpoint) and (width < calc(80em + 80px)))
-    or ((width < $settings_overlay_sidebar_collapse_breakpoint) and (width <= 36em))
-) {
-    #subscription_overlay .two-pane-settings-container {
-        .left {
-            .list-toggler-container {
-                height: 5em;
-                justify-content: end;
-                flex-wrap: wrap;
-            }
-
-            .tab-switcher {
-                margin-right: 0;
-            }
-
-            .tab-switcher:first-child {
-                /* This forces the other buttons to the next row */
-                width: 100%;
-                display: flex;
-                justify-content: end;
-            }
-        }
-
-        .right .display-type {
-            height: 5em;
-        }
-
-        .streams-list {
-            /* Calculated from several heights and padding/margin measurements
-            in .list-toggler-container and .stream_filter, with some added
-            fiddling to see what worked best at 12px - 20px font sizes.
-            Notably this height is shorter than the similar calculation
-            below because the toggler is taller.
-            When we redesign this area we should make this less brittle. */
-            height: calc(100% - 5.4em - 40px);
-        }
-
-        #stream_settings {
-            height: calc(100% - 5em);
-        }
-    }
-}
-
 .two-pane-settings-container {
+    display: grid;
+    grid-template-areas:
+        "header   "
+        "subheader"
+        "body     ";
+    grid-template-rows:
+        var(--settings-overlay-header-height)
+        minmax(var(--settings-overlay-subheader-height), max-content)
+        minmax(0, 1fr);
     position: relative;
     height: 95%;
     border-radius: 4px;
     padding: 0;
+    /* TODO(evy) Broken! For some reason the children are not shrinking and growing
+       with the container element. It seems to load fine on page-load, but when I
+       change the size of the screen things start getting cut off.
+       I tried setting 97vw width on every child element too but then the container
+       was shrinking faster than the children. ??? */
     width: 97%;
     overflow: hidden;
     max-width: 1200px;
@@ -489,7 +458,7 @@ h4.user_group_setting_subsection_title {
     }
 
     .two-pane-settings-header {
-        height: var(--settings-overlay-header-height);
+        grid-area: header;
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -512,13 +481,8 @@ h4.user_group_setting_subsection_title {
         cursor: pointer;
     }
 
-    .left,
-    .right {
-        position: relative;
-        display: inline-block;
-        vertical-align: top;
-        height: calc(100% - var(--settings-overlay-header-height));
-        margin: 0 -2px;
+    .two-pane-settings-body {
+        display: flex;
     }
 
     .left .no-streams-to-show,
@@ -651,11 +615,6 @@ h4.user_group_setting_subsection_title {
     position: relative;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    /* Calculated from several heights and padding/margin measurements
-    in .list-toggler-container and .stream_filter, with some added
-    fiddling to see what worked best at 12px - 20px font sizes.
-    When we redesign this area we should make this less brittle. */
-    height: calc(100% - 3.4em - 40px);
     width: 100%;
 }
 
@@ -939,9 +898,8 @@ h4.user_group_setting_subsection_title {
         .settings-sticky-footer {
             display: flex;
             justify-content: space-between;
-            position: absolute;
-            bottom: 0;
-            width: calc(100% - 27px);
+            /* Subtract 15px padding on either side. */
+            width: calc(100% - 30px);
             padding: 9px 15px 15px;
             text-align: right;
             background-color: var(--color-background-modal-bar);
@@ -1163,7 +1121,6 @@ h4.user_group_setting_subsection_title {
 
     .settings {
         position: relative;
-        height: calc(100% - var(--settings-overlay-header-height));
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
 
@@ -1435,10 +1392,6 @@ div.settings-radio-input-parent {
     .two-pane-settings-overlay .two-pane-settings-container {
         position: relative;
         overflow: hidden;
-
-        .list-toggler-container {
-            text-align: left;
-        }
 
         .two-pane-settings-header .fa-chevron-left {
             visibility: visible;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -277,8 +277,8 @@ h4.user_group_setting_subsection_title {
     margin: 0;
 }
 
-.subscriptions-container .subscriptions-header .fa-chevron-left,
-.user-groups-container .user-groups-header .fa-chevron-left {
+.two-pane-settings-container .subscriptions-header .fa-chevron-left,
+.two-pane-settings-container .user-groups-header .fa-chevron-left {
     position: relative;
     transform: translate(-50px, 0);
     opacity: 0;
@@ -288,13 +288,14 @@ h4.user_group_setting_subsection_title {
     padding: 2px 10px;
 
     cursor: pointer;
+    visibility: hidden;
 
     transition: 0.3s ease;
     transition-property: opacity, transform;
 }
 
-.user-groups-container .user-groups-header.slide-left .fa-chevron-left,
-.subscriptions-container .subscriptions-header.slide-left .fa-chevron-left,
+.two-pane-settings-container .user-groups-header.slide-left .fa-chevron-left,
+.two-pane-settings-container .subscriptions-header.slide-left .fa-chevron-left,
 #settings_overlay_container
     .settings-header.mobile.slide-left
     .fa-chevron-left {
@@ -339,7 +340,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-.subscriptions-container {
+#subscription_overlay .two-pane-settings-container {
     container: subscriptions / inline-size;
 }
 
@@ -356,7 +357,7 @@ h4.user_group_setting_subsection_title {
     ((width >= $settings_overlay_sidebar_collapse_breakpoint) and (width < calc(80em + 80px)))
     or ((width < $settings_overlay_sidebar_collapse_breakpoint) and (width <= 36em))
 ) {
-    #subscription_overlay .subscriptions-container {
+    #subscription_overlay .two-pane-settings-container {
         .left {
             .list-toggler-container {
                 height: 5em;
@@ -396,8 +397,7 @@ h4.user_group_setting_subsection_title {
     }
 }
 
-.user-groups-container,
-.subscriptions-container {
+.two-pane-settings-container {
     position: relative;
     height: 95%;
     border-radius: 4px;
@@ -427,10 +427,6 @@ h4.user_group_setting_subsection_title {
         font-weight: 700;
         background-color: var(--color-background-modal-bar);
         border-bottom: 1px solid var(--color-border-modal-bar);
-
-        .fa-chevron-left {
-            visibility: hidden;
-        }
 
         .exit {
             font-weight: 600;
@@ -1425,12 +1421,11 @@ div.settings-radio-input-parent {
 }
 
 @media (width < $lg_min) {
-    .user-groups-container,
-    .subscriptions-container {
+    .two-pane-settings-container {
         max-width: 95%;
     }
 
-    .subscriptions-container .left .list-toggler-container {
+    .two-pane-settings-container .left .list-toggler-container {
         flex-wrap: wrap;
     }
 
@@ -1450,8 +1445,7 @@ div.settings-radio-input-parent {
    Longer-term we should extract this logic two-column-overlay class
    to read more naturally. */
 @container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
-    .user-groups-container,
-    .subscriptions-container {
+    .two-pane-settings-container {
         position: relative;
         overflow: hidden;
 
@@ -1499,8 +1493,7 @@ div.settings-radio-input-parent {
 
     #subscription_overlay,
     #groups_overlay {
-        .user-groups-container,
-        .subscriptions-container {
+        .two-pane-settings-container {
             height: 95%;
         }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -277,8 +277,7 @@ h4.user_group_setting_subsection_title {
     margin: 0;
 }
 
-.two-pane-settings-container .subscriptions-header .fa-chevron-left,
-.two-pane-settings-container .user-groups-header .fa-chevron-left {
+.two-pane-settings-container .two-pane-settings-header .fa-chevron-left {
     position: relative;
     transform: translate(-50px, 0);
     opacity: 0;
@@ -294,8 +293,9 @@ h4.user_group_setting_subsection_title {
     transition-property: opacity, transform;
 }
 
-.two-pane-settings-container .user-groups-header.slide-left .fa-chevron-left,
-.two-pane-settings-container .subscriptions-header.slide-left .fa-chevron-left,
+.two-pane-settings-container
+    .two-pane-settings-header.slide-left
+    .fa-chevron-left,
 #settings_overlay_container
     .settings-header.mobile.slide-left
     .fa-chevron-left {
@@ -417,8 +417,7 @@ h4.user_group_setting_subsection_title {
         }
     }
 
-    .user-groups-header,
-    .subscriptions-header {
+    .two-pane-settings-header {
         height: var(--settings-overlay-header-height);
         display: flex;
         align-items: center;
@@ -1453,8 +1452,7 @@ div.settings-radio-input-parent {
             text-align: left;
         }
 
-        .user-groups-header .fa-chevron-left,
-        .subscriptions-header .fa-chevron-left {
+        .two-pane-settings-header .fa-chevron-left {
             visibility: visible;
         }
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -390,7 +390,6 @@ h4.user_group_setting_subsection_title {
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
-            margin: 20px 10px 0;
 
             &.showing-info-title {
                 display: -webkit-box;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -517,7 +517,6 @@ h4.user_group_setting_subsection_title {
         position: relative;
         display: inline-block;
         vertical-align: top;
-        width: 40%;
         height: calc(100% - var(--settings-overlay-header-height));
         margin: 0 -2px;
     }
@@ -571,6 +570,7 @@ h4.user_group_setting_subsection_title {
     }
 
     .left {
+        width: 40%;
         border-right: 1px solid var(--color-border-modal-bar);
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -908,13 +908,11 @@ h4.user_group_setting_subsection_title {
 }
 
 #settings_page,
-#groups_overlay,
-#subscription_overlay {
+.two-pane-settings-overlay {
     container: settings-overlay / inline-size;
 }
 
-#groups_overlay,
-#subscription_overlay {
+.two-pane-settings-overlay {
     .tab-switcher {
         display: flex;
         flex-wrap: nowrap;
@@ -1438,10 +1436,10 @@ div.settings-radio-input-parent {
 }
 
 /* Note that this block has settings_page CSS as well, and thus needs
-   to match the media queries in settings.css.
+   to match the media queries in settings.css
 
-   Longer-term we should extract this logic two-column-overlay class
-   to read more naturally. */
+   We should eventually consolidate some of these styles with the settings
+   menu, using shared classnames. */
 @container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
     .two-pane-settings-container {
         position: relative;
@@ -1456,10 +1454,8 @@ div.settings-radio-input-parent {
         }
     }
 
-    #groups_overlay .left,
-    #groups_overlay .right,
-    #subscription_overlay .left,
-    #subscription_overlay .right,
+    .two-pane-settings-overlay .left,
+    .two-pane-settings-overlay .right,
     #settings_page .content-wrapper.right {
         position: absolute;
         display: block;
@@ -1470,8 +1466,7 @@ div.settings-radio-input-parent {
         border: none;
     }
 
-    #groups_overlay .right,
-    #subscription_overlay .right,
+    .two-pane-settings-overlay .right,
     #settings_page .content-wrapper.right {
         position: absolute;
         left: 101%;
@@ -1488,8 +1483,7 @@ div.settings-radio-input-parent {
         }
     }
 
-    #subscription_overlay,
-    #groups_overlay {
+    .two-pane-settings-overlay {
         .two-pane-settings-container {
             height: 95%;
         }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1431,7 +1431,8 @@ div.settings-radio-input-parent {
    We should eventually consolidate some of these styles with the settings
    menu, using shared classnames. */
 @container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
-    .two-pane-settings-container {
+    /* Two classnames for extra specificity to override wide-screen styles. */
+    .two-pane-settings-overlay .two-pane-settings-container {
         position: relative;
         overflow: hidden;
 
@@ -1442,32 +1443,30 @@ div.settings-radio-input-parent {
         .two-pane-settings-header .fa-chevron-left {
             visibility: visible;
         }
-    }
 
-    .two-pane-settings-overlay .left,
-    .two-pane-settings-overlay .right {
-        position: absolute;
-        display: block;
-        margin: 0;
-        width: 100%;
-        height: calc(100% - var(--settings-overlay-header-height));
+        /* default left pane open without `.right-pane-open` present */
+        .left {
+            display: block;
+            width: 100%;
+        }
 
-        border: none;
-    }
+        .right {
+            display: none;
+            background-color: var(--color-background-modal);
+            border-top: none;
+            transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+        }
 
-    .two-pane-settings-overlay .right {
-        position: absolute;
-        left: 101%;
+        &.right-pane-open {
+            .right {
+                display: block;
+                width: 100%;
+            }
 
-        top: var(--settings-overlay-header-height);
-        background-color: var(--color-background-modal);
-        border-top: none;
-
-        transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
-        z-index: 10;
-
-        &.show {
-            left: 0%;
+            .left,
+            .two-pane-settings-subheader {
+                display: none;
+            }
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -350,6 +350,10 @@ h4.user_group_setting_subsection_title {
         height: var(--settings-overlay-subheader-height);
     }
 
+    .stream_sorter_toggle {
+        margin-left: auto;
+    }
+
     #add_new_subscription {
         height: var(--settings-overlay-header-button-height);
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1445,8 +1445,7 @@ div.settings-radio-input-parent {
     }
 
     .two-pane-settings-overlay .left,
-    .two-pane-settings-overlay .right,
-    #settings_page .content-wrapper.right {
+    .two-pane-settings-overlay .right {
         position: absolute;
         display: block;
         margin: 0;
@@ -1456,14 +1455,33 @@ div.settings-radio-input-parent {
         border: none;
     }
 
-    .two-pane-settings-overlay .right,
-    #settings_page .content-wrapper.right {
+    .two-pane-settings-overlay .right {
         position: absolute;
         left: 101%;
 
         top: var(--settings-overlay-header-height);
         background-color: var(--color-background-modal);
         border-top: none;
+
+        transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+        z-index: 10;
+
+        &.show {
+            left: 0%;
+        }
+    }
+
+    #settings_page .content-wrapper.right {
+        position: absolute;
+        display: block;
+        left: 101%;
+        margin: 0;
+        width: 100%;
+        height: calc(100% - var(--settings-overlay-header-height));
+
+        top: var(--settings-overlay-header-height);
+        background-color: var(--color-background-modal);
+        border: none;
 
         transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
         z-index: 10;

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1429,9 +1429,7 @@ div.settings-radio-input-parent {
     .subscriptions-container {
         max-width: 95%;
     }
-}
 
-@media (width < $lg_min) {
     .subscriptions-container .left .list-toggler-container {
         flex-wrap: wrap;
     }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -925,22 +925,6 @@ h4.user_group_setting_subsection_title {
         outline: none;
         -webkit-overflow-scrolling: touch;
 
-        .stream-creation-simplebar-container,
-        .user-group-creation-simplebar-container {
-            height: calc(
-                var(--overlay-container-height) -
-                    var(--settings-overlay-header-height) -
-                    var(--settings-overlay-subheader-height) -
-                    var(--subscriptions-overlay-sticky-footer-height)
-            );
-            max-height: calc(
-                var(--overlay-container-max-height) -
-                    var(--settings-overlay-header-height) -
-                    var(--settings-overlay-subheader-height) -
-                    var(--subscriptions-overlay-sticky-footer-height)
-            );
-        }
-
         .user-group-creation-body,
         .stream-creation-body {
             padding: 15px 15px 0;

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -1,7 +1,7 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'Channel creation' }}">
     <form id="stream_creation_form">
-        <div class="stream-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+        <div class="two-pane-settings-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
             <div class="alert stream_create_info"></div>
             <div id="stream_creating_indicator"></div>
             <div class="stream-creation-body">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -12,7 +12,7 @@
                 <div class="list-toggler-container">
                     <div id="add_new_subscription">
                         {{#if can_create_streams}}
-                        <button class="create_stream_button create_stream_plus_button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
+                        <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
                             <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
                         </button>
                         {{/if}}

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -1,6 +1,6 @@
 <div id="subscription_overlay" class="overlay" data-overlay="subscriptions">
     <div class="flex overlay-content">
-        <div class="subscriptions-container overlay-container">
+        <div class="two-pane-settings-container overlay-container">
             <div class="subscriptions-header">
                 <div class="fa fa-chevron-left"></div>
                 <span class="subscriptions-title">{{t 'Channels' }}</span>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -1,7 +1,7 @@
 <div id="subscription_overlay" class="overlay" data-overlay="subscriptions">
     <div class="flex overlay-content">
         <div class="two-pane-settings-container overlay-container">
-            <div class="subscriptions-header">
+            <div class="two-pane-settings-header">
                 <div class="fa fa-chevron-left"></div>
                 <span class="subscriptions-title">{{t 'Channels' }}</span>
                 <div class="exit">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -1,4 +1,4 @@
-<div id="subscription_overlay" class="overlay" data-overlay="subscriptions">
+<div id="subscription_overlay" class="overlay two-pane-settings-overlay" data-overlay="subscriptions">
     <div class="flex overlay-content">
         <div class="two-pane-settings-container overlay-container">
             <div class="two-pane-settings-header">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -8,78 +8,86 @@
                     <span class="exit-sign">&times;</span>
                 </div>
             </div>
-            <div class="left">
-                <div class="list-toggler-container">
-                    <div id="add_new_subscription">
-                        {{#if can_create_streams}}
-                        <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
-                            <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
-                        </button>
-                        {{/if}}
-                        <div class="float-clear"></div>
-                    </div>
-                </div>
-                <div class="input-append stream_name_search_section" id="stream_filter">
-                    <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
-                      placeholder="{{t 'Filter' }}" value=""/>
-                    <button type="button" class="clear_search_button" id="clear_search_stream_name">
-                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-                    </button>
-                    <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
-                        {{> ../dropdown_widget widget_name="stream_settings_filter"}}
-                    </div>
-                </div>
-                <div class="no-streams-to-show">
-                    <div class="subscribed_streams_tab_empty_text">
-                        <span class="settings-empty-option-text">
-                            {{t 'You are not subscribed to any channels.'}}
-                            {{#if can_view_all_streams}}
-                            <a href="#channels/all">{{t 'View all channels'}}</a>
-                            {{/if}}
-                        </span>
-                    </div>
-                    <div class="not_subscribed_streams_tab_empty_text">
-                        <span class="settings-empty-option-text">
-                            {{t 'No channels to show.'}}
-                            <a href="#channels/all">{{t 'View all channels'}}</a>
-                        </span>
-                    </div>
-                    <div class="no_stream_match_filter_empty_text">
-                        <span class="settings-empty-option-text">
-                            {{t 'No channels match your filter.'}}
-                        </span>
-                    </div>
-                    <div class="all_streams_tab_empty_text">
-                        <span class="settings-empty-option-text">
-                            {{t 'There are no channels you can view in this organization.'}}
+            <div class="two-pane-settings-subheader">
+                <div class="left">
+                    <div class="list-toggler-container">
+                        <div id="add_new_subscription">
                             {{#if can_create_streams}}
-                                <a href="#channels/new">{{t 'Create a channel'}}</a>
+                            <button class="create_stream_button two-pane-settings-plus-button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
+                                <i class="create_button_plus_sign zulip-icon zulip-icon-square-plus" aria-hidden="true"></i>
+                            </button>
                             {{/if}}
-                        </span>
+                            <div class="float-clear"></div>
+                        </div>
                     </div>
                 </div>
-                <div class="streams-list" data-simplebar data-simplebar-tab-index="-1">
+                <div class="right">
+                    <div class="display-type">
+                        <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
+                    </div>
                 </div>
             </div>
-            <div class="right">
-                <div class="display-type">
-                    <div id="stream_settings_title" class="stream-info-title">{{t 'Channel settings' }}</div>
-                </div>
-                <div class="nothing-selected">
-                    <div class="stream-info-banner"></div>
-                    <div class="create-stream-button-container">
-                        <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
-                        {{#unless can_create_streams}}
-                        <span class="settings-empty-option-text">
-                            {{t 'You do not have permission to create channels.' }}
-                        </span>
-                        {{/unless}}
+            <div class="two-pane-settings-body">
+                <div class="left">
+                    <div class="input-append stream_name_search_section two-pane-settings-search" id="stream_filter">
+                        <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
+                          placeholder="{{t 'Filter' }}" value=""/>
+                        <button type="button" class="clear_search_button" id="clear_search_stream_name">
+                            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                        </button>
+                        <div class="stream_settings_filter_container {{#unless realm_has_archived_channels}}hide_filter{{/unless}}">
+                            {{> ../dropdown_widget widget_name="stream_settings_filter"}}
+                        </div>
+                    </div>
+                    <div class="no-streams-to-show">
+                        <div class="subscribed_streams_tab_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'You are not subscribed to any channels.'}}
+                                {{#if can_view_all_streams}}
+                                <a href="#channels/all">{{t 'View all channels'}}</a>
+                                {{/if}}
+                            </span>
+                        </div>
+                        <div class="not_subscribed_streams_tab_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'No channels to show.'}}
+                                <a href="#channels/all">{{t 'View all channels'}}</a>
+                            </span>
+                        </div>
+                        <div class="no_stream_match_filter_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'No channels match your filter.'}}
+                            </span>
+                        </div>
+                        <div class="all_streams_tab_empty_text">
+                            <span class="settings-empty-option-text">
+                                {{t 'There are no channels you can view in this organization.'}}
+                                {{#if can_create_streams}}
+                                    <a href="#channels/new">{{t 'Create a channel'}}</a>
+                                {{/if}}
+                            </span>
+                        </div>
+                    </div>
+                    <div class="streams-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
                     </div>
                 </div>
-                <div id="stream_settings" class="settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                    {{!-- edit stream here --}}
+                <div class="right">
+                    <div class="nothing-selected">
+                        <div class="stream-info-banner"></div>
+                        <div class="create-stream-button-container">
+                            <button type="button" class="create_stream_button animated-purple-button" {{#unless can_create_streams}}disabled{{/unless}}>{{t 'Create channel' }}</button>
+                            {{#unless can_create_streams}}
+                            <span class="settings-empty-option-text">
+                                {{t 'You do not have permission to create channels.' }}
+                            </span>
+                            {{/unless}}
+                        </div>
+                    </div>
+                    <div id="stream_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                        {{!-- edit stream here --}}
+                    </div>
+                    {{> stream_creation_form . }}
                 </div>
-                {{> stream_creation_form . }}
             </div>
         </div>
     </div>

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -1,7 +1,7 @@
 <div class="hide" id="user-group-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'User group creation' }}">
     <form id="user_group_creation_form">
-        <div class="user-group-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
+        <div class="two-pane-settings-creation-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
             <div class="alert user_group_create_info"></div>
             <div id="user_group_creating_indicator"></div>
             <div class="user-group-creation-body">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -1,7 +1,7 @@
 <div id="groups_overlay" class="overlay" data-overlay="group_subscriptions">
     <div class="flex overlay-content">
         <div class="two-pane-settings-container overlay-container">
-            <div class="user-groups-header">
+            <div class="two-pane-settings-header">
                 <div class="fa fa-chevron-left"></div>
                 <span class="user-groups-title">{{t 'User groups' }}</span>
                 <div class="exit">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -1,4 +1,4 @@
-<div id="groups_overlay" class="overlay" data-overlay="group_subscriptions">
+<div id="groups_overlay" class="two-pane-settings-overlay overlay" data-overlay="group_subscriptions">
     <div class="flex overlay-content">
         <div class="two-pane-settings-container overlay-container">
             <div class="two-pane-settings-header">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -1,6 +1,6 @@
 <div id="groups_overlay" class="overlay" data-overlay="group_subscriptions">
     <div class="flex overlay-content">
-        <div class="user-groups-container overlay-container">
+        <div class="two-pane-settings-container overlay-container">
             <div class="user-groups-header">
                 <div class="fa fa-chevron-left"></div>
                 <span class="user-groups-title">{{t 'User groups' }}</span>

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -12,7 +12,7 @@
                 <div class="list-toggler-container">
                     <div id="add_new_user_group">
                         {{#if can_create_user_groups}}
-                        <button class="create_user_group_button create_user_group_plus_button" {{#if (not zulip_plan_is_not_limited)}}disabled{{/if}}>
+                        <button class="create_user_group_button two-pane-settings-plus-button" {{#if (not zulip_plan_is_not_limited)}}disabled{{/if}}>
                             <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
                         </button>
                         {{/if}}

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -8,55 +8,63 @@
                     <span class="exit-sign">&times;</span>
                 </div>
             </div>
-            <div class="left">
-                <div class="list-toggler-container">
-                    <div id="add_new_user_group">
-                        {{#if can_create_user_groups}}
-                        <button class="create_user_group_button two-pane-settings-plus-button" {{#if (not zulip_plan_is_not_limited)}}disabled{{/if}}>
-                            <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
-                        </button>
-                        {{/if}}
-                        <div class="float-clear"></div>
+            <div class="two-pane-settings-subheader">
+                <div class="left">
+                    <div class="list-toggler-container">
+                        <div id="add_new_user_group">
+                            {{#if can_create_user_groups}}
+                            <button class="create_user_group_button two-pane-settings-plus-button" {{#if (not zulip_plan_is_not_limited)}}disabled{{/if}}>
+                                <i class="create_button_plus_sign zulip-icon zulip-icon-user-group-plus" aria-hidden="true"></i>
+                            </button>
+                            {{/if}}
+                            <div class="float-clear"></div>
+                        </div>
                     </div>
                 </div>
-                <div class="input-append group_name_search_section" id="group_filter">
-                    <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
-                      placeholder="{{t 'Filter' }}" value=""/>
-                    <button type="button" class="clear_search_button" id="clear_search_group_name">
-                        <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
-                    </button>
-                    <span>
-                        <label class="checkbox" id="user-group-edit-filter-options">
-                            {{> ../dropdown_widget widget_name="user_group_visibility_settings"}}
-                        </label>
-                    </span>
-                </div>
-                <div class="no-groups-to-show">
-                </div>
-                <div class="user-groups-list" data-simplebar data-simplebar-tab-index="-1">
+                <div class="right">
+                    <div class="display-type">
+                        <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
+                        <i class="fa fa-ban deactivated-user-icon deactivated-user-group-icon-right"></i>
+                    </div>
                 </div>
             </div>
-            <div class="right">
-                <div class="display-type">
-                    <div id="user_group_settings_title" class="user-group-info-title">{{t 'User group settings' }}</div>
-                    <i class="fa fa-ban deactivated-user-icon deactivated-user-group-icon-right"></i>
-                </div>
-                <div class="nothing-selected">
-                    <div class="group-info-banner"></div>
-                    <div class="create-group-button-container">
-                        {{> ../settings/upgrade_tip_widget . }}
-                        <button type="button" class="create_user_group_button animated-purple-button" {{#unless (and can_create_user_groups zulip_plan_is_not_limited)}}disabled{{/unless}}>{{t 'Create user group' }}</button>
-                        {{#unless can_create_user_groups}}
-                        <span class="settings-empty-option-text">
-                            {{t 'You do not have permission to create user groups.' }}
+            <div class="two-pane-settings-body">
+                <div class="left">
+                    <div class="input-append group_name_search_section two-pane-settings-search" id="group_filter">
+                        <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
+                          placeholder="{{t 'Filter' }}" value=""/>
+                        <button type="button" class="clear_search_button" id="clear_search_group_name">
+                            <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
+                        </button>
+                        <span>
+                            <label class="checkbox" id="user-group-edit-filter-options">
+                                {{> ../dropdown_widget widget_name="user_group_visibility_settings"}}
+                            </label>
                         </span>
-                        {{/unless}}
+                    </div>
+                    <div class="no-groups-to-show">
+                    </div>
+                    <div class="user-groups-list two-pane-settings-left-simplebar-container" data-simplebar data-simplebar-tab-index="-1">
                     </div>
                 </div>
-                <div id="user_group_settings" class="settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
-                    {{!-- edit user group here --}}
+                <div class="right">
+                    <div class="nothing-selected">
+                        <div class="group-info-banner"></div>
+                        <div class="create-group-button-container">
+                            {{> ../settings/upgrade_tip_widget . }}
+                            <button type="button" class="create_user_group_button animated-purple-button" {{#unless (and can_create_user_groups zulip_plan_is_not_limited)}}disabled{{/unless}}>{{t 'Create user group' }}</button>
+                            {{#unless can_create_user_groups}}
+                            <span class="settings-empty-option-text">
+                                {{t 'You do not have permission to create user groups.' }}
+                            </span>
+                            {{/unless}}
+                        </div>
+                    </div>
+                    <div id="user_group_settings" class="two-pane-settings-right-simplebar-container settings" data-simplebar data-simplebar-tab-index="-1" data-simplebar-auto-hide="false">
+                        {{!-- edit user group here --}}
+                    </div>
+                    {{> user_group_creation_form . }}
                 </div>
-                {{> user_group_creation_form . }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is a followup to work such as #34017 that was getting too fiddly.

Instead of changing the height of the button subheader depending on the width of the modal, which was fiddly and error prone, we now let grid determine the height of the button subheader, and determine the height of the body through javascript resize calculations.

The first several commits of this PR help these two very similar overlays use more shared classnames, to more easily transition these styles. I'll open a prep PR for those commits that should have no visible changes.

Marked as draft because there's one bug that I haven't been able to figure out, noted as a `TODO(evy) Broken!` comment in the code right now.