### PR TITLE
user_profile_modal: Use icon button component for modal header buttons.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1449,12 +1449,14 @@ export function initialize(): void {
         },
     );
 
+    $("body").on("click", "#user-profile-modal #name .user-profile-manage-own-edit-button", () => {
+        browser_history.go_to_location("#settings/profile");
+        hide_user_profile();
+    });
+
     /* These click handlers are implemented as just deep links to the
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
-    $("body").on("click", "#user-profile-modal #name .user-profile-manage-own-edit-button", () => {
-        hide_user_profile();
-    });
 
     $("body").on("click", "#user-profile-modal .user-profile-channel-list-item", () => {
         hide_user_profile();
@@ -1484,7 +1486,7 @@ export function initialize(): void {
 
     new ClipboardJS(".copy-link-to-user-profile", {
         text(trigger) {
-            const user_id = $(trigger).attr("data-user-id");
+            const user_id = $(trigger).closest("#user-profile-modal").attr("data-user-id");
             const user_profile_link = window.location.origin + "/#user/" + user_id;
 
             return user_profile_link;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -18,17 +18,6 @@
     }
 
     /************************* MODAL DARK THEME *******************/
-    .user-profile-manage-own-edit-button,
-    .user-profile-manage-others-edit-button,
-    .user-profile-manage-own-copy-link-button {
-        color: hsl(200deg 100% 50%);
-        cursor: pointer;
-
-        &:hover {
-            color: hsl(200deg 79% 66%);
-        }
-    }
-
     .modal__content.simplebar-scrollable-y + .modal__footer {
         border-top: 1px solid hsl(0deg 0% 100% / 20%);
     }

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -100,17 +100,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-
-    .user-profile-manage-own-edit-button,
-    .user-profile-manage-others-edit-button,
-    .user-profile-manage-own-copy-link-button {
-        color: hsl(200deg 100% 50%);
-        cursor: pointer;
-
-        &:hover {
-            color: hsl(200deg 100% 25%);
-        }
-    }
 }
 
 .modal__close {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -450,24 +450,9 @@ ul.popover-group-menu-member-list {
         }
     }
 
-    .user-profile-manage-own-edit-button,
-    .user-profile-manage-others-edit-button {
+    .user-profile-header-actions {
         display: flex;
-        text-decoration: none;
-        /* 15px at 22px/1em */
-        font-size: 0.6818em;
-    }
-
-    .user-profile-manage-own-copy-link-button {
-        display: flex;
-        /* 19px at 22px/1em */
-        font-size: 0.8638em;
-        text-decoration: none;
-    }
-
-    .zulip-icon-link,
-    .zulip-icon-edit {
-        vertical-align: middle;
+        gap: 5px;
     }
 
     .deactivated-user-icon {

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -18,19 +18,19 @@
                         <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                     {{/if}}
                     <span class="user-profile-name">{{> user_full_name name=full_name}}</span>
-                    <a class="copy-link-to-user-profile user-profile-manage-own-copy-link-button" tabindex="0" data-user-id="{{user_id}}">
-                        <i class="zulip-icon zulip-icon-link tippy-zulip-tooltip " data-tippy-content="{{t 'Copy link to profile' }}" aria-hidden="true"></i>
-                    </a>
-                    {{#if is_me}}
-                        <a class="user-profile-manage-own-edit-button" href="/#settings/profile">
-                            <i class="zulip-icon zulip-icon-edit tippy-zulip-tooltip" data-tippy-content="{{t 'Edit profile' }}" aria-hidden="true"></i>
-                        </a>
-                    {{/if}}
-                    {{#if can_manage_profile}}
-                        <div class="user-profile-manage-others-edit-button">
-                            <i class="zulip-icon zulip-icon-edit tippy-zulip-tooltip" data-tippy-content="{{#if is_bot}}{{t 'Manage bot'}}{{else}}{{t 'Manage user' }}{{/if}}" aria-hidden="true"></i>
-                        </div>
-                    {{/if}}
+                    <span class="user-profile-header-actions">
+                        {{> components/icon_button custom_classes="copy-link-to-user-profile tippy-zulip-delayed-tooltip" icon="link-alt" intent="neutral" data-tippy-content=(t "Copy link to profile") aria-label=(t "Copy link to profile") }}
+                        {{#if is_me}}
+                            {{> components/icon_button custom_classes="user-profile-manage-own-edit-button tippy-zulip-delayed-tooltip" icon="edit" intent="neutral" data-tippy-content=(t "Edit profile") aria-label=(t "Edit profile") }}
+                        {{/if}}
+                        {{#if can_manage_profile}}
+                            {{#if is_bot}}
+                                {{> components/icon_button custom_classes="user-profile-manage-others-edit-button tippy-zulip-delayed-tooltip" icon="edit" intent="neutral" data-tippy-content=(t "Manage bot") aria-label=(t "Manage bot") }}
+                            {{else}}
+                                {{> components/icon_button custom_classes="user-profile-manage-others-edit-button tippy-zulip-delayed-tooltip" icon="edit" intent="neutral" data-tippy-content=(t "Manage user") aria-label=(t 'Manage user') }}
+                            {{/if}}
+                        {{/if}}
+                    </span>
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </div>


### PR DESCRIPTION
This PR updates the modal header buttons to use the icon button component.

Fixes part of #33027.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

## Screenshots and screen captures:
**1. Normal User**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 27 31 AM](https://github.com/user-attachments/assets/1c77c903-e4f7-4092-b2a8-52b18248bd33) | ![user_profile_header_buttons-light-after](https://github.com/user-attachments/assets/1d292544-9682-43d2-ad3a-35a70f4f0032) |
| ![Screenshot 2025-03-24 at 10 27 22 AM](https://github.com/user-attachments/assets/5a4e3d5b-8616-4dca-921d-f55245f833be) | ![user_profile_header_buttons-dark-after](https://github.com/user-attachments/assets/eb075bdd-200e-4785-a7a4-d4b7c3e74848) | 

**2. Bot User**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 28 02 AM](https://github.com/user-attachments/assets/d242c770-540f-4530-b100-1edc3dd589ec) | ![bot_profile_header_buttons-light-after](https://github.com/user-attachments/assets/eebfa557-c863-4355-8891-fc2164a3fa85) |
| ![Screenshot 2025-03-24 at 10 28 08 AM](https://github.com/user-attachments/assets/d00bf114-d226-4aa3-82d6-44518b686a27) | ![bot_profile_header_buttons-dark-after](https://github.com/user-attachments/assets/e92d3b5d-69fa-42d0-9049-c317a76a7ee9) | 

<details>
<summary>Older Screenshots</summary>

**1. Normal User**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 27 31 AM](https://github.com/user-attachments/assets/1c77c903-e4f7-4092-b2a8-52b18248bd33) | ![Screenshot 2025-03-24 at 10 26 11 AM](https://github.com/user-attachments/assets/d551494e-025b-4fc4-a58e-dbefa87a7b87) |
| ![Screenshot 2025-03-24 at 10 27 22 AM](https://github.com/user-attachments/assets/5a4e3d5b-8616-4dca-921d-f55245f833be) | ![Screenshot 2025-03-24 at 10 26 32 AM](https://github.com/user-attachments/assets/28ab5c29-49a8-4788-a7a8-629956e55db4) | 

**2. Bot User**
| Before | After |
|--------|--------|
| ![Screenshot 2025-03-24 at 10 28 02 AM](https://github.com/user-attachments/assets/d242c770-540f-4530-b100-1edc3dd589ec) | ![Screenshot 2025-03-24 at 10 29 13 AM](https://github.com/user-attachments/assets/86961bb5-2132-4539-850c-bf0df1264a94) |
| ![Screenshot 2025-03-24 at 10 28 08 AM](https://github.com/user-attachments/assets/d00bf114-d226-4aa3-82d6-44518b686a27) | ![Screenshot 2025-03-24 at 10 29 08 AM](https://github.com/user-attachments/assets/51120186-1359-482b-b060-7bd90d361c0e) | 

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
