### PR TITLE
navigate: Fix up keypress behaviour when a long prev message.

### DIFF
--- a/web/src/navigate.ts
+++ b/web/src/navigate.ts
@@ -25,8 +25,8 @@ export function up(): void {
     message_viewport.set_last_movement_direction(-1);
 
     const $selected_message = message_lists.current.selected_row();
+    const viewport_info = message_viewport.message_viewport_info();
     if ($selected_message.length > 0) {
-        const viewport_info = message_viewport.message_viewport_info();
         const message_props = $selected_message.get_offset_to_window();
         // We scroll up to show the hidden top of long messages.
         if (
@@ -38,11 +38,24 @@ export function up(): void {
         }
     }
 
-    const msg_id = message_lists.current.prev();
-    if (msg_id === undefined) {
+    const prev_msg_id = message_lists.current.prev();
+    if (prev_msg_id === undefined) {
         return;
     }
-    go_to_row(msg_id);
+
+    const $prev_message = message_lists.current.get_row(prev_msg_id);
+    assert($prev_message.length > 0);
+    const prev_message_props = $prev_message.get_offset_to_window();
+
+    if (
+        is_long_message(prev_message_props.height) &&
+        prev_message_props.top < viewport_info.visible_top
+    ) {
+        page_up();
+        return;
+    }
+
+    go_to_row(prev_msg_id);
 }
 
 export function down(with_centering = false): void {


### PR DESCRIPTION
Fixes #32970

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20long.20messages.20not.20completely.20readable


When navigating from a short message to a tall message via up keypress, we used to jump to the top of the message. This doesn't align with user's expectation that up / down keypress will let them see the entire message feed.

To fix it, we can `page_up` which scrolls up the correct amount and then our message selection logic kicks in to select the correct message on screen.
