### PR TITLE
settings: Display Translated string after changing default language.

### DIFF
--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -395,7 +395,14 @@ class ChangeSettingsTest(ZulipTestCase):
             data = {setting_name: orjson.dumps(test_value).decode()}
 
         result = self.client_patch("/json/settings", data)
-        self.assert_json_success(result)
+        json_result = self.assert_json_success(result)
+        if setting_name == "default_language":
+            self.assertEqual(
+                json_result["msg"],
+                "Saved. Please <a class='reload_link'>reload</a> for the change to take effect.",
+            )
+        else:
+            self.assertEqual(json_result["msg"], "")
         user_profile = self.example_user("hamlet")
         self.assertEqual(getattr(user_profile, setting_name), test_value)
 

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -13,6 +13,7 @@ from django.utils.html import escape
 from django.utils.safestring import SafeString
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.utils.translation import override as override_language
 from pydantic import Json
 
 from confirmation.models import (
@@ -387,6 +388,11 @@ def json_change_settings(
     # Loop over user_profile.property_types
     request_settings = {k: v for k, v in locals().items() if k in user_profile.property_types}
     for k, v in request_settings.items():
+        if k == "default_language" and v is not None:
+            with override_language(v):
+                result["msg"] = _(
+                    "Saved. Please <a class='reload_link'>reload</a> for the change to take effect."
+                )
         if v is not None and getattr(user_profile, k) != v:
             do_change_user_setting(user_profile, k, v, acting_user=user_profile)
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR makes it so that when the default language is changed in settings the popup that comes up beside the general title is now translated to the changed language.(see the attchment for more details)

This is done by translating it in the backend and sending the message in the response body and then using that in frontend.

The technical choice of putting the translated string in the `'msg'` property  of the response is motivated by [this](https://github.com/zulip/zulip/pull/27226#discussion_r1364177431) feedback of PR #27226 and I couldn't find any better and simpler way to address it.

Things to do:
- update django.po translations

Fixes: #25552

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[Screencast from 2025-04-06 22-26-45.webm](https://github.com/user-attachments/assets/a821b8dd-e58b-4ab0-94af-68cb907aa0dd)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
