### PR TITLE
Add save btn tooltip for exceeded message length

### DIFF
--- a/web/src/compose_validate.ts
+++ b/web/src/compose_validate.ts
@@ -106,6 +106,7 @@ function set_message_too_long_for_compose(status: boolean): void {
 function set_message_too_long_for_edit(status: boolean, $container: JQuery): void {
     const message_too_long = status;
     const $message_edit_save_container = $container.find(".message_edit_save_container");
+    $message_edit_save_container.toggleClass("message-too-long-for-edit", message_too_long);
     const save_is_disabled =
         message_too_long ||
         $message_edit_save_container.hasClass("message-edit-time-limit-expired");
@@ -131,12 +132,14 @@ export function get_disabled_send_tooltip(): string {
 
 export function get_disabled_save_tooltip($container: JQuery): string {
     const $button_wrapper = $container.find(".message_edit_save_container");
+    // The time limit expiry tooltip takes precedence over the message
+    // length exceeded tooltip.
     if ($button_wrapper.hasClass("message-edit-time-limit-expired")) {
         return $t({
             defaultMessage: "You can no longer save changes to this message.",
         });
     }
-    if (message_too_long) {
+    if ($button_wrapper.hasClass("message-too-long-for-edit")) {
         return get_message_too_long_for_compose_error();
     }
     return "";


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [<!-- Issue link, or clear description.-->](https://chat.zulip.org/#narrow/channel/101-design/topic/validation.20tooltip.20in.20message.20edit.20same.20as.20compose.3F/near/2149696)[#design > validation tooltip in message edit same as compose? @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/validation.20tooltip.20in.20message.20edit.20same.20as.20compose.3F/near/2149696)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Message length exceeded | Time limit expiry AND message length exceeded |
|-------|-------|
| ![message-length-exceeded-1744339530524](https://github.com/user-attachments/assets/d16bffdd-8d11-4faf-8629-d93093bde1ce)| ![time-limit-expired-plus-long-message-1744339704525](https://github.com/user-attachments/assets/22fba21b-ca61-4f87-9b8a-0a38d22965f8)|



| Message Length Exceeded | Time limit expiry AND message length exceeded |
|-----------|-------------------|
|![image](https://github.com/user-attachments/assets/359399d5-60bf-466d-90c8-8cf590cc1148)| ![image](https://github.com/user-attachments/assets/edb7dae4-a9f3-4fef-9bea-ace76b185cb5)|




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
