### PR TITLE
Fix channel settings overlay header at 18px font size.

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1070,26 +1070,26 @@ export function keyboard_sub(): void {
 
 export function toggle_view(event: string): void {
     const active_data = stream_settings_components.get_active_data();
-    const stream_filter_tab = active_data.$tabs.first().text();
+    const stream_filter_tab_key = active_data.$tabs.first().attr("data-tab-key");
     assert(toggler !== undefined);
 
     switch (event) {
         case "right_arrow":
-            switch (stream_filter_tab) {
-                case "Subscribed":
+            switch (stream_filter_tab_key) {
+                case "subscribed":
                     toggler.goto("not-subscribed");
                     break;
-                case "Not subscribed":
+                case "not-subscribed":
                     toggler.goto("all-streams");
                     break;
             }
             break;
         case "left_arrow":
-            switch (stream_filter_tab) {
-                case "Not subscribed":
+            switch (stream_filter_tab_key) {
+                case "not-subscribed":
                     toggler.goto("subscribed");
                     break;
-                case "All channels":
+                case "all-streams":
                     toggler.goto("not-subscribed");
                     break;
             }

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -786,7 +786,7 @@ function setup_page(callback: () => void): void {
             values: [
                 {label: $t({defaultMessage: "Subscribed"}), key: "subscribed"},
                 {label: $t({defaultMessage: "Not subscribed"}), key: "not-subscribed"},
-                {label: $t({defaultMessage: "All channels"}), key: "all-streams"},
+                {label: $t({defaultMessage: "All"}), key: "all-streams"},
             ],
             callback(_value, key) {
                 switch_stream_tab(key);

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1555,3 +1555,12 @@ div.settings-radio-input-parent {
         }
     }
 }
+
+.selected-stream-title {
+    max-width: 75%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+    margin: auto;
+}

--- a/web/templates/stream_settings/selected_stream_title.hbs
+++ b/web/templates/stream_settings/selected_stream_title.hbs
@@ -1,4 +1,4 @@
-<a {{#if preview_url}}class="tippy-zulip-delayed-tooltip" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}{{/if}}">
+<a {{#if preview_url}}class="tippy-zulip-delayed-tooltip selected-stream-title" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="top" href="{{preview_url}}{{/if}}">
 {{#unless preview_url}}{{t "Add subscribers to "}}{{/unless}}
 {{> stream_privacy_icon
   invite_only=sub.invite_only


### PR DESCRIPTION
At 19px:

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/52bdc9d0-8188-4c9e-ae7c-44cca11d7876) | ![Screenshot from 2025-03-23 19-57-12](https://github.com/user-attachments/assets/2e605f0b-c957-479c-ac09-e457693795e4) |

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/channel.20settings.20UI.20header.20bugged