### PR TITLE
demo-orgs: Use banners for org settings demo organization warning.

### DIFF
--- a/web/src/demo_organizations_ui.ts
+++ b/web/src/demo_organizations_ui.ts
@@ -108,7 +108,9 @@ export function do_convert_demo_organization(): void {
 }
 
 export function handle_demo_organization_conversion(): void {
-    $(".convert-demo-organization-button").on("click", () => {
+    $(".convert-demo-organization-button").on("click", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
         do_convert_demo_organization();
     });
 

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -1,5 +1,4 @@
 import {addDays} from "date-fns";
-import Handlebars from "handlebars";
 import $ from "jquery";
 import assert from "minimalistic-assert";
 
@@ -12,7 +11,7 @@ import * as channel from "./channel.ts";
 import * as demo_organizations_ui from "./demo_organizations_ui.ts";
 import * as desktop_notifications from "./desktop_notifications.ts";
 import * as feedback_widget from "./feedback_widget.ts";
-import {$t, $t_html} from "./i18n.ts";
+import {$t} from "./i18n.ts";
 import type {LocalStorage} from "./localstorage.ts";
 import {localstorage} from "./localstorage.ts";
 import {page_params} from "./page_params.ts";
@@ -372,16 +371,14 @@ const demo_organization_deadline_banner = (): AlertBanner => {
     return {
         process: "demo-organization-deadline",
         intent: days_remaining <= 7 ? "danger" : "info",
-        label: new Handlebars.SafeString(
-            $t_html(
-                {
-                    defaultMessage:
-                        "This demo organization will be automatically deleted in {days_remaining} days, unless it's converted into a permanent organization.",
-                },
-                {
-                    days_remaining,
-                },
-            ),
+        label: $t(
+            {
+                defaultMessage:
+                    "This demo organization will be automatically deleted in {days_remaining} days, unless it's converted into a permanent organization.",
+            },
+            {
+                days_remaining,
+            },
         ),
         buttons,
         close_button: true,

--- a/web/src/navbar_alerts.ts
+++ b/web/src/navbar_alerts.ts
@@ -503,7 +503,9 @@ export function initialize(): void {
         }, 2000);
     });
 
-    $("#navbar_alerts_wrapper").on("click", ".convert-demo-organization", () => {
+    $("#navbar_alerts_wrapper").on("click", ".convert-demo-organization", (e) => {
+        e.stopPropagation();
+        e.preventDefault();
         demo_organizations_ui.do_convert_demo_organization();
     });
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -541,30 +541,7 @@ input.settings_text_input {
 }
 
 .demo-organization-warning {
-    position: relative;
-    display: block;
-    background-color: var(
-        --color-background-settings-demo-organization-warning
-    );
-    border: 1px solid var(--color-border-settings-demo-organization-warning);
-    border-radius: 4px;
-    padding: 10px;
     margin: 10px 0;
-    font-size: 1rem;
-    line-height: 1.5;
-    color: var(--color-text-settings-demo-organization-warning);
-
-    a {
-        text-decoration: none;
-    }
-
-    .convert-demo-organization-button {
-        &:focus {
-            outline: 1px solid
-                var(--color-focus-outline-settings-convert-demo-organization);
-            outline-offset: 0;
-        }
-    }
 }
 
 .user_status_icon_wrapper {

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1420,24 +1420,6 @@
         hsl(200deg 79% 66%)
     );
 
-    /* Demo Organization colors */
-    --color-text-settings-demo-organization-warning: light-dark(
-        hsl(4deg 58% 33%),
-        hsl(3deg 73% 80%)
-    );
-    --color-background-settings-demo-organization-warning: light-dark(
-        hsl(4deg 35% 90%),
-        hsl(0deg 60% 19%)
-    );
-    --color-border-settings-demo-organization-warning: light-dark(
-        hsl(3deg 57% 33% / 40%),
-        hsl(3deg 73% 74% / 40%)
-    );
-    --color-focus-outline-settings-convert-demo-organization: light-dark(
-        hsl(200deg 100% 25%),
-        hsl(200deg 79% 66%)
-    );
-
     /* Widgets colors */
     --color-border-dropdown-widget-button: light-dark(
         hsl(0deg 0% 80%),

--- a/web/templates/settings/demo_organization_warning.hbs
+++ b/web/templates/settings/demo_organization_warning.hbs
@@ -1,15 +1,3 @@
 {{#if is_demo_organization }}
-<div class="demo-organization-warning">
-    {{#if is_owner }}
-    {{#tr}}
-        This demo organization will be automatically deleted in {days_remaining} days, unless it's <z-link>converted into a permanent organization</z-link>.
-        {{#*inline "z-link"}}<a class="convert-demo-organization-button" role="button" tabindex=0>{{> @partial-block}}</a>{{/inline}}
-    {{/tr}}
-    {{else}}
-    {{#tr}}
-        This demo organization will be automatically deleted in {days_remaining} days, unless it's <z-link>converted into a permanent organization</z-link>.
-        {{#*inline "z-link"}}<a href="/help/demo-organizations" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-    {{/tr}}
-    {{/if}}
-</div>
+<div class="demo-organization-warning banner-wrapper"></div>
 {{/if}}


### PR DESCRIPTION
Fixes #34447 (all other points in issue have been completed in other pull requests):
> **Top of org settings banner**
> Use the same banner as in the navbar (color, buttons, etc.).
>
> Text: remove all links
> Buttons:
>  - Learn more
>      - low emphasis
>      - link to /help/demo-organizations
>  - Convert
>      - medium emphasis
>      - opens conversion modal

**Notes**:
- Migrates the demo organization warning that's shown on all the tabs for organization settings to use the shared banner code, so the color variables for the demo organization warning are no longer needed.
- There are a few differences in the `Banner` used in org settings and the `AlertBanner` used in the navbar alerts, so there's some duplication between the two modules.
- With a narrow browser window the banner's buttons take up a lot of space. As there is other ongoing work on implementing banners in the settings overlay, I wasn't sure if that styling's being addressed in those changes and therefore would apply to these demo organization warning banners as well.
- Once the organization is 7 days from deletion, the banner intent switches from info to danger, which is the same for the navbar alert banner.

---

**Screenshots and screen captures:**

### Org settings banner for owners:
| Description | Screenshot |
| --- | --- |
| Before (link opened the conversion modal) | ![Screenshot from 2025-04-30 17-18-54](https://github.com/user-attachments/assets/eeb3fd78-bed5-48f4-96a6-2aabf9837623)
| After | ![Screenshot from 2025-04-30 17-17-21](https://github.com/user-attachments/assets/297d9d4d-4816-42cc-a700-cbc19fd4606b)

### Org settings banner for non-owners:
| Description | Screenshot |
| --- | --- |
| Before (link opened the help center article) | ![Screenshot from 2025-04-30 17-18-32](https://github.com/user-attachments/assets/28fb2ce5-6d34-4efa-a985-ef4327d9f39c)
| After | ![Screenshot from 2025-04-30 17-17-50](https://github.com/user-attachments/assets/e30fc3a0-6101-4e20-b0dc-6d46f82b529b)

### Narrow browser window - owners case:
| Description | Screenshot |
| --- | --- |
| Before (link opened the conversion modal) | ![Screenshot from 2025-05-01 15-45-51](https://github.com/user-attachments/assets/a32d249b-3c9e-410f-9c4a-171a718c8f86)
| After | ![Screenshot from 2025-05-06 12-57-34](https://github.com/user-attachments/assets/08dbb5b6-2116-4748-9bc4-e52cc2e524f0)



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
