### PR TITLE
docs: Highlight Try It feature in API usage examples

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -118,7 +118,9 @@ specifically the `APIHeaderPreprocessor` class defined in
 `zerver/openapi/markdown_extension.py`.
 
 ### Usage examples
+The "Try It" feature lets you test this API live from your browser.
 
+Use the **Try It** button above to experiment with real data.
 We display usage examples in three languages: Python, JavaScript and
 curl; we may add more in the future. Every endpoint should have
 Python and curl documentation; JavaScript is optional as we don't


### PR DESCRIPTION
Hi! Added a note about the "Try It" feature in `docs/documentation/api.md` to help new users test the API.  
Windows setup stalled—couldn’t test locally yet, but it’s pure Markdown so should render fine.  
Excited to contribute more, like OpenAPI enhancements!