### PR TITLE
Fix compose send disabled without error tooltip.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -238,17 +238,17 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
     $("#compose_select_recipient_widget").trigger("click");
 }
 
-export function show_stream_not_subscribed_error(sub: StreamSubscription): void {
+export function show_stream_not_subscribed_error(
+    sub: StreamSubscription,
+    banner_text: string,
+): void {
     const $banner_container = $("#compose_banners");
     if ($(`#compose_banners .${CSS.escape(CLASSNAMES.user_not_subscribed)}`).length > 0) {
         return;
     }
     const new_row_html = render_compose_banner({
         banner_type: ERROR,
-        banner_text: $t({
-            defaultMessage:
-                "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
-        }),
+        banner_text,
         button_text: stream_data.can_toggle_subscription(sub)
             ? $t({defaultMessage: "Subscribe"})
             : null,

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -40,7 +40,6 @@ import * as user_topics from "./user_topics.ts";
 import * as widget_modal from "./widget_modal.ts";
 
 export function abort_xhr() {
-    $("#compose-send-button").prop("disabled", false);
     upload.compose_upload_cancel();
 }
 

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -60,6 +60,10 @@ export const get_message_too_long_for_compose_error = (): string =>
         {max_length: realm.max_message_length},
     );
 export const NO_MESSAGE_CONTENT_ERROR_MESSAGE = $t({defaultMessage: "Compose a message."});
+export const UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE = $t({
+    defaultMessage:
+        "You're not subscribed to this channel. You will not be notified if other users reply to your message.",
+});
 type StreamWildcardOptions = {
     stream_id: number;
     $banner_container: JQuery;
@@ -741,7 +745,7 @@ export function validate_stream_message_address_info(sub: StreamSubscription): b
     if (sub.subscribed) {
         return true;
     }
-    compose_banner.show_stream_not_subscribed_error(sub);
+    compose_banner.show_stream_not_subscribed_error(sub, UNSUBSCRIBED_CHANNEL_ERROR_MESSAGE);
     return false;
 }
 

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -95,7 +95,7 @@ function set_message_too_long_for_compose(status: boolean): void {
 }
 
 function set_message_too_long_for_edit(status: boolean, $container: JQuery): void {
-    message_too_long = status;
+    const message_too_long = status;
     const $message_edit_save_container = $container.find(".message_edit_save_container");
     const save_is_disabled =
         message_too_long ||
@@ -157,6 +157,7 @@ export function get_disabled_save_tooltip($container: JQuery): string {
     }
     return "";
 }
+
 export function needs_subscribe_warning(user_id: number, stream_id: number): boolean {
     // This returns true if all of these conditions are met:
     //  * the user is valid

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -718,8 +718,6 @@ export function validate_stream_message_mentions(opts: StreamWildcardOptions): b
 
         if (!user_acknowledged_stream_wildcard) {
             show_stream_wildcard_warnings(opts);
-
-            $("#compose-send-button").prop("disabled", false);
             compose_ui.hide_compose_spinner();
             return false;
         }

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -44,6 +44,9 @@ let no_private_recipient = true;
 let no_message_content = false;
 let message_too_long = false;
 
+export const NO_PERMISSION_TO_POST_IN_CHANNEL_ERROR_MESSAGE = $t({
+    defaultMessage: "You do not have permission to post in this channel.",
+});
 export const NO_PRIVATE_RECIPIENT_ERROR_MESSAGE = $t({
     defaultMessage: "Please add a valid recipient.",
 });
@@ -114,9 +117,7 @@ export function get_posting_policy_error_message(): string {
 
     const stream = sub_store.get(compose_state.selected_recipient_id);
     if (stream && !stream_data.can_post_messages_in_stream(stream)) {
-        return $t({
-            defaultMessage: "You do not have permission to post in this channel.",
-        });
+        return NO_PERMISSION_TO_POST_IN_CHANNEL_ERROR_MESSAGE;
     }
     return "";
 }
@@ -783,9 +784,7 @@ function validate_stream_message(scheduling_message: boolean, show_banner = true
 
     if (!stream_data.can_post_messages_in_stream(sub)) {
         compose_banner.show_error_message(
-            $t({
-                defaultMessage: "You do not have permission to post in this channel.",
-            }),
+            NO_PERMISSION_TO_POST_IN_CHANNEL_ERROR_MESSAGE,
             compose_banner.CLASSNAMES.no_post_permissions,
             $banner_container,
         );

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -705,7 +705,13 @@ export function initialize(): void {
 
     tippy.delegate("body", {
         target: ".generate-channel-email-button-container.disabled_setting_tooltip",
-        content: $t({defaultMessage: "You do not have permission to post in this channel."}),
+        onShow(instance) {
+            instance.setContent(
+                ui_util.parse_html(
+                    $("#compose_disable_stream_reply_button_tooltip_template").html(),
+                ),
+            );
+        },
         appendTo: () => document.body,
         onHidden(instance) {
             instance.destroy();

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -41,7 +41,6 @@ const compose_fade = mock_esm("../src/compose_fade", {
     update_all: noop,
 });
 const compose_pm_pill = mock_esm("../src/compose_pm_pill", {
-    get_user_ids_string: () => "",
     get_user_ids: () => [],
 });
 const compose_ui = mock_esm("../src/compose_ui", {

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -155,7 +155,6 @@ function stub_message_row($textarea) {
 function initialize_pm_pill(mock_template) {
     $.clear_all_elements();
 
-    $("#compose-send-button").prop("disabled", false);
     $("#compose-send-button").trigger("focus");
     $("#compose-send-button .loader").hide();
 
@@ -303,7 +302,6 @@ test_ui("validate", ({mock_template, override}) => {
     };
     assert.ok(!compose_validate.validate());
     assert.ok(!$("#compose-send-button .loader").visible());
-    assert.equal($("#compose-send-button").prop("disabled"), false);
     compose_validate.validate();
 
     // Now add content to compose, and expect to see the banner.
@@ -455,7 +453,6 @@ test_ui("validate_stream_message", ({override, override_rewire, mock_template}) 
     override(realm, "realm_can_mention_many_users_group", everyone.id);
     compose_state.message_content("Hey @**all**");
     assert.ok(!compose_validate.validate());
-    assert.equal($("#compose-send-button").prop("disabled"), false);
     assert.ok(stream_wildcard_warning_rendered);
 
     let wildcards_not_allowed_rendered = false;

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -152,8 +152,6 @@ test("show_error_message", ({mock_template}) => {
         return "<banner-stub>";
     });
 
-    $("#compose-send-button").prop("disabled", true);
-
     upload.show_error_message(upload.compose_config, "Error message");
     assert.ok(!$("#compose-send-button").hasClass("disabled-message-send-controls"));
     assert.ok(banner_shown);


### PR DESCRIPTION
Made some code changes to perform all the check in `validate` only and set error messages there.

States tested:

* No channel selected
* Topic missing
* No permission to post in channel
* No permission to use wildcard mentions
* DM recipient missing / invalid
* DM not allowed for recipient.
* No message content
* Message too long
* Upload in progress.