### PR TITLE
typeahead: Cache diacritic-less names for performance.

### DIFF
--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -90,10 +90,6 @@ export function last_prefix_match(prefix: string, words: string[]): number | nul
     return null;
 }
 
-// This function attempts to match a query in order with a source text.
-// * query is the user-entered search query
-// * source_str is the string we're matching in, e.g. a user's name
-// * split_char is the separator for this syntax (e.g. ' ').
 export function query_matches_string_in_order(
     query: string,
     source_str: string,
@@ -105,6 +101,18 @@ export function query_matches_string_in_order(
     query = query.toLowerCase();
     query = remove_diacritics(query);
 
+    return query_matches_string_in_order_assume_canonicalized(query, source_str, split_char);
+}
+
+// This function attempts to match a query in order with a source text.
+// * query is the user-entered search query
+// * source_str is the string we're matching in, e.g. a user's name
+// * split_char is the separator for this syntax (e.g. ' ').
+export function query_matches_string_in_order_assume_canonicalized(
+    query: string,
+    source_str: string,
+    split_char: string,
+): boolean {
     if (!query.includes(split_char)) {
         // If query is a single token (doesn't contain a separator),
         // the match can be anywhere in the string.

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -95,11 +95,13 @@ export function query_matches_string_in_order(
     source_str: string,
     split_char: string,
 ): boolean {
-    source_str = source_str.toLowerCase();
-    source_str = remove_diacritics(source_str);
-
     query = query.toLowerCase();
-    query = remove_diacritics(query);
+    source_str = source_str.toLowerCase();
+
+    const should_remove_diacritics = /^[a-z]+$/.test(query);
+    if (should_remove_diacritics) {
+        source_str = remove_diacritics(source_str);
+    }
 
     return query_matches_string_in_order_assume_canonicalized(query, source_str, split_char);
 }

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -671,8 +671,12 @@ export function get_person_suggestions(
                 })),
             ];
         }
-
-        return person_items.filter((item) => typeahead_helper.query_matches_person(query, item));
+        const should_remove_diacritics = people.should_remove_diacritics_for_query(
+            query.toLowerCase(),
+        );
+        return person_items.filter((item) =>
+            typeahead_helper.query_matches_person(query, item, should_remove_diacritics),
+        );
     }
 
     let groups: UserGroup[];

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1292,18 +1292,39 @@ export function get_people_for_search_bar(query: string): User[] {
     return filter_all_persons(pred);
 }
 
-export function build_termlet_matcher(termlet: string): (user: User) => boolean {
-    termlet = termlet.trim();
+export function should_remove_diacritics_for_query(query_lower_case: string): boolean {
+    // We only do diacritic-sensitive matching for queries that do not
+    // contain diacritics themselves.
+    //
+    // TODO: This check is too strict; ideally we'd check for presence
+    // of diacritics; punctuation should not be relevant.
+    return /^[a-z]+$/.test(query_lower_case);
+}
 
-    const is_ascii = /^[a-z]+$/.test(termlet);
+export function maybe_remove_diacritics_from_name(
+    user: User,
+    should_remove_diacritics: boolean,
+): string {
+    // Callers should compute should_remove_diacritics using
+    // should_remove_diacritics_for_query. It's fastest if the caller
+    // computes that once outside the loop over all users.
+    if (should_remove_diacritics) {
+        // Reuse removed diacritics version of the `full_name` if
+        // present, since it's expensive to compute.
+        user.name_with_diacritics_removed ??= typeahead.remove_diacritics(user.full_name);
+        return user.name_with_diacritics_removed;
+    }
+    return user.full_name;
+}
+
+export function build_termlet_matcher(termlet: string): (user: User) => boolean {
+    // Note: termlets are required to be lower case.
+    termlet = termlet.trim();
+    const should_remove_diacritics = should_remove_diacritics_for_query(termlet);
 
     return function (user: User): boolean {
-        let full_name = user.full_name;
-        // Only ignore diacritics if the query is plain ascii
-        if (is_ascii) {
-            user.name_with_diacritics_removed ??= typeahead.remove_diacritics(full_name);
-            full_name = user.name_with_diacritics_removed;
-        }
+        const full_name = maybe_remove_diacritics_from_name(user, should_remove_diacritics);
+
         const names = full_name.toLowerCase().split(" ");
 
         return names.some((name) => name.startsWith(termlet));


### PR DESCRIPTION

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
#### Profiling results on local realm with 50K users:
| Query | Before | After|
|------|-------|-------|
|`@aaron` | ![image.png](https://chat.zulip.org/user_uploads/2/8f/ZiGamYUdcJ6xd3LYA9N4BlwA/image.png) |![image.png](https://chat.zulip.org/user_uploads/2/20/EUPyCPamEZhXmZh0gpHK6U00/image.png) |
|`@peter` | ![image.png](https://chat.zulip.org/user_uploads/2/6f/wDg9GS12ZvIzsHrCcY_raj9p/image.png) |![image.png](https://chat.zulip.org/user_uploads/2/ab/IhIkUK69wMEXUb5gCwSZpBIp/image.png) |
|`@michael10012` | ![image.png](https://chat.zulip.org/user_uploads/2/3c/Q7Ftwj4mVHD8K589dFvsuwQR/image.png) |![image.png](https://chat.zulip.org/user_uploads/2/49/OAzkoIHL4jk90v2uwYuMVMzr/image.png) |
|`@m` | ![image.png](https://chat.zulip.org/user_uploads/2/67/xCpQqXqrghXsr-ahjrFAR_NQ/image.png) |![image.png](https://chat.zulip.org/user_uploads/2/49/ooEPDhj_0yawzUnA1zQ-RsOz/image.png) |



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
