### PR TITLE
test-api: Make desdemona consenting to private data export.

### DIFF
--- a/tools/test-api
+++ b/tools/test-api
@@ -37,6 +37,7 @@ with test_server_running(
         do_deactivate_realm,
         do_reactivate_realm,
     )
+    from zerver.actions.user_settings import do_change_user_setting
     from zerver.actions.users import change_user_is_active
     from zerver.lib.test_helpers import reset_email_visibility_to_everyone_in_zulip_realm
     from zerver.models.groups import NamedUserGroup, SystemGroups
@@ -86,6 +87,8 @@ with test_server_running(
     email = "desdemona@zulip.com"  # desdemona is an owner
     realm = get_realm("zulip")
     user = get_user(email, realm)
+
+    do_change_user_setting(user, "allow_private_data_export", True, acting_user=user)
 
     api_key = user.api_key
     site = "http://zulip.zulipdev.com:9981"


### PR DESCRIPTION
Fixes CI - it was failing due to the API test for organization exports, which was returning an error due to there being no Organization Owners with consent to private data export.

