### PR TITLE
markdown: Adjust list, blockquote styles to spec.

### DIFF
--- a/web/src/postprocess_content.ts
+++ b/web/src/postprocess_content.ts
@@ -208,6 +208,8 @@ export function postprocess_content(html: string): string {
         // and use that to offset the list accordingly in CSS
         const max_list_counter_string_length = max_list_counter.toString().length;
         ol.classList.add(`counter-length-${max_list_counter_string_length}`);
+        // We subtract 1 from list_start, as `count 0` displays 1.
+        ol.style.setProperty("counter-reset", `count ${list_start - 1}`);
     }
 
     for (const inline_img of template.content.querySelectorAll<HTMLImageElement>(

--- a/web/styles/app_variables.css
+++ b/web/styles/app_variables.css
@@ -1297,6 +1297,10 @@
         hsl(0deg 0% 15%),
         var(--color-text-default)
     );
+    --color-text-message-blockquote-border: light-dark(
+        hsl(0deg 0% 15% / 25%),
+        hsl(0deg 0% 87% / 40%)
+    );
     --color-text-message-header-archived: hsl(0deg 0% 50%);
     --color-text-message-view-header: light-dark(
         hsl(0deg 0% 20% / 100%),

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -12,7 +12,7 @@
 
     & ul {
         margin: 0 0 var(--markdown-interelement-space-px) 0;
-        margin-inline-start: 3.5ch;
+        margin-inline-start: 2ch;
     }
 
     & ol {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -29,29 +29,31 @@
         padding-top: var(--message-box-link-focus-ring-block-padding);
     }
 
-    /* We set margin according to the length of the longest list counter. */
+    /* We set margin according to the length of the longest list counter.
+       The values here keep the counters flush left, just like paragraph
+       text. */
     .counter-length-1 {
-        margin-inline-start: 2.5ch;
+        margin-inline-start: 1.95ch;
     }
 
     .counter-length-2 {
-        margin-inline-start: 3.5ch;
+        margin-inline-start: 2.95ch;
     }
 
     .counter-length-3 {
-        margin-inline-start: 4.5ch;
+        margin-inline-start: 3.95ch;
     }
 
     .counter-length-4 {
-        margin-inline-start: 5.5ch;
+        margin-inline-start: 4.95ch;
     }
 
     .counter-length-5 {
-        margin-inline-start: 6.5ch;
+        margin-inline-start: 5.95ch;
     }
 
     .counter-length-6 {
-        margin-inline-start: 7.5ch;
+        margin-inline-start: 6.95ch;
     }
 
     & hr {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -123,18 +123,24 @@
 
     /* Formatting for blockquotes */
     & blockquote {
-        padding-left: 5px;
-        margin: 0 0 var(--markdown-interelement-space-px) 10px;
-        border-left: 5px solid hsl(0deg 0% 87%);
+        /* This keeps the blockquote text block
+           aligned with list-item text blocks.
+           12.4px at 16px/1em */
+        padding: 0 0 0 0.775em;
+        /* We want to keep the border roughly centered
+           with bullets and single-digit list markers.
+           3.5px at 16px/1em */
+        margin: 0 0 var(--markdown-interelement-space-px) 0.2188em;
+        border-left: 4px solid var(--color-text-message-blockquote-border);
     }
 
     &.rtl blockquote {
-        padding-left: unset;
-        padding-right: 5px;
-        margin-left: unset;
-        margin-right: 10px;
+        /* 12.4px at 16px/1em */
+        padding: 0 0.775em 0 0;
+        /* 3.5px at 16px/1em */
+        margin: 0 0.2188em var(--markdown-interelement-space-px) 0;
         border-left: unset;
-        border-right: 5px solid hsl(0deg 0% 87%);
+        border-right: 4px solid hsl(0deg 0% 65%);
     }
 
     /* Formatting for Markdown tables */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -20,6 +20,11 @@
         margin-inline-start: 3.5ch;
     }
 
+    li {
+        /* 3px at 16px/1em */
+        padding: 0 0 0 0.1875em;
+    }
+
     /* To avoid cutting off the focus ring on links, we set
        padding on first children most likely to take links.
        We account for this extra space on `.message_content`. */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -1,3 +1,15 @@
+/* We use a custom counter here for Safari to
+   get better control of its counter positioning.
+   Because Safari does not recognize `content`
+   properties on `::marker`, the style here better
+   approximates the same styles set on `::marker`
+   below. */
+@counter-style numbers {
+    system: numeric;
+    symbols: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9";
+    suffix: ".";
+}
+
 .rendered_markdown {
     & p {
         margin: 0 0 var(--markdown-interelement-space-px);
@@ -12,17 +24,62 @@
 
     & ul {
         margin: 0 0 var(--markdown-interelement-space-px) 0;
-        margin-inline-start: 2ch;
+        /* Because browsers use inline padding, we set the
+           same property here to offset bullets. */
+        padding-inline-start: 1.1ch;
+        /* By setting Unicode characters of our own, we
+           gain better, cross-browser alignment of bullets. */
+        list-style-type: "•";
+
+        & ul {
+            list-style-type: "◦";
+
+            & ul {
+                list-style-type: "▪︎";
+            }
+        }
+
+        li {
+            /* This aligns bullets to roughly the
+               center of a single-digit counter.
+               11.2px at 16px/1em */
+            padding-inline-start: 0.7em;
+        }
+
+        & li::marker {
+            /* This is an eyeballed value, but it makes the
+               otherwise diminutive markers specified above
+               both larger *and* better vertically centered. */
+            font-size: 1.3em;
+            /* We do not want the line-height for the item text
+               affected by the larger font-size, though. So we
+               zero it out. */
+            line-height: 0;
+        }
     }
 
     & ol {
+        /* For the sake of Safari, we reference the `numbers`
+           counter defined on `@counter-style` above. */
+        list-style: numbers;
+        /* To preserve the `start` attribute on lists that
+           begin with a number other than 1, we update the
+           `counter-reset` in postprocess_content.ts. */
+        counter-reset: count;
         margin: 0 0 var(--markdown-interelement-space-px) 0;
-        margin-inline-start: 3.5ch;
-    }
+        /* Because browsers use inline padding, we set the
+           same here to offset the counters. */
+        padding-inline-start: 2.1ch;
 
-    li {
-        /* 3px at 16px/1em */
-        padding: 0 0 0 0.1875em;
+        & li {
+            counter-increment: count 1;
+            /* 3.2px at 16px/1em */
+            padding-inline-start: 0.2em;
+        }
+
+        & li::marker {
+            content: counter(count, decimal) ". ";
+        }
     }
 
     /* To avoid cutting off the focus ring on links, we set
@@ -38,27 +95,27 @@
        The values here keep the counters flush left, just like paragraph
        text. */
     .counter-length-1 {
-        margin-inline-start: 1.95ch;
+        padding-inline-start: 2.1ch;
     }
 
     .counter-length-2 {
-        margin-inline-start: 2.95ch;
+        padding-inline-start: 3.1ch;
     }
 
     .counter-length-3 {
-        margin-inline-start: 3.95ch;
+        padding-inline-start: 4.1ch;
     }
 
     .counter-length-4 {
-        margin-inline-start: 4.95ch;
+        padding-inline-start: 5.1ch;
     }
 
     .counter-length-5 {
-        margin-inline-start: 5.95ch;
+        padding-inline-start: 6.1ch;
     }
 
     .counter-length-6 {
-        margin-inline-start: 6.95ch;
+        padding-inline-start: 7.1ch;
     }
 
     & hr {

--- a/web/tests/postprocess_content.test.cjs
+++ b/web/tests/postprocess_content.test.cjs
@@ -81,7 +81,7 @@ run_test("postprocess_content", () => {
 run_test("ordered_lists", () => {
     assert.equal(
         postprocess_content('<ol start="9"><li>Nine</li><li>Ten</li></ol>'),
-        '<ol start="9" class="counter-length-2"><li>Nine</li><li>Ten</li></ol>',
+        '<ol start="9" class="counter-length-2" style="counter-reset: count 8;"><li>Nine</li><li>Ten</li></ol>',
     );
 });
 


### PR DESCRIPTION
This PR adjusts the alignment and spacing on lists and blockquotes, and the color of the border on block quotes, in line with @terpimost's [Figma spec](https://www.figma.com/file/jbNOiBWvbtLuHaiTj4CW0G/Zulip-Web-App?node-id=2038%3A130639).

[CZO discussion](https://chat.zulip.org/#narrow/channel/101-design/topic/updating.20lists.2C.20blockquotes.20to.20spec/near/2164267)

Fixes [high-priority remaining parts](https://github.com/zulip/zulip/issues/22022#issuecomment-2828766009) of #22022

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures** (updated 2025-05-08):

| Before | After |
| --- | --- |
| ![firefox-markers-light-before](https://github.com/user-attachments/assets/7579d51a-d8e6-4bde-a5d3-9e36129c95aa) | ![firefox-markers-light-after](https://github.com/user-attachments/assets/b913b965-eda3-4d02-83b8-08bd0e499324) |
| ![firefox-markers-dark-before](https://github.com/user-attachments/assets/43b36719-62f2-48a2-a16e-5197d8db6013) | ![firefox-markers-dark-after](https://github.com/user-attachments/assets/da3862fa-a698-40cd-86a3-e8f4619555ad) |

| Safari, before | Safari, after |
| --- | --- |
| ![markers-safari-before](https://github.com/user-attachments/assets/8e6c8894-3e63-473a-98b4-f6388a565884) | ![markers-safari-after](https://github.com/user-attachments/assets/dd5c0e44-6f83-4981-9864-af59cd63e082) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>