### PR TITLE
    buddy_list: Fetch full subscriber data before showing user counts.

### DIFF
--- a/web/src/activity_ui.ts
+++ b/web/src/activity_ui.ts
@@ -2,8 +2,6 @@ import $ from "jquery";
 import _ from "lodash";
 import assert from "minimalistic-assert";
 
-import render_empty_list_widget_for_list from "../templates/empty_list_widget_for_list.hbs";
-
 import * as activity from "./activity.ts";
 import * as blueslip from "./blueslip.ts";
 import * as buddy_data from "./buddy_data.ts";
@@ -120,17 +118,6 @@ export function searching(): boolean {
     return user_filter?.searching() ?? false;
 }
 
-export function render_empty_user_list_message_if_needed($container: JQuery): void {
-    const empty_list_message = $container.attr("data-search-results-empty");
-
-    if (!empty_list_message || $container.children().length > 0) {
-        return;
-    }
-
-    const empty_list_widget_html = render_empty_list_widget_for_list({empty_list_message});
-    $container.append($(empty_list_widget_html));
-}
-
 export let build_user_sidebar = (): number[] | undefined => {
     if (realm.realm_presence_disabled) {
         return undefined;
@@ -142,9 +129,6 @@ export let build_user_sidebar = (): number[] | undefined => {
     const all_user_ids = buddy_data.get_filtered_and_sorted_user_ids(filter_text);
 
     buddy_list.populate({all_user_ids});
-
-    render_empty_user_list_message_if_needed(buddy_list.$users_matching_view_list);
-    render_empty_user_list_message_if_needed(buddy_list.$other_users_list);
 
     return all_user_ids; // for testing
 };

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -408,12 +408,19 @@ export class BuddyList extends BuddyListConf {
             return;
         }
 
-        const {get_all_participant_ids} = this.render_data;
+        const {current_sub, get_all_participant_ids} = this.render_data;
         $("#buddy-list-users-matching-view .empty-list-message").remove();
         if ((await this.non_participant_users_matching_view_count()) > 0) {
             // There are more subscribers, so we don't need an empty list message.
             return;
-        } else if (get_all_participant_ids().size > 0) {
+        }
+        // After the `await`, we might have changed to a different channel view.
+        // If so, we shouldn't update the DOM anymore, and should let the newer `populate`
+        // call set things up with fresh data.
+        if (current_sub !== this.render_data.current_sub) {
+            return;
+        }
+        if (get_all_participant_ids().size > 0) {
             add_or_update_empty_list_placeholder(
                 "#buddy-list-users-matching-view",
                 $t({defaultMessage: "No other subscribers."}),
@@ -444,6 +451,13 @@ export class BuddyList extends BuddyListConf {
             non_participant_users_matching_view_count,
         );
         const formatted_other_users_count = get_formatted_user_count(other_users_count);
+
+        // After the `await`, we might have changed to a different channel view.
+        // If so, we shouldn't update the DOM anymore, and should let the newer `populate`
+        // call set things up with fresh data.
+        if (current_sub !== this.render_data.current_sub) {
+            return;
+        }
 
         $("#buddy-list-participants-container .buddy-list-heading-user-count").text(
             formatted_participants_count,
@@ -679,6 +693,13 @@ export class BuddyList extends BuddyListConf {
             (await this.non_participant_users_matching_view_count()) >
             this.users_matching_view_ids.length;
         const has_inactive_other_users = other_users_count > this.other_user_ids.length;
+
+        // After the `await`, we might have changed to a different channel view.
+        // If so, we shouldn't update the DOM anymore, and should let the newer `populate`
+        // call set things up with fresh data.
+        if (current_sub !== this.render_data.current_sub) {
+            return;
+        }
 
         // For stream views, we show a link at the bottom of the list of subscribed users that
         // lets a user find the full list of subscribed users and information about them.

--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -224,9 +224,23 @@ export class BuddyList extends BuddyListConf {
                         } else if (elem_id === "buddy-list-users-matching-view-section-heading") {
                             void (async () => {
                                 let tooltip_text;
-                                const users_matching_view_count =
-                                    await non_participant_users_matching_view_count();
-                                if (narrow_state.stream_sub()) {
+                                const stream_sub = narrow_state.stream_sub();
+                                if (stream_sub) {
+                                    // If we need to fetch the full data, show the total subscriber
+                                    // count in the meantime.
+                                    if (!peer_data.has_full_subscriber_data(stream_sub.stream_id)) {
+                                        instance.setContent(
+                                            $t(
+                                                {
+                                                    defaultMessage:
+                                                        "{N, plural, one {# total subscriber} other {# total subscribers}}",
+                                                },
+                                                {N: total_human_subscribers_count()},
+                                            ),
+                                        );
+                                    }
+                                    const users_matching_view_count =
+                                        await non_participant_users_matching_view_count();
                                     tooltip_text = $t(
                                         {
                                             defaultMessage:
@@ -235,6 +249,10 @@ export class BuddyList extends BuddyListConf {
                                         {N: users_matching_view_count},
                                     );
                                 } else {
+                                    // This will happen immediately because we don't need
+                                    // to fetch subscriber data.
+                                    const users_matching_view_count =
+                                        await non_participant_users_matching_view_count();
                                     tooltip_text = $t(
                                         {
                                             defaultMessage:

--- a/web/templates/buddy_list/section_header.hbs
+++ b/web/templates/buddy_list/section_header.hbs
@@ -1,7 +1,8 @@
 <i class="buddy-list-section-toggle zulip-icon zulip-icon-heading-triangle-right {{#if is_collapsed}}rotate-icon-right{{else}}rotate-icon-down{{/if}}" aria-hidden="true"></i>
-<h5 id="{{id}}" data-user-count="{{user_count}}" class="buddy-list-heading no-style hidden-for-spectators">
+<h5 id="{{id}}" class="buddy-list-heading no-style hidden-for-spectators">
     <span class="buddy-list-heading-text">{{header_text}}</span>
-    <span class="buddy-list-heading-user-count-with-parens">
-        (<span class="buddy-list-heading-user-count">{{user_count}}</span>)
+    {{!-- Hide the count until we have fetched data to display the correct count --}}
+    <span class="buddy-list-heading-user-count-with-parens hide">
+        (<span class="buddy-list-heading-user-count"></span>)
     </span>
 </h5>

--- a/web/tests/activity.test.cjs
+++ b/web/tests/activity.test.cjs
@@ -469,29 +469,6 @@ test("first/prev/next", ({override, override_rewire, mock_template}) => {
     assert.equal(buddy_list.next_key(fred.user_id), undefined);
 });
 
-test("render_empty_user_list_message", ({override, mock_template}) => {
-    const empty_list_message = "No matching users.";
-    mock_template("empty_list_widget_for_list.hbs", false, (data) => {
-        assert.equal(data.empty_list_message, empty_list_message);
-        return "<empty-list-stub>";
-    });
-
-    let $appended_data;
-    override(buddy_list, "$container", {
-        append($data) {
-            $appended_data = $data;
-        },
-        attr(name) {
-            assert.equal(name, "data-search-results-empty");
-            return empty_list_message;
-        },
-        children: () => [],
-    });
-
-    activity_ui.render_empty_user_list_message_if_needed(buddy_list.$container);
-    assert.equal($appended_data.selector, "<empty-list-stub>");
-});
-
 test("insert_one_user_into_empty_list", ({override, mock_template}) => {
     override(user_settings, "user_list_style", 2);
 

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -181,7 +181,10 @@ test("subscribers", () => {
 
     // Verify noop for bad stream when removing subscriber
     const bad_stream_id = 999999;
-    blueslip.expect("warn", "We called get_user_set for an untracked stream: " + bad_stream_id);
+    blueslip.expect(
+        "warn",
+        "We called get_loaded_subscriber_subset for an untracked stream: " + bad_stream_id,
+    );
     blueslip.expect("warn", "We tried to remove invalid subscriber: 104");
     ok = peer_data.remove_subscriber(bad_stream_id, brutus.user_id);
     assert.ok(!ok);
@@ -223,7 +226,10 @@ test("subscribers", () => {
     blueslip.reset();
 
     // Verify that we don't crash for a bad stream.
-    blueslip.expect("warn", "We called get_user_set for an untracked stream: 9999999");
+    blueslip.expect(
+        "warn",
+        "We called get_loaded_subscriber_subset for an untracked stream: 9999999",
+    );
     peer_data.add_subscriber(9999999, brutus.user_id);
     blueslip.reset();
 
@@ -253,7 +259,7 @@ test("get_subscriber_count", () => {
     };
     stream_data.clear_subscriptions();
 
-    blueslip.expect("warn", "We called get_user_set for an untracked stream: 102");
+    blueslip.expect("warn", "We called get_loaded_subscriber_subset for an untracked stream: 102");
     assert.equal(peer_data.get_subscriber_count(india.stream_id), 0);
 
     stream_data.add_sub(india);
@@ -305,13 +311,22 @@ test("is_subscriber_subset", () => {
     }
 
     // Two untracked streams should never be passed into us.
-    blueslip.expect("warn", "We called get_user_set for an untracked stream: 88888");
-    blueslip.expect("warn", "We called get_user_set for an untracked stream: 99999");
+    blueslip.expect(
+        "warn",
+        "We called get_loaded_subscriber_subset for an untracked stream: 88888",
+    );
+    blueslip.expect(
+        "warn",
+        "We called get_loaded_subscriber_subset for an untracked stream: 99999",
+    );
     peer_data.is_subscriber_subset(99999, 88888);
     blueslip.reset();
 
     // Warn about hypothetical undefined stream_ids.
-    blueslip.expect("warn", "We called get_user_set for an untracked stream: undefined");
+    blueslip.expect(
+        "warn",
+        "We called get_loaded_subscriber_subset for an untracked stream: undefined",
+    );
     peer_data.is_subscriber_subset(undefined, sub_a.stream_id);
     blueslip.reset();
 });

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -295,7 +295,14 @@ test("maybe_fetch_stream_subscribers", async () => {
     };
     peer_data.clear_for_testing();
     blueslip.expect("error", "Failure fetching channel subscribers");
-    peer_data.maybe_fetch_stream_subscribers(india.stream_id);
+    assert.equal(await peer_data.maybe_fetch_is_user_subscribed(india.stream_id, 5), null);
+    // If we know they're subscribed, we return `true` even though we don't have complete
+    // data.
+    peer_data.bulk_add_subscribers({
+        stream_ids: [india.stream_id],
+        user_ids: [5],
+    });
+    assert.equal(await peer_data.maybe_fetch_is_user_subscribed(india.stream_id, 5), true);
 });
 
 test("get_subscriber_count", () => {

--- a/web/tests/peer_data.test.cjs
+++ b/web/tests/peer_data.test.cjs
@@ -267,6 +267,21 @@ test("maybe_fetch_stream_subscribers", async () => {
     assert.equal(channel_get_calls, 1);
 
     peer_data.clear_for_testing();
+    const pending_promise = peer_data.maybe_fetch_stream_subscribers(india.stream_id);
+    peer_data.bulk_add_subscribers({
+        stream_ids: [india.stream_id],
+        user_ids: [7, 9],
+    });
+    peer_data.bulk_remove_subscribers({
+        stream_ids: [india.stream_id],
+        user_ids: [3],
+    });
+    const subscribers_before_fetch_completes = peer_data.get_subscribers(india.stream_id);
+    assert.deepEqual(subscribers_before_fetch_completes, [7, 9]);
+    const subscribers_after_fetch = await pending_promise;
+    assert.deepEqual([...subscribers_after_fetch.keys()], [1, 2, 4, 7, 9]);
+
+    peer_data.clear_for_testing();
     assert.equal(await peer_data.maybe_fetch_is_user_subscribed(india.stream_id, 2), true);
     assert.equal(peer_data.has_full_subscriber_data(india.stream_id), true);
 


### PR DESCRIPTION
Work towards #34244.

Note that this doesn't show the right counts when the counts appear, because #34246 isn't complete. But that's fine, because none of this is in production yet. We can double check functionality after that change is complete.

This should change nothing in production. Use `env PARTIAL_SUBSCRIBERS=1 ./tools/run-dev` to see changes locally.