### PR TITLE
message_feed: Correct regression on dateline, bookend borders.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -465,7 +465,7 @@
     --scale-message-reaction-active: 0.96;
 
     /* Message group bookend and date row UI */
-    --color-border-mesaage-group-spacer-line: light-dark(
+    --color-border-message-group-spacer-line: light-dark(
         color-mix(in oklch, hsl(0deg 0% 0%) 15%, transparent),
         color-mix(in oklch, hsl(0deg 0% 100%) 15%, transparent)
     );

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1137,7 +1137,7 @@ of the base style defined for a read-only textarea in dark mode. */
     vertical-align: middle;
     height: 0;
     opacity: 0.15;
-    border-bottom: 1px solid var(--color-border-mesaage-group-spacer-line);
+    border-bottom: 1px solid var(--color-border-message-group-spacer-line);
 }
 
 .bookend-label::before,

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1136,7 +1136,6 @@ of the base style defined for a read-only textarea in dark mode. */
     content: " ";
     vertical-align: middle;
     height: 0;
-    opacity: 0.15;
     border-bottom: 1px solid var(--color-border-message-group-spacer-line);
 }
 

--- a/zerver/tests/test_muted_users.py
+++ b/zerver/tests/test_muted_users.py
@@ -208,11 +208,11 @@ class MutedUsersTests(ZulipTestCase):
         self.assertEqual(set(), cache_get(get_muting_users_cache_key(cordelia.id))[0])
 
     def assert_usermessage_read_flag(self, user: UserProfile, message: int, flag: bool) -> None:
-        usermesaage = UserMessage.objects.get(
+        usermessage = UserMessage.objects.get(
             user_profile=user,
             message=message,
         )
-        self.assertTrue(usermesaage.flags.read == flag)
+        self.assertTrue(usermessage.flags.read == flag)
 
     def test_new_messages_from_muted_user_marked_as_read(self) -> None:
         hamlet = self.example_user("hamlet")


### PR DESCRIPTION
This PR fixes a regression introduced in #34354, which did not remove a compounding opacity value made unnecessary by the `color-mix()` function.

Additionally, this corrects misspelled CSS variables and some test variables: `mesaage` > `message`.

CZO discussion

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_Bookends:_
| Before | After |
| --- | --- |
| ![bookend-light-before](https://github.com/user-attachments/assets/b13f4d1e-2c40-44a0-a0de-91fda3e76233) | ![bookend-light-after](https://github.com/user-attachments/assets/8cc83c2d-9597-4514-8ac3-0e3cfd9d510a) |
| ![bookend-dark-before](https://github.com/user-attachments/assets/14c4bd40-71d7-46f4-8a72-abd85c60a619) | ![bookend-dark-after](https://github.com/user-attachments/assets/383ee3a5-ee36-4c76-84b4-87fe81e20670) |

_Datelines:_

| Before | After |
| --- | --- |
| ![dateline-light-before](https://github.com/user-attachments/assets/3f75d93f-e7d4-4d3b-8548-4fe8147f6939) | ![dateline-light-after](https://github.com/user-attachments/assets/c16c756a-3da0-498a-a576-64e70f40e2b0) |
| ![dateline-dark-before](https://github.com/user-attachments/assets/87140dd3-473d-42c7-9c41-181996407bb7) | ![dateline-dark-after](https://github.com/user-attachments/assets/be1d1ba6-3b3e-48fa-a83a-82fb8a648e74) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>