### PR TITLE
rest_api: Add logging to REST path.

### DIFF
--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -25,8 +25,6 @@ from zerver.lib.sessions import narrow_request_user
 ParamT = ParamSpec("ParamT")
 METHODS = ("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH")
 
-logger = logging.getLogger("zulip.rest")
-
 
 def default_never_cache_responses(
     view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponse],
@@ -95,7 +93,12 @@ def get_target_view_function_or_response(
     # Override requested method if magic method=??? parameter exists
     method_to_use = request.method
     if request.POST and "method" in request.POST:
-        logger.warning("Overriding method")  # %s with %s", request.method, request.POST["method"])
+        logging.warning(
+            "Overriding HTTP method via 'method' parameter: original=%s, override=%s, client=%s",
+            request.method,
+            request.POST["method"],
+            request_notes.client_name,
+        )
         method_to_use = request.POST["method"]
 
     if method_to_use in supported_methods:

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from functools import wraps
 from typing import Concatenate
@@ -23,6 +24,8 @@ from zerver.lib.sessions import narrow_request_user
 
 ParamT = ParamSpec("ParamT")
 METHODS = ("GET", "HEAD", "POST", "PUT", "DELETE", "PATCH")
+
+logger = logging.getLogger("zulip.rest")
 
 
 def default_never_cache_responses(
@@ -92,6 +95,7 @@ def get_target_view_function_or_response(
     # Override requested method if magic method=??? parameter exists
     method_to_use = request.method
     if request.POST and "method" in request.POST:
+        logger.warning("Overriding method")  # %s with %s", request.method, request.POST["method"])
         method_to_use = request.POST["method"]
 
     if method_to_use in supported_methods:

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1791,12 +1791,16 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             "method": "PATCH",
         }
         email = "hambot-bot@zulip.testserver"
-        # Important: We intentionally use the wrong method, post, here.
-        result = self.client_post(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
+
+        with self.assertLogs("zulip.rest", "WARN") as m:
+            # Important: We intentionally use the wrong method, post, here.
+            result = self.client_post(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
 
         # TODO: The "method" parameter is not currently tracked as a processed parameter
         # by typed_endpoint. Assert it is returned as an ignored parameter.
         response_dict = self.assert_json_success(result, ignored_parameters=["method"])
+
+        self.assertEqual(m.output, ["WARNING:zulip.rest:Overriding method"])
 
         self.assertEqual("Fred", response_dict["full_name"])
 


### PR DESCRIPTION
This will help audit the usage of this in chat.zulip.org and Zulip cloud.

Fixes part of #1403.

<!-- Describe your pull request here.-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
