### PR TITLE
hotkey: Fix warning about unused `login_to_access` import.

### DIFF
--- a/web/src/spectators.ts
+++ b/web/src/spectators.ts
@@ -26,7 +26,7 @@ export function build_login_link(): string {
     return login_link;
 }
 
-export function login_to_access(empty_narrow?: boolean): void {
+export let login_to_access = (empty_narrow?: boolean): void => {
     // Hide all overlays, popover and go back to the previous hash if the
     // hash has changed.
     const login_link = build_login_link();
@@ -49,4 +49,8 @@ export function login_to_access(empty_narrow?: boolean): void {
             browser_history.return_to_web_public_hash();
         },
     });
+};
+
+export function rewire_login_to_access(value: typeof login_to_access): void {
+    login_to_access = value;
 }

--- a/web/tests/hotkey.test.cjs
+++ b/web/tests/hotkey.test.cjs
@@ -96,9 +96,7 @@ mock_esm("../src/recent_view_ui", {
     is_in_focus: () => false,
 });
 
-const spectators = mock_esm("../src/spectators", {
-    login_to_access() {},
-});
+const spectators = zrequire("../src/spectators");
 
 message_lists.current = {
     visibly_empty() {
@@ -569,11 +567,11 @@ run_test("test new user input hook called", () => {
     assert.ok(hook_called);
 });
 
-run_test("e shortcut works for anonymous users", () => {
+run_test("e shortcut works for anonymous users", ({override_rewire}) => {
     page_params.is_spectator = true;
 
     const stub = make_stub();
-    spectators.login_to_access = stub.f;
+    override_rewire(spectators, "login_to_access", stub.f);
 
     const e = {
         which: "e".codePointAt(0),
@@ -581,4 +579,7 @@ run_test("e shortcut works for anonymous users", () => {
 
     process_keydown(e);
     assert.equal(stub.num_calls, 0, "login_to_access should not be called for 'e' shortcut");
+    // Fake call to avoid warning about unused stub.
+    spectators.login_to_access();
+    assert.equal(stub.num_calls, 1);
 });


### PR DESCRIPTION
Fixes unused import warning on running hotkey node tests. This was introduced in #34314.