### PR TITLE
settings: Redesign buttons in channel and group settings.

### DIFF
--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -1178,4 +1178,9 @@ export function initialize(): void {
         $(".right").removeClass("show");
         $("#channels_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
+
+    $("#channels_overlay_container").on("click", "#preview-stream-button", () => {
+        const stream_id = Number.parseInt($(".stream_settings_header").attr("data-stream-id")!, 10);
+        window.location.href = hash_util.by_stream_url(stream_id);
+    });
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1003,7 +1003,7 @@ h4.user_group_setting_subsection_title {
     }
 
     .inner-box {
-        margin: 20px;
+        margin: 18px;
     }
 
     .group_settings_header,
@@ -1034,23 +1034,9 @@ h4.user_group_setting_subsection_title {
 
             .subscribe-button,
             .join_leave_button,
-            #preview-stream-button,
-            .deactivate {
-                margin-right: 3px;
-                text-decoration: none;
-                padding: 0 10px;
+            #preview-stream-button {
                 height: 100%;
-                display: flex;
-                align-items: center;
-                box-sizing: border-box;
-            }
-
-            .deactivate {
-                height: 100%;
-
-                .icon-container {
-                    display: flex;
-                }
+                margin-left: 3px;
             }
         }
     }
@@ -1086,8 +1072,6 @@ h4.user_group_setting_subsection_title {
         #open_group_info_modal {
             display: flex;
             align-items: center;
-            padding: 7px 10px;
-            font-size: 1.1em;
         }
 
         .button-group {
@@ -1220,6 +1204,10 @@ h4.user_group_setting_subsection_title {
         .inline {
             display: inline !important;
         }
+    }
+
+    .icon-button {
+        font-size: 1.2em;
     }
 }
 

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -11,7 +11,7 @@
                     {{/tr}}
                 </span>
             </template>
-            <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button"  data-tooltip-template-id="toggle-subscription-tooltip-template" {{#unless should_display_subscription_button}}disabled="disabled"{{/unless}}>
+            <button class="action-button action-button-quiet-brand subscribe-button sub_unsub_button {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button"  data-tooltip-template-id="toggle-subscription-tooltip-template" {{#unless should_display_subscription_button}}disabled="disabled"{{/unless}}>
                 {{#if subscribed }}
                     {{t "Unsubscribe" }}
                 {{else}}
@@ -19,13 +19,22 @@
                 {{/if}}
             </button>
         </div>
-        <a href="{{preview_url}}" class="button small rounded tippy-zulip-delayed-tooltip" id="preview-stream-button" role="button" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="bottom" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
+        {{> ../components/action_button
+          icon="eye"
+          attention="quiet"
+          intent="info"
+          custom_classes="tippy-zulip-delayed-tooltip"
+          data-tooltip-template-id="view-stream-tooltip-template"
+          id="preview-stream-button"
+          hidden=(not should_display_preview_button)
+          }}
         {{#if can_archive_stream}}
-        <button class="button small rounded button-danger deactivate tippy-zulip-delayed-tooltip" type="button" data-tippy-content="{{t 'Archive channel'}}">
-            <span class="icon-container">
-                <i class="zulip-icon zulip-icon-archive" aria-hidden="true"></i>
-            </span>
-        </button>
+        {{> ../components/icon_button
+          icon="archive"
+          intent="danger"
+          custom_classes="tippy-zulip-delayed-tooltip deactivate"
+          data-tippy-content=(t 'Archive channel')
+          }}
         {{/if}}
     </div>
     {{/with}}
@@ -48,9 +57,13 @@
                 </div>
                 <div class="stream_change_property_info alert-notification"></div>
                 <div class="button-group" {{#unless can_change_name_description}}style="display:none"{{/unless}}>
-                    <button id="open_stream_info_modal" class="button rounded small button-warning tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edit channel name and description' }}">
-                        <i class="fa fa-pencil" aria-hidden="true"></i>
-                    </button>
+                    {{> ../components/icon_button
+                      icon="edit"
+                      intent="neutral"
+                      custom_classes="tippy-zulip-delayed-tooltip"
+                      id="open_stream_info_modal"
+                      data-tippy-content=(t 'Edit channel name and description' )
+                      }}
                 </div>
             </div>
             <div class="stream-description">
@@ -95,9 +108,15 @@
                         {{> ../help_link_widget link="/help/message-a-channel-by-email" }}
                     </p>
                     <span class="generate-channel-email-button-container {{#unless can_access_stream_email}}disabled_setting_tooltip{{/unless}}">
-                        <button class="button small rounded copy_email_button" {{#unless can_access_stream_email}}disabled="disabled"{{/unless}} id="copy_stream_email_button" type="button">
-                            <span class="copy_button">{{t "Generate email address" }}</span>
-                        </button>
+                        {{> ../components/action_button
+                          label=(t "Generate email address")
+                          attention="quiet"
+                          intent="neutral"
+                          type="button"
+                          custom_classes="copy_email_button"
+                          id="copy_stream_email_button"
+                          disabled=(not can_access_stream_email)
+                          }}
                     </span>
                 </div>
             </div>
@@ -137,7 +156,13 @@
                 </div>
                 <p>{{t "In muted channels, channel notification settings apply only to unmuted topics." }}</p>
                 <div class="input-group">
-                    <button class="button small rounded reset-stream-notifications-button" type="button">{{t "Reset to default notifications" }}</button>
+                    {{> ../components/action_button
+                      label=(t "Reset to default notifications")
+                      attention="quiet"
+                      intent="neutral"
+                      custom_classes="reset-stream-notifications-button"
+                      type="button"
+                      }}
                 </div>
                 {{#each notification_settings}}
                     <div class="input-group">

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -2,16 +2,17 @@
     <div class="tab-container"></div>
     <div class="button-group">
         <div class="join_leave_button_wrapper inline-block">
-            <button class="button small rounded join_leave_button" type="button" name="button">
-                {{#if is_direct_member}}
-                    {{t "Leave group" }}
-                {{else}}
-                    {{t "Join group" }}
-                {{/if}}
-            </button>
+            {{#if is_direct_member}}
+            {{> ../components/action_button label=(t "Leave group") custom_classes="join_leave_button" type="button"
+              attention="quiet" intent="brand" }}
+            {{else}}
+            {{> ../components/action_button label=(t "Join group") custom_classes="join_leave_button" type="button"
+              attention="quiet" intent="brand" }}
+            {{/if}}
         </div>
         {{#unless group.deactivated}}
-        <button class="button small rounded button-danger deactivate deactivate-group-button tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Deactivate group'}}" type="button"> <i class="zulip-icon zulip-icon-user-group-x" aria-hidden="true"></i></button>
+        {{> ../components/icon_button icon="user-group-x" intent="danger" custom_classes="deactivate-group-button deactivate tippy-zulip-delayed-tooltip"
+          data-tippy-content=(t 'Deactivate group') }}
         {{/unless}}
     </div>
 </div>
@@ -26,9 +27,8 @@
                 </div>
                 <div class="group_change_property_info alert-notification"></div>
                 <div class="button-group">
-                    <button id="open_group_info_modal" class="button rounded small button-warning tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Change group info' }}">
-                        <i class="zulip-icon zulip-icon-user-group-edit" aria-hidden="true"></i>
-                    </button>
+                    {{> ../components/icon_button icon="user-group-edit" intent="neutral" custom_classes="tippy-zulip-delayed-tooltip"
+                      data-tippy-content=(t 'Change group info') id="open_group_info_modal" }}
                 </div>
             </div>
             <div class="group-description-wrapper">


### PR DESCRIPTION
Fixes: #34253.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**




| Location | **Before (At 16px)** | **After (At 12px)** | **After (At 16px)** | **After (At 20px)** |
|----------|----------------------|----------------------|----------------------|----------------------|
| Stream Settings | <img width="423" alt="Screenshot 2025-04-15 at 1 21 12 AM" src="https://github.com/user-attachments/assets/c6abc3a2-a79b-4ebf-9630-e97e03400de1" /> | <img width="187" alt="Screenshot 2025-04-15 at 1 14 07 AM" src="https://github.com/user-attachments/assets/34360d7d-c2bb-4ca8-ab1c-429bd0092d3f" /> | <img width="206" alt="Screenshot 2025-04-15 at 1 14 53 AM" src="https://github.com/user-attachments/assets/112d6c02-b442-4470-bad7-f9cecfdfc132" /> | <img width="259" alt="Screenshot 2025-04-15 at 1 15 17 AM" src="https://github.com/user-attachments/assets/2cde07e8-501e-4d59-bc5b-afe91700bf7c" />
| Generate Email Address | <img width="182" alt="Screenshot 2025-04-14 at 2 43 58 PM" src="https://github.com/user-attachments/assets/fadd71bd-b5ab-4eef-b0a4-6ac19a1165fc" />  | <img width="156" alt="Screenshot 2025-04-14 at 1 49 19 PM" src="https://github.com/user-attachments/assets/a2bd8271-ca62-439c-b200-1a32520df16b" /> | <img width="209" alt="Screenshot 2025-04-14 at 1 50 32 PM" src="https://github.com/user-attachments/assets/6a2184ea-0e0a-4d5f-a542-f3a2d15c841d" /> | <img width="263" alt="Screenshot 2025-04-14 at 1 52 14 PM" src="https://github.com/user-attachments/assets/9649361e-7045-49b4-94d7-fd62ca6fabb3" /> |
| Reset default |<img width="237" alt="Screenshot 2025-04-14 at 2 44 02 PM" src="https://github.com/user-attachments/assets/1700993f-0023-4eba-ad05-c62109e76e99" /> | <img width="178" alt="Screenshot 2025-04-14 at 1 49 28 PM" src="https://github.com/user-attachments/assets/094374d2-47a2-49e3-a304-18475ab39fbe" /> | <img width="247" alt="Screenshot 2025-04-14 at 1 50 40 PM" src="https://github.com/user-attachments/assets/e56fb666-147e-4c62-9e3c-6e48754dfda9" /> | <img width="327" alt="Screenshot 2025-04-14 at 1 52 20 PM" src="https://github.com/user-attachments/assets/44cf05fd-d19d-4622-8f74-ad12ad42af49" /> |
| Group Settings |<img width="722" alt="Screenshot 2025-04-14 at 2 44 22 PM" src="https://github.com/user-attachments/assets/0b9b48fe-80c4-49c1-b5da-92668978e245" /> | <img width="525" alt="Screenshot 2025-04-14 at 1 49 56 PM" src="https://github.com/user-attachments/assets/ecd0eeb7-6db5-49f3-bc40-c1b482caaf15" /> | <img width="536" alt="Screenshot 2025-04-14 at 1 51 24 PM" src="https://github.com/user-attachments/assets/43d84d15-3edc-402c-b252-f40a529ee5a1" /> | <img width="883" alt="Screenshot 2025-04-14 at 1 52 58 PM" src="https://github.com/user-attachments/assets/4b2330e5-b537-47f7-9cf1-7c76df7eee10" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
