### PR TITLE
activity: Use IdleDetector API when available.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -63,6 +63,7 @@ EXEMPT_FILES = make_set(
         "web/src/blueslip_stacktrace.ts",
         "web/src/bootstrap_typeahead.ts",
         "web/src/browser_history.ts",
+        "web/src/browser_idle_detection.ts",
         "web/src/buddy_list.ts",
         "web/src/buttons.ts",
         "web/src/click_handlers.ts",

--- a/web/src/activity.ts
+++ b/web/src/activity.ts
@@ -2,6 +2,8 @@ import $ from "jquery";
 import assert from "minimalistic-assert";
 import {z} from "zod";
 
+import * as blueslip from "./blueslip.ts";
+import * as browser_idle_detection from "./browser_idle_detection.ts";
 import * as channel from "./channel.ts";
 import {electron_bridge} from "./electron_bridge.ts";
 import {page_params} from "./page_params.ts";
@@ -191,16 +193,54 @@ export function mark_client_active(): void {
     }
 }
 
+export function setup_idle_handler(): void {
+    const idle_handler = $(window).idle({
+        idle: DEFAULT_IDLE_TIMEOUT_MS,
+        onIdle: mark_client_idle,
+        onActive: mark_client_active,
+        keepTracking: true,
+    });
+    // This code is separated out of `initialize` to facilitate testing
+    if (!browser_idle_detection.supported()) {
+        blueslip.log("Browser idle detector not supported");
+        return;
+    }
+
+    $(document).one("keypress click", () => {
+        void browser_idle_detection.request_permission();
+    });
+
+    browser_idle_detection.on_permission_change(() => {
+        void browser_idle_detection
+            .init({
+                idle_timeout: 60 * 1000,
+                on_idle: mark_client_idle,
+                on_active: mark_client_active,
+            })
+            .then((result) => {
+                if (result === "started") {
+                    // We no longer need to track idle state with jQuery.
+                    idle_handler.cancel();
+                    blueslip.info("Browser IdleDetector started");
+                    return;
+                }
+                if (result.name !== "NotAllowedError") {
+                    // We don't need to handle `NotAllowedError` specifically
+                    // since we have requested for the permission above, and
+                    // when we do get permission, the change handler
+                    // will call this callback again.
+                    blueslip.error("Browser IdleDetector failed to start: " + result.message);
+                }
+            });
+    });
+}
+
 export function initialize(): void {
     $("html").on("mousemove", () => {
         set_new_user_input(true);
     });
 
     $(window).on("focus", mark_client_active);
-    $(window).idle({
-        idle: DEFAULT_IDLE_TIMEOUT_MS,
-        onIdle: mark_client_idle,
-        onActive: mark_client_active,
-        keepTracking: true,
-    });
+
+    setup_idle_handler();
 }

--- a/web/src/browser_idle_detection.ts
+++ b/web/src/browser_idle_detection.ts
@@ -1,0 +1,83 @@
+declare global {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Window {
+        IdleDetector: {
+            requestPermission: () => Promise<"granted" | "rejected">;
+            new (): {
+                start: (options: {threshold: number}) => Promise<void>;
+                userState: "active" | "idle";
+                screenState: "locked" | "unlocked";
+                addEventListener: (type: "change", listener: () => void) => void;
+            };
+        };
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Permission {
+        query: (permission_info: {name: "idle-detection"}) => Promise<{
+            state: "granted" | "denied" | "prompt";
+            addEventListener: (type: "change", listener: () => void) => void;
+        }>;
+    }
+}
+
+export function supported(): boolean {
+    // This API doesn't have widespread support yet, and probably
+    // never will. It is not available in Firefox and Safari.
+    return "IdleDetector" in window;
+}
+
+// Must be called from a handler in a user gesture (ie, click, keypress etc)
+export async function request_permission(): Promise<"granted" | "rejected"> {
+    if (!supported()) {
+        return "rejected";
+    }
+    return window.IdleDetector.requestPermission();
+}
+
+export async function init({
+    idle_timeout,
+    on_idle,
+    on_active,
+}: {
+    idle_timeout: number;
+    on_idle: () => void;
+    on_active: () => void;
+}): Promise<"started" | Error> {
+    try {
+        const idleDetector = new window.IdleDetector();
+        idleDetector.addEventListener("change", () => {
+            const userState = idleDetector.userState;
+            const screenState = idleDetector.screenState;
+            if (userState === "idle" || screenState === "locked") {
+                on_idle();
+            } else {
+                on_active();
+            }
+        });
+
+        await idleDetector.start({
+            threshold: idle_timeout,
+        });
+        return "started";
+    } catch (error) {
+        if (error instanceof Error) {
+            return error;
+        }
+        return new Error(JSON.stringify(error));
+    }
+}
+
+export function on_permission_change(on_granted: () => void): void {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    void navigator.permissions.query({name: "idle-detection"}).then((permissionStatus) => {
+        if (permissionStatus.state === "granted") {
+            on_granted();
+        }
+        permissionStatus.addEventListener("change", () => {
+            if (permissionStatus.state === "granted") {
+                on_granted();
+            }
+        });
+    });
+}

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -11,6 +11,7 @@ const {
 } = require("./lib/buddy_list.cjs");
 const {make_message_list} = require("./lib/message_list.cjs");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace.cjs");
+const {make_stub} = require("./lib/stub.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
 const $ = require("./lib/zjquery.cjs");
@@ -18,16 +19,22 @@ const {page_params} = require("./lib/zpage_params.cjs");
 
 const $window_stub = $.create("window-stub");
 set_global("to_$", () => $window_stub);
-$(window).idle = noop;
+const idle_handler_cancel_stub = make_stub();
+const idle_handler = {cancel: idle_handler_cancel_stub.f};
+$(window).idle = () => noop;
 
 const _document = {
     hasFocus() {
         return true;
     },
+    to_$() {
+        return $("document-stub");
+    },
 };
 
 const channel = mock_esm("../src/channel");
 const electron_bridge = mock_esm("../src/electron_bridge");
+const browser_idle_detection = mock_esm("../src/browser_idle_detection");
 const keydown_util = mock_esm("../src/keydown_util", {handle() {}});
 const padded_widget = mock_esm("../src/padded_widget");
 const pm_list = mock_esm("../src/pm_list");
@@ -786,6 +793,8 @@ test("initialize", ({override, override_rewire}) => {
         func();
     });
 
+    override(browser_idle_detection, "supported", () => false);
+
     activity.initialize();
     activity_ui.initialize({narrow_by_email() {}});
     payload.success({
@@ -892,4 +901,42 @@ test("check_should_redraw_new_user", ({override}) => {
     override(realm, "realm_presence_disabled", false);
     // A new user that didn't have presence info should not be redrawn.
     assert.equal(activity_ui.check_should_redraw_new_user(99999), false);
+});
+
+test("browser_idle_detection", ({override}) => {
+    // Browser APIs `IdleDetector` and `navigator` handle much of the logic
+    // around switching to browser IdleDetector, so there's very little to
+    // test.
+    override(browser_idle_detection, "supported", () => false);
+    $(window).idle = () => idle_handler;
+    activity.setup_idle_handler();
+    blueslip.expect("log", "Browser idle detector not supported");
+    assert.equal(idle_handler_cancel_stub.num_calls, 0);
+
+    override(browser_idle_detection, "supported", () => true);
+
+    let on_granted;
+    override(browser_idle_detection, "init", () => ({
+        // eslint-disable-next-line unicorn/no-thenable
+        then(cb) {
+            on_granted = cb;
+        },
+    }));
+    override(browser_idle_detection, "on_permission_change", (cb) => cb());
+    $(window).idle = () => idle_handler;
+    activity.setup_idle_handler();
+    blueslip.expect("info", "Browser IdleDetector started");
+    on_granted("started");
+    assert.equal(idle_handler_cancel_stub.num_calls, 1);
+
+    on_granted({name: "NotAllowedError"});
+    assert.equal(idle_handler_cancel_stub.num_calls, 1);
+
+    blueslip.expect("error", "Browser IdleDetector failed to start: error message");
+    on_granted({name: "SomeOtherError", message: "error message"});
+    assert.equal(idle_handler_cancel_stub.num_calls, 1);
+
+    // For full coverage.
+    override(browser_idle_detection, "request_permission", noop);
+    $(document).trigger("keypress click");
 });


### PR DESCRIPTION
The IdleDetector API does not have much support
across browsers due to privacy concerns.
See https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector#browser_compatibility

Practically, it is a chromium-only feature, yet it is still useful to implement this feature since the
majority of our web users are in Chromium-based
browsers that do support it.

From manual testing, the following situations arise:

----
| Case | userState | screenState | Description|
| -----| ------------| ---------------| --- |
| 1 | idle | locked | The screen was locked due to user inactivity. |
| 2 | idle | unlocked | The user has not interacted with the computer for at least `DEFAULT_IDLE_TIMEOUT_MS`, though the screen is unlocked. |
| 3 | active | locked | The user has themselves locked the screen , and is effectively idle. |
| 4 | active | unlocked | The user is interacting with the computer - though they might not be interacting with the Zulip tab. |

We consider the user to be inactive in all cases except the last.

Fixes #25056

[CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/chrome.20idle.20detection/near/1537514)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
