### PR TITLE
streams: Send different peer events for web & non-web public streams.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1834,20 +1834,21 @@ class NormalActionsTest(BaseAction):
         realm.signup_announcements_stream = get_stream("core team", realm)
         realm.save(update_fields=["signup_announcements_stream"])
 
-        with self.verify_action(num_events=5) as events:
+        with self.verify_action(num_events=6) as events:
             self.register("test1@zulip.com", "test1")
-        self.assert_length(events, 5)
+        self.assert_length(events, 6)
 
         check_realm_user_add("events[0]", events[0])
         new_user_profile = get_user_by_delivery_email("test1@zulip.com", self.user_profile.realm)
         self.assertEqual(new_user_profile.delivery_email, "test1@zulip.com")
 
         check_subscription_peer_add("events[3]", events[3])
+        check_subscription_peer_add("events[4]", events[4])
 
-        check_message("events[4]", events[4])
+        check_message("events[5]", events[5])
         self.assertIn(
             f'data-user-id="{new_user_profile.id}">test1_zulip.com</span> joined this organization.',
-            events[4]["message"]["content"],
+            events[5]["message"]["content"],
         )
 
         check_user_group_add_members("events[1]", events[1])
@@ -1865,19 +1866,20 @@ class NormalActionsTest(BaseAction):
         realm.signup_announcements_stream = get_stream("core team", realm)
         realm.save(update_fields=["signup_announcements_stream"])
 
-        with self.verify_action(num_events=5) as events:
+        with self.verify_action(num_events=6) as events:
             self.register("test1@zulip.com", "test1")
-        self.assert_length(events, 5)
+        self.assert_length(events, 6)
         check_realm_user_add("events[0]", events[0])
         new_user_profile = get_user_by_delivery_email("test1@zulip.com", self.user_profile.realm)
         self.assertEqual(new_user_profile.email, f"user{new_user_profile.id}@zulip.testserver")
 
         check_subscription_peer_add("events[3]", events[3])
+        check_subscription_peer_add("events[4]", events[4])
 
-        check_message("events[4]", events[4])
+        check_message("events[5]", events[5])
         self.assertIn(
             f'data-user-id="{new_user_profile.id}">test1_zulip.com</span> joined this organization',
-            events[4]["message"]["content"],
+            events[5]["message"]["content"],
         )
 
         check_user_group_add_members("events[1]", events[1])
@@ -3479,6 +3481,7 @@ class NormalActionsTest(BaseAction):
             name="hamletcharacters", realm=self.user_profile.realm
         )
         hamlet = self.example_user("hamlet")
+        self.user_profile = hamlet
         setting_group = self.create_or_update_anonymous_group_for_setting(
             [user_profile, hamlet], [members_group]
         )
@@ -3575,16 +3578,17 @@ class NormalActionsTest(BaseAction):
         self.make_stream("Test new stream")
         self.subscribe(user_profile, "Test new stream")
         self.subscribe(self.user_profile, "Test new stream")
-        with self.verify_action(num_events=6) as events:
+        with self.verify_action(num_events=7) as events:
             do_deactivate_user(user_profile, acting_user=None)
         check_subscription_peer_remove("events[0]", events[0])
-        check_user_group_remove_members("events[1]", events[1])
+        check_subscription_peer_remove("events[1]", events[1])
         check_user_group_remove_members("events[2]", events[2])
         check_user_group_remove_members("events[3]", events[3])
-        check_user_group_update("events[4]", events[4], {"can_mention_group"})
-        check_realm_user_remove("events[5]]", events[5])
+        check_user_group_remove_members("events[4]", events[4])
+        check_user_group_update("events[5]", events[5], {"can_mention_group"})
+        check_realm_user_remove("events[6]]", events[6])
         self.assertEqual(
-            events[4]["data"]["can_mention_group"],
+            events[5]["data"]["can_mention_group"],
             UserGroupMembersDict(direct_members=[], direct_subgroups=[members_group.id]),
         )
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -6405,9 +6405,11 @@ class SubscriptionAPITest(ZulipTestCase):
         stream4 = self.make_stream("stream4")
         stream5 = self.make_stream("stream5", is_web_public=True)
         stream6 = self.make_stream("stream6", is_web_public=True)
+        stream7 = self.make_stream("stream7")
         private = self.make_stream("private_stream", invite_only=True)
 
         self.subscribe(user1, "stream1")
+        self.subscribe(user1, "stream7")
         self.subscribe(user2, "stream1")
         self.subscribe(user3, "stream1")
 
@@ -6416,6 +6418,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.subscribe(user2, "stream4")
         self.subscribe(user2, "stream5")
         self.subscribe(user2, "stream6")
+        self.subscribe(user2, "stream7")
 
         self.subscribe(guest, "stream4")
 
@@ -6447,17 +6450,17 @@ class SubscriptionAPITest(ZulipTestCase):
             private, "can_subscribe_group", user8_group_member_dict, acting_user=user8
         )
 
-        # Sends 3 peer-remove events, 2 unsubscribe events
+        # Sends 5 peer-remove events, 2 unsubscribe events
         # and 2 stream delete events for private streams.
         with (
-            self.assert_database_query_count(23),
+            self.assert_database_query_count(25),
             self.assert_memcached_count(4),
             self.capture_send_event_calls(expected_num_events=9) as events,
         ):
             bulk_remove_subscriptions(
                 realm,
                 [user1, user2],
-                [stream1, stream2, stream3, stream4, stream5, stream6, private],
+                [stream1, stream2, stream3, stream4, stream5, stream6, stream7, private],
                 acting_user=None,
             )
 
@@ -6504,15 +6507,23 @@ class SubscriptionAPITest(ZulipTestCase):
                     {user1.id, user2.id},
                     {user3.id, user4.id, user6.id, user7.id, user8.id},
                 ),
+                # stream1 and stream7 are non-guest public streams,
+                # remove peer events for them will be sent together as
+                # a separate event since they will have the same peer
+                # user ids. This is not sent along with the stream2
+                # and stream3 event as user1 is not subscribed to
+                # stream2 and stream3 and thus peer_ids will be different.
                 (
-                    "stream1",
+                    "stream1,stream7",
                     {user1.id, user2.id},
                     {user3.id, user4.id, user5.id, user6.id, user7.id, user8.id},
                 ),
                 # stream2 and stream3 are non-guest public streams,
                 # remove peer events for them will be sent together as
                 # a separate event since they will have the same peer
-                # user ids.
+                # user ids. This is not sent along with the stream1
+                # and stream7 event as user1 is not subscribed to
+                # stream2 and stream3 and thus peer_ids will be different.
                 (
                     "stream2,stream3",
                     {user2.id},

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1002,7 +1002,7 @@ class QueryCountTest(ZulipTestCase):
         with (
             self.assert_database_query_count(86),
             self.assert_memcached_count(20),
-            self.capture_send_event_calls(expected_num_events=10) as events,
+            self.capture_send_event_calls(expected_num_events=11) as events,
         ):
             fred = do_create_user(
                 email="fred@zulip.com",
@@ -1023,7 +1023,7 @@ class QueryCountTest(ZulipTestCase):
             notifications.add(",".join(stream_names))
 
         self.assertEqual(
-            notifications, {"Denmark,Scotland,Verona", "private_stream1", "private_stream2"}
+            notifications, {"private_stream1", "private_stream2", "Verona", "Denmark,Scotland"}
         )
 
 


### PR DESCRIPTION
Earlier, we used to send a single event for all web-public and public streams. But public streams can have guests, which means the peer user ids for each of them can be different based on which guests are subscribed to which channel.
In the previous code, we were using the last stream id from another loop to get subscribers, which was causing a lot of non-deterministic failures in our test, since that stream id could keep on changing. Moreover, it doesn't make much sense to use that id here. This commit still keeps around the optimisation for public channels with non-guest users. It will send one event for all public channels with non-guest users, one for web public channels and for the rest of the channels it will send an event for each channel with a different set of peer user ids.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
