### PR TITLE
left_sidebar: Correct for bleedthrough on zoomed-in channel.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -1879,9 +1879,13 @@ li.topic-list-item {
 .zoom-in {
     .narrow-filter > .bottom_left_row {
         position: sticky;
+        /* We subtract a quarter pixel of space to correct
+           for possible bleedthrough under certain viewing
+           conditions (e.g., external monitors.) This same
+           technique is used on #streams_header. */
         top: calc(
             var(--left-sidebar-sections-vertical-gutter) +
-                var(--line-height-sidebar-row-prominent)
+                var(--line-height-sidebar-row-prominent) - 0.25px
         );
         z-index: 2;
         padding-bottom: 1px;


### PR DESCRIPTION
This PR uses the same quarter-pixel adjustment to avoid bleedthrough around sticky headers as was used in #32906.

[CZO issue](https://chat.zulip.org/#narrow/channel/9-issues/topic/bleedthrough.20in.20.22all.20conversations.22.20view/near/2146978)
