### PR TITLE
doc: Add an error explanation in schema migrations.

### DIFF
--- a/docs/subsystems/schema-migrations.md
+++ b/docs/subsystems/schema-migrations.md
@@ -112,8 +112,17 @@ migrations.
   django.db.utils.OperationalError: cannot ALTER TABLE "table_name" because it has pending trigger events
   ```
 
-  when testing the migration, the reason is often that these operations
-  were incorrectly mixed. To resolve this, consider making the migration
+  when testing the migration, the reason is:
+
+  PostgreSQL prohibits schema changes (e.g., `ALTER TABLE`)
+  if there are deferred trigger events still pending.
+  Now most Zulip constraints are `DEFERRABLE INITIALLY DEFERRED` which means
+  the constraint will not be checked until the transaction is committed,
+  and You are not allowed to update, insert, alter or any other query
+  that will modify the table without executing all pending triggers which would be
+  constraint checking in this case.
+
+  To resolve this, consider making the migration
   non-atomic, splitting it into two migration files (recommended), or replacing the
   `RunPython` logic with pure SQL (though this can generally be difficult).
 


### PR DESCRIPTION
The following error mentioned in [Schema migrations doc](https://zulip.readthedocs.io/en/latest/subsystems/schema-migrations.html#:~:text=Another%20important%20note)
 
```shell
  django.db.utils.OperationalError: cannot ALTER TABLE "table_name" because it has pending trigger events
  ```

Saying:

> the reason is often that these operations were incorrectly mixed

is very ambiguous, so I did my search to find the actual cause for that error, hence better understandability and experience for our developers.


See [Information source](https://support.atlassian.com/confluence/kb/upgrade-failed-with-the-error-message-error-cannot-alter-table-content-because-it-has-pending-trigger-events/#:~:text=for%20all%20constraint.-,Cause,-By%20default%2C%20the)


See [updated doc](https://zulip--34393.org.readthedocs.build/en/34393/subsystems/schema-migrations.html#:~:text=Another%20important%20note)

## Updated doc screenshot
![schema-migration-updated-doc](https://github.com/user-attachments/assets/d71ed353-641f-4f0c-a198-00f869a0de4f)

