### PR TITLE
css: Remove unused transition property.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -363,7 +363,7 @@ div.overlay {
     visibility: hidden;
 
     transition: 0.2s ease-in;
-    transition-property: opacity, visibility;
+    transition-property: opacity;
     overflow: hidden;
 
     .overlay-content {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -501,7 +501,7 @@
         opacity: 0;
         visibility: hidden;
         transition: 0.2s ease;
-        transition-property: opacity, visibility;
+        transition-property: opacity;
         /* Allow buttons to grow to fill the available space,
            in concord with the column calculated for the
            .messagebox-content grid. */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2091,9 +2091,7 @@ body:not(.spectator-view) {
     right: 0;
     visibility: hidden;
     opacity: 0;
-    transition:
-        visibility 500ms,
-        opacity 500ms ease-in-out;
+    transition: opacity 500ms ease-in-out;
 
     &.show {
         visibility: visible;


### PR DESCRIPTION
`visibility` cannot be animated since it is a boolean.

Composition for some transition still fails which seems related to how the browser's rendering engine works to reduce load on CPU when performing animations.

Not sure if it is worth digging more here. 

discussion: https://chat.zulip.org/#narrow/channel/6-frontend/topic/message_control_button.20animations/with/2140570

Comparison when scrolling combined feed:
| before | after |
| --- | --- |
| ![Screenshot from 2025-03-31 09-59-48](https://github.com/user-attachments/assets/341acfea-e95e-46d3-96db-19748922adc3) | ![Screenshot from 2025-03-31 11-09-08](https://github.com/user-attachments/assets/a68a03cb-0ac4-4463-8b18-a7df349ca25e) |
