### PR TITLE
Parse Accept header correctly

### DIFF
--- a/corporate/lib/decorator.py
+++ b/corporate/lib/decorator.py
@@ -16,6 +16,7 @@ from corporate.lib.remote_billing_util import (
     get_remote_server_and_user_from_session,
 )
 from zerver.lib.exceptions import RemoteBillingAuthenticationError
+from zerver.lib.request import get_preferred_type
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.url_encoding import append_url_query_string
 from zilencer.models import RemoteRealm
@@ -123,7 +124,9 @@ def authenticated_remote_realm_management_endpoint(
                 url = append_url_query_string(url, query)
 
             # Return error for AJAX requests with url.
-            if request.headers.get("x-requested-with") == "XMLHttpRequest":  # nocoverage
+            if (
+                get_preferred_type(request, ["application/json", "text/html"]) != "text/html"
+            ):  # nocoverage
                 return session_expired_ajax_response(url)
 
             return HttpResponseRedirect(url)
@@ -207,7 +210,9 @@ def authenticated_remote_server_management_endpoint(
                 url = append_url_query_string(url, query)
 
             # Return error for AJAX requests with url.
-            if request.headers.get("x-requested-with") == "XMLHttpRequest":  # nocoverage
+            if (
+                get_preferred_type(request, ["application/json", "text/html"]) != "text/html"
+            ):  # nocoverage
                 return session_expired_ajax_response(url)
 
             return HttpResponseRedirect(url)

--- a/corporate/tests/test_remote_billing.py
+++ b/corporate/tests/test_remote_billing.py
@@ -500,7 +500,9 @@ class RemoteBillingAuthenticationTest(RemoteRealmBillingTestCase):
             now + timedelta(seconds=REMOTE_BILLING_SESSION_VALIDITY_SECONDS + 1),
             tick=False,
         ):
-            result = self.client_get(final_url, subdomain="selfhosting")
+            result = self.client_get(
+                final_url, subdomain="selfhosting", HTTP_ACCEPT="text/html, */*;q=0.8"
+            )
 
             self.assertEqual(result.status_code, 302)
             self.assertEqual(
@@ -1510,7 +1512,11 @@ class LegacyServerLoginTest(RemoteServerTestCase):
         hamlet = self.example_user("hamlet")
         now = timezone_now()
         # Try to open a page with no auth at all.
-        result = self.client_get(f"/server/{self.uuid}/billing/", subdomain="selfhosting")
+        result = self.client_get(
+            f"/server/{self.uuid}/billing/",
+            subdomain="selfhosting",
+            HTTP_ACCEPT="text/html, */*;q=0.8",
+        )
         self.assertEqual(result.status_code, 302)
         # Redirects to the login form with appropriate next_page value.
         self.assertEqual(result["Location"], "/serverlogin/?next_page=billing")
@@ -1534,7 +1540,11 @@ class LegacyServerLoginTest(RemoteServerTestCase):
                 next_page="upgrade",
                 return_without_clicking_confirmation_link=True,
             )
-        result = self.client_get(f"/server/{self.uuid}/billing/", subdomain="selfhosting")
+        result = self.client_get(
+            f"/server/{self.uuid}/billing/",
+            subdomain="selfhosting",
+            HTTP_ACCEPT="text/html, */*;q=0.8",
+        )
         self.assertEqual(result.status_code, 302)
         # Redirects to the login form with appropriate next_page value.
         self.assertEqual(result["Location"], "/serverlogin/?next_page=billing")
@@ -1561,7 +1571,11 @@ class LegacyServerLoginTest(RemoteServerTestCase):
             now + timedelta(seconds=REMOTE_BILLING_SESSION_VALIDITY_SECONDS + 30),
             tick=False,
         ):
-            result = self.client_get(f"/server/{self.uuid}/upgrade/", subdomain="selfhosting")
+            result = self.client_get(
+                f"/server/{self.uuid}/upgrade/",
+                subdomain="selfhosting",
+                HTTP_ACCEPT="text/html, */*;q=0.8",
+            )
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/serverlogin/?next_page=upgrade")
 

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -98,3 +98,22 @@ class RequestVariableConversionError(JsonableError):
 
 
 arguments_map: dict[str, list[str]] = defaultdict(list)
+
+
+# Equivalent to request.get_preferred_type() in Django 5.2.
+def get_preferred_type(request: HttpRequest, media_types: list[str]) -> str | None:
+    best_type = None
+    best_score = 0.0, True, True
+    for accepted_type in request.accepted_types:
+        score = (
+            float(accepted_type.params.get("q", "1")),
+            accepted_type.main_type != "*",
+            accepted_type.sub_type != "*",
+        )
+        if best_score < score:
+            for media_type in media_types:
+                if accepted_type.match(media_type):
+                    best_type = media_type
+                    best_score = score
+                    break
+    return best_type

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -33,7 +33,7 @@ from zerver.lib.exceptions import ErrorCode, JsonableError, MissingAuthenticatio
 from zerver.lib.markdown import get_markdown_requests, get_markdown_time
 from zerver.lib.per_request_cache import flush_per_request_caches
 from zerver.lib.rate_limiter import RateLimitResult
-from zerver.lib.request import RequestNotes
+from zerver.lib.request import RequestNotes, get_preferred_type
 from zerver.lib.response import (
     AsynchronousResponse,
     json_response,
@@ -377,7 +377,7 @@ class LogRequests(MiddlewareMixin):
 class JsonErrorHandler(MiddlewareMixin):
     def process_exception(self, request: HttpRequest, exception: Exception) -> HttpResponse | None:
         if isinstance(exception, MissingAuthenticationError):
-            if "text/html" in request.headers.get("Accept", ""):
+            if get_preferred_type(request, ["application/json", "text/html"]) == "text/html":
                 # If this looks like a request from a top-level page in a
                 # browser, send the user to the login page.
                 #


### PR DESCRIPTION
A few of our decorators use HTTP headers to detect whether to serve a JSON error or redirect to a login page. Fix them to do so correctly.