### PR TITLE
message_move: Show "general chat" in link of confirmation toast.

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1590,7 +1590,8 @@ type ToastParams = {
 
 function show_message_moved_toast(toast_params: ToastParams): void {
     const new_stream_name = sub_store.maybe_get_stream_name(toast_params.new_stream_id);
-    const stream_topic = `#${new_stream_name} > ${toast_params.new_topic_name}`;
+    const new_topic_display_name = util.get_final_topic_display_name(toast_params.new_topic_name);
+    const is_empty_string_topic = toast_params.new_topic_name === "";
     const new_location_url = hash_util.by_stream_topic_url(
         toast_params.new_stream_id,
         toast_params.new_topic_name,
@@ -1598,8 +1599,10 @@ function show_message_moved_toast(toast_params: ToastParams): void {
     feedback_widget.show({
         populate($container) {
             const widget_body_html = render_message_moved_widget_body({
-                stream_topic,
+                new_stream_name,
+                new_topic_display_name,
                 new_location_url,
+                is_empty_string_topic,
             });
             $container.html(widget_body_html);
         },

--- a/web/templates/message_moved_widget_body.hbs
+++ b/web/templates/message_moved_widget_body.hbs
@@ -1,6 +1,12 @@
 <div>
     {{#tr}}
-    Message moved to <z-link>{stream_topic}</z-link>.
-    {{#*inline "z-link"}}<a class="white-space-preserve-wrap" href="{{new_location_url}}">{{> @partial-block}}</a>{{/inline}}
+        Message moved to <z-link></z-link>.
+        {{#*inline "z-link"~}}
+            <a class="white-space-preserve-wrap" href="{{new_location_url}}">
+                {{~!-- squash whitespace --~}}
+                #{{new_stream_name}} &gt; <span {{#if is_empty_string_topic}}class="empty-topic-display"{{/if}}>{{new_topic_display_name}}</span>
+                {{~!-- squash whitespace --~}}
+            </a>
+        {{~/inline}}
     {{/tr}}
 </div>


### PR DESCRIPTION
For realms that allow _general chat_ topics (the realm doesn't require topics in channel messages), when we move a message from a topic to _general chat_ using the "Move only this message" option a confirmation toast is shown. We currently don't show _general chat_ in the link of the confirmation toast as we show in the message moved notice link.

This PR adds support to show _general chat_ in the link of the confirmation toast when a message is moved to it.

<!-- Describe your pull request here.-->

Fixes: [#issues > general chat topic not shown in message move toast @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/general.20chat.20topic.20not.20shown.20in.20message.20move.20toast/near/2133592).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Description            | Before | After |
|------------------------|--------------|-------------|
| Empty topic names - _General Chat_ | ![image](https://github.com/user-attachments/assets/e81741ca-1a32-4ed9-b0d7-290a48965994) | ![image](https://github.com/user-attachments/assets/37e09719-5fb6-4b89-bc9d-155b0efa7f12) |
| Non-empty topic names (_No changes_) | ![image](https://github.com/user-attachments/assets/7c8f4812-dee7-42f8-bc2e-f63979de6cc9) | ![image](https://github.com/user-attachments/assets/94409caf-e68d-476d-bbf5-ed38843c12ff) |


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
