### PR TITLE
compose-closed-ui: Add assert for inbox or recent view.

### DIFF
--- a/web/src/compose_closed_ui.ts
+++ b/web/src/compose_closed_ui.ts
@@ -1,15 +1,18 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 
 import render_reply_recipient_label from "../templates/reply_recipient_label.hbs";
 
 import * as compose_actions from "./compose_actions.ts";
 import {$t} from "./i18n.ts";
+import * as inbox_util from "./inbox_util.ts";
 import * as message_lists from "./message_lists.ts";
 import * as message_store from "./message_store.ts";
 import * as message_util from "./message_util.ts";
 import * as narrow_state from "./narrow_state.ts";
 import {page_params} from "./page_params.ts";
 import * as people from "./people.ts";
+import * as recent_view_util from "./recent_view_util.ts";
 import * as stream_data from "./stream_data.ts";
 import * as util from "./util.ts";
 
@@ -43,7 +46,8 @@ export function get_recipient_label(
     recipient_information?: ReplyRecipientInformation,
 ): RecipientLabel | undefined {
     if (recipient_information !== undefined) {
-        // If we're in either the Inbox or Recent Conversations view,
+        assert(recent_view_util.is_visible() || inbox_util.is_visible());
+        // When we're in either the Inbox or Recent Conversations view,
         // we try to update the closed compose box button label with
         // information about the reply target from the focused row in
         // the view.


### PR DESCRIPTION
Asserts that either the inbox or recent conversation view is visible when a `ReplyRecipientInformation` object is passed as a parameter to `compose_closed_ui.get_recipient_label`.

Updates the related test to more clearly check the expected reply button text for the inbox/recent conversations case.

Follow up to #34144.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
