### PR TITLE
webpack: Use CORS requests for stylesheets

### DIFF
--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -30,7 +30,7 @@
         {% block webpack %}
             {% for filename in webpack_entry(entrypoint) -%}
                 {% if filename.endswith(".css") -%}
-                    <link href="{{ filename }}" rel="stylesheet" {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %} />
+                    <link href="{{ filename }}" rel="stylesheet" crossorigin="anonymous" {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %} />
                 {% elif filename.endswith(".js") -%}
                     <script src="{{ filename }}" defer crossorigin="anonymous" {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}></script>
                 {% endif -%}


### PR DESCRIPTION
This seems to be required for [webpack-dev-server 5.2.1](https://github.com/webpack/webpack-dev-server/releases/tag/v5.2.1), for reasons that have not yet been made public. This relies on the `Access-Control-Allow-Origin: *` header that we already set for static content in both development and production.

[Discussion](https://chat.zulip.org/#narrow/channel/49-development-help/topic/create.20new.20realm.20not.20loading.20CSS/near/2150761). MDN documentation: [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin), [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin).