### PR TITLE
trash-icon: Replace remaining fa-trash icons with zulip-icon-trash and update buttons.

### DIFF
--- a/help/collaborative-to-do-lists.md
+++ b/help/collaborative-to-do-lists.md
@@ -26,8 +26,8 @@
 
     To reorder the list of todos, click and drag the **vertical dots**
     (<i class="zulip-icon zulip-icon-grip-vertical"></i>) to the left of
-    each option. To delete an option, click the **trash**
-    (<i class="fa fa-trash-o"></i>) icon to the right of it.
+    each option. To delete an option, click the **delete**
+    (<i class="zulip-icon zulip-icon-trash"></i>) icon to the right of it.
 
 {tab|via-markdown}
 

--- a/help/create-a-poll.md
+++ b/help/create-a-poll.md
@@ -26,8 +26,8 @@
 
     To reorder the list of options, click and drag the **vertical dots**
     (<i class="zulip-icon zulip-icon-grip-vertical"></i>) to the left of each
-    option. To delete an option, click the **trash**
-    (<i class="fa fa-trash-o"></i>) icon to the right of it.
+    option. To delete an option, click the **delete**
+    (<i class="zulip-icon zulip-icon-trash"></i>) icon to the right of it.
 
 {tab|via-markdown}
 

--- a/help/saved-snippets.md
+++ b/help/saved-snippets.md
@@ -89,7 +89,7 @@ message you're composing.
    open the saved snippets menu.
 
 1. Hover over the saved snippet you'd like to delete, and click the **Delete
-   snippet** (<i class="fa fa-trash-o"></i>) icon on the right.
+   snippet** (<i class="zulip-icon zulip-icon-trash"></i>) icon on the right.
 
 !!! keyboard_tip ""
 

--- a/help/schedule-a-message.md
+++ b/help/schedule-a-message.md
@@ -86,7 +86,7 @@ can schedule a message for next morning to avoid disturbing others.
 
 {!go-to-scheduled-messages.md!}
 
-1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the message you
+1. Click the **delete** (<i class="zulip-icon zulip-icon-trash"></i>) icon on the message you
    want to delete.
 
 !!! keyboard_tip ""

--- a/help/view-and-edit-your-message-drafts.md
+++ b/help/view-and-edit-your-message-drafts.md
@@ -97,7 +97,7 @@ counter next to the **Drafts** button in the compose box shows how many there ar
 
 {!go-to-draft-messages.md!}
 
-1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the draft you
+1. Click the **delete** (<i class="zulip-icon zulip-icon-trash"></i>) icon on the draft you
    want to delete.
 
 !!! keyboard_tip ""
@@ -111,7 +111,7 @@ counter next to the **Drafts** button in the compose box shows how many there ar
 
 1. Click the **Drafts** button on the right side of the compose box.
 
-1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the draft you
+1. Click the **delete** (<i class="zulip-icon zulip-icon-trash"></i>) icon on the draft you
    want to delete.
 
 !!! keyboard_tip ""
@@ -133,7 +133,7 @@ counter next to the **Drafts** button in the compose box shows how many there ar
    the drafts view, or select the drafts you want to delete
    by toggling the checkboxes on the right.
 
-1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon in the
+1. Click the **delete** (<i class="zulip-icon zulip-icon-trash"></i>) icon in the
    upper right corner of the drafts view to delete all selected drafts.
 
 !!! keyboard_tip ""
@@ -150,7 +150,7 @@ counter next to the **Drafts** button in the compose box shows how many there ar
    the drafts view, or select the drafts you want to delete
    by toggling the checkboxes on the right.
 
-1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon in the
+1. Click the **delete** (<i class="zulip-icon zulip-icon-trash"></i>) icon in the
    upper right corner of the drafts view to delete all selected drafts.
 
 !!! keyboard_tip ""

--- a/web/src/settings_profile_fields.ts
+++ b/web/src/settings_profile_fields.ts
@@ -300,7 +300,7 @@ function add_choice_row(this: HTMLElement, e: JQuery.TriggeredEvent): void {
     }
     // Display delete buttons for all existing choices before creating the new row,
     // which will not have the delete button so that there is at least one option present.
-    $curr_choice_row.find("button.delete-choice").show();
+    $curr_choice_row.find("button.delete-choice").removeClass("hide");
     $curr_choice_row.find("span.move-handle").removeClass("invisible");
     assert(e.delegateTarget instanceof HTMLElement);
     const choices_div = e.delegateTarget;

--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -770,6 +770,22 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".delete-option",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        placement: "top",
+        onShow(instance) {
+            /* Ensure the tooltip remains visible even when data-reference-hidden is set. */
+            $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
+
+            instance.setContent($t({defaultMessage: "Delete"}));
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: [
             "#personal-menu-dropdown .info-density-button-container",
             "#user-preferences .info-density-button-container",

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1058,6 +1058,8 @@ input.settings_text_input {
                 cursor: pointer;
                 color: hsl(357deg 52% 57%);
                 opacity: 0.7;
+                padding: 0;
+                font-size: 1.2em;
 
                 &:hover {
                     opacity: 1;
@@ -1072,6 +1074,10 @@ input.settings_text_input {
             background: transparent;
         }
     }
+}
+
+.delete-selected-drafts-button-container {
+    display: flex;
 }
 
 .dropdown-widget-button {

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -69,7 +69,7 @@
     }
 
     .draft-selection-checkbox {
-        margin-top: 5px;
+        margin-top: 0.25em;
         /* Required to make sure that the checkbox icon stays inside
            the grid. Any value greater than 13px (original width of
            the checkbox icon) will work. */

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -462,6 +462,25 @@
     }
 }
 
+.edit_profile_field_choices_container,
+#profile_field_choices {
+    .modal_text_input {
+        margin-bottom: 0;
+    }
+
+    .choice-row {
+        display: flex;
+        align-items: center;
+    }
+}
+
+.choice-row,
+.option-row {
+    .icon-button {
+        font-size: 1.1em;
+    }
+}
+
 #create_bot_short_name {
     /* A shorter dropdown width (~200px at 14px em)
        to ensure the email all fits on one line. */

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -722,6 +722,14 @@ input[type="checkbox"] {
     text-align: right;
 }
 
+.delete-choice {
+    display: inline-flex;
+
+    &.hide {
+        display: none;
+    }
+}
+
 #add-default-stream-modal {
     .dropdown-widget-button {
         display: inline-flex;

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -51,7 +51,7 @@
                                 <i class="zulip-icon zulip-icon-copy" aria-hidden="true"></i>
                             </span>
                             <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-delayed-tooltip" aria-hidden="true" data-tooltip-template-id="restore-draft-tooltip-template"></i>
-                            <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-delayed-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
+                            {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-delayed-tooltip" icon="trash" data-tooltip-template-id="delete-draft-tooltip-template" aria-label=(t "Delete") }}
                             <div class="draft-selection-tooltip">
                                 <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
                             </div>

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -13,9 +13,7 @@
                     </div>
                     <div class="delete-drafts-group">
                         <div class="delete-selected-drafts-button-container">
-                            <button class="button small rounded delete-selected-drafts-button" type="button" disabled>
-                                <i class="fa fa-trash-o fa-lg" aria-hidden="true"></i>
-                            </button>
+                            {{> ./components/icon_button intent="danger" custom_classes="delete-selected-drafts-button" icon="trash" disabled=true  }}
                         </div>
                         <button class="button small rounded select-drafts-button" role="checkbox" aria-checked="false">
                             <span>{{t "Select all drafts" }}</span>

--- a/web/templates/poll_modal_option.hbs
+++ b/web/templates/poll_modal_option.hbs
@@ -1,7 +1,5 @@
 <li class="option-row">
     <i class="zulip-icon zulip-icon-grip-vertical drag-icon"></i>
     <input type="text" class="poll-option-input modal_text_input" placeholder="{{t 'New option' }}" />
-    <button type="button" class="button rounded small delete-option" title="{{t 'Delete' }}">
-        <i class="fa fa-trash-o" aria-hidden="true"></i>
-    </button>
+    {{> ./components/icon_button intent="danger" custom_classes="delete-option" icon="trash" }}
 </li>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -37,7 +37,7 @@
                         <div class="message_top_line">
                             <div class="overlay_message_controls">
                                 <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-scheduled-message-tooltip-template"></i>
-                                <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-scheduled-message-tooltip-template"></i>
+                                {{> ./components/icon_button intent="danger" custom_classes="delete-overlay-message tippy-zulip-tooltip" icon="trash" data-tooltip-template-id="delete-scheduled-message-tooltip-template" aria-label=(t "Delete") }}
                             </div>
                         </div>
                         <div class="message_content rendered_markdown restore-overlay-message" data-tooltip-template-id="restore-scheduled-message-tooltip-template">{{rendered_markdown rendered_content}}</div>

--- a/web/templates/settings/default_stream_choice.hbs
+++ b/web/templates/settings/default_stream_choice.hbs
@@ -1,6 +1,4 @@
 <div class="choice-row" data-value="{{value}}">
     {{> ../dropdown_widget widget_name=stream_dropdown_widget_name default_text=(t 'Select channel')}}
-    <button type="button" class="button rounded small delete-choice tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Delete' }}">
-        <i class="fa fa-trash-o" aria-hidden="true"></i>
-    </button>
+    {{> ../components/icon_button intent="danger" custom_classes="delete-choice tippy-zulip-delayed-tooltip" icon="trash" data-tippy-content=(t "Delete") aria-label=(t "Delete") }}
 </div>

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -4,8 +4,5 @@
         <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     </span>
     <input type='text' class="modal_text_input" placeholder='{{t "New option" }}' value="{{ text }}" />
-
-    <button type='button' class="button rounded small delete-choice tippy-zulip-tooltip {{#if new_empty_choice_row}} hide {{/if}}" data-tippy-content="{{t 'Delete' }}">
-        <i class="fa fa-trash-o" aria-hidden="true"></i>
-    </button>
+    {{> ../components/icon_button intent="danger" custom_classes="delete-choice tippy-zulip-tooltip" hidden=new_empty_choice_row icon="trash" data-tippy-content=(t "Delete") aria-label=(t "Delete") }}
 </div>

--- a/web/templates/todo_modal_task.hbs
+++ b/web/templates/todo_modal_task.hbs
@@ -4,7 +4,5 @@
     <div class="todo-description-container">
         <input type="text" class="todo-description-input modal_text_input" disabled="true" placeholder="{{t 'Task description (optional)'}}" />
     </div>
-    <button type="button" class="button rounded small btn-secondary delete-option" title="{{t 'Delete' }}">
-        <i class="fa fa-trash-o" aria-hidden="true"></i>
-    </button>
+    {{> ./components/icon_button intent="danger" custom_classes="delete-option" icon="trash" aria-label=(t "Delete") }}
 </li>


### PR DESCRIPTION
Fixes: #34378.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Icon-buttons

| Location | **Before (At 16px)** | **After (At 12px)** | **After (At 16px)** | **After (At 20px)** |
|----|----------------------|---------------------|----------------------|----------------------|
| Delete all drafts | <img width="280" alt="c1r1" src="https://github.com/user-attachments/assets/cee284ab-63f3-4cc4-9019-89dcd04ce062" /> | <img width="245" alt="c2r1" src="https://github.com/user-attachments/assets/50889824-d257-4607-a1b8-d6406469c134" /> | <img width="250" alt="c3r1" src="https://github.com/user-attachments/assets/360e08c3-b3ea-4f6c-8389-80ef29d9046a" /> | <img width="324" alt="c4r1" src="https://github.com/user-attachments/assets/9c762350-d9a3-4af9-a95a-5826c90aeab4" /> |
| Delete a draft | <img width="127" alt="c1r2" src="https://github.com/user-attachments/assets/b7075709-4b08-4e0e-81d7-05ae7f88df5c" /> | <img width="123" alt="c2r2" src="https://github.com/user-attachments/assets/baf55ebc-e21b-4a22-a26f-d9d014a94116" /> | <img width="136" alt="c3r2" src="https://github.com/user-attachments/assets/de17f400-4c39-410f-9800-9917d8d55984" /> | <img width="151" alt="c4r2" src="https://github.com/user-attachments/assets/2e4b13df-c8d3-433c-93b5-bedf102173a7" /> |
| Scheduled Messages | <img width="70" alt="c1r3" src="https://github.com/user-attachments/assets/fa890654-24c6-466d-8052-c71f3a43dfb2" /> | <img width="85" alt="c2r3" src="https://github.com/user-attachments/assets/97a30d05-c4d5-4d4b-adca-d91175c5ecc2" /> | <img width="81" alt="c3r3" src="https://github.com/user-attachments/assets/bf1ccfdc-15b2-4723-9abf-c4c21d0f389f" /> | <img width="89" alt="c4r3" src="https://github.com/user-attachments/assets/4c7174f6-d239-4160-94f1-7d73e1c47c8e" /> |
| Poll | <img width="115" alt="c1r4" src="https://github.com/user-attachments/assets/4a483ced-e70d-412c-b19c-67d0881233d8" /> | <img width="98" alt="c2r4" src="https://github.com/user-attachments/assets/737128d6-9e62-432b-91b6-126f5d885a40" /> | <img width="108" alt="c3r4" src="https://github.com/user-attachments/assets/4b532257-0d29-496a-9976-9e3aab6e5197" /> | <img width="124" alt="c4r4" src="https://github.com/user-attachments/assets/9afc36ef-8e8d-46e4-b1c8-3c0555fe6919" /> |
| Todo list | <img width="114" alt="c1r5" src="https://github.com/user-attachments/assets/e830e37f-3fa2-4db4-acd3-769cee47a73a" /> | <img width="89" alt="c2r5" src="https://github.com/user-attachments/assets/06f337a9-5b8a-4cf5-b5a9-5c05cfd5b44d" /> | <img width="112" alt="c3r5" src="https://github.com/user-attachments/assets/63f53ba8-43b0-4820-8f3e-ca3070ed908f" /> | <img width="144" alt="c4r5" src="https://github.com/user-attachments/assets/79a5908d-3be3-4747-9347-3bb803f6777c" /> |
| Custom Profile Field | <img width="288" alt="c1r6" src="https://github.com/user-attachments/assets/824ed8d4-4af5-4ad6-a482-d9951c65da84" /> | <img width="265" alt="Screenshot 2025-04-14 at 7 12 48 PM" src="https://github.com/user-attachments/assets/a161a40e-a0e0-4752-beaf-dc69f5d289d5" /> |  <img width="289" alt="Screenshot 2025-04-14 at 7 12 26 PM" src="https://github.com/user-attachments/assets/30ba1134-b441-4471-a6bd-09d76ec0cc85" /> | <img width="297" alt="Screenshot 2025-04-14 at 7 13 06 PM" src="https://github.com/user-attachments/assets/a40e1c1a-d801-416f-8c0d-5d271ba3693f" /> |
| Add Default Stream | <img width="259" alt="c1r7" src="https://github.com/user-attachments/assets/becb2224-6c4d-4fce-b36b-6ac31d10c71a" /> | <img width="244" alt="c2r7" src="https://github.com/user-attachments/assets/cda54a65-5ab8-40cb-8d78-5ac5807bf73c" /> | <img width="253" alt="c3r7" src="https://github.com/user-attachments/assets/0b8c4d73-13f7-4416-9a2f-21ce104b19c3" /> | <img width="270" alt="c4r7" src="https://github.com/user-attachments/assets/fc7e3547-c70f-49f9-b703-c6eb009cc168" /> |


### Help-center


| Location | **Before** | **After** |
|------|-----------------------|-----------------------|
| Todo List | <img width="683" alt="Screenshot 2025-04-14 at 7 33 43 PM" src="https://github.com/user-attachments/assets/4cf0ca41-8742-4c96-ac97-4bc237e39da5" /> | <img width="683" alt="Screenshot 2025-04-15 at 1 58 49 AM" src="https://github.com/user-attachments/assets/c3d6b011-ef8c-4d8c-958b-7a6796aff5c3" /> |
| Poll | <img width="681" alt="Screenshot 2025-04-14 at 7 34 14 PM" src="https://github.com/user-attachments/assets/8003dcb5-f72b-49c2-904a-1dc5228ade7e" /> | <img width="694" alt="Screenshot 2025-04-15 at 1 59 01 AM" src="https://github.com/user-attachments/assets/e53b5bd5-2459-481e-b719-d4fc2b042fb0" /> |
| Saved Snippets | <img width="680" alt="Screenshot 2025-04-14 at 7 34 46 PM" src="https://github.com/user-attachments/assets/c1edd8bd-21c1-4527-a34e-50204eb658a0" /> | <img width="686" alt="Screenshot 2025-04-14 at 7 36 46 PM" src="https://github.com/user-attachments/assets/e40e086c-0545-40f5-8bd8-3de2da104a25" /> |
| Scheduled Messages | <img width="697" alt="Screenshot 2025-04-14 at 7 35 12 PM" src="https://github.com/user-attachments/assets/b1c943e5-976e-4d35-970e-3334e9a5f195" /> | <img width="537" alt="Screenshot 2025-04-15 at 1 59 48 AM" src="https://github.com/user-attachments/assets/deacfc37-2ca3-4ad5-b7cc-a994e76a98f9" /> |
| Delete a drafts | <img width="445" alt="Screenshot 2025-04-14 at 7 35 33 PM" src="https://github.com/user-attachments/assets/fe148685-7178-4a77-a8cc-673f6cd73f1e" /> | <img width="460" alt="Screenshot 2025-04-15 at 2 00 06 AM" src="https://github.com/user-attachments/assets/61867a6d-1556-49db-81fb-5a4cba639d26" /> |
| Delete all draft | <img width="702" alt="Screenshot 2025-04-14 at 7 35 39 PM" src="https://github.com/user-attachments/assets/6870c26e-6ca1-43a3-8ed1-fae2cf3e4a87" /> | <img width="684" alt="Screenshot 2025-04-15 at 2 00 12 AM" src="https://github.com/user-attachments/assets/6f0f484b-c1f3-4301-90f6-8b1488a75a46" /> |





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
