### PR TITLE
postgresql: Remove inaccurate comment.

### DIFF
--- a/puppet/zulip/templates/postgresql/13/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/13/postgresql.conf.template.erb
@@ -833,11 +833,11 @@ primary_conninfo = 'host=<%= @replication_primary %> user=<%= @replication_user 
 <% end -%>
 
 <% unless @ssl_cert_file.nil? -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
+ssl_cert_file = '<%= @ssl_cert_file %>'
 <% end -%>
 <% unless @ssl_key_file.nil? -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
+ssl_key_file = '<%= @ssl_key_file %>'
 <% end -%>
 <% unless @ssl_ca_file.nil? -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
+ssl_ca_file = '<%= @ssl_ca_file %>'
 <% end -%>

--- a/puppet/zulip/templates/postgresql/14/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/14/postgresql.conf.template.erb
@@ -854,11 +854,11 @@ primary_conninfo = 'host=<%= @replication_primary %> user=<%= @replication_user 
 <% end -%>
 
 <% unless @ssl_cert_file.nil? -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
+ssl_cert_file = '<%= @ssl_cert_file %>'
 <% end -%>
 <% unless @ssl_key_file.nil? -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
+ssl_key_file = '<%= @ssl_key_file %>'
 <% end -%>
 <% unless @ssl_ca_file.nil? -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
+ssl_ca_file = '<%= @ssl_ca_file %>'
 <% end -%>

--- a/puppet/zulip/templates/postgresql/zulip.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/zulip.conf.template.erb
@@ -54,11 +54,11 @@ primary_conninfo = 'host=<%= @replication_primary %> user=<%= @replication_user 
 <% end -%>
 
 <% unless @ssl_cert_file.nil? -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
+ssl_cert_file = '<%= @ssl_cert_file %>'
 <% end -%>
 <% unless @ssl_key_file.nil? -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
+ssl_key_file = '<%= @ssl_key_file %>'
 <% end -%>
 <% unless @ssl_ca_file.nil? -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
+ssl_ca_file = '<%= @ssl_ca_file %>'
 <% end -%>


### PR DESCRIPTION
PostgreSQL 10 and later can adjust their TLS configuration without a restart, with `SELECT pg_reload_conf()` or `pg_ctlcluster 16 main reload`.

-----

Ironically, of course, this adjustment will trigger a server restart.