### PR TITLE
Minor fixes in stream settings UI.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -834,6 +834,16 @@ export class Typeahead<ItemType extends string | object> {
             // when the user clicks anywhere on the input element.
             return;
         }
+
+        if (
+            this.input_element.type === "contenteditable" &&
+            this.input_element.$element.prop("contenteditable") === "false"
+        ) {
+            // We do not want to show the typeahead if user cannot type in
+            // the input, for cases like user not having required permission.
+            return;
+        }
+
         // Update / hide the typeahead menu if the user clicks anywhere
         // inside the typing area. This is important in textarea elements
         // such as the compose box where multiple typeahead can exist,

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -346,6 +346,17 @@ function remove_subscriber({
             return;
         }
 
+        if (
+            people.is_my_user_id(target_user_id) &&
+            stream_data.has_content_access_via_group_permissions(sub)
+        ) {
+            // We do not show any confirmation modal if user is unsubscribing
+            // themseleves and also has the permission to subscribe to the
+            // stream again.
+            remove_user_from_private_stream();
+            return;
+        }
+
         const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({
             stream: sub,
         });

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -352,7 +352,10 @@ function remove_subscriber({
 
         const html_body = render_unsubscribe_private_stream_modal({
             unsubscribing_other_user,
-            display_stream_archive_warning: sub_count === 1,
+            organization_will_lose_content_access:
+                sub_count === 1 &&
+                user_groups.is_setting_group_set_to_nobody_group(sub.can_subscribe_group) &&
+                user_groups.is_setting_group_set_to_nobody_group(sub.can_add_subscribers_group),
         });
 
         let html_heading;

--- a/web/src/stream_settings_components.ts
+++ b/web/src/stream_settings_components.ts
@@ -19,6 +19,7 @@ import * as stream_data from "./stream_data.ts";
 import * as stream_settings_data from "./stream_settings_data.ts";
 import type {StreamSubscription} from "./sub_store.ts";
 import * as ui_report from "./ui_report.ts";
+import * as user_groups from "./user_groups.ts";
 
 export let filter_dropdown_widget: DropdownWidget;
 
@@ -228,7 +229,11 @@ export function unsubscribe_from_private_stream(sub: StreamSubscription): void {
 
     const html_body = render_unsubscribe_private_stream_modal({
         unsubscribing_other_user: false,
-        display_stream_archive_warning: sub_count === 1 && invite_only,
+        organization_will_lose_content_access:
+            sub_count === 1 &&
+            invite_only &&
+            user_groups.is_setting_group_set_to_nobody_group(sub.can_subscribe_group) &&
+            user_groups.is_setting_group_set_to_nobody_group(sub.can_add_subscribers_group),
     });
 
     function unsubscribe_from_stream(): void {

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -305,6 +305,19 @@ export function is_setting_group_empty(setting_group: GroupSettingValue): boolea
     return true;
 }
 
+export function is_setting_group_set_to_nobody_group(setting_group: GroupSettingValue): boolean {
+    if (typeof setting_group === "number") {
+        const user_group = get_user_group_from_id(setting_group);
+        if (user_group.name === "role:nobody") {
+            return true;
+        }
+
+        return false;
+    }
+
+    return setting_group.direct_subgroups.length === 0 && setting_group.direct_members.length === 0;
+}
+
 export function get_user_groups_of_user(
     user_id: number,
     include_deactivated_groups = false,

--- a/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
@@ -1,18 +1,8 @@
 {{#unless unsubscribing_other_user}}
     <p>{{t "Once you leave this channel, you will not be able to rejoin."}}</p>
 {{/unless}}
-{{#if display_stream_archive_warning}}
+{{#if organization_will_lose_content_access}}
     <p>
-        {{#if unsubscribing_other_user}}
-            {{#tr}}
-            Because you are removing the last subscriber from a private channel, it will be automatically <z-link>archived</z-link>.
-            {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-channel">{{> @partial-block}}</a>{{/inline}}
-            {{/tr}}
-        {{else}}
-            {{#tr}}
-            Because you are the only subscriber, this channel will be automatically <z-link>archived</z-link>.
-            {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-channel">{{> @partial-block}}</a>{{/inline}}
-            {{/tr}}
-        {{/if}}
+        {{t "Your organization will lose access content in this channel, and nobody will be able to subscribe to it in the future."}}
     </p>
 {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix warning in modal when unsubscribing last user from a private stream.
- Second commit is to not show the modal when user can subscribe again to the private stream.
- Third commit is to not show typeahead on clicking on the disabled input.

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Screenshots for modified warning in first commit
| When last user is someone else | When last user is the user themselves|
| --------- | --------- |
|![Screenshot from 2025-04-14 09-19-21](https://github.com/user-attachments/assets/0066170d-0ee8-44c1-b059-2659913c61b5) |![Screenshot from 2025-04-14 09-17-38](https://github.com/user-attachments/assets/a5107baa-e166-4f8f-a13f-22763f4b544c) |

Changes in second commit
| Before | After |
| --------- | ------- |
|![second-commit-before](https://github.com/user-attachments/assets/4c2feeb5-7244-4442-968e-1afecdfcb577)|![second-commit-after](https://github.com/user-attachments/assets/45c4c0df-980e-4832-a8da-0ce1276c5b30)|

Change in third commit on clicking the input when it is disabled
| Before | After |
| --------- | --------- |
|![third-commit-before](https://github.com/user-attachments/assets/6d54b7e8-2820-4715-8fbb-931682f282b4) |![third-commit-after](https://github.com/user-attachments/assets/f4073f66-485f-48e1-8eaa-7a3a8976bbdc) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
