### PR TITLE
ui: Hide stream name in topic header bar when already shown in navbar

### DIFF
--- a/web/templates/stream_topic_widget.hbs
+++ b/web/templates/stream_topic_widget.hbs
@@ -1,3 +1,8 @@
 <strong>
-    <span class="stream">{{stream_name}}</span> &gt; <span class="topic white-space-preserve-wrap {{#if is_empty_string_topic}}empty-topic-display{{/if}}">{{topic_display_name}}</span>
+    {{#unless hide_stream_name}}
+        <span class="stream">{{stream_name}}</span> &gt;
+    {{/unless}}
+    <span class="topic white-space-preserve-wrap {{#if is_empty_string_topic}}empty-topic-display{{/if}}">
+        {{topic_display_name}}
+    </span>
 </strong>


### PR DESCRIPTION
This change updates the topic header bar UI to hide the stream name and chevron (`›`) when the stream name is already displayed in the navbar. 
If the user is narrowed into a specific stream, the stream name is already visible at the top, so it no longer needs to be shown again in the topic bar.

The `hide_stream_name` conditional is safely handled in the template to support both views.

Tested locally in conversation view and topic-only view to confirm correct behavior.