### PR TITLE
thumbnails: Better size and present thumbnails in message area.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -114,10 +114,21 @@ export function postprocess_content(html: string): string {
 
                 const original_width = Number(original_dimensions[0]);
                 const original_height = Number(original_dimensions[1]);
+                const font_size_in_use = user_settings.web_font_size_px;
+                // "Dinky" images are those that are smaller than the
+                // 10em box reserved for thumbnails
+                const image_box_em = 10;
+                const is_dinky_image =
+                    original_width / font_size_in_use <= image_box_em &&
+                    original_height / font_size_in_use <= image_box_em;
                 const is_portrait_image = original_width <= original_height;
 
                 inline_image.setAttribute("width", `${original_width}`);
                 inline_image.setAttribute("height", `${original_height}`);
+
+                if (is_dinky_image) {
+                    inline_image.classList.add("dinky-thumbnail");
+                }
 
                 if (is_portrait_image) {
                     inline_image.classList.add("portrait-thumbnail");

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -115,12 +115,21 @@ export function postprocess_content(html: string): string {
                 const original_width = Number(original_dimensions[0]);
                 const original_height = Number(original_dimensions[1]);
                 const font_size_in_use = user_settings.web_font_size_px;
+                // At 20px/1em, image boxes are 200px by 80px in either
+                // horizontal or vertical orientation; 80 / 200 = 0.4
+                // We need to show more of the background color behind
+                // these extremely tall or extremely wide images, and
+                // use a subtler background color than on other images
+                const image_min_aspect_ratio = 0.4;
                 // "Dinky" images are those that are smaller than the
                 // 10em box reserved for thumbnails
                 const image_box_em = 10;
                 const is_dinky_image =
                     original_width / font_size_in_use <= image_box_em &&
                     original_height / font_size_in_use <= image_box_em;
+                const has_extreme_aspect_ratio =
+                    original_width / original_height <= image_min_aspect_ratio ||
+                    original_height / original_width <= image_min_aspect_ratio;
                 const is_portrait_image = original_width <= original_height;
 
                 inline_image.setAttribute("width", `${original_width}`);
@@ -128,6 +137,10 @@ export function postprocess_content(html: string): string {
 
                 if (is_dinky_image) {
                     inline_image.classList.add("dinky-thumbnail");
+                }
+
+                if (has_extreme_aspect_ratio) {
+                    inline_image.classList.add("extreme-aspect-ratio");
                 }
 
                 if (is_portrait_image) {

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -52,6 +52,26 @@ export function postprocess_content(html: string): string {
             elt.removeAttribute("target");
         }
 
+        if (elt.querySelector("img") || elt.querySelector("video")) {
+            // We want a class to refer to media links
+            elt.classList.add("media-anchor-element");
+            // Add a class to the video, if it exists
+            if (elt.querySelector("video")) {
+                elt.querySelector("video")?.classList.add("media-video-element");
+            }
+            // Add a class to the image, if it exists
+            if (elt.querySelector("img")) {
+                elt.querySelector("img")?.classList.add("media-image-element");
+            }
+        }
+
+        if (elt.querySelector("video")) {
+            // We want a class to refer to media links
+            elt.classList.add("media-anchor-element");
+            // And likewise a class to refer to image elements
+            elt.querySelector("video")?.classList.add("media-image-element");
+        }
+
         // Update older, smaller default.jpg YouTube preview images
         // with higher-quality preview images (320px wide)
         if (elt.parentElement?.classList.contains("youtube-video")) {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1552,10 +1552,18 @@
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
     --color-background-image-thumbnail: light-dark(
+        hsl(0deg 0% 0% / 8%),
+        hsl(0deg 0% 100% / 13%)
+    );
+    --color-background-image-thumbnail-hover: light-dark(
+        hsl(0deg 0% 0% / 20%),
+        hsl(0deg 0% 100% / 25%)
+    );
+    --color-background-image-thumbnail-dinky: light-dark(
         hsl(0deg 0% 0% / 3%),
         hsl(0deg 0% 100% / 3%)
     );
-    --color-background-image-thumbnail-hover: light-dark(
+    --color-background-image-thumbnail-dinky-hover: light-dark(
         hsl(0deg 0% 0% / 15%),
         hsl(0deg 0% 100% / 15%)
     );

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1556,8 +1556,8 @@
         hsl(0deg 0% 100% / 13%)
     );
     --color-background-image-thumbnail-hover: light-dark(
-        hsl(0deg 0% 0% / 20%),
-        hsl(0deg 0% 100% / 25%)
+        hsl(0deg 0% 0% / 30%),
+        hsl(0deg 0% 100% / 45%)
     );
     --color-background-image-thumbnail-dinky: light-dark(
         hsl(0deg 0% 0% / 3%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1551,6 +1551,14 @@
         var(--color-text-generic-link-interactive)
     );
     --color-markdown-code-link-hover: var(--color-markdown-link-hover);
+    --color-background-image-thumbnail: light-dark(
+        hsl(0deg 0% 0% / 3%),
+        hsl(0deg 0% 100% / 3%)
+    );
+    --color-background-image-thumbnail-hover: light-dark(
+        hsl(0deg 0% 0% / 15%),
+        hsl(0deg 0% 100% / 15%)
+    );
 
     /* Icon colors */
     --color-icon-bot: light-dark(
@@ -2020,6 +2028,9 @@
     );
     /* The SVG must be adjusted when changing the border color above. */
     --svg-url-rendered-checkbox: url("../images/checkbox.svg");
+
+    /* Theme-dependent SVGs */
+    --svg-url-thumbnail-loader: url("../images/loading/loader-black.svg");
 
     /* Emoji-picker colors */
     --color-background-emoji-picker-popover: light-dark(
@@ -2805,6 +2816,9 @@
     /* Zulip-style checkbox values. */
     /* The SVG must be adjusted when changing the border color above. */
     --svg-url-rendered-checkbox: url("../images/checkbox-dark-mode.svg");
+
+    /* Theme-dependent SVGs */
+    --svg-url-thumbnail-loader: url("../images/loading/loader-white.svg");
 }
 
 @media screen {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -107,18 +107,6 @@
         opacity: 0.4;
     }
 
-    .rendered_markdown .message_inline_image {
-        background: hsl(0deg 0% 100% / 3%);
-
-        img.image-loading-placeholder {
-            content: url("../images/loading/loader-white.svg");
-        }
-
-        &:hover {
-            background: hsl(0deg 0% 100% / 15%);
-        }
-    }
-
     & input[type="text"],
     input[type="email"],
     input[type="password"],

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -630,6 +630,10 @@
     .message_inline_video,
     .message_inline_animated_image_still,
     .youtube-video .media-anchor-element {
+        /* We require a relative positioning context
+           for the sake of play buttons. */
+        position: relative;
+
         &:hover {
             &::after {
                 transform: scale(1);
@@ -647,7 +651,7 @@
             /* Match the width to the background size. */
             width: 2.2857em;
             height: 2.2857em;
-            /* Center according to those widths; at present,
+            /* Center according to those widths; media
                thumbnails are 8em tall and 12em wide. So,
                2.2857em / 2 = 1.1429em as the center of the
                play button. We subtract that value from half
@@ -664,8 +668,12 @@
         & .media-video-element {
             display: block;
             object-fit: contain;
-            height: 100%;
-            width: 100%;
+            /* Since we do not yet read height and width
+               values for media thumbnails, we carry forward
+               reasonable dimensions for a landscape thumbnail
+               here. */
+            height: 8em;
+            width: 12em;
         }
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -431,10 +431,10 @@
            container. */
         border: solid 1px transparent;
         transition: background 0.3s ease;
-        background: hsl(0deg 0% 0% / 3%);
+        background: var(--color-background-image-thumbnail);
 
         &:hover {
-            background: hsl(0deg 0% 0% / 15%);
+            background: var(--color-background-image-thumbnail-hover);
         }
 
         & .media-anchor-element {
@@ -501,7 +501,7 @@
         }
 
         img.image-loading-placeholder {
-            content: url("../images/loading/loader-black.svg");
+            content: var(--svg-url-thumbnail-loader);
         }
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -460,7 +460,7 @@
             background: hsl(0deg 0% 0% / 15%);
         }
 
-        & a {
+        & .media-anchor-element {
             display: block;
             height: 100%;
             width: 100%;
@@ -522,8 +522,8 @@
         }
 
         p:first-child > .katex-display > .katex,
-        .message_inline_image a,
-        .message_inline_image video {
+        .message_inline_image .media-anchor-element,
+        .message_inline_image .media-video-element {
             /* We explicitly place the containing
                media element in the thumbnail area. */
             grid-area: media;
@@ -575,9 +575,9 @@
         margin-right: 5px;
     }
 
-    .twitter-image img,
-    .message_inline_image img,
-    .message_inline_ref img {
+    .twitter-image .media-image-element,
+    .message_inline_image .media-image-element,
+    .message_inline_ref .media-image-element {
         /* We use `scale-down` so that images smaller than the container are
            neither scaled up nor cropped to fit. This preserves
            their aspect ratio, which is often helpful. */
@@ -595,17 +595,17 @@
         border-radius: inherit;
     }
 
-    .message_inline_image img {
+    .message_inline_image .media-image-element {
         cursor: zoom-in;
     }
 
-    .youtube-video img,
-    .vimeo-video img,
-    .embed-video img {
+    .youtube-video .media-image-element,
+    .vimeo-video .media-image-element,
+    .embed-video .media-image-element {
         cursor: pointer;
     }
 
-    .youtube-video img {
+    .youtube-video .media-image-element {
         /* We do this for the sake of increasing
            the size of older YouTube thumbnail
            previews, but there are no ill effects
@@ -613,21 +613,21 @@
         object-fit: contain;
     }
 
-    &.rtl .twitter-image img,
-    &.rtl .message_inline_image img,
-    &.rtl .message_inline_ref img {
+    &.rtl .twitter-image .media-image-element,
+    &.rtl .message_inline_image .media-image-element,
+    &.rtl .message_inline_ref .media-image-element {
         float: right;
         margin-right: unset;
         margin-left: 10px;
     }
 
-    & li .message_inline_image img {
+    & li .message_inline_image .media-image-element {
         float: none;
     }
 
     .message_inline_video,
     .message_inline_animated_image_still,
-    .youtube-video a[data-id] {
+    .youtube-video .media-anchor-element {
         &:hover {
             &::after {
                 transform: scale(1);
@@ -659,7 +659,7 @@
             transition: transform 0.2s;
         }
 
-        & video {
+        & .media-video-element {
             display: block;
             object-fit: contain;
             height: 100%;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -653,9 +653,12 @@
     .message_inline_video,
     .message_inline_animated_image_still,
     .youtube-video .media-anchor-element {
-        /* We require a relative positioning context
-           for the sake of play buttons. */
-        position: relative;
+        /* Once collections of thumbnails are set to render as
+           flex items, this can be updated to use `display: grid`
+           instead of `display: inline-grid`. */
+        display: inline-grid;
+        grid-template: "media" minmax(0, auto) / minmax(0, auto);
+        place-items: center center;
 
         &:hover {
             &::after {
@@ -663,26 +666,26 @@
             }
         }
 
+        /* The .media-anchor-selector is for all media
+           except YouTube, which needs to place
+           .media-image-element on the grid. */
+        & .media-anchor-element,
+        & .media-image-element {
+            grid-area: media;
+        }
+
         &::after {
+            grid-area: media;
             content: "";
             background-image: url("../images/play_button.svg");
             background-position: center center;
             background-repeat: no-repeat;
             /* 32px at 14px/1em */
             background-size: 2.2857em;
-            position: absolute;
-            /* Match the width to the background size. */
+            /* Match the box to the play button's
+               background-size value. */
             width: 2.2857em;
             height: 2.2857em;
-            /* Center according to those widths; media
-               thumbnails are 8em tall and 12em wide. So,
-               2.2857em / 2 = 1.1429em as the center of the
-               play button. We subtract that value from half
-               the height (8em/2) to get the `top:` value,
-               and then subtract the same from half the width
-               (12em/2) to get the `left:` value. */
-            top: 2.8571em;
-            left: 4.8571em;
             border-radius: 100%;
             transform: scale(0.8);
             transition: transform 0.2s;
@@ -698,6 +701,13 @@
             height: 8em;
             width: 12em;
         }
+    }
+
+    .youtube-video .media-anchor-element {
+        /* We display the youtube-video anchor
+           as a grid, not inline grid, to avoid
+           additional space beneath the thumbnail. */
+        display: grid;
     }
 
     .message_embed {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -426,10 +426,9 @@
         margin-bottom: var(--markdown-interelement-space-px);
         margin-right: 5px;
 
-        /* Set a background for the image; the background will be visible for
-           messages whose aspect ratio is different from that of this
-           container. */
-        border: solid 1px transparent;
+        /* Set a background for the image; the background will be visible
+           behind the width of the transparent border. */
+        border: solid 3px transparent;
         transition: background 0.3s ease;
         background: var(--color-background-image-thumbnail);
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -443,6 +443,7 @@
 
         & .media-image-element {
             display: block;
+            object-fit: scale-down;
 
             /* Sizing CSS for inline images requires care, because images load
                asynchronously, and browsers will unfortunately jump your
@@ -481,10 +482,21 @@
                orientation. */
             &.landscape-thumbnail {
                 width: 10em;
+
+                /* For dinky thumbnails (those whose dimensions are
+                   less than 10em on both sides), we set a 4em
+                   thumbnail. */
+                &.dinky-thumbnail {
+                    width: 4em;
+                }
             }
 
             &.portrait-thumbnail {
                 height: 10em;
+
+                &.dinky-thumbnail {
+                    height: 4em;
+                }
             }
         }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -420,34 +420,11 @@
 
     .twitter-image,
     .message_inline_image {
-        position: relative;
+        display: inline-block;
+        vertical-align: middle;
+
         margin-bottom: var(--markdown-interelement-space-px);
         margin-right: 5px;
-
-        /* Sizing CSS for inline images requires care, because images load
-           asynchronously, and browsers will unfortunately jump your
-           scroll position when elements load above the current
-           position in the message feed in a way that changes the
-           height of elements. (As of March 2022, both Firefox and
-           Chrome exhibit this problem, though in Chrome it is pretty
-           subtle).
-
-           We prevent this by setting a fixed height for inline
-           previews. 8em is chosen because we don't want images to
-           overwhelm conversation in message feeds, as it does in chat
-           tools that show images at half-screen height or larger.
-
-           If there are several images next to each other, we display
-           them in a grid format; the same considerations requires
-           that either use a scrollable region or set a fixed width
-           for images so that the browser statically knows whether
-           it'll need to overflow. We choose fixed width here. */
-        height: 8em;
-        width: 12em;
-
-        /* Inline image containers also need an inline-block display in order
-           to implement the desired grid layout. */
-        display: inline-block;
 
         /* Set a background for the image; the background will be visible for
            messages whose aspect ratio is different from that of this
@@ -462,8 +439,53 @@
 
         & .media-anchor-element {
             display: block;
-            height: 100%;
-            width: 100%;
+        }
+
+        & .media-image-element {
+            display: block;
+
+            /* Sizing CSS for inline images requires care, because images load
+               asynchronously, and browsers will unfortunately jump your
+               scroll position when elements load above the current
+               position in the message feed in a way that changes the
+               height of elements. (As of March 2022, both Firefox and
+               Chrome exhibit this problem, though in Chrome it is pretty
+               subtle).
+
+               We prevent this by utilizing dimensions on the `<img>` elements,
+               but further care is needed because different layout mechanisms,
+               including inline-block, can ignore those dimensions. For that
+               reason, we enforce a minimum 4em square for "dinky" images,
+               and a maximum 10em square for all others.
+
+               If there are several images next to each other, we display
+               them in a grid format; the same considerations require
+               use to either use a scrollable region or set a predictable
+               size for images so that the browser statically knows whether
+               it'll need to overflow. We choose predictable sizes here. */
+
+            /* Ensure a reasonable clickable area on
+               extremely tall or extremely wide images. */
+            min-width: 4em;
+            min-height: 4em;
+
+            /* Constrain height and width to a 10em box. */
+            max-width: 10em;
+            max-height: 10em;
+
+            /* Allow height and width to grow as needed... */
+            width: auto;
+            height: auto;
+
+            /* But set specific widths based on the image's
+               orientation. */
+            &.landscape-thumbnail {
+                width: 10em;
+            }
+
+            &.portrait-thumbnail {
+                height: 10em;
+            }
         }
 
         img.image-loading-placeholder {
@@ -573,26 +595,6 @@
     &.rtl .message_inline_ref {
         margin-left: unset;
         margin-right: 5px;
-    }
-
-    .twitter-image .media-image-element,
-    .message_inline_image .media-image-element,
-    .message_inline_ref .media-image-element {
-        /* We use `scale-down` so that images smaller than the container are
-           neither scaled up nor cropped to fit. This preserves
-           their aspect ratio, which is often helpful. */
-        object-fit: scale-down;
-
-        /* We need to explicitly specify the image dimensions to have
-           object-fit work; likely because internally object-fit needs
-           to know the frame it is targeting, and images don't default
-           to container dimensions. */
-        height: 100%;
-        width: 100%;
-
-        float: left;
-        margin-right: 10px;
-        border-radius: inherit;
     }
 
     .message_inline_image .media-image-element {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -432,6 +432,18 @@
         transition: background 0.3s ease;
         background: var(--color-background-image-thumbnail);
 
+        /* Inline videos also take the dinky color, as they
+           currently display a larger clickable area than
+           necessary. */
+        &.message_inline_video,
+        &:has(.dinky-thumbnail, .extreme-aspect-ratio) {
+            background: var(--color-background-image-thumbnail-dinky);
+
+            &:hover {
+                background: var(--color-background-image-thumbnail-dinky-hover);
+            }
+        }
+
         &:hover {
             background: var(--color-background-image-thumbnail-hover);
         }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -456,10 +456,6 @@
         transition: background 0.3s ease;
         background: hsl(0deg 0% 0% / 3%);
 
-        &:first-child {
-            margin-top: var(--markdown-interelement-space-px);
-        }
-
         &:hover {
             background: hsl(0deg 0% 0% / 15%);
         }

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -107,6 +107,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
     override(thumbnail, "preferred_format", thumbnail_formats[3]);
     override(thumbnail, "animated_format", thumbnail_formats[2]);
 
+    // Test for landscape thumbnails
     assert.equal(
         postprocess_content(
             '<div class="message_inline_image">' +
@@ -117,7 +118,23 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
+            "</a>" +
+            "</div>",
+    );
+
+    // Test for portrait thumbnails
+    assert.equal(
+        postprocess_content(
+            '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="100x200" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>",
+        ),
+        '<div class="message_inline_image">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="100x200" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element portrait-thumbnail" width="100" height="200" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -134,7 +151,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" class="media-image-element" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -151,7 +168,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message_inline_image message_inline_animated_image_still">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -167,7 +184,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message_inline_image message_inline_animated_image_still">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element" loading="lazy">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
             "</div>",
     );

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -25,6 +25,11 @@ run_test("postprocess_content", () => {
                 '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" title="inline image">upload</a> ' +
                 '<a role="button">button</a> ' +
                 "</div>" +
+                '<div class="message_inline_image message_inline_video">' +
+                '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp4">' +
+                '<video src="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp4"></video>' +
+                "</a>" +
+                "</div>" +
                 '<div class="youtube-video message_inline_image">' +
                 '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM">' +
                 '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/default.jpg">' +
@@ -40,9 +45,14 @@ run_test("postprocess_content", () => {
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
             '<a role="button">button</a> ' +
             "</div>" +
+            '<div class="message_inline_image message_inline_video">' +
+            '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp4" target="_blank" rel="noopener noreferrer" class="media-anchor-element">' +
+            '<video src="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.mp4" class="media-video-element media-image-element"></video>' +
+            "</a>" +
+            "</div>" +
             '<div class="youtube-video message_inline_image">' +
-            '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
-            '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" loading="lazy">' +
+            '<a class="media-anchor-element" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
+            '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" class="media-image-element" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -106,8 +116,8 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</div>",
         ),
         '<div class="message_inline_image">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" loading="lazy">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -123,8 +133,8 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</div>",
         ),
         '<div class="message_inline_image">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" loading="lazy">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" class="media-image-element" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -140,8 +150,8 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</div>",
         ),
         '<div class="message_inline_image message_inline_animated_image_still">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" loading="lazy">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element" loading="lazy">' +
             "</a>" +
             "</div>",
     );
@@ -156,8 +166,8 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</div>",
         ),
         '<div class="message_inline_image message_inline_animated_image_still">' +
-            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" aria-label="image.png">' +
-            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" loading="lazy">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element" loading="lazy">' +
             "</a>" +
             "</div>",
     );

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -150,7 +150,7 @@ run_test("message_inline_animated_image_still", ({override}) => {
         ),
         '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
-            '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element dinky-thumbnail portrait-thumbnail" width="1" height="10" loading="lazy">' +
+            '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element dinky-thumbnail extreme-aspect-ratio portrait-thumbnail" width="1" height="10" loading="lazy">' +
             "</a>" +
             "</div>",
     );

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -10,7 +10,7 @@ const thumbnail = mock_esm("../src/thumbnail");
 const {postprocess_content} = zrequire("postprocess_content");
 const {initialize_user_settings} = zrequire("user_settings");
 
-const user_settings = {};
+const user_settings = {web_font_size_px: 16};
 initialize_user_settings({user_settings});
 
 run_test("postprocess_content", () => {
@@ -135,6 +135,22 @@ run_test("message_inline_animated_image_still", ({override}) => {
         '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="100x200" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element portrait-thumbnail" width="100" height="200" loading="lazy">' +
+            "</a>" +
+            "</div>",
+    );
+
+    // Test for dinky thumbnails
+    assert.equal(
+        postprocess_content(
+            '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>",
+        ),
+        '<div class="message_inline_image">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element dinky-thumbnail portrait-thumbnail" width="1" height="10" loading="lazy">' +
             "</a>" +
             "</div>",
     );


### PR DESCRIPTION
This PR makes use of image dimensions on thumbnails in order to present thumbnails without a gray box around them, except in the case of "dinky" images.

Previously, images were held to a 12em × 8em box. The consequence of that was that the same size image in landscape orientation would appear physically larger than the same size but in portrait orientation.

To fix for that, the previous 12em × 8em box is here replaced for image thumbnails as a 10em × 10em box, meaning that neither portrait nor landscape images are favored in terms of which appears visibly larger.

A planned follow-up to this PR is to present image galleries using flexbox (a draft effort of this is in #31689), but to reduce churn and make these changes easier to review and burn in on CZO, the `inline-block`-style presentation remains in this PR.

Fixes: #31502 

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/grey.20background.20around.20image.20thumbnails/near/2138967)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Update, 2025-04-01: Larger, higher-contrast thumbnail borders on "typical" images (the `2` image shows the hover state colors):_

| Light mode | Dark mode |
| --- | --- |
| ![extreme-images-light](https://github.com/user-attachments/assets/74de1254-d483-4978-8fa5-bcb256048fdd) | ![extreme-images-dark](https://github.com/user-attachments/assets/e6d36e26-1026-47e2-9e44-61da3822ab3b) |

_Update, 2025-03-31: Larger, higher-contrast thumbnail borders:_

| Original PR | Proposed |
| --- | --- |
| ![thumbnail-background-pr-original-light](https://github.com/user-attachments/assets/c8c628f2-4c7e-4690-b108-d6f45b6614f8) | ![thumbnail-background-pr-proposed-light](https://github.com/user-attachments/assets/e032b765-2173-4151-8999-388c193d61f6) |
| ![thumbnail-background-pr-original-dark](https://github.com/user-attachments/assets/4498e673-22dc-4042-b2d6-fb3edf17c83a) | ![thumbnail-background-pr-proposed-dark](https://github.com/user-attachments/assets/dfc56354-a63d-4c68-97a4-7d92b44d151a) |

_Note that square and portrait images now appear pleasingly larger, while landscape images are smaller--but right-sized relative to portrait/landscape images:_

| Before | After |
| --- | --- |
| ![inline-thumbnails-before](https://github.com/user-attachments/assets/bbd0ac2e-a70a-41b2-878f-bdd9f41c4340) | ![inline-thumbnails-after](https://github.com/user-attachments/assets/a49730ac-cfa6-40db-9995-5b22ba71852f) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>