### PR TITLE
border: Change the border focus color to use color-mix.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -319,6 +319,17 @@
         gap: 0 6px;
     }
 
+    .messagebox:has(.new_message_textarea:focus) {
+        #message-formatting-controls-container {
+            border-color: color-mix(
+                in srgb,
+                var(--color-message-content-container-border-focus) 75%,
+                transparent
+            );
+            background-color: var(--color-background-panel);
+        }
+    }
+
     .message_content {
         margin-right: 0;
     }
@@ -336,7 +347,11 @@
     transition: border-color 0.2s ease;
 
     &:has(.new_message_textarea:focus) {
-        border-color: var(--color-message-content-container-border-focus);
+        border-color: color-mix(
+            in srgb,
+            var(--color-message-content-container-border-focus) 60%,
+            transparent
+        );
     }
 
     &:has(.new_message_textarea.invalid),


### PR DESCRIPTION
This commit modifies the previously used border color variable to be used with color-mix for fixing the issue of button spilling out of compose box when zoomed out.

Fixes: [CZO Thread](https://chat.zulip.org/#narrow/channel/9-issues/topic/.F0.9F.8E.AF.20buttons.20spilling.20out.20of.20compose.20box.20when.20zoomed.20out/with/2106449)

I have added an extra: `background-color: var(--color-background-panel);` for formatting button container which somehow fixes the spill UI issue, otherwise without that just adding the color-mix is not solving the issue.

Device: Macbook Air M1

### Screenshot of the changes

|Before(Chrome-33%) - Left|After(Chrome-33%) - Left|
|----|----|
|<img width="95" alt="Screenshot 2025-04-25 at 9 21 29 AM" src="https://github.com/user-attachments/assets/2c214488-f0d0-4727-b91a-7421306064ac" />|<img width="95" alt="Screenshot 2025-04-25 at 9 20 37 AM" src="https://github.com/user-attachments/assets/9a092ffe-deec-4fde-b770-22d18c283481" />|



|Before(Chrome-33%) - Right|After(Chrome-33%) - Right|
|----|----|
|<img width="95" alt="Screenshot 2025-04-25 at 9 24 46 AM" src="https://github.com/user-attachments/assets/f85344bf-daf1-461a-8e8d-47bf3ce59a9d" />|<img width="95" alt="Screenshot 2025-04-25 at 9 24 37 AM" src="https://github.com/user-attachments/assets/b300304d-d184-4657-b93f-6c432bc796ab" />

|Before(Chrome-33%) - Left|After(Chrome-33%) - Left|
|----|----|
|<img width="95" alt="Screenshot 2025-04-25 at 9 22 43 AM" src="https://github.com/user-attachments/assets/401b6ddb-9530-40a5-9a4e-a324117bc31f" />|<img width="95" alt="Screenshot 2025-04-25 at 9 22 30 AM" src="https://github.com/user-attachments/assets/9a3af305-c79d-4221-9036-139cf5eea798" />|






|Before(Chrome-33%) - Right|After(Chrome-33%) - Right|
|----|----|
|<img width="95" alt="Screenshot 2025-04-25 at 9 23 47 AM" src="https://github.com/user-attachments/assets/f3755189-4182-414a-b65c-2f0646b78e00" />|<img width="95" alt="Screenshot 2025-04-25 at 9 23 37 AM" src="https://github.com/user-attachments/assets/3e09da3c-be99-43c5-b23b-58db224a0f4a" />|

|Before(Safari- Full Zoom Out) - Left|After(Safari - Full Zoom Out) - Left|
|----|----|
|<img width="136" alt="Screenshot 2025-04-25 at 9 08 45 AM" src="https://github.com/user-attachments/assets/233ef0e7-81b0-4781-9524-01e108af4885" />|<img width="136" alt="Screenshot 2025-04-25 at 9 08 24 AM" src="https://github.com/user-attachments/assets/9901f64b-38b8-46ef-9010-400497ce6f67" />|




|Before(Safari- Full Zoom Out) - Right|After(Safari - Full Zoom Out) - Right|
|----|----|
|<img width="136" alt="Screenshot 2025-04-25 at 9 09 47 AM" src="https://github.com/user-attachments/assets/62f772b7-1378-44f8-9649-683c34be3976" />|<img width="136" alt="Screenshot 2025-04-25 at 9 09 38 AM" src="https://github.com/user-attachments/assets/f426285d-4017-466a-b03a-7de049faf612" />|

|Before(Safari- Full Zoom Out) - Left|After(Safari - Full Zoom Out) - Left|
|----|----|
|<img width="136" alt="Screenshot 2025-04-25 at 9 12 12 AM" src="https://github.com/user-attachments/assets/ed8037dc-f90c-44d9-ba1a-48cd756de871" />|<img width="136" alt="Screenshot 2025-04-25 at 9 12 17 AM" src="https://github.com/user-attachments/assets/564a94b3-3d04-47a6-af31-5361a7906a49" />|

|Before(Safari- Full Zoom Out) - Right|After(Safari - Full Zoom Out) - Right|
|----|----|
|<img width="136" alt="Screenshot 2025-04-25 at 9 10 56 AM" src="https://github.com/user-attachments/assets/653307f5-6139-4903-8388-676e27ce0c08" />|<img width="136" alt="Screenshot 2025-04-25 at 9 10 44 AM" src="https://github.com/user-attachments/assets/2e4910e5-208f-4a8f-abea-9489465320f8" />|















<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
