### PR TITLE
messages: Drop misleading comment on `zerver_message_edit_history_id` idx.

### DIFF
--- a/zerver/models/messages.py
+++ b/zerver/models/messages.py
@@ -244,7 +244,11 @@ class Message(AbstractMessage):
                 name="zerver_message_realm_id",
             ),
             models.Index(
-                # Used by 0680_rename_general_chat_to_empty_string_topic
+                # Potentially useful for migrations that rewrite
+                # message edit history. Originally added for
+                # 0680_rename_general_chat_to_empty_string_topic,
+                # though that migration was adjusted in a way that no
+                # longer uses this.
                 fields=["id"],
                 condition=Q(edit_history__isnull=False),
                 name="zerver_message_edit_history_id",


### PR DESCRIPTION
[#backend > general chat - migration discussion @ 💬](https://chat.zulip.org/#narrow/channel/3-backend/topic/general.20chat.20-.20migration.20discussion/near/2111414):
> We no longer need the zerver_message_edit_history_id index added in 0679... in 0680..., should we add a new migration to remove that index or we want to keep that:

> I think that migration may be helpful for other things, so no reason to remove it.

PR to remove a misleading comment regarding `zerver_message_edit_history_id` index.



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
