### PR TITLE
Fix channel demote inactives setting being ignored.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -901,8 +901,8 @@ export function dispatch_normal_event(event) {
                 $("body").toggleClass("high-contrast");
             }
             if (event.property === "demote_inactive_streams") {
-                stream_list.update_streams_sidebar();
                 stream_list_sort.set_filter_out_inactives();
+                stream_list.update_streams_sidebar();
             }
             if (event.property === "web_animate_image_previews") {
                 // Rerender the whole message list UI

--- a/web/src/stream_list.ts
+++ b/web/src/stream_list.ts
@@ -485,7 +485,7 @@ class StreamSidebarRow {
     }
 
     update_whether_active(): void {
-        if (this.sub.is_recently_active || this.sub.pin_to_top) {
+        if (stream_list_sort.has_recent_activity(this.sub)) {
             this.$list_item.removeClass("inactive_stream");
         } else {
             this.$list_item.addClass("inactive_stream");

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -57,10 +57,6 @@ export function is_filtering_inactives(): boolean {
     return filter_out_inactives;
 }
 
-export function has_recent_activity_but_muted(sub: StreamSubscription): boolean {
-    return sub.is_recently_active && sub.is_muted;
-}
-
 type StreamListSortResult = {
     same_as_before: boolean;
     pinned_streams: number[];

--- a/web/src/stream_list_sort.ts
+++ b/web/src/stream_list_sort.ts
@@ -57,6 +57,20 @@ export function is_filtering_inactives(): boolean {
     return filter_out_inactives;
 }
 
+export function has_recent_activity(sub: StreamSubscription): boolean {
+    if (!filter_out_inactives || sub.pin_to_top) {
+        // If users don't want to filter inactive streams
+        // to the bottom, we respect that setting and don't
+        // treat any streams as dormant.
+        //
+        // Currently this setting is automatically determined
+        // by the number of streams.  See the callers
+        // to set_filter_out_inactives.
+        return true;
+    }
+    return sub.is_recently_active || sub.newly_subscribed;
+}
+
 type StreamListSortResult = {
     same_as_before: boolean;
     pinned_streams: number[];
@@ -78,7 +92,7 @@ export function sort_groups(stream_ids: number[], search_term: string): StreamLi
     );
 
     function is_normal(sub: StreamSubscription): boolean {
-        return sub.is_recently_active;
+        return has_recent_activity(sub);
     }
 
     const pinned_streams = [];

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -23,6 +23,7 @@ import * as recent_senders from "./recent_senders.ts";
 import * as settings_config from "./settings_config.ts";
 import {realm} from "./state_data.ts";
 import * as stream_data from "./stream_data.ts";
+import * as stream_list_sort from "./stream_list_sort.ts";
 import type {StreamPill, StreamPillData} from "./stream_pill.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import type {UserGroupPill, UserGroupPillData} from "./user_group_pill.ts";
@@ -847,7 +848,7 @@ function activity_score(sub: StreamSubscription): number {
     if (sub.pin_to_top) {
         stream_score += 2;
     }
-    if (sub.is_recently_active) {
+    if (stream_list_sort.has_recent_activity(sub)) {
         stream_score += 1;
     }
     return stream_score;

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -542,6 +542,7 @@ export function initialize_everything(state_data) {
     muted_users.initialize(state_data.muted_users);
     stream_settings_ui.initialize();
     left_sidebar_navigation_area.initialize();
+    stream_list_sort.initialize();
     stream_list.initialize({
         on_stream_click(stream_id, trigger) {
             const sub = sub_store.get(stream_id);
@@ -558,7 +559,6 @@ export function initialize_everything(state_data) {
             );
         },
     });
-    stream_list_sort.initialize();
     condense.initialize();
     spoilers.initialize();
     lightbox.initialize();

--- a/web/tests/stream_list.test.cjs
+++ b/web/tests/stream_list.test.cjs
@@ -46,9 +46,14 @@ const stream_list = zrequire("stream_list");
 const stream_list_sort = zrequire("stream_list_sort");
 const user_groups = zrequire("user_groups");
 const {initialize_user_settings} = zrequire("user_settings");
+const settings_config = zrequire("settings_config");
 
-const user_settings = {};
+// Start with always filtering out inactive streams.
+const user_settings = {
+    demote_inactive_streams: settings_config.demote_inactive_streams_values.always.code,
+};
 initialize_user_settings({user_settings});
+stream_list_sort.set_filter_out_inactives();
 
 const me = {
     email: "me@example.com",

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -201,18 +201,6 @@ test("basics", () => {
     assert.deepEqual(sorted.dormant_streams, []);
 });
 
-test("has_recent_activity_but_muted", () => {
-    const sub = {
-        name: "cats",
-        subscribed: true,
-        stream_id: 111,
-        is_muted: true,
-        is_recently_active: true,
-    };
-    stream_data.add_sub(sub);
-    assert.ok(stream_list_sort.has_recent_activity_but_muted(sub));
-});
-
 test("filter inactives", ({override}) => {
     override(
         user_settings,

--- a/web/tests/stream_list_sort.test.cjs
+++ b/web/tests/stream_list_sort.test.cjs
@@ -12,8 +12,12 @@ const stream_list_sort = zrequire("stream_list_sort");
 const settings_config = zrequire("settings_config");
 const {initialize_user_settings} = zrequire("user_settings");
 
-const user_settings = {};
+// Start with always filtering out inactive streams.
+const user_settings = {
+    demote_inactive_streams: settings_config.demote_inactive_streams_values.always.code,
+};
 initialize_user_settings({user_settings});
+stream_list_sort.set_filter_out_inactives();
 
 const scalene = {
     subscribed: true,
@@ -202,12 +206,15 @@ test("basics", () => {
 });
 
 test("filter inactives", ({override}) => {
+    // Test that we automatically switch to filtering out inactive streams
+    // once the user has more than 30 streams.
     override(
         user_settings,
         "demote_inactive_streams",
         settings_config.demote_inactive_streams_values.automatic.code,
     );
 
+    stream_list_sort.set_filter_out_inactives();
     assert.ok(!stream_list_sort.is_filtering_inactives());
 
     _.times(30, (i) => {
@@ -225,6 +232,17 @@ test("filter inactives", ({override}) => {
     stream_list_sort.set_filter_out_inactives();
 
     assert.ok(stream_list_sort.is_filtering_inactives());
+
+    override(
+        user_settings,
+        "demote_inactive_streams",
+        settings_config.demote_inactive_streams_values.never.code,
+    );
+    stream_list_sort.set_filter_out_inactives();
+    assert.ok(!stream_list_sort.is_filtering_inactives());
+    // Even inactive channels are marked active.
+    assert.ok(!pneumonia.is_recently_active);
+    assert.ok(stream_list_sort.has_recent_activity(pneumonia));
 });
 
 test("initialize", ({override}) => {


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/channel/137-feedback/topic/inactive.20channels.20despite.20Never/with/2134382

Tested by deleted all the messages in a channel and then running `./manage.py update_channel_recently_active_status`.

After that tested that different settings inactive channel management work as expected.