### PR TITLE
Provide arm64 app build by default for macOS.

### DIFF
--- a/templates/corporate/apps.html
+++ b/templates/corporate/apps.html
@@ -31,7 +31,7 @@
                         <a class="download-from-apple-app-store" hidden href=""><img src="{{ static('images/store-badges/app-store-badge.svg') }}" alt=""/></a>
                         <span id="download-from-microsoft-store" hidden>or <a href="https://apps.microsoft.com/store/detail/XP8HN41S4PLGZ3">download from the Microsoft Store</a></span>
                         <span id="download-android-apk" hidden>or <a href="https://github.com/zulip/zulip-mobile/releases/latest">manually download APK</a></span>
-                        <span id="download-mac-arm64" hidden>or <a href="">download Apple silicon native build</a></span>
+                        <span id="download-mac-intel" hidden>or <a href="">download <strong>Intel</strong> processor build <i>(some older Macs)</i></a></span>
                         <p class="download-instructions"></p>
                     </div>
                 </div>

--- a/web/src/portico/landing-page.ts
+++ b/web/src/portico/landing-page.ts
@@ -21,7 +21,7 @@ type VersionInfo = {
     | {
           alt: "macOS";
           download_link: string;
-          mac_arm64_link: string;
+          mac_intel_link: string;
           install_guide: string;
       }
     | {
@@ -71,8 +71,8 @@ const apps_events = function (): void {
             alt: "macOS",
             description:
                 "The Zulip desktop app comes with native <a class='apps-page-link' href='/help/desktop-notifications'>desktop notifications</a>, support for multiple Zulip accounts, and a dedicated tray icon.",
-            download_link: "/apps/download/mac",
-            mac_arm64_link: "/apps/download/mac-arm64",
+            download_link: "/apps/download/mac-arm64",
+            mac_intel_link: "/apps/download/mac-intel",
             show_instructions: true,
             install_guide: "/help/desktop-app-install-guide",
             app_type: "desktop",
@@ -132,7 +132,7 @@ const apps_events = function (): void {
         const $download_from_google_play_store = $(".download-from-google-play-store");
         const $download_from_apple_app_store = $(".download-from-apple-app-store");
         const $download_from_microsoft_store = $("#download-from-microsoft-store");
-        const $download_mac_arm64 = $("#download-mac-arm64");
+        const $download_mac_intel = $("#download-mac-intel");
         const $desktop_download_link = $(".desktop-download-link");
         const version_info = info[version];
 
@@ -147,7 +147,7 @@ const apps_events = function (): void {
         } else {
             $desktop_download_link.attr("href", version_info.download_link);
             if (version_info.alt === "macOS") {
-                $download_mac_arm64.find("a").attr("href", version_info.mac_arm64_link);
+                $download_mac_intel.find("a").attr("href", version_info.mac_intel_link);
             }
             assert(version_info.download_instructions);
             $download_instructions.html(version_info.download_instructions);
@@ -161,7 +161,7 @@ const apps_events = function (): void {
         $download_from_google_play_store.toggle(version === "android");
         $download_from_apple_app_store.toggle(version === "ios");
         $download_from_microsoft_store.toggle(version === "windows");
-        $download_mac_arm64.toggle(version === "mac");
+        $download_mac_intel.toggle(version === "mac");
     };
 
     // init

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -2112,7 +2112,7 @@ button {
 
 #download-from-microsoft-store,
 #download-android-apk,
-#download-mac-arm64 {
+#download-mac-intel {
     display: block;
     color: hsl(0deg 0% 100%);
     font-size: 13px;
@@ -2124,7 +2124,7 @@ button {
 }
 
 #download-from-microsoft-store,
-#download-mac-arm64 {
+#download-mac-intel {
     margin-top: 10px;
 }
 

--- a/zerver/lib/github.py
+++ b/zerver/lib/github.py
@@ -37,7 +37,8 @@ def verify_release_download_link(link: str) -> bool:
 
 PLATFORM_TO_SETUP_FILE = {
     "linux": "Zulip-{version}-x86_64.AppImage",
-    "mac": "Zulip-{version}-x64.dmg",
+    "mac": "Zulip-{version}-arm64.dmg",
+    "mac-intel": "Zulip-{version}-x64.dmg",
     "mac-arm64": "Zulip-{version}-arm64.dmg",
     "windows": "Zulip-Web-Setup-{version}.exe",
 }

--- a/zerver/tests/test_github.py
+++ b/zerver/tests/test_github.py
@@ -43,11 +43,31 @@ class GitHubTestCase(ZulipTestCase):
 
         responses.add(
             responses.HEAD,
-            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x64.dmg",
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-arm64.dmg",
             status=302,
         )
         self.assertEqual(
             get_latest_github_release_download_link_for_platform("mac"),
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-arm64.dmg",
+        )
+
+        responses.add(
+            responses.HEAD,
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-arm64.dmg",
+            status=302,
+        )
+        self.assertEqual(
+            get_latest_github_release_download_link_for_platform("mac-arm64"),
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-arm64.dmg",
+        )
+
+        responses.add(
+            responses.HEAD,
+            "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x64.dmg",
+            status=302,
+        )
+        self.assertEqual(
+            get_latest_github_release_download_link_for_platform("mac-intel"),
             "https://desktop-download.zulip.com/v5.4.3/Zulip-5.4.3-x64.dmg",
         )
 


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![Screenshot from 2025-03-27 08-50-41](https://github.com/user-attachments/assets/dfacc296-a698-467a-b1f3-73da4363122f) | ![image](https://github.com/user-attachments/assets/bd7496ee-ce73-46fe-aa14-6c9da7a5176e) |

Testing that clicking on both links downloads the advertised version of the app.