### PR TITLE
corporate: Show "Fixed" as rate for fixed-rate plans in activity charts.

### DIFF
--- a/corporate/lib/activity.py
+++ b/corporate/lib/activity.py
@@ -172,7 +172,13 @@ def remote_installation_support_link(hostname: str) -> Markup:
     return Markup('<a href="{url}"><i class="fa fa-gear"></i></a>').format(url=url)
 
 
-def get_plan_rate_percentage(discount: str | None) -> str:
+def get_plan_rate_percentage(discount: str | None, has_fixed_price: bool) -> str:
+    # We want to clearly note plans with a fixed price, and not show
+    # them as paying 100%, as they are usually a special, negotiated
+    # rate with the customer.
+    if has_fixed_price:
+        return "Fixed"
+
     # CustomerPlan.discount is a string field that stores the discount.
     if discount is None or discount == "0":
         return "100%"
@@ -194,6 +200,7 @@ def get_remote_activity_plan_data(
 ) -> RemoteActivityPlanData:
     from corporate.lib.stripe import RemoteRealmBillingSession, RemoteServerBillingSession
 
+    has_fixed_price = plan.fixed_price is not None
     if plan.tier == CustomerPlan.TIER_SELF_HOSTED_LEGACY or plan.status in (
         CustomerPlan.DOWNGRADE_AT_END_OF_FREE_TRIAL,
         CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE,
@@ -207,13 +214,13 @@ def get_remote_activity_plan_data(
         renewal_cents = RemoteRealmBillingSession(
             remote_realm=remote_realm
         ).get_annual_recurring_revenue_for_support_data(plan, license_ledger)
-        current_rate = get_plan_rate_percentage(plan.discount)
+        current_rate = get_plan_rate_percentage(plan.discount, has_fixed_price)
     else:
         assert remote_server is not None
         renewal_cents = RemoteServerBillingSession(
             remote_server=remote_server
         ).get_annual_recurring_revenue_for_support_data(plan, license_ledger)
-        current_rate = get_plan_rate_percentage(plan.discount)
+        current_rate = get_plan_rate_percentage(plan.discount, has_fixed_price)
 
     return RemoteActivityPlanData(
         current_status=plan.get_plan_status_as_text(),
@@ -254,7 +261,10 @@ def get_estimated_arr_and_rate_by_realm() -> tuple[dict[str, int], dict[str, str
             realm=plan.customer.realm
         ).get_annual_recurring_revenue_for_support_data(plan, latest_ledger_entry)
         annual_revenue[plan.customer.realm.string_id] = renewal_cents
-        plan_rate[plan.customer.realm.string_id] = get_plan_rate_percentage(plan.discount)
+        has_fixed_price = plan.fixed_price is not None
+        plan_rate[plan.customer.realm.string_id] = get_plan_rate_percentage(
+            plan.discount, has_fixed_price
+        )
     return annual_revenue, plan_rate
 
 


### PR DESCRIPTION
Show "Fixed" as the rate with `CustomerPlan.fixed_price` is not `None` in the support activity charts.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![Screenshot from 2025-04-21 13-26-36](https://github.com/user-attachments/assets/2fefdbfa-7140-4da5-9083-544fcb42f7cc) | ![Screenshot from 2025-04-21 13-26-09](https://github.com/user-attachments/assets/cef751d0-eff0-4977-8844-1545b7c9364e) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
