### PR TITLE
settings: Change button intents on account & privacy panel.

### DIFF
--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -15,7 +15,7 @@
                         {{> ../components/icon_button
                           id="change_email_button"
                           icon="edit"
-                          intent="brand"
+                          intent="neutral"
                           custom_classes="tippy-zulip-delayed-tooltip"
                           hidden=(not user_can_change_email)
                           aria-label=(t "Change your email")
@@ -61,7 +61,7 @@
                         {{> ../components/action_button
                           label=(t "Change your password")
                           attention="quiet"
-                          intent="brand"
+                          intent="neutral"
                           id="change_password"
                           }}
                     </div>
@@ -110,7 +110,7 @@
                     {{> ../components/action_button
                       label=(t "Manage your API key")
                       attention="quiet"
-                      intent="brand"
+                      intent="neutral"
                       id="api_key_button"
                       disabled=(not user_has_email_set)
                       }}


### PR DESCRIPTION
I think we don't need to emphasize these actions with a brand color; neutral seems more appropriate.

## Before
![Screenshot 2025-05-01 at 13 47 30](https://github.com/user-attachments/assets/f112da09-a459-4a4d-b8d0-e29e27ac3cff)

## After
![Screenshot 2025-05-01 at 13 51 04](https://github.com/user-attachments/assets/ff3e28ec-d564-4395-a9a5-363684a9ab90)
