### PR TITLE
Gitlab event coverage

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/feature_flag_hook__activated.json
+++ b/zerver/webhooks/gitlab/fixtures/feature_flag_hook__activated.json
@@ -1,0 +1,35 @@
+{
+    "object_kind": "feature_flag",
+    "project": {
+        "id": 68452408,
+        "name": "sample",
+        "description": null,
+        "web_url": "https://gitlab.com/kolanuvarun/sample",
+        "avatar_url": null,
+        "git_ssh_url": "git@gitlab.com:kolanuvarun/sample.git",
+        "git_http_url": "https://gitlab.com/kolanuvarun/sample.git",
+        "namespace": "kolanuvarun",
+        "visibility_level": 0,
+        "path_with_namespace": "kolanuvarun/sample",
+        "default_branch": "master",
+        "ci_config_path": "",
+        "homepage": "https://gitlab.com/kolanuvarun/sample",
+        "url": "git@gitlab.com:kolanuvarun/sample.git",
+        "ssh_url": "git@gitlab.com:kolanuvarun/sample.git",
+        "http_url": "https://gitlab.com/kolanuvarun/sample.git"
+    },
+    "user": {
+        "id": 26076637,
+        "name": "Varun Kolanu",
+        "username": "kolanuvarun739",
+        "avatar_url": "https://secure.gravatar.com/avatar/dde05c11435528ac083e918ce384c5b943c7ec54be520b7f4a4bcd3863b36060?s=80&d=identicon",
+        "email": "[REDACTED]"
+    },
+    "user_url": "https://gitlab.com/kolanuvarun739",
+    "object_attributes": {
+        "id": 2073324,
+        "name": "sample-feature-flag",
+        "description": "",
+        "active": true
+    }
+}

--- a/zerver/webhooks/gitlab/fixtures/feature_flag_hook__deactivated.json
+++ b/zerver/webhooks/gitlab/fixtures/feature_flag_hook__deactivated.json
@@ -1,0 +1,35 @@
+{
+    "object_kind": "feature_flag",
+    "project": {
+        "id": 68452408,
+        "name": "sample",
+        "description": null,
+        "web_url": "https://gitlab.com/kolanuvarun/sample",
+        "avatar_url": null,
+        "git_ssh_url": "git@gitlab.com:kolanuvarun/sample.git",
+        "git_http_url": "https://gitlab.com/kolanuvarun/sample.git",
+        "namespace": "kolanuvarun",
+        "visibility_level": 0,
+        "path_with_namespace": "kolanuvarun/sample",
+        "default_branch": "master",
+        "ci_config_path": "",
+        "homepage": "https://gitlab.com/kolanuvarun/sample",
+        "url": "git@gitlab.com:kolanuvarun/sample.git",
+        "ssh_url": "git@gitlab.com:kolanuvarun/sample.git",
+        "http_url": "https://gitlab.com/kolanuvarun/sample.git"
+    },
+    "user": {
+        "id": 26076637,
+        "name": "Varun Kolanu",
+        "username": "kolanuvarun739",
+        "avatar_url": "https://secure.gravatar.com/avatar/dde05c11435528ac083e918ce384c5b943c7ec54be520b7f4a4bcd3863b36060?s=80&d=identicon",
+        "email": "[REDACTED]"
+    },
+    "user_url": "https://gitlab.com/kolanuvarun739",
+    "object_attributes": {
+        "id": 2073324,
+        "name": "sample-feature-flag",
+        "description": "",
+        "active": false
+    }
+}

--- a/zerver/webhooks/gitlab/fixtures/resource_access_token_hook__group_expiry.json
+++ b/zerver/webhooks/gitlab/fixtures/resource_access_token_hook__group_expiry.json
@@ -1,0 +1,17 @@
+{
+    "object_kind": "access_token",
+    "group": {
+      "group_name": "Twitter",
+      "group_path": "twitter",
+      "group_id": 35,
+      "full_path": "twitter"
+    },
+    "object_attributes": {
+      "user_id": 90,
+      "created_at": "2024-01-24 16:27:40 UTC",
+      "id": 25,
+      "name": "acd",
+      "expires_at": "2024-01-26"
+    },
+    "event_name": "expiring_access_token"
+  }

--- a/zerver/webhooks/gitlab/fixtures/resource_access_token_hook__project_expiry.json
+++ b/zerver/webhooks/gitlab/fixtures/resource_access_token_hook__project_expiry.json
@@ -1,0 +1,29 @@
+{
+    "object_kind": "access_token",
+    "project": {
+      "id": 7,
+      "name": "Flight",
+      "description": "Eum dolore maxime atque reprehenderit voluptatem.",
+      "web_url": "https://example.com/flightjs/Flight",
+      "avatar_url": null,
+      "git_ssh_url": "ssh://git@example.com/flightjs/Flight.git",
+      "git_http_url": "https://example.com/flightjs/Flight.git",
+      "namespace": "Flightjs",
+      "visibility_level": 0,
+      "path_with_namespace": "flightjs/Flight",
+      "default_branch": "master",
+      "ci_config_path": null,
+      "homepage": "https://example.com/flightjs/Flight",
+      "url": "ssh://git@example.com/flightjs/Flight.git",
+      "ssh_url": "ssh://git@example.com/flightjs/Flight.git",
+      "http_url": "https://example.com/flightjs/Flight.git"
+    },
+    "object_attributes": {
+      "user_id": 90,
+      "created_at": "2024-01-24 16:27:40 UTC",
+      "id": 25,
+      "name": "acd",
+      "expires_at": "2024-01-26"
+    },
+    "event_name": "expiring_access_token"
+  }

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -669,3 +669,15 @@ A trivial change that should probably be ignored.
         expected_message = "Release v1.1 for tag v1.1 was deleted."
 
         self.check_webhook("release_hook__delete", expected_topic_name, expected_message)
+
+    def test_feature_flag_activate_event_message(self) -> None:
+        expected_topic_name = "sample"
+        expected_message = "Varun Kolanu **activated** the [sample-feature-flag](https://gitlab.com/kolanuvarun/sample/-/feature_flags) feature flag."
+
+        self.check_webhook("feature_flag_hook__activated", expected_topic_name, expected_message)
+
+    def test_feature_flag_deactivate_event_message(self) -> None:
+        expected_topic_name = "sample"
+        expected_message = "Varun Kolanu **deactivated** the [sample-feature-flag](https://gitlab.com/kolanuvarun/sample/-/feature_flags) feature flag."
+
+        self.check_webhook("feature_flag_hook__deactivated", expected_topic_name, expected_message)

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -681,3 +681,19 @@ A trivial change that should probably be ignored.
         expected_message = "Varun Kolanu **deactivated** the [sample-feature-flag](https://gitlab.com/kolanuvarun/sample/-/feature_flags) feature flag."
 
         self.check_webhook("feature_flag_hook__deactivated", expected_topic_name, expected_message)
+
+    def test_resource_access_token_project_expiry(self) -> None:
+        expected_topic_name = "Flight"
+        expected_message = "The access token [acd](https://example.com/flightjs/Flight/-/settings/access_tokens) is going to expire on **Jan 26, 2024**"
+
+        self.check_webhook(
+            "resource_access_token_hook__project_expiry", expected_topic_name, expected_message
+        )
+
+    def test_resource_access_token_group_expiry(self) -> None:
+        expected_topic_name = "Twitter"
+        expected_message = "The access token [acd](https://gitlab.com/groups/twitter/-/settings/access_tokens) is going to expire on **Jan 26, 2024**"
+
+        self.check_webhook(
+            "resource_access_token_hook__group_expiry", expected_topic_name, expected_message
+        )

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -36,6 +36,8 @@ DESIGN_COMMENT_MESSAGE_TEMPLATE = (
     "{user_name} {action} on design [{design_name}]({design_url}):\n{content_message}"
 )
 
+FEATURE_FLAG_MESSAGE_TEMPLATE = "{user} **{action}** the [{name}]({url}) feature flag."
+
 
 def fixture_to_headers(fixture_name: str) -> dict[str, str]:
     if fixture_name.startswith("build"):
@@ -408,6 +410,19 @@ def get_release_event_body(payload: WildValue, include_title: bool) -> str:
     return body
 
 
+def get_feature_flag_event_body(payload: WildValue, include_title: bool) -> str:
+    repo_url = payload["project"]["web_url"].tame(check_string)
+    feature_flag = payload["object_attributes"]
+    action = "activated" if feature_flag["active"] else "deactivated"
+
+    return FEATURE_FLAG_MESSAGE_TEMPLATE.format(
+        user=payload["user"]["name"].tame(check_string),
+        action=action,
+        name=feature_flag["name"].tame(check_string),
+        url=f"{repo_url}/-/feature_flags",
+    )
+
+
 def get_repo_name(payload: WildValue) -> str:
     if "project" in payload:
         return payload["project"]["name"].tame(check_string)
@@ -491,6 +506,7 @@ EVENT_FUNCTION_MAPPER: dict[str, EventFunction] = {
     "Build Hook": get_build_hook_event_body,
     "Pipeline Hook": get_pipeline_event_body,
     "Release Hook": get_release_event_body,
+    "Feature Flag Hook": get_feature_flag_event_body,
 }
 
 ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timezone
 from typing import Protocol
 
 from django.http import HttpRequest, HttpResponse
@@ -37,6 +38,10 @@ DESIGN_COMMENT_MESSAGE_TEMPLATE = (
 )
 
 FEATURE_FLAG_MESSAGE_TEMPLATE = "{user} **{action}** the [{name}]({url}) feature flag."
+
+ACCESS_TOKEN_EXPIRY_MESSAGE_TEMPLATE = (
+    "The access token [{name}]({url}) is going to expire on **{date}**"
+)
 
 
 def fixture_to_headers(fixture_name: str) -> dict[str, str]:
@@ -423,6 +428,33 @@ def get_feature_flag_event_body(payload: WildValue, include_title: bool) -> str:
     )
 
 
+def get_access_token_page_url(payload: WildValue) -> str:
+    if payload.get("group"):
+        group_path = payload["group"]["group_path"].tame(check_string)
+        return f"https://gitlab.com/groups/{group_path}/-/settings/access_tokens"
+
+    # The access token expiry event payload contains either a group field
+    # or a project field, depending on where the access token exists.
+    project_url = payload["project"]["web_url"].tame(check_string)
+    return f"{project_url}/-/settings/access_tokens"
+
+
+def get_resource_access_token_expiry_event_body(payload: WildValue, include_title: bool) -> str:
+    access_token = payload["object_attributes"]
+    expiry_date = access_token["expires_at"].tame(check_string)
+    formatted_date = (
+        datetime.strptime(expiry_date, "%Y-%m-%d")
+        .replace(tzinfo=timezone.utc)
+        .strftime("%b %d, %Y")
+    )
+
+    return ACCESS_TOKEN_EXPIRY_MESSAGE_TEMPLATE.format(
+        name=access_token["name"].tame(check_string),
+        url=get_access_token_page_url(payload),
+        date=formatted_date,
+    )
+
+
 def get_repo_name(payload: WildValue) -> str:
     if "project" in payload:
         return payload["project"]["name"].tame(check_string)
@@ -507,6 +539,7 @@ EVENT_FUNCTION_MAPPER: dict[str, EventFunction] = {
     "Pipeline Hook": get_pipeline_event_body,
     "Release Hook": get_release_event_body,
     "Feature Flag Hook": get_feature_flag_event_body,
+    "Resource Access Token Hook": get_resource_access_token_expiry_event_body,
 }
 
 ALL_EVENT_TYPES = list(EVENT_FUNCTION_MAPPER.keys())
@@ -615,6 +648,9 @@ def get_topic_based_on_event(event: str, payload: WildValue, use_merge_request_t
             id=payload["snippet"]["id"].tame(check_int),
             title=payload["snippet"]["title"].tame(check_string),
         )
+
+    elif event == "Resource Access Token Hook" and payload.get("group"):
+        return payload["group"]["group_name"].tame(check_string)
     return get_repo_name(payload)
 
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes #34405.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

- This PR adds support for the `Feature Flag Hook` event and `Access Token Expiry` events.
- The `Comment events` mentioned in the issue are already supported currently by zulip.
- Dates are formatted into a readable format like `Jan 26, 2024` for Access Token Expiry events.

**Some assumptions from my side**:

1. There isn't a direct link corresponding to each feature flag event. Instead, all the flags are listed on a single page called `feature_flags`. So, I linked the feature flag name to that global page.
2. The Access Token Expiry event is triggered 1 day, 1 week, 30 days, and 60 days before expiry. I considered including labels like "expiring tomorrow" or "expiring after 7 days," but decided against it because the timeline might be inaccurate if the user doesn't see the alert on the same day it was issued.
3. To test the Access Token Expiry event, I would need a self-hosted GitLab instance, which I currently don't have. Therefore, I used the webhook payload provided directly in the GitLab documentation.

**Screenshots and screen captures:**

Feature Flag Event:

![image](https://github.com/user-attachments/assets/25b52d9f-0ea0-499b-8c71-1580e7618079)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
