### PR TITLE
compose: Prevent picker from collapsing.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1496,7 +1496,9 @@ textarea.new_message_textarea {
     /* Allow the contents wrapped here to
        expand the available space... */
     white-space: nowrap;
-    flex: 0 1 fit-content;
+    /* And follow the fitted content on the
+       flexbox. */
+    flex: 0 0 fit-content;
     /* But force an ellipsis here, rather than
        just on an inner element. */
     overflow: hidden;


### PR DESCRIPTION
This corrects for an incorrectly collapsing picker area.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/issue.20in.20compose.20select.20recipient.20widget/near/2140740)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_No change on the channel picker, even with long channel names:_

| Before | After |
| --- | --- |
| ![dm-many-recipients-before](https://github.com/user-attachments/assets/38a96eab-4431-4889-bf2c-fe6e2fd90992) | ![dm-many-recipients-after](https://github.com/user-attachments/assets/286b514d-a8e7-40db-bfce-3013f10553fe) |
| ![picker-long-channel-before](https://github.com/user-attachments/assets/4b6c73f3-c8ca-4928-9d03-ddf006676abe) | ![picker-long-channel-after](https://github.com/user-attachments/assets/a1d99e42-002b-4cb8-bd3f-b3ecbb868fb5) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
