### PR TITLE
peer_data: Add ability to retry failed subscriber fetch.

### DIFF
--- a/web/src/buddy_list.ts
+++ b/web/src/buddy_list.ts
@@ -305,6 +305,7 @@ export class BuddyList extends BuddyListConf {
             const is_subscribed = await peer_data.maybe_fetch_is_user_subscribed(
                 current_sub.stream_id,
                 user_id,
+                false,
             );
             // This means a request failed and we don't know the count.
             if (is_subscribed === null) {

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -567,7 +567,7 @@ export function is_topic_name_considered_empty(topic: string): boolean {
 }
 
 export function get_retry_backoff_seconds(
-    xhr: JQuery.jqXHR<unknown>,
+    xhr: JQuery.jqXHR<unknown> | undefined,
     attempts: number,
     tighter_backoff = false,
 ): number {
@@ -592,8 +592,8 @@ export function get_retry_backoff_seconds(
         "retry-after": z.number(),
         code: z.literal("RATE_LIMIT_HIT"),
     });
-    const parsed = rate_limited_error_schema.safeParse(xhr.responseJSON);
-    if (xhr.status === 429 && parsed?.success && parsed?.data) {
+    const parsed = rate_limited_error_schema.safeParse(xhr?.responseJSON);
+    if (xhr?.status === 429 && parsed?.success && parsed?.data) {
         // Add a bit of jitter to the required delay suggested by the
         // server, because we may be racing with other copies of the web
         // app.


### PR DESCRIPTION
Merge [#34259](https://github.com/zulip/zulip/pull/34259) first -- this PR is just the last commit.

Work towards https://github.com/zulip/zulip/issues/34244.