### PR TITLE
url_previews: Clamp title, description text to two lines each.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -211,6 +211,7 @@ js_rules = RuleList(
             "description": "Avoid using the `style=` attribute; we prefer styling in CSS files",
             "exclude": {
                 "web/tests/compose_paste.test.cjs",
+                "web/tests/postprocess_content.test.cjs",
             },
             "good_lines": ["#my-style {color: blue;}", "const style =", 'some_style = "test"'],
             "bad_lines": ['<p style="color: blue;">Foo</p>', 'style = "color: blue;"'],

--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -84,6 +84,11 @@ export function postprocess_content(html: string): string {
             }
         }
 
+        // Add a class to the anchor tag on
+        if (elt.parentElement?.classList.contains("message_embed_title")) {
+            elt.classList.add("message-embed-title-link");
+        }
+
         if (elt.parentElement?.classList.contains("message_inline_image")) {
             // For inline images we want to handle the tooltips explicitly, and disable
             // the browser's built in handling of the title attribute.

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -460,9 +460,12 @@
     --message-box-timestamp-column-width: 0;
 
     /* This length is the primary reference for height
-       and image width on URL preview embeds.
-       80px at 14px/1em */
-    --length-message-preview-embeds: 5.7143em;
+       and image width on URL preview embeds. 112px
+       comes from the height of a two-line title and a
+       two-line description at a +2 (maximum)
+       line-height setting.
+       112px at 16px/1em */
+    --length-message-preview-embeds: 7em;
 
     /*
     Reaction container UI scaling.

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -716,7 +716,6 @@
         height: calc(var(--length-message-preview-embeds) + 10px);
         padding: 5px;
         border-left: 3px solid hsl(0deg 0% 93%);
-        text-shadow: hsl(0deg 0% 0% / 1%) 0 0 1px;
 
         .message_embed_title {
             font-size: 1.2em;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -732,7 +732,7 @@
                 color: var(--color-markdown-link-hover);
             }
 
-            a {
+            .message-embed-title-link {
                 /* Line-clamp lines seem to have a small
                    interline area that's not clickable
                    unless we set the anchor to display as

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -721,6 +721,36 @@
             font-size: 1.2em;
             /* 5px at 16.8px (1.2 * 14px) */
             margin-top: -0.2976em;
+            /* We set the markdown link colors here so
+               that the ellipsis takes it on truncated
+               lines. The ellipsis will not take an
+               underline even if we specify one, so
+               that is deliberately omitted here. */
+            color: var(--color-markdown-link);
+
+            &:hover {
+                color: var(--color-markdown-link-hover);
+            }
+
+            a {
+                /* Line-clamp lines seem to have a small
+                   interline area that's not clickable
+                   unless we set the anchor to display as
+                   a block. */
+                display: block;
+            }
+        }
+
+        .message_embed_title,
+        .message_embed_description {
+            /* Clamp multi-line titles and descriptions
+               to two lines. */
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+            overflow: hidden;
+            /* Break overflowing words as necessary. */
+            overflow-wrap: break-word;
         }
 
         .message_embed_image {
@@ -735,18 +765,6 @@
         .data-container {
             grid-area: data-container;
             overflow: hidden;
-        }
-
-        &::after {
-            content: " ";
-            grid-area: fader;
-            height: 100%;
-
-            background: linear-gradient(
-                0deg,
-                var(--color-background-stream-message-content),
-                transparent 100%
-            );
         }
     }
 

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -34,6 +34,15 @@ run_test("postprocess_content", () => {
                 '<a class="" href="https://www.youtube.com/watch?v=tyKJueEk0XM">' +
                 '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/default.jpg">' +
                 "</a>" +
+                "</div>" +
+                '<div class="message_embed">' +
+                '<a class="message_embed_image" href="https://example.com/about" style="background-image: url(&quot;https://example.com/preview.jpeg&quot;)"></a>' +
+                '<div class="data-container">' +
+                '<div class="message_embed_title">' +
+                '<a href="https://example.com/about">About us</a>' +
+                "</div>" +
+                '<div class="message_embed_description">All about us.</div>' +
+                "</div>" +
                 "</div>",
         ),
         '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
@@ -55,6 +64,15 @@ run_test("postprocess_content", () => {
             '<a class="media-anchor-element" href="https://www.youtube.com/watch?v=tyKJueEk0XM" target="_blank" rel="noopener noreferrer">' +
             '<img src="https://i.ytimg.com/vi/tyKJueEk0XM/mqdefault.jpg" class="media-image-element" loading="lazy">' +
             "</a>" +
+            "</div>" +
+            "</div>" +
+            '<div class="message_embed">' +
+            '<a class="message_embed_image" href="https://example.com/about" style="background-image: url(&quot;https://example.com/preview.jpeg&quot;)" target="_blank" rel="noopener noreferrer" title="https://example.com/about"></a>' +
+            '<div class="data-container">' +
+            '<div class="message_embed_title">' +
+            '<a href="https://example.com/about" target="_blank" rel="noopener noreferrer" class="message-embed-title-link" title="https://example.com/about">About us</a>' +
+            "</div>" +
+            '<div class="message_embed_description">All about us.</div>' +
             "</div>" +
             "</div>",
     );


### PR DESCRIPTION
This PR is an immediate followup to #34488. It does two primary things:

1) It opens up the height of the preview area to accommodate two lines of text each for the title and description at a +2 line-height as set by users.
2) It removes the past fading technique and instead clamps the line with an ellipsis.

Also removed here is a `text-shadow` effect that was too subtle to notice in light or dark mode. 

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/URL.20previews/near/2161694)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![long-titles-pr-original](https://github.com/user-attachments/assets/9336a04b-929d-4e5b-8278-8142456f8fa1) | ![long-titles-pr-proposed](https://github.com/user-attachments/assets/ad7230c8-cc59-4a81-8635-aa646a8ae13e) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>