### PR TITLE
channel_settings: Fix channel name incorrect hidden.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1557,7 +1557,6 @@ div.settings-radio-input-parent {
 }
 
 .selected-stream-title {
-    max-width: 75%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
`max-width` was not working correctly here. Removing it gets us in good state.

Bug was introduced in [#34133](https://github.com/zulip/zulip/pull/34133)


| before | after |
| --- | --- |
| ![Screenshot from 2025-03-25 08-39-07](https://github.com/user-attachments/assets/c456d85d-e4c5-404f-8a22-3d464260efff) | ![Screenshot from 2025-03-25 08-38-15](https://github.com/user-attachments/assets/6c4b6ea8-8d7a-40d5-a146-ed54dd6d8fd7) |
| ![Screenshot from 2025-03-25 08-39-04](https://github.com/user-attachments/assets/25308dac-3a33-48dc-80be-942e9fd16cb1) | ![Screenshot from 2025-03-25 08-38-19](https://github.com/user-attachments/assets/f4002537-5132-481a-a021-c2e66c9d6e88) |

