### PR TITLE
css: Remove `.thinner` class used in Settings > Preferences.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -363,13 +363,6 @@ select.settings_select {
 .input-group {
     margin: 0 0 20px;
 
-    /* Class to use when the following input-group is related and should
-       appear just after this element. Normally the margin is 20px, but
-       for related settings, we set it to 10px. */
-    &.thinner {
-        margin-bottom: 10px;
-    }
-
     & label.checkbox + label {
         cursor: pointer;
     }

--- a/web/templates/settings/preferences_information.hbs
+++ b/web/templates/settings/preferences_information.hbs
@@ -49,7 +49,7 @@
         </div>
     </div>
 
-    <div class="input-group thinner setting-next-is-related">
+    <div class="input-group">
         <label for="{{prefix}}web_animate_image_previews" class="settings-field-label">{{t "Play animated images" }}</label>
         <select name="web_animate_image_previews" class="setting_web_animate_image_previews prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_animate_image_previews" data-setting-widget-type="string">
             {{> dropdown_options_widget option_values=web_animate_image_previews_values}}

--- a/web/templates/settings/preferences_navigation.hbs
+++ b/web/templates/settings/preferences_navigation.hbs
@@ -4,7 +4,7 @@
         {{> settings_save_discard_widget section_name="navigation-settings" show_only_indicator=(not for_realm_settings) }}
     </div>
 
-    <div class="input-group thinner setting-next-is-related">
+    <div class="input-group">
         <label for="{{prefix}}web_home_view" class="settings-field-label">{{t "Home view" }}
             {{> ../help_link_widget link="/help/configure-home-view" }}
         </label>

--- a/web/templates/settings/settings_numeric_input.hbs
+++ b/web/templates/settings/settings_numeric_input.hbs
@@ -1,5 +1,5 @@
 {{#unless (eq render_only false)}}
-<div class="input-group setting-next-is-related {{#if is_disabled}}control-label-disabled{{/if}}">
+<div class="input-group {{#if is_disabled}}control-label-disabled{{/if}}">
     <label for="{{#if prefix}}{{prefix}}{{/if}}{{setting_name}}" class="{{setting_name}}_label" id="{{#if prefix}}{{prefix}}{{/if}}{{setting_name}}_label">
         {{label}}
         {{#if label_parens_text}}


### PR DESCRIPTION
This PR removes the `thinner` CSS class from the "Play animated images" setting. It applies the class to the "Show unread counts for" setting, since the next setting, "Show counts for starred messages" is related to it.

Hence, the bottom margin for the "Play animated images" setting is changed to `20px` (initially it was `10px`). 
For the "Show unread counts for" setting, the bottom margin is set to `10px` (initially it was `20px`), since the next setting, "Show counts for starred messages", is related to it.

<!-- Describe your pull request here.-->

Fixes: [#34226 (comment)](https://github.com/zulip/zulip/pull/34226#discussion_r2026449812).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- In Personal settings > Preferences:

| Description | Before | After |
|-------------|--------|-------|
| "Home view" setting | ![image](https://github.com/user-attachments/assets/f32ae22e-4eab-4901-80e3-276131411606) | ![image](https://github.com/user-attachments/assets/451f8e87-f8ff-43e0-87df-ec191e991057) |
| "Play animated images" setting | ![image](https://github.com/user-attachments/assets/a3ad53e4-7150-4aaf-9d7c-a84d7ef8e36e) | ![image](https://github.com/user-attachments/assets/db78b13d-e32a-4642-b371-61289fca58a0) |

- In Organization settings > Default user settings:

| Description | Before | After |
|-------------|--------|-------|
| "Home view" setting | ![image](https://github.com/user-attachments/assets/a88a1d99-b3ba-4ac0-ad24-fddd14900735) | ![image](https://github.com/user-attachments/assets/6be21010-bec8-479f-96c5-1b280cf4b584) |
| "Play animated images" setting | ![image](https://github.com/user-attachments/assets/5594441e-eb94-49dd-8ac8-915f02150330) | ![image](https://github.com/user-attachments/assets/86724f98-2973-4f47-b067-98e41e79421e) |


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
