### PR TITLE
webpack: Disable cross-origin-header-check middleware

### DIFF
--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -30,7 +30,7 @@
         {% block webpack %}
             {% for filename in webpack_entry(entrypoint) -%}
                 {% if filename.endswith(".css") -%}
-                    <link href="{{ filename }}" rel="stylesheet" crossorigin="anonymous" {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %} />
+                    <link href="{{ filename }}" rel="stylesheet" {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %} />
                 {% elif filename.endswith(".js") -%}
                     <script src="{{ filename }}" defer crossorigin="anonymous" {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}></script>
                 {% endif -%}

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -255,6 +255,8 @@ const config = (
                 "Access-Control-Allow-Origin": "*",
                 "Timing-Allow-Origin": "*",
             },
+            setupMiddlewares: (middlewares) =>
+                middlewares.filter((middleware) => middleware.name !== "cross-origin-header-check"),
         },
         infrastructureLogging: {
             level: "warn",


### PR DESCRIPTION
This middleware in webpack-dev-server 5.2.1 appears to be intended to
plug some undisclosed browser-specific vulnerability that allows
stealing code from closed-source projects.

- [Discussion](https://chat.zulip.org/#narrow/channel/49-development-help/topic/create.20new.20realm.20not.20loading.20CSS/near/2150761).
- Followup to #34359.