### PR TITLE
streams: Fix error while sending notice in deactivated stream.

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1180,7 +1180,11 @@ def send_change_stream_permission_notification(
             new_policy=new_policy_name,
         )
         internal_send_stream_message(
-            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME), notification_string
+            sender,
+            stream,
+            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            notification_string,
+            archived_channel_notice=stream.deactivated,
         )
 
 
@@ -1408,7 +1412,11 @@ def send_stream_posting_permission_update_notification(
             new_setting_description=new_setting_description,
         )
         internal_send_stream_message(
-            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME), notification_string
+            sender,
+            stream,
+            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            notification_string,
+            archived_channel_notice=stream.deactivated,
         )
 
 
@@ -1467,6 +1475,7 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
                 old_channel_name=f"**{old_name}**",
                 new_channel_name=f"**{new_name}**",
             ),
+            archived_channel_notice=stream.deactivated,
         )
 
 
@@ -1495,7 +1504,11 @@ def send_change_stream_description_notification(
         )
 
         internal_send_stream_message(
-            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME), notification_string
+            sender,
+            stream,
+            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            notification_string,
+            archived_channel_notice=stream.deactivated,
         )
 
 
@@ -1585,7 +1598,11 @@ def send_change_stream_message_retention_days_notification(
             summary_line=summary_line,
         )
         internal_send_stream_message(
-            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME), notification_string
+            sender,
+            stream,
+            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC_NAME),
+            notification_string,
+            archived_channel_notice=stream.deactivated,
         )
 
 


### PR DESCRIPTION
Sending messages to a deactivated stream is not allowed with the exception of notices sent in "channel events" topic.

Earlier, notice sent to a deactivated stream when it is deactivated was working correctly but it was resulting in an error in the following cases:
* Renaming stream
* Changing stream description
* Changing message retention period
* Changing posting permission
* Changing access permission

This PR makes sure to send notice successfully in those cases.

Error previously:
> ERR  [] Error queueing internal message by notification-bot@zulip.com: Not authorized to send to channel 'support'

Now:
<img width="629" alt="Screenshot 2025-04-08 at 4 45 56 PM" src="https://github.com/user-attachments/assets/0e033423-729d-4bda-8317-e1c50bf70fb1" />



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
