### PR TITLE
Rework subscribe users confirmations

### DIFF
--- a/web/src/add_subscribers_pill.ts
+++ b/web/src/add_subscribers_pill.ts
@@ -107,6 +107,11 @@ export function set_up_handlers_for_add_button_state(
     // Disable the add button first time the pill container is created.
     $pill_widget_button.prop("disabled", true);
 
+    const $check_icon = $pill_widget_button.find(".zulip-icon-check");
+    if ($check_icon) {
+        $check_icon.hide();
+    }
+
     // If all the pills are removed, disable the add button.
     pill_widget.onPillRemove(() =>
         $pill_widget_button.prop("disabled", pill_widget.items().length === 0),

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -81,13 +81,22 @@ function show_stream_subscription_request_result({
     already_subscribed_users?: User[];
     ignored_deactivated_users?: User[];
 }): void {
+    const subscribed_users_count = subscribed_users?.length;
+    const already_subscribed_users_count = already_subscribed_users?.length;
+    const is_total_subscriber_more_than_five =
+        (subscribed_users_count ?? 0) + (already_subscribed_users_count ?? 0) > 5;
+
     const $stream_subscription_req_result_elem = $(
         ".stream_subscription_request_result",
     ).expectOne();
+
     const html = render_stream_subscription_request_result({
         message,
         subscribed_users,
         already_subscribed_users,
+        subscribed_users_count,
+        already_subscribed_users_count,
+        is_total_subscriber_more_than_five,
         ignored_deactivated_users,
     });
     scroll_util.get_content_element($stream_subscription_req_result_elem).html(html);

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -245,6 +245,25 @@ function subscribe_new_users({pill_user_ids}: {pill_user_ids: number[]}): void {
             people.get_by_user_id(Number(user_id)),
         );
 
+        const $pill_widget_button = $("button.add-subscriber-button");
+        const $pill_widget_button_text = $pill_widget_button.find("span");
+        const $check_icon = $pill_widget_button.find("i");
+
+        const original_width = $pill_widget_button.outerWidth();
+        const original_height = $pill_widget_button.outerHeight();
+        if (original_width !== undefined && original_height !== undefined) {
+            $pill_widget_button.css("width", original_width).css("height", original_height);
+        }
+
+        $pill_widget_button.addClass("text-success");
+        $pill_widget_button_text.hide();
+        $check_icon.show();
+        setTimeout(() => {
+            $check_icon.hide();
+            $pill_widget_button_text.show();
+            $pill_widget_button.removeClass("text-success");
+        }, 1000);
+
         show_stream_subscription_request_result({
             add_class: "text-success",
             remove_class: "text-error",

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -13,6 +13,7 @@
               attention="quiet"
               intent="brand"
               type="submit"
+              icon="check"
               }}
         </div>
     {{/if}}

--- a/web/templates/stream_settings/stream_subscription_request_result.hbs
+++ b/web/templates/stream_settings/stream_subscription_request_result.hbs
@@ -1,26 +1,42 @@
 {{#if message}}
-{{message}}
-<br />
-{{/if}}
-{{#if subscribed_users}}
-    {{#if subscribed_users.[1]}}
-    {{t "Successfully subscribed users:" }}
-    {{else}}
-    {{t "Successfully subscribed user:" }}
-    {{/if}}
-    {{#each subscribed_users}}
-        <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
-    {{/each}}
+    {{message}}
     <br />
 {{/if}}
-{{#if already_subscribed_users}}
-    {{#each already_subscribed_users}}
-        {{#if @first}}
-        {{t "Already subscribed users:" }}
+{{#if (eq subscribed_users_count 0)}}
+    {{t "All users were already subscribed."}}
+    <br />
+{{else}}
+    {{#if subscribed_users}}
+        {{#if is_total_subscriber_more_than_five }}
+            {{t "{subscribed_users_count, plural,
+              one {Subscribed: {subscribed_users_count} user.}
+                other {Subscribed: {subscribed_users_count} users.}
+            }"}}
+        {{else}}
+            {{t "Subscribed:" }}
+            {{#each subscribed_users}}
+                <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
+            {{/each}}
         {{/if}}
-        <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
-    {{/each}}
-    <br />
+    {{/if}}
+    {{#if already_subscribed_users}}
+        {{#if is_total_subscriber_more_than_five }}
+            {{#if already_subscribed_users_count}}
+                {{t "{already_subscribed_users_count, plural,
+                  one {Already subscribed: {already_subscribed_users_count} user.}
+                    other {Already subscribed: {already_subscribed_users_count} users.}
+                }"}}
+            {{/if}}
+        {{else}}
+            {{#each already_subscribed_users}}
+                {{#if @first}}
+                {{t "Already a subscriber:" }}
+                {{/if}}
+                <a data-user-id="{{user_id}}" class="view_user_profile">{{full_name}}</a>{{#unless @last}},{{else}}.{{/unless}}
+            {{/each}}
+        {{/if}}
+    {{/if}}
+    <br/>
 {{/if}}
 {{#if ignored_deactivated_users}}
     {{#each ignored_deactivated_users}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: Partially fixes #34347 
As described in the issue, I have reworked the subscribe users confirmation UI into 3 cases:
- No new user subscribed
![image](https://github.com/user-attachments/assets/f923ad3e-3525-4c4e-bdc9-e4cc0e053133)

- Less than or equal to 5 users subscribed or already subscribed
![image](https://github.com/user-attachments/assets/4c9aa49d-9d17-4c93-a620-9bd4e4c43866)

- More than 5 users subscribed or already subscribed
![image](https://github.com/user-attachments/assets/b299c8f2-ade9-49ee-91c4-bada99645f51)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


PS: This change has to done on both channel setting and group settings but in this PR I have only worked on channel setting side. If everything looks good to the reviewers I will proceed to do the changes on group settings side.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
