### PR TITLE
dark_theme: Clean up compose banners.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2654,6 +2654,46 @@
         hsl(38deg 44% 27% / 15%),
         hsl(50deg 45% 61% / 20%)
     );
+    --color-error-main-view-banner: light-dark(
+        hsl(4deg 58% 33%),
+        hsl(3deg 73% 80%)
+    );
+    --color-background-error-main-view-banner: light-dark(
+        hsl(4deg 35% 90%),
+        hsl(0deg 60% 19%)
+    );
+    --color-border-error-main-view-banner: light-dark(
+        hsl(3deg 57% 33% / 40%),
+        hsl(3deg 73% 74% / 40%)
+    );
+    --color-error-main-view-banner-close-button: light-dark(
+        hsl(4deg 58% 33% / 50%),
+        hsl(3deg 73% 74% / 50%)
+    );
+    --color-error-main-view-banner-close-button-hover: light-dark(
+        hsl(4deg 58% 33%),
+        hsl(3deg 73% 74%)
+    );
+    --color-error-main-view-banner-close-button-active: light-dark(
+        hsl(4deg 58% 33% / 75%),
+        hsl(3deg 73% 74% / 75%)
+    );
+    --color-error-main-view-banner-action-button: light-dark(
+        inherit,
+        hsl(3deg 73% 74%)
+    );
+    --color-background-error-main-view-banner-action-button: light-dark(
+        hsl(3deg 57% 33% / 10%),
+        hsl(3deg 73% 74% / 10%)
+    );
+    --color-background-error-main-view-banner-action-button-hover: light-dark(
+        hsl(3deg 57% 33% / 12%),
+        hsl(3deg 73% 74% / 15%)
+    );
+    --color-background-error-main-view-banner-action-button-active: light-dark(
+        hsl(3deg 57% 33% / 15%),
+        hsl(3deg 73% 74% / 20%)
+    );
 
     /* Info density update UI */
     --color-info-density-control-border: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2614,6 +2614,46 @@
         hsl(147deg 57% 25% / 15%),
         hsl(147deg 51% 55% / 20%)
     );
+    --color-warning-main-view-banner: light-dark(
+        hsl(38deg 44% 27%),
+        hsl(50deg 45% 80%)
+    );
+    --color-background-warning-main-view-banner: light-dark(
+        hsl(50deg 75% 92%),
+        hsl(53deg 100% 11%)
+    );
+    --color-border-warning-main-view-banner: light-dark(
+        hsl(38deg 44% 27% / 40%),
+        hsl(38deg 44% 60% / 40%)
+    );
+    --color-warning-main-view-banner-close-button: light-dark(
+        hsl(38deg 44% 27% / 50%),
+        hsl(50deg 45% 61% / 50%)
+    );
+    --color-warning-main-view-banner-close-button-hover: light-dark(
+        hsl(38deg 44% 27%),
+        hsl(50deg 45% 61%)
+    );
+    --color-warning-main-view-banner-close-button-active: light-dark(
+        hsl(38deg 44% 27% / 75%),
+        hsl(50deg 45% 61% / 75%)
+    );
+    --color-warning-main-view-banner-action-button: light-dark(
+        inherit,
+        hsl(50deg 45% 61%)
+    );
+    --color-background-warning-main-view-banner-action-button: light-dark(
+        hsl(38deg 44% 27% / 10%),
+        hsl(50deg 45% 61% / 10%)
+    );
+    --color-background-warning-main-view-banner-action-button-hover: light-dark(
+        hsl(38deg 44% 27% / 12%),
+        hsl(50deg 45% 61% / 15%)
+    );
+    --color-background-warning-main-view-banner-action-button-active: light-dark(
+        hsl(38deg 44% 27% / 15%),
+        hsl(50deg 45% 61% / 20%)
+    );
 
     /* Info density update UI */
     --color-info-density-control-border: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2577,6 +2577,44 @@
         hsl(0deg 52% 18%)
     );
 
+    /* .main-view-banner colors */
+    --color-success-main-view-banner: light-dark(
+        hsl(147deg 57% 25%),
+        hsl(147deg 51% 80%)
+    );
+    --color-background-success-main-view-banner: light-dark(
+        hsl(147deg 43% 92%),
+        hsl(147deg 100% 8%)
+    );
+    --color-border-success-main-view-banner: light-dark(
+        hsl(147deg 57% 25% / 40%),
+        hsl(149deg 48% 52% / 40%)
+    );
+    --color-success-main-view-banner-close-button: light-dark(
+        hsl(147deg 57% 25% / 50%),
+        hsl(147deg 51% 55% / 50%)
+    );
+    --color-success-main-view-banner-close-button-hover: light-dark(
+        hsl(147deg 57% 25%),
+        hsl(147deg 51% 55%)
+    );
+    --color-success-main-view-banner-close-button-active: light-dark(
+        hsl(147deg 57% 25% / 75%),
+        hsl(147deg 51% 55% / 75%)
+    );
+    --color-background-success-main-view-banner-action-button: light-dark(
+        hsl(147deg 57% 25% / 10%),
+        hsl(147deg 51% 55% / 10%)
+    );
+    --color-background-success-main-view-banner-action-button-hover: light-dark(
+        hsl(147deg 57% 25% / 12%),
+        hsl(147deg 51% 55% / 15%)
+    );
+    --color-background-success-main-view-banner-action-button-active: light-dark(
+        hsl(147deg 57% 25% / 15%),
+        hsl(147deg 51% 55% / 20%)
+    );
+
     /* Info density update UI */
     --color-info-density-control-border: light-dark(
         hsl(0deg 0% 0% / 20%),

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2694,6 +2694,46 @@
         hsl(3deg 57% 33% / 15%),
         hsl(3deg 73% 74% / 20%)
     );
+    --color-info-main-view-banner: light-dark(
+        hsl(204deg 49% 29%),
+        hsl(205deg 58% 80%)
+    );
+    --color-background-info-main-view-banner: light-dark(
+        hsl(204deg 58% 92%),
+        hsl(204deg 100% 12%)
+    );
+    --color-border-info-main-view-banner: light-dark(
+        hsl(204deg 49% 29% / 40%),
+        hsl(205deg 58% 69% / 40%)
+    );
+    --color-info-main-view-banner-close-button: light-dark(
+        hsl(204deg 49% 29% / 50%),
+        hsl(205deg 58% 69% / 50%)
+    );
+    --color-info-main-view-banner-close-button-hover: light-dark(
+        hsl(204deg 49% 29%),
+        hsl(205deg 58% 69%)
+    );
+    --color-info-main-view-banner-close-button-active: light-dark(
+        hsl(204deg 49% 29% / 75%),
+        hsl(205deg 58% 69% / 75%)
+    );
+    --color-info-main-view-banner-action-button: light-dark(
+        inherit,
+        hsl(205deg 58% 69%)
+    );
+    --color-background-info-main-view-banner-action-button: light-dark(
+        hsl(204deg 49% 29% / 10%),
+        hsl(205deg 58% 69% / 10%)
+    );
+    --color-background-info-main-view-banner-action-button-hover: light-dark(
+        hsl(204deg 49% 29% / 12%),
+        hsl(205deg 58% 69% / 15%)
+    );
+    --color-background-info-main-view-banner-action-button-active: light-dark(
+        hsl(204deg 49% 29% / 15%),
+        hsl(205deg 58% 69% / 20%)
+    );
 
     /* Info density update UI */
     --color-info-density-control-border: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2738,6 +2738,10 @@
         var(--color-text-generic-link),
         hsl(200deg 100% 50%)
     );
+    --color-background-main-view-banner-moving-bar: light-dark(
+        hsl(204deg 63% 85%),
+        hsl(204deg 63% 18%)
+    );
 
     /* Info density update UI */
     --color-info-density-control-border: light-dark(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2734,6 +2734,10 @@
         hsl(204deg 49% 29% / 15%),
         hsl(205deg 58% 69% / 20%)
     );
+    --color-main-view-banner-action-link: light-dark(
+        var(--color-text-generic-link),
+        hsl(200deg 100% 50%)
+    );
 
     /* Info density update UI */
     --color-info-density-control-border: light-dark(

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -953,34 +953,40 @@
     }
 
     &.info {
-        background-color: hsl(204deg 58% 92%);
-        border-color: hsl(204deg 49% 29% / 40%);
         position: relative;
-        color: hsl(204deg 49% 29%);
+        background-color: var(--color-background-info-main-view-banner);
+        border-color: var(--color-border-info-main-view-banner);
+        color: var(--color-info-main-view-banner);
 
         .main-view-banner-close-button {
-            color: hsl(204deg 49% 29% / 50%);
+            color: var(--color-info-main-view-banner-close-button);
 
             &:hover {
-                color: hsl(204deg 49% 29%);
+                color: var(--color-info-main-view-banner-close-button-hover);
             }
 
             &:active {
-                color: hsl(204deg 49% 29% / 75%);
+                color: var(--color-info-main-view-banner-close-button-active);
             }
         }
 
         .main-view-banner-action-button,
         .upload_banner_cancel_button {
-            background-color: hsl(204deg 49% 29% / 10%);
-            color: inherit;
+            background-color: var(
+                --color-background-info-main-view-banner-action-button
+            );
+            color: var(--color-info-main-view-banner-action-button);
 
             &:hover {
-                background-color: hsl(204deg 49% 29% / 12%);
+                background-color: var(
+                    --color-background-info-main-view-banner-action-button-hover
+                );
             }
 
             &:active {
-                background-color: hsl(204deg 49% 29% / 15%);
+                background-color: var(
+                    --color-background-info-main-view-banner-action-button-active
+                );
             }
         }
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -834,32 +834,40 @@
     }
 
     &.success {
-        background-color: hsl(147deg 43% 92%);
-        border: 1px solid hsl(147deg 57% 25% / 40%);
-        color: hsl(147deg 57% 25%);
+        background-color: var(--color-background-success-main-view-banner);
+        border: 1px solid var(--color-border-success-main-view-banner);
+        color: var(--color-success-main-view-banner);
 
         .main-view-banner-close-button {
-            color: hsl(147deg 57% 25% / 50%);
+            color: var(--color-success-main-view-banner-close-button);
 
             &:hover {
-                color: hsl(147deg 57% 25%);
+                color: var(--color-success-main-view-banner-close-button-hover);
             }
 
             &:active {
-                color: hsl(147deg 57% 25% / 75%);
+                color: var(
+                    --color-success-main-view-banner-close-button-active
+                );
             }
         }
 
         .main-view-banner-action-button {
-            background-color: hsl(147deg 57% 25% / 10%);
+            background-color: var(
+                --color-background-success-main-view-banner-action-button
+            );
             color: inherit;
 
             &:hover {
-                background-color: hsl(147deg 57% 25% / 12%);
+                background-color: var(
+                    --color-background-success-main-view-banner-action-button-hover
+                );
             }
 
             &:active {
-                background-color: hsl(147deg 57% 25% / 15%);
+                background-color: var(
+                    --color-background-success-main-view-banner-action-button-active
+                );
             }
         }
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1009,7 +1009,7 @@
         /* The progress updates seem to come every second or so,
         so this is the smoothest it can probably get. */
         transition: width 1s ease-in-out; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
-        background: hsl(204deg 63% 85%);
+        background: var(--color-background-main-view-banner-moving-bar);
         top: 0;
         bottom: 0;
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -695,6 +695,10 @@
     align-items: center;
     line-height: 1.2em; /* 18px at 15px/1em. */
 
+    .above_compose_banner_action_link {
+        color: var(--color-main-view-banner-action-link);
+    }
+
     .main-view-banner-elements-wrapper {
         display: flex;
         align-items: center;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -916,32 +916,38 @@
     }
 
     &.error {
-        background-color: hsl(4deg 35% 90%);
-        border-color: hsl(3deg 57% 33% / 40%);
-        color: hsl(4deg 58% 33%);
+        background-color: var(--color-background-error-main-view-banner);
+        border-color: var(--color-border-error-main-view-banner);
+        color: var(--color-error-main-view-banner);
 
         .main-view-banner-close-button {
-            color: hsl(4deg 58% 33% / 50%);
+            color: var(--color-error-main-view-banner-close-button);
 
             &:hover {
-                color: hsl(4deg 58% 33%);
+                color: var(--color-error-main-view-banner-close-button-hover);
             }
 
             &:active {
-                color: hsl(4deg 58% 33% / 75%);
+                color: var(--color-error-main-view-banner-close-button-active);
             }
         }
 
         .main-view-banner-action-button {
-            background-color: hsl(3deg 57% 33% / 10%);
-            color: inherit;
+            background-color: var(
+                --color-background-error-main-view-banner-action-button
+            );
+            color: var(--color-error-main-view-banner-action-button);
 
             &:hover {
-                background-color: hsl(3deg 57% 33% / 12%);
+                background-color: var(
+                    --color-background-error-main-view-banner-action-button-hover
+                );
             }
 
             &:active {
-                background-color: hsl(3deg 57% 33% / 15%);
+                background-color: var(
+                    --color-background-error-main-view-banner-action-button-active
+                );
             }
         }
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -877,32 +877,40 @@
     for some of the banners, for which we use the warning-style class. */
     &.warning,
     &.warning-style {
-        background-color: hsl(50deg 75% 92%);
-        border-color: hsl(38deg 44% 27% / 40%);
-        color: hsl(38deg 44% 27%);
+        background-color: var(--color-background-warning-main-view-banner);
+        border-color: var(--color-border-warning-main-view-banner);
+        color: var(--color-warning-main-view-banner);
 
         .main-view-banner-close-button {
-            color: hsl(38deg 44% 27% / 50%);
+            color: var(--color-warning-main-view-banner-close-button);
 
             &:hover {
-                color: hsl(38deg 44% 27%);
+                color: var(--color-warning-main-view-banner-close-button-hover);
             }
 
             &:active {
-                color: hsl(38deg 44% 27% / 75%);
+                color: var(
+                    --color-warning-main-view-banner-close-button-active
+                );
             }
         }
 
         .main-view-banner-action-button {
-            background-color: hsl(38deg 44% 27% / 10%);
-            color: inherit;
+            background-color: var(
+                --color-background-warning-main-view-banner-action-button
+            );
+            color: var(--color-warning-main-view-banner-action-button);
 
             &:hover {
-                background-color: hsl(38deg 44% 27% / 12%);
+                background-color: var(
+                    --color-background-warning-main-view-banner-action-button-hover
+                );
             }
 
             &:active {
-                background-color: hsl(38deg 44% 27% / 15%);
+                background-color: var(
+                    --color-background-warning-main-view-banner-action-button-active
+                );
             }
         }
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -85,40 +85,6 @@
         .above_compose_banner_action_link {
             color: hsl(200deg 100% 50%);
         }
-
-        &.info {
-            background-color: hsl(204deg 100% 12%);
-            border-color: hsl(205deg 58% 69% / 40%);
-            position: relative;
-            color: hsl(205deg 58% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(205deg 58% 69% / 50%);
-
-                &:hover {
-                    color: hsl(205deg 58% 69%);
-                }
-
-                &:active {
-                    color: hsl(205deg 58% 69% / 75%);
-                }
-            }
-
-            .main-view-banner-action-button,
-            .upload_banner_cancel_button {
-                background-color: hsl(205deg 58% 69% / 10%);
-                border-color: transparent;
-                color: hsl(205deg 58% 69%);
-
-                &:hover {
-                    background-color: hsl(205deg 58% 69% / 15%);
-                }
-
-                &:active {
-                    background-color: hsl(205deg 58% 69% / 20%);
-                }
-            }
-        }
     }
 
     .upload_banner {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -81,12 +81,6 @@
         }
     }
 
-    .upload_banner {
-        .moving_bar {
-            background: hsl(204deg 63% 18%);
-        }
-    }
-
     /* this one is because in the app we have blue and in dark-theme it should be white. */
     .popover a {
         color: inherit;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -81,12 +81,6 @@
         }
     }
 
-    .main-view-banner {
-        .above_compose_banner_action_link {
-            color: hsl(200deg 100% 50%);
-        }
-    }
-
     .upload_banner {
         .moving_bar {
             background: hsl(204deg 63% 18%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -86,37 +86,6 @@
             color: hsl(200deg 100% 50%);
         }
 
-        &.error {
-            background-color: hsl(0deg 60% 19%);
-            border-color: hsl(3deg 73% 74% / 40%);
-            color: hsl(3deg 73% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(3deg 73% 74% / 50%);
-
-                &:hover {
-                    color: hsl(3deg 73% 74%);
-                }
-
-                &:active {
-                    color: hsl(3deg 73% 74% / 75%);
-                }
-            }
-
-            .main-view-banner-action-button {
-                background-color: hsl(3deg 73% 74% / 10%);
-                color: hsl(3deg 73% 74%);
-
-                &:hover {
-                    background: hsl(3deg 73% 74% / 15%);
-                }
-
-                &:active {
-                    background: hsl(3deg 73% 74% / 20%);
-                }
-            }
-        }
-
         &.info {
             background-color: hsl(204deg 100% 12%);
             border-color: hsl(205deg 58% 69% / 40%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -86,37 +86,6 @@
             color: hsl(200deg 100% 50%);
         }
 
-        &.success {
-            background-color: hsl(147deg 100% 8%);
-            border-color: hsl(149deg 48% 52% / 40%);
-            color: hsl(147deg 51% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(147deg 51% 55% / 50%);
-
-                &:hover {
-                    color: hsl(147deg 51% 55%);
-                }
-
-                &:active {
-                    color: hsl(147deg 51% 55% / 75%);
-                }
-            }
-
-            .main-view-banner-action-button {
-                background-color: hsl(147deg 51% 55% / 10%);
-                color: inherit;
-
-                &:hover {
-                    background-color: hsl(147deg 51% 55% / 15%);
-                }
-
-                &:active {
-                    background-color: hsl(147deg 51% 55% / 20%);
-                }
-            }
-        }
-
         &.warning,
         &.warning-style {
             background-color: hsl(53deg 100% 11%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -86,38 +86,6 @@
             color: hsl(200deg 100% 50%);
         }
 
-        &.warning,
-        &.warning-style {
-            background-color: hsl(53deg 100% 11%);
-            border-color: hsl(38deg 44% 60% / 40%);
-            color: hsl(50deg 45% 80%);
-
-            .main-view-banner-close-button {
-                color: hsl(50deg 45% 61% / 50%);
-
-                &:hover {
-                    color: hsl(50deg 45% 61%);
-                }
-
-                &:active {
-                    color: hsl(50deg 45% 61% / 75%);
-                }
-            }
-
-            .main-view-banner-action-button {
-                background-color: hsl(50deg 45% 61% / 10%);
-                color: hsl(50deg 45% 61%);
-
-                &:hover {
-                    background-color: hsl(50deg 45% 61% / 15%);
-                }
-
-                &:active {
-                    background-color: hsl(50deg 45% 61% / 20%);
-                }
-            }
-        }
-
         &.error {
             background-color: hsl(0deg 60% 19%);
             border-color: hsl(3deg 73% 74% / 40%);


### PR DESCRIPTION
This PR cleans up dark theme for all references to the compose banners (`.main-view-banner`).

With this work, `dark_theme.css` drops from ~725 lines down to ~585 lines.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

