### PR TITLE
banners: Fix banner grid layout for medium and small variants.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -655,13 +655,15 @@
     --banner-grid-template-rows-lg: 0.3125em auto 0.3125em; /* 5px at 16px/1em */
     --banner-grid-template-areas-md: ". . . . banner-close-button banner-close-button"
         ". . banner-label banner-label banner-close-button banner-close-button"
-        ". banner-action-buttons banner-action-buttons banner-action-buttons . .";
+        ". banner-action-buttons banner-action-buttons banner-action-buttons banner-close-button banner-close-button"
+        ". . . . banner-close-button banner-close-button";
     --banner-grid-template-columns-md: var(--banner-horizontal-padding) 0
         minmax(auto, 1fr) 0 minmax(0, auto) var(--banner-horizontal-padding);
     --banner-grid-template-rows-md: 0.3125em auto auto 0.3125em; /* 5px at 16px/1em */
     --banner-grid-template-areas-sm: ". . . . banner-close-button banner-close-button"
         ". . banner-label banner-label banner-close-button banner-close-button"
-        ". banner-action-buttons banner-action-buttons banner-action-buttons banner-action-buttons .";
+        ". banner-action-buttons banner-action-buttons banner-action-buttons banner-close-button banner-close-button"
+        ". . . . banner-close-button banner-close-button";
 
     /* Popup banner related variables */
     --popup-banner-translate-y-distance: 100px;


### PR DESCRIPTION
The banner grid layout for the medium and small variants has 4 rows, while the previously described `grid-template-areas` only had the placement information for the first 3 rows.

This commit adds the spatial description of the banner elements in the the final row, fixing the alignment of the banner elements in the cases where there are no action buttons and only the banner label.

Related PR: #34433

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-04-18 at 1 10 24 AM](https://github.com/user-attachments/assets/b8666e9c-c572-419f-9285-1b978e9c2ea2) | ![Screenshot 2025-04-18 at 1 10 58 AM](https://github.com/user-attachments/assets/c5e72057-667b-4bb8-b0da-a3728f8388b1) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
