### PR TITLE
settings: Prevent save discard widget override.

### DIFF
--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -48,15 +48,20 @@ async function test_change_new_stream_announcements_stream(page: Page): Promise<
 }
 
 async function test_change_signup_announcements_stream(page: Page): Promise<void> {
-    console.log('Changing signup notifications stream to Verona by filtering with "verona"');
+    await page.click("#realm_signup_announcements_stream_id_widget.dropdown-widget-button");
+    await page.waitForSelector(".dropdown-list-container", {
+        visible: true,
+    });
 
-    await page.click("#realm_signup_announcements_stream_id_widget");
-    await page.waitForSelector(".dropdown-list-search-input", {visible: true});
+    await page.type(".dropdown-list-search-input", "rome");
 
-    await page.type(".dropdown-list-search-input", "verona");
-    await page.waitForSelector(".dropdown-list .list-item", {visible: true});
-    await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("Enter");
+    const rome_in_dropdown = await page.waitForSelector(
+        `xpath///*[${common.has_class_x("list-item")}][normalize-space()="Rome"]`,
+        {visible: true},
+    );
+    assert.ok(rome_in_dropdown);
+    await rome_in_dropdown.click();
+
     await submit_announcements_stream_settings(page);
 }
 

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -560,6 +560,13 @@ export function change_save_button_state($element: JQuery, state: string): void 
         return;
     }
 
+    if (state === "succeeded" && $save_button.attr("data-status") === "unsaved") {
+        // We don't show the "saved" state if the save button is in the "unsaved"
+        // state, as that would indicate that user has made some other changes
+        // during the saving process.
+        return;
+    }
+
     if (state !== "saving") {
         buttons.hide_button_loading_indicator($save_button);
     }


### PR DESCRIPTION
This PR prevents the save button in the save discard widget from showing the "Saved" label when the user has made some other changes in the settings while the saving process was in action — which resulted in the "Save changes" label in the save button, and thus shouldn't be replaced with "Saved".

This PR also fixes the failing puppeteer tests in `web/e2e-tests/admin.test.ts` which was introduced in https://github.com/zulip/zulip/pull/34081.

Fixes: [#issues > 🎯 save/discard buttons misaligned on some browsers @ 💬](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20save.2Fdiscard.20buttons.20misaligned.20on.20some.20browsers/near/2148415)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![save_discard_override-before](https://github.com/user-attachments/assets/093895f0-8970-4d03-82ea-aec97dcc8f7d) | ![save_discard_override-after](https://github.com/user-attachments/assets/4a4cf60d-7f39-4a82-8487-d97d09291b22) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
