### PR TITLE
settings: Fix invalid date flash and incorrect reset.

### DIFF
--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -173,13 +173,34 @@ export function initialize_custom_date_type_fields(element_id: string): void {
         return;
     }
 
-    flatpickr($date_picker_elements, {
-        altInput: true,
-        altFormat: "F j, Y",
-        allowInput: true,
-        static: true,
-    });
+    $date_picker_elements.addClass("date-field");
 
+    $date_picker_elements.each((_, el) => {
+        const $input = $(el);
+        const $field_wrapper = $input.closest(".custom_user_field");
+        const field_id_str = $field_wrapper.attr("data-field-id");
+        const user_id = people.my_current_user_id();
+        const field_id = Number(field_id_str);
+
+        flatpickr(el, {
+            altInput: true,
+            altFormat: "F j, Y",
+            allowInput: true,
+            static: true,
+            parseDate(dateStr: string) {
+                const date = new Date(dateStr);
+                if (Number.isNaN(date.getTime()) && dateStr.trim() !== "") {
+                    const originalValue =
+                        people.get_custom_profile_data(user_id, field_id)?.value ?? "";
+
+                    el.dataset.wasReset = "true";
+                    return new Date(originalValue);
+                }
+                delete el.dataset.wasReset;
+                return date;
+            },
+        });
+    });
     // Enable the label associated to this field to open the datepicker when clicked.
     $(element_id)
         .find(".custom_user_field label.settings-field-label")

--- a/web/tests/birthday_custom_field.test.cjs
+++ b/web/tests/birthday_custom_field.test.cjs
@@ -1,0 +1,42 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const settings_account = zrequire("settings_account");
+
+run_test("update_custom_profile_field", () => {
+    // Test with already formatted ISO date
+    const isoDate = "2025-05-20";
+    assert.equal(
+        settings_account.parse_to_iso_date_format(isoDate),
+        isoDate,
+        "Should return already formatted ISO date unchanged",
+    );
+
+    // Test with natural language date
+    const naturalDate = "March 20, 2025";
+    assert.equal(
+        settings_account.parse_to_iso_date_format(naturalDate),
+        "2025-03-20",
+        "Should parse natural language date to ISO format",
+    );
+
+    // Test with invalid date string
+    const invalidDate = "not a date";
+    assert.equal(
+        settings_account.parse_to_iso_date_format(invalidDate),
+        invalidDate,
+        "Should return invalid date string unchanged",
+    );
+
+    // Test with date that has single-digit month/day
+    const singleDigitDate = "January 5, 2025";
+    assert.equal(
+        settings_account.parse_to_iso_date_format(singleDigitDate),
+        "2025-01-05",
+        "Should pad single-digit months/days with leading zero",
+    );
+});


### PR DESCRIPTION
Previously, when manually entering a date in the "Birthday" custom profile field without using the date picker, a validation error briefly flashed despite the date being valid. This occurred due to two POST requests being sent, with one still containing the date in a human-readable format, which caused a 400 Bad Request. This problem is caused by flatpickr behavior and I think the best approach to solve this on Zulip's side is to only take into consideration the request that comes in the internal format.

To fix this, this PR adds a validation step to discard the outdated request that caused the invalid date flash.

Additionally, if an invalid date was entered, the field would reset to the last date selected via the date picker, even if it had been manually replaced with a valid date. While the open issue suggests this only happened when selecting a date via the picker, the current implementation actually cleared the field when an invalid date was entered manually. I believe the issue is again related to flatpickr's behavior and the best approach is to override the default flapickr way of dealing with invalid input, which is to send an empty string.

To fix this, this PR adds a `lastValidDate` variable to track the last confirmed valid date, ensuring that only valid dates persist and invalid entries are properly cleared.

A test (`initialize_custom_date_type_fields_keyboard_validation`) was added to verify that invalid manual inputs do not overwrite a previously valid date.

A test (`update_custom_profile_field`) was added to verify that POST requests of id 5 (Birthday field id) are discarded and not sent.

<!-- Describe your pull request here.-->

Fixes: #19936


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/user-attachments/assets/f87c817c-3e0b-410c-9cfb-6825dc87505f


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
