### PR TITLE
left_sidebar: Fix bugs that broke topic filtering.

### DIFF
--- a/web/src/topic_list.ts
+++ b/web/src/topic_list.ts
@@ -49,7 +49,7 @@ export function clear(): void {
 export function focus_topic_search_filter(): void {
     popovers.hide_all();
     sidebar_ui.show_left_sidebar();
-    const $filter = $("#filter-topic-input").expectOne();
+    const $filter = $("#left-sidebar-filter-topic-input").expectOne();
     $filter.trigger("focus");
 }
 
@@ -273,7 +273,7 @@ export class LeftSidebarTopicListWidget extends TopicListWidget {
 
 export function clear_topic_search(e: JQuery.Event): void {
     e.stopPropagation();
-    const $input = $("#filter-topic-input");
+    const $input = $("#left-sidebar-filter-topic-input");
     if ($input.length > 0) {
         $input.val("");
         $input.trigger("blur");
@@ -389,7 +389,7 @@ export function zoom_in(): void {
 }
 
 export function get_left_sidebar_topic_search_term(): string {
-    const $filter = $<HTMLInputElement>("input#filter-topic-input");
+    const $filter = $<HTMLInputElement>("input#left-sidebar-filter-topic-input");
     const filter_val = $filter.val();
     if (filter_val === undefined) {
         return "";
@@ -429,7 +429,7 @@ export function initialize({
         },
     );
 
-    $("body").on("input", "#filter-topic-input", (): void => {
+    $("body").on("input", "#left-sidebar-filter-topic-input", (): void => {
         const stream_id = active_stream_id();
         assert(stream_id !== undefined);
         active_widgets.get(stream_id)?.build();

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1148,10 +1148,14 @@ li.top_left_scheduled_messages {
 
 .left-sidebar-filter-row {
     display: grid;
+    /* The final 2px column keeps the filter box from going
+       to the edge of the highlighted channel box, and also
+       matches the right edge to the right edge of the vdots
+       on the channel row. (The vdots take a 2px right margin.) */
     grid-template-columns:
         [filter-box-start] minmax(0, 1fr)
         [clear-button-start] var(--line-height-sidebar-row-prominent)
-        [clear-button-end filter-box-end];
+        [clear-button-end filter-box-end] 2px;
     grid-template-rows: [filter-box-start clear-button-start] auto [clear-button-end filter-box-end];
     align-content: center;
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1465,13 +1465,13 @@ li.top_left_scheduled_messages {
     }
 }
 
-#streams_list ul.topic-list {
+ul.topic-list {
     line-height: var(--line-height-sidebar-row-prominent);
     list-style-type: none;
     font-weight: normal;
 }
 
-#streams_list ul.topic-list.topic-list-has-topics::before {
+ul.topic-list.topic-list-has-topics::before {
     content: " ";
     display: block;
     position: absolute;
@@ -1486,7 +1486,7 @@ li.top_left_scheduled_messages {
     pointer-events: none;
 }
 
-#streams_list ul.topic-list.topic-list-has-topics::after {
+ul.topic-list.topic-list-has-topics::after {
     content: " ";
     display: block;
     position: absolute;
@@ -1500,7 +1500,7 @@ li.top_left_scheduled_messages {
     pointer-events: none;
 }
 
-#streams_list ul.topic-list:has(.show-more-topics)::after {
+ul.topic-list:has(.show-more-topics)::after {
     /* When the show all topics control is displayed,
        extend the bottom bracket. */
     width: 18px;


### PR DESCRIPTION
This PR corrects some bugs introduced in #34340 that broke topic filtering (stale references to `#filter-topic-input`, which that PR removed). It also removes what appear to be unnecessary `#stream_filters` components to the left sidebar CSS, whose extremely high specificity prevented existing CSS intended to hide the topic-grouping brackets when zoomed in.

I've also added a subtle fix to keep the filter input box from butting up against the righthand edge of the highlighted channel area, when filtering in that state.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/Topic.20filtering.20is.20broken/near/2152018)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![left-sidebar-filtering-bugs-before](https://github.com/user-attachments/assets/9fe997a4-39a9-4279-9feb-208299122fa4) | ![left-sidebar-filtering-bugs-after](https://github.com/user-attachments/assets/7582a965-1ea8-45fb-b642-c6f90e195fe5) |
| ![highlighted-channel-before](https://github.com/user-attachments/assets/0611537f-06fb-43f8-a66e-580c50b193d8) | ![highlighted-channel-after](https://github.com/user-attachments/assets/b85c7fae-bd68-4628-b106-bc4ebc262b82) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>