### PR TITLE
drafts: Fix bug opening drafts in 'general chat'.

### DIFF
--- a/web/src/drafts.ts
+++ b/web/src/drafts.ts
@@ -506,9 +506,9 @@ export function filter_drafts_by_compose_box_and_recipient(
         // Match by stream and topic.
         if (
             stream_id &&
-            topic &&
+            topic !== undefined &&
             draft.type === "stream" &&
-            draft.topic &&
+            draft.topic !== undefined &&
             draft.stream_id !== undefined &&
             util.same_recipient(
                 {type: "stream", stream_id: draft.stream_id, topic: draft.topic},
@@ -518,7 +518,12 @@ export function filter_drafts_by_compose_box_and_recipient(
             narrow_drafts_ids.push(id);
         }
         // Match by only stream.
-        else if (draft.type === "stream" && stream_id && !topic && draft.stream_id === stream_id) {
+        else if (
+            draft.type === "stream" &&
+            stream_id &&
+            topic === undefined &&
+            draft.stream_id === stream_id
+        ) {
             narrow_drafts_ids.push(id);
         }
         // Match by direct message recipient.


### PR DESCRIPTION
This was likely a longstanding issue that wasn't caught because we required topics on CZO. The new logic ensures topic match even for empty string (general chat) topics.

[CZO report](https://chat.zulip.org/#narrow/channel/9-issues/topic/drafts.20moved.20to.20.22general.20chat.22/near/2133842):

> A couple of times this morning I've seen the following happen:
> * There's a message in *general chat* in some channel. (#**mobile-dev-help**, then #**mobile**.)
> * I hit "r" to reply.
> * The compose box gets filled in with a draft that I definitely didn't write for "general chat" — it looks like I wrote it for some other thread in the same channel.

