### PR TITLE
Handle gravatar domain blocked for navbar avatar

### DIFF
--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -151,7 +151,10 @@ export const update_person = function update(event: UserUpdate): void {
             current_user.avatar_url = url;
             current_user.avatar_url_medium = event.avatar_url_medium;
             $("#user-avatar-upload-widget .image-block").attr("src", event.avatar_url_medium);
-            $("#personal-menu .header-button-avatar").attr("src", `${event.avatar_url_medium}`);
+            $("#personal-menu .header-button-avatar-image").attr(
+                "src",
+                `${event.avatar_url_medium}`,
+            );
         }
 
         message_live_update.update_avatar(user.user_id, event.avatar_url);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2340,12 +2340,22 @@ body:not(.spectator-view) {
 
 #personal-menu {
     .header-button-avatar {
+        /* Put styling on div rather than img to gracefully handle
+           uBlock Origin blocking of gravatar, which seems to make
+           the img disappear. */
         width: 1.5em; /* 24px at 16px em */
         height: 1.5em; /* 24px at 16px em */
         background-size: cover;
         border-radius: 4px;
         background-color: var(--color-background-image-loader);
         border: 1px solid var(--color-border-personal-menu-avatar);
+        overflow: hidden;
+
+        .header-button-avatar-image {
+            /* Overcome `vertical-align: middle`. This prevents the
+               avatar in the navbar from being lower by a pixel. */
+            display: block;
+        }
     }
 }
 

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -55,7 +55,9 @@
             </div>
             <div id="personal-menu" class="hidden-for-spectators navbar-item">
                 <a class="header-button tippy-zulip-delayed-tooltip" tabindex="0" role="button" data-tooltip-template-id="personal-menu-tooltip-template">
-                    <img class="header-button-avatar" src="{{user_avatar}}"/>
+                    <div class="header-button-avatar">
+                        <img class="header-button-avatar-image" src="{{user_avatar}}"/>
+                    </div>
                 </a>
             </div>
             <div class="spectator_narrow_login_button only-visible-for-spectators" data-tippy-content="{{t 'Log in' }}" data-tippy-placement="bottom">

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -1714,7 +1714,6 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     $("form#send_message_form").off("keydown");
     $("form#send_message_form").off("keyup");
     $("#private_message_recipient").off("blur");
-    $("#send_later").css = noop;
     ct.initialize({
         on_enter_send: finish,
     });

--- a/web/tests/popover_menus_data.test.cjs
+++ b/web/tests/popover_menus_data.test.cjs
@@ -153,8 +153,6 @@ function set_page_params_no_edit_restrictions({override}) {
 function test(label, f) {
     run_test(label, (helpers) => {
         // Stubs for calculate_timestamp_widths()
-        $("<div>").css = noop;
-        $(":root").css = noop;
         $("<div>").width = noop;
         $("<div>").remove = noop;
 

--- a/web/tests/upload.test.cjs
+++ b/web/tests/upload.test.cjs
@@ -141,7 +141,6 @@ test("config", () => {
 });
 
 test("show_error_message", ({mock_template}) => {
-    $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
 
     let banner_shown = false;
@@ -167,7 +166,6 @@ test("show_error_message", ({mock_template}) => {
 
 test("upload_files", async ({mock_template, override, override_rewire}) => {
     $("#compose_banners .upload_banner").remove = noop;
-    $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
 
     let files = [
@@ -456,7 +454,6 @@ test("copy_paste", ({override, override_rewire}) => {
 });
 
 test("uppy_events", ({override_rewire, mock_template}) => {
-    $("#compose_banners .upload_banner .moving_bar").css = noop;
     $("#compose_banners .upload_banner").length = 0;
     override_rewire(compose_ui, "smart_insert_inline", noop);
     override_rewire(compose_validate, "validate_and_update_send_button_status", noop);

--- a/web/tests/user_events.test.cjs
+++ b/web/tests/user_events.test.cjs
@@ -5,7 +5,6 @@ const assert = require("node:assert/strict");
 const {mock_esm, zrequire} = require("./lib/namespace.cjs");
 const {run_test, noop} = require("./lib/test.cjs");
 const blueslip = require("./lib/zblueslip.cjs");
-const $ = require("./lib/zjquery.cjs");
 
 const message_live_update = mock_esm("../src/message_live_update");
 const navbar_alerts = mock_esm("../src/navbar_alerts");
@@ -222,8 +221,6 @@ run_test("updates", ({override}) => {
     assert.equal(person.full_name, "Sir Isaac");
     assert.equal(user_id, isaac.user_id);
     assert.equal(person.avatar_url, avatar_url);
-
-    $("#personal-menu .header-button-avatar").css = noop;
 
     user_events.update_person({user_id: me.user_id, avatar_url: "http://gravatar.com/789456"});
     person = people.get_by_email(me.email);


### PR DESCRIPTION
* Fixes part of #19123 (graceful blocking of gravatar for navbar avatar only)
* Removes some apparently unneeded lines in tests

This issue was initially reported for the avatar uploader widget being broken when using uBlock Origin to block gravatar. However, the scope was expanded in the discussion to include all similar outcomes of blocking the gravatar domain. I decided to start with the avatar (and user menu button) being invisible (though still clickable) in the navbar. Since it's my first PR for Zulip I decided to keep it simple and stick to that.

For my fix I used the grey background (as `timabbot` suggested for the avatar uploader). Though as an alternate idea, we could have the placeholder be zulip-icon-user or something similar. It would fit in with the rest of the navbar. LMK if that's preferable.

I also deleted some test code as a tangentially related issue (I'm happy to split this into a separate PR). I searched for the relevant css class in this PR and found it in the`user_events` test code. It was for a `css = noop` override. In trying to figure out how to update it appropriately, I found that it wasn't even necessary for tests to pass. I concluded that it was either vestigial, or (as CI may soon tell me) platform-specific. I decided to remove all `css = noop` in the front end tests that were not required for them to pass. If this is wrong I figure I'll learn something here.

# Results

There seem to be three modes for the avatars:

* working correctly
* browser-specific broken image icon
* image removed

I'm guessing that the "image removed" state is due to ~some Zulip code that tries to detect broken imgs and hides the img tag to avoid the broken image icon. Is that right? Though it doesn't always happen.~ Update: I now suspect that uBlock Origin is doing it.

I took some screenshots in Firefox and Chromium for all the cases I could reproduce. I think that in each case, my change is no worse and sometimes better. I didn't take the time to take shots of the smaller navbar that shows up when the window is shrunk (i.e. responsive design) but it looks basically the same. I can take those screenshots if you'd like though.

## Firefox

"working correctly" before/after:

![ff_main_good_img](https://github.com/user-attachments/assets/96489ea2-5f9c-40ac-8984-dac0c2456da1) ![ff_branch_good_img](https://github.com/user-attachments/assets/6ba06e34-1559-4e65-895b-aa0bc54cd2df)

"broken image icon" (blocking gravatar with my hosts file, or putting an invalid image URL) before/after:

![ff_main_broken-img-icon](https://github.com/user-attachments/assets/42fa41e4-2105-405e-bf3f-14af57bce32b) ![ff_branch_broken-img-icon](https://github.com/user-attachments/assets/ae758bb8-a532-4005-a4b2-a11deb5c08a2)

"image removed" (blocking gravatar with uBlock Origin) before/after:

![ff_main_removed-img](https://github.com/user-attachments/assets/c480d329-abcf-45f9-a8af-0d14395ba66c) ![ff_branch_removed-img](https://github.com/user-attachments/assets/e3d5c0b1-c279-454a-bcd9-05422ee65a9e)

## Chromium

"working correctly" before/after:

![chromium_main_good_img](https://github.com/user-attachments/assets/e6fdf017-03b0-47e7-b41d-329346d031ab)    ![chromium_branch_good_img](https://github.com/user-attachments/assets/ef91236c-ffd3-4d74-8182-db4507818fed)

"broken image icon" (blocking gravatar with my hosts file or the network panel) before/after:

![chromium_main_broken-img-icon](https://github.com/user-attachments/assets/543b5e8f-1ea0-4632-8c48-04560faf7c61) ![chromium_branch_broken-img-icon](https://github.com/user-attachments/assets/8a2f0cf4-82cc-49aa-ab99-d4860e56b08d)

uBlock Origin was notably removed from the Chromium web store so I can't show you "image removed". Though I could try to simulate it by just deleting the img tag, if that's valuable.
