### PR TITLE
unread_data: Ensure deterministic ordering of unread message rows.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -857,6 +857,7 @@ def get_raw_unread_data(
             "flags",
             "recipient_id",
         )
+        # Descending order, so truncation keeps the latest unreads.
         .order_by("-message_id")
     )
 
@@ -909,9 +910,13 @@ def get_raw_unread_data(
                     "recipient__type",
                     "recipient__type_id",
                 )
+                # Output in ascending order. We can't just reverse,
+                # since the CTE join does not guarantee that it
+                # preserves the original descending order.
+                .order_by("message_id")
             )
 
-            rows = list(reversed(user_msgs))
+            rows = list(user_msgs)
         finally:
             cursor.execute("SET enable_bitmapscan TO on")
         return extract_unread_data_from_um_rows(rows, user_profile)


### PR DESCRIPTION
[#automated testing > main failing @ 💬](https://chat.zulip.org/#narrow/channel/43-automated-testing/topic/main.20failing/near/2157045)

> This is probably a real bug of some sort, at least I'd hope that test_unreads_case_insensitive_topics is written correctly to look for bugs in the handling of that:

> File "/__w/zulip/zulip/zerver/tests/test_event_system.py", line 850, in test_unreads_case_insensitive_topics
    self.assertEqual(result["unread_msgs"]["streams"][0]["topic"], "case DOES not MATTER")
    ^^^^^^^^^^^^^^^^^
  File "/__w/zulip/zulip/zerver/lib/test_classes.py", line 289, in assertEqual
    raise AssertionError(
    ^^^^^^^^^^^^^^^^^
AssertionError: Actual and expected outputs do not match; showing diff.
-CASE does NOT matter
+case DOES not MATTER

I wasn't able to replicate/verify this locally, but I think the reason explained in the commit message is the right fix. 

The ordering would depend on whether the db will retain CTE ordering while doing join, so sometimes it fails.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
