### PR TITLE
Add option to subscribe user to all default streams in change role UI.

### DIFF
--- a/web/src/user_profile.ts
+++ b/web/src/user_profile.ts
@@ -1198,6 +1198,43 @@ export function show_edit_user_info_modal(user_id: number, $container: JQuery): 
         toggle_submit_button($("#edit-user-form"));
     });
 
+    $("#user-profile-modal").on("click", "#subscribe-to-default-streams", () => {
+        const user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id")!, 10);
+        const stream_ids = stream_data.get_default_stream_ids();
+        const default_streams = [];
+
+        for (const stream_id of stream_ids) {
+            const stream_name = stream_data.get_stream_name_from_id(stream_id);
+            default_streams.push({name: stream_name});
+        }
+
+        const url = "/json/users/me/subscriptions";
+        const data = {
+            subscriptions: JSON.stringify(default_streams),
+            principals: JSON.stringify([user_id]),
+        };
+
+        const $subscribe_button = $("#user-profile-modal #subscribe-to-default-streams");
+        show_button_spinner($subscribe_button);
+
+        channel.post({
+            url,
+            data,
+            success() {
+                $("#edit-user-form-error").hide();
+                hide_button_spinner($subscribe_button);
+                ui_report.success($t_html({defaultMessage: "Subscribed"}), $subscribe_button, 1000);
+            },
+            error(xhr) {
+                ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $subscribe_button);
+                $("#edit-user-form")
+                    .closest(".simplebar-content-wrapper")
+                    .animate({scrollTop: 0}, "fast");
+                hide_button_spinner($subscribe_button);
+            },
+        });
+    });
+
     $("#user-profile-modal").on("click", ".dialog_submit_button", () => {
         const role = Number.parseInt(
             $<HTMLSelectOneElement>("select:not([multiple])#user-role-select").val()!.trim(),

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -24,6 +24,11 @@
                 {{> dropdown_options_widget option_values=user_role_values}}
             </select>
         </div>
+        <div class="input-group">
+            <button id="subscribe-to-default-streams" class="button rounded sea-green">
+                {{t "Subscribe to default streams" }}
+            </button>
+        </div>
         <div class="custom-profile-field-form"></div>
     </form>
     <div class="input-group {{#if hide_deactivate_button}}hide{{/if}}">


### PR DESCRIPTION
The PR enables the admin to subscribe any user to all the default streams in change role UI.

Fixes: #16487

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
