### PR TITLE
Construct new channel notification message as a whole string rather than gluing strings together

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -39,7 +39,7 @@ from zerver.lib.streams import (
     can_access_stream_metadata_user_ids,
     check_basic_stream_access,
     get_anonymous_group_membership_dict_for_streams,
-    get_stream_permission_policy_name,
+    get_stream_permission_policy_key,
     get_stream_post_policy_value_based_on_group_setting,
     get_user_ids_with_metadata_access_via_permission_groups,
     get_users_dict_with_metadata_access_to_streams_via_permission_groups,
@@ -1339,16 +1339,18 @@ def do_change_stream_permission(
     )
     send_event_on_commit(stream.realm, event, notify_stream_update_ids)
 
-    old_policy_name = get_stream_permission_policy_name(
+    old_policy_key = get_stream_permission_policy_key(
         invite_only=old_invite_only_value,
         history_public_to_subscribers=old_history_public_to_subscribers_value,
         is_web_public=old_is_web_public_value,
     )
-    new_policy_name = get_stream_permission_policy_name(
+    old_policy_name = Stream.PERMISSION_POLICIES[old_policy_key]["policy_name"]
+    new_policy_key = get_stream_permission_policy_key(
         invite_only=stream.invite_only,
         history_public_to_subscribers=stream.history_public_to_subscribers,
         is_web_public=stream.is_web_public,
     )
+    new_policy_name = Stream.PERMISSION_POLICIES[new_policy_key]["policy_name"]
     send_change_stream_permission_notification(
         stream,
         old_policy_name=old_policy_name,

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -90,24 +90,24 @@ class StreamDict(TypedDict, total=False):
     can_subscribe_group: UserGroup | None
 
 
-def get_stream_permission_policy_name(
+def get_stream_permission_policy_key(
     *,
     invite_only: bool | None = None,
     history_public_to_subscribers: bool | None = None,
     is_web_public: bool | None = None,
 ) -> str:
-    policy_name = None
-    for permission_dict in Stream.PERMISSION_POLICIES.values():
+    policy_key = None
+    for permission_key, permission_dict in Stream.PERMISSION_POLICIES.items():
         if (
             permission_dict["invite_only"] == invite_only
             and permission_dict["history_public_to_subscribers"] == history_public_to_subscribers
             and permission_dict["is_web_public"] == is_web_public
         ):
-            policy_name = permission_dict["policy_name"]
+            policy_key = permission_key
             break
 
-    assert policy_name is not None
-    return policy_name
+    assert policy_key is not None
+    return policy_key
 
 
 def get_default_value_for_history_public_to_subscribers(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -72,7 +72,7 @@ from zerver.lib.streams import (
     filter_stream_authorization_for_adding_subscribers,
     get_anonymous_group_membership_dict_for_streams,
     get_stream_permission_default_group,
-    get_stream_permission_policy_name,
+    get_stream_permission_policy_key,
     list_to_streams,
     stream_to_dict,
     user_has_content_access,
@@ -879,6 +879,12 @@ def send_messages_for_new_subscribers(
                     stream_description = "*" + _("No description.") + "*"
                 else:
                     stream_description = stream.description
+
+                policy_key = get_stream_permission_policy_key(
+                    invite_only=stream.invite_only,
+                    history_public_to_subscribers=stream.history_public_to_subscribers,
+                    is_web_public=stream.is_web_public,
+                )
                 notifications.append(
                     internal_prep_stream_message(
                         sender=sender,
@@ -888,11 +894,7 @@ def send_messages_for_new_subscribers(
                             "**{policy}** channel created by {user_name}. **Description:**"
                         ).format(
                             user_name=silent_mention_syntax_for_user(user_profile),
-                            policy=get_stream_permission_policy_name(
-                                invite_only=stream.invite_only,
-                                history_public_to_subscribers=stream.history_public_to_subscribers,
-                                is_web_public=stream.is_web_public,
-                            ),
+                            policy=Stream.PERMISSION_POLICIES[policy_key]["policy_name"],
                         )
                         + f"\n```` quote\n{stream_description}\n````",
                     ),

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -885,16 +885,35 @@ def send_messages_for_new_subscribers(
                     history_public_to_subscribers=stream.history_public_to_subscribers,
                     is_web_public=stream.is_web_public,
                 )
+                new_channel_message = None
+
+                # Policy `public_protected_history` is missing here as those channels don't get
+                # channel creation notification.
+                if policy_key == "web_public":
+                    new_channel_message = _(
+                        "**Web-public** channel created by {user_name}. **Description:**"
+                    )
+                elif policy_key == "public":
+                    new_channel_message = _(
+                        "**Public** channel created by {user_name}. **Description:**"
+                    )
+                elif policy_key == "private_shared_history":
+                    new_channel_message = _(
+                        "**Private, shared history** channel created by {user_name}. **Description:**"
+                    )
+                elif policy_key == "private_protected_history":
+                    new_channel_message = _(
+                        "**Private, protected history** channel created by {user_name}. **Description:**"
+                    )
+
+                assert new_channel_message is not None
                 notifications.append(
                     internal_prep_stream_message(
                         sender=sender,
                         stream=stream,
                         topic_name=str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
-                        content=_(
-                            "**{policy}** channel created by {user_name}. **Description:**"
-                        ).format(
+                        content=new_channel_message.format(
                             user_name=silent_mention_syntax_for_user(user_profile),
-                            policy=Stream.PERMISSION_POLICIES[policy_key]["policy_name"],
                         )
                         + f"\n```` quote\n{stream_description}\n````",
                     ),


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR solves the issue which is described in this [comment](https://github.com/zulip/zulip/issues/30212#issuecomment-2246375514) as the original issue was already solved by updating the translation.

Note: "Channel created" event messages aren't sent for public_protected_history channels available only in Zephyr realms. This is an existing behaviour and this PR doesn't change that.

as the Previous PR #31009 for this issue was near completion I only had to fix conflicts.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.F0.9F.93.82.C2.A0.20Inconsistent.20localization.20in.20new.20channel.20notif.20.2330212)

Fixes: #30212


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<table border="1">
    <tr>
        <th>Before/main branch</th>
        <th>After/issue#30212 branch</th>
    </tr>
    <tr>
        <td><img src="https://github.com/user-attachments/assets/7fdc72c7-2ce6-41b3-a3d5-45a355f46f38" alt="Before Image 1" ></td>
        <td><img src="https://github.com/user-attachments/assets/81015d06-9a22-4d80-846c-2cd725cf3337" alt="Before Image 1" ></td>
</table>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
