### PR TITLE
settings_tables: Fix background color, heading collapsing.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -770,9 +770,12 @@ input.settings_text_input {
         }
     }
 
+    & thead {
+        background-color: var(--color-background-table-header);
+    }
+
     & thead th {
         color: inherit;
-        background-color: var(--color-background-table-header);
         word-break: normal;
 
         .table-sortable-arrow {
@@ -805,7 +808,7 @@ input.settings_text_input {
             cursor: pointer;
             background-color: var(
                 --color-background-table-header-sortable-hover
-            ) !important;
+            );
             transition: background-color 100ms ease-in-out;
         }
     }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -772,7 +772,7 @@ input.settings_text_input {
 
     & thead th {
         color: inherit;
-        background-color: hsl(0deg 0% 100%);
+        background-color: var(--color-background-table-header);
         word-break: normal;
 
         .table-sortable-arrow {
@@ -803,7 +803,9 @@ input.settings_text_input {
 
         &[data-sort]:hover {
             cursor: pointer;
-            background-color: hsl(0deg 0% 95%) !important;
+            background-color: var(
+                --color-background-table-header-sortable-hover
+            ) !important;
             transition: background-color 100ms ease-in-out;
         }
     }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -775,6 +775,12 @@ input.settings_text_input {
     }
 
     & thead th {
+        /* Prevent headers from collapsing.
+           For headers that sort, this keeps
+           the icon on the same line as the
+           header text. */
+        min-width: max-content;
+        white-space: nowrap;
         color: inherit;
         word-break: normal;
 

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1462,6 +1462,14 @@
     );
 
     /* Settings table colors */
+    --color-background-table-header: light-dark(
+        hsl(0deg 0% 100%),
+        hsl(0deg 0% 0%)
+    );
+    --color-background-table-header-sortable-hover: light-dark(
+        hsl(0deg 0% 95%),
+        hsl(211deg 29% 14%)
+    );
     --color-border-table-striped: light-dark(
         hsl(0deg 0% 87%),
         hsl(0deg 0% 0% / 20%)

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -62,14 +62,6 @@
         }
     }
 
-    & table.table-striped thead.table-sticky-headers th {
-        background-color: hsl(0deg 0% 0%);
-
-        &[data-sort]:hover {
-            background-color: hsl(211deg 29% 14%) !important;
-        }
-    }
-
     /* Extend the 'light-border' TippyJS theme, which is intended for
        popovers/menus that should use default background colors, to use
        our dark theme colors in Zulip's dark theme.
@@ -374,11 +366,6 @@
         color: hsl(0deg 0% 100%);
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
-    }
-
-    .table-striped thead th {
-        background-color: hsl(0deg 0% 0% / 50%);
-        border-color: hsl(0deg 0% 0% / 90%);
     }
 
     & input[type="text"]:focus,


### PR DESCRIPTION
This PR includes two fixes mentioned in comments on #34263:

1. It fixes a bleed-through bug in Chrome where the underlying table background would appear at certain points between table-header cells. (This fix also removes the need for `!important` on the `:hover` style, and does some nice cleanup--including some unreachable styles--in `dark_theme.css`.)
2. It prevents table headers or their sort icon from wrapping onto a second line. Because tables are scrollable when they don't entirely fit in the viewport, the potentially wider columns are arguably nicer looking than their collapsing counterparts.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


| Before | After |
| --- | --- |
| ![table-headings-light-before](https://github.com/user-attachments/assets/8a0830a9-1f66-4e5a-bb81-5b54ea8f1ddb) | ![table-headings-light-after](https://github.com/user-attachments/assets/ee248572-660a-459c-885b-7a9cca3f7944) |
| ![table-headings-dark-before](https://github.com/user-attachments/assets/69a693f8-33bc-4d62-ba47-521d8c407aa6) | ![table-headings-dark-after](https://github.com/user-attachments/assets/710d8284-31b3-4a36-b83e-1e4a480ac207) |

_Scaling with resize, before (including Chrome cell bug) and after:_

| Before | After |
| --- | --- |
| ![table-scaling-before](https://github.com/user-attachments/assets/cb768e92-5f1b-48ff-a3d3-a5fe61a89ff8) | ![table-scaling-after](https://github.com/user-attachments/assets/62494327-712c-4101-8bbe-b0caa0440960) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
