### PR TITLE
inline_topic_edit: Fix inline topic edit input field width for topic="".

### DIFF
--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -450,9 +450,9 @@ function handle_inline_topic_edit_keydown(this: HTMLElement, e: JQuery.KeyDownEv
     }
 }
 
-function handle_inline_topic_edit_change(this: HTMLInputElement): void {
-    const $inline_topic_edit_input = $(this);
-
+function update_inline_topic_edit_input_max_width(
+    $inline_topic_edit_input: JQuery<HTMLInputElement>,
+): void {
     // We use a hidden span element, which we update with the value
     // of the input field on every input change to calculate the
     // width of the topic value. This allows us to dynamically adjust
@@ -460,9 +460,10 @@ function handle_inline_topic_edit_change(this: HTMLInputElement): void {
     const $topic_value_mirror = $inline_topic_edit_input
         .closest(".topic_edit_form")
         .find(".topic_value_mirror");
-    $topic_value_mirror.text(this.value);
+    const input_value = $inline_topic_edit_input.val()!;
+    $topic_value_mirror.text(input_value);
     const topic_width = $topic_value_mirror.width();
-    if (this.value.length > 0) {
+    if (input_value.length > 0) {
         // When the user starts typing in the inline topic edit input field,
         // we dynamically adjust the max-width of the input field to match
         // width of the text in the input field + 1ch width for some cushion.
@@ -483,6 +484,12 @@ function handle_inline_topic_edit_change(this: HTMLInputElement): void {
             $inline_topic_edit_input.css("max-width", "20ch");
         }
     }
+}
+
+function handle_inline_topic_edit_change(this: HTMLInputElement): void {
+    const $inline_topic_edit_input = $(this);
+
+    update_inline_topic_edit_input_max_width($inline_topic_edit_input);
 
     if ($inline_topic_edit_input.hasClass("invalid-input")) {
         // If invalid-input class is present on the inline topic edit
@@ -988,11 +995,7 @@ export function start_inline_topic_edit($recipient_row: JQuery): void {
     const topic = message.topic;
     const $inline_topic_edit_input = $form.find<HTMLInputElement>("input.inline_topic_edit");
     $inline_topic_edit_input.val(topic).trigger("select").trigger("focus");
-    const $stream_topic = $recipient_row.find(".stream_topic");
-    const topic_width = $stream_topic.width();
-    // Set the width of the inline topic edit input to the
-    // width of the topic name + 1ch width for some cushion.
-    $inline_topic_edit_input.css("max-width", `calc(${topic_width}px + 1ch)`);
+    update_inline_topic_edit_input_max_width($inline_topic_edit_input);
     const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     composebox_typeahead.initialize_topic_edit_typeahead(
         $inline_topic_edit_input,


### PR DESCRIPTION
[CZO Bug report](https://chat.zulip.org/#narrow/channel/9-issues/topic/general.20chat.20missing.20from.20header.20bar.20in.20search.20view/near/2135677)


Earlier, for `topic=""` and `mandatory_topics=False`, the inline topic edit input field width was not set correctly when the inline topic edit was started for the first time.

This resulted in overflowing placeholder.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before | After |
|-------|------|
<img width="836" alt="Screenshot 2025-03-26 at 6 38 30 PM" src="https://github.com/user-attachments/assets/381f42ff-9abe-4845-ad99-90a9de8162f5" /> | <img width="632" alt="Screenshot 2025-03-26 at 6 37 26 PM" src="https://github.com/user-attachments/assets/9acc7f8b-71c9-44ef-9c06-5ea9faab0586" /> | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
