### PR TITLE
mention: Skip fetching group membership for non-permitted mention.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1658,8 +1658,7 @@ def check_update_message(
                 raise TopicWildcardMentionNotAllowedError
 
         if rendering_result.mentions_user_group_ids:
-            mentioned_group_ids = list(rendering_result.mentions_user_group_ids)
-            check_user_group_mention_allowed(user_profile, mentioned_group_ids)
+            check_user_group_mention_allowed(rendering_result.mentions_user_group_ids, mention_data)
 
     if isinstance(message_edit_request, StreamMessageEditRequest):
         user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1770,8 +1770,7 @@ def check_update_message(
                 raise TopicWildcardMentionNotAllowedError
 
         if rendering_result.mentions_user_group_ids:
-            mentioned_group_ids = list(rendering_result.mentions_user_group_ids)
-            check_user_group_mention_allowed(user_profile, mentioned_group_ids)
+            check_user_group_mention_allowed(rendering_result.mentions_user_group_ids, mention_data)
 
     if isinstance(message_edit_request, StreamMessageEditRequest):
         user_group_membership_details = UserGroupMembershipDetails(user_recursive_group_ids=None)

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1921,8 +1921,8 @@ def check_message(
         raise TopicWildcardMentionNotAllowedError
 
     if message_send_dict.rendering_result.mentions_user_group_ids:
-        mentioned_group_ids = list(message_send_dict.rendering_result.mentions_user_group_ids)
-        check_user_group_mention_allowed(sender, mentioned_group_ids)
+        mentioned_group_ids = message_send_dict.rendering_result.mentions_user_group_ids
+        check_user_group_mention_allowed(mentioned_group_ids, message_send_dict.mention_data)
 
     return message_send_dict
 

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -683,10 +683,15 @@ def build_message_send_dict(
     if mention_backend is None:
         mention_backend = MentionBackend(realm.id)
 
+    message_sender_recursive_group_ids = None
+    if user_group_membership_details is not None:
+        message_sender_recursive_group_ids = user_group_membership_details.user_recursive_group_ids
+
     mention_data = MentionData(
         mention_backend=mention_backend,
         content=message.content,
         message_sender=message.sender,
+        message_sender_recursive_group_ids=message_sender_recursive_group_ids,
     )
 
     if message.is_channel_message:
@@ -2023,8 +2028,8 @@ def check_message(
         raise TopicWildcardMentionNotAllowedError
 
     if message_send_dict.rendering_result.mentions_user_group_ids:
-        mentioned_group_ids = list(message_send_dict.rendering_result.mentions_user_group_ids)
-        check_user_group_mention_allowed(sender, mentioned_group_ids)
+        mentioned_group_ids = message_send_dict.rendering_result.mentions_user_group_ids
+        check_user_group_mention_allowed(mentioned_group_ids, message_send_dict.mention_data)
 
     return message_send_dict
 

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -6,7 +6,7 @@ from re import Match
 from typing import Literal
 
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django_stubs_ext import StrPromise
 
 from zerver.lib.streams import get_content_access_streams
@@ -14,8 +14,8 @@ from zerver.lib.topic import get_latest_message_for_user_in_topic
 from zerver.lib.types import UserDisplayRecipient
 from zerver.lib.user_groups import (
     UserGroupMembershipDetails,
+    get_recursive_membership_groups,
     get_root_id_annotated_recursive_subgroups_for_groups,
-    user_has_permission_for_group_setting,
 )
 from zerver.lib.users import get_inaccessible_user_ids
 from zerver.models import NamedUserGroup, UserProfile
@@ -374,7 +374,11 @@ def get_possible_mentions_info(
 
 class MentionData:
     def __init__(
-        self, mention_backend: MentionBackend, content: str, message_sender: UserProfile | None
+        self,
+        mention_backend: MentionBackend,
+        content: str,
+        message_sender: UserProfile | None,
+        message_sender_recursive_group_ids: set[int] | None = None,
     ) -> None:
         self.mention_backend = mention_backend
         realm_id = mention_backend.realm_id
@@ -385,7 +389,11 @@ class MentionData:
         )
         self.full_name_info = {row.full_name.lower(): row for row in possible_mentions_info}
         self.user_id_info = {row.id: row for row in possible_mentions_info}
-        self.init_user_group_data(realm_id=realm_id, content=content)
+        self.init_user_group_data(
+            realm_id=realm_id,
+            content=content,
+            message_sender_recursive_group_ids=message_sender_recursive_group_ids,
+        )
         self.has_stream_wildcards = mentions.message_has_stream_wildcards
         self.has_topic_wildcards = mentions.message_has_topic_wildcards
 
@@ -395,39 +403,61 @@ class MentionData:
     def message_has_topic_wildcards(self) -> bool:
         return self.has_topic_wildcards
 
-    def init_user_group_data(self, realm_id: int, content: str) -> None:
+    def init_user_group_data(
+        self,
+        realm_id: int,
+        content: str,
+        message_sender_recursive_group_ids: set[int] | None,
+    ) -> None:
         self.user_group_name_info: dict[str, NamedUserGroup] = {}
+        self.user_group_names: dict[int, str] = {}
         self.user_group_members: dict[int, set[int]] = defaultdict(set)
+        self.allowed_mention_group_ids: set[int] = set()
         user_group_names_mentions = possible_user_group_mentions(content)
         if user_group_names_mentions:
             named_user_groups = NamedUserGroup.objects.filter(
                 realm_for_sharding_id=realm_id, name__in=user_group_names_mentions
-            )
+            ).select_related("can_mention_group", "can_mention_group__named_user_group")
 
-            # No filter here as we need user_group_name_info for all groups mentions.
-            self.user_group_name_info = {group.name.lower(): group for group in named_user_groups}
+            # No filter here as we need user_group_name_info
+            # and user_group_names for all groups mentions.
+            for group in named_user_groups:
+                self.user_group_name_info[group.name.lower()] = group
+                self.user_group_names[group.id] = group.name
 
-            # We only fetch group membership mentions that can
+            # message_sender can be None when mentioning
+            # a group inside a channel/channel folder description,
+            # in such case we allow the mention.
+            # TODO: This is not consistent, the permission
+            # to mention a group must be the same everywhere.
+            if self.message_sender is None:
+                self.allowed_mention_group_ids = set(self.user_group_names.keys())
+            else:
+                self.allowed_mention_group_ids = bulk_get_groups_sender_can_mention(
+                    self.message_sender, named_user_groups, message_sender_recursive_group_ids
+                )
+
+            # We only fetch group memberships that can
             # possibly trigger notifications.
-            filtered_group_ids = [
+            group_ids_to_fetch_membership_for = [
                 group.id
                 for group in named_user_groups
                 if not group.deactivated
                 and user_group_names_mentions.get(group.name) == "non-silent"
+                and group.id in self.allowed_mention_group_ids
             ]
 
             # Avoid doing a database query if there's nothing to fetch.
-            #
-            # This isn't quite optimal -- we've not checked our user
-            # has permission to mention the group yet.
-            if len(filtered_group_ids) == 0:
+            if len(group_ids_to_fetch_membership_for) == 0:
                 return
 
             # Fetch membership for the groups filtered above in a
             # single, efficient bulk query, mapping each group to its
             # direct and indirect members.
             for group_root_id, member_id in (
-                get_root_id_annotated_recursive_subgroups_for_groups(filtered_group_ids, realm_id)
+                get_root_id_annotated_recursive_subgroups_for_groups(
+                    group_ids_to_fetch_membership_for, realm_id
+                )
                 .filter(direct_members__is_active=True)
                 .values_list("root_id", "direct_members")  # type: ignore[misc]  # root_id is an annotated field.
             ):
@@ -453,6 +483,9 @@ class MentionData:
 
     def get_user_group(self, name: str) -> NamedUserGroup | None:
         return self.user_group_name_info.get(name.lower(), None)
+
+    def get_user_group_name(self, group_id: int) -> str:
+        return self.user_group_names.get(group_id, "")
 
     def get_group_members(self, user_group_id: int) -> set[int]:
         return self.user_group_members.get(user_group_id, set())
@@ -486,23 +519,59 @@ def get_user_group_mention_display_name(user_group: NamedUserGroup) -> StrPromis
     return user_group.name
 
 
-def sender_can_mention_group(sender: UserProfile | None, named_group: NamedUserGroup) -> bool:
-    can_mention_group = named_group.can_mention_group
+def bulk_get_groups_sender_can_mention(
+    sender: UserProfile,
+    named_user_groups: QuerySet[NamedUserGroup],
+    sender_recursive_group_ids: set[int] | None,
+) -> set[int]:
+    # Ids of NamedUserGroup that don't need to be checked against
+    # the sender's permission.
+    group_ids_everyone_can_mention = set()
 
-    if (
-        hasattr(can_mention_group, "named_user_group")
-        and can_mention_group.named_user_group.name == SystemGroups.EVERYONE
+    # NamedUserGroups that must be checked against the sender's permission.
+    named_groups_requiring_permission_check = set()
+
+    permissive_system_groups = {SystemGroups.EVERYONE, SystemGroups.EVERYONE_ON_INTERNET}
+
+    for named_group in named_user_groups:
+        can_mention_group = named_group.can_mention_group
+
+        if hasattr(can_mention_group, "named_user_group") and (
+            can_mention_group.named_user_group.name in permissive_system_groups
+        ):
+            group_ids_everyone_can_mention.add(named_group.id)
+        else:
+            named_groups_requiring_permission_check.add(named_group)
+
+    if not named_groups_requiring_permission_check or is_cross_realm_bot_email(
+        sender.delivery_email
     ):
-        return True
+        return group_ids_everyone_can_mention
 
-    assert sender is not None
+    setting_config = NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_mention_group"]
+    if not setting_config.allow_everyone_group and sender.is_guest:
+        # Currently dead code: allow_everyone_group is always True
+        # for can_mention_group. But this check serves as
+        # a safeguard and short-circuits in case config changes in future;
+        # in which case guests will only be able to
+        # mention group_ids_everyone_can_mention.
+        return group_ids_everyone_can_mention  # nocoverage
 
-    if is_cross_realm_bot_email(sender.delivery_email):
-        return False
+    # Ids of all direct and indirect groups the sender is a member of.
+    if sender_recursive_group_ids is None:
+        sender_recursive_group_ids = set(
+            get_recursive_membership_groups(sender).values_list("id", flat=True)
+        )
 
-    return user_has_permission_for_group_setting(
-        can_mention_group.id,
-        sender,
-        NamedUserGroup.GROUP_PERMISSION_SETTINGS["can_mention_group"],
-        direct_member_only=False,
-    )
+    # The sender can mention a named_group if  they are direct/indirect
+    # member of that named_group.can_mention_group.
+    group_ids_sender_can_mention = {
+        named_group.id
+        for named_group in named_groups_requiring_permission_check
+        if named_group.can_mention_group_id in sender_recursive_group_ids
+    }
+
+    # The sender is allowed to mention a NamedUserGroup if that group:
+    # already allows mention by everyone OR
+    # required permission check and have passed it for that sender.
+    return group_ids_everyone_can_mention | group_ids_sender_can_mention

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -18,7 +18,7 @@ from zerver.lib.cache import generic_bulk_cached_fetch, to_dict_cache_key_id
 from zerver.lib.display_recipient import get_display_recipient, get_display_recipient_by_id
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult
-from zerver.lib.mention import MentionData, sender_can_mention_group, silent_mention_syntax_for_user
+from zerver.lib.mention import MentionData, silent_mention_syntax_for_user
 from zerver.lib.message_cache import MessageDict, extract_message_dict, stringify_message_dict
 from zerver.lib.partial import partial
 from zerver.lib.request import RequestVariableConversionError
@@ -46,7 +46,6 @@ from zerver.lib.user_topics import build_get_topic_visibility_policy, get_topic_
 from zerver.lib.users import get_inaccessible_user_ids
 from zerver.models import (
     Message,
-    NamedUserGroup,
     Realm,
     Recipient,
     Stream,
@@ -1594,16 +1593,14 @@ def stream_wildcard_mention_allowed(sender: UserProfile, stream: Stream, realm: 
     return can_mention_many_users(sender)
 
 
-def check_user_group_mention_allowed(sender: UserProfile, user_group_ids: list[int]) -> None:
-    user_groups = NamedUserGroup.objects.filter(id__in=user_group_ids).select_related(
-        "can_mention_group", "can_mention_group__named_user_group"
-    )
-
-    for group in user_groups:
-        if not sender_can_mention_group(sender, group):
+def check_user_group_mention_allowed(
+    mentioned_group_ids: set[int], mention_data: MentionData
+) -> None:
+    for group_id in mentioned_group_ids:
+        if group_id not in mention_data.allowed_mention_group_ids:
             raise JsonableError(
                 _("You are not allowed to mention user group '{user_group_name}'.").format(
-                    user_group_name=group.name
+                    user_group_name=mention_data.get_user_group_name(group_id)
                 )
             )
 

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -18,7 +18,7 @@ from zerver.lib.cache import generic_bulk_cached_fetch, to_dict_cache_key_id
 from zerver.lib.display_recipient import get_display_recipient_by_id
 from zerver.lib.exceptions import JsonableError, MissingAuthenticationError
 from zerver.lib.markdown import MessageRenderingResult
-from zerver.lib.mention import MentionData, sender_can_mention_group, silent_mention_syntax_for_user
+from zerver.lib.mention import MentionData, silent_mention_syntax_for_user
 from zerver.lib.message_cache import MessageDict, extract_message_dict, stringify_message_dict
 from zerver.lib.partial import partial
 from zerver.lib.request import RequestVariableConversionError
@@ -46,7 +46,6 @@ from zerver.lib.user_topics import build_get_topic_visibility_policy, get_topic_
 from zerver.lib.users import get_inaccessible_user_ids
 from zerver.models import (
     Message,
-    NamedUserGroup,
     Realm,
     Recipient,
     Stream,
@@ -1521,16 +1520,14 @@ def stream_wildcard_mention_allowed(sender: UserProfile, stream: Stream, realm: 
     return can_mention_many_users(sender)
 
 
-def check_user_group_mention_allowed(sender: UserProfile, user_group_ids: list[int]) -> None:
-    user_groups = NamedUserGroup.objects.filter(id__in=user_group_ids).select_related(
-        "can_mention_group", "can_mention_group__named_user_group"
-    )
-
-    for group in user_groups:
-        if not sender_can_mention_group(sender, group):
+def check_user_group_mention_allowed(
+    mentioned_group_ids: set[int], mention_data: MentionData
+) -> None:
+    for group_id in mentioned_group_ids:
+        if group_id not in mention_data.allowed_mention_group_ids:
             raise JsonableError(
                 _("You are not allowed to mention user group '{user_group_name}'.").format(
-                    user_group_name=group.name
+                    user_group_name=mention_data.get_user_group_name(group_id)
                 )
             )
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -23,6 +23,7 @@ from zerver.actions.streams import do_change_stream_group_based_setting
 from zerver.actions.user_groups import (
     add_subgroups_to_user_group,
     check_add_user_group,
+    do_change_user_group_permission_setting,
     do_deactivate_user_group,
 )
 from zerver.actions.user_settings import do_change_user_setting
@@ -309,23 +310,6 @@ class MarkdownMiscTest(ZulipTestCase):
         mention_data = MentionData(mention_backend, content, message_sender=None)
         self.assertEqual(mention_data.get_group_members(group.id), {hamlet.id})
 
-    def test_bulk_user_group_mentions(self) -> None:
-        realm = get_realm("zulip")
-        hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-        othello = self.example_user("othello")
-        mention_backend = MentionBackend(realm.id)
-
-        content = ""
-        for i in range(5):
-            group_name = f"group{i}"
-            check_add_user_group(realm, group_name, [hamlet, cordelia], acting_user=othello)
-            content += f" @*{group_name}*"
-
-        CONSTANT_QUERY_COUNT = 2  # even if it increases in future, make sure it's constant.
-        with self.assert_database_query_count(CONSTANT_QUERY_COUNT):
-            MentionData(mention_backend, content, message_sender=None)
-
     def test_mention_user_groups_with_common_subgroup(self) -> None:
         # Mention multiple groups (class-A and class-B) with a common sub-group (good-students)
         # and make sure each mentioned group has the expected members
@@ -393,6 +377,155 @@ class MarkdownMiscTest(ZulipTestCase):
         content = "@_*hamletcharacters*, @*hamletcharacters*"
         mention_data = MentionData(mention_backend, content, message_sender=None)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), {hamlet.id, cordelia.id})
+
+    def test_fetch_group_membership_when_mention_group_permission_changes(self) -> None:
+        # Test we ONLY fetch group membership when sender
+        # is allowed, via direct/indirect membership, to mention that group.
+        # This also tests an edge case where a sender's permission changes
+        # (i.e. they can't mention that group) while sending the message
+        # and after writing @group_name in compose box,
+        # in which case we should NOT fetch membership.
+        realm = get_realm("zulip")
+
+        # hamlet_group members
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        iago = self.example_user("iago")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        prospero = self.example_user("prospero")
+        othello = self.example_user("othello")
+
+        mention_backend = MentionBackend(realm.id)
+        test_group = check_add_user_group(realm, "test_group", [aaron], acting_user=iago)
+
+        sub_group_lvl_1 = check_add_user_group(realm, "sub_group_lvl_1", [zoe], acting_user=iago)
+        sub_group_lvl_2 = check_add_user_group(
+            realm, "sub_group_lvl_2", [prospero], acting_user=iago
+        )
+        hamlet_group = NamedUserGroup.objects.get(realm=realm, name="hamletcharacters")
+        content = "@*hamletcharacters*"
+        hamlet_members_ids = {hamlet.id, cordelia.id}
+
+        # Change permission, so that only test_group (with aaron being the only member)
+        # can mention hamlet_group.
+        do_change_user_group_permission_setting(
+            hamlet_group,
+            "can_mention_group",
+            test_group,
+            acting_user=None,
+        )
+
+        # We should fetch group membership when sender (aaron) is allowed to mention the group.
+        mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+
+        # We should NOT fetch group membership when sender is NOT allowed
+        # (only aaron is allowed at this point) to mention the group.
+        mention_data = MentionData(mention_backend, content, message_sender=othello)
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), set())
+
+        # Add 2 levels of sub-groups to test_group.
+        add_subgroups_to_user_group(test_group, [sub_group_lvl_1], acting_user=iago)
+        add_subgroups_to_user_group(sub_group_lvl_1, [sub_group_lvl_2], acting_user=iago)
+
+        # 3 senders (which are direct/indirect members of test_group)
+        # mention hamlet_group.
+        aaron_mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        zoe_mention_data = MentionData(mention_backend, content, message_sender=zoe)
+        prospero_mention_data = MentionData(mention_backend, content, message_sender=prospero)
+
+        # We should fetch group membership, as all senders are allowed to mention that group.
+        self.assertEqual(aaron_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(zoe_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(
+            prospero_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids
+        )
+
+    def test_fetch_group_membership_for_bulk_mention_groups(self) -> None:
+        # Same as test_fetch_group_membership_when_mention_group_permission_changes
+        # but for bulk mentioning groups in a single message.
+        # This test ensures we do the permission check for bulk groups mentions correctly
+        # and in a constant time.
+        realm = get_realm("zulip")
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        hamlet_members_ids = {hamlet.id, cordelia.id}
+        iago = self.example_user("iago")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        othello = self.example_user("othello")
+
+        mention_backend = MentionBackend(realm.id)
+
+        test_group = check_add_user_group(realm, "can_mention_group", [aaron], acting_user=iago)
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm=realm, is_system_group=True
+        )
+        sub_group = check_add_user_group(realm, "sub_group", [zoe], acting_user=iago)
+        add_subgroups_to_user_group(test_group, [sub_group], acting_user=iago)
+        hamlet_group = NamedUserGroup.objects.get(realm=realm, name="hamletcharacters")
+
+        content = "@*hamletcharacters*, "
+        mentioned_groups = []
+
+        for i in range(6):
+            group_name = f"group_{i}"
+            group = check_add_user_group(realm, group_name, [othello], acting_user=iago)
+            mentioned_groups.append(group)
+            content += f"@*{group_name}*, "
+
+        # Bulk mention groups with the default mention permission i.e. SystemGroups.EVERYONE.
+        # We make sure it's constant.
+        with self.assert_database_query_count(2):
+            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+
+        # We should fetch group memberships for all mentioned groups,
+        # since the default is to allow mention by all.
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        for group in mentioned_groups:
+            self.assertEqual(mention_data.get_group_members(group.id), {othello.id})
+
+        # Now, change the default permission for each group to allow some groups
+        # to be mentioned by the sender "zoe" through test_group,
+        # but prevent other groups through moderators_group. This way we can test that
+        # our algorithm correctly and efficiently does the permission
+        # check against different mention permissions for different groups.
+        for i, group in enumerate(mentioned_groups):
+            if i % 2 == 0:
+                do_change_user_group_permission_setting(
+                    group,
+                    "can_mention_group",
+                    test_group,
+                    acting_user=None,
+                )
+            else:
+                do_change_user_group_permission_setting(
+                    group,
+                    "can_mention_group",
+                    moderators_group,
+                    acting_user=None,
+                )
+
+        # Bulk mention groups that have different (non default) mention permissions.
+        # This is one extra query than the previous case which is
+        # triggered when any or all mentioned group/s needs
+        # a permission check (e.g. not SystemGroups.EVERYONE).
+        # Again, we make sure it's constant.
+        with self.assert_database_query_count(3):
+            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+
+        # We should fetch group membership, ONLY for groups the sender "zoe" is allowed
+        # to mention.
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[0].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[1].id), set())
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[2].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[3].id), set())
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[4].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[5].id), set())
 
     def test_invalid_katex_path(self) -> None:
         with self.settings(DEPLOY_ROOT="/nonexistent"):

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -25,6 +25,7 @@ from zerver.actions.streams import do_change_stream_group_based_setting
 from zerver.actions.user_groups import (
     add_subgroups_to_user_group,
     check_add_user_group,
+    do_change_user_group_permission_setting,
     do_deactivate_user_group,
 )
 from zerver.actions.user_settings import do_change_user_setting
@@ -313,23 +314,6 @@ class MarkdownMiscTest(ZulipTestCase):
         mention_data = MentionData(mention_backend, content, message_sender=None)
         self.assertEqual(mention_data.get_group_members(group.id), {hamlet.id})
 
-    def test_bulk_user_group_mentions(self) -> None:
-        realm = get_realm("zulip")
-        hamlet = self.example_user("hamlet")
-        cordelia = self.example_user("cordelia")
-        othello = self.example_user("othello")
-        mention_backend = MentionBackend(realm.id)
-
-        content = ""
-        for i in range(5):
-            group_name = f"group{i}"
-            check_add_user_group(realm, group_name, [hamlet, cordelia], acting_user=othello)
-            content += f" @*{group_name}*"
-
-        CONSTANT_QUERY_COUNT = 2  # even if it increases in future, make sure it's constant.
-        with self.assert_database_query_count(CONSTANT_QUERY_COUNT):
-            MentionData(mention_backend, content, message_sender=None)
-
     def test_mention_user_groups_with_common_subgroup(self) -> None:
         # Mention multiple groups (class-A and class-B) with a common sub-group (good-students)
         # and make sure each mentioned group has the expected members
@@ -397,6 +381,149 @@ class MarkdownMiscTest(ZulipTestCase):
         content = "@_*hamletcharacters*, @*hamletcharacters*"
         mention_data = MentionData(mention_backend, content, message_sender=None)
         self.assertEqual(mention_data.get_group_members(hamlet_group.id), {hamlet.id, cordelia.id})
+
+    def test_fetch_group_membership_when_mention_group_permission_changes(self) -> None:
+        # Test we ONLY fetch a group membership when sender
+        # is allowed, via direct/indirect membership, to mention that group.
+        realm = get_realm("zulip")
+
+        # hamlet_group members.
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+
+        iago = self.example_user("iago")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        prospero = self.example_user("prospero")
+        othello = self.example_user("othello")
+
+        mention_backend = MentionBackend(realm.id)
+
+        aaron_group = check_add_user_group(realm, "aaron_group", [aaron], acting_user=iago)
+        zoe_group = check_add_user_group(realm, "zoe_group", [zoe], acting_user=iago)
+        prospero_group = check_add_user_group(realm, "prospero_group", [prospero], acting_user=iago)
+        hamlet_group = NamedUserGroup.objects.get(realm=realm, name="hamletcharacters")
+
+        content = "@*hamletcharacters*"
+        hamlet_members_ids = {hamlet.id, cordelia.id}
+
+        # Change permission, so that only aaron_group can mention hamlet_group.
+        do_change_user_group_permission_setting(
+            hamlet_group,
+            "can_mention_group",
+            aaron_group,
+            acting_user=None,
+        )
+
+        # We should fetch group membership when sender (aaron) is allowed to mention the group.
+        mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+
+        # We should NOT fetch group membership when sender is NOT allowed
+        # (only aaron is allowed at this point) to mention the group.
+        mention_data = MentionData(mention_backend, content, message_sender=othello)
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), set())
+
+        # Add 2 levels of sub-groups to aaron_group.
+        add_subgroups_to_user_group(aaron_group, [zoe_group], acting_user=iago)
+        add_subgroups_to_user_group(zoe_group, [prospero_group], acting_user=iago)
+
+        # 3 senders, who are direct and indirect members of aaron_group,
+        # mention hamlet_group.
+        aaron_mention_data = MentionData(mention_backend, content, message_sender=aaron)
+        zoe_mention_data = MentionData(mention_backend, content, message_sender=zoe)
+        prospero_mention_data = MentionData(mention_backend, content, message_sender=prospero)
+
+        # We should fetch group membership, as all senders are allowed to mention that group.
+        self.assertEqual(aaron_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(zoe_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(
+            prospero_mention_data.get_group_members(hamlet_group.id), hamlet_members_ids
+        )
+
+    def test_fetch_group_membership_for_bulk_mention_groups(self) -> None:
+        # Same as test_fetch_group_membership_when_mention_group_permission_changes
+        # but for bulk mentioning groups in a single message.
+        # This test ensures we do the permission check for bulk groups
+        # mentions correctly and in a constant time.
+        realm = get_realm("zulip")
+
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        hamlet_members_ids = {hamlet.id, cordelia.id}
+        iago = self.example_user("iago")
+        aaron = self.example_user("aaron")
+        zoe = self.example_user("ZOE")
+        othello = self.example_user("othello")
+
+        mention_backend = MentionBackend(realm.id)
+
+        aaron_group = check_add_user_group(realm, "aaron_group", [aaron], acting_user=iago)
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm=realm, is_system_group=True
+        )
+        zoe_group = check_add_user_group(realm, "zoe_group", [zoe], acting_user=iago)
+        add_subgroups_to_user_group(aaron_group, [zoe_group], acting_user=iago)
+        hamlet_group = NamedUserGroup.objects.get(realm=realm, name="hamletcharacters")
+
+        content = "@*hamletcharacters*, "
+        mentioned_groups = []
+
+        for i in range(6):
+            group_name = f"group_{i}"
+            group = check_add_user_group(realm, group_name, [othello], acting_user=iago)
+            mentioned_groups.append(group)
+            content += f"@*{group_name}*, "
+
+        # Bulk mention groups with the default mention permission i.e. SystemGroups.EVERYONE.
+        # We make sure it's constant.
+        with self.assert_database_query_count(2):
+            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+
+        # We should fetch group memberships for all mentioned groups,
+        # since the default is to allow mention by all.
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        for group in mentioned_groups:
+            self.assertEqual(mention_data.get_group_members(group.id), {othello.id})
+
+        # Now, change the default permission for each group to allow some groups
+        # to be mentioned by the sender zoe through aaron_group (zoe's parent group),
+        # but prevent other groups through moderators_group.
+        # This way we can test that our algorithm correctly and efficiently does the permission
+        # check against different mention permissions for different groups.
+        for i, group in enumerate(mentioned_groups):
+            if i % 2 == 0:
+                do_change_user_group_permission_setting(
+                    group,
+                    "can_mention_group",
+                    aaron_group,
+                    acting_user=None,
+                )
+            else:
+                do_change_user_group_permission_setting(
+                    group,
+                    "can_mention_group",
+                    moderators_group,
+                    acting_user=None,
+                )
+
+        # Bulk mention groups that have different mention permissions.
+        # This is one extra query than the previous.
+        # Triggered when any mentioned group needs
+        # permission check (e.g., NOT SystemGroups.EVERYONE).
+        # Again, we make sure it's constant.
+        with self.assert_database_query_count(3):
+            mention_data = MentionData(mention_backend, content, message_sender=zoe)
+
+        # We should fetch group membership, ONLY for groups the sender "zoe" is allowed
+        # to mention.
+        self.assertEqual(mention_data.get_group_members(hamlet_group.id), hamlet_members_ids)
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[0].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[1].id), set())
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[2].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[3].id), set())
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[4].id), {othello.id})
+        self.assertEqual(mention_data.get_group_members(mentioned_groups[5].id), set())
 
     def test_invalid_katex_path(self) -> None:
         with self.settings(DEPLOY_ROOT="/nonexistent"):


### PR DESCRIPTION
Fixes: #32934

Follow up to #33097

Bulk compute groups the sender is allowed to mention, this eliminiates  `O(n)` behaviour in the case where many groups need to be checked for that permission, also we skip fetching membership for those non-allowed-to-mention groups.

Also this handles the edge case where a sender's permission changes while sending the message and after writing `@group_name` in compose box, in this case, we also should NOT fetch membership for that group.

## Changes

1. Add `bulk_get_groups_sender_can_menion` which efficiently computes and fetches groups the sender is allowed to mention, sets the result as `allowed_mention_group_ids` inside `MentionData`, this new bulk function mimics the same logic with the same order of checks of the removed function `sender_can_mention_group`

1. `allowed_mention_group_ids` is then used to check mentioned_groups against, in `init_user_group_data` and in `check_user_group_mention_allowed`.

3. Remove `NamedUserGroup.objects.filter...`, and the `can_mention_group` check for every group, inside `check_user_group_mention_allowed`.

4. Avoid converting `mentioned_group_ids` into a `list`, which saves us an operation.

5. Add test case.
