### PR TITLE
org_settings: Correctly display long channel names.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -830,6 +830,23 @@ input[type="checkbox"] {
 #organization-settings {
     .dropdown-widget-button {
         color: hsl(0deg 0% 33%);
+
+        .dropdown_widget_value {
+            /* The max-width should account for the
+               16px-square box (at 16px/1em) for the
+               chevron icon. */
+            max-width: calc(100% - 1em);
+            display: flex;
+            align-items: baseline;
+            /* Mimic the space from the previous inline
+               layout. */
+            gap: 0.4ch;
+        }
+
+        .decorated-channel-name {
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+        }
     }
 }
 


### PR DESCRIPTION
This corrects the display of long channels in org settings.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/long.20one-word.20channel.20name.20breaks.20announcement.20settings/near/2163246)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

_No change for short channel names:_

| Before | After |
| --- | --- |
| ![long-channels-before](https://github.com/user-attachments/assets/db47a78f-0525-4663-a0c1-49195c8bd60e) | ![long-channels-after](https://github.com/user-attachments/assets/7ad82e70-5b46-4c8f-b576-55b4511383bc) |
| ![short-channels-before](https://github.com/user-attachments/assets/3d6a7569-f5db-4d4c-80e2-66d6332b2784) | ![short-channels-after](https://github.com/user-attachments/assets/f539a034-2745-485d-a320-56d055060644) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>