### PR TITLE
demo-orgs: Update convert form text to be clearer.

### DIFF
--- a/web/templates/settings/convert_demo_organization_form.hbs
+++ b/web/templates/settings/convert_demo_organization_form.hbs
@@ -1,16 +1,13 @@
 <div id="convert-demo-organization-form">
+    {{#unless user_has_email_set}}
     <div class="tip">
-        {{#unless user_has_email_set}}
-            {{#tr}}
-                You must <z-link>configure your email</z-link> to access this feature.
-                {{#*inline "z-link"}}<a href="/help/demo-organizations#configure-email-for-demo-organization-owner" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
-            {{/tr}}
-        {{else}}
-            {{t "All users will need to log in again at your new organization URL." }}
-        {{/unless}}
+        {{#tr}}
+            You must <z-link>configure your email</z-link> to access this feature.
+            {{#*inline "z-link"}}<a href="/help/demo-organizations#configure-email-for-demo-organization-owner" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
+        {{/tr}}
     </div>
-
-    <p>{{t "You can convert this demo organization to a permanent Zulip organization. All users and message history will be preserved." }}</p>
+    {{/unless}}
+    <p>{{t "Everyone will need to log in again at the new URL for your organization." }}</p>
     <form class="subdomain-setting">
         <div class="input-group">
             <label for="organization_type" class="modal-field-label">{{t "Organization type" }}


### PR DESCRIPTION
As noted in https://github.com/zulip/zulip/issues/34448#issuecomment-2843755963:
> Thinking about this one, I think we can just make it text instead of a banner. We can make the text:
> > Everyone will need to log in again at the new URL for your organization.
>
> I think we don't need any of the text that's currently there above the form -- it's actually confusing, because not just users and messages are preserved, but everything else, too. So let's just drop that note.

**Screenshots and screen captures:**

### Owner email is set:
| Before | After |
| --- | --- |
| ![Screenshot from 2025-05-01 11-41-59](https://github.com/user-attachments/assets/99f87946-e6f6-4999-925a-17b531b920fa) | ![Screenshot from 2025-05-01 11-34-36](https://github.com/user-attachments/assets/d7f0b7b5-b20e-4980-9b31-e9372b294247)

### Owner email is not set:
*Tip banner revisions are specified in #34448.*
| Before | After |
| --- | --- |
| ![Screenshot from 2025-05-01 11-41-38](https://github.com/user-attachments/assets/235a3d30-47ef-4506-bbf1-ae626e622c4c) | ![Screenshot from 2025-05-01 11-33-31](https://github.com/user-attachments/assets/a79fa07f-19ef-4c56-aa68-53ac23bcfabc)


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
