### PR TITLE
left_sidebar: Present two-line DM rows.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -271,6 +271,7 @@
 
             .zulip-icon:not(.user-circle) {
                 color: var(--color-left-sidebar-dm-partners-icon);
+                vertical-align: -0.2em;
             }
         }
 
@@ -914,24 +915,17 @@ li.top_left_scheduled_messages {
     grid-area: row-content;
     overflow: hidden;
     text-overflow: ellipsis;
-    /* Use an inline grid to provide a modern layout
-       for status emoji in DM rows, while preserving
-       the expected ellipsis behavior on long usernames
-       or large DM groups.
-       The 16px-tall emoji will also align well
-       vertically with the 18px line-height here. */
-    display: inline-grid;
-    /* Provide a two-column grid, sized to accommodate
-       the content of the conversation list and status
-       emoji, if any. */
-    grid-template-columns: repeat(2, minmax(0, max-content));
-    align-items: center;
 }
 
 .conversation-partners .status-emoji {
     /* Prevent status emoji from colliding
        with unread counts. */
     margin-right: 3px;
+    /* To make status emoji look good with
+       multiline usernames, we need to fall
+       back to inline-block display here. */
+    display: inline-block;
+    vertical-align: -0.25em;
 }
 
 /* New grid definitions here. */

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1328,6 +1328,11 @@ li.top_left_scheduled_messages {
     }
 }
 
+.dm-markers-and-unreads,
+.conversation-partners {
+    align-self: baseline;
+}
+
 .channel-new-topic-button {
     /* display: flex; is set on visible channels and
        channel-row hovers. */
@@ -1356,12 +1361,25 @@ li.top_left_scheduled_messages {
     grid-area: ending-anchor-element;
 }
 
-.conversation-partners-list,
 .stream-name {
     white-space: nowrap;
     overflow-x: hidden;
     overflow-x: clip;
     text-overflow: ellipsis;
+    padding: 0 var(--left-sidebar-before-unread-count-padding) 0 0;
+}
+
+.conversation-partners-list {
+    /* Clamp multi-line DMs to two lines. */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    /* Break overflowing usernames as necessary. */
+    overflow-wrap: break-word;
+
+    line-height: var(--line-height-sidebar-topic-inner);
+    margin: var(--spacing-top-bottom-sidebar-topic-inner) 0;
     padding: 0 var(--left-sidebar-before-unread-count-padding) 0 0;
 }
 
@@ -1512,6 +1530,10 @@ li.topic-list-item {
     .conversation-partners-icon {
         grid-area: starting-anchor-element;
         place-self: center;
+
+        &:not(.user-circle) {
+            place-self: start center;
+        }
     }
 
     .dm-name {
@@ -1519,10 +1541,9 @@ li.topic-list-item {
     }
 
     .user-circle {
-        /* Tighten the line-height to match the icon's size... */
-        line-height: 1;
-        /* ...which is approximately 8px at 15px/1em. */
+        /* User circles are approximately 8px at 15px/1em. */
         font-size: 0.5333em;
+        align-self: start;
     }
 
     .unread_count {

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -8,11 +8,12 @@
         {{/if}}
 
         <a href="{{url}}" class="conversation-partners">
-            <span class="conversation-partners-list">{{recipients}}</span>
-            {{> status_emoji status_emoji_info}}
-            {{#if is_bot}}
-                <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
-            {{/if}}
+            <span class="conversation-partners-list">{{recipients}} {{> status_emoji status_emoji_info}}
+                {{#if is_bot}}
+                    <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
+                {{/if}}
+            </span>
+
         </a>
         <div class="dm-markers-and-unreads">
             {{#if has_unread_mention}}


### PR DESCRIPTION
Following a very similar technique as for multiline topics (#32341), this PR introduces multiline DMs--which as the screenshots show might either be for group DMs or for users with very long usernames.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/multi-line.20DMs.20in.20left.20sidebar/near/2137632)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dms-area-before](https://github.com/user-attachments/assets/def1c921-edca-4507-a08c-8e45c6bf84fd) | ![dms-area-after](https://github.com/user-attachments/assets/0ff71876-a38d-483e-8a82-b6d892addc9e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>