### PR TITLE
Do not prefetch `can_access_all_users_group` setting in user queries.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -398,11 +398,6 @@ def notify_created_user(user_profile: UserProfile, notify_user_ids: list[int]) -
     else:
         active_realm_users = list(user_profile.realm.get_active_users())
 
-        # This call to user_access_restricted_in_realm results in
-        # one extra query in the user creation codepath to check
-        # "realm.can_access_all_users_group.name" because we do
-        # not prefetch realm and its related fields when fetching
-        # PreregistrationUser object.
         if user_access_restricted_in_realm(user_profile):
             for user in active_realm_users:
                 if user.is_guest:

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1666,7 +1666,7 @@ def get_recipients_for_user_creation_events(
     if len(guest_recipients) == 0:
         return recipients_for_user_creation_events
 
-    if realm.can_access_all_users_group.named_user_group.name == SystemGroups.EVERYONE:
+    if not user_access_restricted_in_realm(sender):
         return recipients_for_user_creation_events
 
     if len(user_profiles) == 1:

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -122,10 +122,6 @@ def get_usable_missed_message_address(address: str) -> MissedMessageEmailAddress
         mm_address = MissedMessageEmailAddress.objects.select_related(
             "user_profile",
             "user_profile__realm",
-            # Fetch group settings that are needed to determine whether a user
-            # can send a direct message to a given recipient.
-            "user_profile__realm__can_access_all_users_group",
-            "user_profile__realm__can_access_all_users_group__named_user_group",
             "message",
             "message__sender",
             "message__recipient",

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1529,7 +1529,7 @@ def check_user_group_mention_allowed(sender: UserProfile, user_group_ids: list[i
             )
 
         if not user_has_permission_for_group_setting(
-            can_mention_group,
+            can_mention_group.id,
             sender,
             NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_mention_group"],
             direct_member_only=False,

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -471,7 +471,7 @@ def check_stream_access_based_on_can_send_message_group(
             raise JsonableError(_("You do not have permission to post in this channel."))
 
     if not user_has_permission_for_group_setting(
-        stream.can_send_message_group,
+        stream.can_send_message_group_id,
         sender,
         Stream.stream_permission_group_settings["can_send_message_group"],
         direct_member_only=False,
@@ -1165,10 +1165,10 @@ def get_streams_to_which_user_cannot_add_subscribers(
 def can_administer_accessible_channel(channel: Stream, user_profile: UserProfile) -> bool:
     # IMPORTANT: This function expects its callers to have already
     # checked that the user can access the provided channel.
-    group_allowed_to_administer_channel = channel.can_administer_channel_group
-    assert group_allowed_to_administer_channel is not None
+    group_id_allowed_to_administer_channel = channel.can_administer_channel_group_id
+    assert group_id_allowed_to_administer_channel is not None
     return user_has_permission_for_group_setting(
-        group_allowed_to_administer_channel,
+        group_id_allowed_to_administer_channel,
         user_profile,
         Stream.stream_permission_group_settings["can_administer_channel_group"],
     )

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -171,7 +171,7 @@ def access_user_group_for_update(
         return user_group
 
     user_has_permission = user_has_permission_for_group_setting(
-        user_group.can_manage_group,
+        user_group.can_manage_group_id,
         user_profile,
         NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_manage_group"],
     )
@@ -181,7 +181,7 @@ def access_user_group_for_update(
     if permission_setting != "can_manage_group":
         assert permission_setting in NamedUserGroup.GROUP_PERMISSION_SETTINGS
         user_has_permission = user_has_permission_for_group_setting(
-            getattr(user_group, permission_setting),
+            getattr(user_group, permission_setting).id,
             user_profile,
             NamedUserGroup.GROUP_PERMISSION_SETTINGS[permission_setting],
         )
@@ -836,7 +836,7 @@ def get_recursive_membership_groups(user_profile: UserProfile) -> QuerySet[UserG
 
 
 def user_has_permission_for_group_setting(
-    user_group: UserGroup,
+    user_group_id: int,
     user: UserProfile,
     setting_config: GroupPermissionSetting,
     *,
@@ -845,7 +845,7 @@ def user_has_permission_for_group_setting(
     if not setting_config.allow_everyone_group and user.is_guest:
         return False
 
-    return is_user_in_group(user_group.id, user, direct_member_only=direct_member_only)
+    return is_user_in_group(user_group_id, user, direct_member_only=direct_member_only)
 
 
 def is_any_user_direct_member(user_group_id: int, user_ids: Iterable[int]) -> bool:

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -36,7 +36,7 @@ from zerver.models import (
     UserMessage,
     UserProfile,
 )
-from zerver.models.groups import SystemGroups
+from zerver.models.groups import SystemGroups, get_realm_system_groups_name_dict
 from zerver.models.realms import get_fake_email_domain, require_unique_names
 from zerver.models.users import (
     active_non_guest_user_ids,
@@ -670,12 +670,19 @@ def format_user_row(
     return result
 
 
+def all_users_accessible_by_everyone_in_realm(realm: Realm) -> bool:
+    system_groups_name_dict = get_realm_system_groups_name_dict(realm.id)
+    if system_groups_name_dict[realm.can_access_all_users_group_id] == SystemGroups.EVERYONE:
+        return True
+
+    return False
+
+
 def user_access_restricted_in_realm(target_user: UserProfile) -> bool:
     if target_user.is_bot:
         return False
 
-    realm = target_user.realm
-    if realm.can_access_all_users_group.named_user_group.name == SystemGroups.EVERYONE:
+    if all_users_accessible_by_everyone_in_realm(target_user.realm):
         return False
 
     return True

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -186,14 +186,14 @@ def add_service(
 
 def check_can_create_bot(user_profile: UserProfile, bot_type: int) -> None:
     if user_has_permission_for_group_setting(
-        user_profile.realm.can_create_bots_group,
+        user_profile.realm.can_create_bots_group_id,
         user_profile,
         Realm.REALM_PERMISSION_GROUP_SETTINGS["can_create_bots_group"],
     ):
         return
 
     if bot_type == UserProfile.INCOMING_WEBHOOK_BOT and user_has_permission_for_group_setting(
-        user_profile.realm.can_create_write_only_bots_group,
+        user_profile.realm.can_create_write_only_bots_group_id,
         user_profile,
         Realm.REALM_PERMISSION_GROUP_SETTINGS["can_create_write_only_bots_group"],
     ):
@@ -692,7 +692,7 @@ def check_user_can_access_all_users(acting_user: UserProfile | None) -> bool:
 
     realm = acting_user.realm
     if user_has_permission_for_group_setting(
-        realm.can_access_all_users_group,
+        realm.can_access_all_users_group_id,
         acting_user,
         Realm.REALM_PERMISSION_GROUP_SETTINGS["can_access_all_users_group"],
     ):

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1044,9 +1044,6 @@ def get_accessible_user_ids(
 def get_user_dicts_in_realm(
     realm: Realm, user_profile: UserProfile | None
 ) -> tuple[list[RawUserDict], list[APIUserDict]]:
-    group_allowed_to_access_all_users = realm.can_access_all_users_group
-    assert group_allowed_to_access_all_users is not None
-
     all_user_dicts = get_realm_user_dicts(realm.id)
     if check_user_can_access_all_users(user_profile):
         return (all_user_dicts, [])

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -926,11 +926,7 @@ def base_bulk_get_user_queryset() -> QuerySet[UserProfile]:
     prefetches can_access_all_users_group, which is often necessary
     for calculations of where events should be sent.
     """
-    return UserProfile.objects.select_related(
-        "realm",
-        "realm__can_access_all_users_group",
-        "realm__can_access_all_users_group__named_user_group",
-    )
+    return UserProfile.objects.select_related("realm")
 
 
 def base_get_user_queryset() -> QuerySet[UserProfile]:
@@ -938,12 +934,7 @@ def base_get_user_queryset() -> QuerySet[UserProfile]:
     In contrast with base_bulk_get_user_queryset, additionally fetches
     fields that are relevant for this user sending a message.
     """
-    return UserProfile.objects.select_related(
-        "realm",
-        "realm__can_access_all_users_group",
-        "realm__can_access_all_users_group__named_user_group",
-        "bot_owner",
-    )
+    return UserProfile.objects.select_related("realm", "bot_owner")
 
 
 @cache_with_key(user_profile_by_id_cache_key, timeout=3600 * 24 * 7)

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -826,9 +826,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
             # the number of database queries by fetching the group
             # setting fields using select_related.
             realm = self.realm
-        allowed_user_group = getattr(realm, policy_name)
+        allowed_user_group_id = getattr(realm, policy_name).id
         setting_config = Realm.REALM_PERMISSION_GROUP_SETTINGS[policy_name]
-        return user_has_permission_for_group_setting(allowed_user_group, self, setting_config)
+        return user_has_permission_for_group_setting(allowed_user_group_id, self, setting_config)
 
     def can_create_public_streams(self, realm: Optional["Realm"] = None) -> bool:
         return self.has_permission("can_create_public_channel_group", realm)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1364,7 +1364,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         incoming_valid_message["To"] = mm_address
         incoming_valid_message["Reply-to"] = user_profile.delivery_email
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(18):
             process_message(incoming_valid_message)
 
         # confirm that Hamlet got the message

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -171,7 +171,7 @@ class EventsEndpointTest(ZulipTestCase):
                 status_code=401,
             )
 
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(14):
             result = self.client_post("/json/register")
             result_dict = self.assert_json_success(result)
             self.assertEqual(result_dict["queue_id"], None)

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -109,7 +109,7 @@ class StreamSetupTest(ZulipTestCase):
 
         new_user = self.create_simple_new_user(realm, "alice@zulip.com")
 
-        with self.assert_database_query_count(14):
+        with self.assert_database_query_count(13):
             set_up_streams_and_groups_for_new_human_user(
                 user_profile=new_user,
                 prereg_user=None,
@@ -145,7 +145,7 @@ class StreamSetupTest(ZulipTestCase):
 
         new_user = self.create_simple_new_user(realm, new_user_email)
 
-        with self.assert_database_query_count(15):
+        with self.assert_database_query_count(16):
             set_up_streams_and_groups_for_new_human_user(
                 user_profile=new_user,
                 prereg_user=prereg_user,

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1624,7 +1624,7 @@ class StreamMessagesTest(ZulipTestCase):
             setting_value=UserProfile.AUTOMATICALLY_CHANGE_VISIBILITY_POLICY_NEVER,
             acting_user=None,
         )
-        with self.assert_database_query_count(13):
+        with self.assert_database_query_count(14):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1644,7 +1644,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 5 queries: 1 to check if it is the first message in the topic +
         # 1 to check if the topic is already followed + 3 to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(18):
+        with self.assert_database_query_count(19):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1664,7 +1664,7 @@ class StreamMessagesTest(ZulipTestCase):
         # a message to a topic with visibility policy other than FOLLOWED.
         # 1 to check if the topic is already followed + 3 queries to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(18):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1675,7 +1675,7 @@ class StreamMessagesTest(ZulipTestCase):
         # If the topic is already FOLLOWED, there will be an increase in the query
         # count of 1 to check if the topic is already followed.
         flush_per_request_caches()
-        with self.assert_database_query_count(14):
+        with self.assert_database_query_count(15):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1700,7 +1700,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 1 to get the user_id of the mentioned user + 1 to check if the topic
         # is already followed + 3 queries to follow the topic.
         flush_per_request_caches()
-        with self.assert_database_query_count(22):
+        with self.assert_database_query_count(23):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1713,7 +1713,7 @@ class StreamMessagesTest(ZulipTestCase):
         # 1 to get the user_id of the mentioned user + 1 to check if the topic is
         # already followed.
         flush_per_request_caches()
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(20):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1723,7 +1723,7 @@ class StreamMessagesTest(ZulipTestCase):
             )
 
         flush_per_request_caches()
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(17):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1746,7 +1746,7 @@ class StreamMessagesTest(ZulipTestCase):
         )
         flush_per_request_caches()
 
-        with self.assert_database_query_count(17):
+        with self.assert_database_query_count(18):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1028,8 +1028,8 @@ class LoginTest(ZulipTestCase):
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
         with (
-            self.assert_database_query_count(94),
-            self.assert_memcached_count(15),
+            self.assert_database_query_count(93),
+            self.assert_memcached_count(18),
             self.captureOnCommitCallbacks(execute=True),
         ):
             self.register(self.nonreg_email("test"), "test")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3436,7 +3436,7 @@ class StreamAdminTest(ZulipTestCase):
         If you're not an admin, you can't remove other people from streams except your own bots.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=7,
+            query_count=8,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=False,
             is_subbed=True,
@@ -3451,7 +3451,7 @@ class StreamAdminTest(ZulipTestCase):
         those you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=14,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3478,8 +3478,8 @@ class StreamAdminTest(ZulipTestCase):
             for name in ["cordelia", "prospero", "iago", "hamlet", "outgoing_webhook_bot"]
         ]
         result = self.attempt_unsubscribe_of_principal(
-            query_count=20,
-            cache_count=8,
+            query_count=21,
+            cache_count=13,
             target_users=target_users,
             is_realm_admin=True,
             is_subbed=True,
@@ -3496,7 +3496,7 @@ class StreamAdminTest(ZulipTestCase):
         are on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=16,
+            query_count=17,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3513,7 +3513,7 @@ class StreamAdminTest(ZulipTestCase):
         streams you aren't on.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=16,
+            query_count=17,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -3527,7 +3527,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_cant_remove_others_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=7,
+            query_count=8,
             is_realm_admin=False,
             is_subbed=True,
             invite_only=False,
@@ -3539,7 +3539,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_admin_remove_others_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=14,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3553,7 +3553,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_admin_remove_multiple_users_from_stream_legacy_emails(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=15,
+            query_count=16,
             target_users=[self.example_user("cordelia"), self.example_user("prospero")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3567,7 +3567,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_remove_unsubbed_user_along_with_subbed(self) -> None:
         result = self.attempt_unsubscribe_of_principal(
-            query_count=12,
+            query_count=13,
             target_users=[self.example_user("cordelia"), self.example_user("iago")],
             is_realm_admin=True,
             is_subbed=True,
@@ -3584,7 +3584,7 @@ class StreamAdminTest(ZulipTestCase):
         fails gracefully.
         """
         result = self.attempt_unsubscribe_of_principal(
-            query_count=6,
+            query_count=7,
             target_users=[self.example_user("cordelia")],
             is_realm_admin=True,
             is_subbed=False,
@@ -3600,7 +3600,7 @@ class StreamAdminTest(ZulipTestCase):
         webhook_bot = self.example_user("webhook_bot")
         do_change_bot_owner(webhook_bot, bot_owner=user_profile, acting_user=user_profile)
         result = self.attempt_unsubscribe_of_principal(
-            query_count=13,
+            query_count=14,
             target_users=[webhook_bot],
             is_realm_admin=False,
             is_subbed=True,
@@ -6081,7 +6081,7 @@ class SubscriptionAPITest(ZulipTestCase):
         streams_to_sub = ["multi_user_stream"]
         with (
             self.capture_send_event_calls(expected_num_events=5) as events,
-            self.assert_database_query_count(42),
+            self.assert_database_query_count(43),
         ):
             self.subscribe_via_post(
                 self.test_user,
@@ -6107,7 +6107,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Now add ourselves
         with (
             self.capture_send_event_calls(expected_num_events=2) as events,
-            self.assert_database_query_count(18),
+            self.assert_database_query_count(19),
         ):
             self.subscribe_via_post(
                 self.test_user,
@@ -6453,8 +6453,8 @@ class SubscriptionAPITest(ZulipTestCase):
         # Sends 5 peer-remove events, 2 unsubscribe events
         # and 2 stream delete events for private streams.
         with (
-            self.assert_database_query_count(25),
-            self.assert_memcached_count(4),
+            self.assert_database_query_count(26),
+            self.assert_memcached_count(5),
             self.capture_send_event_calls(expected_num_events=9) as events,
         ):
             bulk_remove_subscriptions(
@@ -6595,7 +6595,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Verify that peer_event events are never sent in Zephyr
         # realm. This does generate stream creation events from
         # send_stream_creation_events_for_previously_inaccessible_streams.
-        with self.assert_database_query_count(num_streams + 17):
+        with self.assert_database_query_count(num_streams + 18):
             with self.capture_send_event_calls(expected_num_events=num_streams + 1) as events:
                 self.subscribe_via_post(
                     mit_user,
@@ -6676,8 +6676,8 @@ class SubscriptionAPITest(ZulipTestCase):
         test_user_ids = [user.id for user in test_users]
 
         with (
-            self.assert_database_query_count(21),
-            self.assert_memcached_count(3),
+            self.assert_database_query_count(22),
+            self.assert_memcached_count(11),
             mock.patch("zerver.views.streams.send_messages_for_new_subscribers"),
         ):
             self.subscribe_via_post(
@@ -7054,7 +7054,7 @@ class SubscriptionAPITest(ZulipTestCase):
         ]
 
         # Test creating a public stream when realm does not have a notification stream.
-        with self.assert_database_query_count(42):
+        with self.assert_database_query_count(43):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[0]],
@@ -7062,7 +7062,7 @@ class SubscriptionAPITest(ZulipTestCase):
             )
 
         # Test creating private stream.
-        with self.assert_database_query_count(50):
+        with self.assert_database_query_count(51):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[1]],
@@ -7074,7 +7074,7 @@ class SubscriptionAPITest(ZulipTestCase):
         new_stream_announcements_stream = get_stream(self.streams[0], self.test_realm)
         self.test_realm.new_stream_announcements_stream_id = new_stream_announcements_stream.id
         self.test_realm.save()
-        with self.assert_database_query_count(54):
+        with self.assert_database_query_count(55):
             self.subscribe_via_post(
                 self.test_user,
                 [new_streams[2]],
@@ -7859,7 +7859,7 @@ class GetSubscribersTest(ZulipTestCase):
             polonius.id,
         ]
 
-        with self.assert_database_query_count(50):
+        with self.assert_database_query_count(51):
             self.subscribe_via_post(
                 self.user_profile,
                 stream_names,

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1867,7 +1867,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         with (
             mock.patch("zerver.views.user_groups.notify_for_user_group_subscription_changes"),
-            self.assert_database_query_count(16),
+            self.assert_database_query_count(15),
         ):
             result = self.client_post(f"/json/user_groups/{user_group.id}/members", info=params)
         self.assert_json_success(result)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1000,8 +1000,8 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(86),
-            self.assert_memcached_count(20),
+            self.assert_database_query_count(85),
+            self.assert_memcached_count(23),
             self.capture_send_event_calls(expected_num_events=11) as events,
         ):
             fred = do_create_user(
@@ -1724,7 +1724,7 @@ class UserProfileTest(ZulipTestCase):
 
         # Subscribe to the stream.
         self.subscribe(iago, stream.name)
-        with self.assert_database_query_count(7):
+        with self.assert_database_query_count(8):
             result = orjson.loads(
                 self.client_get(f"/json/users/{iago.id}/subscriptions/{stream.id}").content
             )


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First two commits are refactor commits.
- Last commit is to update code to not prefetch setting.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
