### PR TITLE
pill_input: Fix pill input width to take all horizontal space.

### DIFF
--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -180,6 +180,7 @@
 
         min-width: 2px;
         overflow-wrap: anywhere;
+        flex-grow: 1;
 
         outline: none;
 


### PR DESCRIPTION
The `.pill-container .input` had a minimum width of `2px` due to which right-clicking outside this was not opening the text field menu. This issue is resolved by adding `flex-grow: 1` property to the input field.

Note: It impacts all `.pill-container .input` elements, and as I've checked other such elements like `private_message_recipient`, I don't see any issue with this change.

[CZO Discussion]([#issues > pasting invite email addresses](https://chat.zulip.org/#narrow/channel/9-issues/topic/pasting.20invite.20email.20addresses))

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
|Before|After|
|----------|-------|
|![image](https://github.com/user-attachments/assets/f4bd3a09-9487-4e42-b640-7fbe716b1874)|![image](https://github.com/user-attachments/assets/d4a719d6-56a2-44b8-8982-637873683f88)|
|![image](https://github.com/user-attachments/assets/4317d252-3099-44c4-a1ee-986458863f80)|![image](https://github.com/user-attachments/assets/4e12d7bc-857e-4dae-a0b3-d757d95749df)|
|![image](https://github.com/user-attachments/assets/01cf73d8-bcab-4288-bb36-d1e21e8030b5)|![image](https://github.com/user-attachments/assets/50a9c755-ca5c-4983-ad40-af6e899cdaa4)|
|![image](https://github.com/user-attachments/assets/9728fb5d-9f4e-4594-b840-2571ee5c22bc)|![image](https://github.com/user-attachments/assets/a123831c-0661-49b7-b84b-214c1168f6c5)|


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
