### PR TITLE
test_message_topics: Optimize test by limiting `fetch_event_types`.

### DIFF
--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -816,6 +816,7 @@ class EmptyTopicNameTest(ZulipTestCase):
                 client_capabilities=ClientCapabilities(
                     empty_topic_name=True, notification_settings_null=False
                 ),
+                fetch_event_types=["update_message_flags", "message", "user_topic"],
             )
         self.assertEqual(state_data["unread_msgs"]["streams"][0]["topic"], "")
         self.assertEqual(state_data["unread_msgs"]["streams"][1]["topic"], "")
@@ -830,6 +831,7 @@ class EmptyTopicNameTest(ZulipTestCase):
                 client_capabilities=ClientCapabilities(
                     empty_topic_name=False, notification_settings_null=False
                 ),
+                fetch_event_types=["update_message_flags", "message", "user_topic"],
             )
         self.assertEqual(
             state_data["unread_msgs"]["streams"][0]["topic"], Message.EMPTY_TOPIC_FALLBACK_NAME


### PR DESCRIPTION
PR to address https://github.com/zulip/zulip/pull/32330#discussion_r1906201785

> This sort of test should probably pass a short fetch_event_types to make the test do ~20x less work; too many do_events_register calls without that slows down the test suite.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
