### PR TITLE
buttons: Improve button outline on focus state.

### DIFF
--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -2101,6 +2101,13 @@
         var(--grey-400)
     );
 
+    /* Shared button CSS variables */
+    --color-outline-button-focus: light-dark(
+        hsl(0deg 0% 0%),
+        hsl(0deg 0% 100%)
+    );
+    --outline-width-button-focus: 1.5px;
+    --outline-offset-button-focus: 1px;
     /* Actions buttons */
     --color-inner-shadow-action-button: light-dark(
         color-mix(in oklch, hsl(0deg 0% 0%) 20%, transparent),

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -21,7 +21,8 @@
     transition: 0.05s ease-in;
     transition-property: background-color, clip-path;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-neutral-quiet-action-button-hover
         );
@@ -76,7 +77,8 @@
     color: var(--color-text-neutral-primary-action-button);
     background-color: var(--color-background-neutral-primary-action-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-neutral-primary-action-button-hover
         );
@@ -94,7 +96,8 @@
     background-color: var(--color-background-neutral-quiet-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-neutral-quiet-action-button-hover
         );
@@ -111,7 +114,8 @@
     color: var(--color-text-neutral-borderless-action-button);
     background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-neutral-borderless-action-button-hover
         );
@@ -129,7 +133,8 @@
     color: var(--color-text-brand-primary-action-button);
     background-color: var(--color-background-brand-primary-action-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-brand-primary-action-button-hover
         );
@@ -147,7 +152,8 @@
     background-color: var(--color-background-brand-quiet-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-brand-quiet-action-button-hover
         );
@@ -164,7 +170,8 @@
     color: var(--color-text-brand-borderless-action-button);
     background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-brand-borderless-action-button-hover
         );
@@ -182,7 +189,8 @@
     color: var(--color-text-info-primary-action-button);
     background-color: var(--color-background-info-primary-action-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-info-primary-action-button-hover
         );
@@ -200,7 +208,8 @@
     background-color: var(--color-background-info-quiet-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-info-quiet-action-button-hover
         );
@@ -217,7 +226,8 @@
     color: var(--color-text-info-borderless-action-button);
     background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-info-borderless-action-button-hover
         );
@@ -235,7 +245,8 @@
     color: var(--color-text-success-primary-action-button);
     background-color: var(--color-background-success-primary-action-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-success-primary-action-button-hover
         );
@@ -253,7 +264,8 @@
     background-color: var(--color-background-success-quiet-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-success-quiet-action-button-hover
         );
@@ -270,7 +282,8 @@
     color: var(--color-text-success-borderless-action-button);
     background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-success-borderless-action-button-hover
         );
@@ -288,7 +301,8 @@
     color: var(--color-text-warning-primary-action-button);
     background-color: var(--color-background-warning-primary-action-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-warning-primary-action-button-hover
         );
@@ -306,7 +320,8 @@
     background-color: var(--color-background-warning-quiet-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-warning-quiet-action-button-hover
         );
@@ -323,7 +338,8 @@
     color: var(--color-text-warning-borderless-action-button);
     background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-warning-borderless-action-button-hover
         );
@@ -341,7 +357,8 @@
     color: var(--color-text-danger-primary-action-button);
     background-color: var(--color-background-danger-primary-action-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-danger-primary-action-button-hover
         );
@@ -359,7 +376,8 @@
     background-color: var(--color-background-danger-quiet-action-button);
     box-shadow: 0 0 0.5px 0.5px var(--color-inner-shadow-action-button) inset;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-danger-quiet-action-button-hover
         );
@@ -376,7 +394,8 @@
     color: var(--color-text-danger-borderless-action-button);
     background-color: transparent;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --color-background-danger-borderless-action-button-hover
         );
@@ -407,7 +426,8 @@
     transition: 0.05s ease-in;
     transition-property: background-color, clip-path;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         transition: 0.1s ease-out;
         transition-property: background-color, clip-path;
     }
@@ -448,7 +468,8 @@
 .icon-button-neutral {
     color: var(--color-text-neutral-icon-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         color: var(--color-text-neutral-icon-button-hover);
     }
 
@@ -457,7 +478,8 @@
     }
 
     &.icon-button-square {
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --color-background-neutral-icon-button-square-hover
             );
@@ -475,7 +497,8 @@
 .icon-button-brand {
     color: var(--color-text-brand-icon-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         color: var(--color-text-brand-icon-button-hover);
     }
 
@@ -484,7 +507,8 @@
     }
 
     &.icon-button-square {
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --color-background-brand-icon-button-square-hover
             );
@@ -502,7 +526,8 @@
 .icon-button-info {
     color: var(--color-text-info-icon-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         color: var(--color-text-info-icon-button-hover);
     }
 
@@ -511,7 +536,8 @@
     }
 
     &.icon-button-square {
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --color-background-info-icon-button-square-hover
             );
@@ -529,7 +555,8 @@
 .icon-button-success {
     color: var(--color-text-success-icon-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         color: var(--color-text-success-icon-button-hover);
     }
 
@@ -538,7 +565,8 @@
     }
 
     &.icon-button-square {
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --color-background-success-icon-button-square-hover
             );
@@ -556,7 +584,8 @@
 .icon-button-warning {
     color: var(--color-text-warning-icon-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         color: var(--color-text-warning-icon-button-hover);
     }
 
@@ -565,7 +594,8 @@
     }
 
     &.icon-button-square {
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --color-background-warning-icon-button-square-hover
             );
@@ -583,7 +613,8 @@
 .icon-button-danger {
     color: var(--color-text-danger-icon-button);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         color: var(--color-text-danger-icon-button-hover);
     }
 
@@ -592,7 +623,8 @@
     }
 
     &.icon-button-square {
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --color-background-danger-icon-button-square-hover
             );

--- a/web/styles/buttons.css
+++ b/web/styles/buttons.css
@@ -43,9 +43,19 @@
 
     &:focus-visible {
         /* Override common button outline style set in zulip.css and dark_theme.css */
-        outline: 1px solid var(--color-outline-focus) !important;
-        outline-offset: 2px;
-        clip-path: inset(-3px);
+        outline: var(--outline-width-button-focus) solid
+            var(--color-outline-button-focus) !important;
+        outline-offset: var(--outline-offset-button-focus);
+        clip-path: inset(
+            calc(
+                    -1 *
+                        (
+                            var(--outline-width-button-focus) +
+                                var(--outline-offset-button-focus)
+                        )
+                )
+                round 4px
+        );
     }
 
     &:disabled {
@@ -413,9 +423,19 @@
 
     &:focus-visible {
         /* Override common button outline style set in zulip.css and dark_theme.css */
-        outline: 1px solid var(--color-outline-focus) !important;
-        outline-offset: 2px;
-        clip-path: inset(-3px);
+        outline: var(--outline-width-button-focus) solid
+            var(--color-outline-button-focus) !important;
+        outline-offset: var(--outline-offset-button-focus);
+        clip-path: inset(
+            calc(
+                    -1 *
+                        (
+                            var(--outline-width-button-focus) +
+                                var(--outline-offset-button-focus)
+                        )
+                )
+                round 4px
+        );
     }
 
     &:disabled {


### PR DESCRIPTION
This PR contains 2 commits:
- Commit 1: Improves button outline on focus by tweaking the outline color, width and offset.
- Commit 2: Adds hover state styles to focus state styles.

Fixes: [#design > button keyboard selection indicators @ 💬](https://chat.zulip.org/#narrow/channel/101-design/topic/button.20keyboard.20selection.20indicators/near/2126847)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
|--------|--------|
| ![Screenshot 2025-04-24 at 5 49 46 AM](https://github.com/user-attachments/assets/9bfd65dc-7db4-4196-8de5-9e5798e00dae) | ![Screenshot 2025-04-24 at 5 54 18 AM](https://github.com/user-attachments/assets/974ea4b7-ad7b-4e80-b49a-3cdd70b7eb0d) |
| ![Screenshot 2025-04-24 at 5 54 51 AM](https://github.com/user-attachments/assets/46c5ab59-6947-4110-92ae-d1a845d7a7ff) | ![Screenshot 2025-04-24 at 5 54 27 AM](https://github.com/user-attachments/assets/3ac35a67-8441-41c5-9d76-ac5bec21c027) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
