### PR TITLE
alert_words: Use banner to indicate alert words removal status.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -280,7 +280,7 @@ async function test_your_bots_section(page: Page): Promise<void> {
     await test_invalid_edit_bot_form(page);
 }
 
-const alert_word_status_selector = "#alert_word_status";
+const alert_word_status_banner_selector = ".alert-word-status-banner";
 
 async function add_alert_word(page: Page, word: string): Promise<void> {
     await page.click("#open-add-alert-word-modal");
@@ -298,15 +298,18 @@ async function check_alert_word_added(page: Page, word: string): Promise<void> {
 }
 
 async function get_alert_words_status_text(page: Page): Promise<string> {
-    await page.waitForSelector(alert_word_status_selector, {visible: true});
-    const status_text = await common.get_text_from_selector(page, ".alert_word_status_text");
+    await page.waitForSelector(alert_word_status_banner_selector, {visible: true});
+    const status_text = await common.get_text_from_selector(
+        page,
+        ".alert-word-status-banner .banner-label",
+    );
     return status_text;
 }
 
 async function close_alert_words_status(page: Page): Promise<void> {
-    const status_close_button = ".close-alert-word-status";
+    const status_close_button = ".alert-word-status-banner .banner-close-button";
     await page.click(status_close_button);
-    await page.waitForSelector(alert_word_status_selector, {hidden: true});
+    assert.ok((await page.$(alert_word_status_banner_selector)) === null);
 }
 
 async function test_duplicate_alert_words_cannot_be_added(

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -340,7 +340,7 @@ async function delete_alert_word(page: Page, word: string): Promise<void> {
 async function test_alert_word_deletion(page: Page, word: string): Promise<void> {
     await delete_alert_word(page, word);
     const status_text = await get_alert_words_status_text(page);
-    assert.strictEqual(status_text, `Alert word "${word}" removed successfully!`);
+    assert.strictEqual(status_text, `Alert word ${word} removed successfully!`);
     await close_alert_words_status(page);
 }
 

--- a/web/src/alert_words_ui.ts
+++ b/web/src/alert_words_ui.ts
@@ -1,3 +1,4 @@
+import Handlebars from "handlebars";
 import $ from "jquery";
 
 import render_add_alert_word from "../templates/settings/add_alert_word.hbs";
@@ -50,12 +51,19 @@ const open_alert_word_status_banner = (alert_word: string, is_error: boolean): v
         custom_classes: "alert-word-status-banner",
     };
     if (is_error) {
-        alert_word_status_banner.label = $t({defaultMessage: "Error removing alert word!"});
+        alert_word_status_banner.label = new Handlebars.SafeString(
+            $t_html(
+                {defaultMessage: "Error removing alert word <b>{alert_word}</b>!"},
+                {alert_word},
+            ),
+        );
         alert_word_status_banner.intent = "danger";
     } else {
-        alert_word_status_banner.label = $t(
-            {defaultMessage: `Alert word "{alert_word}" removed successfully!`},
-            {alert_word},
+        alert_word_status_banner.label = new Handlebars.SafeString(
+            $t_html(
+                {defaultMessage: "Alert word <b>{alert_word}</b> removed successfully!"},
+                {alert_word},
+            ),
         );
         alert_word_status_banner.intent = "success";
     }

--- a/web/src/alert_words_ui.ts
+++ b/web/src/alert_words_ui.ts
@@ -4,6 +4,8 @@ import render_add_alert_word from "../templates/settings/add_alert_word.hbs";
 import render_alert_word_settings_item from "../templates/settings/alert_word_settings_item.hbs";
 
 import * as alert_words from "./alert_words.ts";
+import * as banners from "./banners.ts";
+import type {Banner} from "./banners.ts";
 import * as channel from "./channel.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
@@ -39,16 +41,26 @@ export function rewire_rerender_alert_words_ui(value: typeof rerender_alert_word
     rerender_alert_words_ui = value;
 }
 
-function update_alert_word_status(status_text: string, is_error: boolean): void {
-    const $alert_word_status = $("#alert_word_status");
+const open_alert_word_status_banner = (alert_word: string, is_error: boolean): void => {
+    const alert_word_status_banner: Banner = {
+        intent: "danger",
+        label: "",
+        buttons: [],
+        close_button: true,
+        custom_classes: "alert-word-status-banner",
+    };
     if (is_error) {
-        $alert_word_status.removeClass("alert-success").addClass("alert-danger");
+        alert_word_status_banner.label = $t({defaultMessage: "Error removing alert word!"});
+        alert_word_status_banner.intent = "danger";
     } else {
-        $alert_word_status.removeClass("alert-danger").addClass("alert-success");
+        alert_word_status_banner.label = $t(
+            {defaultMessage: `Alert word "{alert_word}" removed successfully!`},
+            {alert_word},
+        );
+        alert_word_status_banner.intent = "success";
     }
-    $alert_word_status.find(".alert_word_status_text").text(status_text);
-    $alert_word_status.show();
-}
+    banners.open(alert_word_status_banner, $("#alert_word_status"));
+};
 
 function add_alert_word(): void {
     const alert_word = $<HTMLInputElement>("input#add-alert-word-name").val()!.trim();
@@ -74,16 +86,10 @@ function remove_alert_word(alert_word: string): void {
         url: "/json/users/me/alert_words",
         data: {alert_words: JSON.stringify(words_to_be_removed)},
         success() {
-            update_alert_word_status(
-                $t(
-                    {defaultMessage: `Alert word "{alert_word}" removed successfully!`},
-                    {alert_word},
-                ),
-                false,
-            );
+            open_alert_word_status_banner(alert_word, false);
         },
         error() {
-            update_alert_word_status($t({defaultMessage: "Error removing alert word!"}), true);
+            open_alert_word_status_banner(alert_word, true);
         },
     });
 }
@@ -130,12 +136,6 @@ export function set_up_alert_words(): void {
     $("#alert-words-table").on("click", ".remove-alert-word", (event) => {
         const word = $(event.currentTarget).parents("tr").find(".value").text().trim();
         remove_alert_word(word);
-    });
-
-    $("#alert-word-settings").on("click", ".close-alert-word-status", (event) => {
-        event.preventDefault();
-        const $alert = $(event.currentTarget).parents(".alert");
-        $alert.hide();
     });
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -554,8 +554,8 @@ input[type="checkbox"] {
     margin-top: 1px;
 }
 
-.alert_word_status_text {
-    overflow-wrap: anywhere;
+.alert-word-status-banner {
+    margin-bottom: 20px;
 }
 
 .alert-notification {

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -14,12 +14,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Alert words"}}</h3>
     </div>
-    <div class="alert" id="alert_word_status" role="alert">
-        <button type="button" class="close close-alert-word-status" aria-label="{{t 'Close' }}">
-            <span aria-hidden="true">&times;</span>
-        </button>
-        <span class="alert_word_status_text"></span>
-    </div>
+    <div class="banner-wrapper" id="alert_word_status"></div>
     <div class="progressive-table-wrapper" data-simplebar data-simplebar-tab-index="-1">
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">

--- a/web/tests/alert_words_ui.test.cjs
+++ b/web/tests/alert_words_ui.test.cjs
@@ -11,6 +11,7 @@ const channel = mock_esm("../src/channel");
 
 const alert_words = zrequire("alert_words");
 const alert_words_ui = zrequire("alert_words_ui");
+const banners = mock_esm("../src/banners");
 
 alert_words.initialize({
     alert_words: ["foo", "bar"],
@@ -78,45 +79,26 @@ run_test("remove_alert_word", ({override_rewire}) => {
 
     remove_func(event);
 
-    const $alert_word_status = $("#alert_word_status");
-    const $alert_word_status_text = $(".alert_word_status_text");
-    $alert_word_status.set_find_results(".alert_word_status_text", $alert_word_status_text);
+    const $alert_word_status_banner = $(".alert-word-status-banner");
+    const $alert_word_status_banner_label = $(".alert-word-status-banner .banner-label");
+    banners.open = (banner, _container) => {
+        $alert_word_status_banner.addClass(`banner-${banner.intent}`);
+        $alert_word_status_banner_label.text(banner.label);
+    };
 
     // test failure
     fail_func();
-    assert.ok($alert_word_status.hasClass("alert-danger"));
-    assert.equal($alert_word_status_text.text(), "translated: Error removing alert word!");
-    assert.ok($alert_word_status.visible());
+    assert.ok($alert_word_status_banner.hasClass("banner-danger"));
+    assert.equal(
+        $alert_word_status_banner_label.text(),
+        "translated: Error removing alert word!",
+    );
 
     // test success
     success_func();
-    assert.ok($alert_word_status.hasClass("alert-success"));
+    assert.ok($alert_word_status_banner.hasClass("banner-success"));
     assert.equal(
-        $alert_word_status_text.text(),
+        $alert_word_status_banner_label.text(),
         `translated: Alert word "translated: zot" removed successfully!`,
     );
-    assert.ok($alert_word_status.visible());
-});
-
-run_test("close_status_message", ({override_rewire}) => {
-    override_rewire(alert_words_ui, "rerender_alert_words_ui", noop);
-    alert_words_ui.set_up_alert_words();
-
-    const $alert_word_settings = $("#alert-word-settings");
-    const close = $alert_word_settings.get_on_handler("click", ".close-alert-word-status");
-
-    const $alert = $(".alert");
-    const $close_button = $(".close-alert-word-status");
-    $close_button.set_parents_result(".alert", $alert);
-
-    $alert.show();
-
-    const event = {
-        preventDefault() {},
-        currentTarget: ".close-alert-word-status",
-    };
-
-    assert.ok($alert.visible());
-    close(event);
-    assert.ok(!$alert.visible());
 });

--- a/web/tests/alert_words_ui.test.cjs
+++ b/web/tests/alert_words_ui.test.cjs
@@ -91,7 +91,7 @@ run_test("remove_alert_word", ({override_rewire}) => {
     assert.ok($alert_word_status_banner.hasClass("banner-danger"));
     assert.equal(
         $alert_word_status_banner_label.text(),
-        "translated: Error removing alert word!",
+        `translated HTML: Error removing alert word <b>translated: zot</b>!`,
     );
 
     // test success
@@ -99,6 +99,6 @@ run_test("remove_alert_word", ({override_rewire}) => {
     assert.ok($alert_word_status_banner.hasClass("banner-success"));
     assert.equal(
         $alert_word_status_banner_label.text(),
-        `translated: Alert word "translated: zot" removed successfully!`,
+        `translated HTML: Alert word <b>translated: zot</b> removed successfully!`,
     );
 });


### PR DESCRIPTION
This PR converts the alert words removal status alert to a banner component.

I have also opened #34432, for the layout issues I faced while working on this banner which has no buttons in it.

Fixes: [#frontend > bootstrap CSS reset removal @ 💬](https://chat.zulip.org/#narrow/channel/6-frontend/topic/bootstrap.20CSS.20reset.20removal/near/2145855)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2025-04-18 at 2 14 27 AM](https://github.com/user-attachments/assets/88676c59-5810-497e-b59e-740fe8c36b82) | ![Screenshot 2025-04-18 at 2 13 08 AM](https://github.com/user-attachments/assets/8c003c43-c89a-4557-900d-830355b85c74) |
| ![Screenshot 2025-04-18 at 2 14 33 AM](https://github.com/user-attachments/assets/be4b0caa-2fef-4587-b4bb-f7666af55d3b) | ![Screenshot 2025-04-18 at 2 12 59 AM](https://github.com/user-attachments/assets/4d644c8a-f470-4d48-b9ca-0d8b48c604ef) |
| ![Screenshot 2025-04-18 at 2 14 52 AM](https://github.com/user-attachments/assets/63534583-2037-45a4-bbe3-bbadb01356a5) | ![Screenshot 2025-04-24 at 6 26 22 AM](https://github.com/user-attachments/assets/d2846d2b-f0e7-46a8-983a-e317a637bec7) |
| ![Screenshot 2025-04-18 at 2 14 44 AM](https://github.com/user-attachments/assets/55252f86-0d26-44fb-83e3-710a999eefba) | ![Screenshot 2025-04-24 at 6 25 55 AM](https://github.com/user-attachments/assets/9050e853-2890-4fa0-b0b0-c52c8ac4a6c0) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
