### PR TITLE
api-docs: Add note about realm being present in fetch_event_types.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14970,6 +14970,8 @@ paths:
                       realm_date_created:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           The UNIX timestamp (UTC) for when the organization was
                           created.
 
@@ -14977,7 +14979,8 @@ paths:
                       demo_organization_scheduled_deletion_date:
                         type: integer
                         description: |
-                          Present if the realm is a demo organization.
+                          Present if `realm` is present in `fetch_event_types`,
+                          and the realm is a demo organization.
 
                           The UNIX timestamp (UTC) when the demo organization will be
                           automatically deleted. Clients should use this to display a
@@ -15104,6 +15107,8 @@ paths:
                       server_presence_ping_interval_seconds:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           For clients implementing the [presence](/api/get-presence) system,
                           the time interval the client should use for sending presence requests
                           to the server (and thus receive presence updates from the server).
@@ -15119,6 +15124,8 @@ paths:
                       server_presence_offline_threshold_seconds:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           How old a presence timestamp for a given user can be before the user
                           should be displayed as offline by clients displaying Zulip presence
                           data. See the related `server_presence_ping_interval_seconds` for details.
@@ -15129,6 +15136,8 @@ paths:
                       server_typing_started_expiry_period_milliseconds:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           For clients implementing [typing notifications](/api/set-typing-status)
                           protocol, the time interval in milliseconds that the client should wait
                           for additional [typing start](/api/get-events#typing-start) events from
@@ -15140,6 +15149,8 @@ paths:
                       server_typing_stopped_wait_period_milliseconds:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           For clients implementing [typing notifications](/api/set-typing-status)
                           protocol, the time interval in milliseconds that the client should wait
                           when a user stops interacting with the compose UI before sending a stop
@@ -15151,6 +15162,8 @@ paths:
                       server_typing_started_wait_period_milliseconds:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           For clients implementing [typing notifications](/api/set-typing-status)
                           protocol, the time interval in milliseconds that the client should use
                           to send regular start notifications to the server to indicate that the
@@ -17077,6 +17090,8 @@ paths:
                       realm_message_edit_history_visibility_policy:
                         type: string
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           What typesof message edit history are accessible to users via
                           [message edit history](/help/view-a-messages-edit-history).
 
@@ -17122,6 +17137,8 @@ paths:
                       realm_can_add_subscribers_group:
                         allOf:
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the set of
                               users who have permission to add subscribers to channels in the organization.
 
@@ -17224,6 +17241,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to create user
                               groups in this organization.
@@ -17235,6 +17254,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to create all types of bot users
                               in the organization. See also `can_create_write_only_bots_group`.
@@ -17246,6 +17267,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to create bot users that
                               can only send messages in the organization, i.e. incoming webhooks,
@@ -17258,6 +17281,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values)
                               defining the set of users who have permission to
                               administer all existing groups in this organization.
@@ -17283,6 +17308,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the set of
                               users who have permission to manage plans and billing in the organization.
 
@@ -17293,6 +17320,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to create public
                               channels in this organization.
@@ -17304,6 +17333,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to create private
                               channels in this organization.
@@ -17315,6 +17346,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to create web-public
                               channels in this organization.
@@ -17330,6 +17363,8 @@ paths:
                       realm_can_resolve_topics_group:
                         allOf:
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining
                               the set of users who have permission to [resolve topics](/help/resolve-a-topic)
                               in the organization.
@@ -17505,6 +17540,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the
                               set of users who are allowed to create [reusable invitation
                               links](/help/invite-new-users#create-a-reusable-invitation-link)
@@ -17557,6 +17594,8 @@ paths:
                       realm_require_unique_names:
                         type: boolean
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           Indicates whether the organization is configured to require users
                           to have unique full names. If true, the server will reject attempts
                           to create a new user, or change the name of an existing user, where
@@ -17642,6 +17681,8 @@ paths:
                       realm_video_chat_provider:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           The configured [video call provider](/help/configure-call-provider) for the
                           organization.
 
@@ -17665,6 +17706,8 @@ paths:
                         type: string
                         nullable: true
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           The URL of the custom Jitsi Meet server configured in this organization's
                           settings.
 
@@ -17704,6 +17747,8 @@ paths:
                       realm_direct_message_initiator_group:
                         allOf:
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the set of
                               users who have permission to start a new direct message conversation
                               involving other non-bot users. Users who are outside this group and attempt
@@ -17719,6 +17764,8 @@ paths:
                       realm_direct_message_permission_group:
                         allOf:
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the set of
                               users who have permission to fully use direct messages. Users outside
                               this group can only send direct messages to conversations where all the
@@ -18133,6 +18180,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the
                               set of users who are allowed to access all users in the
                               organization.
@@ -18145,6 +18194,8 @@ paths:
                         allOf:
                           - $ref: "#/components/schemas/GroupSettingValue"
                           - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
                               A [group-setting value](/api/group-setting-values) defining the
                               set of users who are allowed to use AI summarization.
 
@@ -18322,6 +18373,8 @@ paths:
                           that feature.
                       server_thumbnail_formats:
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           A list describing the image formats that uploaded
                           images will be thumbnailed into. Any image with a
                           source starting with `/user_uploads/thumbnail/` can
@@ -18422,6 +18475,8 @@ paths:
                         type: string
                         nullable: true
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           The URL of the Jitsi server that the Zulip server is configured to use by
                           default; the organization-level setting `realm_jitsi_server_url` takes
                           precedence over this setting when both are set.
@@ -18471,6 +18526,8 @@ paths:
                       realm_moderation_request_channel_id:
                         type: integer
                         description: |
+                          Present if `realm` is present in `fetch_event_types`.
+
                           The ID of the private channel to which messages flagged by users for
                           moderation are sent. Moderators can use this channel to review and
                           act on reported content.


### PR DESCRIPTION
Adds "Present if realm is present in fetch_event_types" to the fields in the `POST /register` response that are added to the state data via `fetch_initial_state_data` in the `if want("realm")` block.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/channel/412-api-documentation/topic/.60.2Fregister.60.3A.20fields.20missing.20.22Present.20if.20.5B.E2.80.A6.5D.22.3F/near/1707782)

<details>
<summary>API docs diff</summary>

```diff
diff -r -B -u current_api_html/register-queue.html new_api_html/register-queue.html
--- current_api_html/register-queue.html	2025-04-18 13:31:15.468052537 +0200
+++ new_api_html/register-queue.html	2025-04-18 13:30:35.622051689 +0200
@@ -856,13 +856,15 @@
 </li>
 <li>
 <p><code>realm_date_created</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>The UNIX timestamp (UTC) for when the organization was
 created.</p>
 <p><strong>Changes</strong>: New in Zulip 8.0 (feature level 203).</p>
 </li>
 <li>
 <p><code>demo_organization_scheduled_deletion_date</code>: <span class="api-field-type">integer</span></p>
-<p>Present if the realm is a demo organization.</p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>,
+and the realm is a demo organization.</p>
 <p>The UNIX timestamp (UTC) when the demo organization will be
 automatically deleted. Clients should use this to display a
 prominent warning to the user that the organization will be
@@ -1009,6 +1011,7 @@
 </li>
 <li>
 <p><code>server_presence_ping_interval_seconds</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>For clients implementing the <a href="/api/get-presence">presence</a> system,
 the time interval the client should use for sending presence requests
 to the server (and thus receive presence updates from the server).</p>
@@ -1022,6 +1025,7 @@
 </li>
 <li>
 <p><code>server_presence_offline_threshold_seconds</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>How old a presence timestamp for a given user can be before the user
 should be displayed as offline by clients displaying Zulip presence
 data. See the related <code>server_presence_ping_interval_seconds</code> for details.</p>
@@ -1031,6 +1035,7 @@
 </li>
 <li>
 <p><code>server_typing_started_expiry_period_milliseconds</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>For clients implementing <a href="/api/set-typing-status">typing notifications</a>
 protocol, the time interval in milliseconds that the client should wait
 for additional <a href="/api/get-events#typing-start">typing start</a> events from
@@ -1041,6 +1046,7 @@
 </li>
 <li>
 <p><code>server_typing_stopped_wait_period_milliseconds</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>For clients implementing <a href="/api/set-typing-status">typing notifications</a>
 protocol, the time interval in milliseconds that the client should wait
 when a user stops interacting with the compose UI before sending a stop
@@ -1051,6 +1057,7 @@
 </li>
 <li>
 <p><code>server_typing_started_wait_period_milliseconds</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>For clients implementing <a href="/api/set-typing-status">typing notifications</a>
 protocol, the time interval in milliseconds that the client should use
 to send regular start notifications to the server to indicate that the
@@ -4559,6 +4566,7 @@
 </li>
 <li>
 <p><code>realm_message_edit_history_visibility_policy</code>: <span class="api-field-type">string</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>What typesof message edit history are accessible to users via
 <a href="/help/view-a-messages-edit-history">message edit history</a>.</p>
 <ul>
@@ -4616,6 +4624,7 @@
 </li>
 <li>
 <p><code>realm_can_add_subscribers_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the set of
 users who have permission to add subscribers to channels in the organization.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 341). Previously, this
@@ -4832,6 +4841,7 @@
 </li>
 <li>
 <p><code>realm_can_create_groups</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to create user
 groups in this organization.</p>
@@ -4861,6 +4871,7 @@
 </li>
 <li>
 <p><code>realm_can_create_bots_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to create all types of bot users
 in the organization. See also <code>can_create_write_only_bots_group</code>.</p>
@@ -4890,6 +4901,7 @@
 </li>
 <li>
 <p><code>realm_can_create_write_only_bots_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to create bot users that
 can only send messages in the organization, i.e. incoming webhooks,
@@ -4920,6 +4932,7 @@
 </li>
 <li>
 <p><code>realm_can_manage_all_groups</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a>
 defining the set of users who have permission to
 administer all existing groups in this organization.</p>
@@ -4961,6 +4974,7 @@
 </li>
 <li>
 <p><code>realm_can_manage_billing_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the set of
 users who have permission to manage plans and billing in the organization.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 363). Previously, only owners
@@ -4989,6 +5003,7 @@
 </li>
 <li>
 <p><code>realm_can_create_public_channel_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to create public
 channels in this organization.</p>
@@ -5018,6 +5033,7 @@
 </li>
 <li>
 <p><code>realm_can_create_private_channel_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to create private
 channels in this organization.</p>
@@ -5047,6 +5063,7 @@
 </li>
 <li>
 <p><code>realm_can_create_web_public_channel_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to create web-public
 channels in this organization.</p>
@@ -5080,6 +5097,7 @@
 </li>
 <li>
 <p><code>realm_can_resolve_topics_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining
 the set of users who have permission to <a href="/help/resolve-a-topic">resolve topics</a>
 in the organization.</p>
@@ -5234,6 +5252,7 @@
 </li>
 <li>
 <p><code>realm_create_multiuse_invite_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the
 set of users who are allowed to create <a href="/help/invite-new-users#create-a-reusable-invitation-link">reusable invitation
 links</a>
@@ -5299,6 +5318,7 @@
 </li>
 <li>
 <p><code>realm_require_unique_names</code>: <span class="api-field-type">boolean</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>Indicates whether the organization is configured to require users
 to have unique full names. If true, the server will reject attempts
 to create a new user, or change the name of an existing user, where
@@ -5369,6 +5389,7 @@
 </li>
 <li>
 <p><code>realm_video_chat_provider</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>The configured <a href="/help/configure-call-provider">video call provider</a> for the
 organization.</p>
 <ul>
@@ -5387,6 +5408,7 @@
 </li>
 <li>
 <p><code>realm_jitsi_server_url</code>: <span class="api-field-type">string | null</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>The URL of the custom Jitsi Meet server configured in this organization's
 settings.</p>
 <p><code>null</code>, the default, means that the organization is using the should use the
@@ -5418,6 +5440,7 @@
 </li>
 <li>
 <p><code>realm_direct_message_initiator_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the set of
 users who have permission to start a new direct message conversation
 involving other non-bot users. Users who are outside this group and attempt
@@ -5450,6 +5473,7 @@
 </li>
 <li>
 <p><code>realm_direct_message_permission_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the set of
 users who have permission to fully use direct messages. Users outside
 this group can only send direct messages to conversations where all the
@@ -5836,6 +5860,7 @@
 </li>
 <li>
 <p><code>realm_can_access_all_users_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the
 set of users who are allowed to access all users in the
 organization.</p>
@@ -5865,6 +5890,7 @@
 </li>
 <li>
 <p><code>realm_can_summarize_topics_group</code>: <span class="api-field-type">integer | object</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A <a href="/api/group-setting-values">group-setting value</a> defining the
 set of users who are allowed to use AI summarization.</p>
 <p><strong>Changes</strong>: New in Zulip 10.0 (feature level 350).</p>
@@ -6046,6 +6072,7 @@
 </li>
 <li>
 <p><code>server_thumbnail_formats</code>: <span class="api-field-type">(object)[]</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>A list describing the image formats that uploaded
 images will be thumbnailed into. Any image with a
 source starting with <code>/user_uploads/thumbnail/</code> can
@@ -6130,6 +6157,7 @@
 </li>
 <li>
 <p><code>server_jitsi_server_url</code>: <span class="api-field-type">string | null</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>The URL of the Jitsi server that the Zulip server is configured to use by
 default; the organization-level setting <code>realm_jitsi_server_url</code> takes
 precedence over this setting when both are set.</p>
@@ -6171,6 +6199,7 @@
 </li>
 <li>
 <p><code>realm_moderation_request_channel_id</code>: <span class="api-field-type">integer</span></p>
+<p>Present if <code>realm</code> is present in <code>fetch_event_types</code>.</p>
 <p>The ID of the private channel to which messages flagged by users for
 moderation are sent. Moderators can use this channel to review and
 act on reported content.</p>
```
</details>

---

**Screenshots and screen captures:**

Example of changes to register response fields ...

| Before | After |
| --- | --- |
| ![Screenshot from 2025-04-17 16-16-14](https://github.com/user-attachments/assets/df2c53fb-ef1f-4182-97e0-5d9dee553b5b) | ![Screenshot from 2025-04-17 16-17-04](https://github.com/user-attachments/assets/bdd9b612-e319-466a-b8ae-5c9e8725f4a5) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
