### PR TITLE
Fix group pill expand button and refactor code to handle subscribers and members pill widget.

### DIFF
--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -53,12 +53,6 @@ export function create_item_from_text(
     text: string,
     current_items: CombinedPill[],
 ): CombinedPill | undefined {
-    const funcs = [
-        stream_pill.create_item_from_stream_name,
-        user_group_pill.create_item_from_group_name,
-        user_pill.create_item_from_email,
-    ];
-
     const stream_item = stream_pill.create_item_from_stream_name(text, current_items);
     if (stream_item) {
         return stream_item;
@@ -85,13 +79,8 @@ export function create_item_from_text(
 
         return undefined;
     }
-    for (const func of funcs) {
-        const item = func(text, current_items);
-        if (item) {
-            return item;
-        }
-    }
-    return undefined;
+
+    return user_pill.create_item_from_email(text, current_items);
 }
 
 export function create({

--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -8,7 +8,6 @@ import type {User} from "./people.ts";
 import * as stream_pill from "./stream_pill.ts";
 import type {CombinedPill, CombinedPillContainer} from "./typeahead_helper.ts";
 import * as user_group_components from "./user_group_components.ts";
-import * as user_group_create_members_data from "./user_group_create_members_data.ts";
 import * as user_group_pill from "./user_group_pill.ts";
 import * as user_groups from "./user_groups.ts";
 import type {UserGroup} from "./user_groups.ts";
@@ -87,10 +86,16 @@ export function create({
     $pill_container,
     get_potential_members,
     get_potential_groups,
+    with_add_button,
+    onPillCreateAction,
+    onPillRemoveAction,
 }: {
     $pill_container: JQuery;
     get_potential_members: () => User[];
     get_potential_groups: () => UserGroup[];
+    with_add_button: boolean;
+    onPillCreateAction?: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
+    onPillRemoveAction?: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
@@ -100,6 +105,19 @@ export function create({
         generate_pill_html: add_subscribers_pill.generate_pill_html,
         show_outline_on_invalid_input: true,
     });
+
+    if (onPillCreateAction) {
+        pill_widget.onPillCreate(() => {
+            onPillCreateAction(get_pill_user_ids(pill_widget), get_pill_group_ids(pill_widget));
+        });
+    }
+
+    if (onPillRemoveAction) {
+        pill_widget.onPillRemove(() => {
+            onPillRemoveAction(get_pill_user_ids(pill_widget), get_pill_group_ids(pill_widget));
+        });
+    }
+
     function get_users(): User[] {
         const potential_members = get_potential_members();
         return user_pill.filter_taken_users(potential_members, pill_widget);
@@ -123,57 +141,9 @@ export function create({
         for_stream_subscribers: false,
     });
 
-    add_subscribers_pill.set_up_handlers_for_add_button_state(pill_widget, $pill_container);
-
-    return pill_widget;
-}
-
-export function create_without_add_button({
-    $pill_container,
-    onPillCreateAction,
-    onPillRemoveAction,
-}: {
-    $pill_container: JQuery;
-    onPillCreateAction: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
-    onPillRemoveAction: (pill_user_ids: number[], pill_subgroup_ids: number[]) => void;
-}): CombinedPillContainer {
-    const pill_widget = input_pill.create<CombinedPill>({
-        $container: $pill_container,
-        create_item_from_text,
-        get_text_from_item: add_subscribers_pill.get_text_from_item,
-        get_display_value_from_item: add_subscribers_pill.get_display_value_from_item,
-        generate_pill_html: add_subscribers_pill.generate_pill_html,
-        show_outline_on_invalid_input: true,
-    });
-    function get_users(): User[] {
-        const potential_members = user_group_create_members_data.get_potential_members();
-        return user_pill.filter_taken_users(potential_members, pill_widget);
+    if (with_add_button) {
+        add_subscribers_pill.set_up_handlers_for_add_button_state(pill_widget, $pill_container);
     }
-
-    function get_user_groups(): UserGroup[] {
-        let potential_subgroups = user_group_create_members_data.get_potential_subgroups();
-        potential_subgroups = potential_subgroups.filter((item) => item.name !== "role:nobody");
-        return user_group_pill.filter_taken_groups(potential_subgroups, pill_widget);
-    }
-
-    pill_widget.onPillCreate(() => {
-        onPillCreateAction(get_pill_user_ids(pill_widget), get_pill_group_ids(pill_widget));
-    });
-    pill_widget.onPillRemove(() => {
-        onPillRemoveAction(get_pill_user_ids(pill_widget), get_pill_group_ids(pill_widget));
-    });
-
-    pill_widget.onPillExpand((pill) => {
-        expand_group_pill(pill, pill_widget);
-    });
-
-    add_subscribers_pill.set_up_pill_typeahead({
-        pill_widget,
-        $pill_container,
-        get_users,
-        get_user_groups,
-        for_stream_subscribers: false,
-    });
 
     return pill_widget;
 }

--- a/web/src/add_group_members_pill.ts
+++ b/web/src/add_group_members_pill.ts
@@ -69,6 +69,13 @@ export function create_item_from_text(
         const subgroup = user_groups.get_user_group_from_id(group_item.group_id);
         group_item.show_expand_button =
             subgroup.members.size > 0 || subgroup.direct_subgroup_ids.size > 0;
+
+        if (user_group_components.active_group_id === undefined) {
+            // Checking whether this group can be used as a subgroup
+            // is not needed when creating a new group.
+            return group_item;
+        }
+
         const current_group_id = user_group_components.active_group_id;
         assert(current_group_id !== undefined);
         const current_group = user_groups.get_user_group_from_id(current_group_id);
@@ -143,7 +150,7 @@ export function create_without_add_button({
 }): CombinedPillContainer {
     const pill_widget = input_pill.create<CombinedPill>({
         $container: $pill_container,
-        create_item_from_text: add_subscribers_pill.create_item_from_text,
+        create_item_from_text,
         get_text_from_item: add_subscribers_pill.get_text_from_item,
         get_display_value_from_item: add_subscribers_pill.get_display_value_from_item,
         generate_pill_html: add_subscribers_pill.generate_pill_html,

--- a/web/src/stream_create_subscribers.ts
+++ b/web/src/stream_create_subscribers.ts
@@ -53,10 +53,11 @@ function build_pill_widget({
     const $pill_container = $parent_container.find(".pill-container");
     const get_potential_subscribers = stream_create_subscribers_data.get_potential_subscribers;
     const get_user_groups = user_groups.get_all_realm_user_groups;
-    return add_subscribers_pill.create_without_add_button({
+    return add_subscribers_pill.create({
         $pill_container,
         get_potential_subscribers,
         get_user_groups,
+        with_add_button: false,
         onPillCreateAction: add_user_ids,
         // It is better to sync the current set of user ids in the input
         // instead of removing user_ids from the user_ids_set, otherwise

--- a/web/src/stream_edit_subscribers.ts
+++ b/web/src/stream_edit_subscribers.ts
@@ -121,6 +121,7 @@ export function enable_subscriber_management({
         $pill_container,
         get_potential_subscribers,
         get_user_groups: user_groups.get_all_realm_user_groups,
+        with_add_button: true,
     });
 
     $pill_container.find(".input").on("input", () => {

--- a/web/src/user_group_create_members.ts
+++ b/web/src/user_group_create_members.ts
@@ -73,8 +73,11 @@ function sync_members(user_ids: number[], subgroup_ids: number[]): void {
 function build_pill_widget({$parent_container}: {$parent_container: JQuery}): void {
     const $pill_container = $parent_container.find(".pill-container");
 
-    pill_widget = add_group_members_pill.create_without_add_button({
+    pill_widget = add_group_members_pill.create({
         $pill_container,
+        get_potential_members: user_group_create_members_data.get_potential_members,
+        get_potential_groups: user_group_create_members_data.get_potential_subgroups,
+        with_add_button: false,
         onPillCreateAction: add_members,
         // It is better to sync the current set of user and subgroup ids
         // in the input instead of removing them from the user_ids_set

--- a/web/src/user_group_edit_members.ts
+++ b/web/src/user_group_edit_members.ts
@@ -145,6 +145,7 @@ export function enable_member_management({
         $pill_container,
         get_potential_members,
         get_potential_groups: get_potential_subgroups,
+        with_add_button: true,
     });
 
     $pill_container.find(".input").on("input", () => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to fix "Expand" button not visible in group pills in group creation form when pill is created without selecting an option from typeahead.
- Second commit is a small refactor of `add_group_members_pill.create_item_from_text`.
- Third commit is to have single function instead of two separate `create` and `create_without_add_button`.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
