### PR TITLE
tests: clean tests and pass update_fields to all stream.save() 

### DIFF
--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1695,7 +1695,7 @@ def do_change_stream_group_based_setting(
         )
 
     setattr(stream, setting_name, user_group)
-    stream.save()
+    stream.save(update_fields=[setting_name, "name"])
 
     new_setting_api_value = get_group_setting_value_for_api(user_group)
     RealmAuditLog.objects.create(

--- a/zerver/migrations/0210_stream_first_message_id.py
+++ b/zerver/migrations/0210_stream_first_message_id.py
@@ -17,7 +17,7 @@ def backfill_first_message_id(apps: StateApps, schema_editor: BaseDatabaseSchema
             continue
 
         stream.first_message_id = first_message.id
-        stream.save()
+        stream.save(update_fields=["first_message_id"])
 
 
 class Migration(migrations.Migration):

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -500,7 +500,7 @@ class TestDigestEmailMessages(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         stream = create_stream_if_needed(cordelia.realm, "New stream")[0]
         stream.date_created = timezone_now()
-        stream.save()
+        stream.save(update_fields=["date_created"])
 
         realm = cordelia.realm
 
@@ -521,7 +521,7 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         # but they do if we make it web-public
         stream.is_web_public = True
-        stream.save()
+        stream.save(update_fields=["is_web_public"])
 
         recently_created_streams = get_recently_created_streams(realm, cutoff)
         stream_count, stream_info = gather_new_streams(
@@ -531,7 +531,7 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         # Make the stream appear to be older.
         stream.date_created = timezone_now() - timedelta(days=7)
-        stream.save()
+        stream.save(update_fields=["date_created"])
 
         recently_created_streams = get_recently_created_streams(realm, cutoff)
         stream_count, stream_info = gather_new_streams(

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -5032,7 +5032,7 @@ class SubscribeActionTest(BaseAction):
         # Subscribe to a totally new invite-only stream, so it's just Hamlet on it
         stream = self.make_stream("private", self.user_profile.realm, invite_only=True)
         stream.message_retention_days = 10
-        stream.save()
+        stream.save(update_fields=["message_retention_days"])
 
         user_profile = self.example_user("hamlet")
         with self.verify_action(include_subscribers=include_subscribers, num_events=2) as events:
@@ -5056,7 +5056,7 @@ class SubscribeActionTest(BaseAction):
         check_stream_delete("events[1]", events[1])
 
         stream.invite_only = False
-        stream.save()
+        stream.save(update_fields=["invite_only"])
 
         # Test events for guest user.
         self.user_profile = self.example_user("polonius")

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1409,7 +1409,7 @@ class RealmImportExportTest(ExportFile):
 
         denmark_stream = get_stream("Denmark", original_realm)
         denmark_stream.creator = hamlet
-        denmark_stream.save()
+        denmark_stream.save(update_fields=["creator"])
 
         internal_realm = get_realm(settings.SYSTEM_BOT_REALM)
         cross_realm_bot = get_system_bot(settings.WELCOME_BOT, internal_realm.id)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2512,8 +2512,7 @@ class StreamMessagesTest(ZulipTestCase):
         # Mark a stream as inactive
         stream = self.make_stream("inactive_stream")
         stream.is_recently_active = False
-        stream.save()
-        self.assertEqual(stream.is_recently_active, False)
+        stream.save(update_fields=["is_recently_active"])
 
         # Send a message to the stream
         sender = self.example_user("hamlet")

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -122,7 +122,7 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
         self, stream: Stream, retention_period: int | None
     ) -> None:
         stream.message_retention_days = retention_period
-        stream.save()
+        stream.save(update_fields=["message_retention_days"])
 
     def _change_messages_date_sent(self, msgs_ids: list[int], date_sent: datetime) -> None:
         Message.objects.filter(id__in=msgs_ids).update(date_sent=date_sent)
@@ -1044,11 +1044,11 @@ class TestGetRealmAndStreamsForArchiving(ZulipTestCase):
 
         archiving_blocked_zephyr_stream = self.make_stream("no archiving", realm=zephyr_realm)
         archiving_blocked_zephyr_stream.message_retention_days = -1
-        archiving_blocked_zephyr_stream.save()
+        archiving_blocked_zephyr_stream.save(update_fields=["message_retention_days"])
 
         archiving_enabled_zephyr_stream = self.make_stream("with archiving", realm=zephyr_realm)
         archiving_enabled_zephyr_stream.message_retention_days = 1
-        archiving_enabled_zephyr_stream.save()
+        archiving_enabled_zephyr_stream.save(update_fields=["message_retention_days"])
 
         no_archiving_realm = do_create_realm(string_id="no_archiving", name="no_archiving")
         do_set_realm_property(no_archiving_realm, "invite_required", False, acting_user=None)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -6590,7 +6590,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         for stream in streams:
             stream.is_in_zephyr_realm = True
-            stream.save()
+            stream.save(update_fields=["is_in_zephyr_realm"])
 
         # Verify that peer_event events are never sent in Zephyr
         # realm. This does generate stream creation events from
@@ -6629,7 +6629,7 @@ class SubscriptionAPITest(ZulipTestCase):
         realm = get_realm("zephyr")
         stream = self.make_stream("stream_1", realm=realm)
         stream.is_in_zephyr_realm = True
-        stream.save()
+        stream.save(update_fields=["is_in_zephyr_realm"])
 
         result = self.subscribe_via_post(
             starnine,

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -6,6 +6,7 @@ import time_machine
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.reactions import check_add_reaction, do_add_reaction
+from zerver.actions.streams import do_deactivate_stream
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.stream_topic import StreamTopicTarget
@@ -35,8 +36,7 @@ class MutedTopicsTestsDeprecated(ZulipTestCase):
             result = self.api_patch(user, url, data)
             self.assert_json_success(result)
 
-        stream.deactivated = True
-        stream.save()
+        do_deactivate_stream(stream, acting_user=None)
 
         self.assertNotIn([stream.name, "Verona3", mock_date_muted], get_topic_mutes(user))
         self.assertIn([stream.name, "Verona3", mock_date_muted], get_topic_mutes(user, True))
@@ -266,8 +266,7 @@ class MutedTopicsTests(ZulipTestCase):
             result = self.api_post(user, url, data)
             self.assert_json_success(result)
 
-        stream.deactivated = True
-        stream.save()
+        do_deactivate_stream(stream, acting_user=None)
 
         self.assertNotIn([stream.name, "Verona3", mock_date_muted], get_topic_mutes(user))
         self.assertIn([stream.name, "Verona3", mock_date_muted], get_topic_mutes(user, True))


### PR DESCRIPTION
A Prep-PR to [stream: Add subscriber_count field.](https://github.com/zulip/zulip/pull/34308)

Explicitly pass the fields to be updated, This increases performance but most importantly prevents overwriting the db-saved value of `subscriber_count` field (added in #34308) with the in-memory default value of 0,
since `subscriber_count` will **only** be updted via db.

Migrate some tests to use `do_` functions instead of direclty modifying the state.



