### PR TITLE
peer_data: Process partial_subscriber data.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -6,6 +6,7 @@ import * as sub_store from "./sub_store.ts";
 
 // This maps a stream_id to a LazySet of user_ids who are subscribed.
 const stream_subscribers = new Map<number, LazySet>();
+const fetched_stream_ids = new Set<number>();
 
 export function clear_for_testing(): void {
     stream_subscribers.clear();
@@ -95,9 +96,12 @@ export function get_subscribers(stream_id: number): number[] {
     return [...subscribers.keys()];
 }
 
-export function set_subscribers(stream_id: number, user_ids: number[]): void {
+export function set_subscribers(stream_id: number, user_ids: number[], full_data = true): void {
     const subscribers = new LazySet(user_ids);
     stream_subscribers.set(stream_id, subscribers);
+    if (full_data) {
+        fetched_stream_ids.add(stream_id);
+    }
 }
 
 export function add_subscriber(stream_id: number, user_id: number): void {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -925,7 +925,11 @@ export function create_sub_from_server_data(
         ...attrs,
     };
 
-    peer_data.set_subscribers(sub.stream_id, subscriber_user_ids ?? []);
+    if (attrs.partial_subscribers !== undefined) {
+        peer_data.set_subscribers(sub.stream_id, attrs.partial_subscribers, false);
+    } else {
+        peer_data.set_subscribers(sub.stream_id, subscriber_user_ids ?? []);
+    }
 
     clean_up_description(sub);
 

--- a/web/src/stream_types.ts
+++ b/web/src/stream_types.ts
@@ -57,6 +57,7 @@ export const api_stream_schema = stream_schema.extend({
 
 export const never_subscribed_stream_schema = api_stream_schema.extend({
     subscribers: z.array(z.number()).optional(),
+    partial_subscribers: z.array(z.number()).optional(),
 });
 
 export const stream_properties_schema = stream_specific_notification_settings_schema.extend({
@@ -70,6 +71,7 @@ export const api_stream_subscription_schema = api_stream_schema
     .merge(stream_properties_schema)
     .extend({
         subscribers: z.array(z.number()).optional(),
+        partial_subscribers: z.array(z.number()).optional(),
     });
 
 export const updatable_stream_properties_schema = api_stream_subscription_schema.extend({

--- a/web/tests/stream_data.test.cjs
+++ b/web/tests/stream_data.test.cjs
@@ -1005,6 +1005,7 @@ test("create_sub", () => {
         name: "Antarctica",
         subscribed: true,
         color: "#76ce90",
+        partial_subscribers: [1, 2, 3],
     };
 
     const india_sub = stream_data.create_sub_from_server_data(india);
@@ -1024,6 +1025,7 @@ test("create_sub", () => {
     const antarctica_sub = stream_data.create_sub_from_server_data(antarctica);
     assert.ok(antarctica_sub);
     assert.equal(antarctica_sub.color, "#76ce90");
+    assert.deepEqual(antarctica_sub.partial_subscribers, [1, 2, 3]);
 });
 
 test("creator_id", ({override}) => {


### PR DESCRIPTION
Work towards #34244. This shouldn't change production at all, since we only send partial_subscribers when a dev flag is set.