### PR TITLE
home_views: Let Recents/Inbox view filter fit content.

### DIFF
--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -575,7 +575,14 @@
 
 .recent-view-filter-dropdown-list-container .dropdown-list-wrapper,
 .inbox-filter-dropdown-list-container .dropdown-list-wrapper {
-    width: 15.7142em; /* 220px at 14px em */
+    /* We want these dropdowns to open to fit their
+       contents, which differ based on the language
+       in use. */
+    width: 100%;
+    /* We also don't want to set a min-width, again
+       so that the content is in charge. This pushes
+       back against more generic styles. */
+    min-width: unset;
 }
 
 .recent-view-filter-dropdown-list-container
@@ -584,6 +591,13 @@
 .inbox-filter-dropdown-list-container
     .dropdown-list
     .dropdown-list-item-common-styles {
+    /* Parallel to the `width: 100%` set on
+       .dropdown-list-wrapper above, we set
+       min-width here to max-content so that
+       the box opens to accommodate different
+       lengths of text--and to ensure that
+       hovered/selectable areas look correct. */
+    min-width: max-content;
     padding: 5px 10px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This PR improves the internationalization on the dropdown filters in both Inbox and Recent Views.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/view.20type.20dropdown.20width)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Note that the English filter gets slightly smaller; that's owing to previous brittle eyeballed values._

| Before | After |
| --- | --- |
| ![russian-filters-recents-before](https://github.com/user-attachments/assets/3126e444-0a84-4c27-8ba6-ebe7049746b6) | ![russian-filters-recents-after](https://github.com/user-attachments/assets/a670ac05-9aa7-4dd5-acae-e1fb33b7478c) |
| ![russian-filters-before](https://github.com/user-attachments/assets/439614fb-65e3-40c2-abb4-389598c4e95a) | ![russian-filters-after](https://github.com/user-attachments/assets/d470d7cb-842a-4cce-b173-90ae5dd4b37b) |
| ![english-filters-before](https://github.com/user-attachments/assets/6b0f789d-09dc-4875-b34e-106035dfd1e6) | ![english-filters-after](https://github.com/user-attachments/assets/7b3b5c7c-d125-4347-9003-b2d0d966a274) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>