### PR TITLE
upload: Duplicate upload should succeed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@uppy/drag-drop": "^4.0.2",
     "@uppy/progress-bar": "^4.0.0",
     "@uppy/tus": "^4.1.5",
+    "@uppy/utils": "^6.1.3",
     "@zxcvbn-ts/core": "^3.0.1",
     "@zxcvbn-ts/language-common": "^3.0.2",
     "@zxcvbn-ts/language-en": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@uppy/tus':
         specifier: ^4.1.5
         version: 4.2.2(@uppy/core@4.4.4)
+      '@uppy/utils':
+        specifier: ^6.1.3
+        version: 6.1.3
       '@zxcvbn-ts/core':
         specifier: ^3.0.1
         version: 3.0.4

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 390
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (326, 7)  # bumped 2025-05-23 to add @types/winchan
+PROVISION_VERSION = (326, 8)  # bumped 2025-05-27 to add @uppy/utils

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -464,6 +464,12 @@ export function setup_upload(config: Config): Uppy<Meta, TusBody> {
 
     uppy.on("upload-success", (file, response) => {
         assert(file !== undefined);
+        if (response.status !== 200) {
+            blueslip.warn("Tus server returned an error, expected a 200 OK response code.", {
+                response,
+            });
+            return;
+        }
         let upload_response;
         try {
             upload_response = zulip_upload_response_schema.parse(

--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -1,4 +1,4 @@
-import type {Meta, UppyFile} from "@uppy/core";
+import type {Meta} from "@uppy/core";
 import {Uppy} from "@uppy/core";
 import Tus, {type TusBody} from "@uppy/tus";
 import $ from "jquery";
@@ -32,8 +32,8 @@ export function feature_check(): XMLHttpRequestUpload {
     return window.XMLHttpRequest && new window.XMLHttpRequest().upload;
 }
 
-export function get_translated_status(file: File | UppyFile<Meta, TusBody>): string {
-    const status = $t({defaultMessage: "Uploading {filename}…"}, {filename: file.name});
+export function get_translated_status(filename: string): string {
+    const status = $t({defaultMessage: "Uploading {filename}…"}, {filename});
     return "[" + status + "]()";
 }
 
@@ -225,7 +225,7 @@ export let upload_files = (
         let file_id;
         try {
             compose_ui.insert_syntax_and_focus(
-                get_translated_status(file),
+                get_translated_status(file.name),
                 config.textarea(),
                 "block",
                 1,
@@ -256,7 +256,7 @@ export let upload_files = (
         );
         // eslint-disable-next-line @typescript-eslint/no-loop-func
         config.upload_banner_cancel_button(file_id).on("click", () => {
-            compose_ui.replace_syntax(get_translated_status(file), "", config.textarea());
+            compose_ui.replace_syntax(get_translated_status(file.name), "", config.textarea());
             compose_ui.autosize_textarea(config.textarea());
             config.textarea().trigger("focus");
 
@@ -482,7 +482,7 @@ export function setup_upload(config: Config): Uppy<Meta, TusBody> {
         const syntax_to_insert = "[" + filtered_filename + "](" + url + ")";
         const $text_area = config.textarea();
         const replacement_successful = compose_ui.replace_syntax(
-            get_translated_status(file),
+            get_translated_status(file.name!),
             syntax_to_insert,
             $text_area,
         );
@@ -543,13 +543,13 @@ export function setup_upload(config: Config): Uppy<Meta, TusBody> {
         // Hide the upload status banner on error so only the error banner shows
         hide_upload_banner(uppy, config, file.id);
         show_error_message(config, message, file.id);
-        compose_ui.replace_syntax(get_translated_status(file), "", config.textarea());
+        compose_ui.replace_syntax(get_translated_status(file.name!), "", config.textarea());
         compose_ui.autosize_textarea(config.textarea());
     });
 
     uppy.on("restriction-failed", (file) => {
         assert(file !== undefined);
-        compose_ui.replace_syntax(get_translated_status(file), "", config.textarea());
+        compose_ui.replace_syntax(get_translated_status(file.name!), "", config.textarea());
         compose_ui.autosize_textarea(config.textarea());
     });
 


### PR DESCRIPTION
Fixes
https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20Attachment.20re-upload.20fails/with/2121989.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
