### PR TITLE
message_fetch: Remove `found_anchor` from API response.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -25,6 +25,11 @@ releases.
 
 ## Changes in Zulip 10.0
 
+**Feature level 373**
+
+* [`GET /messages`](/api/get-messages): Removed `found_anchor` property from response as
+  it hasn't been used since it was introduced in a4a8527ec5de32a91bcda45eefdd9e4770d381ec.
+
 **Feature level 372**
 
 * [`POST /typing`](/api/set-typing-status): The `"(no topic)"` value

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 372  # Last bumped to interpret "(no topic)" as empty string.
+API_FEATURE_LEVEL = 373  # Last bumped for removing `found_anchor`.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/message_fetch.ts
+++ b/web/src/message_fetch.ts
@@ -33,7 +33,6 @@ export const response_schema = z.object({
     anchor: z.number(),
     found_newest: z.boolean(),
     found_oldest: z.boolean(),
-    found_anchor: z.boolean(),
     history_limited: z.boolean(),
     messages: z.array(raw_message_schema),
     result: z.string(),

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -1373,7 +1373,6 @@ MessageRowT = TypeVar("MessageRowT", bound=Sequence[Any])
 @dataclass
 class LimitedMessages(Generic[MessageRowT]):
     rows: list[MessageRowT]
-    found_anchor: bool
     found_newest: bool
     found_oldest: bool
     history_limited: bool
@@ -1421,7 +1420,6 @@ def post_process_limited_query(
 
     limited_rows = [*before_rows, *anchor_rows, *after_rows]
 
-    found_anchor = len(anchor_rows) == 1
     found_oldest = anchored_to_left or (len(before_rows) < num_before)
     found_newest = anchored_to_right or (len(after_rows) < num_after)
     # BUG: history_limited is incorrect False in the event that we had
@@ -1439,7 +1437,6 @@ def post_process_limited_query(
 
     return LimitedMessages(
         rows=limited_rows,
-        found_anchor=found_anchor,
         found_newest=found_newest,
         found_oldest=found_oldest,
         history_limited=history_limited,
@@ -1564,7 +1561,6 @@ def fetch_messages(
             visible_rows = rows
         return FetchedMessages(
             rows=visible_rows,
-            found_anchor=False,
             found_newest=False,
             found_oldest=False,
             history_limited=False,
@@ -1586,7 +1582,6 @@ def fetch_messages(
 
     return FetchedMessages(
         rows=query_info.rows,
-        found_anchor=query_info.found_anchor,
         found_newest=query_info.found_newest,
         found_oldest=query_info.found_oldest,
         history_limited=query_info.history_limited,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7285,14 +7285,6 @@ paths:
                           Whether the server promises that the `messages` list includes the very
                           oldest messages matching the narrow (used by clients that paginate their
                           requests to decide whether there may be more messages to fetch).
-                      found_anchor:
-                        type: boolean
-                        description: |
-                          Whether the anchor message is included in the
-                          response. If the message with the ID specified
-                          in the request does not exist, did not match
-                          the narrow, or was excluded via
-                          `"include_anchor": false`, this will be false.
                       history_limited:
                         type: boolean
                         description: |
@@ -7373,7 +7365,6 @@ paths:
                       {
                         "anchor": 21,
                         "found_newest": true,
-                        "found_anchor": true,
                         "result": "success",
                         "msg": "",
                         "messages":

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -1298,7 +1298,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left: bool,
             anchored_to_right: bool,
             out_ids: list[int],
-            found_anchor: bool,
             found_oldest: bool,
             found_newest: bool,
             history_limited: bool,
@@ -1317,7 +1316,6 @@ class PostProcessTest(ZulipTestCase):
             )
 
             self.assertEqual(info.rows, out_rows)
-            self.assertEqual(info.found_anchor, found_anchor)
             self.assertEqual(info.found_newest, found_newest)
             self.assertEqual(info.found_oldest, found_oldest)
             self.assertEqual(info.history_limited, history_limited)
@@ -1334,7 +1332,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[8, 9, 10, 11, 12],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1348,7 +1345,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[8, 9, 10, 11, 12],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1362,7 +1358,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[9, 10, 11, 12],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1376,7 +1371,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[10, 11, 12],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1390,7 +1384,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[11, 12],
-            found_anchor=False,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1404,7 +1397,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[12],
-            found_anchor=False,
             found_oldest=True,
             found_newest=True,
             history_limited=True,
@@ -1418,7 +1410,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[],
-            found_anchor=False,
             found_oldest=True,
             found_newest=True,
             history_limited=True,
@@ -1435,7 +1426,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_right=False,
             first_visible_message_id=0,
             out_ids=[7, 9, 11, 13],
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1449,7 +1439,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[11, 13],
-            found_anchor=False,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1463,7 +1452,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[9, 11, 13],
-            found_anchor=False,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1480,7 +1468,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[50, 100, 150, 200],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=False,
@@ -1494,7 +1481,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[100, 150, 200],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1511,7 +1497,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[700, 800, 900, 1000],
-            found_anchor=True,
             found_oldest=False,
             found_newest=True,
             history_limited=False,
@@ -1525,7 +1510,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[900, 1000],
-            found_anchor=True,
             found_oldest=True,
             found_newest=True,
             history_limited=True,
@@ -1542,7 +1526,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[50, 100],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=False,
@@ -1556,7 +1539,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[100],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1573,7 +1555,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[700, 800, 900],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1587,7 +1568,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[900],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1604,7 +1584,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[700, 800, 900],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1618,7 +1597,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[900],
-            found_anchor=True,
             found_oldest=True,
             found_newest=False,
             history_limited=True,
@@ -1635,7 +1613,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=True,
             out_ids=[900, 1000],
-            found_anchor=False,
             found_oldest=False,
             found_newest=True,
             history_limited=False,
@@ -1649,7 +1626,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=True,
             out_ids=[1000],
-            found_anchor=False,
             found_oldest=True,
             found_newest=True,
             history_limited=True,
@@ -1663,7 +1639,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=True,
             out_ids=[],
-            found_anchor=False,
             found_oldest=True,
             found_newest=True,
             history_limited=True,
@@ -1680,7 +1655,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[100, 200, 300],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1694,7 +1668,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[100, 200, 300],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1708,7 +1681,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[300, 400],
-            found_anchor=False,
             found_oldest=False,
             # BUG: history_limited should be False here.
             found_newest=False,
@@ -1726,7 +1698,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[900, 1000],
-            found_anchor=True,
             found_oldest=False,
             found_newest=True,
             history_limited=False,
@@ -1740,7 +1711,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[900, 1000],
-            found_anchor=True,
             found_oldest=False,
             found_newest=True,
             history_limited=False,
@@ -1757,7 +1727,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[1000, 1100],
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1771,7 +1740,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[1000, 1100],
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1785,7 +1753,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[1000, 1100],
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1799,7 +1766,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[1100, 1200],
-            found_anchor=False,
             found_oldest=False,
             # BUG: history_limited should be False here.
             found_newest=False,
@@ -1817,7 +1783,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[1000],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1831,7 +1796,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[1000],
-            found_anchor=True,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1845,7 +1809,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[],
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -1862,7 +1825,6 @@ class PostProcessTest(ZulipTestCase):
             anchored_to_left=False,
             anchored_to_right=False,
             out_ids=[],
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
             history_limited=False,
@@ -3682,7 +3644,6 @@ class GetOldMessagesTest(ZulipTestCase):
         data = self.get_messages_response(anchor=message_ids[9], num_before=9, num_after=0)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3692,7 +3653,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[9], num_before=9, num_after=0)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], True)
@@ -3702,7 +3662,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[6], num_before=9, num_after=0)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], True)
@@ -3713,7 +3672,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         self.assert_length(messages, 0)
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], True)
@@ -3721,7 +3679,6 @@ class GetOldMessagesTest(ZulipTestCase):
         data = self.get_messages_response(anchor=message_ids[5], num_before=0, num_after=5)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3731,7 +3688,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[5], num_before=0, num_after=5)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3741,7 +3697,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[0], num_before=0, num_after=5)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3751,7 +3706,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[0], num_before=0, num_after=5)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3763,7 +3717,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         messages_matches_ids(messages, message_ids[0:5])
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3775,7 +3728,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         messages_matches_ids(messages, message_ids[0:5])
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3786,7 +3738,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         messages_matches_ids(messages, message_ids[0:5])
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3794,7 +3745,6 @@ class GetOldMessagesTest(ZulipTestCase):
         data = self.get_messages_response(anchor=message_ids[5], num_before=5, num_after=4)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3802,7 +3752,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         data = self.get_messages_response(anchor=message_ids[5], num_before=10, num_after=10)
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3812,7 +3761,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[5], num_before=5, num_after=4)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], True)
@@ -3822,7 +3770,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[2], num_before=5, num_after=3)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], True)
@@ -3832,7 +3779,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[2], num_before=10, num_after=10)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], True)
         messages_matches_ids(messages, message_ids[5:])
@@ -3841,7 +3787,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[5], num_before=5, num_after=4)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], True)
@@ -3851,7 +3796,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[5], num_before=0, num_after=0)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], True)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3861,7 +3805,6 @@ class GetOldMessagesTest(ZulipTestCase):
             data = self.get_messages_response(anchor=message_ids[2], num_before=0, num_after=0)
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3875,7 +3818,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         self.assert_length(messages, 5)
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3886,7 +3828,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         self.assert_length(messages, 5)
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3898,7 +3839,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         self.assert_length(messages, 5)
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3910,7 +3850,6 @@ class GetOldMessagesTest(ZulipTestCase):
 
         messages = data["messages"]
         self.assert_length(messages, 10)
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], True)
         self.assertEqual(data["found_newest"], True)
         self.assertEqual(data["history_limited"], False)
@@ -3920,7 +3859,6 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)
@@ -3931,7 +3869,6 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         messages = data["messages"]
-        self.assertEqual(data["found_anchor"], False)
         self.assertEqual(data["found_oldest"], False)
         self.assertEqual(data["found_newest"], False)
         self.assertEqual(data["history_limited"], False)

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -317,7 +317,6 @@ def get_messages_backend(
             result="success",
             msg="",
             history_limited=query_info.history_limited,
-            found_anchor=False,
             found_oldest=False,
             found_newest=False,
         )
@@ -326,7 +325,6 @@ def get_messages_backend(
             messages=message_list,
             result="success",
             msg="",
-            found_anchor=query_info.found_anchor,
             found_oldest=query_info.found_oldest,
             found_newest=query_info.found_newest,
             history_limited=query_info.history_limited,


### PR DESCRIPTION
This was never used since it was introduced in
a4a8527ec5de32a91bcda45eefdd9e4770d381ec.

discussion: [#api design > Message matches narrow @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/Message.20matches.20narrow/near/1954132)