### PR TITLE
rendered_markdown: Adjust content blocks for link focus ring.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -414,6 +414,14 @@
     /*
     Message box elements and values.
     */
+    /* At very tight line-heights, the focus ring on
+       links can get cut off on paragraphs and list
+       items that open the senderless message area.
+       This padding fixes the cut-off problem, and
+       can be used to adjust padding elsewhere in the
+       message area as needed.
+       2px at 20px/1em */
+    --message-box-link-focus-ring-block-padding: 0.1em;
     /* 35px at 14px/1em */
     --message-box-avatar-width: 2.5em;
     --message-box-avatar-height: var(--message-box-avatar-width);

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -381,6 +381,16 @@
             grid-area: message;
         }
 
+        /* For the sake of paragraphs and lists that include
+           links, we adjust the vertical space here to keep
+           it uniform. */
+        .message_content:has(p:first-child, ol:first-child, ul:first-child) {
+            padding-top: calc(
+                var(--message-box-markdown-aligned-vertical-space) -
+                    var(--message-box-link-focus-ring-block-padding)
+            );
+        }
+
         .slow-send-spinner {
             align-self: center;
             position: unset;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -20,6 +20,15 @@
         margin-inline-start: 3.5ch;
     }
 
+    /* To avoid cutting off the focus ring on links, we set
+       padding on first children most likely to take links.
+       We account for this extra space on `.message_content`. */
+    & p:first-child,
+    & ul:first-child,
+    & ol:first-child {
+        padding-top: var(--message-box-link-focus-ring-block-padding);
+    }
+
     /* We set margin according to the length of the longest list counter. */
     .counter-length-1 {
         margin-inline-start: 2.5ch;


### PR DESCRIPTION
By adjusting the padding on likely link-containing blocks (paragraphs and lists), and offsetting that padding as needed, we can ensure the proper display of focus rings on links without compromising the way we expect the message area to be laid out and spaced.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/link.20focus.20outlines.20at.2020px)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Showing 20/-2; 16/0; and 12/+2:_

| Before | After |
| --- | --- |
| ![focus-ring-20--2-before](https://github.com/user-attachments/assets/82fb4da0-5bd5-43df-81ce-400f02d27be4) | ![focus-ring-20--2-after](https://github.com/user-attachments/assets/868cddcf-3756-48dd-bff3-51676554df9f) |
| ![focus-ring-16-0-before](https://github.com/user-attachments/assets/18f08332-aeef-4a10-8c50-f5d9978e0365) | ![focus-ring-16-0-after](https://github.com/user-attachments/assets/1cbe732d-89e6-4036-ba32-c56e93f79b24) |
| ![focus-ring-12-+2-before](https://github.com/user-attachments/assets/ff94ab5e-7769-4f3a-87b6-8afa89754c4e) | ![focus-ring-12-+2-after](https://github.com/user-attachments/assets/60bbbd2f-5948-44a2-ae5d-5445466aff3c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>