### PR TITLE
demo-orgs: Fix invite user modal when owner hasn't set an email address.

### DIFF
--- a/web/src/invite.ts
+++ b/web/src/invite.ts
@@ -444,9 +444,10 @@ function open_invite_user_modal(e: JQuery.ClickEvent<Document, undefined>): void
             const $button = $("#invite-user-modal .dialog_submit_button");
             $button.prop(
                 "disabled",
-                (selected_tab === "invite-email-tab" &&
-                    email_pill_widget.items().length === 0 &&
-                    email_pill.get_current_email(email_pill_widget) === null) ||
+                !user_has_email_set ||
+                    (selected_tab === "invite-email-tab" &&
+                        email_pill_widget.items().length === 0 &&
+                        email_pill.get_current_email(email_pill_widget) === null) ||
                     ($expires_in.val() === "custom" && !valid_custom_time),
             );
             if (selected_tab === "invite-email-tab") {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1852,6 +1852,10 @@
         hsl(0deg 0% 100%),
         hsl(0deg 0% 0% / 20%)
     );
+    --color-background-pill-container-input-disabled: light-dark(
+        hsl(0deg 0% 93%),
+        hsl(0deg 0% 0% / 20%)
+    );
 
     /* Inbox view constants - Values from Figma design */
     --height-inbox-search: 1.8571em; /* 26px / 14px em */

--- a/web/styles/input_pill.css
+++ b/web/styles/input_pill.css
@@ -240,6 +240,11 @@
     );
 }
 
+#invitee_emails_container .pill-container.not-editable-by-user {
+    height: var(--height-input-pill);
+    background-color: var(--color-background-pill-container-input-disabled);
+}
+
 .add_subscribers_container .pill-container,
 .add_streams_container .pill-container,
 .add-user-group-container .pill-container,

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -1,5 +1,5 @@
 <form id="invite-user-form">
-    <div class="setup-tips-container {{#unless is_admin}}hide{{/unless}}"></div>
+    <div class="setup-tips-container {{#unless (and is_admin user_has_email_set)}}hide{{/unless}}"></div>
     {{#if development_environment}}
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -15,8 +15,8 @@
         <div id="invite_users_option_tabs_container"></div>
         <div id="invitee_emails_container">
             <label for="invitee_emails" class="modal-field-label">{{t "Emails (one on each line or comma-separated)" }}</label>
-            <div class="pill-container">
-                <div class="input" contenteditable="true"></div>
+            <div class="pill-container {{#unless user_has_email_set}}not-editable-by-user{{/unless}}">
+                <div class="input" {{#if user_has_email_set}}contenteditable="true"{{/if}}></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
**Updates**:
- Only show the notification banners about setting up the organization information after the owner has set their email.
- Disable the submit button at all times if the owner hasn't set their email.
- Disable the email pill input div if the owner hasn't set their email.

**Notes**:
- When we remove `contenteditable: true` from the input div for the email address pills, we now also add a class to the `pill-container` div so that we can set a height on that element.
- I added a color variable so that the email input div wouldn't be an inconsistent color in light mode with the other disabled elements.

---

**Screenshots and screen captures:**

### No owner email set
| Before | After |
| --- | --- |
| ![Screenshot from 2025-04-24 17-21-00](https://github.com/user-attachments/assets/b1674a83-6ef3-4c65-afaa-f69876edb396) | ![Screenshot from 2025-04-24 17-20-00](https://github.com/user-attachments/assets/2bab9eb1-7b34-40ab-8c90-f8824741fd00)
| ![Screenshot from 2025-04-24 17-20-48](https://github.com/user-attachments/assets/d8a83c11-ed68-404d-983e-d23f3a6b5b1a) | ![Screenshot from 2025-04-24 17-20-10](https://github.com/user-attachments/assets/91619aef-6956-48d2-bd84-f44d9490c825)
| ![Screenshot from 2025-04-24 17-19-17](https://github.com/user-attachments/assets/5f10ec4e-ff93-49d4-b0f4-a3186eff3e63) | ![Screenshot from 2025-04-24 17-19-45](https://github.com/user-attachments/assets/2a4915a4-d248-46a0-b04f-09ec3a868ed6)
| ![Screenshot from 2025-04-24 17-18-57](https://github.com/user-attachments/assets/19efd4af-4855-47ae-9692-d82bfc9289f8) | ![Screenshot from 2025-04-24 17-18-24](https://github.com/user-attachments/assets/7f2867da-9754-4b38-ad57-e2677d25f268)


### After owner email is set (NO CHANGE)
| Before | After |
| --- | --- |
| ![Screenshot from 2025-04-24 17-45-38](https://github.com/user-attachments/assets/4ac7b480-ef83-4ff7-bbb3-5c8f82dbce05) | ![Screenshot from 2025-04-24 17-23-44](https://github.com/user-attachments/assets/d171482f-b186-4100-8b45-9b96686d6c27)
| ![Screenshot from 2025-04-24 17-45-28](https://github.com/user-attachments/assets/a6e2e5c9-3559-42a0-b8e4-789ac9268344) | ![Screenshot from 2025-04-24 17-23-32](https://github.com/user-attachments/assets/72b41a91-b356-40f0-b730-241b0a98fc77)
| ![Screenshot from 2025-04-24 17-45-49](https://github.com/user-attachments/assets/b57efdb8-12bc-492c-8c2b-ae2663eef684) | ![Screenshot from 2025-04-24 17-24-01](https://github.com/user-attachments/assets/4096737c-8418-4177-ae6b-7fc400b8a6a5)
| ![Screenshot from 2025-04-24 17-45-13](https://github.com/user-attachments/assets/fa824777-b7f0-4530-92f5-1d8f1996aff4) | ![Screenshot from 2025-04-24 17-24-17](https://github.com/user-attachments/assets/12e57d98-cf54-42e2-959e-47694753ef4e)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
