### PR TITLE
requirements: Upgrade Django from 5.1.10 to 5.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ prod = [
   "google-re2",
 
   # For querying recursive group membership
-  "django-cte",
+  "django-cte>=2.0.0.dev20250610173146", # https://github.com/dimagi/django-cte/pull/116
 
   # SCIM integration
   "django-scim2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 [dependency-groups]
 prod = [
   # Django itself
-  "django[argon2]==5.1.*",
+  "django[argon2]==5.2.*",
   "asgiref", # https://github.com/django/asgiref/pull/494
 
   # needed for NotRequired, ParamSpec

--- a/scripts/setup/upgrade-postgresql
+++ b/scripts/setup/upgrade-postgresql
@@ -37,7 +37,12 @@ fi
 # Django actually stores its data in.  We can only do that if the
 # database server is on the same host as the application server.
 if [ -d /home/zulip/deployments/current ]; then
-    DATA_IS_IN=$(su zulip -c '/home/zulip/deployments/current/manage.py shell -c "from django.db import connection; print(int(connection.cursor().connection.server_version/10000))"')
+    DATA_IS_IN=$(
+        su -s /usr/bin/env -- zulip \
+            DJANGO_SETTINGS_MODULE=zproject.settings \
+            uv run --directory=/home/zulip/deployments/current --no-sync \
+            python -c 'from django.db import connection; print(connection.cursor().connection.server_version // 10000)'
+    )
 
     if [ "$UPGRADE_FROM" != "$DATA_IS_IN" ]; then
         cat <<EOF

--- a/uv.lock
+++ b/uv.lock
@@ -895,11 +895,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/de/a2/7db0b55ff84260aa1
 
 [[package]]
 name = "django-cte"
-version = "1.3.3"
+version = "2.0.0.dev20250610173146"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/56/951f6e176c83bf5e500ef7108c9e8de38785e249b62fa29be12b4c71c4eb/django-cte-1.3.3.tar.gz", hash = "sha256:0c1aeef067278a22886151c1d27f6f665a303952d058900e5ca82a24cde40697", size = 10931, upload-time = "2024-06-07T12:51:06.089Z" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/9c/7699e716095bc87151a1c8937c188d9734a341f414f4491e35375a669ba3/django_cte-2.0.0.dev20250610173146.tar.gz", hash = "sha256:4661c142def3c96b1a579ed23b813f44a3e81e1d68aaf03bb425583688cf538d", size = 11282, upload-time = "2025-06-10T17:32:10.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/02/a9d12e8c1cb767b2541bf7d759fbe713f84238f1c2bd22ed2ef3bed14606/django_cte-1.3.3-py2.py3-none-any.whl", hash = "sha256:85bbc3efb30c2f8c9ae3080ca6f0b9570e43d2cb4b6be10846c8ef9f046873fa", size = 11989, upload-time = "2024-06-07T12:51:04.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/15/1f508d7c05b250d0772141a1f020033723f71dd232e17d3a802b48f72bd5/django_cte-2.0.0.dev20250610173146-py3-none-any.whl", hash = "sha256:c75c97f6230b7af6ae364b3e970a7568e05706540fde6d155368bd92467cb2b1", size = 13166, upload-time = "2025-06-10T17:32:08.832Z" },
 ]
 
 [[package]]
@@ -1260,6 +1263,9 @@ dependencies = [
     { name = "uritemplate" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/99/237cd2510aecca9fabb54007e58553274cc43cb3c18512ee1ea574d11b87/google_api_python_client-2.171.0.tar.gz", hash = "sha256:057a5c08d28463c6b9eb89746355de5f14b7ed27a65c11fdbf1d06c66bb66b23", size = 13028937, upload-time = "2025-06-03T18:57:38.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/db/c397e3eb3ea18f423855479d0a5852bdc9c3f644e3d4194931fa664a70b4/google_api_python_client-2.171.0-py3-none-any.whl", hash = "sha256:c9c9b76f561e9d9ac14e54a9e2c0842876201d5b96e69e48f967373f0784cbe9", size = 13547393, upload-time = "2025-06-10T02:14:38.225Z" },
+]
 
 [[package]]
 name = "google-auth"
@@ -5492,7 +5498,7 @@ dev = [
     { name = "django-auth-ldap" },
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
-    { name = "django-cte" },
+    { name = "django-cte", specifier = ">=2.0.0.dev20250610173146" },
     { name = "django-scim2" },
     { name = "django-stubs" },
     { name = "django-stubs-ext" },
@@ -5624,7 +5630,7 @@ prod = [
     { name = "django-auth-ldap" },
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
-    { name = "django-cte" },
+    { name = "django-cte", specifier = ">=2.0.0.dev20250610173146" },
     { name = "django-scim2" },
     { name = "django-stubs-ext" },
     { name = "django-two-factor-auth", extras = ["call", "phonenumberslite", "sms"] },

--- a/uv.lock
+++ b/uv.lock
@@ -844,16 +844,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.1.10"
+version = "5.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/ca/1c724be89e603eb8b5587ea24c63a8c30094c8ff4d990780b5033ee15c40/django-5.1.10.tar.gz", hash = "sha256:73e5d191421d177803dbd5495d94bc7d06d156df9561f4eea9e11b4994c07137", size = 10714538, upload-time = "2025-06-04T13:53:18.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/af/77b403926025dc6f7fd7b31256394d643469418965eb528eab45d0505358/django-5.2.3.tar.gz", hash = "sha256:335213277666ab2c5cac44a792a6d2f3d58eb79a80c14b6b160cd4afc3b75684", size = 10850303, upload-time = "2025-06-10T10:14:05.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/fc/80dc741ba0acb3241aac1213d7272c573d52d8a62ec2c69e9b3bef1547f2/django-5.1.10-py3-none-any.whl", hash = "sha256:19c9b771e9cf4de91101861aadd2daaa159bcf10698ca909c5755c88e70ccb84", size = 8277457, upload-time = "2025-06-04T13:53:07.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl", hash = "sha256:c517a6334e0fd940066aa9467b29401b93c37cec2e61365d663b80922542069d", size = 8301935, upload-time = "2025-06-10T10:13:58.993Z" },
 ]
 
 [package.optional-dependencies]
@@ -5494,7 +5494,7 @@ dev = [
     { name = "decorator" },
     { name = "defusedxml" },
     { name = "disposable-email-domains" },
-    { name = "django", extras = ["argon2"], specifier = "==5.1.*" },
+    { name = "django", extras = ["argon2"], specifier = "==5.2.*" },
     { name = "django-auth-ldap" },
     { name = "django-bitfield" },
     { name = "django-bmemcached" },
@@ -5626,7 +5626,7 @@ prod = [
     { name = "decorator" },
     { name = "defusedxml" },
     { name = "disposable-email-domains" },
-    { name = "django", extras = ["argon2"], specifier = "==5.1.*" },
+    { name = "django", extras = ["argon2"], specifier = "==5.2.*" },
     { name = "django-auth-ldap" },
     { name = "django-bitfield" },
     { name = "django-bmemcached" },

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 390
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (331, 0)  # bumped 2025-06-10 to upgrade django-cte
+PROVISION_VERSION = (332, 0)  # bumped 2025-06-10 to upgrade Django

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 390
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (330, 0)  # bumped 2025-06-05 to upgrade Python requirements
+PROVISION_VERSION = (331, 0)  # bumped 2025-06-10 to upgrade django-cte

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -653,9 +653,10 @@ def user_groups_in_realm_serialized(
     """
     anonymous_group_ids: set[int] = set()
     if not fetch_anonymous_group_membership:
-        realm_groups = NamedUserGroup.objects.filter(realm=realm)
+        realm_groups_query = NamedUserGroup.objects.filter(realm=realm)
         if not include_deactivated_groups:
-            realm_groups = realm_groups.filter(deactivated=False)
+            realm_groups_query = realm_groups_query.filter(deactivated=False)
+        realm_groups = list(realm_groups_query)
     else:
         groups = UserGroup.objects.filter(realm=realm).select_related("named_user_group")
         realm_groups = []

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -7,7 +7,7 @@ from django.db import connection, transaction
 from django.db.models import F, Q, QuerySet, Value
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
-from django_cte import With
+from django_cte import CTE, with_cte
 from psycopg2.sql import SQL, Literal
 
 from zerver.lib.exceptions import (
@@ -777,23 +777,23 @@ def get_direct_memberships_of_users(user_group: UserGroup, members: list[UserPro
 
 
 def get_recursive_subgroups_union_for_groups(user_group_ids: list[int]) -> QuerySet[UserGroup]:
-    cte = With.recursive(
+    cte = CTE.recursive(
         lambda cte: UserGroup.objects.filter(id__in=user_group_ids)
         .values(group_id=F("id"))
         .union(
             cte.join(NamedUserGroup, direct_supergroups=cte.col.group_id).values(group_id=F("id"))
         )
     )
-    return cte.join(UserGroup, id=cte.col.group_id).with_cte(cte)
+    return with_cte(cte, select=cte.join(UserGroup, id=cte.col.group_id))
 
 
 def get_recursive_supergroups_union_for_groups(user_group_ids: list[int]) -> QuerySet[UserGroup]:
-    cte = With.recursive(
+    cte = CTE.recursive(
         lambda cte: UserGroup.objects.filter(id__in=user_group_ids)
         .values(group_id=F("id"))
         .union(cte.join(UserGroup, direct_subgroups=cte.col.group_id).values(group_id=F("id")))
     )
-    return cte.join(UserGroup, id=cte.col.group_id).with_cte(cte)
+    return with_cte(cte, select=cte.join(UserGroup, id=cte.col.group_id))
 
 
 def get_recursive_subgroups(user_group_id: int) -> QuerySet[UserGroup]:
@@ -804,14 +804,14 @@ def get_recursive_strict_subgroups(user_group: UserGroup) -> QuerySet[NamedUserG
     # Same as get_recursive_subgroups but does not include the
     # user_group passed.
     direct_subgroup_ids = user_group.direct_subgroups.all().values("id")
-    cte = With.recursive(
+    cte = CTE.recursive(
         lambda cte: NamedUserGroup.objects.filter(id__in=direct_subgroup_ids)
         .values(group_id=F("id"))
         .union(
             cte.join(NamedUserGroup, direct_supergroups=cte.col.group_id).values(group_id=F("id"))
         )
     )
-    return cte.join(NamedUserGroup, id=cte.col.group_id).with_cte(cte)
+    return with_cte(cte, select=cte.join(NamedUserGroup, id=cte.col.group_id))
 
 
 def get_recursive_group_members(user_group_id: int) -> QuerySet[UserProfile]:
@@ -828,12 +828,12 @@ def get_recursive_group_members_union_for_groups(
 
 
 def get_recursive_membership_groups(user_profile: UserProfile) -> QuerySet[UserGroup]:
-    cte = With.recursive(
+    cte = CTE.recursive(
         lambda cte: user_profile.direct_groups.values(group_id=F("id")).union(
             cte.join(UserGroup, direct_subgroups=cte.col.group_id).values(group_id=F("id"))
         )
     )
-    return cte.join(UserGroup, id=cte.col.group_id).with_cte(cte)
+    return with_cte(cte, select=cte.join(UserGroup, id=cte.col.group_id))
 
 
 def user_has_permission_for_group_setting(
@@ -896,14 +896,14 @@ def get_subgroup_ids(user_group: UserGroup, *, direct_subgroup_only: bool = Fals
 def get_recursive_subgroups_for_groups(
     user_group_ids: Iterable[int], realm: Realm
 ) -> QuerySet[NamedUserGroup]:
-    cte = With.recursive(
+    cte = CTE.recursive(
         lambda cte: NamedUserGroup.objects.filter(id__in=user_group_ids, realm=realm)
         .values(group_id=F("id"))
         .union(
             cte.join(NamedUserGroup, direct_supergroups=cte.col.group_id).values(group_id=F("id"))
         )
     )
-    recursive_subgroups = cte.join(NamedUserGroup, id=cte.col.group_id).with_cte(cte)
+    recursive_subgroups = with_cte(cte, select=cte.join(NamedUserGroup, id=cte.col.group_id))
     return recursive_subgroups
 
 
@@ -913,7 +913,7 @@ def get_root_id_annotated_recursive_subgroups_for_groups(
     # Same as get_recursive_subgroups_for_groups but keeps track of
     # each group root_id and annotates it with that group.
 
-    cte = With.recursive(
+    cte = CTE.recursive(
         lambda cte: UserGroup.objects.filter(id__in=user_group_ids, realm=realm_id)
         .values(group_id=F("id"), root_id=F("id"))
         .union(
@@ -922,8 +922,8 @@ def get_root_id_annotated_recursive_subgroups_for_groups(
             )
         )
     )
-    recursive_subgroups = (
-        cte.join(UserGroup, id=cte.col.group_id).with_cte(cte).annotate(root_id=cte.col.root_id)
+    recursive_subgroups = with_cte(cte, select=cte.join(UserGroup, id=cte.col.group_id)).annotate(
+        root_id=cte.col.root_id
     )
 
     return recursive_subgroups

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -590,7 +590,7 @@ def get_group_setting_value_for_register_api(
 
 
 def get_members_and_subgroups_of_groups(
-    group_ids: set[int],
+    group_ids: Iterable[int],
 ) -> dict[int, UserGroupMembersData]:
     user_members = (
         UserGroupMembership.objects.filter(user_group_id__in=group_ids)

--- a/zerver/migrations/0001_squashed_0569.py
+++ b/zerver/migrations/0001_squashed_0569.py
@@ -2668,6 +2668,7 @@ class Migration(migrations.Migration):
             field=models.ManyToManyField(
                 related_name="direct_supergroups",
                 through="zerver.GroupGroupMembership",
+                through_fields=("supergroup", "subgroup"),
                 to="zerver.namedusergroup",
             ),
         ),

--- a/zerver/migrations/0366_group_group_membership.py
+++ b/zerver/migrations/0366_group_group_membership.py
@@ -43,6 +43,7 @@ class Migration(migrations.Migration):
             field=models.ManyToManyField(
                 related_name="direct_supergroups",
                 through="zerver.GroupGroupMembership",
+                through_fields=("supergroup", "subgroup"),
                 to="zerver.UserGroup",
             ),
         ),

--- a/zerver/migrations/0514_update_usergroup_foreign_keys_to_namedusergroup.py
+++ b/zerver/migrations/0514_update_usergroup_foreign_keys_to_namedusergroup.py
@@ -39,6 +39,7 @@ class Migration(migrations.Migration):
             field=models.ManyToManyField(
                 related_name="direct_supergroups",
                 through="zerver.GroupGroupMembership",
+                through_fields=("supergroup", "subgroup"),
                 to="zerver.namedusergroup",
             ),
         ),

--- a/zerver/models/groups.py
+++ b/zerver/models/groups.py
@@ -2,7 +2,6 @@ from django.db import models
 from django.db.models import CASCADE
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext_lazy
-from django_cte import CTEManager
 
 from zerver.lib.cache import cache_with_key, get_realm_system_groups_cache_key
 from zerver.lib.types import GroupPermissionSetting
@@ -31,8 +30,7 @@ class SystemGroups:
     }
 
 
-class UserGroup(models.Model):  # type: ignore[django-manager-missing] # django-stubs cannot resolve the custom CTEManager yet https://github.com/typeddjango/django-stubs/issues/1023
-    objects: CTEManager = CTEManager()
+class UserGroup(models.Model):
     direct_members = models.ManyToManyField(
         UserProfile, through="zerver.UserGroupMembership", related_name="direct_groups"
     )
@@ -46,7 +44,7 @@ class UserGroup(models.Model):  # type: ignore[django-manager-missing] # django-
     realm = models.ForeignKey("zerver.Realm", on_delete=CASCADE)
 
 
-class NamedUserGroup(UserGroup):  # type: ignore[django-manager-missing] # django-stubs cannot resolve the custom CTEManager yet https://github.com/typeddjango/django-stubs/issues/1023
+class NamedUserGroup(UserGroup):
     MAX_NAME_LENGTH = 100
     INVALID_NAME_PREFIXES = ["@", "role:", "user:", "stream:", "channel:"]
 

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -155,7 +155,7 @@ class MessageEditHistoryVisibilityPolicyEnum(Enum):
     none = 3
 
 
-class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stubs cannot resolve the custom CTEManager yet https://github.com/typeddjango/django-stubs/issues/1023
+class Realm(models.Model):
     MAX_REALM_NAME_LENGTH = 40
     MAX_REALM_DESCRIPTION_LENGTH = 1000
     MAX_REALM_SUBDOMAIN_LENGTH = 40

--- a/zerver/models/recipients.py
+++ b/zerver/models/recipients.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from django.db import models, transaction
 from django.db.models import QuerySet
-from django_cte import CTEManager
 from typing_extensions import override
 
 from zerver.lib.display_recipient import get_display_recipient
@@ -52,8 +51,6 @@ class Recipient(models.Model):
     STREAM = 2
     # The type group direct messages.
     DIRECT_MESSAGE_GROUP = 3
-
-    objects = CTEManager()  # type: ignore[django-manager-missing] # django-stubs cannot resolve the custom CTEManager yet https://github.com/typeddjango/django-stubs/issues/1023
 
     class Meta:
         unique_together = ("type", "type_id")


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.2/releases/5.2/

Requires investigation:

> Adding [`EmailMultiAlternatives.alternatives`](https://docs.djangoproject.com/en/5.2/topics/email/#django.core.mail.EmailMultiAlternatives.alternatives) is now only supported via the [`attach_alternative()`](https://docs.djangoproject.com/en/5.2/topics/email/#django.core.mail.EmailMultiAlternatives.attach_alternative) method.

Possibly useful:

> The [`shell`](https://docs.djangoproject.com/en/5.2/ref/django-admin/#django-admin-shell) management command now automatically imports models from all installed apps.

> The new [`django.db.models.CompositePrimaryKey`](https://docs.djangoproject.com/en/5.2/ref/models/fields/#django.db.models.CompositePrimaryKey) allows tables to be created with a primary key consisting of multiple fields.

> The new [`HttpResponse.text`](https://docs.djangoproject.com/en/5.2/ref/request-response/#django.http.HttpResponse.text) property provides the string representation of [`HttpResponse.content`](https://docs.djangoproject.com/en/5.2/ref/request-response/#django.http.HttpResponse.content).

> The new [`HttpRequest.get_preferred_type()`](https://docs.djangoproject.com/en/5.2/ref/request-response/#django.http.HttpRequest.get_preferred_type) method can be used to query the preferred media type the client accepts.

> [`reverse()`](https://docs.djangoproject.com/en/5.2/ref/urlresolvers/#django.urls.reverse) and [`reverse_lazy()`](https://docs.djangoproject.com/en/5.2/ref/urlresolvers/#django.urls.reverse_lazy) now accept `query` and `fragment` keyword arguments, allowing the addition of a query string and/or fragment identifier in the generated URL, respectively.