### PR TITLE
keyboard_UI: fix #33838 'e' keyboard shortcut for anonymous user.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1150,7 +1150,12 @@ export function process_hotkey(e, hotkey) {
     if (
         // Allow UI only features for spectators which they can perform.
         page_params.is_spectator &&
-        !["toggle_conversation_view", "show_lightbox", "toggle_sender_info"].includes(event_name)
+        ![
+            "toggle_conversation_view",
+            "show_lightbox",
+            "toggle_sender_info",
+            "edit_message",
+        ].includes(event_name)
     ) {
         spectators.login_to_access();
         return true;

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -2,10 +2,13 @@
 
 const assert = require("node:assert/strict");
 
+const {process_keydown} = require("../src/hotkey.js");
+
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace.cjs");
 const {make_stub} = require("./lib/stub.cjs");
 const {run_test} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
+const {page_params} = require("./lib/zpage_params.cjs");
 
 // Important note on these tests:
 
@@ -91,6 +94,10 @@ const stream_settings_ui = mock_esm("../src/stream_settings_ui");
 
 mock_esm("../src/recent_view_ui", {
     is_in_focus: () => false,
+});
+
+const spectators = mock_esm("../src/spectators", {
+    login_to_access() {},
 });
 
 message_lists.current = {
@@ -560,4 +567,18 @@ run_test("test new user input hook called", () => {
 
     hotkey.process_keydown({which: "S".codePointAt(0)});
     assert.ok(hook_called);
+});
+
+run_test("e shortcut works for anonymous users", () => {
+    page_params.is_spectator = true;
+
+    const stub = make_stub();
+    spectators.login_to_access = stub.f;
+
+    const e = {
+        which: "e".codePointAt(0),
+    };
+
+    process_keydown(e);
+    assert.equal(stub.num_calls, 0, "login_to_access should not be called for 'e' shortcut");
 });


### PR DESCRIPTION
Previously, when in anonymous login, pressing the "view original message" button showed the original message and allowed copying it. However, the corresponding keyboard shortcut ('e') did not work as expected and a login pop-up appeared instead.

Now, by fixing the UI features' permissions for anonymous users, by adding "edit_message" as a feature they can perform, they are allowed to use the 'e' keyboard shortcut as intended.

Additionally, I added a test to ensure the bug is properly fixed.

<!-- Describe your pull request here.-->

Fixes: #33838 


**Screenshots and screen captures:**
What happened before the fix:


https://github.com/user-attachments/assets/eabc1f06-2556-4626-9edc-190aeced3acc


What happens now, after the fix:


https://github.com/user-attachments/assets/dc70973c-5774-4562-b950-76d6f2587892

 


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
