### PR TITLE
message_sending: Show retry/cancel buttons only after message fails

### DIFF
--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -125,11 +125,16 @@ function hide_retry_spinner($row: JQuery): boolean {
 }
 
 function show_message_failed(message_id: number, _failed_msg: string): void {
-    // Failed to send message, so display inline retry/cancel
+    // Don't show retry/cancel buttons if the message doesn't exist or is still
+    // in the sending state (locally_echoed but not yet failed)
+    const message = message_store.get(message_id);
+    if (!message || (message.locally_echoed && !message.failed_request)) {
+        return;
+    }
+
     message_live_update.update_message_in_all_views(message_id, ($row) => {
         $row.find(".slow-send-spinner").addClass("hidden");
-        const $message_controls = $row.find(".message_controls");
-        $message_controls.html(render_message_controls_failed_msg());
+        $row.find(".message_controls").html(render_message_controls_failed_msg());
     });
     // TODO: Show the `_failed_msg` in the UI, describing the reason for the failure.
 }


### PR DESCRIPTION
**Fixes:** Improve part 1 of the issue #29100  

**Description:**  
This PR addresses the remaining issue from #29100 by adding a condition to ensure that the Retry and Cancel buttons only appear when a message has truly failed. The buttons will no longer be shown while the message is still sending (i.e., awaiting server response), as they would not function correctly in that state.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

- [x] [[[Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code)](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
  Communicate decisions, questions, and potential concerns.
  
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

- [ ] Individual commits are ready for review (see [[[commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).
  - [ ] Each commit is a coherent idea.
  - [ ] Commit message(s) explain reasoning and motivation for changes.

- [ ] Completed manual review and testing of the following:
  - [ ] Visual appearance of the changes.
  - [ ] Responsiveness and internationalization.
  - [ ] Strings and tooltips.
  - [ ] End-to-end functionality of buttons, interactions, and flows.
  - [ ] Corner cases, error conditions, and easily imagined bugs.
</details>