### PR TITLE
smokescreen: Move metrics port from the default 9810, to 4760.

### DIFF
--- a/puppet/kandra/manifests/profile/chat_zulip_org.pp
+++ b/puppet/kandra/manifests/profile/chat_zulip_org.pp
@@ -7,7 +7,7 @@ class kandra::profile::chat_zulip_org inherits kandra::profile::base {
   include kandra::app_frontend_monitoring
   include kandra::prometheus::redis
   include kandra::prometheus::postgresql
-  kandra::firewall_allow { 'smokescreen_metrics': port => '9810' }
+  kandra::firewall_allow { 'smokescreen_metrics': port => '4760' }
   kandra::firewall_allow { 'http': }
   kandra::firewall_allow { 'https': }
   kandra::firewall_allow { 'smtp': }

--- a/puppet/kandra/manifests/profile/smokescreen.pp
+++ b/puppet/kandra/manifests/profile/smokescreen.pp
@@ -3,7 +3,7 @@ class kandra::profile::smokescreen inherits kandra::profile::base {
 
   include zulip::profile::smokescreen
   kandra::firewall_allow { 'smokescreen': port => '4750' }
-  kandra::firewall_allow { 'smokescreen_metrics': port => '9810' }
+  kandra::firewall_allow { 'smokescreen_metrics': port => '4760' }
 
   include kandra::camo
 }

--- a/puppet/kandra/templates/prometheus/prometheus.yaml.template.erb
+++ b/puppet/kandra/templates/prometheus/prometheus.yaml.template.erb
@@ -69,14 +69,14 @@ scrape_configs:
   - job_name: "smokescreen"
     ec2_sd_configs:
       - region: us-east-1
-        port: 9810
+        port: 4760
         filters:
           - name: "tag:role"
             values: ["smokescreen"]
           - name: instance-state-name
             values: ["running"]
     static_configs:
-      - targets: ["<%= @czo %>:9810"]
+      - targets: ["<%= @czo %>:4760"]
         labels:
           deploy: prod
           instance: <%= @czo %>

--- a/puppet/zulip/templates/supervisor/smokescreen.conf.erb
+++ b/puppet/zulip/templates/supervisor/smokescreen.conf.erb
@@ -1,5 +1,5 @@
 [program:smokescreen]
-command=<%= @bin %> --listen-ip <%= @listen_address %> --expose-prometheus-metrics
+command=<%= @bin %> --listen-ip <%= @listen_address %> --expose-prometheus-metrics --prometheus-port 4760
 priority=15
 autostart=true
 autorestart=true


### PR DESCRIPTION
This prevents errors if Smokescreen is running on a host with more than 10 Tornado shards.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
