### PR TITLE
settings: Make stream and group settings thead sticky.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -175,18 +175,20 @@ h4.user_group_setting_subsection_title {
                 }
             }
 
-            & thead th {
-                &:first-of-type {
-                    border-top-left-radius: 4px;
-                }
-
-                &:last-of-type {
-                    border-top-right-radius: 4px;
-                }
-
+            & thead {
                 position: sticky;
                 top: 0;
                 z-index: 1;
+
+                th {
+                    &:first-of-type {
+                        border-top-left-radius: 4px;
+                    }
+
+                    &:last-of-type {
+                        border-top-right-radius: 4px;
+                    }
+                }
             }
 
             .hidden-subscriber-email {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> [CZO](https://chat.zulip.org/#narrow/channel/9-issues/topic/Transparent.20table.20header.20in.20members.20and.20subscribers.20tab.2E).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| After |  Before  |
|-----|-----|
| <img width="709" alt="Screenshot 2025-04-16 at 6 40 50 PM" src="https://github.com/user-attachments/assets/9a28e974-108d-4a52-bc48-25a90c0579d7" /> | <img width="706" alt="Screenshot 2025-04-16 at 6 47 35 PM" src="https://github.com/user-attachments/assets/94e1bc44-6a1f-4770-b9f2-e8b7c17e4efe" /> |
| <img width="712" alt="Screenshot 2025-04-16 at 6 41 02 PM" src="https://github.com/user-attachments/assets/16cf8a8d-18db-4235-aec4-9372a37e0a34" /> | <img width="698" alt="Screenshot 2025-04-16 at 6 48 46 PM" src="https://github.com/user-attachments/assets/5c8af0e5-a826-4993-ab68-bc2b174301a2" /> |
| <img width="715" alt="Screenshot 2025-04-16 at 6 41 22 PM" src="https://github.com/user-attachments/assets/aa916ef7-4368-45b0-a727-03714e06bb8c" /> | <img width="711" alt="Screenshot 2025-04-16 at 6 49 17 PM" src="https://github.com/user-attachments/assets/adeb1067-be7f-4b37-a8cf-84456ad6f7f8" /> |
| <img width="706" alt="Screenshot 2025-04-16 at 6 41 30 PM" src="https://github.com/user-attachments/assets/3928c5f3-94c9-48ff-8421-95ba230d3374" /> | <img width="702" alt="Screenshot 2025-04-16 at 6 49 28 PM" src="https://github.com/user-attachments/assets/e3d3e280-698c-4c87-920f-62d58326d2ff" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
