### PR TITLE
left_sidebar: Fix Enter key behavior on "Show all topics" link.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -425,7 +425,8 @@
 #direct-messages-list .bottom_left_row {
     a.stream-name:focus,
     a.sidebar-topic-name:focus,
-    a.conversation-partners:focus {
+    a.conversation-partners:focus,
+    a.sidebar-topic-action-heading:focus {
         outline: none;
         text-decoration: none;
     }
@@ -519,6 +520,12 @@ ul.filters {
 
         &:focus {
             text-decoration: none;
+        }
+    }
+
+    .sidebar-topic-action-heading {
+        &:focus {
+            color: var(--color-text-sidebar-action-heading);
         }
     }
 
@@ -1496,6 +1503,15 @@ ul.topic-list:has(.show-more-topics)::after {
     /* When the show all topics control is displayed,
        extend the bottom bracket. */
     width: 18px;
+}
+
+#stream_filters
+    .narrow-filter
+    .topic-list
+    .bottom_left_row:has(a.sidebar-topic-action-heading:focus-visible) {
+    outline: 2px solid var(--color-outline-focus);
+    outline-offset: -2px;
+    background-color: var(--color-background-hover-narrow-filter);
 }
 
 /* The grouping border should not be shown

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -2,7 +2,7 @@
   {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}
   {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <div class="topic-box">
-        <a class="sidebar-topic-action-heading" tabindex="0">{{t "Show all topics" }}</a>
+        <a href="" class="sidebar-topic-action-heading" tabindex="0">{{t "Show all topics" }}</a>
         <div class="topic-markers-and-unreads">
             {{#if more_topics_have_unread_mention_messages}}
                 <span class="unread_mention_info">


### PR DESCRIPTION
This PR adds href attribute so that pressing the Enter key works on the anchor element.



**Screenshots and screen captures:**

<img width="465" alt="Screenshot 2025-04-06 at 11 47 09 AM" src="https://github.com/user-attachments/assets/1c770119-87f2-4d07-98de-cae013f06569" />


https://github.com/user-attachments/assets/5c09d0f0-9d1f-4c0d-80d1-9aa1569bfbfb





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
