### PR TITLE
narrow-state: Filter out "with" operator for narrowed_by_topic_reply.

### DIFF
--- a/web/src/compose_actions.ts
+++ b/web/src/compose_actions.ts
@@ -339,6 +339,7 @@ export let start = (raw_opts: ComposeActionsStartOpts): void => {
         compose_recipient.on_compose_select_recipient_update();
     } else if (opts.stream_id && opts.topic) {
         compose_state.set_stream_id(opts.stream_id);
+        compose_state.topic(opts.topic);
         compose_recipient.on_compose_select_recipient_update();
     } else if (opts.stream_id) {
         const stream = stream_data.get_sub_by_id(opts.stream_id);

--- a/web/src/narrow_state.ts
+++ b/web/src/narrow_state.ts
@@ -366,7 +366,7 @@ export function narrowed_by_topic_reply(current_filter: Filter | undefined = fil
     if (current_filter === undefined) {
         return false;
     }
-    const terms = current_filter.terms();
+    const terms = current_filter.terms().filter((term) => term.operator !== "with");
     return (
         terms.length === 2 &&
         current_filter.operands("channel").length === 1 &&

--- a/web/src/typing_events.ts
+++ b/web/src/typing_events.ts
@@ -76,10 +76,10 @@ type TypingMessageEditEvent = z.output<typeof typing_edit_message_event_schema>;
 
 function get_users_typing_for_narrow(): number[] {
     if (narrow_state.narrowed_by_topic_reply()) {
-        const current_stream_id = narrow_state.stream_id();
+        const current_stream_id = narrow_state.stream_id(narrow_state.filter(), true);
         const current_topic = narrow_state.topic();
         if (current_stream_id === undefined) {
-            // narrowed to a stream which doesn't exist.
+            // Narrowed to a channel which doesn't exist.
             return [];
         }
         assert(current_topic !== undefined);


### PR DESCRIPTION
When we have the "channel", "topic" and "with" operators in the narrowed view, we still want to identify that as a view where opening the compose box would be replying to the "channel" and "topic" combination.

**Notes**:
- The first commit is a prep commit to use the validated version of `narrow_state.stream_id` when we're checking for typing events in a channel and topic conversation. Manually testing this change caused me to notice that typing notifications in channels weren't working.
- The second commit updates `narrow_state.narrowed_by_topic_reply` to filter out the "with" operator, like we do in `narrow_state.narrowed_by_pm_reply`.
- The third commit fixes the only bug I could find when reviewing the functions that call `narrowed_by_topic_reply` and `narrowed_by_reply` for the changes in the second commit.
  - We now set the `compose_state.topic` slightly sooner when a non-empty string is passed as the `opts.topic` to `compose_actions.start`, so that checks on whether showing things like the faded messages banners for new users aren't triggered at the wrong time.
  - There's probably a bigger refactor to do here, but this addresses the visible bug noted in the point above without also changing a lot of the existing logic of what's done when the compose box opens.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/channel/9-issues/topic/typing.20notification.20in.20channel.20not.20visible/with/2137316)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
