### PR TITLE
utils: Fix decode_stream_topic_from_url to pass origin to construct url.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -323,7 +323,7 @@ export function decode_stream_topic_from_url(
     url_str: string,
 ): {stream_id: number; topic_name?: string; message_id?: string} | null {
     try {
-        const url = new URL(url_str);
+        const url = new URL(url_str, window.location.origin);
         if (url.origin !== window.location.origin || !url.hash.startsWith("#narrow")) {
             return null;
         }

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -239,9 +239,7 @@ export const update_elements = ($content: JQuery): void => {
     $content.find("a.stream-topic, a.message-link").each(function (): void {
         const narrow_url = $(this).attr("href");
         assert(narrow_url !== undefined);
-        const channel_topic = hash_util.decode_stream_topic_from_url(
-            window.location.origin + narrow_url,
-        );
+        const channel_topic = hash_util.decode_stream_topic_from_url(narrow_url);
         assert(channel_topic !== null);
         const channel_name = sub_store.maybe_get_stream_name(channel_topic.stream_id);
         if (channel_name !== undefined && $(this).find(".highlight").length === 0) {


### PR DESCRIPTION
This PR refactors the `decode_stream_topic_from_url` to pass `window.location.origin` to the `new URL()` constructor to generate complete URL.

discussion: [link](https://github.com/zulip/zulip/pull/33402#issuecomment-2833605005)
related pr: #33402 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
