### PR TITLE
typing: Rename "(no topic)" to empty string topic.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -25,6 +25,11 @@ releases.
 
 ## Changes in Zulip 10.0
 
+**Feature level 372**
+
+* [`POST /typing`](/api/set-typing-status): The `"(no topic)"` value
+  when used for `topic` parameter is now interpreted as an empty string.
+
 **Feature level 371**
 
 No changes; feature level used for Zulip 10.0 release.

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 371  # Last bumped for Zulip 10.0 release.
+API_FEATURE_LEVEL = 372  # Last bumped to interpret "(no topic)" as empty string.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -21419,11 +21419,14 @@ paths:
                     Topic to which message is being typed. Required for the `"stream"` or `"channel"`
                     type. Ignored in the case of `"direct"` type.
 
-                    Note: When the value of `realm_empty_topic_display_name` found in
-                    the [POST /register](/api/register-queue) response is used for this
+                    Note: When `"(no topic)"` or the value of `realm_empty_topic_display_name`
+                    found in the [POST /register](/api/register-queue) response is used for this
                     parameter, it is interpreted as an empty string.
 
-                    **Changes**: Before Zulip 10.0 (feature level 334), empty string
+                    **Changes**: Before Zulip 10.0 (feature level 372),
+                    `"(no topic)"` was not interpreted as an empty string.
+
+                    Before Zulip 10.0 (feature level 334), empty string
                     was not a valid topic name for channel messages.
 
                     New in Zulip 4.0 (feature level 58). Previously, typing notifications

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -15,7 +15,10 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id_for_message, access_stream_for_send_message
-from zerver.lib.topic import maybe_rename_general_chat_to_empty_topic
+from zerver.lib.topic import (
+    maybe_rename_general_chat_to_empty_topic,
+    maybe_rename_no_topic_to_empty_topic,
+)
 from zerver.lib.typed_endpoint import ApiParamConfig, OptionalTopic, PathOnly, typed_endpoint
 from zerver.models import Recipient, UserProfile
 from zerver.models.recipients import get_direct_message_group_user_ids
@@ -54,6 +57,7 @@ def send_notification_backend(
         stream = access_stream_by_id_for_message(user_profile, stream_id)[0]
         access_stream_for_send_message(user_profile, stream, forwarder_user_profile=None)
         topic = maybe_rename_general_chat_to_empty_topic(topic)
+        topic = maybe_rename_no_topic_to_empty_topic(topic)
         do_send_stream_typing_notification(user_profile, operator, stream, topic)
     else:
         if notification_to is None:


### PR DESCRIPTION
[#backend > general chat - migration discussion @ 💬](https://chat.zulip.org/#narrow/channel/3-backend/topic/general.20chat.20-.20migration.20discussion/near/2135913)

This PR renames `"(no topic)"` to `""` when used as topic name in `POST /typing`.

Message sent in `"(no topic)"` is translated as being sent in `""` by the server, so it makes sense to show the typing notification in `""` when message is being composed.



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Typing in `"(no topic)"`, typing notification appears in `""` / *general chat*:

<img width="1512" alt="Screenshot 2025-03-27 at 2 19 59 PM" src="https://github.com/user-attachments/assets/cae4058b-3dd1-4a0a-8c42-19f6d66df9c3" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
