### PR TITLE
email_change: Make "user deactivated" error have UI.

### DIFF
--- a/templates/zerver/portico_error_pages/user_deactivated.html
+++ b/templates/zerver/portico_error_pages/user_deactivated.html
@@ -1,0 +1,20 @@
+{% extends "zerver/portico_error_pages/portico_error_page.html" %}
+
+{% block title %}
+<title>{{ _("Account is deactivated") }} | Zulip</title>
+{% endblock %}
+
+{% block error_page_content %}
+<img src="{{ static('images/errors/400art.svg') }}" alt=""/>
+<div class="errorbox">
+    <div class="errorcontent">
+        <h1 class="lead">{{ _("Account is deactivated") }}</h1>
+        <p>
+            {% trans %}
+            Your Zulip account on <a href="{{ realm_url }}">{{ realm_url }}</a>
+            has been deactivated, and you will no longer be able to log in.
+            {% endtrans %}
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -155,6 +155,8 @@ class EmailChangeTestCase(ZulipTestCase):
         do_deactivate_user(user_profile, acting_user=None)
         response = self.client_get(activation_url)
         self.assertEqual(response.status_code, 401)
+        error_page_title = "<title>Account is deactivated | Zulip</title>"
+        self.assert_in_response(error_page_title, response)
 
         do_reactivate_user(user_profile, acting_user=None)
         self.login_user(user_profile)


### PR DESCRIPTION
Currently, when a deactivated user tries to access the change email link (generated when their account is still active), a JSON error message will be shown.

This adds a new portico error page for the user-deactivated error. Now, `confirm_email_change` renders a portico error page when the user trying to change their email is deactivated.

[CZO](https://chat.zulip.org/#narrow/channel/101-design/topic/change.20email.2C.20deactivated.20user.20error.20.2320227)

Fixes #20227.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/21d6ac7a-bb77-40b8-bf08-4099795c3373) |![image](https://github.com/user-attachments/assets/1f11387a-746e-45f8-a656-03337d2d0617) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
