### PR TITLE
tooltips: Show tooltip on disabled "Add" button in group and channel settings.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -505,6 +505,36 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
+        target: ".add-users-button-wrapper",
+        onShow(instance) {
+            const $wrapper = $(instance.reference);
+            const $button = $wrapper.find("button");
+            const $container = $wrapper.closest(".add-button-container").find(".pill-container");
+
+            const button_is_disabled = Boolean($button.prop("disabled"));
+            const container_is_enabled =
+                $container.find(".input").prop("contenteditable") === "true";
+
+            if (button_is_disabled && container_is_enabled) {
+                instance.setContent(
+                    $t({
+                        defaultMessage: "Enter who should be added.",
+                    }),
+                );
+                return undefined;
+            }
+
+            return false;
+        },
+        appendTo: () => document.body,
+        placement: "top",
+        delay: INSTANT_HOVER_DELAY,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
         target: ".user_row .actions button",
         trigger: "mouseenter",
         onShow(instance) {

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -6,7 +6,7 @@
         </div>
     </div>
     {{#if (not hide_add_button)}}
-        <div class="add_subscriber_button_wrapper inline-block">
+        <div class="add_subscriber_button_wrapper add-users-button-wrapper inline-block">
             {{> ../components/action_button
               label=(t "Add")
               custom_classes="add-subscriber-button add-users-button"

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -6,7 +6,7 @@
         </div>
     </div>
     {{#if (not hide_add_button)}}
-        <div class="add_member_button_wrapper inline-block">
+        <div class="add_member_button_wrapper add-users-button-wrapper inline-block">
             {{> ../components/action_button
               label=(t "Add")
               custom_classes="add-member-button add-users-button"

--- a/web/templates/user_group_settings/add_members_form.hbs
+++ b/web/templates/user_group_settings/add_members_form.hbs
@@ -20,7 +20,7 @@
 </div>
 <div class="add-members-subtitle">
     {{#tr}}
-        You can add subscribers by name or email address.
+        You can add members by name or email address.
         Enter a <z-user-roles-link>user role</z-user-roles-link>,
         <z-user-groups-link>user group</z-user-groups-link>,
         or <z-channel-link>#channel</z-channel-link> to add multiple users at once.


### PR DESCRIPTION
This PR adds tooltip on the disbaled "Add" button in group and channel settings.

- The permissions tooltip takes precedence over this new tooltip.
- We are only showing one tooltip at a time.
- Unlike the permissions tooltip, this tooltip is on the button, not on the entire input field.

Fixes: #34325.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Permissions disabled tooltip | Add button tooltip |
|-----|-----|
| <img width="523" alt="Screenshot 2025-04-17 at 3 30 45 AM" src="https://github.com/user-attachments/assets/96b9703a-9180-4425-b313-12f974461a98" /> | <img width="820" alt="Screenshot 2025-04-26 at 1 37 25 AM" src="https://github.com/user-attachments/assets/d2f841d6-6a1c-4fc8-8b32-fbbc8e2775fd" /> |
| <img width="714" alt="Screenshot 2025-04-17 at 3 31 16 AM" src="https://github.com/user-attachments/assets/0d1a00f3-318c-405a-8538-780acfa3ab80" /> | <img width="806" alt="Screenshot 2025-04-26 at 1 37 38 AM" src="https://github.com/user-attachments/assets/0c9d2a83-8d6c-4cef-8092-d84a15f34fae" /> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
