### PR TITLE
[EXPERIMENT] message_controls: Experiment with over-message hover.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -857,6 +857,15 @@
         hsl(0deg 0% 0% / 40%),
         hsl(0deg 0% 0%)
     );
+    --color-border-message-controls: light-dark(
+        hsl(0deg 0% 0% / 35%),
+        hsl(0deg 0% 0% / 40%)
+    );
+    --color-background-message-controls: light-dark(
+        hsl(0deg 0% 97%),
+        hsl(0deg 0% 17%)
+    );
+    --box-shadow-message-controls: 0 0.25em 0.5em 0 hsl(0deg 0% 0% / 10%);
     --color-border-personal-menu-avatar: light-dark(
         hsl(0deg 0% 0% / 10%),
         hsl(0deg 0% 100% / 20%)

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -427,6 +427,7 @@
     --message-box-avatar-height: var(--message-box-avatar-width);
     /* 46px at 14px/1em */
     --message-box-avatar-column-width: 3.2857em;
+    --message-box-star-marker-column-width: 1.5em;
     /* Increase the margin here to account for the
        focus ring, which is offset by -1px, as well
        as the vertical height between the hover icons

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -437,10 +437,6 @@
     --message-box-markdown-aligned-vertical-space: var(
         --markdown-interelement-space-px
     );
-    /* 22px matches to the width of the padded icon.
-       22px at 16px/1em
-    */
-    --message-box-icon-width: 1.375em;
     /* 25px at 16px/1em */
     --message-box-icon-height: 1.6667em;
     --message-box-height-senderless-single-line-message: calc(

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -79,12 +79,18 @@
       padding on either side of the message box. */
     padding: 0 5px 0 3px;
 
-    &:hover .message_controls {
-        opacity: 1;
-        visibility: visible;
+    &:hover {
+        .star_container {
+            opacity: 1;
+        }
 
-        .empty-star:hover {
-            cursor: pointer;
+        .message_controls {
+            opacity: 1;
+            visibility: visible;
+
+            .empty-star:hover {
+                cursor: pointer;
+            }
         }
     }
 }
@@ -108,20 +114,26 @@
     grid-template:
         var(--message-box-sender-line-height) repeat(3, auto) /
         var(--message-box-avatar-column-width) minmax(0, 1fr)
-        8px minmax(var(--message-box-timestamp-column-width), max-content);
+        var(--message-box-star-marker-column-width) minmax(
+            var(--message-box-timestamp-column-width),
+            max-content
+        );
     /* Named grid areas provide flexibility for positioning grid items
        reliably, even if the row or column definitions of the grid change. */
     grid-template-areas:
-        "edited message   . time"
-        ".      message   . .   "
-        ".      more      . .   "
-        ".      reactions . .   ";
+        "edited message   star-marker time"
+        ".      message   .           .   "
+        ".      more      .           .   "
+        ".      reactions .           .   ";
 
     &.content_edit_mode {
         cursor: default;
         grid-template-columns:
             var(--message-box-avatar-column-width) minmax(0, 1fr)
-            8px minmax(var(--message-box-timestamp-column-width), max-content);
+            var(--message-box-star-marker-column-width) minmax(
+                var(--message-box-timestamp-column-width),
+                max-content
+            );
     }
 
     .message_edit_notice {
@@ -268,10 +280,10 @@
 .messagebox-includes-sender {
     .messagebox-content {
         grid-template-areas:
-            "avatar sender    . time"
-            "avatar message   . .   "
-            ".      more      . .   "
-            ".      reactions . .   ";
+            "avatar sender    star-marker time"
+            "avatar message   .           .   "
+            ".      more      .           .   "
+            ".      reactions .           .   ";
 
         .message_edit {
             /* No top margin when there's a sender row */
@@ -280,11 +292,11 @@
 
         &.is-me-message {
             grid-template-areas:
-                ".      .         . .   "
-                "avatar sender    . time"
-                "avatar sender    . .   "
-                ".      more      . .   "
-                ".      reactions . .   ";
+                ".      .         .           .   "
+                "avatar sender    star-marker time"
+                "avatar sender    .           .   "
+                ".      more      .           .   "
+                ".      reactions .           .   ";
             grid-template-rows:
                 var(--message-box-vertical-margin) var(
                     --message-box-avatar-height
@@ -608,14 +620,38 @@
             animation: rotate 1s infinite linear;
         }
     }
+}
 
-    .star_container {
-        &:not(.empty-star) {
-            /* Color, opacity, and visibility, as though the message is hovered. */
-            color: var(--color-message-star-action);
-            opacity: 1;
-            visibility: visible !important;
-        }
+.star_container {
+    grid-area: star-marker;
+    place-self: center center;
+    /* We introduce a slight manual offset here
+       to lift stars a bit higher relative to
+       the timestamp.
+       2px at 16px/1em */
+    margin-top: -0.125em;
+    height: var(--message-box-sender-line-height);
+    display: flex;
+    place-items: center center;
+    color: var(--color-message-action-visible);
+    opacity: 0;
+    transform: scale(0.75);
+    transition: 0.2s ease;
+    transition-property: opacity, transform;
+
+    .star:focus {
+        outline: 0 !important;
+    }
+
+    &:hover {
+        opacity: 1;
+        transform: scale(1.25);
+    }
+
+    &:not(.empty-star) {
+        /* Color, opacity, and visibility, as though the message is hovered. */
+        color: var(--color-message-star-action);
+        opacity: 1;
     }
 }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -478,11 +478,10 @@
        which is padded right by 5px. */
     right: 5px;
     padding: 0.25em;
-    /* Color the message controls box like a popover. */
-    background-color: var(--color-background-popover-menu);
-    border: 1px solid var(--color-border-popover-menu);
+    background-color: var(--color-background-message-controls);
+    border: 1px solid var(--color-border-message-controls);
     border-radius: 6px;
-    box-shadow: var(--box-shadow-popover-menu);
+    box-shadow: var(--box-shadow-message-controls);
 
     /* Let the controls occupy the entire height
        of the row; inner flexboxes handle the

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -105,7 +105,7 @@
         ensures the timestamp will always have enough space
         in the column. */
     grid-template:
-        minmax(var(--message-box-sender-line-height), auto) repeat(3, auto) /
+        var(--message-box-sender-line-height) repeat(3, auto) /
         var(--message-box-avatar-column-width) minmax(0, 1fr) max-content
         8px minmax(var(--message-box-timestamp-column-width), max-content);
     /* Named grid areas provide flexibility for positioning grid items

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -576,8 +576,6 @@
     }
 
     .edit_content {
-        width: var(--message-box-icon-width);
-
         &:hover {
             cursor: pointer;
         }
@@ -1016,12 +1014,6 @@ of the base style defined for a read-only textarea in dark mode. */
         .message_controls
         .message_control_button:not(.failed_message_action) {
         visibility: hidden;
-    }
-    /* The actual star icon is not added to the DOM when a
-       message is locally echoed, so we set the equivalent
-       width on its container. */
-    .star_container {
-        width: var(--message-box-icon-width);
     }
 }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -80,18 +80,19 @@
     padding: 0 5px 0 3px;
 
     &:hover .message_controls {
+        opacity: 1;
+        visibility: visible;
+
         .empty-star:hover {
             cursor: pointer;
-        }
-
-        > .message_control_button {
-            opacity: 1;
-            visibility: visible;
         }
     }
 }
 
 .messagebox-content {
+    /* We set a positioning context solely for the
+       sake of hover controls positioning. */
+    position: relative;
     display: grid;
     align-items: baseline;
     padding-left: 10px;
@@ -106,26 +107,21 @@
         in the column. */
     grid-template:
         var(--message-box-sender-line-height) repeat(3, auto) /
-        var(--message-box-avatar-column-width) minmax(0, 1fr) max-content
+        var(--message-box-avatar-column-width) minmax(0, 1fr)
         8px minmax(var(--message-box-timestamp-column-width), max-content);
     /* Named grid areas provide flexibility for positioning grid items
        reliably, even if the row or column definitions of the grid change. */
     grid-template-areas:
-        "edited message   controls . time"
-        ".      message   .        . .   "
-        ".      more      .        . .   "
-        ".      reactions .        . .   ";
+        "edited message   . time"
+        ".      message   . .   "
+        ".      more      . .   "
+        ".      reactions . .   ";
 
     &.content_edit_mode {
         cursor: default;
-        /* Set the controls area to 0 to give more space
-           to the edit/source view area. */
         grid-template-columns:
             var(--message-box-avatar-column-width) minmax(0, 1fr)
-            0 8px minmax(
-                var(--message-box-timestamp-column-width),
-                max-content
-            );
+            8px minmax(var(--message-box-timestamp-column-width), max-content);
     }
 
     .message_edit_notice {
@@ -272,10 +268,10 @@
 .messagebox-includes-sender {
     .messagebox-content {
         grid-template-areas:
-            "avatar sender    controls . time"
-            "avatar message   .        . .   "
-            ".      more      .        . .   "
-            ".      reactions .        . .   ";
+            "avatar sender    . time"
+            "avatar message   . .   "
+            ".      more      . .   "
+            ".      reactions . .   ";
 
         .message_edit {
             /* No top margin when there's a sender row */
@@ -284,11 +280,11 @@
 
         &.is-me-message {
             grid-template-areas:
-                ".      .         .        . .   "
-                "avatar sender    controls . time"
-                "avatar sender    .        . .   "
-                ".      more      .        . .   "
-                ".      reactions .        . .   ";
+                ".      .         . .   "
+                "avatar sender    . time"
+                "avatar sender    . .   "
+                ".      more      . .   "
+                ".      reactions . .   ";
             grid-template-rows:
                 var(--message-box-vertical-margin) var(
                     --message-box-avatar-height
@@ -317,6 +313,9 @@
                    available grid row height on me-messages, we
                    align to center here. */
                 align-self: center;
+                /* Me-messages are offset by the avatar height, so this
+                   is the value to offset message controls. */
+                top: var(--message-box-avatar-height);
             }
 
             .message_sender {
@@ -465,7 +464,26 @@
 }
 
 .message_controls {
-    grid-area: controls;
+    position: absolute;
+    /* We bump the z-index to 5 so the controls appear above
+       the message text and the dividers between topics in
+       an interleaved view. */
+    z-index: 5;
+    /* Experiment with pulling the controls below the timestamp,
+       using 75% of the sender line-height. This looks nice on
+       a single-line message that includes a sender, with the
+       focus ring showing. */
+    top: calc(var(--message-box-sender-line-height) * 0.75);
+    /* Let the controls share the righthand edge of the timestamp,
+       which is padded right by 5px. */
+    right: 5px;
+    padding: 0.25em;
+    /* Color the message controls box like a popover. */
+    background-color: var(--color-background-popover-menu);
+    border: 1px solid var(--color-border-popover-menu);
+    border-radius: 6px;
+    box-shadow: var(--box-shadow-popover-menu);
+
     /* Let the controls occupy the entire height
        of the row; inner flexboxes handle the
        centering of the icons. */
@@ -478,27 +496,10 @@
     /* Ensure square icons for better centering. */
     line-height: 1;
 
-    @container message-lists (width < $cq_sm_min) {
-        /* This is intended to target the first message_controls child
-           when there are 3 displayed. */
-        .message_control_button:nth-last-child(3) {
-            display: none;
-        }
-    }
-
-    /* Media-query fallback. Note that because we're treating
-       #message-lists-container as its own container, we can
-       express a much simpler query there. The more complex
-       conditions are necessary only for media queries. */
-    @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
-        .without-container-query-support {
-            /* This is intended to target the first message_controls child
-            when there are 3 displayed. */
-            .message_control_button:nth-last-child(3) {
-                display: none;
-            }
-        }
-    }
+    opacity: 0;
+    visibility: hidden;
+    transition: 0.2s ease;
+    transition-property: opacity, visibility;
 
     /* This is a bit tricky; we need to reserve space for the message
        controls even when the message isn't hovered, so that hover
@@ -506,10 +507,6 @@
        visibility: hidden, but that cannot be animated, so we set
        opacity as well, which can be animated. */
     .message_control_button {
-        opacity: 0;
-        visibility: hidden;
-        transition: 0.2s ease;
-        transition-property: opacity, visibility;
         /* Allow buttons to grow to fill the available space,
            in concord with the column calculated for the
            .messagebox-content grid. */

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -152,7 +152,7 @@
     }
 }
 
-.active-emoji-picker-reference,
+.message_controls:has(.active-emoji-picker-reference),
 .active-playground-links-reference {
     visibility: visible !important;
     pointer-events: all !important;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -911,7 +911,7 @@ strong {
 
 /* Make the action icon on the message row
    always visible while the popover is open */
-.has_actions_popover .actions_hover {
+.has_actions_popover .message_controls {
     visibility: visible !important;
     pointer-events: all !important;
     opacity: 1 !important;

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -26,6 +26,12 @@
     {{/if}}
 </span>
 
+<div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tooltip-template-id="{{#if msg/starred}}unstar{{else}}star{{/if}}-message-tooltip-template">
+    {{#unless msg/locally_echoed}}
+    <i role="button" tabindex="0" class="message-controls-icon star zulip-icon {{#if msg/starred}}zulip-icon-star-filled{{else}}zulip-icon-star{{/if}}"></i>
+    {{/unless}}
+</div>
+
 <a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message-time">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -26,11 +26,12 @@
     {{/if}}
 </span>
 
+{{#unless msg/locally_echoed}}
 <div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tooltip-template-id="{{#if msg/starred}}unstar{{else}}star{{/if}}-message-tooltip-template">
-    {{#unless msg/locally_echoed}}
     <i role="button" tabindex="0" class="message-controls-icon star zulip-icon {{#if msg/starred}}zulip-icon-star-filled{{else}}zulip-icon-star{{/if}}"></i>
-    {{/unless}}
 </div>
+{{/unless}}
+
 
 <a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message-time">
     {{#unless include_sender}}

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -18,9 +18,3 @@
 <div class="actions_hover message_control_button" data-tooltip-template-id="message-actions-tooltip-template" >
     <i class="message-controls-icon message-actions-menu-button zulip-icon zulip-icon-more-vertical-spread" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Message actions' }}"></i>
 </div>
-
-<div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tooltip-template-id="{{#if msg/starred}}unstar{{else}}star{{/if}}-message-tooltip-template">
-    {{#unless msg/locally_echoed}}
-    <i role="button" tabindex="0" class="message-controls-icon star zulip-icon {{#if msg/starred}}zulip-icon-star-filled{{else}}zulip-icon-star{{/if}}"></i>
-    {{/unless}}
-</div>


### PR DESCRIPTION
This PR introduces experimental hover controls that do not sit within the message grid. Instead, they appear below the timestamp.

In this iteration, stars have been moved out of the hover-control group and placed in their own small column to the left of the timestamp. They are hoverable and interactive.

An issue yet to be addressed here is the likely unwanted display of hover controls appearing when the top of the message box has scrolled off screen.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_2025-04-16 afternoon update (note, as always, that the arrow cursor is an artifact of macOS screen recording):_


![hover-controls-2025-04-16](https://github.com/user-attachments/assets/0e2dee90-30c0-47e7-8d0c-b975ad97c211)


