### PR TITLE
navbar-banners: Update banner-link class for no underline (without hover).

### DIFF
--- a/web/src/portico/showroom.ts
+++ b/web/src/portico/showroom.ts
@@ -124,16 +124,10 @@ const alert_banners: Record<string, AlertBanner> = {
         process: "notifications",
         intent: "brand",
         label: new Handlebars.SafeString(
-            $t_html(
-                {
-                    defaultMessage:
-                        "Zulip needs your permission to enable desktop notifications for messages you receive. You can <z-link>customize</z-link> what kinds of messages trigger notifications.",
-                },
-                {
-                    "z-link": (content_html) =>
-                        `<a class="banner-link" href="https://zulip.com/help/desktop-notifications#desktop-notifications" target="_blank" rel="noopener noreferrer">${content_html.join("")}</a>`,
-                },
-            ),
+            $t_html({
+                defaultMessage:
+                    "Zulip needs your permission to enable desktop notifications for important messages.",
+            }),
         ),
         buttons: [
             {

--- a/web/styles/banners.css
+++ b/web/styles/banners.css
@@ -16,7 +16,7 @@
 
 .banner-link {
     color: var(--color-text-link);
-    text-decoration: underline;
+    text-decoration: none;
     text-decoration-color: var(--color-text-link-decoration);
 
     &:hover {


### PR DESCRIPTION
Changes:
- Updates the **banner-link** class to have "text-decoration: none" set, instead of underline.
- Updates the desktop notification banner text in the devtools testing of banners in `showroom.ts` to match what's currently used in `navbar_alerts.ts`, so that the only place that the **banner-link** class is currently used is on the demo organization deletion deadline alert.

**Screenshots and screen captures:**

### Desktop notification alert:
| Where | Screenshot |
| --- | --- |
| Current banner in web app | ![Screenshot from 2025-04-17 15-47-19](https://github.com/user-attachments/assets/dc63eb5b-98e1-4524-b435-56d556e35a69) |
| Banner in showroom before changes | ![Screenshot from 2025-04-17 15-45-12](https://github.com/user-attachments/assets/96d6826c-f8ca-4785-b1df-689789739ca6) |
| Banner in showroom after changes | ![Screenshot from 2025-04-17 15-45-38](https://github.com/user-attachments/assets/b936250d-b589-40cd-9a16-f2d59759bfa4) |

### Demo organization alert:
| Where | Screenshot |
| --- | --- |
| Before changes | ![Screenshot from 2025-04-17 15-46-10](https://github.com/user-attachments/assets/f285dec5-d483-419f-b8e3-e872f309b430)  |
| After changes | ![Screenshot from 2025-04-17 15-45-58](https://github.com/user-attachments/assets/40b238fd-e9f4-45de-98f1-94dcfe8def72) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
