### PR TITLE
settings: Ensure focus remains confined to overlays.

### DIFF
--- a/web/src/overlay_util.ts
+++ b/web/src/overlay_util.ts
@@ -13,3 +13,51 @@ export function disable_scrolling(): void {
 export function enable_scrolling(): void {
     $("html").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
 }
+
+/*
+ * Trap keyboard focus within an overlay container with visible focus indicators
+ */
+export function trap_focus($container: JQuery): () => void {
+    const $focusableElements = $container
+        .find('a[href], button, input, textarea, select, [tabindex]:not([tabindex="-1"])')
+        .filter(":visible");
+    const $firstFocusable = $focusableElements.first();
+    const $lastFocusable = $focusableElements.last();
+
+    const $startSentinel = $(document.createElement("div"))
+        .attr("tabindex", "0")
+        .attr("aria-hidden", "true")
+        .addClass("focus-sentinel");
+    const $endSentinel = $(document.createElement("div"))
+        .attr("tabindex", "0")
+        .attr("aria-hidden", "true")
+        .addClass("focus-sentinel");
+
+    $container.prepend($startSentinel);
+    $container.append($endSentinel);
+
+    const handleFocus = (e: JQuery.TriggeredEvent): void => {
+        if (e.target === $startSentinel[0] && $lastFocusable.length > 0) {
+            $lastFocusable[0]!.focus();
+        } else if (e.target === $endSentinel[0] && $firstFocusable.length > 0) {
+            $firstFocusable[0]!.focus();
+        }
+    };
+
+    $startSentinel.on("focus", handleFocus);
+    $endSentinel.on("focus", handleFocus);
+
+    setTimeout(() => {
+        if ($firstFocusable.length > 0) {
+            $firstFocusable[0]!.focus({preventScroll: true});
+        } else {
+            $container.attr("tabindex", "0");
+            $container[0]!.focus({preventScroll: true});
+        }
+    }, 0);
+
+    return () => {
+        $startSentinel.off("focus", handleFocus).remove();
+        $endSentinel.off("focus", handleFocus).remove();
+    };
+}

--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -14,6 +14,7 @@ type OverlayOptions = {
 type Overlay = {
     $element: JQuery;
     close_handler: () => void;
+    remove_focus_trap: () => void;
 };
 
 let active_overlay: Overlay | undefined;
@@ -23,6 +24,9 @@ const pre_open_hooks: Hook[] = [];
 const pre_close_hooks: Hook[] = [];
 
 function reset_state(): void {
+    if (active_overlay) {
+        active_overlay.remove_focus_trap();
+    }
     active_overlay = undefined;
     open_overlay_name = undefined;
 }
@@ -110,7 +114,9 @@ export function open_overlay(opts: OverlayOptions): void {
             opts.on_close();
             reset_state();
         },
+        remove_focus_trap: overlay_util.trap_focus(opts.$overlay),
     };
+
     if (document.activeElement) {
         $(document.activeElement).trigger("blur");
     }
@@ -140,6 +146,9 @@ export function close_overlay(name: string): void {
     }
 
     blueslip.debug("close overlay: " + name);
+
+    active_overlay.remove_focus_trap();
+
     active_overlay.$element.removeClass("show");
 
     active_overlay.$element.attr("aria-hidden", "true");

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -292,6 +292,11 @@ input::placeholder {
             outline: none;
         }
 
+        &:focus-visible {
+            outline: 1px solid var(--color-outline-focus);
+            outline-offset: -2px;
+        }
+
         &:not(.selected) {
             border: 1px solid var(--color-border-tab-switcher-ind-tab);
         }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1464,6 +1464,12 @@ label.preferences-radio-choice-label {
                 background-color: var(--color-active-row-modal);
             }
 
+            &:focus-visible {
+                border-radius: 4px;
+                outline: 1px solid var(--color-outline-focus);
+                outline-offset: -2px;
+            }
+
             .sidebar-item-icon {
                 font-size: 1.4em;
                 text-align: center;


### PR DESCRIPTION
<!-- Describe your pull request here. -->

This PR improves the accessibility and user experience of overlays by ensuring that keyboard focus is properly constrained within active overlays. Previously, users could unintentionally tab out of an overlay and interact with elements behind it, which could lead to confusing behavior or unwanted side effects.

To address this, the PR introduces a new `trap_focus()` utility function that programmatically traps focus within a given container using two invisible sentinel elements placed at the beginning and end of the focusable content. When users tab past the last focusable element, focus is cycled back to the other end, keeping it strictly within the overlay.

The `trap_focus()` function is automatically applied when an overlay is opened and properly removed when the overlay is closed, ensuring that focus management stays clean and predictable.

Alongside the functional changes, this PR adds `:focus-visible` styles for key interactive components inside overlays to clearly indicate keyboard focus, improving visual feedback for accessibility.

Fixes: #26941

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


<video src="https://github.com/user-attachments/assets/3871ca18-f8fa-4955-bb32-d58bdce19937" controls></video>



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability.
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
