### PR TITLE
[IGNORE] typeahead: Cache diacritic-less names for performance.

### DIFF
--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -90,10 +90,6 @@ export function last_prefix_match(prefix: string, words: string[]): number | nul
     return null;
 }
 
-// This function attempts to match a query in order with a source text.
-// * query is the user-entered search query
-// * source_str is the string we're matching in, e.g. a user's name
-// * split_char is the separator for this syntax (e.g. ' ').
 export function query_matches_string_in_order(
     query: string,
     source_str: string,
@@ -104,18 +100,34 @@ export function query_matches_string_in_order(
 
     query = query.toLowerCase();
     query = remove_diacritics(query);
+    return match_query_with_source(query, source_str, split_char);
+}
 
-    if (!query.includes(split_char)) {
+// This function attempts to match a query in order with a source text.
+// * query is the user-entered search query
+// * source_str is the string we're matching in, e.g. a user's name
+// * split_char is the separator for this syntax (e.g. ' ').
+// Precondition: `query` and `source_str` must have diacritics removed
+// before calling this function.
+export function match_query_with_source(
+    query_with_diacritics_removed: string,
+    source_str_with_diacritics_removed: string,
+    split_char: string,
+): boolean {
+    if (!query_with_diacritics_removed.includes(split_char)) {
         // If query is a single token (doesn't contain a separator),
         // the match can be anywhere in the string.
-        return source_str.includes(query);
+        return source_str_with_diacritics_removed.includes(query_with_diacritics_removed);
     }
 
     // If there is a separator character in the query, then we
     // require the match to start at the start of a token.
     // (E.g. for 'ab cd ef', query could be 'ab c' or 'cd ef',
     // but not 'b cd ef'.)
-    return source_str.startsWith(query) || source_str.includes(split_char + query);
+    return (
+        source_str_with_diacritics_removed.startsWith(query_with_diacritics_removed) ||
+        source_str_with_diacritics_removed.includes(split_char + query_with_diacritics_removed)
+    );
 }
 
 // Match the words in the query to the words in the source text, in any order.

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -671,8 +671,10 @@ export function get_person_suggestions(
                 })),
             ];
         }
-
-        return person_items.filter((item) => typeahead_helper.query_matches_person(query, item));
+        const query_with_diacritics_removed = typeahead.remove_diacritics(query.toLowerCase());
+        return person_items.filter((item) =>
+            typeahead_helper.query_matches_person(query_with_diacritics_removed, item),
+        );
     }
 
     let groups: UserGroup[];

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -1,5 +1,7 @@
 import assert from "minimalistic-assert";
 
+import * as typeahead from "../shared/src/typeahead.ts";
+
 import * as blueslip from "./blueslip.ts";
 import {Typeahead} from "./bootstrap_typeahead.ts";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead.ts";
@@ -16,9 +18,10 @@ import * as user_pill from "./user_pill.ts";
 import type {UserPillData, UserPillWidget} from "./user_pill.ts";
 
 function person_matcher(query: string, item: UserPillData): boolean {
+    const query_with_diacritics_removed = typeahead.remove_diacritics(query.toLowerCase());
     return (
         people.is_known_user_id(item.user.user_id) &&
-        typeahead_helper.query_matches_person(query, item)
+        typeahead_helper.query_matches_person(query_with_diacritics_removed, item)
     );
 }
 


### PR DESCRIPTION
We cache user names with diacritics removed instead of calculating them everytime.

Fixes:
https://chat.zulip.org/#narrow/channel/9-issues/topic/Mention.20typeahead.20performance/with/2155535.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
