### PR TITLE
message_feed UI: Update logo dimensions for better scalability.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -241,9 +241,9 @@ p.n-margin {
 .alert-zulip-logo,
 .top-messages-logo,
 .bottom-messages-logo {
-    width: 24px;
-    height: 24px;
-    margin: 0 auto 12px;
+    width: 1.7143em; /* 24px at 14px/em */
+    height: 1.7143em;
+    margin: 0 auto 0.8571em; /* 12px at 14px/em */
 
     & svg {
         & circle {
@@ -267,10 +267,6 @@ p.n-margin {
     /* Since padding under message header is not transparent
        we need to position it below the padding. */
     padding-top: var(--header-padding-bottom);
-    margin-bottom: 0;
-    /* To fit the logo inside the spinner. */
-    position: relative;
-    top: -2px;
 }
 
 /* See https://web.dev/animations-guide/#triggers before adding any funny animation properties here. */
@@ -1229,13 +1225,20 @@ nav {
 #loading_newer_messages_indicator_box_container {
     position: absolute;
     left: 50%;
+
+    /* Override the base rules in app_components.css, which would require
+       coordination with loading.make_indicator */
+    .loading_indicator_spinner {
+        height: 2.7143em; /* 38px at 14px/em */
+        width: 2.7143em; /* 38px at 14px/em */
+    }
 }
 
 #loading_older_messages_indicator_box,
 #loading_newer_messages_indicator_box {
     position: relative;
-    left: -50%;
-    top: -43px;
+    left: -1.3571em; /* 50% of 38px = 19px at 14px/em */
+    top: -3.0714em; /* -43px at 14px/em */
     z-index: 1;
     border-radius: 6px;
 }


### PR DESCRIPTION
change 'z' logo dimensions so that it scales according to chosen font size.

Fixes: #34266 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### before (12px )
![image](https://github.com/user-attachments/assets/f440deb9-1a19-42f1-9c22-fb7cda519736)
![image](https://github.com/user-attachments/assets/dfbecaf4-b634-46c3-bf6e-d72b8b1b3d64)
### before (20px)
![image](https://github.com/user-attachments/assets/ad190299-68e0-46fb-bdea-b59cdabad75f) 
![image](https://github.com/user-attachments/assets/94061a01-27fb-41cd-93a6-f19680049cb9)

### after (12px)
![image](https://github.com/user-attachments/assets/c2a00405-3c90-4fc0-968f-46fdb8a8f9a4)
![image](https://github.com/user-attachments/assets/a6b52664-54d7-48ab-af61-5705b0d00819)


### after (20px)
![image](https://github.com/user-attachments/assets/b88a16b8-273d-45b2-b9c3-8b0295ba1231)
![image](https://github.com/user-attachments/assets/6e5896a0-da41-4cd4-808e-41f915a65011)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
