### PR TITLE
message_move: Fix some bugs found in moving messages/topics.

### DIFF
--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -771,6 +771,20 @@ export async function build_move_topic_to_stream_popover(
         }
     }
 
+    function setup_resize_observer($topic_input: JQuery<HTMLInputElement>): void {
+        // Update position of topic typeahead because showing/hiding the
+        // "topic already exists" warning changes the size of the modal.
+        const update_topic_typeahead_position = new ResizeObserver((_entries) => {
+            requestAnimationFrame(() => {
+                $topic_input.trigger(new $.Event("typeahead.refreshPosition"));
+            });
+        });
+        const move_topic_form = document.querySelector("#move_topic_form");
+        if (move_topic_form) {
+            update_topic_typeahead_position.observe(move_topic_form);
+        }
+    }
+
     function move_topic_post_render(): void {
         $("#move_topic_modal .dialog_submit_button").prop("disabled", true);
         $("#move_topic_modal .move_topic_warning_container").hide();
@@ -811,6 +825,8 @@ export async function build_move_topic_to_stream_popover(
                 });
             });
         }
+
+        setup_resize_observer($topic_input);
 
         if (only_topic_edit) {
             // Set select_stream_id to current_stream_id since we user is not allowed
@@ -855,18 +871,6 @@ export async function build_move_topic_to_stream_popover(
             assert(topic_input_value !== undefined);
             update_topic_input_placeholder_visibility(topic_input_value);
         });
-
-        // Update position of topic typeahead because showing/hiding the
-        // "topic already exists" warning changes the size of the modal.
-        const update_topic_typeahead_position = new ResizeObserver((_entries) => {
-            requestAnimationFrame(() => {
-                $topic_input.trigger(new $.Event("typeahead.refreshPosition"));
-            });
-        });
-        const move_topic_form = document.querySelector("#move_topic_form");
-        if (move_topic_form) {
-            update_topic_typeahead_position.observe(move_topic_form);
-        }
 
         if (!args.from_message_actions_popover) {
             update_move_messages_count_text("change_all");

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -616,7 +616,12 @@ export async function build_move_topic_to_stream_popover(
         if ($("#move_topic_modal select.message_edit_topic_propagate").val() === "change_one") {
             return false;
         }
-        const {new_topic_name} = get_params_from_form();
+        let {new_topic_name} = get_params_from_form();
+        if (!settings_data.user_can_move_messages_to_another_topic()) {
+            // new_topic_name is undefined since the new topic input is disabled when
+            // user does not have permission to edit topic.
+            new_topic_name = args.topic_name;
+        }
         assert(new_topic_name !== undefined);
         // Don't show warning for empty topic as the user is probably
         // about to type a new topic name. Note that if topics are

--- a/web/src/stream_popover.ts
+++ b/web/src/stream_popover.ts
@@ -865,7 +865,8 @@ export async function build_move_topic_to_stream_popover(
         render_selected_stream();
         $("#move_topic_to_stream_widget").prop("disabled", disable_stream_input);
         $topic_input.on("input", () => {
-            update_submit_button_disabled_state(current_stream_id);
+            assert(stream_widget_value !== undefined);
+            update_submit_button_disabled_state(stream_widget_value);
             maybe_show_topic_already_exists_warning();
             const topic_input_value = $topic_input.val();
             assert(topic_input_value !== undefined);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR solves bugs being found in moving messages/topics in the move topic modal.

Fixes: [#issues > mis-alignment of typeahead in move topic/messages modal](https://chat.zulip.org/#narrow/channel/9-issues/topic/mis-alignment.20of.20typeahead.20in.20move.20topic.2Fmessages.20modal).

---

**First commit**: [message_move: Initialize ResizeObserver for Rename topic modal.](https://github.com/zulip/zulip/pull/34203/commits/00691cc9eb4fdeb173d816612aa1394af1fe61e4)  
Steps to reproduce:  
1. Ensure the current user has permission only to rename a topic.  
2. In a channel (e.g., `#test`), create 2-3 topics with the same initial characters (e.g., 1, 12, 123).  
3. Open the "Rename Topic" modal from the left sidebar for a topic (e.g., 1).  
4. In the "Rename Topic" field, type another topic with the same initial characters (e.g., 123)—the "Topic already exists" warning appears.  
5. Erase the characters up to the shared initial characters (e.g., backspace to 1). The typeahead remains in the same position, but the modal resizes due to hiding the "Topic already exists" warning.

<details>
<summary>Screenshots and screen captures</summary>

| Before | After |
|:--------------:|:-------------:|
| ![image](https://github.com/user-attachments/assets/fa4ea675-7455-4ddf-9aef-8e00317eb31c) | ![image](https://github.com/user-attachments/assets/8aacff49-ac5a-489c-85cb-f3efbb9080a4) |

- **Before:**  
  ![typeahead misaligned rename](https://github.com/user-attachments/assets/51a50210-cefd-43b0-8068-3d0636ca076b)

- **After:**  
  ![typeahead aligned rename](https://github.com/user-attachments/assets/df2a415f-c4c0-4277-957f-4e47563fc435)

</details>

---

**Second commit**: [message_move: Pass `stream_widget_value` to update submit button state.](https://github.com/zulip/zulip/pull/34203/commits/e9543b0a4346760770d05c283c79ac23cc7a47f9)  
Steps to reproduce:  
1. Ensure that the current user has permission to move messages between channels as well as between topics.  
2. In two channels, create topics of the same name (e.g., `#design > test` and `#test > test`).  
3. When a user tries to move messages (single or all) from a topic (say `#design > test` to `#test > test`), they select `#test` from the channel dropdown.  
4. If the user erases some characters from the "New topic" input and retypes the same topic name (here, `test`), the submit button is disabled, and the "Topic already exists" warning also does not appear.

<details>
<summary>Screenshots and screen captures</summary>

- **Before:**  
  ![stream widget value passed](https://github.com/user-attachments/assets/4a9fd4d6-fcd9-481a-8631-40e1ac0a5258)

- **After:**  
  ![stream widget value](https://github.com/user-attachments/assets/420041fe-fe78-42f8-851e-97016c83bf7f)

</details>

---

**Third commit**: [message_move: Handle assertion error in move topic modal.](https://github.com/zulip/zulip/pull/34203/commits/6beff68d3b6b3fb810be95c3a4ebf04e6a418fcb)  
Steps to reproduce:  
1. Ensure that the current user has permission to move messages between channels but doesn't have permission to move messages between topics.  
2. In two channels, create topics of the same name (e.g., `#design > test` and `#test > test`).  
3. Try to move all messages from a topic to an already existing topic in a different channel (e.g., from `#design > test` to `#test > test`).  
4. The `show_topic_already_exists_warning()` function in [web/src/stream_popover.ts](https://github.com/zulip/zulip/blob/main/web/src/stream_popover.ts) throws an Assertion error. This happens because the [`new_topic_name`](https://github.com/zulip/zulip/blob/main/web/src/stream_popover.ts#L620) parameter, received from the move topic modal, is `undefined` since its `<input>` element is disabled in the move topic modal.

<details>
<summary>Screenshots and screen captures</summary>

- **Before:**  
  ![topic already exists assertion error](https://github.com/user-attachments/assets/906bc6b5-37ba-4b61-b1b9-cf6578c4bae9)

- **After:**  
  ![topic already exists fix](https://github.com/user-attachments/assets/276f62ab-199f-42dc-8df9-4606dcaa9900)

</details>




<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
