### PR TITLE
test-backend: Remove outdated reference to MarkdownTest class

### DIFF
--- a/docs/subsystems/markdown.md
+++ b/docs/subsystems/markdown.md
@@ -85,7 +85,7 @@ testcases in `markdown_test_cases.json` that you want to ignore. This
 is a workaround due to lack of comments support in JSON. Revert your
 "ignore" changes before committing. After this, you can run the frontend
 tests with `tools/test-js-with-node markdown` and backend tests with
-`tools/test-backend zerver.tests.test_markdown.MarkdownTest.test_markdown_fixtures`.
+`tools/test-backend zerver.tests.test_markdown.MarkdownFixtureTest.test_markdown_fixtures`.
 
 ## Changing Zulip's Markdown processor
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -33,8 +33,8 @@ typically involve running subsets of the tests with commands like these:
 
 ```bash
 ./tools/lint zerver/models/__init__.py # Lint the file you just changed
-./tools/test-backend zerver.tests.test_markdown.MarkdownTest.test_inline_youtube
-./tools/test-backend MarkdownTest # Run `test-backend --help` for more options
+./tools/test-backend zerver.tests.test_markdown.MarkdownEmbedsTest.test_inline_youtube
+./tools/test-backend MarkdownEmbedsTest # Run `test-backend --help` for more options
 ./tools/test-js-with-node util
 # etc.
 ```

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -211,10 +211,10 @@ def main() -> None:
     test-backend zerver.tests.test_markdown # run all tests in a test module
     test-backend zerver/tests/test_markdown.py # run all tests in a test module
     test-backend test_markdown # run all tests in a test module
-    test-backend zerver.tests.test_markdown.MarkdownTest # run all tests in a test class
-    test-backend MarkdownTest # run all tests in a test class
-    test-backend zerver.tests.test_markdown.MarkdownTest.test_inline_youtube # run a single test
-    test-backend MarkdownTest.test_inline_youtube # run a single test"""
+    test-backend zerver.tests.test_markdown.MarkdownEmbedsTest # run all tests in a test class
+    test-backend MarkdownEmbedsTest # run all tests in a test class
+    test-backend zerver.tests.test_markdown.MarkdownEmbedsTest.test_inline_youtube # run a single test
+    test-backend MarkdownEmbedsTest.test_inline_youtube # run a single test"""
 
     parser = argparse.ArgumentParser(
         description=usage, formatter_class=argparse.RawTextHelpFormatter


### PR DESCRIPTION
Fix outdated references to MarkdownTest in test-backend --help
Summary
This PR updates the test-backend --help output to replace outdated references to MarkdownTest, which no longer exists, with the correct test class names:
Why this change?
The MarkdownTest class no longer exists, leading to a ModuleNotFoundError when running the test examples.
This update ensures that contributors following the test documentation do not run into errors.

Testing
Verified that the new test references exist in the codebase and run successfully.

<details>
<summary>Self-review checklist</summary>

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>