### PR TITLE
app: Track keyboard overlaps with compose box bug as a TODO.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -7,11 +7,14 @@
 {% set PAGE_DESCRIPTION = _("Browse the publicly accessible channels in {org_name} without logging in.").format(org_name=realm_name)  %}
 
 {% block meta_viewport %}
-<!-- From version 132, Firefox now defaults to not resize the viewport
+<!--
+From version 132, Firefox now defaults to not resize the viewport
 content but only the visual viewport. While this works well in
 Chrome Android, it creates a buggy experience in Firefox Android
 where the compose box is hidden under keyboard. To fix it, we rollback
-to resizing content when keyboard is shown on Firefox Android. -->
+to resizing content when keyboard is shown on Firefox Android.
+TODO: Remove this when Firefox Android fixes the bug -
+https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no {% if is_firefox_android %}, interactive-widget=resizes-content{% endif %}" />
 {% endblock %}
 


### PR DESCRIPTION
This will help us revert back to `resizes-visual` on Firefox Android when the bug is fixed.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/Keyboard.20hides.20composebox.20on.20mobile.20web.20on.20Firefox/with/2140295

report - https://bugzilla.mozilla.org/show_bug.cgi?id=1943053