### PR TITLE
message_row: Restore copy button in edit textbox.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -780,6 +780,10 @@
     }
 
     .message-edit-textbox {
+        /* Setting `position:relative` on this container ensures that .copy-button
+           (a possible immediate child with `position: absolute`) is positioned
+           relative to this container instead of <html>. */
+        position: relative;
         grid-area: message-edit-content;
 
         .textarea-over-limit {


### PR DESCRIPTION

**Screenshots and screen captures:**
| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/7d3fa57e-bfd7-4b17-8f67-8276b08244f7)|![after](https://github.com/user-attachments/assets/0a490d13-878c-4238-a69c-0feecb3a71e5) |

Fixes: [#feedback > Copy button for View Original Message](https://chat.zulip.org/#narrow/channel/137-feedback/topic/Copy.20button.20for.20View.20Original.20Message)