### PR TITLE
Settings overlay closes when clicking on empty area below the left panel. 

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -166,7 +166,7 @@ export function close_for_hash_change(): void {
 }
 
 export function initialize(): void {
-    $("body").on("click", "div.overlay, div.overlay .exit", (e) => {
+    $("body").on("click", "div.overlay .exit", (e) => {
         let $target = $(e.target);
 
         if (document.getSelection()?.type === "Range") {


### PR DESCRIPTION
It was reported that in an overlay, when we open a select box, then clicking on the empty area below the left panel closes the overlay.

This PR fixes the bug.

Fixes: #33464

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
