### PR TITLE
attachment: Refresh images after deleting an attachment.

### DIFF
--- a/web/src/lightbox.ts
+++ b/web/src/lightbox.ts
@@ -481,6 +481,22 @@ function supports_heic(): boolean {
     return !Number.isNaN(version) && version >= 17;
 }
 
+export function is_url_in_asset_map(url: string): boolean {
+    return asset_map.keys().some((key) => key.includes(url));
+}
+
+export function set_media_preview_in_asset_map(url: string, preview: string): void {
+    const media = asset_map.get(url);
+    if (!media) {
+        return;
+    }
+
+    asset_map.set(url, {
+        ...media,
+        preview,
+    });
+}
+
 // retrieve the metadata from the DOM and store into the asset_map.
 export function parse_media_data(media: HTMLMediaElement | HTMLImageElement): Media {
     const canonical_url = canonical_url_of_media(media);

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -124,6 +124,10 @@ export function dispatch_normal_event(event) {
             stream_settings_ui.update_is_default_stream();
             break;
 
+        case "delete_message_image_attachment":
+            message_events.reload_images_for_deleted_attachment(event.attachment);
+            break;
+
         case "delete_message": {
             const msg_ids = event.message_ids;
             // message is passed to unread.get_unread_messages,

--- a/zerver/views/attachments.py
+++ b/zerver/views/attachments.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest, HttpResponse
 
-from zerver.actions.uploads import notify_attachment_update
-from zerver.lib.attachments import access_attachment_by_id, remove_attachment, user_attachments
+from zerver.actions.uploads import do_delete_attachment
+from zerver.lib.attachments import access_attachment_by_id, user_attachments
 from zerver.lib.response import json_success
 from zerver.models import UserProfile
 
@@ -18,6 +18,7 @@ def list_by_user(request: HttpRequest, user_profile: UserProfile) -> HttpRespons
 
 def remove(request: HttpRequest, user_profile: UserProfile, attachment_id: int) -> HttpResponse:
     attachment = access_attachment_by_id(user_profile, attachment_id, needs_owner=True)
-    remove_attachment(user_profile, attachment)
-    notify_attachment_update(user_profile, "remove", {"id": attachment_id})
+
+    do_delete_attachment(attachment, user_profile)
+
     return json_success(request)


### PR DESCRIPTION
Currently, when an attachment is deleted, recipients of messages containing that attachment aren’t notified. As a result, its thumbnail/preview remains visible until the page is refreshed.

Steps to reproduce:
- Send an image to someone
- Go to your uploaded files & delete that image
- The receiver/sender will keep seeing the image

This commit introduces a new event `delete_message_image_attachment`, that is sent to all the recipients when an attachment is deleted. Upon receiving the event, all images containing the attachment are refreshed. This is currently a prototype, so I haven’t added any tests yet. I’ll proceed once I receive confirmation that this is the desired approach. (See the [CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20thumbnail.20not.20deleted/near/2141418))

Fixes: [CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.93.82.20thumbnail.20not.20deleted/near/2141418)

Fixes #37425.

**Screenshots and screen captures:**

| Before | Now |
| -------- | -------- |
| ![attachment_before](https://github.com/user-attachments/assets/29312528-74bf-4ff5-9ad2-9a81f8b46d6a) | ![attachment_after](https://github.com/user-attachments/assets/4643e8fd-cfc4-406e-80e0-1e2c591babb0) |

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
