### PR TITLE
Minor fixes for group settings.

### DIFF
--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -1,3 +1,4 @@
+import assert from "minimalistic-assert";
 import {z} from "zod";
 
 import * as blueslip from "./blueslip.ts";
@@ -160,6 +161,7 @@ export function get_assigned_permission_object(
     setting_name: RealmGroupSettingName | StreamGroupSettingName | GroupGroupSettingName,
     group_id: number,
     can_edit_settings: boolean,
+    setting_type: "realm" | "stream" | "group",
 ): AssignedGroupPermission | undefined {
     // This function returns an object of type AssignedGroupPermission
     // containing details about whether the user can edit the setting,
@@ -192,6 +194,18 @@ export function get_assigned_permission_object(
             // The group has permission directly, so the user can remove
             // the permission for this particular group, and there is no
             // need to show a tooltip.
+            const permission_config = get_group_permission_setting_config(
+                setting_name,
+                setting_type,
+            );
+            assert(permission_config !== undefined);
+            if (!permission_config.allow_nobody_group) {
+                assigned_permission_object.can_edit = false;
+                assigned_permission_object.tooltip_message = $t({
+                    defaultMessage:
+                        "This permission cannot be removed, as it would mean that nobody is allowed to take this action.",
+                });
+            }
             return assigned_permission_object;
         }
 
@@ -215,6 +229,23 @@ export function get_assigned_permission_object(
     if (direct_subgroup_ids.includes(group_id)) {
         // The group is one of the groups that has permission and can be
         // changed to not have permission.
+        if (
+            setting_value.direct_subgroups.length === 1 &&
+            setting_value.direct_members.length === 0
+        ) {
+            const permission_config = get_group_permission_setting_config(
+                setting_name,
+                setting_type,
+            );
+            assert(permission_config !== undefined);
+            if (!permission_config.allow_nobody_group) {
+                assigned_permission_object.can_edit = false;
+                assigned_permission_object.tooltip_message = $t({
+                    defaultMessage:
+                        "This permission cannot be removed, as it would mean that nobody is allowed to take this action.",
+                });
+            }
+        }
         return assigned_permission_object;
     }
 

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -227,7 +227,7 @@ export function dispatch_normal_event(event) {
                 can_delete_any_message_group: noop,
                 can_delete_own_message_group: noop,
                 can_invite_users_group: noop,
-                can_manage_all_groups: noop,
+                can_manage_all_groups: user_group_edit.update_group_management_ui,
                 can_manage_billing_group: noop,
                 can_mention_many_users_group: noop,
                 can_move_messages_between_channels_group: noop,
@@ -310,6 +310,7 @@ export function dispatch_normal_event(event) {
 
                                 if (Object.hasOwn(realm_settings, key)) {
                                     settings_org.sync_realm_settings(key);
+                                    realm_settings[key]();
                                 }
 
                                 if (

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -1811,6 +1811,7 @@ export function get_group_assigned_realm_permissions(group: UserGroup): {
                     setting_name,
                     group.id,
                     can_edit,
+                    "realm",
                 );
             if (assigned_permission_object !== undefined) {
                 assigned_permission_objects.push(assigned_permission_object);
@@ -1854,6 +1855,7 @@ export function get_group_assigned_stream_permissions(group: UserGroup): {
                     setting_name,
                     group.id,
                     can_edit_settings,
+                    "stream",
                 );
             if (assigned_permission_object !== undefined) {
                 assigned_permission_objects.push(assigned_permission_object);
@@ -1892,6 +1894,7 @@ export function get_group_assigned_user_group_permissions(group: UserGroup): {
                     setting_name,
                     group.id,
                     can_edit_settings,
+                    "group",
                 );
             if (assigned_permission_object !== undefined) {
                 assigned_permission_objects.push(assigned_permission_object);

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1375,6 +1375,30 @@ export function sync_group_permission_setting(property: string, group: UserGroup
     }
 }
 
+export function update_group_right_panel(group: UserGroup, changed_settings: string[]): void {
+    if (changed_settings.includes("can_manage_group")) {
+        update_group_management_ui();
+        return;
+    }
+
+    if (
+        changed_settings.includes("can_add_members_group") ||
+        changed_settings.includes("can_remove_members_group")
+    ) {
+        update_group_membership_button(group.id);
+        update_members_panel_ui(group);
+        return;
+    }
+
+    if (
+        changed_settings.includes("can_join_group") ||
+        changed_settings.includes("can_leave_group")
+    ) {
+        update_group_membership_button(group.id);
+        return;
+    }
+}
+
 export function update_group(event: UserGroupUpdateEvent, group: UserGroup): void {
     if (!overlays.groups_open()) {
         return;
@@ -1397,6 +1421,10 @@ export function update_group(event: UserGroupUpdateEvent, group: UserGroup): voi
         return;
     }
 
+    const changed_group_settings = group_permission_settings
+        .get_group_permission_settings()
+        .filter((setting_name) => event.data[setting_name] !== undefined);
+
     if (get_active_data().id === group.id) {
         // update right side pane
         update_group_details(group);
@@ -1406,36 +1434,16 @@ export function update_group(event: UserGroupUpdateEvent, group: UserGroup): voi
                 .text(user_groups.get_display_group_name(group.name))
                 .addClass("showing-info-title");
         }
-        if (event.data.can_mention_group !== undefined) {
-            sync_group_permission_setting("can_mention_group", group);
-            update_group_management_ui();
-        }
-        if (event.data.can_add_members_group !== undefined) {
-            sync_group_permission_setting("can_add_members_group", group);
-            update_group_management_ui();
-        }
-        if (event.data.can_manage_group !== undefined) {
-            sync_group_permission_setting("can_manage_group", group);
-            update_group_management_ui();
-        }
-        if (event.data.can_join_group !== undefined) {
-            sync_group_permission_setting("can_join_group", group);
-            update_group_membership_button(group.id);
-        }
-        if (event.data.can_leave_group !== undefined) {
-            sync_group_permission_setting("can_leave_group", group);
-            update_group_membership_button(group.id);
-        }
-        if (event.data.can_remove_members_group !== undefined) {
-            sync_group_permission_setting("can_remove_members_group", group);
-            update_group_management_ui();
+
+        if (changed_group_settings.length > 0) {
+            update_group_right_panel(group, changed_group_settings);
         }
     }
 
-    const changed_group_settings = group_permission_settings
-        .get_group_permission_settings()
-        .filter((setting_name) => event.data[setting_name] !== undefined);
     for (const setting_name of changed_group_settings) {
+        if (get_active_data().id === group.id) {
+            sync_group_permission_setting(setting_name, group);
+        }
         update_group_setting_in_permissions_panel(
             setting_name,
             group_setting_value_schema.parse(event.data[setting_name]),

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -764,6 +764,7 @@ export function update_realm_setting_in_permissions_panel(
         setting_name,
         active_group_id,
         can_edit,
+        "realm",
     );
 
     const group_has_permission = assigned_permission_object !== undefined;
@@ -824,6 +825,7 @@ export function update_stream_setting_in_permissions_panel(
         setting_name,
         active_group_id,
         can_edit,
+        "stream",
     );
 
     const group_has_permission = assigned_permission_object !== undefined;
@@ -902,6 +904,7 @@ export function update_group_setting_in_permissions_panel(
         setting_name,
         active_group_id,
         can_edit,
+        "group",
     );
 
     const group_has_permission = assigned_permission_object !== undefined;

--- a/web/tests/lib/example_settings.cjs
+++ b/web/tests/lib/example_settings.cjs
@@ -61,4 +61,14 @@ exports.server_supported_permission_settings = {
             allowed_system_groups: [],
         },
     },
+    group: {
+        can_manage_group: {
+            require_system_group: false,
+            allow_internet_group: false,
+            allow_nobody_group: true,
+            allow_everyone_group: false,
+            default_group_name: "role:nobody",
+            allowed_system_groups: [],
+        },
+    },
 };

--- a/web/tests/user_groups.test.cjs
+++ b/web/tests/user_groups.test.cjs
@@ -850,7 +850,7 @@ run_test("group_has_permission", () => {
     assert.ok(user_groups.group_has_permission(setting_value, group_id));
 });
 
-run_test("get_assigned_group_permission_object", () => {
+run_test("get_assigned_group_permission_object", ({override}) => {
     const admins = {
         name: "Administrators",
         id: 1,
@@ -883,6 +883,11 @@ run_test("get_assigned_group_permission_object", () => {
     user_groups.initialize({
         realm_user_groups: [admins, moderators, all, students],
     });
+    override(
+        realm,
+        "server_supported_permission_settings",
+        example_settings.server_supported_permission_settings,
+    );
 
     const setting_name = "can_manage_group";
     let setting_value = moderators.id;
@@ -894,6 +899,7 @@ run_test("get_assigned_group_permission_object", () => {
             setting_name,
             group_id,
             can_edit_settings,
+            "group",
         ),
         undefined,
     );
@@ -905,6 +911,7 @@ run_test("get_assigned_group_permission_object", () => {
             setting_name,
             group_id,
             can_edit_settings,
+            "group",
         ),
         undefined,
     );
@@ -928,6 +935,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -946,6 +954,7 @@ run_test("get_assigned_group_permission_object", () => {
             setting_name,
             group_id,
             can_edit_settings,
+            "group",
         ),
         undefined,
     );
@@ -956,6 +965,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -969,6 +979,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -982,6 +993,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -999,6 +1011,7 @@ run_test("get_assigned_group_permission_object", () => {
             setting_name,
             group_id,
             can_edit_settings,
+            "group",
         ),
         undefined,
     );
@@ -1010,6 +1023,7 @@ run_test("get_assigned_group_permission_object", () => {
             setting_name,
             group_id,
             can_edit_settings,
+            "group",
         ),
         undefined,
     );
@@ -1020,6 +1034,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1032,6 +1047,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1051,6 +1067,7 @@ run_test("get_assigned_group_permission_object", () => {
             setting_name,
             group_id,
             can_edit_settings,
+            "group",
         ),
         undefined,
     );
@@ -1061,6 +1078,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1073,6 +1091,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1085,6 +1104,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1103,6 +1123,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1117,6 +1138,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1131,6 +1153,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,
@@ -1145,6 +1168,7 @@ run_test("get_assigned_group_permission_object", () => {
         setting_name,
         group_id,
         can_edit_settings,
+        "group",
     );
     assert.deepEqual(permission_obj, {
         setting_name,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to refactor live update code for group permission settings.
- Second commit is to live update UI on updating `can_manage_all_groups` setting.
- Third commit is to disable checkbox when permission cannot be removed due to setting not being allowed to set to nobody group.

Fixes part of #33730. <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Peek 2025-03-28 18-58](https://github.com/user-attachments/assets/dbd5704f-f53b-4c46-9a07-f63215c6fc4b)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
