### PR TITLE
subscription_info: Add option to get partial subscribers.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -4,7 +4,7 @@ import copy
 import logging
 import time
 from collections.abc import Callable, Collection, Iterable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -157,7 +157,7 @@ def fetch_initial_state_data(
     slim_presence: bool = False,
     presence_last_update_id_fetched_by_client: int | None = None,
     presence_history_limit_days: int | None = None,
-    include_subscribers: bool = True,
+    include_subscribers: bool | Literal["partial"] = True,
     include_streams: bool = True,
     spectator_requested_language: str | None = None,
     pronouns_field_type_supported: bool = True,
@@ -1894,7 +1894,7 @@ def do_events_register(
     event_types: Sequence[str] | None = None,
     queue_lifespan_secs: int = 0,
     all_public_streams: bool = False,
-    include_subscribers: bool = True,
+    include_subscribers: bool | Literal["partial"] = True,
     include_streams: bool = True,
     client_capabilities: ClientCapabilities = DEFAULT_CLIENT_CAPABILITIES,
     narrow: Collection[NeverNegatedNarrowTerm] = [],
@@ -2024,7 +2024,7 @@ def do_events_register(
         fetch_event_types=fetch_event_types,
         client_gravatar=client_gravatar,
         slim_presence=slim_presence,
-        include_subscribers=include_subscribers,
+        include_subscribers=True if include_subscribers == "partial" else include_subscribers,
         linkifier_url_template=linkifier_url_template,
         user_list_incomplete=user_list_incomplete,
         include_deactivated_groups=include_deactivated_groups,

--- a/zerver/lib/home.py
+++ b/zerver/lib/home.py
@@ -1,4 +1,5 @@
 import calendar
+import os
 import time
 from dataclasses import dataclass
 
@@ -108,6 +109,7 @@ def build_page_params_for_home_page_load(
     if user_profile is not None:
         client = RequestNotes.get_notes(request).client
         assert client is not None
+        partial_subscribers = os.environ.get("PARTIAL_SUBSCRIBERS") is not None
         state_data = do_events_register(
             user_profile,
             realm,
@@ -120,6 +122,7 @@ def build_page_params_for_home_page_load(
             client_capabilities=client_capabilities,
             narrow=narrow,
             include_streams=False,
+            include_subscribers="partial" if partial_subscribers else True,
         )
         queue_id = state_data["queue_id"]
         default_language = state_data["user_settings"]["default_language"]


### PR DESCRIPTION
It returns just bots for now.

Discussed here: https://chat.zulip.org/#narrow/channel/378-api-design/topic/Extending.20include_subscriber.20for.20parse.20subscriber.20data/with/2141527

Part of  #34244