### PR TITLE
left_sidebar: Avoid misaligned unreads on Safari.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1311,7 +1311,7 @@ li.top_left_scheduled_messages {
     /* Extra margin for unreads. */
     margin-right: var(--left-sidebar-unread-offset);
 
-    &:has(.unread_count:empty) {
+    &:has(.unread_count.hide) {
         margin-right: 0;
     }
 


### PR DESCRIPTION
This fixes a subtle but extremely annoying alignment issue on Safari on iOS/macOS that would leave new unreads (going from 0 to 1+, either when new messages are received or a message is marked unread) out of alignment on the stream row with respect to topic rows below. 

The root of this issue seems to be that Safari does not calculate `:empty` inside of `:has()`. The fix here instead uses the more reliable `.hide` class instead.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![safari-misaligned-unreads-before](https://github.com/user-attachments/assets/dc60d547-1612-4b8f-aaf7-7ba03d91300e) | ![safari-misaligned-unreads-after](https://github.com/user-attachments/assets/7a8da191-8634-4b86-8e96-bd98cd3fb4f1) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>