### PR TITLE
subscription_info: Send partial subscriber info to client separately.

### DIFF
--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -233,6 +233,7 @@ class SubscriptionStreamDict(TypedDict):
     stream_post_policy: int
     stream_weekly_traffic: int | None
     subscribers: NotRequired[list[int]]
+    partial_subscribers: NotRequired[list[int]]
     wildcard_mentions_notify: bool | None
 
 
@@ -259,6 +260,7 @@ class NeverSubscribedStreamDict(TypedDict):
     stream_post_policy: int
     stream_weekly_traffic: int | None
     subscribers: NotRequired[list[int]]
+    partial_subscribers: NotRequired[list[int]]
 
 
 class DefaultStreamDict(TypedDict):


### PR DESCRIPTION
We're doing this so that the client can keep track of which channels it might need to request full subscriber data from, and which already have full subscriber data.

As discussed [here]([#api design > trimming subscriber data #34244 @ 💬](https://chat.zulip.org/#narrow/channel/378-api-design/topic/trimming.20subscriber.20data.20.2334244/near/2142215))

Part of  #34244 