### PR TITLE
Avoid prefetching DM permission group settings.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1577,7 +1577,7 @@ def check_can_send_direct_message(
         or direct_message_permission_group.named_user_group.name != SystemGroups.EVERYONE
     ):
         user_ids = [recipient_user.id for recipient_user in recipient_users] + [sender.id]
-        if not is_any_user_in_group(direct_message_permission_group, user_ids):
+        if not is_any_user_in_group(direct_message_permission_group.id, user_ids):
             is_nobody_group = (
                 hasattr(direct_message_permission_group, "named_user_group")
                 and direct_message_permission_group.named_user_group.name == SystemGroups.NOBODY
@@ -1589,7 +1589,7 @@ def check_can_send_direct_message(
         not hasattr(direct_message_initiator_group, "named_user_group")
         or direct_message_initiator_group.named_user_group.name != SystemGroups.EVERYONE
     ):
-        if is_user_in_group(direct_message_initiator_group, sender):
+        if is_user_in_group(direct_message_initiator_group.id, sender):
             return
 
         # TODO: This check is inefficient; we should in the future be able to cache

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -527,6 +527,10 @@ def active_non_guest_user_ids_cache_key(realm_id: int) -> str:
     return f"active_non_guest_user_ids:{realm_id}"
 
 
+def get_realm_system_groups_cache_key(realm_id: int) -> str:
+    return f"realm_system_groups:{realm_id}"
+
+
 bot_dict_fields: list[str] = [
     "api_key",
     "avatar_source",

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -126,10 +126,6 @@ def get_usable_missed_message_address(address: str) -> MissedMessageEmailAddress
             # can send a direct message to a given recipient.
             "user_profile__realm__can_access_all_users_group",
             "user_profile__realm__can_access_all_users_group__named_user_group",
-            "user_profile__realm__direct_message_initiator_group",
-            "user_profile__realm__direct_message_initiator_group__named_user_group",
-            "user_profile__realm__direct_message_permission_group",
-            "user_profile__realm__direct_message_permission_group__named_user_group",
             "message",
             "message__sender",
             "message__recipient",

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -755,10 +755,6 @@ def get_user_group_direct_member_ids(
     ).values_list("user_profile_id", flat=True)
 
 
-def get_user_group_direct_members(user_group: UserGroup) -> QuerySet[UserProfile]:
-    return user_group.direct_members.filter(is_active=True)
-
-
 def get_direct_memberships_of_users(user_group: UserGroup, members: list[UserProfile]) -> list[int]:
     # Returns the subset of the provided members list who are direct subscribers of the group.
     # If a deactivated user is passed, it will be returned if the user was a member of the
@@ -849,25 +845,31 @@ def user_has_permission_for_group_setting(
     if not setting_config.allow_everyone_group and user.is_guest:
         return False
 
-    return is_user_in_group(user_group, user, direct_member_only=direct_member_only)
+    return is_user_in_group(user_group.id, user, direct_member_only=direct_member_only)
+
+
+def is_any_user_direct_member(user_group_id: int, user_ids: Iterable[int]) -> bool:
+    return UserGroupMembership.objects.filter(
+        user_group_id=user_group_id, user_profile__is_active=True, user_profile_id__in=user_ids
+    ).exists()
 
 
 def is_user_in_group(
-    user_group: UserGroup, user: UserProfile, *, direct_member_only: bool = False
+    user_group_id: int, user: UserProfile, *, direct_member_only: bool = False
 ) -> bool:
     if direct_member_only:
-        return get_user_group_direct_members(user_group=user_group).filter(id=user.id).exists()
+        return is_any_user_direct_member(user_group_id, [user.id])
 
-    return get_recursive_group_members(user_group_id=user_group.id).filter(id=user.id).exists()
+    return get_recursive_group_members(user_group_id=user_group_id).filter(id=user.id).exists()
 
 
 def is_any_user_in_group(
-    user_group: UserGroup, user_ids: Iterable[int], *, direct_member_only: bool = False
+    user_group_id: int, user_ids: Iterable[int], *, direct_member_only: bool = False
 ) -> bool:
     if direct_member_only:
-        return get_user_group_direct_members(user_group=user_group).filter(id__in=user_ids).exists()
+        return is_any_user_direct_member(user_group_id, user_ids)
 
-    return get_recursive_group_members(user_group_id=user_group.id).filter(id__in=user_ids).exists()
+    return get_recursive_group_members(user_group_id=user_group_id).filter(id__in=user_ids).exists()
 
 
 def get_user_group_member_ids(

--- a/zerver/models/groups.py
+++ b/zerver/models/groups.py
@@ -4,6 +4,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext_lazy
 from django_cte import CTEManager
 
+from zerver.lib.cache import cache_with_key, get_realm_system_groups_cache_key
 from zerver.lib.types import GroupPermissionSetting
 from zerver.models.users import UserProfile
 
@@ -186,3 +187,11 @@ class GroupGroupMembership(models.Model):
                 fields=["supergroup", "subgroup"], name="zerver_groupgroupmembership_uniq"
             )
         ]
+
+
+@cache_with_key(get_realm_system_groups_cache_key, timeout=3600 * 24 * 7)
+def get_realm_system_groups_name_dict(realm_id: int) -> dict[int, str]:
+    system_groups = NamedUserGroup.objects.filter(
+        realm_id=realm_id, is_system_group=True
+    ).values_list("id", "name")
+    return dict(system_groups)

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -942,10 +942,6 @@ def base_get_user_queryset() -> QuerySet[UserProfile]:
         "realm",
         "realm__can_access_all_users_group",
         "realm__can_access_all_users_group__named_user_group",
-        "realm__direct_message_initiator_group",
-        "realm__direct_message_initiator_group__named_user_group",
-        "realm__direct_message_permission_group",
-        "realm__direct_message_permission_group__named_user_group",
         "bot_owner",
     )
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -7862,7 +7862,7 @@ class LDAPGroupSyncTest(ZulipTestCase):
 
             self.assertFalse(
                 is_user_in_group(
-                    user_group,
+                    user_group.id,
                     hamlet,
                     direct_member_only=True,
                 )
@@ -7871,7 +7871,7 @@ class LDAPGroupSyncTest(ZulipTestCase):
             sync_user_from_ldap(hamlet, mock.Mock())
             self.assertTrue(
                 is_user_in_group(
-                    user_group,
+                    user_group.id,
                     hamlet,
                     direct_member_only=True,
                 )
@@ -7889,7 +7889,7 @@ class LDAPGroupSyncTest(ZulipTestCase):
 
             self.assertTrue(
                 is_user_in_group(
-                    NamedUserGroup.objects.get(realm=realm, name="cool_test_group"),
+                    NamedUserGroup.objects.get(realm=realm, name="cool_test_group").id,
                     cordelia,
                     direct_member_only=True,
                 )
@@ -7900,7 +7900,7 @@ class LDAPGroupSyncTest(ZulipTestCase):
 
             self.assertFalse(
                 is_user_in_group(
-                    NamedUserGroup.objects.get(realm=realm, name="cool_test_group"),
+                    NamedUserGroup.objects.get(realm=realm, name="cool_test_group").id,
                     cordelia,
                     direct_member_only=True,
                 )

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1267,7 +1267,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("othello")
 
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message
@@ -1312,7 +1312,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = self.example_email("cordelia")
 
-        with self.assert_database_query_count(21):
+        with self.assert_database_query_count(22):
             process_message(incoming_valid_message)
 
         # Confirm Iago received the message.

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -363,7 +363,7 @@ class TestQueryCounts(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(16):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1029,7 +1029,7 @@ class InviteUserTest(InviteUserBase):
             verona, "can_add_subscribers_group", members_group, acting_user=current_user
         )
         invitee = self.nonreg_email("newguy")
-        self.assertEqual(is_user_in_group(admins_group, current_user), False)
+        self.assertEqual(is_user_in_group(admins_group.id, current_user), False)
         self.assert_json_success(
             self.invite(
                 invitee,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -985,7 +985,7 @@ class StreamAdminTest(ZulipTestCase):
             "is_private": orjson.dumps(False).decode(),
         }
         stream = self.subscribe(user_profile, "private_stream_2")
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(f"/json/streams/{stream.id}", params)
         self.assertTrue(stream.invite_only)
         self.assert_json_error(result, "You do not have permission to administer this channel.")
@@ -1069,7 +1069,7 @@ class StreamAdminTest(ZulipTestCase):
             "is_private": orjson.dumps(True).decode(),
         }
         stream = self.subscribe(user_profile, "public_stream_2")
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(f"/json/streams/{stream.id}", params)
         self.assertFalse(stream.invite_only)
         self.assert_json_error(result, "You do not have permission to administer this channel.")
@@ -1265,7 +1265,7 @@ class StreamAdminTest(ZulipTestCase):
             "is_web_public": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
         }
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "You do not have permission to administer this channel.")
 
@@ -1371,7 +1371,7 @@ class StreamAdminTest(ZulipTestCase):
             "is_web_public": orjson.dumps(True).decode(),
             "history_public_to_subscribers": orjson.dumps(True).decode(),
         }
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "You do not have permission to administer this channel.")
 
@@ -1461,7 +1461,7 @@ class StreamAdminTest(ZulipTestCase):
         params = {
             "is_default_stream": orjson.dumps(True).decode(),
         }
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "You do not have permission to administer this channel.")
         self.assertFalse(stream_id in get_default_stream_ids_for_realm(realm.id))
@@ -1501,7 +1501,7 @@ class StreamAdminTest(ZulipTestCase):
 
         # User still needs to be an admin to remove a default channel.
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
-        self.assertTrue(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertTrue(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         self.assertTrue(stream_id in get_default_stream_ids_for_realm(realm.id))
         result = self.client_patch(f"/json/streams/{stream_id}", params)
         self.assert_json_error(result, "You do not have permission to change default channels.")
@@ -2012,7 +2012,7 @@ class StreamAdminTest(ZulipTestCase):
         self.make_stream("new_stream")
         stream = self.subscribe(user_profile, "new_stream")
 
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_delete(f"/json/streams/{stream.id}")
         self.assert_json_error(result, "You do not have permission to administer this channel.")
 
@@ -2266,7 +2266,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(user_profile, "stream_name1")
 
         stream_id = get_stream("stream_name1", user_profile.realm).id
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(f"/json/streams/{stream_id}", {"new_name": "stream_name2"})
         self.assert_json_error(result, "You do not have permission to administer this channel.")
 
@@ -2548,7 +2548,7 @@ class StreamAdminTest(ZulipTestCase):
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
 
         stream = get_stream("stream_name1", user_profile.realm)
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, user_profile))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, user_profile))
         result = self.client_patch(
             f"/json/streams/{stream.id}", {"description": "Test description"}
         )
@@ -2769,7 +2769,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         shiva = self.example_user("shiva")
         self.login_user(shiva)
-        self.assertFalse(is_user_in_group(stream.can_administer_channel_group, shiva))
+        self.assertFalse(is_user_in_group(stream.can_administer_channel_group_id, shiva))
 
         params = {}
         params[setting_name] = orjson.dumps({"new": moderators_system_group.id}).decode()
@@ -2931,7 +2931,7 @@ class StreamAdminTest(ZulipTestCase):
             shiva_group_member_dict,
             acting_user=shiva,
         )
-        self.assertTrue(is_user_in_group(stream.can_administer_channel_group, shiva))
+        self.assertTrue(is_user_in_group(stream.can_administer_channel_group_id, shiva))
         params[setting_name] = orjson.dumps({"new": owners_group.id}).decode()
         self.login_user(shiva)
         result = self.client_patch(

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -481,19 +481,19 @@ class UserGroupTestCase(ZulipTestCase):
             name=SystemGroups.ADMINISTRATORS, realm=realm, is_system_group=True
         )
 
-        self.assertTrue(is_user_in_group(moderators_group, shiva))
+        self.assertTrue(is_user_in_group(moderators_group.id, shiva))
 
         # Iago is member of a subgroup of moderators group.
-        self.assertTrue(is_user_in_group(moderators_group, iago))
-        self.assertFalse(is_user_in_group(moderators_group, iago, direct_member_only=True))
-        self.assertTrue(is_user_in_group(administrators_group, iago, direct_member_only=True))
+        self.assertTrue(is_user_in_group(moderators_group.id, iago))
+        self.assertFalse(is_user_in_group(moderators_group.id, iago, direct_member_only=True))
+        self.assertTrue(is_user_in_group(administrators_group.id, iago, direct_member_only=True))
 
-        self.assertFalse(is_user_in_group(moderators_group, hamlet))
-        self.assertFalse(is_user_in_group(moderators_group, hamlet, direct_member_only=True))
+        self.assertFalse(is_user_in_group(moderators_group.id, hamlet))
+        self.assertFalse(is_user_in_group(moderators_group.id, hamlet, direct_member_only=True))
 
         do_deactivate_user(iago, acting_user=None)
-        self.assertFalse(is_user_in_group(moderators_group, iago))
-        self.assertFalse(is_user_in_group(administrators_group, iago, direct_member_only=True))
+        self.assertFalse(is_user_in_group(moderators_group.id, iago))
+        self.assertFalse(is_user_in_group(administrators_group.id, iago, direct_member_only=True))
 
     def test_is_any_user_in_group(self) -> None:
         realm = get_realm("zulip")
@@ -509,23 +509,25 @@ class UserGroupTestCase(ZulipTestCase):
             name=SystemGroups.ADMINISTRATORS, realm=realm, is_system_group=True
         )
 
-        self.assertTrue(is_any_user_in_group(moderators_group, [shiva, hamlet, polonius]))
+        self.assertTrue(is_any_user_in_group(moderators_group.id, [shiva, hamlet, polonius]))
 
         # Iago is member of a subgroup of moderators group.
-        self.assertTrue(is_any_user_in_group(moderators_group, [iago, hamlet, polonius]))
+        self.assertTrue(is_any_user_in_group(moderators_group.id, [iago, hamlet, polonius]))
         self.assertFalse(
             is_any_user_in_group(
-                moderators_group, [iago, hamlet, polonius], direct_member_only=True
+                moderators_group.id, [iago, hamlet, polonius], direct_member_only=True
             )
         )
         self.assertTrue(
             is_any_user_in_group(
-                administrators_group, [iago, shiva, hamlet], direct_member_only=True
+                administrators_group.id, [iago, shiva, hamlet], direct_member_only=True
             )
         )
 
-        self.assertFalse(is_any_user_in_group(moderators_group, [hamlet, polonius]))
-        self.assertFalse(is_any_user_in_group(moderators_group, [hamlet], direct_member_only=True))
+        self.assertFalse(is_any_user_in_group(moderators_group.id, [hamlet, polonius]))
+        self.assertFalse(
+            is_any_user_in_group(moderators_group.id, [hamlet], direct_member_only=True)
+        )
 
     def test_has_user_group_access_for_subgroup(self) -> None:
         iago = self.example_user("iago")

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -522,7 +522,7 @@ def get_is_user_group_member(
         request,
         data={
             "is_user_group_member": is_user_in_group(
-                user_group, target_user, direct_member_only=direct_member_only
+                user_group.id, target_user, direct_member_only=direct_member_only
             )
         },
     )


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is a refactor commit.
- Second commit is to not prefetch DM permission group settings.

Fixes part of #33677. <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
