### PR TITLE
help-center-stage-2: Add support for including files.

### DIFF
--- a/help-beta/.gitignore
+++ b/help-beta/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log*
 pnpm-debug.log*
 
 *.mdx
+*.md
 
 
 # environment variables

--- a/help-beta/astro.config.mjs
+++ b/help-beta/astro.config.mjs
@@ -304,7 +304,6 @@ export default defineConfig({
                         "restrict-wildcard-mentions",
                         "restrict-moving-messages",
                         "restrict-message-editing-and-deletion",
-                        "disable-message-edit-history",
                         "image-video-and-website-previews",
                         "hide-message-content-in-emails",
                         "message-retention-policy",

--- a/help-beta/package.json
+++ b/help-beta/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "@astrojs/check": "^0.9.3",
     "@astrojs/starlight": "^0.33.0",
+    "@types/hast": "^3.0.4",
     "astro": "^5.1.2",
+    "hast-util-from-html": "^2.0.3",
+    "hast-util-to-html": "^9.0.5",
     "sharp": "^0.34.1",
     "typescript": "^5.4.5"
   }

--- a/help-beta/src/middleware.ts
+++ b/help-beta/src/middleware.ts
@@ -1,0 +1,82 @@
+import {defineMiddleware} from "astro:middleware";
+import type {Element, Root, RootContent} from "hast";
+import {fromHtml} from "hast-util-from-html";
+import {toHtml} from "hast-util-to-html";
+
+function isList(node: Element): boolean {
+    return node.tagName === "ol" || node.tagName === "ul";
+}
+
+// This function traverses the HTML tree and merges lists of the same
+// type if they are adjacent to each other. This is kinda a hack to
+// make file imports work within lists. One of our major use cases
+// for file imports is to have bullet points as partials to import at
+// different places in the project. But when importing the file with
+// Astro, it creates its own lists. So we merge lists together if they
+// have nothing but whitespace between them.
+function mergeAdjacentListsOfSameType(tree: Root): Root {
+    function recursiveMergeAdjacentLists(node: Element | Root): void {
+        if (!node.children) {
+            return;
+        }
+
+        const modifiedChildren: RootContent[] = [];
+        let currentIndex = 0;
+
+        while (currentIndex < node.children.length) {
+            const currentChild = node.children[currentIndex]!;
+
+            if (currentChild.type === "element" && isList(currentChild)) {
+                const mergedList = structuredClone(currentChild);
+                let lookaheadIndex = currentIndex + 1;
+
+                while (lookaheadIndex < node.children.length) {
+                    const lookaheadChild = node.children[lookaheadIndex]!;
+
+                    if (lookaheadChild.type === "element" && isList(lookaheadChild)) {
+                        if (lookaheadChild.tagName === currentChild.tagName) {
+                            mergedList.children.push(...lookaheadChild.children);
+                        }
+                        lookaheadIndex += 1;
+                    } else if (
+                        lookaheadChild.type === "text" &&
+                        /^\s*$/.test(lookaheadChild.value)
+                    ) {
+                        // Whitespace should be allowed in between lists.
+                        lookaheadIndex += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                modifiedChildren.push(mergedList);
+                currentIndex = lookaheadIndex;
+            } else {
+                modifiedChildren.push(currentChild);
+                currentIndex += 1;
+            }
+        }
+
+        node.children = modifiedChildren;
+        for (const child of node.children) {
+            if (child.type === "element") {
+                recursiveMergeAdjacentLists(child);
+            }
+        }
+    }
+
+    recursiveMergeAdjacentLists(tree);
+    return tree;
+}
+
+export const onRequest = defineMiddleware(async (_context, next) => {
+    const response = await next();
+    const html = await response.text();
+    const tree = fromHtml(html);
+    const result = toHtml(mergeAdjacentListsOfSameType(tree));
+
+    return new Response(result, {
+        status: 200,
+        headers: response.headers,
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,9 +503,18 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.33.0
         version: 0.33.0(astro@5.6.1(@types/node@22.14.0)(jiti@1.21.7)(rollup@4.39.0)(sass@1.86.3)(terser@5.39.0)(typescript@5.8.3)(yaml@2.7.1))
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       astro:
         specifier: ^5.1.2
         version: 5.6.1(@types/node@22.14.0)(jiti@1.21.7)(rollup@4.39.0)(sass@1.86.3)(terser@5.39.0)(typescript@5.8.3)(yaml@2.7.1)
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
+      hast-util-to-html:
+        specifier: ^9.0.5
+        version: 9.0.5
       sharp:
         specifier: ^0.34.1
         version: 0.34.1

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import os
+import re
+import shutil
 import sys
 
 import django
 from django.template import engines
 from django.template.backends.jinja2 import Jinja2
+from pydantic.alias_generators import to_pascal
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -48,6 +51,37 @@ def replace_image_path(markdown_string: str) -> str:
     return result.replace('="/static/images/help-beta', '="../../../../static/images/help')
 
 
+def fix_file_imports(markdown_string: str) -> str:
+    def convert_to_pascal(text: str) -> str:
+        return to_pascal(text).replace("-", "").replace(".Md", "")
+
+    def convert_to_astro_tag(match: re.Match[str]) -> str:
+        return "<" + convert_to_pascal(match.group(1)) + " />"
+
+    def append_str_to_line(text: str, destination_str: str, n: int) -> str:
+        lines = destination_str.splitlines()
+        if 1 <= n <= len(lines):
+            lines[n - 1] += "\n" + text + "\n"
+
+        return "\n".join(lines)
+
+    RE = re.compile(r"^ {,3}\{!([^!]+)!\} *$", re.MULTILINE)
+    result = RE.sub(convert_to_astro_tag, markdown_string)
+    matches = RE.findall(markdown_string)
+
+    import_statement_set = {
+        f'import {convert_to_pascal(match)} from "./include/_{match}"' for match in matches
+    }
+    for import_statement in import_statement_set:
+        # First line of the file is always the heading/title of the
+        # file. We rely on the heading being the first line later
+        # in the function inserting frontmatter and thus we add
+        # this to the second line.
+        result = append_str_to_line(import_statement, result, 2)
+
+    return result
+
+
 def escape_curly_braces(markdown_string: str) -> str:
     """
     MDX will treat curly braces as a JS expression,
@@ -82,11 +116,14 @@ def insert_frontmatter(markdown_string: str) -> str:
 
 
 def convert_string_to_mdx(markdown_string: str) -> str:
-    result = escape_curly_braces(markdown_string)
+    result = markdown_string
+    result = fix_file_imports(result)
+    result = escape_curly_braces(result)
     result = fix_relative_path(result)
     result = replace_emoticon_translation_table(result)
     result = replace_image_path(result)
-    return insert_frontmatter(result)
+    result = insert_frontmatter(result)
+    return result
 
 
 def convert_file_to_mdx(
@@ -113,6 +150,10 @@ def run() -> None:
 
     converted_count = 0
 
+    # We delete the directory first to remove any stale files
+    # that might have been deleted in the `help` folder but
+    # their converted mdx files stay around
+    shutil.rmtree(output_dir)
     os.makedirs(output_dir, exist_ok=True)
     for name in os.listdir(input_dir):
         if os.path.isfile(os.path.join(input_dir, name)):
@@ -128,6 +169,18 @@ def run() -> None:
             ) as mdx_file:
                 mdx_file.write(mdx)
     print(f"Converted {converted_count} files. Conversion completed.")
+
+    # All files in the `include` folder will only be imports and not
+    # standalone files. Therefore we do not do any manipulation or
+    # them to mdx.
+    include_source_dir = os.path.join(BASE_DIR, "help/include")
+    include_destination_dir = os.path.join(BASE_DIR, "help-beta/src/content/docs/include")
+    shutil.copytree(include_source_dir, include_destination_dir)
+    for name in os.listdir(include_destination_dir):
+        os.rename(
+            os.path.join(include_destination_dir, name),
+            os.path.join(include_destination_dir, "_" + name),
+        )
 
 
 run()

--- a/tools/convert-help-center-docs-to-mdx
+++ b/tools/convert-help-center-docs-to-mdx
@@ -176,6 +176,10 @@ def run() -> None:
     include_source_dir = os.path.join(BASE_DIR, "help/include")
     include_destination_dir = os.path.join(BASE_DIR, "help-beta/src/content/docs/include")
     shutil.copytree(include_source_dir, include_destination_dir)
+
+    # We do not want Astro to render these include files as standalone
+    # files, prefixing them with an underscore accomplishes that.
+    # https://docs.astro.build/en/guides/routing/#excluding-pages
     for name in os.listdir(include_destination_dir):
         os.rename(
             os.path.join(include_destination_dir, name),

--- a/version.py
+++ b/version.py
@@ -49,4 +49,4 @@ API_FEATURE_LEVEL = 378
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (325, 0)  # bumped 2025-04-09 to upgrade JavaScript dependencies
+PROVISION_VERSION = (325, 1)  # bumped 2025-04-16 to add hast dependencies to help-beta


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Run `./tools/build-help-center` to test this.

Fixes: https://github.com/zulip/zulip/issues/31252
One of our major use cases for file imports is to have bullet points as partials to import at different places in the project. But when importing the file with Astro, it creates its own lists. So we merge lists together if they have nothing but whitespace between them.
    
There were some talks to use a component called FlattenList that would flatten the list inside it, but that would also flatten lists that were nested on purpose. This approach while feeling a bit hacky would not flatten nested lists.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

The uneven spacing between the bullet points is not related to this issue and can be tackled separately at https://chat.zulip.org/#narrow/channel/101-design/topic/help-beta.3A.20Space.20between.20bullet.20points.2E

![Screenshot 2025-04-15 at 5 10 53 PM](https://github.com/user-attachments/assets/8f031ba9-9fa3-4c28-abd8-55f80927e7dd)

Nested lists still work:
![Screenshot 2025-04-15 at 5 14 15 PM](https://github.com/user-attachments/assets/3bdb87cf-2cf6-472c-8612-086925f17b85)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
