### PR TITLE
settings: Hide invisible sections on narrow screens instead of layering.

### DIFF
--- a/web/src/stream_edit.ts
+++ b/web/src/stream_edit.ts
@@ -75,7 +75,7 @@ const realm_labels_schema = z.enum([
 const notification_labels_schema = stream_specific_notification_settings_schema.keyof();
 
 export function setup_subscriptions_tab_hash(tab_key_value: string): void {
-    if ($("#subscription_overlay .right").hasClass("show")) {
+    if ($("#channels_overlay_container .two-pane-settings-container").hasClass("right-pane-open")) {
         return;
     }
     switch (tab_key_value) {

--- a/web/src/stream_settings_ui.ts
+++ b/web/src/stream_settings_ui.ts
@@ -938,7 +938,7 @@ export function switch_to_stream_row(stream_id: number): void {
 }
 
 function show_right_section(): void {
-    $(".right").addClass("show");
+    $("#channels_overlay_container .two-pane-settings-container").addClass("right-pane-open");
     $("#subscription_overlay .two-pane-settings-header").addClass("slide-left");
     resize.resize_stream_subscribers_list();
 }
@@ -1175,7 +1175,9 @@ export function initialize(): void {
     );
 
     $("#channels_overlay_container").on("click", ".fa-chevron-left", () => {
-        $(".right").removeClass("show");
+        $("#channels_overlay_container .two-pane-settings-container").removeClass(
+            "right-pane-open",
+        );
         $("#channels_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
 }

--- a/web/src/user_group_edit.ts
+++ b/web/src/user_group_edit.ts
@@ -1344,7 +1344,7 @@ export function switch_to_group_row(group: UserGroup): void {
 }
 
 function show_right_section(): void {
-    $(".right").addClass("show");
+    $("#groups_overlay .two-pane-settings-container").addClass("right-pane-open");
     $("#groups_overlay .two-pane-settings-header").addClass("slide-left");
 }
 
@@ -2018,7 +2018,7 @@ export function initialize(): void {
     $("#groups_overlay_container").on("click", ".group-row", show_right_section);
 
     $("#groups_overlay_container").on("click", ".fa-chevron-left", () => {
-        $(".right").removeClass("show");
+        $("#groups_overlay .two-pane-settings-container").removeClass("right-pane-open");
         $("#groups_overlay_container .two-pane-settings-header").removeClass("slide-left");
     });
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1424,9 +1424,11 @@ div.settings-radio-input-parent {
    We should eventually consolidate some of these styles with the settings
    menu, using shared classnames. */
 @container settings-overlay (width < $settings_overlay_sidebar_collapse_breakpoint) {
-    .two-pane-settings-container {
+    /* Two classnames for extra specificity to override wide-screen styles. */
+    .two-pane-settings-overlay .two-pane-settings-container {
         position: relative;
         overflow: hidden;
+        height: 95%;
 
         .list-toggler-container {
             text-align: left;
@@ -1435,32 +1437,30 @@ div.settings-radio-input-parent {
         .two-pane-settings-header .fa-chevron-left {
             visibility: visible;
         }
-    }
 
-    .two-pane-settings-overlay .left,
-    .two-pane-settings-overlay .right {
-        position: absolute;
-        display: block;
-        margin: 0;
-        width: 100%;
-        height: calc(100% - var(--settings-overlay-header-height));
+        /* default left pane open without `.right-pane-open` present */
+        .left {
+            display: block;
+            width: 100%;
+        }
 
-        border: none;
-    }
+        .right {
+            display: none;
+            background-color: var(--color-background-modal);
+            border-top: none;
+            transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
+        }
 
-    .two-pane-settings-overlay .right {
-        position: absolute;
-        left: 101%;
+        &.right-pane-open {
+            .right {
+                display: block;
+                width: 100%;
+            }
 
-        top: var(--settings-overlay-header-height);
-        background-color: var(--color-background-modal);
-        border-top: none;
-
-        transition: left 0.3s ease; /* stylelint-disable-line plugin/no-low-performance-animation-properties */
-        z-index: 10;
-
-        &.show {
-            left: 0%;
+            .left,
+            .two-pane-settings-subheader {
+                display: none;
+            }
         }
     }
 
@@ -1485,10 +1485,6 @@ div.settings-radio-input-parent {
     }
 
     .two-pane-settings-overlay {
-        .two-pane-settings-container {
-            height: 95%;
-        }
-
         .settings {
             overflow: auto;
             -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
This is a much cleaner way to sometimes have the left pane be the full width and sometimes the right pane. Previously it was set up so that both were visible, but they were layered with z-index and absolute positioning. This commit refactors the stream and usergroup settings but not the main settings page yet.

This commit should have no visible changes (but someone else double checking would be good)

Prep commit for #34125
