### PR TITLE
stream_settings: Fix channel subscription jitter. 

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -688,7 +688,13 @@ export function initialize(): void {
                     sub.stream_id.toString(),
                 )}']`,
             );
-            stream_settings_components.sub_or_unsub(sub, $stream_row);
+            // If subscribe button on right-side panel is clicked, prevent
+            // displaying loading spinner in the stream row.
+            if ($(this).hasClass("subscribe-button")) {
+                stream_settings_components.sub_or_unsub(sub);
+            } else {
+                stream_settings_components.sub_or_unsub(sub, $stream_row);
+            }
 
             if (!sub.subscribed) {
                 open_edit_panel_for_row(util.the($stream_row));

--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -110,7 +110,7 @@ export function get_active_data(): {
 }
 
 /* For the given stream_row, remove the tick and replace by a spinner. */
-function display_subscribe_toggle_spinner($stream_row: JQuery): void {
+export function display_subscribe_toggle_spinner($stream_row: JQuery): void {
     /* Prevent sending multiple requests by removing the button class. */
     $stream_row.find(".check").removeClass("sub_unsub_button");
 
@@ -125,7 +125,7 @@ function display_subscribe_toggle_spinner($stream_row: JQuery): void {
 }
 
 /* For the given stream_row, add the tick and delete the spinner. */
-function hide_subscribe_toggle_spinner($stream_row: JQuery): void {
+export function hide_subscribe_toggle_spinner($stream_row: JQuery): void {
     /* Re-enable the button to handle requests. */
     $stream_row.find(".check").addClass("sub_unsub_button");
 
@@ -174,10 +174,6 @@ export function ajaxSubscribe(
                 );
             }
             // The rest of the work is done via the subscribe event we will get
-
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
         },
         error(xhr) {
             if ($stream_row !== undefined) {
@@ -203,10 +199,6 @@ function ajaxUnsubscribe(sub: StreamSubscription, $stream_row: JQuery | undefine
         success() {
             $(".stream_change_property_info").hide();
             // The rest of the work is done via the unsubscribe event we will get
-
-            if ($stream_row !== undefined) {
-                hide_subscribe_toggle_spinner($stream_row);
-            }
         },
         error(xhr) {
             if ($stream_row !== undefined) {

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -76,6 +76,16 @@ export function update_left_panel_row(sub: StreamSubscription): void {
         $new_row.addClass("active");
     }
 
+    // Show spinner in $new_row if $row contains spinner.
+    const show_spinner = $($row).find(".sub_unsub_status").children().length > 0;
+    if (show_spinner) {
+        stream_settings_components.display_subscribe_toggle_spinner($new_row);
+        // Hide toggle spinner for after 300ms.
+        setTimeout(() => {
+            stream_settings_components.hide_subscribe_toggle_spinner($new_row);
+        }, 300);
+    }
+
     $row.replaceWith($new_row);
 }
 

--- a/web/src/stream_ui_updates.ts
+++ b/web/src/stream_ui_updates.ts
@@ -503,7 +503,13 @@ export function enable_or_disable_add_subscribers_elements(
 
     if (!stream_creation) {
         const $add_subscribers_button = $container_elem.find(".add-subscriber-button").expectOne();
-        $add_subscribers_button.prop("disabled", !enable_elem);
+
+        if ($input_element.text().length === 0) {
+            $add_subscribers_button.prop("disabled", true);
+        } else {
+            $add_subscribers_button.prop("disabled", !enable_elem);
+        }
+
         if (enable_elem) {
             $add_subscribers_button.css("pointer-events", "");
         }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously, we were showing loading spinner in each stream's row on clicking the sub_unsub button which feels like jitter.

Now we are showing plus or checkmark icon directly instead of loading spinner on clicking the sub/unsub button on the right panel.

On clicking plus or checkmark on the left panel the spinner is still shown and sub/unsub still takes place.

Also the Add button remains unchanged on clicking subscribe/unsubscribe.

It was concluded during the discussion that there doesn’t appear to be a clear need for [this](https://github.com/zulip/zulip/pull/30845#discussion_r1699529642). To address the feedback regarding the spinner spinning indefinitely in case of an error, the spinner is initiated aand  hidden normally within `update_left_panel_row`, and incase of an error the spinner is hidden inside the `error` block in the api call. This ensures the spinner only stops when a request has been made and an error has occurred.

See screen captures for more clarity.

[CZO](https://chat.zulip.org/#narrow/channel/6-frontend/topic/missing.20features.20in.20loading.2Ets/near/2144953) discussion regarding the loader  

Fixes: #33250 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>screenshots and  screen captures: </summary>

## Before/ light mode
[Screencast from 2025-04-04 22-52-59.webm](https://github.com/user-attachments/assets/3e147318-c0b2-4d54-b0e3-c94cb5151cb6)

## After/ light mode
[Screencast from 2025-04-04 22-54-01.webm](https://github.com/user-attachments/assets/c7e755d9-e3bd-43cc-a090-a7ccecd14991)

## Before/Dark mode
[Screencast from 2025-04-04 22-52-08.webm](https://github.com/user-attachments/assets/bb17fb85-246d-4c68-b57b-3accc5896600)

## After/Dark mode
[Screencast from 2025-04-04 22-51-04.webm](https://github.com/user-attachments/assets/b80d2683-9e6e-41b3-850b-aaf46459bbf2)

## Spinner when subscribing/unsubscribing in left pannel
(latency of standard 300ms)

[Screencast from 2025-04-10 14-17-53.webm](https://github.com/user-attachments/assets/ec05dfcf-7e0f-4c27-964b-b989fece760b)



</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Calls out remaining decisions and concerns.
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
