### PR TITLE
thumbnails: Present thumbnails in flexbox galleries.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -238,5 +238,35 @@ export function postprocess_content(html: string): string {
         }
     }
 
+    // After all other processing on images has been done, we look for
+    // adjacent images and tuck them structurally into galleries.
+    // This will also process uploaded video thumbnails, which likewise
+    // take the `.message_inline_image` class
+    for (const elt of template.content.querySelectorAll(".message_inline_image")) {
+        let gallery_element;
+
+        const is_part_of_open_gallery = elt.previousElementSibling?.classList.contains(
+            "message-thumbnail-gallery",
+        );
+
+        if (is_part_of_open_gallery) {
+            // If the the current media element's previous sibling is a gallery,
+            // it should be kept with the other media in that gallery.
+            gallery_element = elt.previousElementSibling;
+        } else {
+            // Otherwise, we've found an image element that follows some other
+            // content (or is the first in the message) and need to create a
+            // gallery for it, and perhaps other adjacent sibling media elements,
+            // if they exist.
+            gallery_element = inertDocument.createElement("div");
+            gallery_element.classList.add("message-thumbnail-gallery");
+            // We insert the gallery just before the media element we've found
+            elt.before(gallery_element);
+        }
+
+        // Finally, the media element gets moved into the current gallery
+        gallery_element?.append(elt);
+    }
+
     return template.innerHTML;
 }

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -414,18 +414,20 @@
     }
 
     /* embedded link previews */
+    .message-thumbnail-gallery {
+        display: flex;
+        flex-flow: row wrap;
+        place-items: center center;
+        gap: 5px;
+        margin-bottom: var(--markdown-interelement-space-px);
+    }
+
     .message_inline_image_title {
         font-weight: bold;
     }
 
     .twitter-image,
     .message_inline_image {
-        display: inline-block;
-        vertical-align: middle;
-
-        margin-bottom: var(--markdown-interelement-space-px);
-        margin-right: 5px;
-
         /* Set a background for the image; the background will be visible
            behind the width of the transparent border. */
         border: solid 3px transparent;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -518,12 +518,6 @@
         }
     }
 
-    &.rtl .twitter-image,
-    &.rtl .message_inline_image {
-        margin-left: unset;
-        margin-right: 5px;
-    }
-
     /* In browsers that support `:has()`, we pull
        `.rendered_markdown` out of the baseline group
        formed with EDITED/MOVED markers and the
@@ -638,18 +632,6 @@
            previews, but there are no ill effects
            on newer preview images. */
         object-fit: contain;
-    }
-
-    &.rtl .twitter-image .media-image-element,
-    &.rtl .message_inline_image .media-image-element,
-    &.rtl .message_inline_ref .media-image-element {
-        float: right;
-        margin-right: unset;
-        margin-left: 10px;
-    }
-
-    & li .message_inline_image .media-image-element {
-        float: none;
     }
 
     .message_inline_video,

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -41,6 +41,7 @@ run_test("postprocess_content", () => {
             "<a>invalid</a> " +
             "<a>unsafe</a> " +
             '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>' +
+            '<div class="message-thumbnail-gallery">' +
             '<div class="message_inline_image">' +
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
             '<a role="button">button</a> ' +
@@ -54,6 +55,7 @@ run_test("postprocess_content", () => {
             '<a class="media-anchor-element" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
             '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" class="media-image-element" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 });
@@ -62,6 +64,61 @@ run_test("ordered_lists", () => {
     assert.equal(
         postprocess_content('<ol start="9"><li>Nine</li><li>Ten</li></ol>'),
         '<ol start="9" class="counter-length-2"><li>Nine</li><li>Ten</li></ol>',
+    );
+});
+
+run_test("inline_image_galleries", ({override}) => {
+    const thumbnail_formats = [
+        {
+            name: "840x560.webp",
+            max_width: 840,
+            max_height: 560,
+            format: "webp",
+            animated: false,
+        },
+    ];
+    override(thumbnail, "preferred_format", thumbnail_formats[0]);
+    assert.equal(
+        postprocess_content(
+            "<p>Message text</p>" +
+                '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>" +
+                '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>" +
+                "<p>Message text</p>" +
+                '<div class="message_inline_image">' +
+                '<a href="/user_uploads/path/to/image.png" title="image.png">' +
+                '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp">' +
+                "</a>" +
+                "</div>",
+        ),
+        "<p>Message text</p>" +
+            '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="1000x2000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element portrait-thumbnail" width="1000" height="2000" loading="lazy">' +
+            "</a>" +
+            "</div>" +
+            '<div class="message_inline_image">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="2000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element landscape-thumbnail" width="2000" height="1000" loading="lazy">' +
+            "</a>" +
+            "</div>" +
+            "</div>" +
+            "<p>Message text</p>" +
+            '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image">' +
+            '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
+            '<img data-original-dimensions="1000x1000" src="/user_uploads/thumbnail/path/to/image.png/840x560.webp" class="media-image-element portrait-thumbnail" width="1000" height="1000" loading="lazy">' +
+            "</a>" +
+            "</div>" +
+            "</div>",
     );
 });
 
@@ -116,10 +173,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -132,10 +191,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="100x200" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element portrait-thumbnail" width="100" height="200" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -148,10 +209,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="1x10" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" class="media-image-element dinky-thumbnail extreme-aspect-ratio portrait-thumbnail" width="1" height="10" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -165,10 +228,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200-anim.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -182,10 +247,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image message_inline_animated_image_still">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image message_inline_animated_image_still">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 
@@ -198,10 +265,12 @@ run_test("message_inline_animated_image_still", ({override}) => {
                 "</a>" +
                 "</div>",
         ),
-        '<div class="message_inline_image message_inline_animated_image_still">' +
+        '<div class="message-thumbnail-gallery">' +
+            '<div class="message_inline_image message_inline_animated_image_still">' +
             '<a href="/user_uploads/path/to/image.png" target="_blank" rel="noopener noreferrer" class="media-anchor-element" aria-label="image.png">' +
             '<img data-original-dimensions="3264x2448" src="/user_uploads/thumbnail/path/to/image.png/300x200.webp" data-animated="true" class="media-image-element landscape-thumbnail" width="3264" height="2448" loading="lazy">' +
             "</a>" +
+            "</div>" +
             "</div>",
     );
 


### PR DESCRIPTION
This PR introduces new processing to place adjacent images into a single container, which then gets displayed as a flexbox. This is the most minimal implementation, and apart from reduced but now horizontally and vertically uniform space between rows of wrapping images, there are no visual changes here except in cases of images appearing inside of lists. Those images now display in their own block, and not inline with list content (an unintentional side-effect of the `display: inline-block` scheme used previously).

This PR also fixes a regression on RTL messages introduced in #34208, where extra lefthand margin on images was not removed. However, _all_ RTL styles are removed in this PR, as flexbox respects the `.rtl { direction: rtl; }` style declared near line 958 of `zulip.css`, making it unnecessary for us to manually adjust the flexbox definition in any way (which is pretty awesome).

Much work remains to take fuller advantage of the different options that flexbox offers here (as well as work to eliminate some continued headaches, not reflected in this PR, with flexbox collapsing the space for thumbnails before the images have loaded--_despite_ images having `height` and `width` attributes). However, this gets us to a state where we can more confidently deploy these changes to production, and perhaps tinker with the relative size of portrait vs. landscape thumbnails.

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/flexbox.20galleries.20for.20image.20thumbnails/near/2160045)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After | After, showing flexbox |
| --- | --- | --- |
| ![multiple-images-before](https://github.com/user-attachments/assets/e427287c-4536-4be1-bdfe-6bbf608c1879) | ![multiple-images-after](https://github.com/user-attachments/assets/ecc7ce6f-dbd9-49a2-8bd6-cfbd5af72950) | ![multiple-images-after--showing-flex](https://github.com/user-attachments/assets/32f6b78d-2478-4be8-9eb3-61faac311fbd) |
| ![rtl-messages-before](https://github.com/user-attachments/assets/bba09082-fe51-4d76-a290-dae33c9036ea) | ![rtl-messages-after](https://github.com/user-attachments/assets/a36c7f46-a30f-4e98-ac7c-d9237e348656) | ![rtl-messages-after--showing-flex](https://github.com/user-attachments/assets/92d05d41-69a0-4229-be49-739fe8f957d6) |
| ![images-in-lists-before](https://github.com/user-attachments/assets/0859d606-40f8-4a5b-bfe6-803d1acfbc22) | ![images-in-lists-after](https://github.com/user-attachments/assets/9eecfe18-8ce1-4e2e-866f-9ce46df657b9) | ![images-in-lists-after--showing-flex](https://github.com/user-attachments/assets/256b85b4-4e8a-444c-880d-0d2967eee974) |
| ![compose-preview-before](https://github.com/user-attachments/assets/169ddf0d-bbcf-431d-969e-858de5f72240) | ![compose-preview-after](https://github.com/user-attachments/assets/c8454d64-f7a7-4775-bc21-75b3615899ca) | ![compose-preview-after--showing-flex](https://github.com/user-attachments/assets/f8f3945a-9db0-4e92-ba52-d705967b8b66) |


<details>
<summary>Self-review checklist</summary>




<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
