### PR TITLE
upload: Fix send button disabled when compose is closed during upload.

### DIFF
--- a/web/src/upload.ts
+++ b/web/src/upload.ts
@@ -139,7 +139,11 @@ export let hide_upload_banner = (
         config.upload_banner(file_id).remove();
     }
 
-    if (uppy.getFiles().every((e) => e.progress.uploadComplete)) {
+    // Allow sending the message if all uploads are complete or cancelled.
+    if (
+        uppy.getFiles().every((e) => e.progress.uploadComplete) ||
+        Object.keys(uppy.getState().currentUploads).length === 0
+    ) {
         if (config.mode === "compose") {
             compose_validate.set_upload_in_progress(false);
         } else {
@@ -547,6 +551,12 @@ export function setup_upload(config: Config): Uppy<Meta, TusBody> {
         assert(file !== undefined);
         compose_ui.replace_syntax(get_translated_status(file), "", config.textarea());
         compose_ui.autosize_textarea(config.textarea());
+    });
+
+    uppy.on("cancel-all", () => {
+        if (config.mode === "compose") {
+            compose_validate.set_upload_in_progress(false);
+        }
     });
 
     return uppy;

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -487,7 +487,7 @@ test("uppy_events", ({override_rewire, mock_template}) => {
         };
     };
     upload.setup_upload(upload.compose_config);
-    assert.equal(Object.keys(callbacks).length, 5);
+    assert.equal(Object.keys(callbacks).length, 6);
 
     const on_upload_success_callback = callbacks["upload-success"];
     const file = {


### PR DESCRIPTION
While uploading a file, if you close the compose box, and reopen it, compose send button remains disabled due to upload in progress being true.

To fix it, we update upload status for compose when upload is cancelled.

discussion: https://chat.zulip.org/#narrow/channel/9-issues/topic/leaked.20uploading.20files.20state