### PR TITLE
attachments: Allow seeing attachments to users with content access.

### DIFF
--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -120,7 +120,7 @@ def validate_attachment_request(
         )
         attachment.refresh_from_db()
 
-    if user_profile == attachment.owner:
+    if user_profile.id == attachment.owner_id:
         # If you own the file, you can access it.
         return True, attachment
     if (

--- a/zerver/lib/attachments.py
+++ b/zerver/lib/attachments.py
@@ -8,7 +8,9 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError, RateLimitedError
+from zerver.lib.streams import is_user_in_groups_granting_content_access
 from zerver.lib.upload import delete_message_attachment
+from zerver.lib.user_groups import get_recursive_membership_groups
 from zerver.models import (
     ArchivedAttachment,
     Attachment,
@@ -131,7 +133,7 @@ def validate_attachment_request(
         # Any user in the realm can access realm-public files
         return True, attachment
 
-    messages = attachment.messages.all()
+    messages = attachment.messages.all().select_related("recipient")
 
     usermessages_channel_ids = set()
     usermessage_rows = UserMessage.objects.filter(
@@ -146,30 +148,50 @@ def validate_attachment_request(
             usermessages_channel_ids.add(um.message.recipient.type_id)
 
     # These are subscriptions to a channel one of the messages was sent to
-    relevant_channel_ids = Subscription.objects.filter(
+    subscribed_channel_ids = Subscription.objects.filter(
         user_profile=user_profile,
         active=True,
         recipient__type=Recipient.STREAM,
         recipient__in=[m.recipient_id for m in messages],
     ).values_list("recipient__type_id", flat=True)
 
-    if usermessages_channel_ids & set(relevant_channel_ids):
+    if usermessages_channel_ids.intersection(subscribed_channel_ids):
         # If the attachment was sent in a channel with public
         # or protected history and the user is still subscribed
         # to the channel then anyone who received that message
         # can access it.
         return True, attachment
 
-    # The user didn't receive any of the messages that included this
-    # attachment. But they might still have access to it, if it was
-    # sent to a stream they are on where history is public to
-    # subscribers.
-    if len(relevant_channel_ids) == 0:
-        return False, attachment
+    message_channel_ids = set()
+    for message in messages:
+        if message.is_stream_message():
+            message_channel_ids.add(message.recipient.type_id)
 
-    return Stream.objects.filter(
-        id__in=relevant_channel_ids, history_public_to_subscribers=True
-    ).exists(), attachment
+    if len(message_channel_ids) > 0:
+        message_channels = Stream.objects.filter(id__in=message_channel_ids)
+        for channel in message_channels:
+            # The user didn't receive any of the messages that included
+            # this attachment. But they might still have access to it,
+            # if it was sent to a stream they are subscribed to where
+            # history is public to subscribers.
+            if channel.id in subscribed_channel_ids and channel.is_history_public_to_subscribers():
+                return True, attachment
+
+        user_recursive_group_ids = set(
+            get_recursive_membership_groups(user_profile).values_list("id", flat=True)
+        )
+        for channel in message_channels:
+            if is_user_in_groups_granting_content_access(channel, user_recursive_group_ids):
+                if channel.is_history_public_to_subscribers():
+                    return True, attachment
+                # If the user had received the message at one point of
+                # time, but they are no longer subscribed to a stream
+                # with protected history. They can still access that
+                # message and it's attachment
+                elif channel.id in usermessages_channel_ids:
+                    return True, attachment
+
+    return False, attachment
 
 
 def get_old_unclaimed_attachments(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -147,6 +147,16 @@ def fix_expected_fields_for_stream_group_settings(expected_fields: set[str]) -> 
     return expected_fields
 
 
+def check_subscriptions_exists(user_profile: UserProfile, stream: Stream) -> bool:
+    return (
+        get_active_subscriptions_for_stream_id(stream.id, include_deactivated_users=True)
+        .filter(
+            user_profile=user_profile,
+        )
+        .exists()
+    )
+
+
 class TestMiscStuff(ZulipTestCase):
     def test_test_helper(self) -> None:
         cordelia = self.example_user("cordelia")
@@ -1818,14 +1828,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(cordelia, stream.name)
         result = self.client_delete(f"/json/streams/{stream.id}")
         self.assert_json_success(result)
-        subscription_exists = (
-            get_active_subscriptions_for_stream_id(stream.id, include_deactivated_users=True)
-            .filter(
-                user_profile=user_profile,
-            )
-            .exists()
-        )
-        self.assertTrue(subscription_exists)
+        self.assertTrue(check_subscriptions_exists(user_profile, stream))
         # Assert that a notification message was sent for the archive.
         message = self.get_last_message()
         expected_content = f"Channel {stream.name} has been archived."
@@ -1855,14 +1858,7 @@ class StreamAdminTest(ZulipTestCase):
         )
         result = self.client_delete(f"/json/streams/{stream.id}")
         self.assert_json_success(result)
-        subscription_exists = (
-            get_active_subscriptions_for_stream_id(stream.id, include_deactivated_users=True)
-            .filter(
-                user_profile=user_profile,
-            )
-            .exists()
-        )
-        self.assertTrue(subscription_exists)
+        self.assertTrue(check_subscriptions_exists(user_profile, stream))
         # Assert that a notification message was sent for the archive.
         message = self.get_last_message()
         expected_content = f"Channel {stream.name} has been archived."

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -890,7 +890,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         def assert_cannot_access_file(user: UserProfile) -> None:
             self.login_user(user)
             # It takes a few extra queries to verify lack of access with shared history.
-            with self.assert_database_query_count(8):
+            with self.assert_database_query_count(10):
                 response = self.client_get(url)
             self.assertEqual(response.status_code, 403)
             self.assert_in_response("You are not authorized to view this file.", response)
@@ -931,7 +931,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         user = self.example_user("aaron")
         self.login_user(user)
-        with self.assert_database_query_count(8):
+        with self.assert_database_query_count(10):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 403)
             self.assert_in_response("You are not authorized to view this file.", response)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -803,7 +803,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Owner user should be able to view file
         self.login_user(hamlet)
-        with self.assert_database_query_count(6):
+        with self.assert_database_query_count(5):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.getvalue(), b"zulip!")
@@ -811,7 +811,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Subscribed user who received the message should be able to view file
         self.login_user(cordelia)
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(8):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.getvalue(), b"zulip!")
@@ -864,7 +864,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Owner user should be able to view file
         self.login_user(user)
-        with self.assert_database_query_count(6):
+        with self.assert_database_query_count(5):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.getvalue(), b"zulip!")
@@ -872,7 +872,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Originally subscribed user should be able to view file
         self.login_user(polonius)
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(8):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.getvalue(), b"zulip!")
@@ -880,7 +880,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Subscribed user who did not receive the message should also be able to view file
         self.login_user(late_subscribed_user)
-        with self.assert_database_query_count(10):
+        with self.assert_database_query_count(9):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.getvalue(), b"zulip!")
@@ -890,7 +890,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         def assert_cannot_access_file(user: UserProfile) -> None:
             self.login_user(user)
             # It takes a few extra queries to verify lack of access with shared history.
-            with self.assert_database_query_count(9):
+            with self.assert_database_query_count(8):
                 response = self.client_get(url)
             self.assertEqual(response.status_code, 403)
             self.assert_in_response("You are not authorized to view this file.", response)
@@ -931,7 +931,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         user = self.example_user("aaron")
         self.login_user(user)
-        with self.assert_database_query_count(9):
+        with self.assert_database_query_count(8):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 403)
             self.assert_in_response("You are not authorized to view this file.", response)
@@ -940,12 +940,12 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         self.subscribe(user, "test-subscribe 2")
 
         # If we were accidentally one query per message, this would be 20+
-        with self.assert_database_query_count(10):
+        with self.assert_database_query_count(9):
             response = self.client_get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.getvalue(), b"zulip!")
 
-        with self.assert_database_query_count(6):
+        with self.assert_database_query_count(5):
             self.assertTrue(validate_attachment_request(user, fp_path_id)[0])
 
         self.logout()


### PR DESCRIPTION
Fixes https://chat.zulip.org/#narrow/channel/9-issues/topic/Can't.20view.20images.20in.20private.20channel.2E


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="640" alt="Screenshot 2025-04-17 at 4 46 14 PM" src="https://github.com/user-attachments/assets/fab073b6-91b3-4a87-bea8-60996c8d4da3" />


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
