### PR TITLE
Fix errors related to user search in logged out view.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -18,6 +18,7 @@ import {$t} from "./i18n.ts";
 import * as message_viewport from "./message_viewport.ts";
 import * as narrow_state from "./narrow_state.ts";
 import * as padded_widget from "./padded_widget.ts";
+import {page_params} from "./page_params.ts";
 import * as peer_data from "./peer_data.ts";
 import * as people from "./people.ts";
 import * as scroll_util from "./scroll_util.ts";
@@ -993,6 +994,10 @@ export class BuddyList extends BuddyListConf {
     }
 
     rerender_participants(): void {
+        if (page_params.is_spectator) {
+            return;
+        }
+
         const all_participant_ids = this.render_data.get_all_participant_ids();
         const users_to_remove = this.participant_user_ids.filter(
             (user_id) => !all_participant_ids.has(user_id),

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1016,6 +1016,9 @@ export function process_hotkey(e, hotkey) {
             }
             return true;
         case "query_users":
+            if (page_params.is_spectator) {
+                return false;
+            }
             activity_ui.initiate_search();
             return true;
         case "search":


### PR DESCRIPTION
Reproducer
* Log out
* Go to a topic where after narrowing, we have to load more messages. (We see an error "cannot show user id at this position"
* Press `w`  to see error - "Cannot highlight key for ListCursor"