### PR TITLE
Fixes: Allow uploading SVGs for Organization logo #21404

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads.types
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads.types
@@ -8,6 +8,7 @@ types {
     image/png                             png;
     image/tiff                            tif tiff;
     image/webp                            webp;
+    image/svg+xml                         svg;
 
     video/3gpp                            3gpp 3gp;
     video/mp4                             mp4;

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1516,7 +1516,7 @@ export function build_page(): void {
         const $error_field = $(`${widget}  .image_file_input_error`).expectOne();
         realm_icon_logo_upload_start($spinner, $upload_text, $delete_button);
         $error_field.hide();
-        
+
         channel.post({
             url,
             data: form_data,

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -1516,6 +1516,7 @@ export function build_page(): void {
         const $error_field = $(`${widget}  .image_file_input_error`).expectOne();
         realm_icon_logo_upload_start($spinner, $upload_text, $delete_button);
         $error_field.hide();
+        
         channel.post({
             url,
             data: form_data,

--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -25,6 +25,7 @@ const supported_types = [
     "image/png",
     "image/tiff",
     "image/webp",
+    "image/svg+xml",
 ];
 
 function is_image_format(file: File): boolean {

--- a/web/templates/settings/image_upload_widget.hbs
+++ b/web/templates/settings/image_upload_widget.hbs
@@ -24,5 +24,5 @@
     </div>
     <img class="image-block" src="{{ image }}"/>
     <input type="file" name="file_input" class="notvisible image_file_input" value="{{ upload_text }}" />
-    <div class="image_file_input_error text-error"> hi </div>
+    <div class="image_file_input_error text-error"></div>
 </div>

--- a/web/templates/settings/image_upload_widget.hbs
+++ b/web/templates/settings/image_upload_widget.hbs
@@ -23,6 +23,6 @@
         </span>
     </div>
     <img class="image-block" src="{{ image }}"/>
-    <input type="file" name="file_input" class="notvisible image_file_input"  value="{{ upload_text }}" />
-    <div class="image_file_input_error text-error"></div>
+    <input type="file" name="file_input" class="notvisible image_file_input" value="{{ upload_text }}" />
+    <div class="image_file_input_error text-error"> hi </div>
 </div>

--- a/zerver/lib/mime_types.py
+++ b/zerver/lib/mime_types.py
@@ -36,6 +36,7 @@ INLINE_MIME_TYPES = [
     "image/jpeg",
     "image/png",
     "image/webp",
+    "image/svg+xml",
     "text/plain",
     "video/mp4",
     "video/webm",

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -134,7 +134,7 @@ pyvips.operation_block_set("VipsForeignLoadJpeg", False)  # image/jpeg
 pyvips.operation_block_set("VipsForeignLoadPng", False)  # image/png
 pyvips.operation_block_set("VipsForeignLoadTiff", False)  # image/tiff
 pyvips.operation_block_set("VipsForeignLoadWebp", False)  # image/webp
-pyvips.operation_block_set("VipsForiegnLoadSvg", False) # image/svg+xml
+pyvips.operation_block_set("VipsForiegnLoadSvg", False)  # image/svg+xml
 pyvips.block_untrusted_set(True)
 
 # Disable the operations cache; our only use here is thumbnail_buffer,

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -115,6 +115,7 @@ THUMBNAIL_ACCEPT_IMAGE_TYPES = frozenset(
         "image/png",
         "image/tiff",
         "image/webp",
+        "image/svg+xml",
     ]
 )
 
@@ -133,6 +134,7 @@ pyvips.operation_block_set("VipsForeignLoadJpeg", False)  # image/jpeg
 pyvips.operation_block_set("VipsForeignLoadPng", False)  # image/png
 pyvips.operation_block_set("VipsForeignLoadTiff", False)  # image/tiff
 pyvips.operation_block_set("VipsForeignLoadWebp", False)  # image/webp
+pyvips.operation_block_set("VipsForiegnLoadSvg", False) # image/svg+xml
 pyvips.block_untrusted_set(True)
 
 # Disable the operations cache; our only use here is thumbnail_buffer,

--- a/zerver/migrations/0544_copy_avatar_images.py
+++ b/zerver/migrations/0544_copy_avatar_images.py
@@ -80,6 +80,7 @@ INLINE_IMAGE_MIME_TYPES = [
     "image/jpeg",
     "image/png",
     "image/webp",
+    "image/svg+xml",
     # To avoid cross-site scripting attacks, DO NOT add types such
     # as image/svg+xml.
 ]

--- a/zerver/migrations/0553_copy_emoji_images.py
+++ b/zerver/migrations/0553_copy_emoji_images.py
@@ -30,6 +30,7 @@ VALID_EMOJI_CONTENT_TYPE = frozenset(
         "image/jpeg",
         "image/png",
         "image/webp",
+        "image/svg+xml",
     ]
 )
 


### PR DESCRIPTION
Fixes: Allow uploading SVGs for Organization logo #21404 

This PR adds support for uploading SVG (`image/svg+xml`) files in the image uploader widget for organization logos. Additionally, it includes necessary configuration to disable `VipsForeignLoadSvg` where required using:

```python
pyvips.operation_block_set("VipsForeignLoadSvg", False)
```

![image](https://github.com/user-attachments/assets/3cfb782a-25a7-4239-b135-9dfce2b9b664)
![image](https://github.com/user-attachments/assets/7b07cb2a-52f5-4c26-9bcd-46a2c40fa55e)
![Screenshot from 2025-03-26 18-59-35](https://github.com/user-attachments/assets/f857f808-df48-4ed9-9a95-ce6d0eec6c90)

<details>
<summary>
Added svg+xml support for image uploader widget
</summary>

### Changes:
- **Added support for `image/svg+xml`** in the following files:
  - `web/src/upload_widget.ts`
  - `zerver/lib/mime_types.py`
  - `zerver/lib/thumbnail.py`
  - `zerver/migrations/0544_copy_avatar_images.py`
  - `zerver/migrations/0553_copy_emoji_images.py`
  - `puppet/zulip/files/nginx/zulip-include-frontend/uploads.types`

- **Disabled `VipsForeignLoadSvg` where necessary** using:
  ```python
  pyvips.operation_block_set("VipsForeignLoadSvg", False)
  ```
</details>
