### PR TITLE
backends: Fix exception with password lengths above 72.

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2569,6 +2569,18 @@ class UserSignUpTest(ZulipTestCase):
         # User should now be logged in.
         self.assert_logged_in_user_id(user_profile.id)
 
+    def test_signup_very_long_password(self) -> None:
+        """
+        Check if signing up without a password works properly when
+        password_auth_enabled is False.
+        """
+        email = self.nonreg_email("newuser")
+        user_profile = self.verify_signup(email=email, password="a" * 80)
+
+        assert isinstance(user_profile, UserProfile)
+        # User should now be logged in.
+        self.assert_logged_in_user_id(user_profile.id)
+
     def test_signup_without_full_name(self) -> None:
         """
         Check if signing up without a full name redirects to a registration

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -490,7 +490,10 @@ def check_password_strength(password: str) -> bool:
         # we need a special case for the empty string password here.
         return False
 
-    if int(zxcvbn(password)["guesses"]) < settings.PASSWORD_MIN_GUESSES:
+    if (
+        int(zxcvbn(password, max_length=settings.PASSWORD_MAX_LENGTH)["guesses"])
+        < settings.PASSWORD_MIN_GUESSES
+    ):
         return False
 
     return True


### PR DESCRIPTION
Apparently, while we set our own maximum password length of 100 characters, zxcvbn had a hardcoded maximum length of 72 characters, and threw an exception if that was exceeded.

The fact that we're discovering this now would suggest that nobody has previously attempted a password between 72 and 100 characters in length.
