### PR TITLE
help: Document option to add the members of a group to a group.

### DIFF
--- a/help/manage-user-groups.md
+++ b/help/manage-user-groups.md
@@ -86,6 +86,12 @@
 
 1. Click **Add**.
 
+!!! tip ""
+
+    Click the <i class="zulip-icon zulip-icon-expand-both-diagonals"></i> icon
+    on a user group pill to add all the members of the group, rather than the
+    group itself.
+
 {end_tabs}
 
 ## Remove user or group from a group


### PR DESCRIPTION
I think this is good enough for documenting #34453, and we don't need to add dedicated instructions at this point to cover this + adding channel members.

Current: https://zulip.com/help/manage-user-groups#add-user-groups-to-a-group

Updated:
![Screenshot 2025-04-24 at 23 58 46@2x](https://github.com/user-attachments/assets/ad6709d6-e320-4dd0-bfd6-31886cedbf93)
