### PR TITLE
settings: Update add/remove buttons on channel/group creation.

### DIFF
--- a/web/e2e-tests/stream_create.test.ts
+++ b/web/e2e-tests/stream_create.test.ts
@@ -6,7 +6,7 @@ import * as common from "./lib/common.ts";
 
 async function user_row_selector(page: Page, name: string): Promise<string> {
     const user_id = await common.get_user_id_from_name(page, name);
-    const selector = `.remove_potential_subscriber[data-user-id="${user_id}"]`;
+    const selector = `.settings-subscriber-row[data-user-id="${user_id}"]`;
     return selector;
 }
 

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -78,19 +78,23 @@ export function create_handlers($container: JQuery): void {
         $(".add-user-list-filter").trigger("focus");
     });
 
-    $container.on("click", ".remove_potential_subscriber", (e) => {
+    $container.on("click", ".remove_potential_subscriber", function (this: HTMLElement, e) {
         e.preventDefault();
-        const $elem = $(e.target);
-        const user_id = Number.parseInt($elem.attr("data-user-id")!, 10);
+        const $subscriber_row = $(this).closest(".settings-subscriber-row");
+        const user_id = Number.parseInt($subscriber_row.attr("data-user-id")!, 10);
         soft_remove_user_id(user_id);
     });
 
-    $container.on("click", ".undo_soft_removed_potential_subscriber", (e) => {
-        e.preventDefault();
-        const $elem = $(e.target);
-        const user_id = Number.parseInt($elem.attr("data-user-id")!, 10);
-        undo_soft_remove_user_id(user_id);
-    });
+    $container.on(
+        "click",
+        ".undo_soft_removed_potential_subscriber",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            const $subscriber_row = $(this).closest(".settings-subscriber-row");
+            const user_id = Number.parseInt($subscriber_row.attr("data-user-id")!, 10);
+            undo_soft_remove_user_id(user_id);
+        },
+    );
 }
 
 export function build_widgets(): void {

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -97,33 +97,44 @@ export function create_handlers($container: JQuery): void {
         $(".add-user-list-filter").trigger("focus");
     });
 
-    $container.on("click", ".remove_potential_subscriber", (e) => {
+    $container.on("click", ".remove_potential_subscriber", function (this: HTMLElement, e) {
         e.preventDefault();
-        const $elem = $(e.target);
-        const user_id = Number.parseInt($elem.attr("data-user-id")!, 10);
+        const $subscriber_row = $(this).closest(".settings-subscriber-row");
+        const user_id = Number.parseInt($subscriber_row.attr("data-user-id")!, 10);
         soft_remove_user_id(user_id);
     });
 
-    $container.on("click", ".undo_soft_removed_potential_subscriber", (e) => {
-        e.preventDefault();
-        const $elem = $(e.target);
-        const user_id = Number.parseInt($elem.attr("data-user-id")!, 10);
-        undo_soft_remove_user_id(user_id);
-    });
+    $container.on(
+        "click",
+        ".undo_soft_removed_potential_subscriber",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            const $subscriber_row = $(this).closest(".settings-subscriber-row");
+            const user_id = Number.parseInt($subscriber_row.attr("data-user-id")!, 10);
+            undo_soft_remove_user_id(user_id);
+        },
+    );
 
-    $container.on("click", ".remove_potential_subgroup", (e) => {
+    $container.on("click", ".remove_potential_subgroup", function (this: HTMLElement, e) {
         e.preventDefault();
-        const $elem = $(e.target);
-        const subgroup_id = Number.parseInt($elem.attr("data-group-id")!, 10);
+        const $user_group_subgroup_row = $(this).closest(".user-group-subgroup-row");
+        const subgroup_id = Number.parseInt($user_group_subgroup_row.attr("data-group-id")!, 10);
         soft_remove_subgroup_id(subgroup_id);
     });
 
-    $container.on("click", ".undo_soft_removed_potential_subgroup", (e) => {
-        e.preventDefault();
-        const $elem = $(e.target);
-        const user_id = Number.parseInt($elem.attr("data-group-id")!, 10);
-        undo_soft_remove_subgroup_id(user_id);
-    });
+    $container.on(
+        "click",
+        ".undo_soft_removed_potential_subgroup",
+        function (this: HTMLElement, e) {
+            e.preventDefault();
+            const $user_group_subgroup_row = $(this).closest(".user-group-subgroup-row");
+            const subgroup_id = Number.parseInt(
+                $user_group_subgroup_row.attr("data-group-id")!,
+                10,
+            );
+            undo_soft_remove_subgroup_id(subgroup_id);
+        },
+    );
 }
 
 export function build_widgets(): void {

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -1,4 +1,4 @@
-<tr>
+<tr class="settings-subscriber-row" data-user-id="{{user_id}}" >
     <td class="panel_user_list">
         {{> ../user_display_only_pill . display_value=full_name strikethrough=soft_removed is_active=true}}
     </td>
@@ -9,9 +9,9 @@
     {{/if}}
     <td>
         {{#if soft_removed}}
-            <button data-user-id="{{user_id}}" class="undo_soft_removed_potential_subscriber button small rounded white">{{t 'Add' }}</button>
+            {{> ../components/action_button custom_classes="undo_soft_removed_potential_subscriber" label=(t "Add") attention="quiet" intent="neutral" aria-label=(t "Add") }}
         {{else}}
-            <button data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded white">{{t 'Remove' }}</button>
+            {{> ../components/action_button custom_classes="remove_potential_subscriber" label=(t "Remove") attention="quiet" intent="neutral" aria-label=(t "Remove") }}
         {{/if}}
     </td>
 </tr>

--- a/web/templates/user_group_settings/new_user_group_subgroup.hbs
+++ b/web/templates/user_group_settings/new_user_group_subgroup.hbs
@@ -1,13 +1,13 @@
-<tr>
+<tr class="user-group-subgroup-row" data-group-id="{{group_id}}">
     <td class="panel_user_list">
         {{> ../user_group_display_only_pill . strikethrough=soft_removed}}
     </td>
     <td class="empty-email-col-for-user-group"></td>
     <td>
         {{#if soft_removed}}
-            <button data-group-id="{{group_id}}" class="undo_soft_removed_potential_subgroup button small rounded white">{{t 'Add' }}</button>
+            {{> ../components/action_button custom_classes="undo_soft_removed_potential_subgroup" label=(t "Add") attention="quiet" intent="neutral" aria-label=(t "Add") }}
         {{else}}
-            <button data-group-id="{{group_id}}" class="remove_potential_subgroup button small rounded white">{{t 'Remove' }}</button>
+            {{> ../components/action_button custom_classes="remove_potential_subgroup" label=(t "Remove") attention="quiet" intent="neutral" aria-label=(t "Remove") }}
         {{/if}}
     </td>
 </tr>


### PR DESCRIPTION
This PR updates the "Add" and "Remove" buttons in the channel/group creation modal to use the action button component.

Fixes part of #33027.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**Channel Creation**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 19 45 AM](https://github.com/user-attachments/assets/332f3bd5-d3db-45f8-acee-7ee6d710d8e5) | ![Screenshot 2025-04-03 at 5 58 45 PM](https://github.com/user-attachments/assets/2de4fea5-9a90-41d1-a208-310b5087a037) | 
| ![Screenshot 2025-03-24 at 10 16 19 AM](https://github.com/user-attachments/assets/4ccb869b-d2a6-40e7-a9ec-bd9c3c6c2bb9) | ![Screenshot 2025-04-03 at 5 59 07 PM](https://github.com/user-attachments/assets/19118e11-2a37-46ac-9d42-4baf3f2f0c78) | 

**Group Creation**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 21 40 AM](https://github.com/user-attachments/assets/fd771134-4527-4674-9658-48968656a02a) | ![Screenshot 2025-04-03 at 6 00 11 PM](https://github.com/user-attachments/assets/08c21719-2591-4e81-bb1b-e0375ff8dfc7) | 
| ![Screenshot 2025-03-24 at 10 20 53 AM](https://github.com/user-attachments/assets/c68481bd-5679-4e67-bd26-d9425ff69d10) | ![Screenshot 2025-04-03 at 6 00 00 PM](https://github.com/user-attachments/assets/f1d1eb53-f488-4312-961c-bd056cac59b7) | 

<details>
<summary>Old Screenshots</summary>

**Screenshots and screen captures:**
**Channel Creation**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 19 45 AM](https://github.com/user-attachments/assets/332f3bd5-d3db-45f8-acee-7ee6d710d8e5) | ![Screenshot 2025-03-24 at 10 16 19 AM](https://github.com/user-attachments/assets/d1f9de04-2a6f-4725-8a4a-91a1810de16a) | 
| ![Screenshot 2025-03-24 at 10 16 19 AM](https://github.com/user-attachments/assets/4ccb869b-d2a6-40e7-a9ec-bd9c3c6c2bb9) | ![Screenshot 2025-03-24 at 10 13 47 AM](https://github.com/user-attachments/assets/8503f1e3-74ac-4d6a-b459-881debe47a0b) | 

**Group Creation**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 21 40 AM](https://github.com/user-attachments/assets/fd771134-4527-4674-9658-48968656a02a) | ![Screenshot 2025-03-24 at 10 11 24 AM](https://github.com/user-attachments/assets/5b5831e5-6dba-4a67-9a10-83a5c5df539f) | 
| ![Screenshot 2025-03-24 at 10 20 53 AM](https://github.com/user-attachments/assets/c68481bd-5679-4e67-bd26-d9425ff69d10) | ![Screenshot 2025-03-24 at 10 11 51 AM](https://github.com/user-attachments/assets/d9835eca-66f8-403a-b425-996140ee32b3) | 

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
