### PR TITLE
do_change_user_email: Store old and new email in the audit log.

### DIFF
--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -114,6 +114,8 @@ def do_change_user_delivery_email(
 ) -> None:
     delete_user_profile_caches([user_profile], user_profile.realm_id)
 
+    original_email = user_profile.delivery_email
+
     user_profile.delivery_email = new_email
     if user_profile.email_address_is_realm_public():
         user_profile.email = new_email
@@ -146,6 +148,7 @@ def do_change_user_delivery_email(
         modified_user=user_profile,
         event_type=AuditLogEventType.USER_EMAIL_CHANGED,
         event_time=event_time,
+        extra_data={RealmAuditLog.OLD_VALUE: original_email, RealmAuditLog.NEW_VALUE: new_email},
     )
 
 

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -282,20 +282,20 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_email(self) -> None:
         now = timezone_now()
         user = self.example_user("hamlet")
+        original_email = user.delivery_email
         new_email = "test@example.com"
         do_change_user_delivery_email(user, new_email, acting_user=user)
-        self.assertEqual(
-            RealmAuditLog.objects.filter(
-                event_type=AuditLogEventType.USER_EMAIL_CHANGED, event_time__gte=now
-            ).count(),
-            1,
-        )
         self.assertEqual(new_email, user.delivery_email)
 
-        # Test the RealmAuditLog stringification
         audit_entry = RealmAuditLog.objects.get(
             event_type=AuditLogEventType.USER_EMAIL_CHANGED, event_time__gte=now
         )
+        self.assertEqual(audit_entry.modified_user, user)
+        self.assertEqual(
+            audit_entry.extra_data,
+            {RealmAuditLog.OLD_VALUE: original_email, RealmAuditLog.NEW_VALUE: new_email},
+        )
+        # Test the RealmAuditLog stringification
         self.assertTrue(
             repr(audit_entry).startswith(
                 f"<RealmAuditLog: {AuditLogEventType.USER_EMAIL_CHANGED.name} "


### PR DESCRIPTION
We forgot to store the actual values in the audit log, making these logs not very helpful in actually auditing a user's email change history.
