### PR TITLE
tests: Fix admin.test.ts puppeteer test case failing.

### DIFF
--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -10,11 +10,8 @@ async function submit_announcements_stream_settings(page: Page): Promise<void> {
     });
 
     const save_button = "#org-notifications .save-button";
-    assert.strictEqual(
-        await common.get_text_from_selector(page, save_button),
-        "Save changes",
-        "Save button has incorrect text.",
-    );
+    const button_text = await common.get_text_from_selector(page, save_button);
+    assert.strictEqual(button_text, "Save changes", "Save button has incorrect text.");
     await page.click(save_button);
 
     await page.waitForSelector('#org-notifications .save-button[data-status="saved"]', {

--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -10,17 +10,26 @@ async function submit_announcements_stream_settings(page: Page): Promise<void> {
     });
 
     const save_button = "#org-notifications .save-button";
-    const button_text = await common.get_text_from_selector(page, save_button);
-    assert.strictEqual(button_text, "Save changes", "Save button has incorrect text.");
+    await page.waitForFunction(
+        (save_button: string) => {
+            const button = document.querySelector(save_button);
+            return button && button.textContent?.trim() === "Save changes";
+        },
+        {},
+        save_button,
+    );
     await page.click(save_button);
 
     await page.waitForSelector('#org-notifications .save-button[data-status="saved"]', {
         visible: true,
     });
-    assert.strictEqual(
-        await common.get_text_from_selector(page, "#org-notifications .save-button"),
-        "Saved",
-        "Saved text didn't appear after saving new stream notifications setting",
+    await page.waitForFunction(
+        (save_button: string) => {
+            const button = document.querySelector(save_button);
+            return button && button.textContent?.trim() === "Saved";
+        },
+        {},
+        save_button,
     );
 
     await page.waitForSelector("#org-notifications .save-button", {hidden: true});


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#issues > 🎯 save/discard buttons misaligned on some browsers @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20save.2Fdiscard.20buttons.20misaligned.20on.20some.20browsers/near/2148415)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
