### PR TITLE
popovers: Add an `x` button to topic field in move topic/move messages modal.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -785,6 +785,16 @@ export async function build_move_topic_to_stream_popover(
         }
     }
 
+    function update_clear_move_topic_button_state(): void {
+        const $clear_topic_name_button = $("#clear_move_topic_new_topic_name");
+        const topic_input_value = $("input#move-topic-new-topic-name").val();
+        if (topic_input_value === "") {
+            $clear_topic_name_button.css("visibility", "hidden");
+        } else {
+            $clear_topic_name_button.css("visibility", "visible");
+        }
+    }
+
     function move_topic_post_render(): void {
         $("#move_topic_modal .dialog_submit_button").prop("disabled", true);
         $("#move_topic_modal .move_topic_warning_container").hide();
@@ -812,6 +822,7 @@ export async function build_move_topic_to_stream_popover(
                     $topic_not_mandatory_placeholder.addClass(
                         "move-topic-new-topic-placeholder-visible",
                     );
+                    $("#clear_move_topic_new_topic_name").css("visibility", "hidden");
                 }
 
                 $topic_input.one("blur", () => {
@@ -821,12 +832,22 @@ export async function build_move_topic_to_stream_popover(
                         );
                         $topic_input.attr("placeholder", empty_string_topic_display_name);
                         $topic_input.addClass("empty-topic-display");
+                        $("#clear_move_topic_new_topic_name").css("visibility", "visible");
                     }
                 });
             });
         }
 
         setup_resize_observer($topic_input);
+        update_clear_move_topic_button_state();
+
+        $("#clear_move_topic_new_topic_name").on("click", (e) => {
+            e.stopPropagation();
+            const $topic_input = $("#move-topic-new-topic-name").expectOne();
+            $topic_input.val("");
+            $topic_input.trigger("input").trigger("focus");
+            move_topic_to_stream_topic_typeahead?.hide();
+        });
 
         if (only_topic_edit) {
             // Set select_stream_id to current_stream_id since we user is not allowed
@@ -838,6 +859,7 @@ export async function build_move_topic_to_stream_popover(
                 const topic_input_value = $topic_input.val();
                 assert(topic_input_value !== undefined);
                 update_topic_input_placeholder_visibility(topic_input_value);
+                update_clear_move_topic_button_state();
             });
             return;
         }
@@ -871,6 +893,7 @@ export async function build_move_topic_to_stream_popover(
             const topic_input_value = $topic_input.val();
             assert(topic_input_value !== undefined);
             update_topic_input_placeholder_visibility(topic_input_value);
+            update_clear_move_topic_button_state();
         });
 
         if (!args.from_message_actions_popover) {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -865,19 +865,28 @@ ul.popover-group-menu-member-list {
         }
     }
 
-    .move_messages_edit_topic {
-        margin-bottom: unset;
-        box-sizing: border-box;
-        width: 100%;
-        height: auto;
-
-        &.empty-topic-display::placeholder {
-            color: inherit;
-        }
-    }
-
     #move-topic-new-topic-input-wrapper {
         position: relative;
+        display: grid;
+        /* 30px at 16px/1em */
+        grid-template:
+            "move-topic-input clear-topic" auto / minmax(0, 1fr)
+            1.875em;
+
+        & input.move_messages_edit_topic {
+            grid-column: move-topic-input-start / clear-topic-end;
+            grid-row: move-topic-input;
+            /* 30px at 16px/1em */
+            padding-right: 1.875em;
+            margin-bottom: unset;
+            box-sizing: border-box;
+            width: 100%;
+            height: auto;
+
+            &.empty-topic-display::placeholder {
+                color: inherit;
+            }
+        }
     }
 
     .move-topic-new-topic-placeholder {

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -14,6 +14,11 @@
                 <span class="move-topic-new-topic-placeholder placeholder">
                     {{> topic_not_mandatory_placeholder_text empty_string_topic_display_name=empty_string_topic_display_name}}
                 </span>
+                {{#unless disable_topic_input}}
+                <button type="button" id="clear_move_topic_new_topic_name" class="clear_search_button">
+                    <i class="zulip-icon zulip-icon-close"></i>
+                </button>
+                {{/unless}}
             </div>
         </div>
         <input name="old_topic_name" type="hidden" value="{{topic_name}}" />


### PR DESCRIPTION
This PR adds an `x` button to the topic field in the move topic/move messages modal.

<!-- Describe your pull request here.-->

Fixes: #33729.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary> Added `x` button to topic field in move topic/move messages modal.</summary>

| Description                          | Screenshot |
|--------------------------------------|------------|
| Move topic/messages modal           | ![Move topic/messages modal](https://github.com/user-attachments/assets/91a3ca2d-10c0-46a9-8f8a-4c93dd86e020) |
| Rename topic modal                   | ![Rename topic modal](https://github.com/user-attachments/assets/cd06de71-feb3-434e-a8bf-7253718d35d3) |
| `x` button is hidden for empty topic field - move topic modal | ![`x` button hidden - move topic modal](https://github.com/user-attachments/assets/c219ce68-5371-4206-a80a-e49ebd8e9408) |
| `x` button is hidden for empty topic field - rename topic modal | ![`x` button hidden - rename topic modal](https://github.com/user-attachments/assets/8fc65420-3b84-4928-a467-9f65978c9c62) |
| `x` button is hidden for disabled topic field - move topic modal. | ![image](https://github.com/user-attachments/assets/e03e022b-4806-45a6-b5ba-141a06975998) |


</details>

<details>
<summary> Interaction with added `x` button. </summary>

- When the realm doesn't require topics in channel messages. - Move topic modal.
![general move](https://github.com/user-attachments/assets/8eff7da7-e365-4209-b1f3-0bac089795d2)

- When the realm doesn't require topics in channel messages. - Rename topic modal.
![general rename](https://github.com/user-attachments/assets/e610cf90-b095-41e1-b4f6-6dc3661c39f0)

- When the realm requires topics in channel messages. - Move topic modal.
![no general move](https://github.com/user-attachments/assets/4566dcea-5345-4472-86cb-108de8b5d46b)

- When the realm requires topics in channel messages. - Rename topic modal.
![no general rename](https://github.com/user-attachments/assets/ff1fece6-3707-40e6-8f23-a6e9abffca24)


</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
