### PR TITLE
message_row: Content box improvements and corrections.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -105,7 +105,7 @@
         ensures the timestamp will always have enough space
         in the column. */
     grid-template:
-        var(--message-box-sender-line-height) repeat(3, auto) /
+        minmax(var(--message-box-sender-line-height), auto) repeat(3, auto) /
         var(--message-box-avatar-column-width) minmax(0, 1fr) max-content
         8px minmax(var(--message-box-timestamp-column-width), max-content);
     /* Named grid areas provide flexibility for positioning grid items
@@ -470,13 +470,11 @@
        of the row; inner flexboxes handle the
        centering of the icons. */
     align-self: stretch;
-    /* But to better set the height to the typical
-       sender-row line height for better centering
-       in all contexts. */
-    height: var(--message-box-sender-line-height);
+    /* Controls flex to the height of the top
+       row of the message box, and center
+       themselves within it. */
     display: flex;
-    /* The flexbox here matches the height set above. */
-    align-items: stretch;
+    align-items: center;
     /* Ensure square icons for better centering. */
     line-height: 1;
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -146,6 +146,7 @@
 
     .message_content {
         grid-area: message;
+        padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
         color: var(--color-text-message-default);
         /* We explicitly set line-height here so that
            the message area is not beholden to the legacy
@@ -376,7 +377,6 @@
         }
 
         .message_content {
-            padding: var(--message-box-markdown-aligned-vertical-space) 0 0;
             /* Pull message content up closer to sender to
                let the text baseline sit adjacent the bottom
                of the avatar. We also need to account for the

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -156,6 +156,16 @@
         position: relative;
         overflow: hidden;
 
+        /* For the sake of paragraphs and lists that include
+           links, we adjust the vertical space here to keep
+           it uniform. */
+        &:has(> p:first-child, > ol:first-child, > ul:first-child) {
+            padding-top: calc(
+                var(--message-box-markdown-aligned-vertical-space) -
+                    var(--message-box-link-focus-ring-block-padding)
+            );
+        }
+
         &:empty {
             display: none;
         }
@@ -379,16 +389,6 @@
                     var(--message-box-markdown-aligned-vertical-space)
             );
             grid-area: message;
-        }
-
-        /* For the sake of paragraphs and lists that include
-           links, we adjust the vertical space here to keep
-           it uniform. */
-        .message_content:has(p:first-child, ol:first-child, ul:first-child) {
-            padding-top: calc(
-                var(--message-box-markdown-aligned-vertical-space) -
-                    var(--message-box-link-focus-ring-block-padding)
-            );
         }
 
         .slow-send-spinner {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -23,9 +23,9 @@
     /* To avoid cutting off the focus ring on links, we set
        padding on first children most likely to take links.
        We account for this extra space on `.message_content`. */
-    & p:first-child,
-    & ul:first-child,
-    & ol:first-child {
+    & > p:first-child,
+    & > ul:first-child,
+    & > ol:first-child {
         padding-top: var(--message-box-link-focus-ring-block-padding);
     }
 


### PR DESCRIPTION
This PR does three things:

1. It better targets first child paragraph blocks in `.message_content` with more specific selectors.
2. It restores padding that was accidentally (?) removed from non-sender-containing messages in #33985.
3. It adjusts the message-box grid definition to account for the restored padding, ensuring that stars/hover controls remain optimally aligned regardless of what content opens a message (the original aim of #33985).

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Spoiler.20alignment)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![corrected-message-box-before](https://github.com/user-attachments/assets/ce505362-1c85-480b-8863-2661c48420cd) | ![corrected-message-box-after](https://github.com/user-attachments/assets/843f9a71-d44b-4fe5-9ff4-da3d101eefa6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>