### PR TITLE
demo-org: Update navbar alert banner to have buttons, instead of links.

### DIFF
--- a/web/src/demo_organizations_ui.ts
+++ b/web/src/demo_organizations_ui.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import assert from "minimalistic-assert";
 import {z} from "zod";
 
 import render_convert_demo_organization_form from "../templates/settings/convert_demo_organization_form.hbs";
@@ -8,13 +9,21 @@ import * as channel from "./channel.ts";
 import * as dialog_widget from "./dialog_widget.ts";
 import {$t} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
-import {get_demo_organization_deadline_days_remaining} from "./navbar_alerts.ts";
 import * as settings_config from "./settings_config.ts";
 import * as settings_data from "./settings_data.ts";
 import * as settings_org from "./settings_org.ts";
 import type {RequestOpts} from "./settings_ui.ts";
 import {current_user, realm} from "./state_data.ts";
 import type {HTMLSelectOneElement} from "./types.ts";
+
+export function get_demo_organization_deadline_days_remaining(): number {
+    const now = Date.now();
+    assert(realm.demo_organization_scheduled_deletion_date !== undefined);
+    const deadline = realm.demo_organization_scheduled_deletion_date * 1000;
+    const day = 24 * 60 * 60 * 1000; // hours * minutes * seconds * milliseconds
+    const days_remaining = Math.round(Math.abs(deadline - now) / day);
+    return days_remaining;
+}
 
 export function insert_demo_organization_warning(): void {
     const days_remaining = get_demo_organization_deadline_days_remaining();

--- a/web/src/demo_organizations_ui.ts
+++ b/web/src/demo_organizations_ui.ts
@@ -35,77 +35,81 @@ export function insert_demo_organization_warning(): void {
     $(".organization-box").find(".settings-section").prepend($(rendered_demo_organization_warning));
 }
 
+export function do_convert_demo_organization(): void {
+    if (!current_user.is_owner) {
+        return;
+    }
+
+    const email_set = !settings_data.user_email_not_configured();
+    const parts = new URL(realm.realm_url).hostname.split(".");
+    parts.shift();
+    const domain = parts.join(".");
+    const html_body = render_convert_demo_organization_form({
+        realm_domain: domain,
+        user_has_email_set: email_set,
+        realm_org_type_values: settings_org.get_org_type_dropdown_options(),
+    });
+
+    function demo_organization_conversion_post_render(): void {
+        const $convert_submit_button = $(
+            "#demo-organization-conversion-modal .dialog_submit_button",
+        );
+        $convert_submit_button.prop("disabled", true);
+        $("#add_organization_type").val(realm.realm_org_type);
+
+        if (!email_set) {
+            // Disable form fields if demo organization owner email not set.
+            $("#add_organization_type").prop("disabled", true);
+            $("#new_subdomain").prop("disabled", true);
+        } else {
+            // Disable submit button if either form field blank.
+            $("#convert-demo-organization-form").on("input change", () => {
+                const string_id = $<HTMLInputElement>("input#new_subdomain").val()!.trim();
+                const org_type = $<HTMLSelectOneElement>(
+                    "select:not([multiple])#add_organization_type",
+                ).val()!;
+                $convert_submit_button.prop(
+                    "disabled",
+                    string_id === "" ||
+                        Number.parseInt(org_type, 10) ===
+                            settings_config.all_org_type_values.unspecified.code,
+                );
+            });
+        }
+    }
+
+    function submit_subdomain(): void {
+        const $string_id = $("#new_subdomain");
+        const $organization_type = $("#add_organization_type");
+        const data = {
+            string_id: $string_id.val(),
+            org_type: $organization_type.val(),
+        };
+        const opts: RequestOpts = {
+            success_continuation(raw_data) {
+                const data = z.object({realm_url: z.string()}).parse(raw_data);
+                window.location.href = data.realm_url;
+            },
+        };
+        dialog_widget.submit_api_request(channel.patch, "/json/realm", data, opts);
+    }
+
+    dialog_widget.launch({
+        html_heading: $t({defaultMessage: "Make organization permanent"}),
+        html_body,
+        on_click: submit_subdomain,
+        post_render: demo_organization_conversion_post_render,
+        html_submit_button: $t({defaultMessage: "Convert"}),
+        id: "demo-organization-conversion-modal",
+        loading_spinner: true,
+        help_link:
+            "/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization",
+    });
+}
+
 export function handle_demo_organization_conversion(): void {
     $(".convert-demo-organization-button").on("click", () => {
-        if (!current_user.is_owner) {
-            return;
-        }
-
-        const email_set = !settings_data.user_email_not_configured();
-        const parts = new URL(realm.realm_url).hostname.split(".");
-        parts.shift();
-        const domain = parts.join(".");
-        const html_body = render_convert_demo_organization_form({
-            realm_domain: domain,
-            user_has_email_set: email_set,
-            realm_org_type_values: settings_org.get_org_type_dropdown_options(),
-        });
-
-        function demo_organization_conversion_post_render(): void {
-            const $convert_submit_button = $(
-                "#demo-organization-conversion-modal .dialog_submit_button",
-            );
-            $convert_submit_button.prop("disabled", true);
-            $("#add_organization_type").val(realm.realm_org_type);
-
-            if (!email_set) {
-                // Disable form fields if demo organization owner email not set.
-                $("#add_organization_type").prop("disabled", true);
-                $("#new_subdomain").prop("disabled", true);
-            } else {
-                // Disable submit button if either form field blank.
-                $("#convert-demo-organization-form").on("input change", () => {
-                    const string_id = $<HTMLInputElement>("input#new_subdomain").val()!.trim();
-                    const org_type = $<HTMLSelectOneElement>(
-                        "select:not([multiple])#add_organization_type",
-                    ).val()!;
-                    $convert_submit_button.prop(
-                        "disabled",
-                        string_id === "" ||
-                            Number.parseInt(org_type, 10) ===
-                                settings_config.all_org_type_values.unspecified.code,
-                    );
-                });
-            }
-        }
-
-        function submit_subdomain(): void {
-            const $string_id = $("#new_subdomain");
-            const $organization_type = $("#add_organization_type");
-            const data = {
-                string_id: $string_id.val(),
-                org_type: $organization_type.val(),
-            };
-            const opts: RequestOpts = {
-                success_continuation(raw_data) {
-                    const data = z.object({realm_url: z.string()}).parse(raw_data);
-                    window.location.href = data.realm_url;
-                },
-            };
-            dialog_widget.submit_api_request(channel.patch, "/json/realm", data, opts);
-        }
-
-        dialog_widget.launch({
-            html_heading: $t({defaultMessage: "Make organization permanent"}),
-            html_body,
-            on_click: submit_subdomain,
-            post_render: demo_organization_conversion_post_render,
-            html_submit_button: $t({defaultMessage: "Convert"}),
-            id: "demo-organization-conversion-modal",
-            loading_spinner: true,
-            help_link:
-                "/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization",
-        });
+        do_convert_demo_organization();
     });
 
     // Treat Enter with convert demo organization link as a click.

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -7,6 +7,7 @@ import render_navbar_banners_testing_popover from "../templates/popovers/navbar_
 
 import * as banners from "./banners.ts";
 import type {AlertBanner} from "./banners.ts";
+import type {ActionButton} from "./buttons.ts";
 import * as channel from "./channel.ts";
 import * as demo_organizations_ui from "./demo_organizations_ui.ts";
 import * as desktop_notifications from "./desktop_notifications.ts";
@@ -351,6 +352,23 @@ const bankruptcy_banner = (): AlertBanner => {
 
 const demo_organization_deadline_banner = (): AlertBanner => {
     const days_remaining = demo_organizations_ui.get_demo_organization_deadline_days_remaining();
+    let buttons: ActionButton[] = [
+        {
+            attention: "borderless",
+            label: $t({defaultMessage: "Learn more"}),
+            custom_classes: "demo-organizations-help",
+        },
+    ];
+    if (current_user.is_owner) {
+        buttons = [
+            ...buttons,
+            {
+                attention: "quiet",
+                label: $t({defaultMessage: "Convert"}),
+                custom_classes: "convert-demo-organization",
+            },
+        ];
+    }
     return {
         process: "demo-organization-deadline",
         intent: days_remaining <= 7 ? "danger" : "info",
@@ -358,18 +376,14 @@ const demo_organization_deadline_banner = (): AlertBanner => {
             $t_html(
                 {
                     defaultMessage:
-                        "This <z-demo-link>demo organization</z-demo-link> will be automatically deleted in {days_remaining} days, unless it's <z-convert-link>converted into a permanent organization</z-convert-link>.",
+                        "This demo organization will be automatically deleted in {days_remaining} days, unless it's converted into a permanent organization.",
                 },
                 {
-                    "z-demo-link": (content_html) =>
-                        `<a class="banner-link" href="https://zulip.com/help/demo-organizations" target="_blank" rel="noopener noreferrer">${content_html.join("")}</a>`,
-                    "z-convert-link": (content_html) =>
-                        `<a class="banner-link" href="https://zulip.com/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">${content_html.join("")}</a>`,
                     days_remaining,
                 },
             ),
         ),
-        buttons: [],
+        buttons,
         close_button: true,
         custom_classes: "navbar-alert-banner",
     };
@@ -490,6 +504,14 @@ export function initialize(): void {
         setTimeout(() => {
             close_navbar_banner_and_resize($banner);
         }, 2000);
+    });
+
+    $("#navbar_alerts_wrapper").on("click", ".convert-demo-organization", () => {
+        demo_organizations_ui.do_convert_demo_organization();
+    });
+
+    $("#navbar_alerts_wrapper").on("click", ".demo-organizations-help", () => {
+        window.open("https://zulip.com/help/demo-organizations", "_blank", "noopener,noreferrer");
     });
 
     $("#navbar_alerts_wrapper").on("click", ".configure-outgoing-mail-instructions", () => {

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -8,6 +8,7 @@ import render_navbar_banners_testing_popover from "../templates/popovers/navbar_
 import * as banners from "./banners.ts";
 import type {AlertBanner} from "./banners.ts";
 import * as channel from "./channel.ts";
+import * as demo_organizations_ui from "./demo_organizations_ui.ts";
 import * as desktop_notifications from "./desktop_notifications.ts";
 import * as feedback_widget from "./feedback_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
@@ -170,15 +171,6 @@ export function toggle_organization_profile_incomplete_banner(): void {
         // this is meant to be a one-time task for administrators.
         open_navbar_banner_and_resize(ORGANIZATION_PROFILE_INCOMPLETE_BANNER);
     }
-}
-
-export function get_demo_organization_deadline_days_remaining(): number {
-    const now = Date.now();
-    assert(realm.demo_organization_scheduled_deletion_date !== undefined);
-    const deadline = realm.demo_organization_scheduled_deletion_date * 1000;
-    const day = 24 * 60 * 60 * 1000; // hours * minutes * seconds * milliseconds
-    const days_remaining = Math.round(Math.abs(deadline - now) / day);
-    return days_remaining;
 }
 
 export function should_offer_to_update_timezone(): boolean {
@@ -358,7 +350,7 @@ const bankruptcy_banner = (): AlertBanner => {
 };
 
 const demo_organization_deadline_banner = (): AlertBanner => {
-    const days_remaining = get_demo_organization_deadline_days_remaining();
+    const days_remaining = demo_organizations_ui.get_demo_organization_deadline_days_remaining();
     return {
         process: "demo-organization-deadline",
         intent: days_remaining <= 7 ? "danger" : "info",

--- a/web/src/portico/showroom.ts
+++ b/web/src/portico/showroom.ts
@@ -103,20 +103,23 @@ const alert_banners: Record<string, AlertBanner> = {
         process: "demo-organization-deadline",
         intent: "info",
         label: new Handlebars.SafeString(
-            $t_html(
-                {
-                    defaultMessage:
-                        "This <demo_link>demo organization</demo_link> will be automatically deleted in 30 days, unless it's <convert_link>converted into a permanent organization</convert_link>.",
-                },
-                {
-                    demo_link: (content_html) =>
-                        `<a class="banner-link" href="https://zulip.com/help/demo-organizations" target="_blank" rel="noopener noreferrer">${content_html.join("")}</a>`,
-                    convert_link: (content_html) =>
-                        `<a class="banner-link" href="https://zulip.com/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">${content_html.join("")}</a>`,
-                },
-            ),
+            $t_html({
+                defaultMessage:
+                    "This demo organization will be automatically deleted in 30 days, unless it's converted into a permanent organization.",
+            }),
         ),
-        buttons: [],
+        buttons: [
+            {
+                attention: "borderless",
+                intent: "info",
+                label: $t({defaultMessage: "Learn more"}),
+            },
+            {
+                attention: "quiet",
+                intent: "info",
+                label: $t({defaultMessage: "Convert"}),
+            },
+        ],
         close_button: true,
         custom_classes: "navbar-alert-banner",
     },

--- a/web/tests/demo_organizations.test.cjs
+++ b/web/tests/demo_organizations.test.cjs
@@ -1,0 +1,27 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {addDays} = require("date-fns");
+
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const demo_organization_ui = zrequire("demo_organizations_ui");
+const {set_realm} = zrequire("state_data");
+
+const realm = {};
+set_realm(realm);
+
+run_test("get_demo_organization_deadline_days_remaining", ({override}) => {
+    const start_time = new Date("2024-01-01T10:00:00.000Z"); // Wednesday 1/1/2024 10:00:00 AM (UTC+0)
+    override(Date, "now", () => start_time);
+
+    const demo_organization_scheduled_deletion_date = addDays(start_time, 7); // Wednesday 1/8/2024 10:00:00 AM (UTC+0)
+    override(
+        realm,
+        "demo_organization_scheduled_deletion_date",
+        Math.trunc(demo_organization_scheduled_deletion_date / 1000),
+    );
+    assert.equal(demo_organization_ui.get_demo_organization_deadline_days_remaining(), 7);
+});

--- a/web/tests/navbar_alerts.test.cjs
+++ b/web/tests/navbar_alerts.test.cjs
@@ -152,16 +152,3 @@ test("should_show_server_upgrade_banner", ({override}) => {
     override(Date, "now", () => addDays(start_time, 8).getTime()); // Thursday 1/9/2024 10:00:00 AM (UTC+0)
     assert.equal(navbar_alerts.should_show_server_upgrade_banner(ls), true);
 });
-
-test("get_demo_organization_deadline_days_remaining", ({override}) => {
-    const start_time = new Date("2024-01-01T10:00:00.000Z"); // Wednesday 1/1/2024 10:00:00 AM (UTC+0)
-    override(Date, "now", () => start_time);
-
-    const demo_organization_scheduled_deletion_date = addDays(start_time, 7); // Wednesday 1/8/2024 10:00:00 AM (UTC+0)
-    override(
-        realm,
-        "demo_organization_scheduled_deletion_date",
-        Math.trunc(demo_organization_scheduled_deletion_date / 1000),
-    );
-    assert.equal(navbar_alerts.get_demo_organization_deadline_days_remaining(), 7);
-});


### PR DESCRIPTION
Part of #34447:

> **Navbar banner**
> Text: remove all links
> Buttons:
>  - Learn more
>      - low emphasis
>      - link to /help/demo-organizations
>  - Convert
>      - medium emphasis
>      - opens conversion modal

**Notes**:
- Only includes the "Convert" button that opens the conversion modal for organization owners. All other users just have the button with the link to the help center.
- Also updates the demo organization banner in the devtools showroom code to match the changes to the implemented banner. I'm not sure if these are still useful to keep in sync or if we just want to keep an example of each type of banner. If it's the latter, then we could also just remove this banner from that page.

---

**Screenshots and screen captures:**

| Description | Screenshot |
| --- | --- |
| Before - all users | ![Screenshot from 2025-04-29 19-48-08](https://github.com/user-attachments/assets/da3d588f-e999-4f3f-af11-a3b2761c80e2)
| After - owners | ![Screenshot from 2025-04-29 19-51-10](https://github.com/user-attachments/assets/7297284e-9af8-4a8c-8ec0-899e4519f485)
| After -  non-owners | ![Screenshot from 2025-04-29 19-50-51](https://github.com/user-attachments/assets/84e5481d-4e53-480d-a2eb-2e99f0aea061)


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
