### PR TITLE
stream_settings: Move muted channels help text to below header.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -135,6 +135,8 @@ h4.user_group_setting_subsection_title {
     font-size: 1.35em;
     font-weight: normal;
     line-height: 1.5;
+    /* Matches right margin on h3 subsection titles */
+    margin-right: 15px;
 }
 
 .member-list-box,

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -134,8 +134,8 @@
                 <div class="subsection-header">
                     <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>
                     <div class="stream_change_property_status alert-notification"></div>
-                    <p>{{t "In muted channels, channel notification settings apply only to unmuted topics." }}</p>
                 </div>
+                <p>{{t "In muted channels, channel notification settings apply only to unmuted topics." }}</p>
                 <div class="input-group">
                     <button class="button small rounded reset-stream-notifications-button" type="button">{{t "Reset to default notifications" }}</button>
                 </div>


### PR DESCRIPTION
at 16px, with widths 800px 900px 1300px (change only at middle width)

| before | after |
| --- | --- |
| ![Screen Shot 2025-03-26 at 14 14 46](https://github.com/user-attachments/assets/267410e2-e956-4252-a53c-b9c0d8f586cd) | ![Screen Shot 2025-03-26 at 13 14 44](https://github.com/user-attachments/assets/9667ee8d-e91a-4a89-b2e1-004b77a8b4ba) |
| ![Screen Shot 2025-03-26 at 14 13 09](https://github.com/user-attachments/assets/91641a8e-f0e9-4e86-95e2-ab066192c853) | ![Screen Shot 2025-03-26 at 14 17 42](https://github.com/user-attachments/assets/5111f774-8d5b-45c0-8898-f42d8a7e4e52) |
| ![Screen Shot 2025-03-26 at 14 14 53](https://github.com/user-attachments/assets/218da1a1-03af-4277-ae78-8d74c66650ac) | ![Screen Shot 2025-03-26 at 13 14 58](https://github.com/user-attachments/assets/30df3ec5-a552-48eb-bd52-8460f3eaa011) |
