### PR TITLE
compose-closed-ui: Fix reply button text for Inbox and Recent Conversations views.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -46,11 +46,13 @@ export function get_recipient_label(
     // actual message objects with fake objects containing just a
     // couple fields, both those constructed here and potentially
     // passed in.
-    if (message_lists.current === undefined) {
-        return undefined;
-    }
 
     if (recipient_information === undefined) {
+        // We check the current message list for information about the
+        // reply recipient for the closed compose box button label.
+        if (message_lists.current === undefined) {
+            return undefined;
+        }
         if (message_lists.current.visibly_empty()) {
             // For empty narrows where there's a clear reply target,
             // i.e. stream+topic or a single direct message conversation,

--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -171,7 +171,7 @@ export function set_standard_text_for_reply_button(): void {
     set_reply_button_label($t({defaultMessage: "Compose message"}));
 }
 
-export function update_reply_recipient_label(message?: ComposeClosedMessage): void {
+export function update_recipient_text_for_reply_button(message?: ComposeClosedMessage): void {
     const recipient_label = get_recipient_label(message);
     if (recipient_label !== undefined) {
         const empty_string_topic_display_name = util.get_final_topic_display_name("");
@@ -194,7 +194,7 @@ export function initialize(): void {
             // message_selected events can occur with Recent Conversations
             // open due to the combined feed view loading in the background,
             // so we only update if message feed is visible.
-            update_reply_recipient_label();
+            update_recipient_text_for_reply_button();
 
             // Disable compose reply button if the selected message is a stream
             // message and the user is not allowed to post in the stream the message

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -898,7 +898,7 @@ function update_closed_compose_text($row: JQuery, is_header_row: boolean): void 
             topic: $row.find(".inbox-topic-name a").text(),
         };
     }
-    compose_closed_ui.update_reply_recipient_label(message);
+    compose_closed_ui.update_recipient_text_for_reply_button(message);
 }
 
 export function get_focused_row_message(): {message?: Message | undefined} & (

--- a/web/src/inbox_ui.ts
+++ b/web/src/inbox_ui.ts
@@ -875,30 +875,25 @@ export function revive_current_focus(): void {
 }
 
 function update_closed_compose_text($row: JQuery, is_header_row: boolean): void {
-    // TODO: This fake "message" object is designed to allow using the
-    // get_recipient_label helper inside compose_closed_ui. Surely
-    // there's a more readable way to write this code.
-    // Similar code is present in recent view.
-
     if (is_header_row) {
         compose_closed_ui.set_standard_text_for_reply_button();
         return;
     }
 
-    let message;
+    let reply_recipient_information: compose_closed_ui.ReplyRecipientInformation;
     const is_dm = $row.parent("#inbox-direct-messages-container").length > 0;
     if (is_dm) {
-        message = {
+        reply_recipient_information = {
             display_reply_to: $row.find(".recipients_name").text(),
         };
     } else {
         const $stream = $row.parent(".inbox-topic-container").prev(".inbox-header");
-        message = {
+        reply_recipient_information = {
             stream_id: Number($stream.attr("data-stream-id")),
             topic: $row.find(".inbox-topic-name a").text(),
         };
     }
-    compose_closed_ui.update_recipient_text_for_reply_button(message);
+    compose_closed_ui.update_recipient_text_for_reply_button(reply_recipient_information);
 }
 
 export function get_focused_row_message(): {message?: Message | undefined} & (

--- a/web/src/message_view.ts
+++ b/web/src/message_view.ts
@@ -1495,7 +1495,7 @@ function handle_post_view_change(
     } else {
         compose_closed_ui.update_buttons_for_non_specific_views();
     }
-    compose_closed_ui.update_reply_recipient_label();
+    compose_closed_ui.update_recipient_text_for_reply_button();
 
     message_view_header.render_title_area();
 

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -340,24 +340,20 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
         }
     }
 
-    // TODO: This fake "message" object is designed to allow using the
-    // get_recipient_label helper inside compose_closed_ui. Surely
-    // there's a more readable way to write this code.
-    // Similar code is present in Inbox.
-    let message;
+    let reply_recipient_information: compose_closed_ui.ReplyRecipientInformation;
     if (type === "private") {
-        message = {
+        reply_recipient_information = {
             display_reply_to: $topic_row.find(".recent_topic_name a").text(),
         };
     } else {
         const stream_name = $topic_row.find(".recent_topic_stream a").text();
         const stream = stream_data.get_sub_by_name(stream_name);
-        message = {
+        reply_recipient_information = {
             stream_id: stream?.stream_id,
             topic: $topic_row.find(".recent_topic_name a").text(),
         };
     }
-    compose_closed_ui.update_recipient_text_for_reply_button(message);
+    compose_closed_ui.update_recipient_text_for_reply_button(reply_recipient_information);
     return true;
 }
 

--- a/web/src/recent_view_ui.ts
+++ b/web/src/recent_view_ui.ts
@@ -357,7 +357,7 @@ function set_table_focus(row: number, col: number, using_keyboard = false): bool
             topic: $topic_row.find(".recent_topic_name a").text(),
         };
     }
-    compose_closed_ui.update_reply_recipient_label(message);
+    compose_closed_ui.update_recipient_text_for_reply_button(message);
     return true;
 }
 

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -150,7 +150,7 @@ run_test("test_custom_message_input", () => {
         stream_id: 10,
     };
     stream_data.add_sub(stream);
-    compose_closed_ui.update_reply_recipient_label({
+    compose_closed_ui.update_recipient_text_for_reply_button({
         stream_id: stream.stream_id,
         topic: "topic test",
     });
@@ -159,7 +159,7 @@ run_test("test_custom_message_input", () => {
 
 run_test("empty_narrow", () => {
     message_lists.current.visibly_empty = () => true;
-    compose_closed_ui.update_reply_recipient_label();
+    compose_closed_ui.update_recipient_text_for_reply_button();
     const label = $("#left_bar_compose_reply_button_big").text();
     assert.equal(label, "translated: Compose message");
 });

--- a/web/tests/compose_closed_ui.test.cjs
+++ b/web/tests/compose_closed_ui.test.cjs
@@ -24,6 +24,9 @@ mock_esm("../src/message_list_view", {
 mock_esm("../src/people.ts", {
     maybe_get_user_by_id: noop,
 });
+mock_esm("../src/settings_data", {
+    user_has_permission_for_group_setting: () => true,
+});
 
 const stream_data = zrequire("stream_data");
 // Code we're actually using/testing
@@ -31,7 +34,10 @@ const compose_closed_ui = zrequire("compose_closed_ui");
 const {Filter} = zrequire("filter");
 const {MessageList} = zrequire("message_list");
 const {MessageListData} = zrequire("message_list_data");
-const {set_realm} = zrequire("state_data");
+const {set_current_user, set_realm} = zrequire("state_data");
+
+const current_user = {};
+set_current_user(current_user);
 
 const REALM_EMPTY_TOPIC_DISPLAY_NAME = "general chat";
 set_realm({realm_empty_topic_display_name: REALM_EMPTY_TOPIC_DISPLAY_NAME});
@@ -74,34 +80,48 @@ run_test("reply_label", () => {
         [
             {
                 id: 0,
+                is_stream: true,
+                is_private: false,
                 stream_id: stream_one.stream_id,
                 topic: "first_topic",
             },
             {
                 id: 1,
+                is_stream: true,
+                is_private: false,
                 stream_id: stream_one.stream_id,
                 topic: "second_topic",
             },
             {
                 id: 2,
+                is_stream: true,
+                is_private: false,
                 stream_id: stream_two.stream_id,
                 topic: "third_topic",
             },
             {
                 id: 3,
+                is_stream: true,
+                is_private: false,
                 stream_id: stream_two.stream_id,
                 topic: "second_topic",
             },
             {
                 id: 4,
+                is_stream: false,
+                is_private: true,
                 display_reply_to: "some user",
             },
             {
                 id: 5,
+                is_stream: false,
+                is_private: true,
                 display_reply_to: "some user, other user",
             },
             {
                 id: 6,
+                is_stream: true,
+                is_private: false,
                 stream_id: stream_two.stream_id,
                 topic: "",
             },


### PR DESCRIPTION
Fixes the "reply to the current conversation" button text when the compose box is closed not updating for the focused row in the Inbox or Recent Conversations view. This was broken in https://github.com/zulip/zulip/commit/f630272b4c614a8ebf18877b94fbaa6076ec64e2 when the current message list was set to undefined for non-message views.

Also, does some general refactoring and clean up of the function that sets the button text for these message recipients and it's callers.

---

**Screenshots and screen captures:**

### Inbox

| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-24 19-23-56](https://github.com/user-attachments/assets/0a6be6dc-70c5-4135-92a3-517abc16c4ce) | ![Screenshot from 2025-03-24 19-23-19](https://github.com/user-attachments/assets/72136000-2a3d-4b03-9f61-0353cbe0cd4b) |
| ![Screenshot from 2025-03-24 19-23-54](https://github.com/user-attachments/assets/dae77fe7-d606-46fd-88f3-4fa7fd7d8022) | ![Screenshot from 2025-03-24 19-23-15](https://github.com/user-attachments/assets/cc18132c-4c08-4afd-8666-f496e0703de2) |
| ![Screenshot from 2025-03-24 19-23-49](https://github.com/user-attachments/assets/d8811fa0-d8e7-4d2c-a98b-615b1797deab) | ![Screenshot from 2025-03-24 19-23-11](https://github.com/user-attachments/assets/321e0ff5-0f20-4385-9a93-8582da8df5f3) |
| ![Screenshot from 2025-03-24 19-23-47](https://github.com/user-attachments/assets/8a51e83b-96f4-4ff0-9fb4-45aff956f4ea) | ![Screenshot from 2025-03-24 19-23-07](https://github.com/user-attachments/assets/163a2ae7-33b8-4d97-a56e-15b19b97acec) |

### Recent Conversations

| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-24 19-26-07](https://github.com/user-attachments/assets/6777e9f4-711e-43f2-aec9-637dde1e586d) | ![Screenshot from 2025-03-24 19-27-14](https://github.com/user-attachments/assets/d10807bf-aa1c-4f73-923a-72b105a4c0ec) |
| ![Screenshot from 2025-03-24 19-26-04](https://github.com/user-attachments/assets/372f0055-2623-4544-bf30-bea6e6cd2eda) | ![Screenshot from 2025-03-24 19-27-07](https://github.com/user-attachments/assets/2179eee1-5237-4eb5-9600-8d3b9c08e188) |
| ![Screenshot from 2025-03-24 19-26-00](https://github.com/user-attachments/assets/378125ff-f02f-424d-a939-f9be39f7bf40) | ![Screenshot from 2025-03-24 19-26-56](https://github.com/user-attachments/assets/a83de0bf-6e85-4db4-9675-87a9df3d1b3a) |
| ![Screenshot from 2025-03-24 19-25-51](https://github.com/user-attachments/assets/52775d51-16b4-4fad-9971-8a0ad5487564) | ![Screenshot from 2025-03-24 19-26-48](https://github.com/user-attachments/assets/b3a805c4-6eda-484c-9929-f61c184736a5) |

### Message list views - no changes

| Before | After |
| --- | --- |
| ![Screenshot from 2025-03-24 19-30-22](https://github.com/user-attachments/assets/b5c805a3-ad72-4c7e-8660-6245885ee630) | ![Screenshot from 2025-03-24 19-30-08](https://github.com/user-attachments/assets/047120b0-f253-4cb3-a297-d7d02cf04ff7) |
| ![Screenshot from 2025-03-24 19-29-35](https://github.com/user-attachments/assets/729e2804-331b-4451-9b32-8c91227d0445) |![Screenshot from 2025-03-24 19-29-19](https://github.com/user-attachments/assets/b5bc2770-62f1-4c5e-b8e3-9869d4d6abed) |
| ![Screenshot from 2025-03-24 19-29-03](https://github.com/user-attachments/assets/e3e64d0c-2a4c-46ae-8b8e-bd7ec75c1e61) | ![Screenshot from 2025-03-24 19-28-51](https://github.com/user-attachments/assets/0aca0d63-0c99-4e0b-9d22-95dc0acb147d) |
| ![Screenshot from 2025-03-24 19-28-26](https://github.com/user-attachments/assets/361ee5b8-c9d0-44da-a7c9-c0052e2365a2) | ![Screenshot from 2025-03-24 19-28-12](https://github.com/user-attachments/assets/0636ad76-2719-4914-a00f-ab9dcfe51686) |
| ![Screenshot from 2025-03-24 19-27-55](https://github.com/user-attachments/assets/07f41a50-0d42-42c9-814e-16130ab82fd1) | ![Screenshot from 2025-03-24 19-27-37](https://github.com/user-attachments/assets/5d26b99e-775c-44a3-b3ae-92514d1de1d7) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
