### PR TITLE
demo-orgs: Update tooltip text for disabled manage API key button.

### DIFF
--- a/web/src/tippyjs.ts
+++ b/web/src/tippyjs.ts
@@ -449,12 +449,20 @@ export function initialize(): void {
     });
 
     tippy.delegate("body", {
-        target: [
-            "#api_key_button_container.disabled_setting_tooltip",
-            "#user_email_address_dropdown_container.disabled_setting_tooltip",
-        ].join(","),
+        target: "#user_email_address_dropdown_container.disabled_setting_tooltip",
         content: $t({
             defaultMessage: "You must configure your email to access this feature.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    tippy.delegate("body", {
+        target: "#api_key_button_container.disabled_setting_tooltip",
+        content: $t({
+            defaultMessage: "Add an email to access your API key.",
         }),
         appendTo: () => document.body,
         onHidden(instance) {


### PR DESCRIPTION
Part of #34447:
>**Manage your API key button**
>Add a tooltip to this button when disabled: "Add an email to create your API key."

There was already a tooltip for this disabled button, so updated the text for that, with a slight adjustment from the suggested text in the issue (see above). The user has an API key; we are just restricting access to it until they add an email and password to their account for the demo organization. Adding an email does not create an API key.

Also, there is another disabled setting on this page with a tooltip (see screenshots below). Checking to see if we want to adjust that text at all as well or keep it the same.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![Screenshot from 2025-04-25 19-26-28](https://github.com/user-attachments/assets/6291b67b-4f5f-4e2a-9e59-617aed4b3713) | ![Screenshot from 2025-04-25 19-26-06](https://github.com/user-attachments/assets/fd4136c5-0fe9-43be-8da5-28acf082d138)

Related disabled tooltip in user account & security settings:
| Section | Hovering over disabled feature |
| --- | --- |
| ![Screenshot from 2025-04-25 19-27-29](https://github.com/user-attachments/assets/265b44cf-620b-4111-9985-2cabf04f4a8f) | ![Screenshot from 2025-04-25 19-27-27](https://github.com/user-attachments/assets/3412aca9-29f9-4b92-acc9-a773f01b369d)



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
