### PR TITLE
compose: Show warning banner for unretrieved quoted message.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -47,6 +47,7 @@ export const CLASSNAMES = {
     private_stream_warning: "private_stream_warning",
     guest_in_dm_recipient_warning: "guest_in_dm_recipient_warning",
     unscheduled_message: "unscheduled_message",
+    quoting_in_progress: "quoting_in_progress",
     search_view: "search_view",
     // errors
     wildcards_not_allowed: "wildcards_not_allowed",

--- a/web/src/compose_setup.js
+++ b/web/src/compose_setup.js
@@ -102,6 +102,19 @@ export function initialize() {
 
     $("#compose form").on("submit", (e) => {
         e.preventDefault();
+
+        // Generates the banner for the first send try when message
+        // retrieval is still in progress.
+        // Removes it during the second try if still in progress.
+        compose_validate.warn_if_quoting_in_progress($("#compose_banners"));
+
+        if ($("#compose_banners").hasClass("showing-quoting-in-progress-banner")) {
+            return;
+        }
+        // The warning banner is now gone.
+        // We remove this css class flag as we've
+        // decided to send anyways with the placeholder.
+        $("#compose_banners").removeClass("message-content-quoting-in-progress");
         compose.finish();
     });
 
@@ -144,6 +157,29 @@ export function initialize() {
                 // would again show the wildcard warning banner when we actually send the message from 'send-later' modal.
                 compose_validate.set_user_acknowledged_stream_wildcard_flag(true);
             } else {
+                compose.finish();
+            }
+        },
+    );
+    $("body").on(
+        "click",
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.quoting_in_progress,
+        )} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+            const $edit_banners_container = $(event.target).closest(".edit_form_banners");
+            if ($edit_banners_container.length > 0) {
+                const $row = $edit_banners_container.closest(".message_row");
+                $edit_banners_container.removeClass("message-content-quoting-in-progress");
+                message_edit.save_message_row_edit($row);
+            } else {
+                // compose-box `Send` button.
+
+                // We remove this css class flag as well the banner as we've
+                // decided to send anyways with the placeholder.
+                compose_validate.clear_quoting_in_progress_warning($edit_banners_container);
+                $("#compose_banners").removeClass("message-content-quoting-in-progress");
                 compose.finish();
             }
         },

--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -454,6 +454,55 @@ export function warn_if_topic_resolved(topic_changed: boolean): void {
     }
 }
 
+export let clear_quoting_in_progress_warning = function ($banner_container: JQuery): void {
+    $banner_container
+        .find(`.${CSS.escape(compose_banner.CLASSNAMES.quoting_in_progress)}`)
+        .remove();
+    $banner_container.removeClass("showing-quoting-in-progress-banner");
+};
+
+export function rewire_clear_quoting_in_progress_warning(
+    value: typeof clear_quoting_in_progress_warning,
+): void {
+    clear_quoting_in_progress_warning = value;
+}
+
+export function warn_if_quoting_in_progress($banner_container: JQuery): void {
+    // We only show the warning banner if it is not triggered beforehand AND quoting is in progress.
+    // In case it is displayed beforehand, we remove it.
+    if (
+        $banner_container.hasClass("message-content-quoting-in-progress") &&
+        !$banner_container.hasClass("showing-quoting-in-progress-banner")
+    ) {
+        const button_text = $t({defaultMessage: "Send now"});
+        const is_edit_container = $banner_container.closest(".edit_form_banners").length > 0;
+        const context = {
+            banner_type: compose_banner.WARNING,
+            banner_text: $t({
+                defaultMessage: `Quoting is in progress. Consider waiting until it completes before sending your message.`,
+            }),
+            button_text,
+            classname: compose_banner.CLASSNAMES.quoting_in_progress,
+        };
+        if (is_edit_container) {
+            context.banner_text = $t({
+                defaultMessage: `Quoting is in progress. Consider waiting until it completes before saving your message.`,
+            });
+            context.button_text = $t({defaultMessage: "Save now"});
+        }
+        const new_row_html = render_compose_banner(context);
+        const appended = compose_banner.append_compose_banner_to_banner_list(
+            $(new_row_html),
+            $banner_container,
+        );
+        if (appended) {
+            $banner_container.addClass("showing-quoting-in-progress-banner");
+        }
+    } else {
+        clear_quoting_in_progress_warning($banner_container);
+    }
+}
+
 export function warn_if_in_search_view(): void {
     const filter = narrow_state.filter();
     if (filter && !filter.supports_collapsing_recipients()) {

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -378,6 +378,20 @@ function handle_keydown(
                 }
             } else {
                 // Enter
+
+                // Generates the banner for the first send try when message
+                // retrieval is still in progress.
+                // Removes it during the second try if still in progress.
+                compose_validate.warn_if_quoting_in_progress($("#compose_banners"));
+
+                if ($("#compose_banners").hasClass("showing-quoting-in-progress-banner")) {
+                    return;
+                }
+                // The warning banner is now gone.
+                // We remove this css class flag as we've
+                // decided to send anyways with the placeholder.
+                $("#compose_banners").removeClass("message-content-quoting-in-progress");
+
                 if (should_enter_send(e)) {
                     e.preventDefault();
                     if (

--- a/web/src/message_edit.ts
+++ b/web/src/message_edit.ts
@@ -1241,6 +1241,15 @@ export function save_message_row_edit($row: JQuery): void {
         }
     }
 
+    compose_validate.warn_if_quoting_in_progress($banner_container);
+    if ($banner_container.hasClass("showing-quoting-in-progress-banner")) {
+        // We are showing the warning, so won't save at this point.
+        // The next time this function is called in the same quoting state
+        // we will force save with the quoting placeholder.
+        return;
+    }
+    $banner_container.removeClass("message-content-quoting-in-progress");
+
     show_message_edit_spinner($row);
 
     // Editing a not-yet-acked message (because the original send attempt failed)

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -666,6 +666,7 @@ test_ui("trigger_submit_compose_form", ({override, override_rewire}) => {
     override_rewire(compose, "finish", () => {
         compose_finish_checked = true;
     });
+    override_rewire(compose_validate, "clear_quoting_in_progress_warning", noop);
 
     new FakeComposeBox().trigger_submit_handler_on_compose_form({
         preventDefault() {

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -87,6 +87,7 @@ const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 const compose_actions = zrequire("compose_actions");
 const compose_reply = zrequire("compose_reply");
+const compose_validate = zrequire("compose_validate");
 const message_lists = zrequire("message_lists");
 const stream_data = zrequire("stream_data");
 const compose_recipient = zrequire("compose_recipient");
@@ -448,6 +449,7 @@ test("quote_message", ({disallow, override, override_rewire}) => {
 
     override_rewire(compose_actions, "complete_starting_tasks", noop);
     override_rewire(compose_actions, "clear_textarea", noop);
+    override_rewire(compose_validate, "clear_quoting_in_progress_warning", noop);
     override_private_message_recipient({override});
 
     let selected_message;

--- a/web/tests/compose_ui.test.cjs
+++ b/web/tests/compose_ui.test.cjs
@@ -16,6 +16,9 @@ mock_esm("autosize", {default: autosize});
 mock_esm("../src/message_lists", {
     current: {},
 });
+mock_esm("../src/compose_validate", {
+    clear_quoting_in_progress_warning: noop,
+});
 
 const compose_ui = zrequire("compose_ui");
 const stream_data = zrequire("stream_data");

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -28,6 +28,7 @@ const compose_validate = mock_esm("../src/compose_validate", {
     stream_wildcard_mention_allowed: () => true,
     warn_if_mentioning_unsubscribed_group: noop,
     initialize: noop,
+    warn_if_quoting_in_progress: noop,
 });
 const input_pill = mock_esm("../src/input_pill");
 const message_user_ids = mock_esm("../src/message_user_ids", {


### PR DESCRIPTION
Fixes: #33923.


**Screenshots and screen captures:**
### Composebox
|Remove banner on fetching message|Clicking banner's `Send now` Button| Clicking compose `Send` button twice|Pressing `Enter` twice|
|----|----|----|-----|
|![compose_disappearing_banner_when_message_is_fetched](https://github.com/user-attachments/assets/8b32d204-02f0-4a10-af39-cfe57647f67e)|![compose_send_and_clicking_banner_send_button](https://github.com/user-attachments/assets/8389cad5-f38b-49e2-ba1f-aec047f7d38b)|![compose_send_and_clicking_compose_send_button](https://github.com/user-attachments/assets/df8da7d7-32dc-4433-b49c-e72b57e3d8f5)|![compose_textarea_and_pressing_enter_twice](https://github.com/user-attachments/assets/26522c00-c7bf-4e19-82d5-b6aab235b947)


### Edit instances
|Remove banner on fetching message|Clicking banner's `Save now` button| Clicking edit  `Save` Button Twice|Pressing `Enter` twice|
|----|----|----|-----|
|![edit_box_disappearing_banner_when_message_is_fetched](https://github.com/user-attachments/assets/0b8819f9-1b73-451e-bc9a-da5e4f112625)|![edit_and_save_with_banner_send_button](https://github.com/user-attachments/assets/e5ed376e-2851-406e-b952-587d52617118)|![edit_and_save_with_default_save_button](https://github.com/user-attachments/assets/6ca70cc8-ba31-4685-b26b-026382b5736d)|![edit_textarea_and_pressing_enter_twice](https://github.com/user-attachments/assets/3e8aa7fe-3c65-40d7-a9a2-41bf58874c83)

#### Multiple instance case
![Multiple instances](https://github.com/user-attachments/assets/38f79c7f-359a-42e6-9e3e-389a9e95cf67)

