### PR TITLE
dev_docs: Better present images in tables.

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -9,3 +9,10 @@
 .wy-table-responsive {
     overflow: visible !important;
 }
+
+/* Present tables with columns of equal size
+   when images are present. */
+.rst-content table.docutils:has(img) {
+    table-layout: fixed;
+    width: 100%;
+}


### PR DESCRIPTION
This corrects an annoyance I noticed while putting up #34449, where despite my care in capturing uniformly sized illustrative images, they displayed at different sizes based on the browser-default table layout algorithm and the size of the content in the table heading.

This PR corrects that problem by applying `table-display: fixed` on tables that include images, plus a `width: 100%` so that the browser divvies up the available space equally among columns--regardless of how many columns an image-containing table might have.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![dev-docs-image-table-before](https://github.com/user-attachments/assets/f070af20-4daf-4932-a6c0-c2adb2a2d20d) | ![dev-docs-image-table-after](https://github.com/user-attachments/assets/4bfa58a5-3b79-426e-8d02-29848ce2b7fb) |
