### PR TITLE
users: Send peer_remove on deactivating user.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
+**Feature level 377**
+
+* [`GET /events`](/api/get-events): When a user is deactivate, send
+  `peer_remove` event to all the subscribers of the streams that the
+  user was subscribed to.
+
 Feature levels 373-376 reserved for future use in 10.x maintenance
 releases.
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,15 +20,17 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 11.0
 
-Feature levels 372-375 reserved for future use in 10.x maintenance
+Feature levels 373-376 reserved for future use in 10.x maintenance
 releases.
 
-## Changes in Zulip 10.0
+## Changes in Zulip 10.1
 
 **Feature level 372**
 
 * [`POST /typing`](/api/set-typing-status): The `"(no topic)"` value
   when used for `topic` parameter is now interpreted as an empty string.
+
+## Changes in Zulip 10.0
 
 **Feature level 371**
 
@@ -1026,10 +1028,10 @@ deactivated groups.
   now contains the superset of the true value that best approximates the actual
   permission setting.
 
-Feature levels 278-279 are reserved for future use in 9.x maintenance
+Feature level 279 is reserved for future use in 9.x maintenance
 releases.
 
-## Changes in Zulip 9.0
+## Changes in Zulip 9.2
 
 **Feature level 278**
 
@@ -1038,6 +1040,8 @@ releases.
   `data-original-dimensions` attributes to placeholder images
   (`image-loading-placeholder`), containing the dimensions of the
   original image. Backported change from feature level 287.
+
+## Changes in Zulip 9.0
 
 **Feature level 277**
 

--- a/version.py
+++ b/version.py
@@ -34,7 +34,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
 
-API_FEATURE_LEVEL = 372  # Last bumped to interpret "(no topic)" as empty string.
+API_FEATURE_LEVEL = 377  # Last bumped to sending peer_remove on user deactivation.
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -916,6 +916,16 @@ paths:
                                     The IDs of the channels from which the users have been
                                     unsubscribed from.
 
+                                    When a user is deactivated, the server will send this event
+                                    removing the user's subscriptions before the `realm_user` event
+                                    for the user's deactivation.
+
+                                    **Changes**: Before Zulip 10.0 (feature level 377), this event
+                                    was not sent on user deactivation. Clients supporting older
+                                    server versions and maintaining peer subscriber data need to
+                                    remove all channel subscriptions for a user when processing the
+                                    `realm_user` event with `op="remove"`.
+
                                     **Changes**: New in Zulip 4.0 (feature level 35), replacing
                                     the `stream_id` integer.
                                   items:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1464,7 +1464,7 @@ class NormalActionsTest(BaseAction):
                 invite_expires_in_minutes=invite_expires_in_minutes,
             )
 
-        with self.verify_action(num_events=2) as events:
+        with self.verify_action(num_events=3) as events:
             do_deactivate_user(user_profile, acting_user=None)
         check_invites_changed("events[0]", events[0])
 
@@ -3484,9 +3484,10 @@ class NormalActionsTest(BaseAction):
             hamletcharacters_group, "can_mention_group", setting_group, acting_user=None
         )
 
-        with self.verify_action(num_events=1) as events:
+        with self.verify_action(num_events=2) as events:
             do_deactivate_user(user_profile, acting_user=None)
-        check_realm_user_update("events[0]", events[0], "is_active")
+        check_subscription_peer_remove("events[0]", events[0])
+        check_realm_user_update("events[1]", events[1], "is_active")
 
         do_reactivate_user(user_profile, acting_user=None)
         self.set_up_db_for_testing_user_access()
@@ -3495,9 +3496,10 @@ class NormalActionsTest(BaseAction):
         # Test that users who can access the deactivated user
         # do not receive the 'user_group/remove_members' event.
         user_profile = self.example_user("cordelia")
-        with self.verify_action(num_events=1) as events:
+        with self.verify_action(num_events=2) as events:
             do_deactivate_user(user_profile, acting_user=None)
-        check_realm_user_update("events[0]", events[0], "is_active")
+        check_subscription_peer_remove("events[0]", events[0])
+        check_realm_user_update("events[1]", events[1], "is_active")
 
         do_reactivate_user(user_profile, acting_user=None)
 
@@ -3567,15 +3569,16 @@ class NormalActionsTest(BaseAction):
         # Guest loses access to deactivated user if the user
         # was not involved in DMs.
         user_profile = self.example_user("hamlet")
-        with self.verify_action(num_events=5) as events:
+        with self.verify_action(num_events=6) as events:
             do_deactivate_user(user_profile, acting_user=None)
-        check_user_group_remove_members("events[0]", events[0])
+        check_subscription_peer_remove("events[0]", events[0])
         check_user_group_remove_members("events[1]", events[1])
         check_user_group_remove_members("events[2]", events[2])
-        check_user_group_update("events[3]", events[3], {"can_mention_group"})
-        check_realm_user_remove("events[4]]", events[4])
+        check_user_group_remove_members("events[3]", events[3])
+        check_user_group_update("events[4]", events[4], {"can_mention_group"})
+        check_realm_user_remove("events[5]]", events[5])
         self.assertEqual(
-            events[3]["data"]["can_mention_group"],
+            events[4]["data"]["can_mention_group"],
             UserGroupMembersDict(direct_members=[], direct_subgroups=[members_group.id]),
         )
 


### PR DESCRIPTION
Fixes #34245.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
