### PR TITLE
Fix: Cache git describe result to optimize performance

### DIFF
--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -1,8 +1,10 @@
 # System documented in https://zulip.readthedocs.io/en/latest/subsystems/logging.html
 import os
 import subprocess
+import functools
 
 
+@functools.lru_cache(maxsize=1)  # Cache result to avoid redundant subprocess calls
 def try_git_describe() -> str | None:
     try:  # nocoverage
         return subprocess.check_output(
@@ -13,3 +15,4 @@ def try_git_describe() -> str | None:
         ).strip()
     except (FileNotFoundError, subprocess.CalledProcessError):  # nocoverage
         return None
+# made changes


### PR DESCRIPTION
**Problem**
Currently, the try_git_describe() function calls subprocess.check_output() every time it is executed. This means:

Every invocation spawns a new subprocess to run git describe.

If the function is called multiple times, it results in redundant subprocess executions, which are costly in terms of performance.

This inefficiency can slow down the application, especially in environments where multiple processes rely on versioning information.

**Solution**

![Screenshot 2025-03-25 214751](https://github.com/user-attachments/assets/04115c82-5d99-47e5-85c3-cf0822c06573)


Introduced @functools.lru_cache(maxsize=1) to cache the result of git describe.

Now, after the first execution, subsequent calls return the cached value instead of executing a new subprocess.

**Testing**

Verified that try_git_describe() still correctly retrieves the version from git describe.

Ensured that multiple calls do not trigger new subprocesses after the first execution.

Checked that the function still handles exceptions properly.

**Why is this important?**

Optimized performance – Reduces redundant subprocess calls.

Improved efficiency – Ensures faster execution when version info is needed multiple times.

### This solves the issue #34159 