### PR TITLE
recipient_row: Fix empty string topic display in keyword search view.

### DIFF
--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -28,7 +28,7 @@
             <a class="message_label_clickable narrows_by_topic tippy-narrow-tooltip"
               href="{{topic_url}}"
               data-tippy-content="{{t 'Go to #{display_recipient} > {topic_display_name}' }}">
-                {{#if use_match_properties}}
+                {{#if (and use_match_properties (not is_empty_string_topic))}}
                     <span class="stream-topic-inner">{{{match_topic}}}</span>
                 {{else}}
                     <span class="stream-topic-inner {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>


### PR DESCRIPTION
[CZO Bug report - first message](https://chat.zulip.org/#narrow/channel/9-issues/topic/general.20chat.20missing.20from.20header.20bar.20in.20search.20view/near/2135677)

Searching for a word that appears in a message in a empty string topic via the search box resulted in a message view where the topic names in the recipient_row were empty string instead of `realm_empty_topic_display_name`.

This PR fixes that bug.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After |
|-------|------|
<img width="888" alt="Screenshot 2025-03-26 at 3 53 47 PM" src="https://github.com/user-attachments/assets/87584d77-43de-4072-a1c4-1c1712a9bd19" /> | <img width="903" alt="Screenshot 2025-03-26 at 3 35 00 PM" src="https://github.com/user-attachments/assets/a5b8522c-3286-4119-ac32-18a6ef1ec5a9" />| 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

